### PR TITLE
Fix #1319 by changing display of Portable Class Library frameworks to include profiles

### DIFF
--- a/Facts/ExtensionMethodsFacts.cs
+++ b/Facts/ExtensionMethodsFacts.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet;
+using Xunit;
+using Xunit.Extensions;
+
+namespace NuGetGallery
+{
+    public class ExtensionMethodsFacts
+    {
+        public class TheToFriendlyNameMethod
+        {
+            [Theory]
+            [InlineData(".NETFramework 4.0", "net40")]
+            [InlineData("Silverlight 4.0", "sl40")]
+            [InlineData("WindowsPhone 8.0", "wp8")]
+            [InlineData("Windows 8.1", "win81")]
+            [InlineData("Portable Class Library (.NETFramework 4.0, Silverlight 4.0, Windows 8.0, WindowsPhone 7.1)", "portable-net40+sl4+win8+wp71")]
+            [InlineData("Portable Class Library (.NETFramework 4.5, Windows 8.0)", "portable-net45+win8")]
+            public void CorrectlyConvertsShortNameToFriendlyName(string expected, string shortName)
+            {
+                var fx = VersionUtility.ParseFrameworkName(shortName);
+                var actual = fx.ToFriendlyName();
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+}

--- a/Facts/Facts.csproj
+++ b/Facts/Facts.csproj
@@ -180,6 +180,7 @@
     <Compile Include="EmailValidationRegex.cs" />
     <Compile Include="Entities\EntitiesContextFacts.cs" />
     <Compile Include="Entities\PackageFacts.cs" />
+    <Compile Include="ExtensionMethodsFacts.cs" />
     <Compile Include="Helpers\EnumHelperFacts.cs" />
     <Compile Include="Infrastructure\AnalysisHelperFacts.cs" />
     <Compile Include="Infrastructure\CookieTempDataProviderFacts.cs" />
@@ -216,6 +217,7 @@
     <Compile Include="TestUtils\TaskAssert.cs" />
     <Compile Include="TestUtils\TestUtility.cs" />
     <Compile Include="UrlExtensionsFacts.cs" />
+    <Compile Include="ViewModels\DependencySetsViewModelFacts.cs" />
     <Compile Include="ViewModels\DisplayPackageViewModelFacts.cs" />
     <Compile Include="ViewModels\PreviousNextPagerViewModelFacts.cs" />
   </ItemGroup>

--- a/Facts/ViewModels/DependencySetsViewModelFacts.cs
+++ b/Facts/ViewModels/DependencySetsViewModelFacts.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGetGallery.ViewModels
+{
+    public class DependencySetsViewModelFacts
+    {
+        public class TheConstructor
+        {
+            [Fact]
+            public void GivenAListOfDependenciesItShouldGroupByTargetFrameworkName()
+            {
+                // Arrange
+                var deps = new[] {
+                    new PackageDependency() { TargetFramework = null },
+                    new PackageDependency() { TargetFramework = "portable-net45+win8" },
+                    new PackageDependency() { TargetFramework = "portable-net40+sl40+win8+wp71", Id = "Microsoft.Net.Http", VersionSpec = "[2.1,3.0)" },
+                };
+
+                // Act
+                var vm = new DependencySetsViewModel(deps);
+
+                // Assert
+                Assert.Equal(3, vm.DependencySets.Count);
+                Assert.Null(vm.DependencySets["All Frameworks"].Single());
+                Assert.Null(vm.DependencySets["Portable Class Library (.NETFramework 4.5, Windows 8.0)"].Single());
+
+                var actual = vm.DependencySets["Portable Class Library (.NETFramework 4.0, Silverlight 4.0, Windows 8.0, WindowsPhone 7.1)"].ToArray();
+                Assert.Equal(1, actual.Length);
+                Assert.Equal("Microsoft.Net.Http", actual[0].Id);
+                Assert.Equal("(≥ 2.1 && < 3.0)", actual[0].VersionSpec);
+            }
+        }
+    }
+}

--- a/Website/ExtensionMethods.cs
+++ b/Website/ExtensionMethods.cs
@@ -287,10 +287,22 @@ namespace NuGetGallery
             }
 
             var sb = new StringBuilder();
-            sb.AppendFormat("{0} {1}", frameworkName.Identifier, frameworkName.Version);
-            if (String.IsNullOrEmpty(frameworkName.Profile))
+            if (String.Equals(frameworkName.Identifier, ".NETPortable", StringComparison.OrdinalIgnoreCase))
             {
-                sb.AppendFormat(" {0}", frameworkName.Profile);
+                sb.Append("Portable Class Library (");
+
+                // Recursively parse the profile
+                var subprofiles = frameworkName.Profile.Split('+');
+                sb.Append(String.Join(", ", subprofiles.Select(s => VersionUtility.ParseFrameworkName(s).ToFriendlyName())));
+                sb.Append(")");
+            }
+            else
+            {
+                sb.AppendFormat("{0} {1}", frameworkName.Identifier, frameworkName.Version);
+                if (!String.IsNullOrEmpty(frameworkName.Profile))
+                {
+                    sb.AppendFormat(" {0}", frameworkName.Profile);
+                }
             }
             return sb.ToString();
         }

--- a/Website/ViewModels/DependencySetsViewModel.cs
+++ b/Website/ViewModels/DependencySetsViewModel.cs
@@ -9,20 +9,29 @@ namespace NuGetGallery
     {
         public DependencySetsViewModel(IEnumerable<PackageDependency> packageDependencies)
         {
-            DependencySets = new Dictionary<string, IEnumerable<DependencyViewModel>>();
-
-            var dependencySets = packageDependencies
-                .GroupBy(d => d.TargetFramework)
-                .OrderBy(ds => ds.Key);
-
-            OnlyHasAllFrameworks = dependencySets.Count() == 1 && dependencySets.First().Key == null;
-
-            foreach (var dependencySet in dependencySets)
+            try
             {
-                var targetFramework = dependencySet.Key == null
-                                          ? "All Frameworks"
-                                          : VersionUtility.ParseFrameworkName(dependencySet.Key).ToFriendlyName();
-                DependencySets.Add(targetFramework, dependencySet.Select(d => d.Id == null ? null : new DependencyViewModel(d.Id, d.VersionSpec)));
+                DependencySets = new Dictionary<string, IEnumerable<DependencyViewModel>>();
+
+                var dependencySets = packageDependencies
+                    .GroupBy(d => d.TargetFramework)
+                    .OrderBy(ds => ds.Key);
+
+                OnlyHasAllFrameworks = dependencySets.Count() == 1 && dependencySets.First().Key == null;
+
+                foreach (var dependencySet in dependencySets)
+                {
+                    var targetFramework = dependencySet.Key == null
+                                              ? "All Frameworks"
+                                              : VersionUtility.ParseFrameworkName(dependencySet.Key).ToFriendlyName();
+                    DependencySets.Add(targetFramework, dependencySet.Select(d => d.Id == null ? null : new DependencyViewModel(d.Id, d.VersionSpec)));
+                }
+            }
+            catch (Exception e)
+            {
+                DependencySets = null;
+                QuietLog.LogHandledException(e);
+                // Just set Dependency Sets to null but still render the package.
             }
         }
 

--- a/Website/Views/Packages/DisplayPackage.cshtml
+++ b/Website/Views/Packages/DisplayPackage.cshtml
@@ -184,7 +184,22 @@
             }
         </ul>
     }
