### PR TITLE
initial commit

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -1290,6 +1290,14 @@ ul.pager li.next { padding-left: 10px; }
     stroke-width: 1.5px;
 }
 
+.line-graph-dot {
+    fill: steelblue;
+}
+
+.line-graph-dot:hover {
+    fill: orange;
+}
+
     /* NuGet Badge */
 
 .nuget-badge code {

--- a/src/NuGetGallery/Scripts/statsgraphs.js
+++ b/src/NuGetGallery/Scripts/statsgraphs.js
@@ -149,5 +149,18 @@ var drawMonthlyDownloadsLineChart = function () {
         .datum(data)
         .attr("class", "line")
         .attr("d", line);
+
+    var formatDownloads = d3.format(',');
+
+    svg.selectAll('.point')
+        .data(data)
+        .enter()
+        .append("svg:circle")
+        .attr("class", "line-graph-dot")
+        .attr("cx", function (d) { return xScale(d.month); })
+        .attr("cy", function (d) { return yScale(d.downloads); })
+        .attr("r", 5)
+        .append("title")
+            .text(function (d) { return formatDownloads(d.downloads); });
 }
 


### PR DESCRIPTION
Fixes #1669 

Added dots and hover to show exact number on line graph of downloads on statistics page.

The point of this is obviously the hover text - the dot gives you something to hover over.

For the hover text, toLocaleString() did not behave consistently on all the browsers (on IE it shows .00 ) so I resorted to d3.format which is not particularly localized (as far as I know) but is consistent with the axis formatting - so this is really a more correct solution

not sure we were tracking an issue for this one yet. fix is very simple and localized anyhow.

So far I've tested on Firefox, IE, Chrome and Opera
