### PR TITLE
PR Fix #1444 - versions should be descending on edit page

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Globalization;
@@ -569,7 +571,9 @@ namespace NuGetGallery
                 PackageId = package.PackageRegistration.Id,
                 PackageTitle = package.Title,
                 Version = package.Version,
-                PackageVersions = packageRegistration.Packages.ToList(),
+                PackageVersions = packageRegistration.Packages
+                    .OrderByDescending(p => new SemanticVersion(p.Version), Comparer<SemanticVersion>.Create((a, b) => a.CompareTo(b)))
+                    .ToList(),
             };
 
             var pendingMetadata = _editPackageService.GetPendingMetadata(package);


### PR DESCRIPTION
Fix #1444 - versions should be shown in descending and logical (not lexical) order on the Edit metadata page.
