### PR TITLE
Fix #1568 by cleaning job logs older than 7 days

### DIFF
--- a/src/NuGetGallery.Backend/Jobs/CleanJobLogsJob.cs
+++ b/src/NuGetGallery.Backend/Jobs/CleanJobLogsJob.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using System.Data.SqlClient;
+using NuGetGallery.Operations;
+using NuGetGallery.Operations.Tasks.Monitoring;
+
+namespace NuGetGallery.Backend.Jobs
+{
+    [Export(typeof(WorkerJob))]
+    public class CleanJobLogsJob : WorkerJob
+    {
+        public override TimeSpan Period
+        {
+            get
+            {
+                return TimeSpan.FromHours(12);
+            }
+        }
+
+        public override void RunOnce()
+        {
+            ExecuteTask(new CleanJobLogsTask
+            {
+                StorageAccount = Settings.DiagnosticsStorage,
+                WhatIf = Settings.WhatIf,
+                MaxAge = TimeSpan.FromDays(7)
+            });
+        }
+    }
+}

--- a/src/NuGetGallery.Backend/NuGetGallery.Backend.csproj
+++ b/src/NuGetGallery.Backend/NuGetGallery.Backend.csproj
@@ -110,6 +110,7 @@
     </Compile>
     <Compile Include="DebugHelper.cs" />
     <Compile Include="JobRunner.cs" />
+    <Compile Include="Jobs\CleanJobLogsJob.cs" />
     <Compile Include="Jobs\BackupPackagesJob.cs" />
     <Compile Include="Jobs\BackupWarehouseJob.cs" />
     <Compile Include="Jobs\BackupDatabaseJob.cs" />

--- a/src/NuGetGallery.Backend/Settings.cs
+++ b/src/NuGetGallery.Backend/Settings.cs
@@ -17,15 +17,15 @@ namespace NuGetGallery.Backend
         private Uri _licenseReportService;
         private NetworkCredential _licenseReportCredentials;
 
-        public virtual string EnvironmentName { get { return GetSetting("EnvironmentName"); } }
+        public virtual string EnvironmentName { get { return GetSetting("Operations.EnvironmentName"); } }
 
-        public virtual string MainConnectionString { get { return GetSetting("Sql.Primary"); } }
+        public virtual string MainConnectionString { get { return GetSetting("Operations.Sql.Primary"); } }
 
-        public virtual string WarehouseConnectionString { get { return GetSetting("Sql.Warehouse"); } }
+        public virtual string WarehouseConnectionString { get { return GetSetting("Operations.Sql.Warehouse"); } }
 
         public virtual bool WhatIf
         {
-            get { return String.Equals("true", GetSetting("WhatIf"), StringComparison.OrdinalIgnoreCase); }
+            get { return String.Equals("true", GetSetting("Operations.WhatIf"), StringComparison.OrdinalIgnoreCase); }
         }
 
         public virtual Uri SqlDac
@@ -33,7 +33,7 @@ namespace NuGetGallery.Backend
             get
             {
                 return _sqlDac ??
-                    (_sqlDac = new Uri(GetSetting("SqlDac")));
+                    (_sqlDac = new Uri(GetSetting("Operations.SqlDac")));
             }
         }
 
@@ -42,7 +42,7 @@ namespace NuGetGallery.Backend
             get
             {
                 return _licenseReportService ??
-                    (_licenseReportService = new Uri(GetSetting("LicenseReport.Service")));
+                    (_licenseReportService = new Uri(GetSetting("Operations.LicenseReport.Service")));
             }
         }
 
@@ -52,8 +52,8 @@ namespace NuGetGallery.Backend
             {
                 if (_licenseReportCredentials == null)
                 {
-                    string user = GetSetting("LicenseReport.User");
-                    string pass = GetSetting("LicenseReport.Password");
+                    string user = GetSetting("Operations.LicenseReport.User");
+                    string pass = GetSetting("Operations.LicenseReport.Password");
                     _licenseReportCredentials = new NetworkCredential(user, pass);
                 }
                 return _licenseReportCredentials;
@@ -65,7 +65,7 @@ namespace NuGetGallery.Backend
             get
             {
                 return _mainStorage ??
-                    (_mainStorage = GetCloudStorageAccount("Storage.Primary"));
+                    (_mainStorage = GetCloudStorageAccount("Operations.Storage.Primary"));
             }
         }
 
