### PR TITLE
Ignore docstates file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ App_Data
 /packages
 _AzurePackage
 *.bak
+NuGetGallery.sln.docstates


### PR DESCRIPTION
Added an entry in .gitignore to ignore the NuGetGallery.sln.docstates file.
