### PR TITLE
Deprecate ExternalPackageUrl (code - data later).

### DIFF
--- a/Facts/Controllers/ApiControllerFacts.cs
+++ b/Facts/Controllers/ApiControllerFacts.cs
@@ -534,30 +534,6 @@ namespace NuGetGallery
                 packageFileService.Verify();
                 packageService.Verify();
             }
-
-            [Fact]
-            public async Task GetPackageReturnsRedirectResultWhenExternalPackageUrlIsNotNull()
-            {
-                var package = new Package { ExternalPackageUrl = "http://theUrl" };
-                var packageService = new Mock<IPackageService>();
-                packageService.Setup(x => x.FindPackageByIdAndVersion("thePackage", "42.1066", false)).Returns(package);
-                var httpRequest = new Mock<HttpRequestBase>();
-                httpRequest.SetupGet(r => r.UserHostAddress).Returns("Foo");
-                httpRequest.SetupGet(r => r.UserAgent).Returns("Qux");
-                NameValueCollection headers = new NameValueCollection();
-                headers.Add("NuGet-Operation", "Install");
-                httpRequest.SetupGet(r => r.Headers).Returns(headers);
-                var httpContext = new Mock<HttpContextBase>();
-                httpContext.SetupGet(c => c.Request).Returns(httpRequest.Object);
-                var controller = CreateController(packageService);
-                var controllerContext = new ControllerContext(new RequestContext(httpContext.Object, new RouteData()), controller);
-                controller.ControllerContext = controllerContext;
-
-                var result = await controller.GetPackage("thePackage", "42.1066") as RedirectResult;
-
-                Assert.NotNull(result);
-                Assert.Equal("http://theUrl", result.Url);
-            }
         }
 
         public class ThePublishPackageAction

--- a/Website/Controllers/ApiController.cs
+++ b/Website/Controllers/ApiController.cs
@@ -88,11 +88,6 @@ namespace NuGetGallery
                     QuietlyLogException(e);
                 }
 
-                if (!String.IsNullOrWhiteSpace(package.ExternalPackageUrl))
-                {
-                    return Redirect(package.ExternalPackageUrl);
-                }
-
                 return await _packageFileService.CreateDownloadPackageActionResultAsync(HttpContext.Request.Url, package);
             }
             catch (SqlException e)

--- a/Website/DataServices/PackageExtensions.cs
+++ b/Website/DataServices/PackageExtensions.cs
@@ -27,7 +27,7 @@ namespace NuGetGallery
                             Dependencies = p.FlattenedDependencies,
                             Description = p.Description,
                             DownloadCount = p.PackageRegistration.DownloadCount,
-                            ExternalPackageUrl = p.ExternalPackageUrl,
+                            ExternalPackageUrl = null,
                             GalleryDetailsUrl = siteRoot + "packages/" + p.PackageRegistration.Id + "/" + p.Version,
                             IconUrl = p.IconUrl,
                             IsLatestVersion = p.IsLatestStable,

--- a/Website/DataServices/V1FeedPackage.cs
+++ b/Website/DataServices/V1FeedPackage.cs
@@ -20,7 +20,7 @@ namespace NuGetGallery
         public string Dependencies { get; set; }
         public string Description { get; set; }
         public int DownloadCount { get; set; }
-        public string ExternalPackageUrl { get; set; }
+        public string ExternalPackageUrl { get; set; } // deprecated: always null/empty
         public string GalleryDetailsUrl { get; set; }
         public string IconUrl { get; set; }
         public bool IsLatestVersion { get; set; }


### PR DESCRIPTION
Remove all the code that specifically supports the old ExternalPackageUrl feature. For issue #422
