### PR TITLE
Added URL Rewrite to rename dotnetframework curated feed to microsoftdotnet

### DIFF
--- a/Website/Web.config
+++ b/Website/Web.config
@@ -266,6 +266,16 @@
                     <match url="^media/default/packages/([a-z0-9_][a-z0-9._-]*)/([0-9.]+)/[\w._ -]+\.([a-z]+)$" />
                     <action type="Redirect" url="https://nugetgallery.blob.core.windows.net/icons/{R:1}.{R:2}.{R:3}" redirectType="Permanent" />
                 </rule>
+                
+                <rule name="Rename DotNetFramework Feed">
+                    <match url="^api/v2/curated-feeds/dotnetframework(.*)$" />
+                    <action url="{MapProtocol:{HTTPS}}{HTTP_HOST}/api/v2/curated-feeds/microsoftdotnet{R:1}" type="Redirect" redirectType="Permanent" />
+                </rule>
+                <rule name="Rename DotNetFramework Feed Format 2">
+                    <match url="^api/v2/curated-feed(.*)name=dotnetframework(.*)$" />
+                    <action url="{MapProtocol:{HTTPS}}{HTTP_HOST}/api/v2/curated-feed/{R:1}name=microsoftdotnet{R:2}" type="Redirect" redirectType="Permanent" />
+                </rule>
+                
                 <rule name="Curated Feed Download URL" stopProcessing="true">
                     <match url="^api/v2/curated-feeds/package/" />
                     <action type="None" />


### PR DESCRIPTION
Decided to just Fix #1330 the easy way for now. XDT transforms can come later :).
