### PR TITLE
Adding support for /api/v2/NuGet.exe route that returns the exe

### DIFF
--- a/Facts/Facts.csproj
+++ b/Facts/Facts.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Services\CloudBlobFileStorageServiceFacts.cs" />
     <Compile Include="Services\FileSystemFileStorageServiceFacts.cs" />
     <Compile Include="Services\MessageServiceFacts.cs" />
+    <Compile Include="Services\NuGetExeDownloaderServiceFacts.cs" />
     <Compile Include="Services\PackageServiceFacts.cs" />
     <Compile Include="Services\UploadFileServiceFacts.cs" />
     <Compile Include="Services\UsersServiceFacts.cs" />

--- a/Facts/Services/NuGetExeDownloaderServiceFacts.cs
+++ b/Facts/Services/NuGetExeDownloaderServiceFacts.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Web.Mvc;
+using Moq;
+using NuGet;
+using Xunit;
+
+namespace NuGetGallery.Services
+{
+    public class NuGetExeDownloaderServiceFacts
+    {
+        private static readonly string _exePath = @"x:\NuGetGallery\nuget.exe";
+
+        [Fact]
+        public void CreateNuGetExeDownloadDoesNotExtractFileIfItAlreadyExistsAndIsRecent()
+        {
+            // Arrange
+            var fileSystem = new Mock<IFileSystemService>(MockBehavior.Strict);
+            fileSystem.Setup(s => s.FileExists(_exePath)).Returns(true).Verifiable();
+            fileSystem.Setup(s => s.GetCreationTimeUtc(_exePath))
+                      .Returns(DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(60)))
+                      .Verifiable();
+
+            // Act
+            var downloaderSvc = GetDownloaderService(fileSystemSvc: fileSystem);
+            var result = downloaderSvc.CreateNuGetExeDownloadActionnResult();
+
+            // Assert
+            fileSystem.Verify();
+            AssertActionResult(result);
+        }
+
+        [Fact]
+        public void CreateNuGetExeDownloadExtractsFileIfItDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new Mock<IFileSystemService>(MockBehavior.Strict);
+            fileSystem.Setup(s => s.FileExists(_exePath)).Returns(false);
+            fileSystem.Setup(s => s.OpenWrite(_exePath)).Returns(Stream.Null);
+
+            var package = new Package { Version = "2.0.0" };
+            var packageService = new Mock<IPackageService>(MockBehavior.Strict);
+            packageService.Setup(s => s.FindPackageByIdAndVersion("NuGet.CommandLine", null, false))
+                          .Returns(package)
+                          .Verifiable();
+            var packageFileSvc = new Mock<IPackageFileService>(MockBehavior.Strict);
+            packageFileSvc.Setup(s => s.DownloadPackageFile(package))
+                          .Returns(CreateCommandLinePackage)
+                          .Verifiable();
+
+            // Act
+            var downloaderSvc = GetDownloaderService(packageService, packageFileSvc, fileSystem);
+            var result = downloaderSvc.CreateNuGetExeDownloadActionnResult();
+
+            // Assert
+            packageFileSvc.Verify();
+            packageService.Verify();
+            AssertActionResult(result);
+        }
+
+        [Fact]
+        public void CreateNuGetExeDownloadExtractsFileIfItExistsButIsNotRecent()
+        {
+            // Arrange
+            var fileSystem = new Mock<IFileSystemService>(MockBehavior.Strict);
+            fileSystem.Setup(s => s.FileExists(_exePath)).Returns(true);
+            fileSystem.Setup(s => s.GetCreationTimeUtc(_exePath))
+                      .Returns(DateTime.UtcNow.Subtract(TimeSpan.FromHours(32)));
+            fileSystem.Setup(s => s.OpenWrite(_exePath)).Returns(Stream.Null);
+
+            var package = new Package { Version = "2.0.0" };
+            var packageService = new Mock<IPackageService>(MockBehavior.Strict);
+            packageService.Setup(s => s.FindPackageByIdAndVersion("NuGet.CommandLine", null, false))
+                          .Returns(package)
+                          .Verifiable();
+            var packageFileSvc = new Mock<IPackageFileService>(MockBehavior.Strict);
+            packageFileSvc.Setup(s => s.DownloadPackageFile(package))
+                          .Returns(CreateCommandLinePackage)
+                          .Verifiable();
+
+            // Act
+            var downloaderSvc = GetDownloaderService(packageService, packageFileSvc, fileSystem);
+            var result = downloaderSvc.CreateNuGetExeDownloadActionnResult();
+
+            // Assert
+            packageFileSvc.Verify();
+            packageService.Verify();
+            AssertActionResult(result);
+        }
+
+        [Fact]
+        public void UpdateExecutableExtractsExeToDisk()
+        {
+            // Arrange
+            var fileSystem = new Mock<IFileSystemService>(MockBehavior.Strict);
+            fileSystem.Setup(s => s.OpenWrite(_exePath)).Returns(Stream.Null);
+
+            var nugetPackage = new Mock<IPackage>();
+            nugetPackage.Setup(s => s.GetFiles()).Returns(new[] { CreateExePackageFile() }.AsQueryable());
+
+            // Act
+            var downloaderSvc = GetDownloaderService(fileSystemSvc: fileSystem);
+            downloaderSvc.UpdateExecutable(nugetPackage.Object);
+
+            // Assert
+            fileSystem.Verify();
+        }
+
+        private static void AssertActionResult(ActionResult result)
+        {
+            Assert.IsType<FilePathResult>(result);
+            var filePathResult = (FilePathResult)result;
+            Assert.Equal(_exePath, filePathResult.FileName);
+            Assert.Equal(@"application/octet-stream", filePathResult.ContentType);
+            Assert.Equal(@"NuGet.exe", filePathResult.FileDownloadName);
+        }
+
+        private static Stream CreateCommandLinePackage()
+        {
+            var packageBuilder = new PackageBuilder
+                                 {
+                                     Id = "NuGet.CommandLine",
+                                     Version = new SemanticVersion("2.0.0"),
+                                     Description = "Some desc"
+                                 };
+            packageBuilder.Authors.Add("test");
+            var exeFile = CreateExePackageFile();
+            packageBuilder.Files.Add(exeFile);
+
+            var memoryStream = new MemoryStream();
+            packageBuilder.Save(memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            return memoryStream;
+        }
+
+        private static IPackageFile CreateExePackageFile()
+        {
+            var exeFile = new Mock<IPackageFile>();
+            exeFile.Setup(s => s.Path).Returns(@"tools\NuGet.exe");
+            exeFile.Setup(s => s.GetStream()).Returns(Stream.Null);
+            return exeFile.Object;
+        }
+
+        private static NuGetExeDownloaderService GetDownloaderService(
+            Mock<IPackageService> packageSvc = null,
+            Mock<IPackageFileService> packageFileSvc = null,
+            Mock<IFileSystemService> fileSystemSvc = null)
+        {
+            packageSvc = packageSvc ?? new Mock<IPackageService>(MockBehavior.Strict);
+            packageFileSvc = packageFileSvc ?? new Mock<IPackageFileService>(MockBehavior.Strict);
+            fileSystemSvc = fileSystemSvc ?? new Mock<IFileSystemService>(MockBehavior.Strict);
+
+            return new NuGetExeDownloaderService(packageSvc.Object, packageFileSvc.Object, fileSystemSvc.Object)
+            {
+                NuGetExePath = _exePath
+            };
+        }
+    }
+}

