### PR TITLE
Fix #1053 - Preserve whitespace in release notes 

### DIFF
--- a/Website/Views/Packages/DisplayPackage.cshtml
+++ b/Website/Views/Packages/DisplayPackage.cshtml
@@ -154,10 +154,9 @@
     @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
     {
         <h3>Release Notes</h3>
-        foreach (var note in Model.ReleaseNotes.Split('\n'))
-        {
-            <p>@note</p>
-        }
+        <p>
+            @Html.Raw(HttpUtility.HtmlEncode(Model.ReleaseNotes).Replace("\n", "<br />").Replace("  ", "&nbsp; "))
+        </p>
     }
 
     <h3>Owners</h3>


### PR DESCRIPTION
Current code preserve spaces in release notes.

Without this change, it makes displaying release notes difficult. For example, https://nuget.org/packages/Glimpse/1.3.0 should look more like http://getglimpse.com/version/install?Glimpse=1.2.0..1.3.0.

Also can we please have the line breaks as br's instead of p's. Again the formatting looks kinda sucky if we are trying to do anything more than a block of text with release notes.

<!---
@huboard:{"order":666.5}
-->
