### PR TITLE
Expose IsPrerelease property on V2Feed

### DIFF
--- a/Website/DataServices/PackageExtensions.cs
+++ b/Website/DataServices/PackageExtensions.cs
@@ -71,6 +71,7 @@ namespace NuGetGallery
                          IconUrl = p.IconUrl,
                          IsLatestVersion = p.IsLatestStable, // To maintain parity with v1 behavior of the feed, IsLatestVersion would only be used for stable versions.
                          IsAbsoluteLatestVersion = p.IsLatest,
+                         IsPrerelease = p.IsPrerelease,
                          LastUpdated = p.LastUpdated,
                          LicenseUrl = p.LicenseUrl,
                          Language = null,

--- a/Website/DataServices/V2FeedPackage.cs
+++ b/Website/DataServices/V2FeedPackage.cs
@@ -24,6 +24,7 @@ namespace NuGetGallery
         public string IconUrl { get; set; }
         public bool IsLatestVersion { get; set; }
         public bool IsAbsoluteLatestVersion { get; set; }
+        public bool IsPrerelease { get; set; }
         public DateTime LastUpdated { get; set; }
         public DateTime Published { get; set; }
         public string Language { get; set; }


### PR DESCRIPTION
MyGet wants to use the IsPrerelease property to query in a more fine-grained fashion. This means that the IsPrerelease property should be exposed on the V2Feed so that MyGet can consume it.

This pull request implements the scenario described.
