### PR TITLE
Fix #1434 by rewriting Icon URLs to be protocol independent

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -28,8 +28,7 @@
     </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
     <TargetFrameworkProfile />
-    <IISExpressSSLPort>
-    </IISExpressSSLPort>
+    <IISExpressSSLPort>443</IISExpressSSLPort>
     <DownloadNuGetExe>true</DownloadNuGetExe>
     <IISExpressAnonymousAuthentication>enabled</IISExpressAnonymousAuthentication>
     <IISExpressWindowsAuthentication>disabled</IISExpressWindowsAuthentication>
@@ -1337,11 +1336,11 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>False</UseIIS>
+          <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>8085</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://nuget.localtest.me</IISUrl>
+          <IISUrl>http://localhost:8085</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/src/NuGetGallery/ViewModels/PackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageViewModel.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
             Version = package.Version;
             Description = package.Description;
             ReleaseNotes = package.ReleaseNotes;
-            IconUrl = package.IconUrl;
+            IconUrl = MakeProtocolIndependent(package.IconUrl);
             ProjectUrl = package.ProjectUrl;
             LicenseUrl = package.LicenseUrl;
             HideLicenseReport = package.HideLicenseReport;
@@ -70,6 +70,17 @@ namespace NuGetGallery
         public bool IsCurrent(IPackageVersionModel current)
         {
             return current.Version == Version && current.Id == Id;
+        }
+
+        private string MakeProtocolIndependent(string url)
+        {
+            Uri parsed;
+            if (!Uri.TryCreate(url, UriKind.Absolute, out parsed))
+            {
+                return url; // Unknown URL type?
+            }
+            // Strip the scheme
+            return url.Substring(parsed.Scheme.Length + 1); // +1 for the colon
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -94,6 +94,9 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\build\NuGetGallery.xunit.targets" />

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -251,6 +251,9 @@
       <Name>NuGetGallery</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <Import Project="$(MSBuildThisFileDirectory)\..\..\build\NuGetGallery.xunit.targets" />

--- a/tests/NuGetGallery.Facts/ViewModels/PackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/PackageViewModelFacts.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using Xunit;
+using Xunit.Extensions;
 
 namespace NuGetGallery.ViewModels
 {
@@ -66,6 +67,22 @@ namespace NuGetGallery.ViewModels
             };
             var packageViewModel = new PackageViewModel(package);
             Assert.NotNull(packageViewModel.LicenseUrl);
+        }
+
+        [Theory]
+        [InlineData("http://foo", "//foo")]
+        [InlineData("https://foo", "//foo")]
+        [InlineData("foo/bar/baz", "foo/bar/baz")]
+        [InlineData("ftp://foo/bar/baz", "//foo/bar/baz")]
+        [InlineData("gopher://foo/bar/baz", "//foo/bar/baz")] // Because why not :)
+        public void IconUrlIsRewritten(string input, string result)
+        {
+            var package = new Package()
+            {
+                IconUrl = input
+            };
+            var viewModel = new PackageViewModel(package);
+            Assert.Equal(result, viewModel.IconUrl);
         }
     }
 }


### PR DESCRIPTION
Fixes #1434 

This shouldn't affect our vague plan to host the icons ourselves, but it's a small fix to get us to always all-SSL (no more mixed content warnings!)
