### PR TITLE
Fix #854 - Harden CloudBlobClientWrapper to wrong config

### DIFF
--- a/Website/App_Start/ContainerBindings.cs
+++ b/Website/App_Start/ContainerBindings.cs
@@ -203,10 +203,10 @@ namespace NuGetGallery
                         .To<FileSystemFileStorageService>()
                         .InSingletonScope();
                     break;
-                case PackageStoreType.AzureStorageBlob:
+                case PackageStoreType.AzureStorageBlob: 
                     Bind<ICloudBlobClient>()
                         .ToMethod(
-                            context => new CloudBlobClientWrapper(CloudStorageAccount.Parse(configuration.AzureStorageConnectionString).CreateCloudBlobClient()))
+                            _ => new CloudBlobClientWrapper(configuration.AzureStorageConnectionString))
                         .InSingletonScope();
                     Bind<IFileStorageService>()
                         .To<CloudBlobFileStorageService>()

--- a/Website/Services/CloudBlobClientWrapper.cs
+++ b/Website/Services/CloudBlobClientWrapper.cs
@@ -1,18 +1,25 @@
-﻿using Microsoft.WindowsAzure.Storage.Blob;
+﻿using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace NuGetGallery
 {
     public class CloudBlobClientWrapper : ICloudBlobClient
     {
-        private readonly CloudBlobClient _blobClient;
+        private readonly string _storageConnectionString;
+        private CloudBlobClient _blobClient;
 
-        public CloudBlobClientWrapper(CloudBlobClient blobClient)
+        public CloudBlobClientWrapper(string storageConnectionString)
         {
-            _blobClient = blobClient;
+            _storageConnectionString = storageConnectionString;
         }
 
         public ICloudBlobContainer GetContainerReference(string containerAddress)
         {
+            if (_blobClient == null)
+            {
+                _blobClient = CloudStorageAccount.Parse(_storageConnectionString).CreateCloudBlobClient();
+            }
+
             return new CloudBlobContainerWrapper(_blobClient.GetContainerReference(containerAddress));
         }
     }


### PR DESCRIPTION
Harden CloudBlobClientWrapper against CloudBlobStorageAccount.Parse() throwing FormatException during app startup. Addresses issue #854.
