### PR TITLE
Fix #1327 by cleaning up the text around package ownership transfers

### DIFF
--- a/Facts/Services/PackageServiceFacts.cs
+++ b/Facts/Services/PackageServiceFacts.cs
@@ -213,7 +213,7 @@ namespace NuGetGallery
         public class TheConfirmPackageOwnerMethod
         {
             [Fact]
-            public void WithValidUserAndMatchingTokenReturnsTrue()
+            public void WithValidUserAndMatchingTokenReturnsSuccess()
             {
                 var package = new PackageRegistration { Key = 2, Id = "pkg42" };
                 var pendingOwner = new User { Key = 100, Username = "teamawesome" };
@@ -230,13 +230,13 @@ namespace NuGetGallery
 
                 var result = service.ConfirmPackageOwner(package, pendingOwner, "secret-token");
 
-                Assert.True(result);
+                Assert.Equal(ConfirmOwnershipResult.Success, result);
                 Assert.Contains(pendingOwner, package.Owners);
                 packageRepository.VerifyAll();
             }
 
             [Fact]
-            public void WhenUserIsAlreadyOwnerReturnsTrue()
+            public void WhenUserIsAlreadyOwnerReturnsAlreadyOwner()
             {
                 var pendingOwner = new User { Key = 100, Username = "teamawesome" };
                 var package = new PackageRegistration { Key = 2, Id = "pkg42", Owners = new[] { pendingOwner } };
@@ -250,11 +250,11 @@ namespace NuGetGallery
 
                 var result = service.ConfirmPackageOwner(package, pendingOwner, "secret-token");
 
-                Assert.True(result);
+                Assert.Equal(ConfirmOwnershipResult.AlreadyOwner, result);
             }
 
             [Fact]
-            public void WithNoMatchingPackgageOwnerRequestReturnsFalse()
+            public void WithNoMatchingPackgageOwnerRequestReturnsFailure()
             {
                 var package = new PackageRegistration { Key = 2, Id = "pkg42" };
                 var pendingOwner = new User { Key = 100, Username = "teamawesome" };
@@ -268,11 +268,11 @@ namespace NuGetGallery
 
                 var result = service.ConfirmPackageOwner(package, pendingOwner, "secret-token");
 
-                Assert.False(result);
+                Assert.Equal(ConfirmOwnershipResult.Failure, result);
             }
 
             [Fact]
-            public void WithValidUserAndNonMatchingTokenReturnsFalse()
+            public void WithValidUserAndNonMatchingTokenReturnsFailure()
             {
                 var package = new PackageRegistration { Key = 2, Id = "pkg42" };
                 var pendingOwner = new User { Key = 100, Username = "teamawesome" };
@@ -289,7 +289,7 @@ namespace NuGetGallery
 
                 var result = service.ConfirmPackageOwner(package, pendingOwner, "secret-token");
 
-                Assert.False(result);
+                Assert.Equal(ConfirmOwnershipResult.Failure, result);
                 Assert.DoesNotContain(pendingOwner, package.Owners);
             }
 

--- a/Website/Services/ConfirmOwnershipResult.cs
+++ b/Website/Services/ConfirmOwnershipResult.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NuGetGallery
+{
+    public enum ConfirmOwnershipResult
+    {
+        Success,
+        AlreadyOwner,
+        Failure
+    }
+}

--- a/Website/Services/IPackageService.cs
+++ b/Website/Services/IPackageService.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet;
+using NuGetGallery;
 
 namespace NuGetGallery
 {
@@ -44,7 +45,7 @@ namespace NuGetGallery
         void AddDownloadStatistics(PackageStatistics stats);
 
         PackageOwnerRequest CreatePackageOwnerRequest(PackageRegistration package, User currentOwner, User newOwner);
-        bool ConfirmPackageOwner(PackageRegistration package, User user, string token);
+        ConfirmOwnershipResult ConfirmPackageOwner(PackageRegistration package, User user, string token);
         void AddPackageOwner(PackageRegistration package, User user);
         void RemovePackageOwner(PackageRegistration package, User user);
     }

--- a/Website/Services/PackageService.cs
+++ b/Website/Services/PackageService.cs
@@ -347,7 +347,7 @@ namespace NuGetGallery
             return newRequest;
         }
 
