### PR TITLE
Fix the gallery not to spam people with 'your email address changed' ...

### DIFF
--- a/Website/Controllers/UsersController.cs
+++ b/Website/Controllers/UsersController.cs
@@ -220,7 +220,7 @@ namespace NuGetGallery
         {
             if (ModelState.IsValid)
             {
-                var user = _userService.FindByUnconfimedEmailAddress(model.Email);
+                var user = _userService.FindByUnconfirmedEmailAddress(model.Email);
                 if (user != null && !user.Confirmed)
                 {
                     var confirmationUrl = Url.ConfirmationUrl(
@@ -279,7 +279,9 @@ namespace NuGetGallery
                     SuccessfulConfirmation = _userService.ConfirmEmailAddress(user, token)
                 };
 
-            if (!model.ConfirmingNewAccount)
+            // SuccessfulConfirmation is required so that the confirm Action isn't a way to spam people.
+            // Change notice not required for new accounts.
+            if (model.SuccessfulConfirmation && !model.ConfirmingNewAccount)
             {
                 _messageService.SendEmailChangeNoticeToPreviousEmailAddress(user, existingEmail);
             }

--- a/Website/Services/IUserService.cs
+++ b/Website/Services/IUserService.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
 
         User FindByEmailAddress(string emailAddress);
 
-        User FindByUnconfimedEmailAddress(string unconfirmedEmailAddress);
+        User FindByUnconfirmedEmailAddress(string unconfirmedEmailAddress);
 
         User FindByUsername(string username);
 

--- a/Website/Services/UserService.cs
+++ b/Website/Services/UserService.cs
@@ -98,7 +98,7 @@ namespace NuGetGallery
             return _userRepository.GetAll().SingleOrDefault(u => u.EmailAddress == emailAddress);
         }
 
-        public virtual User FindByUnconfimedEmailAddress(string unconfirmedEmailAddress)
+        public virtual User FindByUnconfirmedEmailAddress(string unconfirmedEmailAddress)
         {
             // TODO: validate input
 
@@ -194,6 +194,7 @@ namespace NuGetGallery
             {
                 throw new ArgumentNullException("user");
             }
+
             if (String.IsNullOrEmpty(token))
             {
                 throw new ArgumentNullException("token");


### PR DESCRIPTION
messages by sending to users with unconfirmed email addresses or by email in response to requests that include an invalid challenge token.
