### PR TITLE
Fix issue with API header binding when running under a subdirectory

### DIFF
--- a/Website/Infrastructure/HttpHeaderValueProviderFactory.cs
+++ b/Website/Infrastructure/HttpHeaderValueProviderFactory.cs
@@ -10,7 +10,7 @@ namespace NuGetGallery
             var request = controllerContext.RequestContext.HttpContext.Request;
             
             // Use this value provider only if a route is located under "API"
-            if (request.Path.TrimStart('/').StartsWith("api", StringComparison.OrdinalIgnoreCase))
+            if (request.Path.Contains("/api/"))
                 return new HttpHeaderValueProvider(request, "ApiKey");
             return null;
         }


### PR DESCRIPTION
Related to issue #409. The HttpHeaderValueProviderFactory only enables the HttpHeaderValueProvider if the URL starts with "/api".  When running the NuGet Gallery under a subdirectory (eg. http://devlocal/nuget/), the URL will not start with /api and hence the value provider is not added correctly.
