### PR TITLE
Modifying Lucene to store latest and latest stable packages for prerelease filtering

### DIFF
--- a/Facts/Controllers/PackagesControllerFacts.cs
+++ b/Facts/Controllers/PackagesControllerFacts.cs
@@ -307,7 +307,9 @@ namespace NuGetGallery
             {
                 var fakeIdentity = new Mock<IIdentity>();
                 var httpContext = new Mock<HttpContextBase>();
-                var controller = CreateController(fakeIdentity: fakeIdentity, httpContext: httpContext);
+                var searchService = new Mock<ISearchService>();
+                
+                var controller = CreateController(fakeIdentity: fakeIdentity, httpContext: httpContext, searchService: searchService);
 
                 var result = controller.ListPackages(" test ") as ViewResult;
 
@@ -1263,8 +1265,8 @@ namespace NuGetGallery
         private static Mock<ISearchService> CreateSearchService()
         {
             var searchService = new Mock<ISearchService>();
-            searchService.Setup(s => s.Search(It.IsAny<IQueryable<Package>>(), It.IsAny<string>())).Returns((IQueryable<Package> p, string searchTerm) => p);
-            searchService.Setup(s => s.SearchWithRelevance(It.IsAny<IQueryable<Package>>(), It.IsAny<string>())).Returns((IQueryable<Package> p, string searchTerm) => p);
+            int total;
+            searchService.Setup(s => s.Search(It.IsAny<IQueryable<Package>>(), It.IsAny<SearchFilter>(), out total)).Returns((IQueryable<Package> p, string searchTerm) => p);
 
             return searchService;
         }

--- a/Facts/Infrastructure/LuceneIndexingServiceFacts.cs
+++ b/Facts/Infrastructure/LuceneIndexingServiceFacts.cs
@@ -40,32 +40,9 @@ namespace NuGetGallery.Infrastructure
             var indexingService = new Mock<LuceneIndexingService>() { CallBase = true };
             indexingService.Setup(s => s.CreateContext()).Returns<DbContext>(null);
             indexingService.Setup(s => s.GetPackages(null, null)).Returns(new List<PackageIndexEntity> { new PackageIndexEntity() });
-            indexingService.Setup(s => s.GetIndexCreationTime()).Returns<DateTime?>(null);
             indexingService.Setup(s => s.GetLastWriteTime()).Returns<DateTime?>(null);
 
             indexingService.Setup(s => s.WriteIndex(true, It.IsAny<List<PackageIndexEntity>>())).Verifiable();
-            indexingService.Setup(s => s.UpdateLastWriteTime()).Verifiable();
-            indexingService.Setup(s => s.EnsureIndexDirectory()).Verifiable();
-
-            // Act
-            indexingService.Object.UpdateIndex();
-
-            // Assert
-            indexingService.Verify();
-        }
-
-        [Fact]
-        public void UpdateIndexRecreatesIndexIfOld()
-        {
-            // Arrange
-            var lastWriteTime = DateTime.UtcNow.AddMinutes(-3);
-            var indexingService = new Mock<LuceneIndexingService>() { CallBase = true };
-            indexingService.Setup(s => s.CreateContext()).Returns<DbContext>(null);
-            indexingService.Setup(s => s.GetPackages(null, lastWriteTime)).Returns(new List<PackageIndexEntity>());
-            indexingService.Setup(s => s.GetIndexCreationTime()).Returns(DateTime.UtcNow.AddDays(-3).AddMinutes(-1));
-            indexingService.Setup(s => s.GetLastWriteTime()).Returns(lastWriteTime);
-
-            indexingService.Setup(s => s.ClearLuceneDirectory()).Verifiable();
             indexingService.Setup(s => s.UpdateLastWriteTime()).Verifiable();
 
             // Act

--- a/Facts/Services/FeedServiceFacts.cs
+++ b/Facts/Services/FeedServiceFacts.cs
@@ -22,7 +22,8 @@ namespace NuGetGallery.Services
             var configuration = new Mock<IConfiguration>(MockBehavior.Strict);
             configuration.Setup(c => c.GetSiteRoot(It.IsAny<bool>())).Returns("https://localhost:8081/");
             var searchService = new Mock<ISearchService>(MockBehavior.Strict);
-            searchService.Setup(s => s.SearchWithRelevance(It.IsAny<IQueryable<Package>>(), It.IsAny<String>())).Returns<IQueryable<Package>, string>((_, __) => _);
+            int total;
+            searchService.Setup(s => s.Search(It.IsAny<IQueryable<Package>>(), It.IsAny<SearchFilter>(), out total)).Returns<IQueryable<Package>, string>((_, __) => _);
             var v1Service = new TestableV1Feed(repo.Object, configuration.Object, searchService.Object);
 
             // Act
@@ -47,7 +48,8 @@ namespace NuGetGallery.Services
                 new Package { PackageRegistration = new PackageRegistration { Id ="baz" }, Version = "2.0", Listed = false, DownloadStatistics = new List<PackageStatistics>() },
             }.AsQueryable());
             var searchService = new Mock<ISearchService>(MockBehavior.Strict);
