### PR TITLE
Migrations add a default row to GallerySettings

### DIFF
--- a/Website/Migrations/MigrationsConfiguration.cs
+++ b/Website/Migrations/MigrationsConfiguration.cs
@@ -19,6 +19,13 @@ namespace NuGetGallery.Migrations
                 roles.Add(new Role { Name = Constants.AdminRoleName });
                 context.SaveChanges();
             }
+
+            var gallerySettings = context.Set<GallerySetting>();
+            if (!gallerySettings.Any())
+            {
+                gallerySettings.Add(new GallerySetting { Key = 1 });
+                context.SaveChanges();
+            }
         }
     }
 }


### PR DESCRIPTION
Without this, the GallerySettings row cannot be updated when the statistics job is run, and the last updated operation is not stored. This means the download count of each package is incremented by the total count of download operations every 5 minutes, rather than a running total of new operations.

Fixes #1110
