### PR TITLE
Fix AutomaticPackageCurator query so that it will be case insensitive

### DIFF
--- a/Website/PackageCurators/AutomaticPackageCurator.cs
+++ b/Website/PackageCurators/AutomaticPackageCurator.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.Contracts;
+﻿using System;
 using System.Linq;
 using System.Web.Mvc;
 using NuGet;
@@ -23,7 +23,10 @@ namespace NuGetGallery
                 return true;
             }
 
-            return galleryPackage.Dependencies.All(d => curatedFeed.Packages.Where(p => p.Included).Select(p => p.PackageRegistration.Id).Contains(d.Id));
+            return galleryPackage.Dependencies.All(
+                d => curatedFeed.Packages
+                    .Where(p => p.Included)
+                    .Any(p => p.PackageRegistration.Id.Equals(d.Id, StringComparison.InvariantCultureIgnoreCase)));
         }
     }
 }


### PR DESCRIPTION
Because it was doing case sensitive package ID matching, it would fail to let packages be listed in the webmatrix feed if they depend on another package inside the webmatrix feed, but didn't specify the package with exactly the right case.
