### PR TITLE
Fix 1525 Package Icons smaller than 50x50 look blurry on nuget.org

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -777,8 +777,8 @@ button.undo-button {
     /* Large Icon 128x128 */
 
 .logo {
-    height: 128px;
-    width: 128px;
+    max-height: 128px;
+    max-width: 128px;
 }
 
 #sideColumn .logo {
@@ -898,8 +898,10 @@ section.package .side {
 }
 
 section.package .side img {
-    height: 50px;
-    width: 50px;
+    display: block;
+    margin: 0 auto;
+    max-width: 48px;
+    max-height: 48px;
 }
 
 /* Package Contents page */


### PR DESCRIPTION
See #1525 for issue, https://github.com/NuGet/NuGetGallery/pull/1524 for original community PR which actually describes issue.