-    @Html.Partial("_PackageDependencies", Model.Dependencies)
+    @if (Model.Dependencies.DependencySets == null)
+    {
+        if(Model.IsOwner(User)) {
+            <h3>Dependencies</h3>
+            <p>
+                An error occurred processing dependencies. 
+                Your package can still be downloaded and installed, but dependencies cannot be shown.
+                Please @Html.ActionLink("Contact Support", MVC.Packages.ReportMyPackage(Model.Id, Model.Version)) if you have questions.</p>
+            <p>
+                <strong>Note: This message is only visible to you and any other package owners.</strong></p>
+        }
+    }
+    else {
+        <h3>Dependencies</h3>
+        @Html.Partial("_PackageDependencies", Model.Dependencies)
+    }
     <h3>Version History</h3>
     <table class="sexy-table">
         <thead>

--- a/Website/Views/Packages/_PackageDependencies.cshtml
+++ b/Website/Views/Packages/_PackageDependencies.cshtml
@@ -1,5 +1,4 @@
 ﻿@model DependencySetsViewModel
-<h3>Dependencies</h3>
 @if (Model.DependencySets.Any())
 {
     <ul id="dependencySets">


### PR DESCRIPTION
This issue was caused by the code for processing Framework Names into "Friendly" Display Names having an inverted condition. Instead of adding the Profile field to the name, if present, it only adds it if NOT present :).

Along with this, I've added some code to pretty-print Portable Class Library frameworks a little better:

![Pretty-Print PCLs](https://f.cloud.github.com/assets/7574/799923/f872c0d8-ed7e-11e2-9612-f31db8dca3e5.PNG)

Also, in keeping with our practice of being as tolerant of bad data as possible, I added errors checking so that corrupt dependencies won't cause a WSOD (White Screen of Death ;)). Instead, it will silently log the exception and not show dependencies at all. The **owners** will see this message so they can follow up with us (in the long term we should notify the gallery operators, but this will do as a quick fix, it's highly unlikely to get in this scenario again):

![Error Message](https://f.cloud.github.com/assets/7574/799941/21564f6a-ed7f-11e2-8cf4-636af3476c0d.png)

Fixes #1319
