### PR TITLE
Fix 1468 Make Description and Authors look 'required' on the edit package metadata page

### DIFF
--- a/src/NuGetGallery/Views/Packages/Edit.cshtml
+++ b/src/NuGetGallery/Views/Packages/Edit.cshtml
@@ -278,7 +278,6 @@
         To edit package dependencies, target frameworks, or license URL, you must upload a new version of the package. 
         Edits to package Icon, Title, and Summary may take a while to be shown in package search results.
     </p>
-    <img src="@Url.Content("~/content/images/required.png")" alt="Blue border on left means required." />
     <input type="submit" value="Save" title="Save" />
     </fieldset>
 }

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -141,7 +141,6 @@
     </ul>
 
     @Html.AntiForgeryToken()
-    <img src="@Url.Content("~/content/images/required.png")" alt="Blue border on left means required." />
     <input type="submit" value="Submit" title="Verify Details &amp; Submit" /> 
     <a class="cancel" href="@Url.CancelUpload()" title="Cancel the upload in progress.">Cancel</a>
 </fieldset>


### PR DESCRIPTION
Fixing #1468. They will now look required until you edit them. And you will get validation errors when you try to submit the form without entering them.
