### PR TITLE
Disable stats temporarily

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -118,8 +118,8 @@ namespace NuGetGallery
                         DependentPackage = Request.Headers["NuGet-DependentPackage"],
                         ProjectGuids = Request.Headers["NuGet-ProjectGuids"],
                     };
-
-                    PackageService.AddDownloadStatistics(stats);
+                   //Temporarily disable stats.
+                   // PackageService.AddDownloadStatistics(stats);
                 }
                 catch (ReadOnlyModeException)
                 {

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -336,7 +336,8 @@ namespace NuGetGallery
                 var actionResult = new EmptyResult();
                 var controller = new TestableApiController(MockBehavior.Strict);
                 controller.MockPackageService.Setup(x => x.FindPackageByIdAndVersion(PackageId, "1.0.1", false)).Returns(package);
-                controller.MockPackageService.Setup(x => x.AddDownloadStatistics(It.IsAny<PackageStatistics>())).Verifiable();
+                //Disable it temporarily as AddDownloadStats is not being invoked currently
+                // controller.MockPackageService.Setup(x => x.AddDownloadStatistics(It.IsAny<PackageStatistics>())).Verifiable();
                 controller.MockPackageFileService.Setup(s => s.CreateDownloadPackageActionResultAsync(HttpRequestUrl, PackageId, package.NormalizedVersion))
                               .Returns(Task.FromResult<ActionResult>(actionResult))
                               .Verifiable();
@@ -410,7 +411,8 @@ namespace NuGetGallery
                 var actionResult = new EmptyResult();
                 var controller = new TestableApiController(MockBehavior.Strict);
                 controller.MockPackageService.Setup(x => x.FindPackageByIdAndVersion(PackageId, "", false)).Returns(package);
-                controller.MockPackageService.Setup(x => x.AddDownloadStatistics(It.IsAny<PackageStatistics>())).Verifiable();
+                //Disable it temporarily as AddDownloadStats is not being invoked currently
+               // controller.MockPackageService.Setup(x => x.AddDownloadStatistics(It.IsAny<PackageStatistics>())).Verifiable();
 
                 controller.MockPackageFileService.Setup(s => s.CreateDownloadPackageActionResultAsync(HttpRequestUrl, PackageId, package.NormalizedVersion))
                               .Returns(Task.FromResult<ActionResult>(actionResult))


### PR DESCRIPTION
Disabled the download stats for now.
Updated the related unit tests.

Tested manually to make sure that no entry to added to PackageStatistics table during package download.