-            searchService.Setup(s => s.SearchWithRelevance(It.IsAny<IQueryable<Package>>(), It.IsAny<String>())).Returns<IQueryable<Package>, string>((_, __) => _);
+            int total;
+            searchService.Setup(s => s.Search(It.IsAny<IQueryable<Package>>(), It.IsAny<SearchFilter>(), out total)).Returns<IQueryable<Package>, string>((_, __) => _);
             var configuration = new Mock<IConfiguration>(MockBehavior.Strict);
             configuration.Setup(c => c.GetSiteRoot(It.IsAny<bool>())).Returns("http://test.nuget.org/");
             var v1Service = new TestableV1Feed(repo.Object, configuration.Object, searchService.Object);
@@ -75,7 +77,8 @@ namespace NuGetGallery.Services
                 new Package { PackageRegistration = packageRegistration, Version = "1.0.1-a", IsPrerelease = true, Listed = true, DownloadStatistics = new List<PackageStatistics>() },
             }.AsQueryable());
             var searchService = new Mock<ISearchService>(MockBehavior.Strict);
-            searchService.Setup(s => s.SearchWithRelevance(It.IsAny<IQueryable<Package>>(), It.IsAny<String>())).Returns<IQueryable<Package>, string>((_, __) => _);
+            int total;
+            searchService.Setup(s => s.Search(It.IsAny<IQueryable<Package>>(), It.IsAny<SearchFilter>(), out total)).Returns<IQueryable<Package>, string>((_, __) => _);
             var configuration = new Mock<IConfiguration>(MockBehavior.Strict);
             configuration.Setup(c => c.GetSiteRoot(It.IsAny<bool>())).Returns("https://staged.nuget.org/");
             var v2Service = new TestableV2Feed(repo.Object, configuration.Object, searchService.Object);

--- a/Website/Controllers/PackagesController.cs
+++ b/Website/Controllers/PackagesController.cs
@@ -136,7 +136,6 @@ namespace NuGetGallery
                 page = 1;
             }
 
-
             IQueryable<Package> packageVersions = packageSvc.GetLatestPackageVersions(allowPrerelease: true);
 
             q = (q ?? "").Trim();
@@ -161,20 +160,12 @@ namespace NuGetGallery
             int totalHits;
             if (!String.IsNullOrEmpty(q))
             {
-                if (sortOrder.Equals(Constants.RelevanceSortOrder, StringComparison.OrdinalIgnoreCase))
+                var searchFilter = GetSearchFilter(q, sortOrder, page);
+                packageVersions = searchSvc.Search(packageVersions, searchFilter, out totalHits);
+                if (page == 1 && !packageVersions.Any())
                 {
-                    packageVersions = searchSvc.SearchWithRelevance(packageVersions, q, take: page * Constants.DefaultPackageListPageSize, totalHits: out totalHits);
-                    if (page == 1 && !packageVersions.Any())
-                    {
-                        // In the event the index wasn't updated, we may get an incorrect count. 
-                        totalHits = 0;
-                    }
-                }
-                else
-                {
-                    packageVersions = searchSvc.Search(packageVersions, q)
-                                                   .SortBy(GetSortExpression(sortOrder));
-                    totalHits = packageVersions.Count();
+                    // In the event the index wasn't updated, we may get an incorrect count. 
+                    totalHits = 0;
                 }
             }
             else
@@ -194,20 +185,6 @@ namespace NuGetGallery
             ViewBag.SearchTerm = q;
 
             return View(viewModel);
-        }
-
-        private static string GetSortExpression(string sortOrder)
-        {
-            switch (sortOrder)
-            {
-                case Constants.AlphabeticSortOrder:
-                    return "PackageRegistration.Id";
-                case Constants.RecentSortOrder:
-                    return "Published desc";
-                case Constants.PopularitySortOrder:
-                default:
-                    return "PackageRegistration.DownloadCount desc";
-            }
         }
 
         // NOTE: Intentionally NOT requiring authentication
