### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,9 @@ If this fails, you are likely to get more useful output by passing -Debug than -
  2. In an ADMIN powershell prompt, run the .\build\Enable-LocalTestMe.ps1 file. It allows non-admins to host websites at: http://nuget.localtest.me, it configures an IIS Express site at that URL and creates a self-signed SSL certificate. For more information on localtest.me, check out [readme.localtest.me](readme.localtest.me)
  3. If you're having trouble, go to the Project Properties for the Website project, click on the Web tab and change the URL to localhost:port where _port_ is some port number above 1024.
 
-7. Ensure the 'NuGetGallery' project (under the Frontend folder) is set to the Startup Project
+7. Change the value of Gallery.ConfirmEmailAddresses to false in Web.Config file under src\NuGetGallery, this is required to upload the packages after registration.
+
+8. Ensure the 'NuGetGallery' project (under the Frontend folder) is set to the Startup Project
   
 
 That's it! You should now be able to press Ctrl-F5 to run the site!


### PR DESCRIPTION
Added missing step to change the value of Gallery.ConfirmEmailAddresses to false in Readme.

Change the value of Gallery.ConfirmEmailAddresses to false in Web.Config file under src\NuGetGallery, this is required to upload the packages after registration.
