### PR TITLE
Fix #1410 by adding some clever inheritance tricks to make OData clients work properly

### DIFF
--- a/src/NuGetGallery/DataServices/FeedServiceBase.cs
+++ b/src/NuGetGallery/DataServices/FeedServiceBase.cs
@@ -11,7 +11,8 @@ using NuGetGallery.Configuration;
 namespace NuGetGallery
 {
     [ServiceBehavior(ConcurrencyMode = ConcurrencyMode.Multiple)]
-    public abstract class FeedServiceBase<TPackage> : DataService<FeedContext<TPackage>>, IDataServiceStreamProvider, IServiceProvider
+    public abstract class FeedServiceBase<TContext, TPackage> : DataService<TContext>, IDataServiceStreamProvider, IServiceProvider
+        where TContext : FeedContext<TPackage>
     {
         private readonly ConfigurationService _configuration;
 
@@ -96,7 +97,6 @@ namespace NuGetGallery
         public abstract Uri GetReadStreamUri(
             object entity,
             DataServiceOperationContext operationContext);
-
 
         public string GetStreamContentType(
             object entity,

--- a/src/NuGetGallery/DataServices/V1Feed.svc.cs
+++ b/src/NuGetGallery/DataServices/V1Feed.svc.cs
@@ -9,7 +9,9 @@ using NuGetGallery.Configuration;
 
 namespace NuGetGallery
 {
-    public class V1Feed : FeedServiceBase<V1FeedPackage>
+    public class V1FeedContext : FeedContext<V1FeedPackage> { }
+
+    public class V1Feed : FeedServiceBase<V1FeedContext, V1FeedPackage>
     {
         private const int FeedVersion = 1;
 
@@ -27,9 +29,9 @@ namespace NuGetGallery
             InitializeServiceBase(config);
         }
 
-        protected override FeedContext<V1FeedPackage> CreateDataSource()
+        protected override V1FeedContext CreateDataSource()
         {
-            return new FeedContext<V1FeedPackage>
+            return new V1FeedContext
                 {
                     Packages = PackageRepository.GetAll()
                         .Where(p => !p.IsPrerelease)

--- a/src/NuGetGallery/DataServices/V2CuratedFeed.svc.cs
+++ b/src/NuGetGallery/DataServices/V2CuratedFeed.svc.cs
@@ -13,11 +13,11 @@ namespace NuGetGallery
 {
     // TODO : Have V2CuratedFeed derive from V2Feed?
     [RewriteBaseUrlMessageInspector]
-    public class V2CuratedFeed : FeedServiceBase<V2FeedPackage>
+    public class V2CuratedFeed : FeedServiceBase<V2FeedContext, V2FeedPackage>
     {
         private const int FeedVersion = 2;
 
-        ICuratedFeedService _curatedFeedService;
+        private ICuratedFeedService _curatedFeedService;
 
         public V2CuratedFeed()
             : this(DependencyResolver.Current.GetService<ICuratedFeedService>())
@@ -36,7 +36,7 @@ namespace NuGetGallery
             _curatedFeedService = curatedFeedService;
         }
 
-        protected override FeedContext<V2FeedPackage> CreateDataSource()
+        protected override V2FeedContext CreateDataSource()
         {
             var curatedFeedName = GetCuratedFeedName();
 
@@ -47,7 +47,7 @@ namespace NuGetGallery
 
             var packages = _curatedFeedService.GetPackages(curatedFeedName);
 
-            return new FeedContext<V2FeedPackage>
+            return new V2FeedContext
                 {
                     Packages = packages.ToV2FeedPackageQuery(Configuration.GetSiteRoot(UseHttps()))
                 };
@@ -83,7 +83,7 @@ namespace NuGetGallery
         [WebGet]
         public IQueryable<V2FeedPackage> Search(string searchTerm, string targetFramework, bool includePrerelease)
         {
-            var curatedFeedName =  GetCuratedFeedName();
+            var curatedFeedName = GetCuratedFeedName();
             var curatedFeedKey = _curatedFeedService.GetKey(curatedFeedName);
             if (curatedFeedKey == null)
             {

--- a/src/NuGetGallery/DataServices/V2Feed.svc.cs
+++ b/src/NuGetGallery/DataServices/V2Feed.svc.cs
@@ -13,7 +13,9 @@ using NuGetGallery.Helpers;
 
 namespace NuGetGallery
 {
-    public class V2Feed : FeedServiceBase<V2FeedPackage>
+    public class V2FeedContext : FeedContext<V2FeedPackage> { }
+
+    public class V2Feed : FeedServiceBase<V2FeedContext, V2FeedPackage>
     {
         private const int FeedVersion = 2;
 
@@ -26,9 +28,9 @@ namespace NuGetGallery
         {
         }
 
-        protected override FeedContext<V2FeedPackage> CreateDataSource()
+        protected override V2FeedContext CreateDataSource()
         {
-            return new FeedContext<V2FeedPackage>
+            return new V2FeedContext
                 {
                     Packages = PackageRepository.GetAll()
                         .WithoutVersionSort()


### PR DESCRIPTION
I love it when my first hunch works out perfectly :).

By changing our usage of the FeedContext&lt;T&gt; to be a base-class rather than using it directly, we bypass the problem with "FeedContext`1" (which is a Generic Type Name). Now, the entity context type is either V1FeedContext or V2FeedContext (but those types are still just simple shims around FeedContext&lt;V1/V2FeedPackage&gt;)

Fixes #1410
