### PR TITLE
Fixes for work items 406, 400

### DIFF
--- a/Website/Controllers/PackagesController.cs
+++ b/Website/Controllers/PackagesController.cs
@@ -150,6 +150,11 @@ namespace NuGetGallery
                 if (String.IsNullOrEmpty(sortOrder))
                 {
                     packageVersions = searchSvc.SearchWithRelevance(packageVersions, q, take: page * Constants.DefaultPackageListPageSize, totalHits: out totalHits);
+                    if (page == 1 && packageVersions.Count() == 0)
+                    {
+                        // In the event the index wasn't updated, we may get an incorrect count. 
+                        totalHits = 0;
+                    }
                 }
                 else
                 {

--- a/Website/Infrastructure/Lucene/LuceneSearchService.cs
+++ b/Website/Infrastructure/Lucene/LuceneSearchService.cs
@@ -80,6 +80,7 @@ namespace NuGetGallery
                 var analyzer = new StandardAnalyzer(LuceneCommon.LuceneVersion);
                 var queryParser = new MultiFieldQueryParser(LuceneCommon.LuceneVersion, new[] { "Id-Exact", "Id", "Title", "Author", "Description", "Tags" }, analyzer, boosts);
 
+                searchTerm = QueryParser.Escape(searchTerm);
                 var query = queryParser.Parse(searchTerm);
                 var results = searcher.Search(query, filter: null, n: 1000, sort: Sort.RELEVANCE);
                 var keys = results.scoreDocs.Select(c => Int32.Parse(searcher.Doc(c.doc).Get("Key"), CultureInfo.InvariantCulture))

--- a/Website/Infrastructure/Lucene/PackageIndexEntity.cs
+++ b/Website/Infrastructure/Lucene/PackageIndexEntity.cs
@@ -14,6 +14,6 @@
 
         public string Authors { get; set; }
 
-        public int LatestKey { get; set; }
+        public int? LatestKey { get; set; }
     }
 }


### PR DESCRIPTION
#406: Escape search string prior to querying Lucene.
#400: Modify indexer to correctly remove package when no version is listed.
