### PR TITLE
Fix 1453 better uri validation msg

### DIFF
--- a/src/NuGetGallery/Constants.cs
+++ b/src/NuGetGallery/Constants.cs
@@ -44,6 +44,6 @@
         }
 
         public const string UrlValidationRegEx = @"(https?):\/\/[^ ""]+$";
-
+        public const string UrlValidationErrorMessage = "This doesn't appear to be a valid HTTP/HTTPS URL";
     }
 }

--- a/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
@@ -47,7 +47,7 @@ namespace NuGetGallery
         [StringLength(256)]
         [Display(Name = "Icon URL")]
         [DataType(DataType.ImageUrl)]
-        [RegularExpression(Constants.UrlValidationRegEx, ErrorMessage = "This doesn't appear to be a valid URL")]
+        [RegularExpression(Constants.UrlValidationRegEx, ErrorMessage = Constants.UrlValidationErrorMessage)]
         public string IconUrl { get; set; }
 
         [StringLength(1024)]
@@ -62,7 +62,7 @@ namespace NuGetGallery
         [StringLength(256)]
         [Display(Name = "Project Home Page URL")]
         [DataType(DataType.Text)]
-        [RegularExpression(Constants.UrlValidationRegEx, ErrorMessage = "This doesn't appear to be a valid URL")]
+        [RegularExpression(Constants.UrlValidationRegEx, ErrorMessage = Constants.UrlValidationErrorMessage)]
         public string ProjectUrl { get; set; }
 
         [StringLength(512)]


### PR DESCRIPTION
To address #1453 be explicit about http/https urls in the error message.
