### PR TITLE
Canonicalized on 'www.nuget.org' :(

### DIFF
--- a/Scripts/Enable-LocalTestMe.ps1
+++ b/Scripts/Enable-LocalTestMe.ps1
@@ -1,5 +1,9 @@
 param([switch]$Force, [string]$Subdomain="nuget")
 
+if(!(([Security.Principal.WindowsPrincipal]([System.Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator"))) {
+    throw "This script must be run as an admin."
+}
+
 $WebSite = Resolve-Path (Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "..\Website")
 
 # Enable access to the necessary URLs

--- a/Website/Web.config
+++ b/Website/Web.config
@@ -43,7 +43,7 @@
         <!--<add key="Gallery.Require" value="true" />
         <add key="Gallery.SSLPort" value="44300" /> -->
         <!-- VS usually uses "44300" as the port. If that's taken, it uses "44301", "44302", and so on. -->
-        
+
         <add key="Gallery.Environment" value="Development" />
         <add key="Gallery.SiteRoot" value="http://nuget.org/" />
         <add key="Gallery.GalleryOwner" value="NuGet Gallery &lt;nugetgallery@outercurve.org&gt;" />
@@ -56,20 +56,20 @@
         <add name="Gallery.SqlServer" connectionString="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetGallery;Integrated Security=SSPI" providerName="System.Data.SqlClient"/>
     </connectionStrings>
     <elmah>
-    <security allowRemoteAccess="true" />
+        <security allowRemoteAccess="true" />
         <errorFilter>
             <test>
-        <equal binding="HttpStatusCode" value="404" type="Int32" />
+                <equal binding="HttpStatusCode" value="404" type="Int32" />
             </test>
         </errorFilter>
-    <errorLog type="Elmah.SqlErrorLog, Elmah" connectionStringName="NuGetGallery" />
+        <errorLog type="Elmah.SqlErrorLog, Elmah" connectionStringName="NuGetGallery" />
     </elmah>
     <!-- Ensure only Admins may access elmah and glimpse -->
     <location path="Admin" inheritInChildApplications="false">
         <system.web>
             <httpHandlers>
                 <add verb="GET" path="Glimpse" type="Glimpse.AspNet.HttpHandler, Glimpse.AspNet" />
-        <add verb="POST,GET,HEAD" path="Errors.axd" type="Elmah.ErrorLogPageFactory, Elmah" />
+                <add verb="POST,GET,HEAD" path="Errors.axd" type="Elmah.ErrorLogPageFactory, Elmah" />
             </httpHandlers>
             <authorization>
                 <allow roles="Admins" />
@@ -80,7 +80,7 @@
         <system.webServer>
             <handlers>
                 <add name="Glimpse" path="Glimpse" verb="GET" type="Glimpse.AspNet.HttpHandler, Glimpse.AspNet" preCondition="integratedMode" />
-        <add name="Elmah" path="Errors.axd" verb="POST,GET,HEAD" type="Elmah.ErrorLogPageFactory, Elmah" preCondition="integratedMode" />
+                <add name="Elmah" path="Errors.axd" verb="POST,GET,HEAD" type="Elmah.ErrorLogPageFactory, Elmah" preCondition="integratedMode" />
             </handlers>
             <httpErrors>
                 <clear />
@@ -90,15 +90,15 @@
     <!-- Allow some very specific set of name to be used with the ~/package and ~/api/vX/package/ routes -->
     <location path="packages">
         <system.web>
-      <httpHandlers configSource="Web.ForbiddenHandlers.config" />
+            <httpHandlers configSource="Web.ForbiddenHandlers.config" />
         </system.web>
         <system.webServer>
             <security>
                 <requestFiltering>
                     <fileExtensions allowUnlisted="true">
-            <remove fileExtension=".config" />
-            <remove fileExtension=".rules" />
-            <remove fileExtension=".resources" />
+                        <remove fileExtension=".config" />
+                        <remove fileExtension=".rules" />
+                        <remove fileExtension=".resources" />
                     </fileExtensions>
                 </requestFiltering>
             </security>
@@ -106,15 +106,15 @@
     </location>
     <location path="api/v1/package">
         <system.web>
-      <httpHandlers configSource="Web.ForbiddenHandlers.config" />
+            <httpHandlers configSource="Web.ForbiddenHandlers.config" />
         </system.web>
         <system.webServer>
             <security>
                 <requestFiltering>
                     <fileExtensions allowUnlisted="true">
-            <remove fileExtension=".config" />
-            <remove fileExtension=".rules" />
-            <remove fileExtension=".resources" />
+                        <remove fileExtension=".config" />
+                        <remove fileExtension=".rules" />
+                        <remove fileExtension=".resources" />
                     </fileExtensions>
                 </requestFiltering>
             </security>
@@ -122,15 +122,15 @@
     </location>
     <location path="api/v2/package">
         <system.web>
-      <httpHandlers configSource="Web.ForbiddenHandlers.config" />
+            <httpHandlers configSource="Web.ForbiddenHandlers.config" />
         </system.web>
         <system.webServer>
             <security>
                 <requestFiltering>
                     <fileExtensions allowUnlisted="true">
-            <remove fileExtension=".config" />
-            <remove fileExtension=".rules" />
-            <remove fileExtension=".resources" />
+                        <remove fileExtension=".config" />
+                        <remove fileExtension=".rules" />
+                        <remove fileExtension=".resources" />
                     </fileExtensions>
                 </requestFiltering>
             </security>
@@ -147,61 +147,61 @@
     <system.web>
         <compilation debug="true" targetFramework="4.5">
             <assemblies>
-        <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.Routing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+                <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+                <add assembly="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+                <add assembly="System.Web.Routing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+                <add assembly="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+                <add assembly="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
             </assemblies>
         </compilation>
         <authentication mode="Forms">
-      <forms loginUrl="~/Users/Account/LogOn" timeout="2880" />
+            <forms loginUrl="~/Users/Account/LogOn" timeout="2880" />
         </authentication>
         <pages controlRenderingCompatibilityVersion="4.0">
             <namespaces>
-        <add namespace="System.Web.Helpers" />
-        <add namespace="System.Web.Mvc" />
-        <add namespace="System.Web.Mvc.Ajax" />
-        <add namespace="System.Web.Mvc.Html" />
-        <add namespace="System.Web.Routing" />
-        <add namespace="System.Web.WebPages" />
+                <add namespace="System.Web.Helpers" />
+                <add namespace="System.Web.Mvc" />
+                <add namespace="System.Web.Mvc.Ajax" />
+                <add namespace="System.Web.Mvc.Html" />
+                <add namespace="System.Web.Routing" />
+                <add namespace="System.Web.WebPages" />
             </namespaces>
         </pages>
-    <httpRuntime targetFramework="4.5" maxQueryStringLength="12000" maxRequestLength="2000000000" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" />
+        <httpRuntime targetFramework="4.5" maxQueryStringLength="12000" maxRequestLength="2000000000" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" />
         <httpModules>
-      <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah" />
-      <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" />
-      <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" />
-      <add name="AsyncFileUpload" type="NuGetGallery.AsyncFileUpload.AsyncFileUploadModule, NuGetGallery.Website" />
+            <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah" />
+            <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" />
+            <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" />
+            <add name="AsyncFileUpload" type="NuGetGallery.AsyncFileUpload.AsyncFileUploadModule, NuGetGallery.Website" />
         </httpModules>
         <httpHandlers />
         <customErrors mode="RemoteOnly" defaultRedirect="~/Errors/error.html">
-      <error statusCode="404" redirect="~/Errors/404" />
+            <error statusCode="404" redirect="~/Errors/404" />
         </customErrors>
-    <sessionState mode="Off" />
+        <sessionState mode="Off" />
     </system.web>
     <system.webServer>
         <httpProtocol>
             <customHeaders>
-        <add name="X-Frame-Options" value="deny" />
-        <add name="X-XSS-Protection" value="1; mode=block" />
-        <add name="X-Content-Type-Options" value="nosniff" />
-        <add name="Strict-Transport-Security" value="maxage=31536000; includeSubDomains" />
+                <add name="X-Frame-Options" value="deny" />
+                <add name="X-XSS-Protection" value="1; mode=block" />
+                <add name="X-Content-Type-Options" value="nosniff" />
+                <add name="Strict-Transport-Security" value="maxage=31536000; includeSubDomains" />
             </customHeaders>
         </httpProtocol>
         <modules runAllManagedModulesForAllRequests="true">
-      <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" preCondition="managedHandler" />
-      <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" preCondition="managedHandler" />
-      <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah" preCondition="managedHandler" />
-      <add name="AsyncFileUpload" type="NuGetGallery.AsyncFileUpload.AsyncFileUploadModule, NuGetGallery.Website" preCondition="managedHandler" />
+            <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" preCondition="managedHandler" />
+            <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" preCondition="managedHandler" />
+            <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah" preCondition="managedHandler" />
+            <add name="AsyncFileUpload" type="NuGetGallery.AsyncFileUpload.AsyncFileUploadModule, NuGetGallery.Website" preCondition="managedHandler" />
         </modules>
         <validation validateIntegratedModeConfiguration="false" />
         <handlers />
         <httpErrors errorMode="Custom">
-      <remove statusCode="404" subStatusCode="-1" />
-      <error statusCode="404" path="/Errors/404" responseMode="ExecuteURL" />
-      <remove statusCode="500" subStatusCode="-1" />
-      <error statusCode="500" path="/Errors/Error.html" responseMode="ExecuteURL" />
+            <remove statusCode="404" subStatusCode="-1" />
+            <error statusCode="404" path="/Errors/404" responseMode="ExecuteURL" />
+            <remove statusCode="500" subStatusCode="-1" />
+            <error statusCode="500" path="/Errors/Error.html" responseMode="ExecuteURL" />
         </httpErrors>
         <security>
             <requestFiltering>
@@ -210,49 +210,62 @@
             </requestFiltering>
         </security>
         <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">
-      <scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll" />
+            <scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll" />
             <dynamicTypes>
-        <add mimeType="text/*" enabled="true" />
-        <add mimeType="message/*" enabled="true" />
-        <add mimeType="application/javascript" enabled="true" />
-        <add mimeType="application/x-javascript" enabled="true" />
-        <add mimetype="application/json" enabled="true" />
-        <add mimetype="application/atom+xml" enabled="true" />
-        <add mimetype="application/atom+xml;charset=utf-8" enabled="true" />
-        <add mimeType="*/*" enabled="false" />
+                <add mimeType="text/*" enabled="true" />
+                <add mimeType="message/*" enabled="true" />
+                <add mimeType="application/javascript" enabled="true" />
+                <add mimeType="application/x-javascript" enabled="true" />
+                <add mimetype="application/json" enabled="true" />
+                <add mimetype="application/atom+xml" enabled="true" />
+                <add mimetype="application/atom+xml;charset=utf-8" enabled="true" />
+                <add mimeType="*/*" enabled="false" />
             </dynamicTypes>
             <staticTypes>
-        <add mimeType="text/*" enabled="true" />
-        <add mimeType="message/*" enabled="true" />
-        <add mimeType="application/javascript" enabled="true" />
-        <add mimeType="application/x-javascript" enabled="true" />
-        <add mimetype="application/json" enabled="true" />
-        <add mimetype="application/atom+xml" enabled="true" />
-        <add mimetype="application/atom+xml;charset=utf-8" enabled="true" />
-        <add mimeType="*/*" enabled="false" />
+                <add mimeType="text/*" enabled="true" />
+                <add mimeType="message/*" enabled="true" />
+                <add mimeType="application/javascript" enabled="true" />
+                <add mimeType="application/x-javascript" enabled="true" />
+                <add mimetype="application/json" enabled="true" />
+                <add mimetype="application/atom+xml" enabled="true" />
+                <add mimetype="application/atom+xml;charset=utf-8" enabled="true" />
+                <add mimeType="*/*" enabled="false" />
             </staticTypes>
         </httpCompression>
-    <urlCompression doStaticCompression="true" doDynamicCompression="true" />
+        <urlCompression doStaticCompression="true" doDynamicCompression="true" />
         <rewrite>
+            <rewriteMaps>
+                <rewriteMap name="MapProtocol" defaultValue="OFF">
+                    <add key="ON" value="https://" />
+                    <add key="OFF" value="http://" />
+                </rewriteMap>
+            </rewriteMaps>
             <rules>
-                <rule name="Legacy feed root URL" stopProcessing="true">
-          <match url="^$" />
+                <rule name="Cannonicalize Domain Name">
+                    <match url="^(.*)$" />
                     <conditions>
-            <add input="{HTTP_HOST}" pattern="^packages([0-9]?)\.nuget.org$" />
+                        <add input="{HTTP_HOST}" pattern="^nuget\.org$"/>
                     </conditions>
-          <action type="Redirect" url="http://packages.nuget.org/v1/FeedService.svc" redirectType="Permanent" />
+                    <action type="Redirect" url="{MapProtocol:{HTTPS}}www.nuget.org/{R:1}" redirectType="Permanent"/>
+                </rule>
+                <rule name="Legacy feed root URL" stopProcessing="true">
+                    <match url="^$" />
+                    <conditions>
+                        <add input="{HTTP_HOST}" pattern="^packages([0-9]?)\.nuget.org$" />
+                    </conditions>
+                    <action type="Redirect" url="http://packages.nuget.org/v1/FeedService.svc" redirectType="Permanent" />
                 </rule>
                 <rule name="Legacy image icon URL" stopProcessing="true">
-          <match url="^media/default/packages/([a-z0-9_][a-z0-9._-]*)/([0-9.]+)/[\w._ -]+\.([a-z]+)$" />
-          <action type="Redirect" url="https://nugetgallery.blob.core.windows.net/icons/{R:1}.{R:2}.{R:3}" redirectType="Permanent" />
+                    <match url="^media/default/packages/([a-z0-9_][a-z0-9._-]*)/([0-9.]+)/[\w._ -]+\.([a-z]+)$" />
+                    <action type="Redirect" url="https://nugetgallery.blob.core.windows.net/icons/{R:1}.{R:2}.{R:3}" redirectType="Permanent" />
                 </rule>
                 <rule name="Curated Feed Download URL" stopProcessing="true">
-          <match url="^api/v2/curated-feeds/package/" />
-          <action type="None" />
+                    <match url="^api/v2/curated-feeds/package/" />
+                    <action type="None" />
                 </rule>
                 <rule name="Curated Feed" stopProcessing="true">
-          <match url="^api/v2/curated-feeds/([^/]+)(.*)$" />
-          <action type="Rewrite" url="api/v2/curated-feed{R:2}?name={R:1}" />
+                    <match url="^api/v2/curated-feeds/([^/]+)(.*)$" />
+                    <action type="Rewrite" url="api/v2/curated-feed{R:2}?name={R:1}" />
                 </rule>
             </rules>
         </rewrite>
@@ -260,32 +273,32 @@
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+                <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+                <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
             </dependentAssembly>
             <dependentAssembly>
-        <assemblyIdentity name="RouteMagic" publicKeyToken="84b59be021aa4cee" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.2.2.2" newVersion="0.2.2.2" />
+                <assemblyIdentity name="RouteMagic" publicKeyToken="84b59be021aa4cee" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-0.2.2.2" newVersion="0.2.2.2" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="EntityFramework" publicKeyToken="b77a5c561934e089" culture="neutral" />
                 <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
             </dependentAssembly>
             <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+                <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
             </dependentAssembly>
             <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+                <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
             </dependentAssembly>
             <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+                <assemblyIdentity name="System.Web.WebPages.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
             </dependentAssembly>
             <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
+                <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
             </dependentAssembly>
         </assemblyBinding>
     </runtime>
@@ -295,7 +308,7 @@
     <entityFramework>
         <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
             <parameters>
-        <parameter value="Data Source=(localdb)\v11.0; Integrated Security=True; MultipleActiveResultSets=True" />
+                <parameter value="Data Source=(localdb)\v11.0; Integrated Security=True; MultipleActiveResultSets=True" />
             </parameters>
         </defaultConnectionFactory>
     </entityFramework>


### PR DESCRIPTION
Fixes #1016. Wish we could canonicalize on "nuget.org" but due to a) the desire to use CNames and b) Cookie transferring, we need to use "www."
