### PR TITLE
No longer sends confirm emails when email doesn't change. Fixes #244

### DIFF
--- a/Website/Controllers/UsersController.cs
+++ b/Website/Controllers/UsersController.cs
@@ -63,6 +63,7 @@ namespace NuGetGallery
                     return HttpNotFound();
                 }
 
+                string existingConfirmationToken = user.EmailConfirmationToken;
                 try
                 {
                     userService.UpdateProfile(user, profile.EmailAddress, profile.EmailAllowed);
@@ -73,9 +74,9 @@ namespace NuGetGallery
                     return View(profile);
                 }
 
-                if (String.IsNullOrEmpty(user.EmailConfirmationToken))
+                if (existingConfirmationToken == user.EmailConfirmationToken)
                 {
-                    TempData["Message"] = "Account settings Saved!";
+                    TempData["Message"] = "Account settings saved!";
                 }
                 else
                 {

--- a/Website/Services/IUserService.cs
+++ b/Website/Services/IUserService.cs
@@ -9,7 +9,7 @@ namespace NuGetGallery
             string password,
             string emailAddress);
 
-        string UpdateProfile(User user, string emailAddress, bool emailAllowed);
+        void UpdateProfile(User user, string emailAddress, bool emailAllowed);
 
         User FindByApiKey(Guid apiKey);
 

--- a/Website/Services/UserService.cs
+++ b/Website/Services/UserService.cs
@@ -59,7 +59,7 @@ namespace NuGetGallery
             return newUser;
         }
 
-        public string UpdateProfile(User user, string emailAddress, bool emailAllowed)
+        public void UpdateProfile(User user, string emailAddress, bool emailAllowed)
         {
             if (user == null)
             {
@@ -79,7 +79,6 @@ namespace NuGetGallery
 
             user.EmailAllowed = emailAllowed;
             userRepo.CommitChanges();
-            return user.EmailConfirmationToken;
         }
 
         public User FindByApiKey(Guid apiKey)


### PR DESCRIPTION
If a user has a pending email change confirmation, any time the user saved
the profile, even if the email address wasn't changing, would prompt a new
email to be sent to confirm the email address change. This was very confusing.
