### PR TITLE
Fix 1477 space between blue and yellow message banners

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -219,14 +219,13 @@ nav, section { display: block; }
 .pending-edit-message,
 .prerelease-message,
 .not-latest-message {
-    -moz-border-radius: 0 0 5px 5px;
-    -webkit-border-radius: 0 0 5px 5px;
+    -moz-border-radius: 5px 5px 5px 5px;
+    -webkit-border-radius: 5px 5px 5px 5px;
     border: 1px solid;
-    border-radius: 0 0 5px 5px;
-    border-top: none;
+    border-radius: 5px 5px 5px 5px;
     font-size: 1.5em;
-    margin-top: -20px;
-    padding: 10px;
+    margin: -0px 5px 20px 5px;
+    padding: 5px;
     text-align: center;
 }
 


### PR DESCRIPTION
Fixes #1477

![beautifully](https://f.cloud.github.com/assets/2711795/996507/4b5aeb2c-09d1-11e3-9f14-2b8449802a72.png)
