### PR TITLE
Prevent FormsAuth from hijacking 403s (Small change)

### DIFF
--- a/Website/api/Web.config
+++ b/Website/api/Web.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0"?>
 <configuration>
+  <system.web>
+    <authentication mode="None" />
+  </system.web>
   <system.webServer>
     <httpErrors errorMode="Custom">
       <!-- Require this to prevent custom error pages from being served -->


### PR DESCRIPTION
When we return a HttpUnauthorizedResult from our API controller, forms auth seems to hijack it and redirect us to the login url. Not sure if there's a nicer way to do this.
