### PR TITLE
Fix data loss issues in Azure Table Log

### DIFF
--- a/Website/Infrastructure/TableErrorLog.cs
+++ b/Website/Infrastructure/TableErrorLog.cs
@@ -124,7 +124,7 @@ namespace NuGetGallery.Infrastructure
                             StatusCode = 888,
                             HostName = Environment.MachineName,
                             Time = DateTime.UtcNow,
-                            Detail = "Error Log Entry Will Not Fit In Table Store" + serializedError.Substring(0, 4000)
+                            Detail = "Error Log Entry Will Not Fit In Table Store: " + serializedError.Substring(0, 4000)
                         });
                 }
 


### PR DESCRIPTION
Fix #990 by

1) Gracefully handle the case where retrieving the range of Table Entries retrieves a placeholder entry.

2) Workaround the horrible limit of 64KB max Table Property size which sometimes stops us saving elmah logs!
