### PR TITLE
Securing elmah.axd for real

### DIFF
--- a/Website/Web.config
+++ b/Website/Web.config
@@ -36,14 +36,25 @@
     <errorLog type="Elmah.SqlErrorLog, Elmah" connectionStringName="NuGetGallery" />
   </elmah>
   <!-- Ensure only Admins may access elmah.axd -->
-  <location path="elmah.axd">
-    <system.web>
-      <authorization>
-        <allow roles="Admins" />
-        <deny users="*" />
-      </authorization>
-    </system.web>
-  </location>
+ <location path="elmah.axd">
+	<system.web>
+	  <httpHandlers>
+		 <add verb="POST,GET,HEAD" path="elmah.axd" 
+			type="Elmah.ErrorLogPageFactory, Elmah" />
+	  </httpHandlers>
+	  <authorization>
+		 <allow roles="Admins" />
+		 <deny users="*" />
+	  </authorization>
+	</system.web>
+	<system.webServer>
+	  <handlers>
+		 <add name="Elmah" path="elmah.axd" verb="POST,GET,HEAD"
+			type="Elmah.ErrorLogPageFactory, Elmah"
+			preCondition="integratedMode" />
+	  </handlers>
+	</system.webServer>
+ </location>
   <system.web>
     <compilation debug="true" targetFramework="4.0">
       <assemblies>
@@ -74,7 +85,7 @@
       <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" />
     </httpModules>
     <httpHandlers>
-      <add verb="POST,GET,HEAD" path="elmah.axd" type="Elmah.ErrorLogPageFactory, Elmah" />
+
     </httpHandlers>
     <customErrors mode="RemoteOnly" defaultRedirect="~/Errors/error.html">
       <error statusCode="404" redirect="~/Errors/404" />
@@ -89,7 +100,7 @@
     </modules>
     <validation validateIntegratedModeConfiguration="false" />
     <handlers>
-      <add name="Elmah" path="elmah.axd" verb="POST,GET,HEAD" type="Elmah.ErrorLogPageFactory, Elmah" preCondition="integratedMode" />
+
     </handlers>
     <httpErrors errorMode="Custom">
       <remove statusCode="404" subStatusCode="-1" />


### PR DESCRIPTION
Changed web.config so elmah.axd is secure, only available from the root of the application. Check this [article](http://www.troyhunt.com/2012/01/aspnet-session-hijacking-with-google.html) for details on the vulnerability.
