### PR TITLE
Combined error message in ReportAbuse

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -326,8 +326,7 @@ namespace NuGetGallery
             ReportPackageReason.IsFraudulent,
             ReportPackageReason.ViolatesALicenseIOwn,
             ReportPackageReason.ContainsMaliciousCode,
-            ReportPackageReason.HasABug,
-            ReportPackageReason.FailedToInstall,
+            ReportPackageReason.HasABugOrFailedToInstall,          
             ReportPackageReason.Other
         };
 

--- a/src/NuGetGallery/ViewModels/ReportAbuseViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ReportAbuseViewModel.cs
@@ -12,8 +12,8 @@ namespace NuGetGallery
         [Description("Other")]
         Other,
 
-        [Description("The package has a bug")]
-        HasABug,
+        [Description("The package has a bug/failed to install")]
+        HasABugOrFailedToInstall,
 
         [Description("The package contains malicious code")]
         ContainsMaliciousCode,
@@ -31,10 +31,7 @@ namespace NuGetGallery
         PublishedWithWrongVersion,
 
         [Description("The package was not intended to be published publically on nuget.org")]
-        ReleasedInPublicByAccident,
-
-        [Description("The package failed to install")]
-        FailedToInstall,
+        ReleasedInPublicByAccident,       
     }
 
     public class ReportAbuseViewModel
@@ -47,8 +44,7 @@ namespace NuGetGallery
         [Display(Name = "Contacted Owner")]
         public bool AlreadyContactedOwner { get; set; }
 
-        [NotEqual(ReportPackageReason.HasABug, ErrorMessage = "Unfortunately we cannot provide support for bugs in NuGet Packages. You should contact the owner(s) for assistance.")]
-        [NotEqual(ReportPackageReason.FailedToInstall, ErrorMessage = "Unfortunately we cannot provide support for bugs in NuGet Packages. You should contact the owner(s) for assistance.")]
+        [NotEqual(ReportPackageReason.HasABugOrFailedToInstall, ErrorMessage = "Unfortunately we cannot provide support for bugs in NuGet Packages. Please contact owner(s) for assistance.")]       
         [Required(ErrorMessage = "You must select a reason for reporting the package")]
         [Display(Name = "Reason")]
         public ReportPackageReason? Reason { get; set; }

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -78,7 +78,7 @@
                 $form.validate().element($('#Reason'));
             }
 
-            if (val === 'HasABug') {
+            if (val === 'HasABugOrFailedToInstall') {
                 $form.find("input, textarea, select").not('#form-field-reason *').attr('disabled', 'disabled');
             } else {
                 $form.find("input, textarea, select").not('#form-field-reason').removeAttr('disabled');


### PR DESCRIPTION
Fixes #1724 

Clubbed "package has a bug" and "package failed to install" to one single reason. When this option is chosen an error message will be popped out and all other fields will be disabled.

Manually tested the below:

Report abuse after logging in and chose "Package has a bug/Failed to install".
Report abuse without logging in and chose "Package has a bug/Failed to install".
Switch back and forth between reasons and make sure the fields get disabled and enabled appropriately.
