### PR TITLE
Fixes #1014 - whole UI jumping due to social button render issues (butto...

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -212,8 +212,10 @@
     { 
         <p>Requires NuGet @Model.MinClientVersion or higher.</p>
     }
-    <div><a href="https://twitter.com/share" class="twitter-share-button" data-url="@absolutePackageUrl" data-text="Check out @Model.Id on #NuGet!">Tweet</a></div>
-    <div class="fb-like" data-href="@absolutePackageUrl" data-send="false" data-width="450" data-show-faces="true"></div>
+    <div id="socialbuttons" style="height: 60px; display: block;">
+        <div><a href="https://twitter.com/share" class="twitter-share-button" data-url="@absolutePackageUrl" data-text="Check out @Model.Id on #NuGet!">Tweet</a></div>
+        <div class="fb-like" data-href="@absolutePackageUrl" data-send="false" data-width="450" data-show-faces="true"></div>
+    </div>
 
     @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
     {


### PR DESCRIPTION
Fixes #1014 - whole UI jumping due to social button render issues (button area still look a bit jumpy with this fix but now it wont affect rest of this page)
