### PR TITLE
Fix #785 - Added Package ID to Tweet button

### DIFF
--- a/Website/Views/Packages/DisplayPackage.cshtml
+++ b/Website/Views/Packages/DisplayPackage.cshtml
@@ -137,7 +137,7 @@
                 }</code></p>
     </div>
  
-    <div><a href="https://twitter.com/share" class="twitter-share-button" data-url="@absolutePackageUrl" data-text="Check out this cool #nuget package!">Tweet</a></div>
+    <div><a href="https://twitter.com/share" class="twitter-share-button" data-url="@absolutePackageUrl" data-text="Check out @Model.Id on #NuGet!">Tweet</a></div>
     <div class="fb-like" data-href="@absolutePackageUrl" data-send="false" data-width="450" data-show-faces="true"></div>
 
     @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))


### PR DESCRIPTION
Short and sweet. Seriously, it's that simple. Can't put anything in the Facebook button unfortunately, so it's just for Twitter.
