### PR TITLE
Raise the value of maxQueryLength property.

### DIFF
--- a/Website/Web.config
+++ b/Website/Web.config
@@ -80,7 +80,7 @@
         <add namespace="System.Web.WebPages" />
       </namespaces>
     </pages>
-    <httpRuntime maxRequestLength="2000000000" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" />
+    <httpRuntime maxQueryStringLength="4000" maxRequestLength="2000000000" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" />
     <httpModules>
       <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah" />
       <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" />
@@ -106,6 +106,11 @@
       <remove statusCode="500" subStatusCode="-1" />
       <error statusCode="500" path="/Errors/Error.html" responseMode="ExecuteURL" />
     </httpErrors>
+    <security>
+      <requestFiltering>
+        <requestLimits maxQueryString="4000" />
+      </requestFiltering>
+    </security>
     <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">
       <scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll" />
       <dynamicTypes>


### PR DESCRIPTION
The NuGet client auto converts HTTP GETs to POSTs when the query string
exceeds 4000 characters. However the server defaults to a max length of
2048 and begins rejecting queries longer than that. We need to keep the
two in sync.