--- a/Website/ApiController.generated.cs
+++ b/Website/ApiController.generated.cs
@@ -75,6 +75,7 @@ namespace NuGetGallery {
         [GeneratedCode("T4MVC", "2.0"), DebuggerNonUserCode]
         public class ActionNamesClass {
             public readonly string GetPackage = "GetPackageApi";
+            public readonly string GetNuGetExe = "GetNuGetExeApi";
             public readonly string VerifyPackageKey = "VerifyPackageKeyApi";
             public readonly string CreatePackagePut = "PushPackageApi";
             public readonly string CreatePackagePost = "PushPackageApi";
@@ -99,6 +100,11 @@ namespace NuGetGallery {
             var callInfo = new T4MVC_ActionResult(Area, Name, ActionNames.GetPackage);
             callInfo.RouteValueDictionary.Add("id", id);
             callInfo.RouteValueDictionary.Add("version", version);
+            return callInfo;
+        }
+
+        public override System.Web.Mvc.ActionResult GetNuGetExe() {
+            var callInfo = new T4MVC_ActionResult(Area, Name, ActionNames.GetNuGetExe);
             return callInfo;
         }
 

--- a/Website/App_Start/ContainerBindings.cs
+++ b/Website/App_Start/ContainerBindings.cs
@@ -89,6 +89,10 @@ namespace NuGetGallery
                 .To<LuceneIndexingService>()
                 .InRequestScope();
 
+            Bind<INuGetExeDownloaderService>()
+                .To<NuGetExeDownloaderService>()
+                .InRequestScope();
+
             Lazy<IMailSender> mailSenderThunk = new Lazy<IMailSender>(() =>
             {
                 var settings = Kernel.Get<GallerySetting>();

--- a/Website/App_Start/Routes.cs
+++ b/Website/App_Start/Routes.cs
@@ -198,6 +198,11 @@ namespace NuGetGallery
                 defaults: null,
                 constraints: new { httpMethod = new HttpMethodConstraint("DELETE") });
 
+            routes.MapRoute(
+               "v2" + RouteName.DownloadNuGetExe,
+               "api/v2/nuget.exe",
+               new { controller = MVC.Api.Name, action = MVC.Api.ActionNames.GetNuGetExe });
+
             routes.MapServiceRoute(
                 RouteName.V2ApiCuratedFeed,
                 "api/v2/curated-feed",

--- a/Website/Constants.cs
+++ b/Website/Constants.cs
@@ -10,6 +10,7 @@ namespace NuGetGallery
         public const int DefaultPasswordResetTokenExpirationHours = 24;
         public const int MaxEmailSubjectLength = 255;
         public const string PackageContentType = "application/zip";
+        public const string OctetStreamContentType = "application/octet-stream";
         public const string NuGetPackageFileExtension = ".nupkg";
         public const string PackageFileDownloadUriTemplate = "packages/{0}/{1}/download";
         public const string PackageFileSavePathTemplate = "{0}.{1}{2}";

--- a/Website/RouteNames.cs
+++ b/Website/RouteNames.cs
@@ -10,6 +10,7 @@
         public const string Profile = "Profile";
         public const string DisplayPackage = "package-route";
         public const string DownloadPackage = "DownloadPackage";
+        public const string DownloadNuGetExe = "DownloadNuGetExe";
         public const string Home = "Home";
         public const string Policies = "Policies";
         public const string ListPackages = "ListPackages";

--- a/Website/Services/FileSystemService.cs
+++ b/Website/Services/FileSystemService.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace NuGetGallery
 {
@@ -32,6 +33,11 @@ namespace NuGetGallery
         public Stream OpenWrite(string path)
         {
             return File.OpenWrite(path);
+        }
+
+        public DateTimeOffset GetCreationTimeUtc(string path)
+        {
+            return File.GetCreationTimeUtc(path);
         }
     }
 }

--- a/Website/Services/IFileSystemService.cs
+++ b/Website/Services/IFileSystemService.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace NuGetGallery
 {
@@ -10,5 +11,6 @@ namespace NuGetGallery
         bool FileExists(string path);
         Stream OpenRead(string path);
         Stream OpenWrite(string path);
+        DateTimeOffset GetCreationTimeUtc(string path);
     }
 }

--- a/Website/Services/INuGetExeDownloaderService.cs
+++ b/Website/Services/INuGetExeDownloaderService.cs
@@ -1,0 +1,12 @@
+﻿using System.Web.Mvc;
+using NuGet;
+
+namespace NuGetGallery
+{
+    public interface INuGetExeDownloaderService
+    {
+        ActionResult CreateNuGetExeDownloadActionnResult();
+
+        void UpdateExecutable(IPackage package);
+    }
+}

--- a/Website/Services/IPackageFileService.cs
+++ b/Website/Services/IPackageFileService.cs
@@ -5,8 +5,24 @@ namespace NuGetGallery
 {
     public interface IPackageFileService
     {
+        /// <summary>
+        /// Creates an ActionResult that allows a third-party client to download the nupkg for the package.
+        /// </summary>
         ActionResult CreateDownloadPackageActionResult(Package package);
+
+        /// <summary>
+        /// Deletes the nupkg from the file storage.
+        /// </summary>
         void DeletePackageFile(string id, string version);
+
+        /// <summary>
+        /// Saves the contents of the package represented by the stream into the file storage.
+        /// </summary>
         void SavePackageFile(Package package, Stream packageFile);
+        
+        /// <summary>
+        /// Downloads the package from the file storage and reads it into a Stream.
+        /// </summary>
+        Stream DownloadPackageFile(Package package);
     }
 }

--- a/Website/Services/NuGetExeDownloaderService.cs
+++ b/Website/Services/NuGetExeDownloaderService.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+using NuGet;
+
+namespace NuGetGallery
+{
+    public class NuGetExeDownloaderService : INuGetExeDownloaderService
+    {
+        private static readonly TimeSpan _exeRefreshInterval = TimeSpan.FromDays(1);
+        private static readonly Lazy<string> _defaultNuGetExePath = new Lazy<string>(() => Path.Combine(HttpRuntime.AppDomainAppPath, "App_Data", "NuGet.exe"));
+        private static readonly object fileLock = new object();
+        private readonly IPackageService packageSvc;
+        private readonly IPackageFileService packageFileSvc;
+        private readonly IFileSystemService fileSystem;
+        private string _nugetExePath;
+
+        public NuGetExeDownloaderService(
+            IPackageService packageSvc,
+            IPackageFileService packageFileSvc,
+            IFileSystemService fileSystem)
+        {
+            this.packageSvc = packageSvc;
+            this.packageFileSvc = packageFileSvc;
+            this.fileSystem = fileSystem;
+        }
+
+        public string NuGetExePath
+        {
+            get { return _nugetExePath ?? _defaultNuGetExePath.Value; }
+            set { _nugetExePath = value; }
+        }
+
+        public ActionResult CreateNuGetExeDownloadActionnResult()
+        {
+            EnsureNuGetExe();
+            var result = new FilePathResult(NuGetExePath, Constants.OctetStreamContentType)
+                         {
+                             FileDownloadName = "NuGet.exe"
+                         };
+            return result;
+        }
+
+        public void UpdateExecutable(IPackage zipPackage)
+        {
+            lock (fileLock)
+            {
+                ExtractNuGetExe(zipPackage);
+            }
+        }
+
+        private void EnsureNuGetExe()
+        {
+            if (fileSystem.FileExists(NuGetExePath) && (DateTime.UtcNow - fileSystem.GetCreationTimeUtc(NuGetExePath)) < _exeRefreshInterval)
+            {
+                // Ensure the file exists and it is recent enough.
+                return;
+            }
+
+            lock (fileLock)
+            {
+                var package = packageSvc.FindPackageByIdAndVersion("NuGet.CommandLine", version: null, allowPrerelease: false);
+                if (package == null)
+                {
+                    throw new InvalidOperationException("Unable to find NuGet.CommandLine.");
+                }
+
+                using (var packageStream = packageFileSvc.DownloadPackageFile(package))
+                {
+                    var zipPackage = new ZipPackage(packageStream);
+                    ExtractNuGetExe(zipPackage);
+                }
+            }
+        }
+
+        private void ExtractNuGetExe(IPackage package)
+        {
+            var executable = package.GetFiles("tools")
+                                       .First(f => f.Path.Equals(@"tools\NuGet.exe", StringComparison.OrdinalIgnoreCase));
+
+            using (Stream fileStream = fileSystem.OpenWrite(NuGetExePath),
+                          packageFileStream = executable.GetStream())
+            {
+                packageFileStream.CopyTo(fileStream);
+            }
+        }
+    }
+}

--- a/Website/Services/PackageFileService.cs
+++ b/Website/Services/PackageFileService.cs
@@ -8,40 +8,24 @@ namespace NuGetGallery
     public class PackageFileService : IPackageFileService
     {
         private readonly IFileStorageService fileStorageSvc;
-        
+
         public PackageFileService(
             IFileStorageService fileStorageSvc)
         {
             this.fileStorageSvc = fileStorageSvc;
         }
 
-        private static string BuildFileName(
-            string id, 
-            string version)
-        {
-            return String.Format(CultureInfo.InvariantCulture, Constants.PackageFileSavePathTemplate, id, version, Constants.NuGetPackageFileExtension);
-        }
-
         public ActionResult CreateDownloadPackageActionResult(Package package)
         {
-            if (package == null)
-                throw new ArgumentNullException("package");
-            if (package.PackageRegistration == null 
-                || String.IsNullOrWhiteSpace(package.PackageRegistration.Id) 
-                || String.IsNullOrWhiteSpace(package.Version))
-                throw new ArgumentException("The package is missing required data.", "package");
-            
-            var fileName = BuildFileName(
-                package.PackageRegistration.Id,
-                package.Version);
+            var fileName = BuildFileName(package);
 
             return fileStorageSvc.CreateDownloadFileActionResult(
-                Constants.PackagesFolderName, 
+                Constants.PackagesFolderName,
                 fileName);
         }
 
         public void DeletePackageFile(
-            string id, 
+            string id,
             string version)
         {
             if (String.IsNullOrWhiteSpace(id))
@@ -52,7 +36,7 @@ namespace NuGetGallery
             var fileName = BuildFileName(id, version);
 
             fileStorageSvc.DeleteFile(
-                Constants.PackagesFolderName, 
+                Constants.PackagesFolderName,
                 fileName);
         }
 
@@ -60,23 +44,49 @@ namespace NuGetGallery
             Package package,
             Stream packageFile)
         {
-            if (package == null)
-                throw new ArgumentNullException("package");
             if (packageFile == null)
                 throw new ArgumentNullException("packageFile");
-            if (package.PackageRegistration == null 
-                || String.IsNullOrWhiteSpace(package.PackageRegistration.Id) 
-                || String.IsNullOrWhiteSpace(package.Version))
-                throw new ArgumentException("The package is missing required data.", "package");
 
-            var fileName = BuildFileName(
-                package.PackageRegistration.Id,
-                package.Version);
+            var fileName = BuildFileName(package);
 
             fileStorageSvc.SaveFile(
-                Constants.PackagesFolderName, 
-                fileName, 
+                Constants.PackagesFolderName,
+                fileName,
                 packageFile);
+        }
+
+
+        public Stream DownloadPackageFile(Package package)
+        {
+            var fileName = BuildFileName(package);
+
+            return fileStorageSvc.GetFile(
+                Constants.PackagesFolderName,
+                fileName);
+        }
+
+        private static string BuildFileName(
+            string id,
+            string version)
+        {
+            return String.Format(CultureInfo.InvariantCulture, Constants.PackageFileSavePathTemplate, id, version, Constants.NuGetPackageFileExtension);
+        }
+
+
+        private static string BuildFileName(Package package)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException("package");
+            }
+            if (package.PackageRegistration == null
+                || String.IsNullOrWhiteSpace(package.PackageRegistration.Id)
+                || String.IsNullOrWhiteSpace(package.Version))
+            {
+                throw new ArgumentException("The package is missing required data.", "package");
+            }
+
+            return BuildFileName(package.PackageRegistration.Id, package.Version);
         }
     }
 }

--- a/Website/Website.csproj
+++ b/Website/Website.csproj
@@ -345,8 +345,10 @@
     <Compile Include="Services\ICloudBlobContainer.cs" />
     <Compile Include="Services\IFileStorageService.cs" />
     <Compile Include="Services\IIndexingService.cs" />
+    <Compile Include="Services\INuGetExeDownloaderService.cs" />
     <Compile Include="Services\ISearchService.cs" />
     <Compile Include="Services\IUploadFileService.cs" />
+    <Compile Include="Services\NuGetExeDownloaderService.cs" />
     <Compile Include="Services\PackageFileService.cs" />
     <Compile Include="RequireRemoteHttpsAttribute.cs" />
     <Compile Include="Services\PackageSearchResults.cs" />


### PR DESCRIPTION
corresponding to the latest NuGet.CommandLine package

Fix for work item  #496
