### PR TITLE
Use PostAppStart instead of PreAppStart

### DIFF
--- a/Website/App_Start/Bootstrapper.cs
+++ b/Website/App_Start/Bootstrapper.cs
@@ -4,7 +4,7 @@ using System.Web.Routing;
 using Elmah.Contrib.Mvc;
 using NuGetGallery.Migrations;
 
-[assembly: WebActivator.PreApplicationStartMethod(typeof(NuGetGallery.Bootstrapper), "Start")]
+[assembly: WebActivator.PostApplicationStartMethod(typeof(NuGetGallery.Bootstrapper), "Start")]
 namespace NuGetGallery
 {
     public static class Bootstrapper


### PR DESCRIPTION
Generally, we should avoid doing things that can fail in PreAppStart, and instead do them in PostAppStart. PostAppStart is basically HttpModule init time.

We actually ran into a case where something was blowing up as a result.
