### PR TITLE
Fix #1569 by de-duplicating license names before insertion

### DIFF
--- a/src/NuGetGallery.Operations/Tasks/UpdateLicenseReportsTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/UpdateLicenseReportsTask.cs
@@ -270,7 +270,7 @@ namespace NuGetGallery.Operations.Tasks
 
                 DataTable licensesNames = new DataTable();
                 licensesNames.Columns.Add("Name", typeof(string));
-                foreach (string license in report.Licenses)
+                foreach (string license in report.Licenses.Select(l => l.Trim()).Distinct(StringComparer.OrdinalIgnoreCase))
                 {
                     licensesNames.Rows.Add(license);
                 }


### PR DESCRIPTION
Fixes #1569.
## Deployment Notes:
- [ ] Deploy the worker, as usual
- [ ] Reset the GallerySettings.NextLicenseReport column to null to refresh all reports.