@@ -74,7 +74,16 @@ namespace NuGetGallery.Backend
             get
             {
                 return _backupStorage ??
-                    (_backupStorage = GetCloudStorageAccount("Storage.Backup"));
+                    (_backupStorage = GetCloudStorageAccount("Operations.Storage.Backup"));
+            }
+        }
+
+        public virtual CloudStorageAccount DiagnosticsStorage
+        {
+            get
+            {
+                return _backupStorage ??
+                    (_backupStorage = GetCloudStorageAccount("Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString"));
             }
         }
 
@@ -93,7 +102,6 @@ namespace NuGetGallery.Backend
             string val;
             if (!_overrideSettings.TryGetValue(name, out val))
             {
-                name = "Operations." + name;
                 // Try Azure Config
                 try
                 {

--- a/src/NuGetGallery.Backend/WorkerRole.cs
+++ b/src/NuGetGallery.Backend/WorkerRole.cs
@@ -57,13 +57,13 @@ namespace NuGetGallery.Backend
                 // File Target
                 FileTarget jobLogTarget = new FileTarget()
                 {
-                    FileName = Path.Combine(logDir, "Jobs", "${logger:shortName=true}.${date:yyyy-MM-dd}.log.json"),
+                    FileName = Path.Combine(logDir, "Jobs", "${logger:shortName=true}.${date:yyyy-MM-dd-HHmm}.log.json"),
                 };
                 ConfigureFileTarget(jobLogTarget);
                 config.AddTarget("file", jobLogTarget);
                 FileTarget hostTarget = new FileTarget()
                 {
-                    FileName = Path.Combine(logDir, "Host", "Host.${date:yyyy-MM-dd}.log")
+                    FileName = Path.Combine(logDir, "Host", "Host.${date:yyyy-MM-dd-HHmm}.log")
                 };
                 ConfigureFileTarget(hostTarget);
                 config.AddTarget("file", hostTarget);
@@ -161,7 +161,7 @@ namespace NuGetGallery.Backend
             hostTarget.Encoding = Encoding.UTF8;
             hostTarget.CreateDirs = true;
             hostTarget.EnableFileDelete = true;
-            hostTarget.ArchiveEvery = FileArchivePeriod.Day;
+            hostTarget.ArchiveEvery = FileArchivePeriod.Hour;
             hostTarget.ConcurrentWrites = false;
         }
 

--- a/src/NuGetGallery.Operations/DeploymentEnvironment.cs
+++ b/src/NuGetGallery.Operations/DeploymentEnvironment.cs
@@ -24,6 +24,8 @@ namespace NuGetGallery.Operations
 
         public CloudStorageAccount BackupStorage { get; private set; }
 
+        public CloudStorageAccount DiagnosticsStorage { get; private set; }
+
         public Uri SqlDacEndpoint { get; private set; }
 
         public Uri LicenseReportService { get; private set; }
@@ -41,6 +43,7 @@ namespace NuGetGallery.Operations
 
             MainStorage = GetCloudStorageAccount("Operations.Storage.Primary");
             BackupStorage = GetCloudStorageAccount("Operations.Storage.Backup") ?? MainStorage;
+            DiagnosticsStorage = GetCloudStorageAccount("Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString") ?? MainStorage;
 
             SqlDacEndpoint = Get("Operations.SqlDac", str => new Uri(str, UriKind.Absolute));
 

--- a/src/NuGetGallery.Operations/Infrastructure/JobLogEntry.cs
+++ b/src/NuGetGallery.Operations/Infrastructure/JobLogEntry.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 using NLog;
 
 namespace NuGetGallery.Operations.Infrastructure
@@ -10,9 +11,21 @@ namespace NuGetGallery.Operations.Infrastructure
     {
         public DateTimeOffset Timestamp { get; set; }
         public string Message { get; set; }
-        public string Level { get; set; }
+        public LogLevel Level { get; set; }
         public Exception Exception { get; set; }
         public string Logger { get; set; }
-        public LogEventInfo FullEvent { get; set; }
+        public JobLogEvent FullEvent { get; set; }
+    }
+
+    public class JobLogEvent
+    {
+        public int SequenceID { get; set; }
+        public DateTime TimeStamp { get; set; }
+        public LogLevel Level { get; set; }
+        public string LoggerName { get; set; }
+        public string LoggerShortName { get; set; }
+        public string Message { get; set; }
+        public string[] Parameters { get; set; }
+        public string FormattedMessage { get; set; }
     }
 }

