### PR TITLE
Fix #1463 by changing HandleQueuedPackageEditsJob to use ExecuteTask

### DIFF
--- a/src/NuGetGallery.Backend/Jobs/HandleQueuedPackageEditsJob.cs
+++ b/src/NuGetGallery.Backend/Jobs/HandleQueuedPackageEditsJob.cs
@@ -18,12 +18,12 @@ namespace NuGetGallery.Backend.Jobs
 
         public override void RunOnce()
         {
-            new HandleQueuedPackageEditsTask
+            ExecuteTask(new HandleQueuedPackageEditsTask
             {
                 ConnectionString = new SqlConnectionStringBuilder(Settings.MainConnectionString),
                 StorageAccount = Settings.MainStorage,
                 WhatIf = Settings.WhatIf
-            }.Execute();
+            });
         }
     }
 } 


### PR DESCRIPTION
Because some idiot made it so you have to execute tasks this way in order for logging to work. Who was that? Oh... right... me...

Fixes #1463 
