### PR TITLE
Adding a download link if a user is logged in to the site

### DIFF
--- a/Website/Views/Packages/DisplayPackage.cshtml
+++ b/Website/Views/Packages/DisplayPackage.cshtml
@@ -36,7 +36,7 @@
             <li><a href="@Url.Action(MVC.Packages.ContactOwners(Model.Id))">Contact Owners</a></li>
             @if (User.Identity.IsAuthenticated)
             {
-                <li><a href="@Url.PackageDownload(2,Model.Id,Model.Version)">Download</a></li>
+                <li><a href="@Url.PackageDownload(2,Model.Id, Model.Version)">Download</a></li>
             } else {
                 <li><a href="@Url.Action(@MVC.Packages.Download())" title="How do I download?">How to Download</a></li>
             }

--- a/Website/Views/Packages/DisplayPackage.generated.cs
+++ b/Website/Views/Packages/DisplayPackage.generated.cs
@@ -223,7 +223,7 @@ WriteLiteral("                <li><a href=\"");
 
             
             #line 39 "..\..\Views\Packages\DisplayPackage.cshtml"
-                        Write(Url.PackageDownload(2,Model.Id,Model.Version));
+                        Write(Url.PackageDownload(2,Model.Id, Model.Version));
 
             
             #line default


### PR DESCRIPTION
One of the most requested features is a downlink on the site. After speaking with a few people we think we can give this to people and avoid confusion about how to use NuGet. If the user is logged into the site we will show them a download link. This works on the assumption that most users will not have NuGet.org accounts they will only have one if they are a package author and therefore already know what they are doing. 
