### PR TITLE
Fix for home page stats issue

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Home.html
+++ b/src/NuGetGallery/App_Data/Files/Content/Home.html
@@ -44,3 +44,9 @@
      title="Creating and submitting a package">how to create and publish a package</a>.
    If you don't plan on submitting a package, there's no need to register.</p>
 
+<script src="/Scripts/stats.js">
+</script>
+<script>
+    $(getStats);
+</script>
+

--- a/src/NuGetGallery/Scripts/stats.js
+++ b/src/NuGetGallery/Scripts/stats.js
@@ -11,7 +11,7 @@
         section.show();
     });
 
-    setTimeout(function () { getStats(currData); }, 30000);
+    setTimeout(function () { getStats(currData); }, 120000);
 }
 
 function update(data, currData, key) {

--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -16,6 +16,7 @@
 
         <link href="@Url.Content("~/favicon.ico")" rel="shortcut icon" type="image/x-icon" />
         @Scripts.Render("~/Scripts/modernizr")
+        @Scripts.Render("~/Scripts/jquery")
         @ViewHelpers.AnalyticsScript()
         @RenderSection("TopScripts", required: false)
         @ViewHelpers.ReleaseMeta()


### PR DESCRIPTION
Fixes #1788 
Added the scripts section to the home page.
Also increased the time interval in which the stats gets updated from 30 minutes to 2 minutes --> since this is an getting total stats is an expensive DB operation ( see #1736 ) and it is not required to update it every 30 seconds as aggregate stats get updated only every 5 minutes in the backend.

Verified Home Page and other pages in IE and chrome.
