### PR TITLE
Fix #1554 by adding some word breaking styles

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -448,7 +448,7 @@ div #Register {
 }
 
 hgroup.page-heading h1,
-hgroup.page-heading h2 { display: inline; word-break: break-all; }
+hgroup.page-heading h2 { display: inline-block; word-break: break-all; }
 
 hgroup.page-heading h2 { padding-left: 7px; }
 
@@ -753,6 +753,7 @@ button.undo-button {
 
 .edit-root {
     font-size: 1.3em;
+    display: inline-block;
     word-break: break-all;
 }
 
@@ -943,6 +944,8 @@ section.package header { margin-bottom: 5px; }
 
 section.package h1 {
     font-size: 1.75em;
+    display: inline-block;
+    word-break: break-all;
     margin: 0;
 }
 


### PR DESCRIPTION
Fixes #1554 

Now it does this:
![image](https://f.cloud.github.com/assets/7574/1386713/47c4b4b2-3b7b-11e3-8ed5-c8ec1abbd316.png)
Not perfect, but better.

Also, fixed word breaking on the package details page:
![image](https://f.cloud.github.com/assets/7574/1386715/5fd8793a-3b7b-11e3-83a3-2d5f660b0c1e.png)
