### PR TITLE
Removed API keys from nuget.config

### DIFF
--- a/FunctionalTests/.nuget/NuGet.Config
+++ b/FunctionalTests/.nuget/NuGet.Config
@@ -2,5 +2,5 @@
 <configuration>
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
-  </solution>
+  </solution>    
 </configuration>


### PR DESCRIPTION
Removed the API keys from the nuget.config that gets in to version control.
