### PR TITLE
Adding FindPackagesById method to feeds

### DIFF
--- a/Website/DataServices/FeedServiceBase.cs
+++ b/Website/DataServices/FeedServiceBase.cs
@@ -51,6 +51,7 @@ namespace NuGetGallery
         public static void InitializeService(DataServiceConfiguration config)
         {
             config.SetServiceOperationAccessRule("Search", ServiceOperationRights.AllRead);
+            config.SetServiceOperationAccessRule("FindPackagesById", ServiceOperationRights.AllRead);
             config.SetEntitySetAccessRule("Packages", EntitySetRights.AllRead);
             config.SetEntitySetPageSize("Packages", 100);
             config.DataServiceBehavior.MaxProtocolVersion = DataServiceProtocolVersion.V2;

--- a/Website/DataServices/V1Feed.svc.cs
+++ b/Website/DataServices/V1Feed.svc.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data.Services;
+using System.Data.Entity;
 using System.Linq;
 using System.ServiceModel.Web;
 using System.Web;
@@ -44,6 +45,14 @@ namespace NuGetGallery
             string url = urlHelper.PackageDownload(FeedVersion, package.Id, package.Version);
 
             return new Uri(url, UriKind.Absolute);
+        }
+
+        [WebGet]
+        public IQueryable<V1FeedPackage> FindPackagesById(string id)
+        {
+            return PackageRepo.GetAll().Include(p => p.PackageRegistration)
+                                       .Where(p => !p.IsPrerelease && p.PackageRegistration.Id.Equals(id, StringComparison.OrdinalIgnoreCase) && p.Listed)
+                                       .ToV1FeedPackageQuery(Configuration.SiteRoot);
         }
 
         [WebGet]

--- a/Website/DataServices/V2Feed.svc.cs
+++ b/Website/DataServices/V2Feed.svc.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data.Entity;
 using System.Data.Services;
 using System.Linq;
 using System.ServiceModel.Web;
@@ -43,6 +44,14 @@ namespace NuGetGallery
             }
             return packages.Search(searchTerm)
                            .ToV2FeedPackageQuery(Configuration.SiteRoot);
+        }
+
+        [WebGet]
+        public IQueryable<V2FeedPackage> FindPackagesById(string id)
+        {
+            return PackageRepo.GetAll().Include(p => p.PackageRegistration)
+                                       .Where(p => p.PackageRegistration.Id.Equals(id, StringComparison.OrdinalIgnoreCase) && p.Listed)
+                                       .ToV2FeedPackageQuery(Configuration.SiteRoot);
         }
 
         public override Uri GetReadStreamUri(


### PR DESCRIPTION
Adding a service method to the gallery. This should allow us to compare package Ids on the server using OrdinalIgnoreCase comparers instead of using culture insensitive ToLower based comparisons
