### PR TITLE
Fix #454 broken feed URLs for packages with ID ending in .cs .config etc...

### DIFF
--- a/Facts/Facts.csproj
+++ b/Facts/Facts.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Services\FeedServiceFacts.cs" />
     <Compile Include="TaskAssert.cs" />
     <Compile Include="TestUtility.cs" />
+    <Compile Include="UrlExtensionsFacts.cs" />
     <Compile Include="ViewModels\DisplayPackageViewModelFacts.cs" />
     <Compile Include="ViewModels\PreviousNextPagerViewModelFacts.cs" />
   </ItemGroup>

--- a/Facts/UrlExtensionsFacts.cs
+++ b/Facts/UrlExtensionsFacts.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class UrlExtensionsFacts
+    {
+        public class TheEnsureTrailingSlashHelperMethod
+        {
+            [Fact]
+            public void Works()
+            {
+                string fixedUrl = UrlExtensions.EnsureTrailingSlash("http://nuget.org/packages/FooPackage.CS");
+                Assert.True(fixedUrl.EndsWith("/", StringComparison.Ordinal));
+            }
+
+            [Fact]
+            public void PropagatesNull()
+            {
+                string fixedUrl = UrlExtensions.EnsureTrailingSlash(null);
+                Assert.Null(fixedUrl);
+            }
+        }
+    }
+}

--- a/Website/UrlExtensions.cs
+++ b/Website/UrlExtensions.cs
@@ -152,14 +152,14 @@ namespace NuGetGallery
             return builder;
         }
 
-        private static string EnsureTrailingSlash(string result)
+        internal static string EnsureTrailingSlash(string url)
         {
-            if (result != null && !result.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+            if (url != null && !url.EndsWith("/", StringComparison.OrdinalIgnoreCase))
             {
-                return result + '/';
+                return url + '/';
             }
 
-            return result;
+            return url;
         }
     }
 }


### PR DESCRIPTION
See #454 and (similar recent bug #657)
