### PR TITLE
Fix invalid request for angle brackes in verify package metadata

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -589,6 +589,7 @@ namespace NuGetGallery
         [HttpPost]
         [RequiresAccountConfirmation("edit a package")]
         [ValidateAntiForgeryToken]
+        [ValidateInput(false)] // Security note: Disabling ASP.Net input validation which does things like disallow angle brackets in submissions. See http://go.microsoft.com/fwlink/?LinkID=212874
         public virtual ActionResult Edit(string id, string version, EditPackageRequest formData, string returnUrl)
         {
             var package = _packageService.FindPackageByIdAndVersion(id, version);


### PR DESCRIPTION
Framework was treating it as an 'attack' by the customer. Fixes #1614.
