### PR TITLE
Fix curated feed host

### DIFF
--- a/Website/DataServices/RewriteBaseUrlMessageInspector.cs
+++ b/Website/DataServices/RewriteBaseUrlMessageInspector.cs
@@ -26,6 +26,10 @@ namespace NuGetGallery
                 UriBuilder baseUriBuilder = new UriBuilder(context.IncomingRequest.UriTemplateMatch.BaseUri);
                 UriBuilder requestUriBuilder = new UriBuilder(context.IncomingRequest.UriTemplateMatch.RequestUri);
 
+                // Replace host
+                baseUriBuilder.Host = HttpContext.Current.Request.Url.Host;
+                requestUriBuilder.Host = baseUriBuilder.Host;
+
                 // Replace "/api/v2/curated-feed" with "/api/v2/curated-feeds/[feedname]"
                 baseUriBuilder.Path = RewriteUrlPath(baseUriBuilder.Path, curatedFeedName);
                 requestUriBuilder.Path = RewriteUrlPath(requestUriBuilder.Path, curatedFeedName);


### PR DESCRIPTION
Issue #1381 is still not fixed.
Look at link rel="next" element in OData output.
This pull request fixes host of output urls.