@@ -552,6 +529,48 @@ namespace NuGetGallery
         protected internal virtual IPackage ReadNuGetPackage(Stream stream)
         {
             return new ZipPackage(stream);
+        }
+
+        private SearchFilter GetSearchFilter(string q, string sortOrder, int page)
+        {
+            var searchFilter = new SearchFilter
+            {
+                SearchTerm = q,
+                Skip = (page - 1) * Constants.DefaultPackageListPageSize, // pages are 1-based. 
+                Take = Constants.DefaultPackageListPageSize
+            };
+
+            switch (sortOrder)
+            {
+                case Constants.AlphabeticSortOrder:
+                    searchFilter.SortProperty = SortProperty.DisplayName;
+                    searchFilter.SortDirection = SortDirection.Ascending;
+                    break;
+                case Constants.RecentSortOrder:
+                    searchFilter.SortProperty = SortProperty.Recent;
+                    break;
+                case Constants.PopularitySortOrder:
+                    searchFilter.SortProperty = SortProperty.DownloadCount;
+                    break;
+                default:
+                    searchFilter.SortProperty = SortProperty.Relevance;
+                    break;
+            }
+            return searchFilter;
+        }
+
+        private static string GetSortExpression(string sortOrder)
+        {
+            switch (sortOrder)
+            {
+                case Constants.AlphabeticSortOrder:
+                    return "PackageRegistration.Id";
+                case Constants.RecentSortOrder:
+                    return "Published desc";
+                case Constants.PopularitySortOrder:
+                default:
+                    return "PackageRegistration.DownloadCount desc";
+            }
         }
     }
 }

--- a/Website/DataServices/V1Feed.svc.cs
+++ b/Website/DataServices/V1Feed.svc.cs
@@ -70,8 +70,8 @@ namespace NuGetGallery
             {
                 return packages.ToV1FeedPackageQuery(Configuration.GetSiteRoot(UseHttps()));
             }
-            return SearchService.Search(packages, searchTerm)
-                                .ToV1FeedPackageQuery(Configuration.GetSiteRoot(UseHttps()));
+            return packages.Search(searchTerm)
+                           .ToV1FeedPackageQuery(Configuration.GetSiteRoot(UseHttps()));
         }
     }
 }

--- a/Website/Infrastructure/Jobs/UpdateStatisticsJob.cs
+++ b/Website/Infrastructure/Jobs/UpdateStatisticsJob.cs
@@ -62,7 +62,8 @@ ON p.[Key] = tmp.PackageKey
 BEGIN TRANSACTION
 
     UPDATE p
-    SET p.DownLoadCount = stats.DownloadCount
+    SET p.DownLoadCount = stats.DownloadCount,
+        p.LastUpdated = GETUTCDATE()
     FROM Packages p INNER JOIN @DownloadStats stats
     ON p.[Key] = stats.PackageKey
 

--- a/Website/Infrastructure/Lucene/LuceneIndexingService.cs
+++ b/Website/Infrastructure/Lucene/LuceneIndexingService.cs
@@ -5,26 +5,21 @@ using System.Data.SqlClient;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Lucene.Net.Analysis.Standard;
 using Lucene.Net.Documents;
 using Lucene.Net.Index;
