### PR TITLE
Fixed exception in AggregateStatsService.cs when database is empty

### DIFF
--- a/Website/Controllers/PagesController.cs
+++ b/Website/Controllers/PagesController.cs
@@ -34,9 +34,9 @@ namespace NuGetGallery
             var stats = statsSvc.GetAggregateStats();
             return Json(new
             {
-                Downloads = stats.Downloads.ToString("#,#"),
-                UniquePackages = stats.UniquePackages.ToString("#,#"),
-                TotalPackages = stats.TotalPackages.ToString("#,#")
+                Downloads = stats.Downloads.ToString("n0"),
+                UniquePackages = stats.UniquePackages.ToString("n0"),
+                TotalPackages = stats.TotalPackages.ToString("n0")
             }, JsonRequestBehavior.AllowGet);
         }
     }

--- a/Website/Services/AggregateStatsService.cs
+++ b/Website/Services/AggregateStatsService.cs
@@ -29,7 +29,7 @@ namespace NuGetGallery
                         {
                             UniquePackages = reader.GetInt32(0),
                             TotalPackages = reader.GetInt32(1),
-                            Downloads = reader.GetInt32(2),
+                            Downloads = reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
                         };
                     }
                 }


### PR DESCRIPTION
This PR fixes an exception that is thrown in the AggregateStatsService when the database is empty and contains no packages/downloads. The "DownloadCount" part of the SQL query returned NULL then, so I added an IsDBNull() check.

I also changed the String.Format() of the JSON response, so a value of "0" is included in the response. The format string is now the same as the one used in [_ListPackage.cshtml](https://github.com/NuGet/NuGetGallery/blob/master/Website/Views/Packages/_ListPackage.cshtml#L30) when showing total downloads count.
