### PR TITLE
Better UX for failed package edits. Successful package edits delete any ...

### DIFF
--- a/src/NuGetGallery/Content/PageStylings.css
+++ b/src/NuGetGallery/Content/PageStylings.css
@@ -109,6 +109,7 @@
 /* Messages on package page (Display Package) */
 
 .pending-edit-message,
+.failed-edit-message,
 .prerelease-message,
 .not-latest-message {
     -moz-border-radius: 5px 5px 5px 5px;

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -28,16 +28,24 @@ namespace NuGetGallery
 
         public void SetPendingMetadata(PackageEdit pendingMetadata)
         {
-            HasPendingMetadata = true;
-            Authors = pendingMetadata.Authors;
-            Copyright = pendingMetadata.Copyright;
-            Description = pendingMetadata.Description;
-            IconUrl = pendingMetadata.IconUrl;
-            LicenseUrl = pendingMetadata.LicenseUrl;
-            ProjectUrl = pendingMetadata.ProjectUrl;
-            ReleaseNotes = pendingMetadata.ReleaseNotes;
-            Tags = pendingMetadata.Tags.ToStringSafe().Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
-            Title = pendingMetadata.Title;
+            if (pendingMetadata.TriedCount < 3)
+            {
+                HasPendingMetadata = true;
+                Authors = pendingMetadata.Authors;
+                Copyright = pendingMetadata.Copyright;
+                Description = pendingMetadata.Description;
+                IconUrl = pendingMetadata.IconUrl;
+                LicenseUrl = pendingMetadata.LicenseUrl;
+                ProjectUrl = pendingMetadata.ProjectUrl;
+                ReleaseNotes = pendingMetadata.ReleaseNotes;
+                Tags = pendingMetadata.Tags.ToStringSafe().Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                Title = pendingMetadata.Title;
+            }
+            else
+            {
+                HasPendingMetadata = false;
+                IsLastEditFailed = true;
+            }
         }
 
         public DependencySetsViewModel Dependencies { get; set; }
@@ -45,6 +53,7 @@ namespace NuGetGallery
         public string Copyright { get; set; }
 
         public bool HasPendingMetadata { get; private set; }
+        public bool IsLastEditFailed { get; private set; }
 
         public bool HasNewerPrerelease
         {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -163,6 +163,14 @@
             </fieldset>
         }
     }
+    @if (Model.HasEditFailures)
+    {
+        <p class="failed-edit-message">
+            Your last edit to this package was not successfully applied. 
+            You can <a href="@Url.EditPackage(Model.Id, Model.Version)>edit</a> 
+            the package and submit the edit again to retry the edit.
+        </p>
+    }
     @if (Model.Prerelease)
     {
         <p class="prerelease-message">


### PR DESCRIPTION
...failed pending edits for that package. Failed package edits are represented as such to the package owner. To address #1541.
