### PR TITLE
Separate Description on Gallery like it was specified in the NuSpec

### DIFF
--- a/Website/Views/Packages/DisplayPackage.cshtml
+++ b/Website/Views/Packages/DisplayPackage.cshtml
@@ -66,7 +66,7 @@
         <h1>@Model.Title</h1>
         <h2>@Model.Version</h2>
     </hgroup>
-    @foreach (var line in Model.Description.Split('\n'))
+    @foreach (var line in Model.Description.ToStringSafe().Split('\n'))
     {
         <p>@line</p>
     }


### PR DESCRIPTION
This is the same behavior that has been implemented for the release notes section.

An example here: 

Without splitting the description into lines: http://nuget.org/packages/chocolatey
With the description split: http://chocolatey.org/packages/chocolatey

Of course that description can now get some cleanup since there is no need to separate sections with || anymore.
