### PR TITLE
Setting CSS properties to max-width and max-height to avoid distorted and blurry upscaled icons

### DIFF
--- a/Website/Content/Site.css
+++ b/Website/Content/Site.css
@@ -741,9 +741,9 @@ ul.dependencySet li {
 
 #sideColumn .logo {
     display: block;
-    height: 128px;
+    max-height: 128px;
     margin: 0 0 20px 0;
-    width: 128px;
+    max-width: 128px;
 }
 
     /* Stats */
@@ -858,8 +858,10 @@ section.package .side {
 }
 
 section.package .side img {
-    height: 50px;
-    width: 50px;
+    display: block;
+    margin: 0 auto;
+    max-width: 48px;
+    max-height: 48px;
 }
 
 /* Package Contents page */


### PR DESCRIPTION
I noticed that in the NuGet Gallery all package icons get scaled to 50&nbsp;×&nbsp;50&nbsp;px / 128&nbsp;×&nbsp;128&nbsp;px. That looks very ugly when the package icon is not square ([example](https://www.nuget.org/packages/Modernizr/)) or has a low resolution. That will result in blurry upscaled icons.

I think max-width and max-height is much better here. In addition I suggest changing the maximum icon size to 48&nbsp;×&nbsp;48&nbsp;px, because that is a common size for icons.