-using Lucene.Net.Search;
 
 namespace NuGetGallery
 {
     public class LuceneIndexingService : IIndexingService
     {
-        private static readonly TimeSpan indexRecreateTime = TimeSpan.FromDays(3);
+        private static readonly object indexLock = new object();
         private static readonly char[] idSeparators = new[] { '.', '-' };
+        private static IndexWriter indexWriter;
 
         public void UpdateIndex()
         {
-            DateTime? createdTime = GetIndexCreationTime();
-            if (createdTime.HasValue && (DateTime.UtcNow - createdTime > indexRecreateTime))
-            {
-                ClearLuceneDirectory();
-            }
-
             DateTime? lastWriteTime = GetLastWriteTime();
             bool creatingIndex = lastWriteTime == null;
             using (var context = CreateContext())
@@ -32,7 +27,6 @@ namespace NuGetGallery
                 var packages = GetPackages(context, lastWriteTime);
                 if (packages.Any())
                 {
-                    EnsureIndexDirectory();
                     WriteIndex(creatingIndex, packages);
                 }
             }
@@ -44,110 +38,98 @@ namespace NuGetGallery
             return new EntitiesContext();
         }
 
-        protected internal virtual List<PackageIndexEntity> GetPackages(DbContext context, DateTime? dateTime)
+        protected internal virtual IEnumerable<PackageIndexEntity> GetPackages(DbContext context, DateTime? lastIndexTime)
         {
-            if (dateTime == null)
+            string sql = @"SELECT p.[Key], pr.Id, p.Title, p.Description, p.Tags, p.FlattenedAuthors as Authors, pr.DownloadCount,
+                                  p.IsLatestStable, p.IsLatest, p.Published
+                          FROM Packages p JOIN PackageRegistrations pr on p.PackageRegistrationKey = pr.[Key]";
+
+            object[] parameters;
+
+            if (lastIndexTime == null)
             {
-                // If we're creating the index for the first time, fetch the new packages.
-                string sql = @"Select p.[Key], pr.Id, p.Title, p.Description, p.Tags, p.FlattenedAuthors as Authors, pr.DownloadCount, p.[Key] as LatestKey
-                         from Packages p join PackageRegistrations pr on p.PackageRegistrationKey = pr.[Key]
-                         where p.IsLatestStable = 1 or (p.IsLatest = 1 and Not exists (Select 1 from Packages iP where iP.PackageRegistrationKey = p.PackageRegistrationKey and iP.IsLatestStable = 1))";
-                return context.Database.SqlQuery<PackageIndexEntity>(sql).ToList();
+                // First time creation. Only pull the latest packages.
+                sql += " WHERE ((p.IsLatest = 1) or (p.IsLatestStable = 1)) ";
+                parameters = new object[0];
             }
             else
             {
-                string sql = @"Select p.[Key], pr.Id, p.Title, p.Description, p.Tags, p.FlattenedAuthors as Authors, pr.DownloadCount,
-                                   LatestKey = CASE When p.IsLatest = 1 then p.[Key] Else (Select pLatest.[Key] from Packages pLatest where pLatest.PackageRegistrationKey = pr.[Key] and pLatest.IsLatest = 1) End
-                                   from Packages p join PackageRegistrations pr on p.PackageRegistrationKey = pr.[Key]
-                                   where p.LastUpdated > @UpdatedDate";
-                return context.Database.SqlQuery<PackageIndexEntity>(sql, new SqlParameter("UpdatedDate", dateTime.Value)).ToList();
+                sql += " WHERE p.LastUpdated > @UpdatedDate";
+                parameters = new[] { new SqlParameter("UpdatedDate", lastIndexTime.Value) };
             }
+            return context.Database.SqlQuery<PackageIndexEntity>(sql, parameters).ToList();
         }
 
-        protected internal virtual void WriteIndex(bool creatingIndex, List<PackageIndexEntity> packages)
+        protected internal virtual void WriteIndex(bool creatingIndex, IEnumerable<PackageIndexEntity> packages)
         {
-            using (var directory = new LuceneFileSystem(LuceneCommon.IndexDirectory))
-            {
-                var analyzer = new StandardAnalyzer(LuceneCommon.LuceneVersion);
-                var indexWriter = new IndexWriter(directory, analyzer, create: creatingIndex, mfl: IndexWriter.MaxFieldLength.UNLIMITED);
-                AddPackages(indexWriter, packages);
-                indexWriter.Close();
-            }
+            EnsureIndexWriter(creatingIndex);
+            AddPackages(indexWriter, packages);
         }
 
-        private static void AddPackages(IndexWriter indexWriter, List<PackageIndexEntity> packages)
+        private static void AddPackages(IndexWriter indexWriter, IEnumerable<PackageIndexEntity> packages)
         {
-            foreach (var package in packages)
-            {
-                if (package.Key != package.LatestKey)
-                {
-                    indexWriter.DeleteDocuments(new TermQuery(new Term("Key", package.Key.ToString(CultureInfo.InvariantCulture))));
-                    continue;
-                }
+            var packagesToDelete = from package in packages
+                                   where !(package.IsLatest || package.IsLatestStable)
+                                   select new Term("Key", package.Key.ToString(CultureInfo.InvariantCulture));
+            indexWriter.DeleteDocuments(packagesToDelete.ToArray());
 
-                // If there's an older entry for this package, remove it.
-                var document = new Document();
+            // As per http://stackoverflow.com/a/3894582. The IndexWriter is CPU bound, so we can try and write multiple packages in parallel.
+            var packagesToUpdate = from package in packages
+                                   where package.IsLatest || package.IsLatestStable
+                                   select package;
+            // The IndexWriter is thread safe and is primarily CPU-bound. 
+            Parallel.ForEach(packagesToUpdate, UpdatePackage);
 
-                document.Add(new Field("Key", package.Key.ToString(CultureInfo.InvariantCulture), Field.Store.YES, Field.Index.NO));
-                document.Add(new Field("Id-Exact", package.Id.ToLowerInvariant(), Field.Store.NO, Field.Index.NOT_ANALYZED));
-
-                document.Add(new Field("Description", package.Description, Field.Store.NO, Field.Index.ANALYZED));
-
-                var tokenizedId = TokenizeId(package.Id);
-                foreach (var idToken in tokenizedId)
-                {
-                    document.Add(new Field("Id", idToken, Field.Store.NO, Field.Index.ANALYZED));
-                }
-
-                // If an element does not have a Title, then add all the tokenized Id components as Title.
-                // Lucene's StandardTokenizer does not tokenize items of the format a.b.c which does not play well with things like "xunit.net". 
-                // We will feed it values that are already tokenized.
-                var titleTokens = String.IsNullOrEmpty(package.Title) ? tokenizedId : package.Title.Split(idSeparators, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var idToken in titleTokens)
-                {
-                    document.Add(new Field("Title", idToken, Field.Store.NO, Field.Index.ANALYZED));
-                }
-
-                if (!String.IsNullOrEmpty(package.Tags))
-                {
-                    document.Add(new Field("Tags", package.Tags, Field.Store.NO, Field.Index.ANALYZED));
-                }
-                document.Add(new Field("Author", package.Authors, Field.Store.NO, Field.Index.ANALYZED));
-                document.Add(new Field("DownloadCount", package.DownloadCount.ToString(CultureInfo.InvariantCulture), Field.Store.NO, Field.Index.ANALYZED_NO_NORMS));
-
-                indexWriter.AddDocument(document);
-            }
+            indexWriter.Commit();
         }
 
-        protected internal virtual void EnsureIndexDirectory()
+        private static void UpdatePackage(PackageIndexEntity package)
         {
-            if (!Directory.Exists(LuceneCommon.IndexDirectory))
-            {
-                Directory.CreateDirectory(LuceneCommon.IndexDirectory);
-            }
-        }
+            string key = package.Key.ToString(CultureInfo.InvariantCulture);
+            var document = new Document();
 
-        protected internal virtual DateTime? GetIndexCreationTime()
-        {
-            if (File.Exists(LuceneCommon.IndexMetadataPath))
-            {
-                var text = File.ReadLines(LuceneCommon.IndexMetadataPath).FirstOrDefault();
-                DateTime dateTime;
-                if (!String.IsNullOrEmpty(text) && DateTime.TryParseExact(text, "R", CultureInfo.InvariantCulture, DateTimeStyles.None, out dateTime))
-                {
-                    return dateTime;
-                }
-            }
-            
-            return null;
-        }
+            var field = new Field("Id-Exact", package.Id.ToLowerInvariant(), Field.Store.NO, Field.Index.NOT_ANALYZED);
+            field.SetBoost(2.5f);
+            document.Add(field);
 
-        protected internal virtual void ClearLuceneDirectory()
-        {
-            if (Directory.Exists(LuceneCommon.IndexDirectory))
+            field = new Field("Description", package.Description, Field.Store.NO, Field.Index.ANALYZED);
+            field.SetBoost(0.1f);
+            document.Add(field);
+
+            var tokenizedId = TokenizeId(package.Id);
+            foreach (var idToken in tokenizedId)
             {
-                Directory.Delete(LuceneCommon.IndexDirectory, recursive: true);
+                field = new Field("Id", idToken, Field.Store.NO, Field.Index.ANALYZED);
+                field.SetBoost(1.2f);
+                document.Add(field);
             }
+
+            // If an element does not have a Title, then add all the tokenized Id components as Title.
+            // Lucene's StandardTokenizer does not tokenize items of the format a.b.c which does not play well with things like "xunit.net". 
+            // We will feed it values that are already tokenized.
+            var titleTokens = String.IsNullOrEmpty(package.Title) ? tokenizedId : package.Title.Split(idSeparators, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var idToken in titleTokens)
+            {
+                document.Add(new Field("Title", idToken, Field.Store.NO, Field.Index.ANALYZED));
+            }
+
+            if (!String.IsNullOrEmpty(package.Tags))
+            {
+                field = new Field("Tags", package.Tags, Field.Store.NO, Field.Index.ANALYZED);
+                field.SetBoost(0.8f);
+                document.Add(field);
+            }
+            document.Add(new Field("Author", package.Authors, Field.Store.NO, Field.Index.ANALYZED));
+
+            // Fields meant for filtering and sorting
+            document.Add(new Field("Key", key, Field.Store.YES, Field.Index.NO));
+            document.Add(new Field("IsLatestStable", package.IsLatestStable.ToString(), Field.Store.NO, Field.Index.NOT_ANALYZED));
+            document.Add(new Field("PublishedDate", package.Published.Ticks.ToString(), Field.Store.NO, Field.Index.NOT_ANALYZED));
+            document.Add(new Field("DownloadCount", package.DownloadCount.ToString(CultureInfo.InvariantCulture), Field.Store.NO, Field.Index.NOT_ANALYZED));
+            string displayName = String.IsNullOrEmpty(package.Title) ? package.Id : package.Title;
+            document.Add(new Field("DisplayName", displayName.ToLower(CultureInfo.CurrentCulture), Field.Store.NO, Field.Index.NOT_ANALYZED));
+
+            indexWriter.UpdateDocument(new Term("Key", key), document);
         }
 
         protected internal virtual DateTime? GetLastWriteTime()
@@ -163,15 +145,36 @@ namespace NuGetGallery
         {
             if (!File.Exists(LuceneCommon.IndexMetadataPath))
             {
-                if (Directory.Exists(LuceneCommon.IndexMetadataPath))
+                if (Directory.Exists(LuceneCommon.IndexDirectory))
                 {
-                    // If the directoey exists, then assume that the index has been created.
-                    File.WriteAllText(LuceneCommon.IndexMetadataPath, DateTime.UtcNow.ToString("R"));
+                    // If the directory exists, then assume that the index has been created.
+                    File.WriteAllBytes(LuceneCommon.IndexMetadataPath, new byte[0]);
                 }
             }
             else
             {
                 File.SetLastWriteTimeUtc(LuceneCommon.IndexMetadataPath, DateTime.UtcNow);
+            }
+        }
+
+        private static void EnsureIndexWriter(bool creatingIndex)
+        {
+            if (!Directory.Exists(LuceneCommon.IndexDirectory))
+            {
+                Directory.CreateDirectory(LuceneCommon.IndexDirectory);
+            }
+
+            if (indexWriter == null)
+            {
+                lock (indexLock)
+                {
+                    if (indexWriter == null)
+                    {
+                        var analyzer = new StandardAnalyzer(LuceneCommon.LuceneVersion);
+                        var directory = new Lucene.Net.Store.SimpleFSDirectory(new DirectoryInfo(LuceneCommon.IndexDirectory));
+                        indexWriter = new IndexWriter(directory, analyzer, create: creatingIndex, mfl: IndexWriter.MaxFieldLength.UNLIMITED);
+                    }
+                }
             }
         }
 
@@ -208,7 +211,7 @@ namespace NuGetGallery
                         // If the remainder is smaller than 2 chars, just return the entire string
                         i = 0;
                     }
