### PR TITLE
For #926. Redescribe nuget as a 'visual studio extension' 

### DIFF
--- a/Website/Errors/Error.html
+++ b/Website/Errors/Error.html
@@ -48,7 +48,7 @@
                     </li>
                     <li>
                         <a href="http://docs.nuget.org/docs/start-here/overview">Overview</a>
-                        <p>NuGet is a Visual Studio 2010 extension that makes it easy to add, remove, and update libraries and...</p>
+                        <p>NuGet is a Visual Studio extension that makes it easy to add, remove, and update libraries and...</p>
                     </li>
                     <li>
                         <a href="http://docs.nuget.org/docs/start-here/installing-nuget">Install</a>

--- a/Website/Errors/ErrorLayout.cshtml
+++ b/Website/Errors/ErrorLayout.cshtml
@@ -39,7 +39,7 @@
                     </li>
                     <li>
                         <a href="http://docs.nuget.org/docs/start-here/overview">Overview</a>
-                        <p>NuGet is a Visual Studio 2010 extension that makes it easy to add, remove, and update libraries and...</p>
+                        <p>NuGet is a Visual Studio extension that makes it easy to add, remove, and update libraries and...</p>
                     </li>
                     <li>
                         <a href="http://docs.nuget.org/docs/start-here/installing-nuget">Install</a>

--- a/Website/Views/Shared/Layout.cshtml
+++ b/Website/Views/Shared/Layout.cshtml
@@ -63,7 +63,7 @@
                         </li>
                         <li>
                             <a href="http://docs.nuget.org/docs/start-here/overview">Overview</a>
-                            <p>NuGet is a Visual Studio 2010 extension that makes it easy to add, remove, and update libraries and...</p>
+                            <p>NuGet is a Visual Studio extension that makes it easy to add, remove, and update libraries and...</p>
                         </li>
                         <li>
                             <a href="http://docs.nuget.org/docs/start-here/installing-nuget">Install</a>


### PR DESCRIPTION
Not a visual studio 2010 extension, since it works with 2012 too. For https://github.com/NuGet/NuGetGallery/issues/926/
