### PR TITLE
Fixed stats formatting on home page when download or package count is 0

### DIFF
--- a/Website/Controllers/PagesController.cs
+++ b/Website/Controllers/PagesController.cs
@@ -34,9 +34,9 @@ namespace NuGetGallery
             var stats = statsSvc.GetAggregateStats();
             return Json(new
             {
-                Downloads = stats.Downloads.ToString("#,#"),
-                UniquePackages = stats.UniquePackages.ToString("#,#"),
-                TotalPackages = stats.TotalPackages.ToString("#,#")
+                Downloads = stats.Downloads.ToString("n0"),
+                UniquePackages = stats.UniquePackages.ToString("n0"),
+                TotalPackages = stats.TotalPackages.ToString("n0")
             }, JsonRequestBehavior.AllowGet);
         }
     }


### PR DESCRIPTION
When download/packages count is 0, the Json for the stats contains an empty string, which doesn't look good on the home page. I changed it to "n0" to be consistent with [_ListPackage.cshtml#L30](https://github.com/NuGet/NuGetGallery/blob/master/Website/Views/Packages/_ListPackage.cshtml#L30) which shows "0" when the download count is 0 :-)

These screenshots show the result of applying the fix:
Before: <img src="http://i.imgur.com/ZkV2f.png"/>
After: <img src="http://i.imgur.com/JKtU9.png"/>