-                        
+
                     yield return term.Substring(i, tokenEnd - i);
                     tokenEnd = i;
                 }

--- a/Website/Infrastructure/Lucene/LuceneSearchService.cs
+++ b/Website/Infrastructure/Lucene/LuceneSearchService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using Lucene.Net.Analysis.Standard;
@@ -15,38 +14,46 @@ namespace NuGetGallery
     {
         private const int MaximumRecordsToReturn = 1000;
 
-        public IQueryable<Package> Search(IQueryable<Package> packages, string searchTerm)
+        public IQueryable<Package> Search(IQueryable<Package> packages, SearchFilter searchFilter, out int totalHits)
         {
-            if (String.IsNullOrEmpty(searchTerm))
+            if (packages == null)
             {
-                return packages;
-            }
-            var keys = SearchCore(searchTerm);
-            return SearchByKeys(packages, keys);
-        }
-
-        public IQueryable<Package> SearchWithRelevance(IQueryable<Package> packages, string searchTerm)
-        {
-            int numberOfHits;
-            return SearchWithRelevance(packages, searchTerm, MaximumRecordsToReturn, out numberOfHits);
-        }
-
-        public IQueryable<Package> SearchWithRelevance(IQueryable<Package> packages, string searchTerm, int take, out int numberOfHits)
-        {
-            numberOfHits = 0;
-            if (String.IsNullOrEmpty(searchTerm))
-            {
-                return packages;
+                throw new ArgumentNullException("packages");
             }
 
-            var keys = SearchCore(searchTerm);
-            if (!keys.Any())
+            if (searchFilter == null)
+            {
+                throw new ArgumentNullException("searchFilter");
+            }
+
+            if (String.IsNullOrEmpty(searchFilter.SearchTerm))
+            {
+                throw new ArgumentException("No term to search for.");
+            }
+
+            if (searchFilter.Skip < 0)
+            {
+                throw new ArgumentOutOfRangeException("skip");
+            }
+
+            if (searchFilter.Take < 0)
+            {
+                throw new ArgumentOutOfRangeException("take");
+            }
+
+            // For the given search term, find the keys that match.
+            var keys = SearchCore(searchFilter);
+            totalHits = keys.Count;
+            if (keys.Count == 0)
             {
                 return Enumerable.Empty<Package>().AsQueryable();
             }
 
-            numberOfHits = keys.Count();
-            var results = SearchByKeys(packages, keys.Take(take));
+            // Query the source for each of the keys that need to be taken.
+            var results = packages.Where(p => keys.Contains(p.Key));
+
+            // When querying the database, these keys are returned in no particular order. We use the original order of queries
+            // and retrieve each of the packages from the result in the same order.
             var lookup = results.ToDictionary(p => p.Key, p => p);
 
             return keys.Select(key => LookupPackage(lookup, key))
@@ -61,51 +68,62 @@ namespace NuGetGallery
             return package;
         }
 
-        private static IQueryable<Package> SearchByKeys(IQueryable<Package> packages, IEnumerable<int> keys)
-        {
-            return packages.Where(p => keys.Contains(p.Key));
-        }
-
-        private static IEnumerable<int> SearchCore(string searchTerm)
+        private static IList<int> SearchCore(SearchFilter searchFilter)
         {
             if (!Directory.Exists(LuceneCommon.IndexDirectory))
             {
-                return Enumerable.Empty<int>();
+                return new int[0];
             }
+
+            SortField sortField = GetSortProperties(searchFilter);
+            int numRecords = Math.Min((1 + searchFilter.Skip) * searchFilter.Take, MaximumRecordsToReturn);
 
             using (var directory = new LuceneFileSystem(LuceneCommon.IndexDirectory))
             {
                 var searcher = new IndexSearcher(directory, readOnly: true);
-                var query = ParseQuery(searchTerm);
-                var results = searcher.Search(query, filter: null, n: 1000, sort: new Sort(new[] { SortField.FIELD_SCORE, new SortField("DownloadCount", SortField.INT, reverse: true) }));
-                var keys = results.scoreDocs.Select(c => Int32.Parse(searcher.Doc(c.doc).Get("Key"), CultureInfo.InvariantCulture))
+                var query = ParseQuery(searchFilter);
+
+                Filter filter = null;
+                if (!searchFilter.IncludePrerelease)
+                {
+                    var isLatestStableQuery = new TermQuery(new Term("IsLatestStable", Boolean.TrueString));
+                    filter = new QueryWrapperFilter(isLatestStableQuery);
+                }
+
+                var results = searcher.Search(query, filter: filter, n: numRecords, sort: new Sort(sortField));
+                var keys = results.scoreDocs.Skip(searchFilter.Skip)
+                                            .Select(c => ParseKey(searcher.Doc(c.doc).Get("Key")))
                                             .ToList();
                 searcher.Close();
                 return keys;
             }
         }
 
-        private static Query ParseQuery(string searchTerm)
+        private static Query ParseQuery(SearchFilter searchFilter)
         {
-            var fields = new Dictionary<string, float> { { "Id", 1.2f }, { "Title", 1.0f }, { "Tags", 0.8f }, { "Description", 0.1f }, 
-                                                         { "Author", 1.0f } };
+            var fields = new[] { "Id", "Title", "Tags", "Description", "Author" };
             var analyzer = new StandardAnalyzer(LuceneCommon.LuceneVersion);
-            var queryParser = new MultiFieldQueryParser(LuceneCommon.LuceneVersion, fields.Keys.ToArray(), analyzer, fields);
+            var queryParser = new MultiFieldQueryParser(LuceneCommon.LuceneVersion, fields, analyzer);
 
+            // All terms in the multi-term query appear in at least one of the fields.
             var conjuctionQuery = new BooleanQuery();
             conjuctionQuery.SetBoost(2.0f);
+
+            // Some terms in the multi-term query appear in at least one of the fields.
             var disjunctionQuery = new BooleanQuery();
             disjunctionQuery.SetBoost(0.1f);
+
+            // Suffix wildcard search e.g. jquer*
             var wildCardQuery = new BooleanQuery();
             wildCardQuery.SetBoost(0.5f);
 
             // Escape the entire term we use for exact searches.
-            var escapedSearchTerm = Escape(searchTerm);
+            var escapedSearchTerm = Escape(searchFilter.SearchTerm);
             var exactIdQuery = new TermQuery(new Term("Id-Exact", escapedSearchTerm));
             exactIdQuery.SetBoost(2.5f);
             var wildCardIdQuery = new WildcardQuery(new Term("Id-Exact", "*" + escapedSearchTerm + "*"));
-            
-            foreach(var term in GetSearchTerms(searchTerm))
+
+            foreach (var term in GetSearchTerms(searchFilter.SearchTerm))
             {
                 var termQuery = queryParser.Parse(term);
                 conjuctionQuery.Add(termQuery, BooleanClause.Occur.MUST);
@@ -113,15 +131,22 @@ namespace NuGetGallery
 
                 foreach (var field in fields)
                 {
-                    var wildCardTermQuery = new WildcardQuery(new Term(field.Key, term + "*"));
-                    wildCardTermQuery.SetBoost(0.7f * field.Value);
+                    var wildCardTermQuery = new WildcardQuery(new Term(field, term + "*"));
+                    wildCardTermQuery.SetBoost(0.7f);
                     wildCardQuery.Add(wildCardTermQuery, BooleanClause.Occur.SHOULD);
                 }
             }
-
-            var downloadCountBooster = new FieldScoreQuery("DownloadCount", FieldScoreQuery.Type.INT);
-            return new CustomScoreQuery(conjuctionQuery.Combine(new Query[] { exactIdQuery, wildCardIdQuery, conjuctionQuery, disjunctionQuery, wildCardQuery }),
-                                       downloadCountBooster);
+            
+            // Create an OR of all the queries that we have
+            var combinedQuery = conjuctionQuery.Combine(new Query[] { exactIdQuery, wildCardIdQuery, conjuctionQuery, disjunctionQuery, wildCardQuery });
+            
+            if (searchFilter.SortProperty == SortProperty.Relevance)
+            {
+                // If searching by relevance, boost scores by download count.
+                var downloadCountBooster = new FieldScoreQuery("DownloadCount", FieldScoreQuery.Type.INT);
+                return new CustomScoreQuery(combinedQuery, downloadCountBooster);
+            }
+            return combinedQuery;
         }
 
         private static IEnumerable<string> GetSearchTerms(string searchTerm)
@@ -132,9 +157,29 @@ namespace NuGetGallery
                              .Select(Escape);
         }
 