-        public bool ConfirmPackageOwner(PackageRegistration package, User pendingOwner, string token)
+        public ConfirmOwnershipResult ConfirmPackageOwner(PackageRegistration package, User pendingOwner, string token)
         {
             if (package == null)
             {
@@ -366,17 +366,17 @@ namespace NuGetGallery
 
             if (package.IsOwner(pendingOwner))
             {
-                return true;
+                return ConfirmOwnershipResult.AlreadyOwner;
             }
 
             var request = FindExistingPackageOwnerRequest(package, pendingOwner);
             if (request != null && request.ConfirmationCode == token)
             {
                 AddPackageOwner(package, pendingOwner);
-                return true;
+                return ConfirmOwnershipResult.Success;
             }
 
-            return false;
+            return ConfirmOwnershipResult.Failure;
         }
 
         private PackageRegistration CreateOrGetPackageRegistration(User currentUser, IPackageMetadata nugetPackage)

--- a/Website/ViewModels/PackageOwnerConfirmationModel.cs
+++ b/Website/ViewModels/PackageOwnerConfirmationModel.cs
@@ -2,7 +2,7 @@
 {
     public class PackageOwnerConfirmationModel
     {
-        public bool Success { get; set; }
+        public ConfirmOwnershipResult Result { get; set; }
         public string PackageId { get; set; }
     }
 }

--- a/Website/Views/Packages/ConfirmOwner.cshtml
+++ b/Website/Views/Packages/ConfirmOwner.cshtml
@@ -5,23 +5,33 @@
 
 <h1 class="page-heading">Confirm Ownership</h1>
 
-@if (Model.Success)
+@switch(Model.Result)
 {
-    <p>
-        You are now an owner of the 
-        '<strong><a href="@Url.Package(@Model.PackageId)" title="The @Model.PackageId package">@Model.PackageId</a></strong>' package.
-    </p>
-}
-else
-{
-    <p class="message error">
-        Could not confirm package ownership for '@Model.PackageId'.
-    </p>
-    <p>
-        Make sure you clicked on the confirmation URL in the email we sent. 
-        It&#8217;s also possible that the existing owner revoked the 
-        request to add you as an owner.
-    </p>
+    case ConfirmOwnershipResult.Success:
+        <p>
+            You are now an owner of the 
+            '<strong><a href="@Url.Package(@Model.PackageId)" title="The @Model.PackageId package">@Model.PackageId</a></strong>' package.
+        </p>
+        break;
+    case ConfirmOwnershipResult.AlreadyOwner:
+        <p class="message error">
+            You are already an owner of the
+            '<strong><a href="@Url.Package(@Model.PackageId)" title="The @Model.PackageId package">@Model.PackageId</a></strong>' package.
+        </p>
+        <p>
+            If you manage multiple accounts, make sure you sign-in as the user who received the request before clicking the confirmation link.
+        </p>
+        break;
+    default:
+        <p class="message error">
+            Could not confirm package ownership for '@Model.PackageId'.
+        </p>
+        <p>
+            Make sure you clicked on the confirmation URL in the email we sent. 
+            It&#8217;s also possible that the existing owner revoked the 
+            request to add you as an owner.
+        </p>
+        break;
 }
 
 

--- a/Website/Website.csproj
+++ b/Website/Website.csproj
@@ -800,6 +800,7 @@
     <Compile Include="Queries\PackageIdsQuery.cs" />
     <Compile Include="RequestModels\ModifyCuratedPackageRequest.cs" />
     <Compile Include="RequestModels\CreateCuratedPackageRequest.cs" />
+    <Compile Include="Services\ConfirmOwnershipResult.cs" />
     <Compile Include="Services\CuratedFeedService.cs" />
     <Compile Include="Services\ICuratedFeedService.cs" />
     <Compile Include="Services\CloudFileReference.cs" />


### PR DESCRIPTION
Fixes #1327.

There isn't an easy way to detect that you are the user who requested the transfer, but we can detect if you are already an owner and provide clearer messaging there. Also, if you're an Admin, you aren't actually a Package Owner, so I clarified the process there too.
