### PR TITLE
Fixes #1060. Deindexing error entries gives the wrong entry because the ...

### DIFF
--- a/Website/Infrastructure/AzureEntityList.cs
+++ b/Website/Infrastructure/AzureEntityList.cs
@@ -213,6 +213,14 @@ namespace NuGetGallery.Infrastructure
             }
         }
 
+        public static long GetLogicalIndex(T entity)
+        {
+            // Chop off leading "Page_"
+            long page = Int64.Parse(entity.PartitionKey.Substring(5), CultureInfo.InvariantCulture);
+            long offset = Int32.Parse(entity.RowKey, CultureInfo.InvariantCulture);
+            return (1000 * page) + offset;
+        }
+
         private long AtomicIncrementCount()
         {
             // 1) retrieve count

--- a/Website/Infrastructure/TableErrorLog.cs
+++ b/Website/Infrastructure/TableErrorLog.cs
@@ -43,10 +43,7 @@ namespace NuGetGallery.Infrastructure
             {
                 get
                 {
-                    // Chop off leading "Page_"
-                    long page = Int64.Parse(((ITableEntity)this).PartitionKey.Substring(5), CultureInfo.InvariantCulture);
-                    long offset = Int32.Parse(((ITableEntity)this).RowKey, CultureInfo.InvariantCulture);
-                    return page + offset;
+                    return AzureEntityList<ErrorEntity>.GetLogicalIndex(this);
                 }
             }
 


### PR DESCRIPTION
...logical index computation doesn't multiply by the partition size (1000). Fixes #1060 