+        private static SortField GetSortProperties(SearchFilter searchFilter)
+        {
+            switch (searchFilter.SortProperty)
+            {
+                case SortProperty.DisplayName:
+                    return new SortField("DisplayName", SortField.STRING, reverse: searchFilter.SortDirection == SortDirection.Descending);
+                case SortProperty.DownloadCount:
+                    return new SortField("DownloadCount", SortField.INT, reverse: true);
+                case SortProperty.Recent:
+                    return new SortField("PublishedDate", SortField.LONG, reverse: true);
+            }
+            return SortField.FIELD_SCORE;
+        }
+
         private static string Escape(string term)
         {
             return QueryParser.Escape(term).ToLowerInvariant();
+        }
+
+        private static int ParseKey(string value)
+        {
+            int key;
+            return Int32.TryParse(value, out key) ? key : 0;
         }
     }
 }

--- a/Website/Infrastructure/Lucene/PackageIndexEntity.cs
+++ b/Website/Infrastructure/Lucene/PackageIndexEntity.cs
@@ -1,4 +1,5 @@
-﻿namespace NuGetGallery
+﻿using System;
+namespace NuGetGallery
 {
     public class PackageIndexEntity
     {
@@ -16,6 +17,10 @@
 
         public int DownloadCount { get; set; }
 
-        public int? LatestKey { get; set; }
+        public bool IsLatest { get; set; }
+
+        public bool IsLatestStable { get; set; }
+
+        public DateTime Published { get; set; }
     }
 }