--- a/src/NuGetGallery.Operations/Infrastructure/LogLevelConverter.cs
+++ b/src/NuGetGallery.Operations/Infrastructure/LogLevelConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
@@ -19,7 +20,6 @@ namespace NuGetGallery.Operations.Infrastructure
             if (reader.TokenType == JsonToken.String)
             {
                 var ret = LogLevel.FromString((string)reader.Value);
-                reader.Read();
                 return ret;
             }
             else if (reader.TokenType == JsonToken.StartObject)
@@ -30,7 +30,10 @@ namespace NuGetGallery.Operations.Infrastructure
                     reader.Read();
                     if (reader.TokenType == JsonToken.String)
                     {
-                        return LogLevel.FromString((string)reader.Value);
+                        string val = (string)reader.Value;
+                        reader.Read();
+                        Debug.Assert(reader.TokenType == JsonToken.EndObject);
+                        return LogLevel.FromString(val);
                     }
                 }
             }

--- a/src/NuGetGallery.Operations/NuGetGallery.Operations.csproj
+++ b/src/NuGetGallery.Operations/NuGetGallery.Operations.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Tasks\ListPackageBlobBackupsTask.cs" />
     <Compile Include="Tasks\LowerCaseAllPackageBlobsTask.cs" />
     <Compile Include="Tasks\IBackupDatabase.cs" />
+    <Compile Include="Tasks\Monitoring\CleanJobLogsTask.cs" />
     <Compile Include="Tasks\Monitoring\ListJobLogsTask.cs" />
     <Compile Include="Tasks\Monitoring\TailJobLogTask.cs" />
     <Compile Include="Tasks\OpsTask.cs" />

