### PR TITLE
Fixed error message in ReportMypackage form

### DIFF
--- a/src/NuGetGallery/ViewModels/ReportAbuseViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ReportAbuseViewModel.cs
@@ -53,7 +53,7 @@ namespace NuGetGallery
         [Display(Name = "Reason")]
         public ReportPackageReason? Reason { get; set; }
 
-        [Required]
+        [Required(ErrorMessage = "Please enter a message.")]
         [AllowHtml]
         [StringLength(4000)]
         [Display(Name = "Abuse Report")]

--- a/src/NuGetGallery/Views/Packages/ContactOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ContactOwners.cshtml
@@ -25,6 +25,7 @@
                 @Html.TextAreaFor(m => m.Message, 10, 50, null)
                 @Html.ValidationMessageFor(m => m.Message)
             </div>
+            <img src="@Url.Content("~/content/images/required.png")" alt="Blue border on left means required." />
             <input type="submit" value="Send" title="Send your message to the owners of '@Model.PackageId'" />
         </fieldset>
     }

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -62,6 +62,7 @@
             @Html.TextAreaFor(m => m.Message, 10, 50, null)
             @Html.ValidationMessageFor(m => m.Message, null, new { id = "report-abuse-message" })
         </div>
+        <img src="@Url.Content("~/content/images/required.png")" alt="Blue border on left means required." />
         @Html.SpamPreventionFields()
         <input id="form-submit" type="submit" value="Report" title="Report '@Model.PackageId' for abuse" />
     </fieldset>

--- a/src/NuGetGallery/Views/Packages/ReportMyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportMyPackage.cshtml
@@ -37,6 +37,7 @@
             @Html.TextAreaFor(m => m.Message, 10, 50, null)
             @Html.ValidationMessageFor(m => m.Message, null, new { id = "report-abuse-message" })
         </div>
+        <img src="@Url.Content("~/content/images/required.png")" alt="Blue border on left means required." />
         @Html.SpamPreventionFields()
         <input type="submit" value="Report" title="Report your problem with '@Model.PackageId'" />
     </fieldset>


### PR DESCRIPTION
Fixes #1750 . The error message is updated to be generic. Also the "Required" icon that we show in login/signin pages is added to the ContactOwners/ReportAbuse Forms.

Tested the following scenarios manually : 
1. ContactOwner and ContactSupport while logged in as package owner.
2. ReportAbuse and ContactOwner without logging in.
3. ReportAbuse and ContactOwner while logged in as a normal user ( who is not the owner of the current package).