--- a/Website/Services/ISearchService.cs
+++ b/Website/Services/ISearchService.cs
@@ -1,14 +1,15 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 
 namespace NuGetGallery
 {
     public interface ISearchService
     {
-        IQueryable<Package> Search(IQueryable<Package> packages, string searchTerm);
-
-        IQueryable<Package> SearchWithRelevance(IQueryable<Package> packages, string searchTerm);
-
-        IQueryable<Package> SearchWithRelevance(IQueryable<Package> packages, string searchTerm, int take, out int totalHits);
+        /// <summary>
+        /// Searches for packages that match the search filter and returns a set of results.
+        /// </summary>
+        /// <param name="packages">A query representing the packages to be searched for.</param>
+        /// <param name="filter">The filter to be used.</param>
+        /// <param name="totalHits">The total number of packages discovered.</param>
+        IQueryable<Package> Search(IQueryable<Package> packages, SearchFilter filter, out int totalHits);
     }
 }

--- a/Website/Services/SearchFilter.cs
+++ b/Website/Services/SearchFilter.cs
@@ -1,0 +1,32 @@
+﻿
+namespace NuGetGallery
+{
+    public class SearchFilter
+    {
+        public string SearchTerm { get; set; }
+
+        public int Skip { get; set; }
+
+        public int Take { get; set; }
+
+        public bool IncludePrerelease { get; set; }
+
+        public SortProperty SortProperty { get; set; }
+
+        public SortDirection SortDirection { get; set; }
+    }
+
+    public enum SortProperty
+    {
+        Relevance,
+        DownloadCount,
+        DisplayName,
+        Recent,
+    }
+
+    public enum SortDirection
+    {
+        Descending,
+        Ascending,
+    }
+}

--- a/Website/Website.csproj
+++ b/Website/Website.csproj
@@ -395,6 +395,7 @@
     <Compile Include="RequireRemoteHttpsAttribute.cs" />
     <Compile Include="Services\PackageSearchResults.cs" />
     <Compile Include="Services\AggregateStatsService.cs" />
+    <Compile Include="Services\SearchFilter.cs" />
     <Compile Include="Services\TestableStorageClientException.cs" />
     <Compile Include="Services\UploadFileService.cs" />
     <Compile Include="SharedController.generated.cs">


### PR DESCRIPTION
- Fixing bug where using multiple IndexWriters would lock the index
- Improving search perf by adding boosts to fields at index time
- Removing the need to recreate index by updating the index when
  aggregate download counts are updated.
