### PR TITLE
Changed default value on friendly names switch

### DIFF
--- a/src/NuGetGallery/Configuration/FeatureConfiguration.cs
+++ b/src/NuGetGallery/Configuration/FeatureConfiguration.cs
@@ -11,7 +11,7 @@ namespace NuGetGallery.Configuration
         /// <summary>
         /// Gets a boolean indicating if license reports are enabled.
         /// </summary>
-        [DefaultValue(false)] // Default: Disabled
+        [DefaultValue(true)] // Default: Enabled
         [Description("Displays reports on license data")]
         public bool FriendlyLicenses { get; set; }
     }

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -62,7 +62,8 @@
         <add key="Gallery.HasWorker" value="false" />
 
         <!-- Feature Configuration -->
-        <add key="Feature.FriendlyLicenses" value="false" />
+        <!-- Set to false to disable this feature. Default is enabled. -->
+        <add key="Feature.FriendlyLicenses" value="" />
         
         <!-- ***************** -->
         <!-- ASP.Net settings. -->


### PR DESCRIPTION
Decided to just change the default rather than remove the switch, could be something people don't want on their custom galleries.

Fixes #1675 
