### PR TITLE
Fix for #498 - added OutputCache attribute

### DIFF
--- a/Website/Controllers/ApiController.cs
+++ b/Website/Controllers/ApiController.cs
@@ -28,7 +28,8 @@ namespace NuGetGallery
             this.nugetExeDownloaderSvc = nugetExeDownloaderSvc;
         }
 
-        [ActionName("GetPackageApi"), HttpGet] 
+        [ActionName("GetPackageApi"), HttpGet]
+        [OutputCache(Duration = Int32.MaxValue, Location = OutputCacheLocation.Downstream)]
         public virtual ActionResult GetPackage(string id, string version)
         {
             // if the version is null, the user is asking for the latest version. Presumably they don't want pre release versions. 


### PR DESCRIPTION
As discussed over in #498, I've added the following:

```
[OutputCache(Duration = Int32.MaxValue, Location = OutputCacheLocation.Downstream)]
```

We can cache the results 'permanently', but only at server/proxy intermediate layers (not at the client).
