### PR TITLE
Change the footer formatting around terms and privacy

### DIFF
--- a/Website/Views/Shared/Layout.cshtml
+++ b/Website/Views/Shared/Layout.cshtml
@@ -84,8 +84,8 @@
                     <div class="license">
                         <a href="http://outercurve.org"><img src="@Links.Content.Images.outercurve_png" alt="Outercurve Foundation" /></a>
                         <p>
-                            &copy; @DateTime.UtcNow.Year Outercurve Foundation. 
-                            @Html.ActionLink("Terms of Use", "Terms", MVC.Pages.Name). 
+                            &copy; @DateTime.UtcNow.Year Outercurve Foundation - 
+                            @Html.ActionLink("Terms of Use", "Terms", MVC.Pages.Name) - 
                             @Html.ActionLink("Privacy Policy", "Privacy", MVC.Pages.Name)
                         </p>
                         @ViewHelpers.ReleaseTag()


### PR DESCRIPTION
There wasn't a period after Privacy Policy. Instead of adding it (which looked someone odd), using dashes between the items.

Here's the screenshot of the change:
![image](https://f.cloud.github.com/assets/1031940/896912/2cd3c996-fae8-11e2-9725-f6183474022c.png)
