### PR TITLE
ReadOnly mode fixes - Fix package download (add statistics) to work with...

### DIFF
--- a/Website/Controllers/ApiController.cs
+++ b/Website/Controllers/ApiController.cs
@@ -43,11 +43,18 @@ namespace NuGetGallery
                     HttpStatusCode.NotFound, String.Format(CultureInfo.CurrentCulture, Strings.PackageWithIdAndVersionNotFound, id, version));
             }
 
-            _packageService.AddDownloadStatistics(
-                package,
-                Request.UserHostAddress,
-                Request.UserAgent,
-                Request.Headers["NuGet-Operation"]);
+            try
+            {
+                _packageService.AddDownloadStatistics(
+                    package,
+                    Request.UserHostAddress,
+                    Request.UserAgent,
+                    Request.Headers["NuGet-Operation"]);
+            }
+            catch (ReadOnlyModeException)
+            {
+                // *gulp* Swallowed. It's OK not to log statistics in read only mode.
+            }
 
             if (!String.IsNullOrWhiteSpace(package.ExternalPackageUrl))
             {

--- a/Website/Controllers/PackagesController.cs
+++ b/Website/Controllers/PackagesController.cs
@@ -64,9 +64,9 @@ namespace NuGetGallery
         [OutputCache(NoStore = true, Duration = 0, VaryByParam = "None")]
         public virtual ActionResult UploadPackageProgress()
         {
-            string username = GetIdentity().Name;
+            var currentUser = _userService.FindByUsername(GetIdentity().Name);
 
-            AsyncFileUploadProgress progress = _cacheService.GetProgress(username);
+            AsyncFileUploadProgress progress = _cacheService.GetProgress(currentUser.Username);
             if (progress == null)
             {
                 return HttpNotFound();

--- a/Website/Errors/ErrorLayout.cshtml
+++ b/Website/Errors/ErrorLayout.cshtml
@@ -18,8 +18,11 @@
                 <ul id="menu">
                     <li><a href="@Href("~/")">Home</a></li>
                     <li><a href="@Href("~/Packages")">Packages</a></li>
-                    <li><a href="http://docs.nuget.org">Documentation</a></li>
+
                     <li><a href="@Href("~/packages/upload")" class="upload">Upload Package</a></li>
+                    <li><a href="@Href("~/stats")">Statistics</a></li>
+                    <li><a href="http://docs.nuget.org">Documentation</a></li>
+                    <li><a href="http://blog.nuget.org">Blog</a></li>
                 </ul>
             </nav>
             <div id="body">

--- a/Website/Views/Packages/ManagePackageOwners.cshtml
+++ b/Website/Views/Packages/ManagePackageOwners.cshtml
@@ -44,8 +44,8 @@
     <script>
         $(function() {
             //TODO Move this to its own script file when we set up QUnit tests
-            var failHandler = function() {
-                alert('An unexpected error occurred!');
+            var failHandler = function(jqXHR, textStatus, errorThrown)  {
+                alert('An unexpected error occurred! "' + errorThrown + '"');
             };
 
             var viewModel = {


### PR DESCRIPTION
... readonly mode. Show HTTP error status strings as detail for ManagePackageOwners AJAX errors in read only mode. Fix Error View Layout to be same as home page layout (statistics link shows unconditionally because I'm scared of the dependency on StatisticsService).
