### PR TITLE
Added helpful error message when ELMAH SQL objects are missing

### DIFF
--- a/Website/Infrastructure/NuGetErrorLogPageFactory.cs
+++ b/Website/Infrastructure/NuGetErrorLogPageFactory.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Data.SqlClient;
+using System.Web;
+using Elmah;
+
+namespace NuGetGallery.Infrastructure
+{
+    public class NuGetErrorLogPageFactory : ErrorLogPageFactory
+    {
+        public override IHttpHandler GetHandler(HttpContext context, string requestType, string url,
+                                                string pathTranslated)
+        {
+            return new HttpHandlerWrapper(base.GetHandler(context, requestType, url, pathTranslated));
+        }
+
+        private class HttpHandlerWrapper : IHttpHandler
+        {
+            private readonly IHttpHandler _handler;
+
+            public HttpHandlerWrapper(IHttpHandler handler)
+            {
+                _handler = handler;
+            }
+
+
+            public bool IsReusable
+            {
+                get { return _handler.IsReusable; }
+            }
+
+            public void ProcessRequest(HttpContext context)
+            {
+                try
+                {
+                    _handler.ProcessRequest(context);
+                }
+                catch (HttpUnhandledException e)
+                {
+                    if (e.InnerException != null && e.InnerException is SqlException &&
+                        (e.InnerException.Message.IndexOf("Could not find stored procedure",
+                                                          StringComparison.OrdinalIgnoreCase) > -1))
+                    {
+                        context.Response.Write("<h1>ELMAH not configured correctly.</h1>");
+                        context.Response.Write(
+                            @"<p>Run the SQL script '<em>Elmah.SqlServer.sql</em>' located in '<em>{SolutionDir}</em>\packages\elmah.sqlserver.1.2\content\App_Readme\' against your SQL database.</p>");
+                        return;
+                    }
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/Website/Web.config
+++ b/Website/Web.config
@@ -40,7 +40,7 @@
   <location path="elmah.axd">
     <system.web>
       <httpHandlers>
-        <add verb="POST,GET,HEAD" path="elmah.axd" type="Elmah.ErrorLogPageFactory, Elmah" />
+        <add verb="POST,GET,HEAD" path="elmah.axd" type="NuGetGallery.Infrastructure.NuGetErrorLogPageFactory, NuGetGallery.Website" />
       </httpHandlers>
       <authorization>
         <allow roles="Admins" />
@@ -49,7 +49,7 @@
     </system.web>
     <system.webServer>
       <handlers>
-        <add name="Elmah" path="elmah.axd" verb="POST,GET,HEAD" type="Elmah.ErrorLogPageFactory, Elmah" preCondition="integratedMode" />
+        <add name="Elmah" path="elmah.axd" verb="POST,GET,HEAD" type="NuGetGallery.Infrastructure.NuGetErrorLogPageFactory, NuGetGallery.Website" preCondition="integratedMode" />
       </handlers>
     </system.webServer>
   </location>

--- a/Website/Website.csproj
+++ b/Website/Website.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Infrastructure\Jobs\WorkItemCleanupJob.cs" />
     <Compile Include="Infrastructure\Jobs\UpdateStatisticsJob.cs" />
     <Compile Include="Infrastructure\Lucene\PackageIndexEntity.cs" />
+    <Compile Include="Infrastructure\NuGetErrorLogPageFactory.cs" />
     <Compile Include="JsonApiController.generated.cs">
       <DependentUpon>T4MVC.tt</DependentUpon>
     </Compile>


### PR DESCRIPTION
When running a clean clone of NuGet gallery, there's a manual configuration step that's required to get ELMAH working.
But the error message ELMAH gives doesn't help much. I added some code so that we present a more helpful message.

```
ELMAH not configured correctly.
Run the SQL script 'Elmah.SqlServer.sql' located in '{SolutionDir}\packages\elmah.sqlserver.1.2\content\App_Readme\' against your SQL database.
```
