### PR TITLE
Enhancement: Allow direct download of packages

### DIFF
--- a/Website/Controllers/PackagesController.cs
+++ b/Website/Controllers/PackagesController.cs
@@ -221,7 +221,6 @@ namespace NuGetGallery {
             return Redirect(Url.Package(id));
         }
 
-        [HttpGet]
         public virtual ActionResult DownloadPackage(string id, string version) {
             var package = packageSvc.FindPackageByIdAndVersion(id, version);
 


### PR DESCRIPTION
This capability was in the old as /Package/Download/{id}/{version}.

switching it around a bit to make sense with new conventions:
/download/package/{id}/{version}
