### PR TITLE
added HasWorker config to control AggregateStats

### DIFF
--- a/Website/App_Start/AppActivator.cs
+++ b/Website/App_Start/AppActivator.cs
@@ -71,7 +71,13 @@ namespace NuGetGallery
 
         private static void BackgroundJobsPostStart(IConfiguration configuration)
         {
-            var jobs = new IJob[]
+            var jobs = configuration.HasWorker ?
+                new IJob[]
+                {
+                    new LuceneIndexingJob(TimeSpan.FromMinutes(10), () => new EntitiesContext(configuration.SqlConnectionString, readOnly: true), timeout: TimeSpan.FromMinutes(2))
+                }                
+                    :
+                new IJob[]
                 {
                     // readonly: false workaround - let statistics background job write to DB in read-only mode since we don't care too much about losing that data
                     new UpdateStatisticsJob(TimeSpan.FromMinutes(5), 

--- a/Website/App_Start/Configuration.cs
+++ b/Website/App_Start/Configuration.cs
@@ -21,6 +21,11 @@ namespace NuGetGallery
             _httpsSiteRootThunk = new Lazy<string>(GetHttpsSiteRoot);
         }
 
+        public bool HasWorker
+        {
+            get { return ReadAppSettings("HasWorker", str => Boolean.Parse(str ?? "true")); }
+        }
+
         public string EnvironmentName
         {
             get { return ReadAppSettings("Environment") ?? "Development"; }

--- a/Website/App_Start/IConfiguration.cs
+++ b/Website/App_Start/IConfiguration.cs
@@ -2,6 +2,7 @@
 {
     public interface IConfiguration
     {
+        bool HasWorker { get; }
         bool RequireSSL { get; }
         int SSLPort { get; }
 


### PR DESCRIPTION
Fixes #907 

This checkin removes the job from the gallery - at least makes its execution configurable. Deploying this will be coupled with adding this job to the Worker role. (Where we guarantee to run it without any concurrency.)
