### PR TITLE
Fix #1828 - In Search results, "By:" is in different font size than

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -497,6 +497,10 @@ fieldset.search {
     padding: 0;
 }
 
+#owners-subheader {
+    font-size: 1em;
+}
+
 /* List Package */
 
 section.package {

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -9,8 +9,8 @@
     <div class="main">
         <header>
             <h1><a href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)">@Model.Title</a></h1>
+            <h2 id="owners-subheader">By:</h2>
             <ul class="owners">
-                <li>By:</li>
                 @foreach (var owner in Model.Owners)
                 {
                     <li><a href="@Url.User(owner)" title="@owner.Username">@owner.Username</a></li>


### PR DESCRIPTION
Owner's names, looks weird

Fix Font Size of 'By: ' in search results
