### PR TITLE
Fixes #1641 - Accept License flag was getting cleared by an automatic edit

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -749,27 +749,28 @@ namespace NuGetGallery
                 }
             }
 
-            return View(
-                new VerifyPackageRequest
+            var model = new VerifyPackageRequest
+            {
+                Id = packageMetadata.Id,
+                Version = packageMetadata.Version.ToNormalizedStringSafe(),
+                LicenseUrl = packageMetadata.LicenseUrl.ToEncodedUrlStringOrNull(),
+                Listed = true,
+                Edit = new EditPackageVersionRequest
                 {
-                    Id = packageMetadata.Id,
-                    Version = packageMetadata.Version.ToNormalizedStringSafe(),
+                    Authors = packageMetadata.Authors.Flatten(),
+                    Copyright = packageMetadata.Copyright,
+                    Description = packageMetadata.Description,
+                    IconUrl = packageMetadata.IconUrl.ToEncodedUrlStringOrNull(),
                     LicenseUrl = packageMetadata.LicenseUrl.ToEncodedUrlStringOrNull(),
-                    Listed = true,
-                    Edit = new EditPackageVersionRequest
-                    {
-                        Authors = packageMetadata.Authors.Flatten(),
-                        Copyright = packageMetadata.Copyright,
-                        Description = packageMetadata.Description,
-                        IconUrl = packageMetadata.IconUrl.ToEncodedUrlStringOrNull(),
-                        ProjectUrl = packageMetadata.ProjectUrl.ToEncodedUrlStringOrNull(),
-                        ReleaseNotes = packageMetadata.ReleaseNotes,
-                        RequiresLicenseAcceptance = packageMetadata.RequireLicenseAcceptance,
-                        Summary = packageMetadata.Summary,
-                        Tags = PackageHelper.ParseTags(packageMetadata.Tags),
-                        VersionTitle = packageMetadata.Title,
-                    }
-                });
+                    ProjectUrl = packageMetadata.ProjectUrl.ToEncodedUrlStringOrNull(),
+                    ReleaseNotes = packageMetadata.ReleaseNotes,
+                    RequiresLicenseAcceptance = packageMetadata.RequireLicenseAcceptance,
+                    Summary = packageMetadata.Summary,
+                    Tags = PackageHelper.ParseTags(packageMetadata.Tags),
+                    VersionTitle = packageMetadata.Title,
+                }
+            };
+            return View(model);
         }
 
         [Authorize]

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -93,7 +93,7 @@
         <li>@EditableField("Tags", m => m.Edit.Tags)</li>
         <li>@EditableField("Release Notes", m => m.Edit.ReleaseNotes, pre: true)</li>
 
-        @if (!String.IsNullOrEmpty(Model.Edit.LicenseUrl))
+        @if (!String.IsNullOrEmpty(Model.LicenseUrl))
         {
             <li>
                 <h4>Requires License Acceptance


### PR DESCRIPTION
Fixes #1641 - Accept License flag was getting cleared by an automatic edit created by the verify package metadata page.