--- a/src/NuGetGallery.Operations/Tasks/Monitoring/CleanJobLogsTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/Monitoring/CleanJobLogsTask.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using NuGetGallery.Operations.Infrastructure;
+
+namespace NuGetGallery.Operations.Tasks.Monitoring
+{
+    [Command("cleanjoblogs", "Cleans old job logs", AltName="cjl")]
+    public class CleanJobLogsTask : DiagnosticsStorageTask
+    {
+        [Option("The maximum allowed age. Provide a value as expected by TimeSpan.Parse. Default: 07.00:00 (7 days)")]
+        public TimeSpan? MaxAge { get; set; }
+
+        public override void ValidateArguments()
+        {
+            base.ValidateArguments();
+
+            if (MaxAge == null)
+            {
+                MaxAge = TimeSpan.FromDays(7);
+            }
+        }
+
+        public override void ExecuteCommand()
+        {
+            // Start by fetching the latest log
+            var joblogs = JobLog.LoadJobLogs(StorageAccount);
+
+            // Iterate over each log
+            foreach (var joblog in joblogs)
+            {
+                Log.Info("Cleaning {0}", joblog.JobName);
+                foreach (var blob in joblog.Blobs.Where(b => (DateTime.UtcNow - b.ArchiveTimestamp) > MaxAge.Value))
+                {
+                    try
+                    {
+                        if (!WhatIf)
+                        {
+                            // Only delete if it matches.
+                            blob.Blob.DeleteIfExists(
+                                accessCondition: AccessCondition.GenerateIfMatchCondition(blob.Blob.Properties.ETag));
+                        }
+                        Log.Info("Deleted {0}", blob.Blob.Name);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.ErrorException("Failed to delete " + blob.Blob.Name, ex);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NuGetGallery.Operations/Tasks/Monitoring/ListJobLogsTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/Monitoring/ListJobLogsTask.cs
@@ -11,7 +11,7 @@ using NuGetGallery.Operations.Infrastructure;
 namespace NuGetGallery.Operations.Tasks.Monitoring
 {
     [Command("listjoblogs", "Lists available job logs", AltName="ljl")]
-    public class ListJobLogsTask : StorageTask
+    public class ListJobLogsTask : DiagnosticsStorageTask
     {
         public override void ExecuteCommand()
         {

--- a/src/NuGetGallery.Operations/Tasks/Monitoring/TailJobLogTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/Monitoring/TailJobLogTask.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -10,7 +11,7 @@ using NuGetGallery.Operations.Infrastructure;
 namespace NuGetGallery.Operations.Tasks.Monitoring
 {
     [Command("tailjoblog", "Show the last few entries from a job log and optionally polls for additional results", AltName = "tjl", MinArgs = 1, MaxArgs = 1)]
-    public class TailJobLogTask : StorageTask
+    public class TailJobLogTask : DiagnosticsStorageTask
     {
         private DateTimeOffset _lastEntryUtc = DateTimeOffset.MinValue;
 
@@ -53,9 +54,12 @@ namespace NuGetGallery.Operations.Tasks.Monitoring
                 // Grab the requested entries
                 var log = candidates.Single();
                 var entries = log.OrderedEntries().Take(NumberOfEntries.Value).Reverse();
+                Log.Info("The following are from the Log for: {0}", log.JobName);
+
+                var logger = LogManager.GetLogger("joblog." + log.JobName);
                 foreach (var entry in entries)
                 {
-                    WriteEntry(log, entry);
+                    WriteEntry(logger, log, entry);
                     _lastEntryUtc = entry.Timestamp;
                 }
 
@@ -73,16 +77,26 @@ namespace NuGetGallery.Operations.Tasks.Monitoring
 
             // Grab new entries
             var entries = log.OrderedEntries().TakeWhile(l => l.Timestamp > _lastEntryUtc).Take(NumberOfEntries.Value);
+            var logger = LogManager.GetLogger("joblog." + log.JobName);
             foreach (var entry in entries)
             {
-                WriteEntry(log, entry);
+                WriteEntry(logger, log, entry);
                 _lastEntryUtc = entry.Timestamp;
             }
         }
 
-        private void WriteEntry(JobLog log, JobLogEntry entry)
+        private void WriteEntry(Logger logger, JobLog log, JobLogEntry entry)
         {
-            Log.Log(entry.FullEvent);
+            LogEventInfo evt = new LogEventInfo(
+                entry.FullEvent.Level,
+                entry.FullEvent.LoggerName,
+                CultureInfo.CurrentCulture,
+                entry.FullEvent.FormattedMessage,
+                new object[0])
+                {
+                    TimeStamp = entry.Timestamp.LocalDateTime
+                };
+            logger.Log(evt);
         }
     }
 }

--- a/src/NuGetGallery.Operations/Tasks/OpsTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/OpsTask.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery.Operations
         
         public Logger Log
         {
-            get { return _logger ?? (_logger = LogManager.GetLogger(GetType().Name)); }
+            get { return _logger ?? (_logger = LogManager.GetLogger("task." + GetType().Name)); }
             set { _logger = value; }
         }
 

--- a/src/NuGetGallery.Operations/Tasks/TaskBases.cs
+++ b/src/NuGetGallery.Operations/Tasks/TaskBases.cs
@@ -59,6 +59,14 @@ namespace NuGetGallery.Operations
         }
     }
 
+    public abstract class DiagnosticsStorageTask : StorageTaskBase
+    {
+        protected override CloudStorageAccount GetStorageAccountFromEnvironment(DeploymentEnvironment environment)
+        {
+            return environment.DiagnosticsStorage;
+        }
+    }
+
     public abstract class DatabaseTaskBase : OpsTask
     {
         [Option("Connection string to the relevant database server", AltName = "db")]

--- a/src/galops/Program.cs
+++ b/src/galops/Program.cs
@@ -14,7 +14,7 @@ namespace NuGetGallery.Operations.Tools
     [Export]
     class Program
     {
-        private Logger _logger = LogManager.GetLogger("Program");
+        private Logger _logger = LogManager.GetLogger("task.Program");
 
         public HelpCommand HelpCommand { get; set; }
 
@@ -104,10 +104,16 @@ namespace NuGetGallery.Operations.Tools
             {
                 Layout = "${message}"
             };
+            var joblogTarget = new SnazzyConsoleTarget()
+            {
+                Layout = "[${date:format=yyyy-MM-dd} ${date:format=HH}:${date:format=mm}:${date:format=ss}] ${message}"
+            };
 
             var config = new LoggingConfiguration();
-            config.AddTarget("console", consoleTarget);
-            config.LoggingRules.Add(new LoggingRule("*", LogLevel.Trace, consoleTarget));
+            config.AddTarget("task", consoleTarget);
+            config.AddTarget("joblog", joblogTarget);
+            config.LoggingRules.Add(new LoggingRule("joblog.*", LogLevel.Trace, joblogTarget));
+            config.LoggingRules.Add(new LoggingRule("task.*", LogLevel.Trace, consoleTarget));
 
             LogManager.Configuration = config;
         }


### PR DESCRIPTION
Fixes #1568 
# Test Notes
- Check the current status of the "wad-joblogs" container on the diagnostics storage account (which is the same as the normal storage account for non-Prod environments). We should see logs that are MORE than 7 days old.
- Deploy the worker to QA/Staging/etc. (NOTE: Staging has not really had an active worker so while it should be updated, it'll be difficult to test)
- Within a few minutes, the jobs should clear down to 7 days. If not, let @anurse know. It may take 12 hours to clean down
