### PR TITLE
Fix #1791 by only sending confirmation email if ConfirmEmailAddresses is true

### DIFF
--- a/src/NuGetGallery/Controllers/AppController.cs
+++ b/src/NuGetGallery/Controllers/AppController.cs
@@ -54,7 +54,7 @@ namespace NuGetGallery
     {
         private Lazy<User> _currentUser;
         
-        public ConfigurationService Config { get; private set; }
+        public ConfigurationService Config { get; internal set; }
         public User CurrentUser { get { return _currentUser.Value; } }
 
         public NuGetContext(AppController ctrl)

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -135,8 +135,8 @@ namespace NuGetGallery
                     }
 
                     user = await AuthService.Register(
-                        model.Register.Username, 
-                        model.Register.EmailAddress, 
+                        model.Register.Username,
+                        model.Register.EmailAddress,
                         result.Credential);
                 }
                 else
@@ -154,13 +154,16 @@ namespace NuGetGallery
             }
 
             // Send a new account email
-            MessageService.SendNewAccountEmail(
-                new MailAddress(user.User.UnconfirmedEmailAddress, user.User.Username),
-                Url.ConfirmationUrl(
-                    "Confirm", 
-                    "Users", 
-                    user.User.Username, 
-                    user.User.EmailConfirmationToken));
+            if(NuGetContext.Config.Current.ConfirmEmailAddresses && !String.IsNullOrEmpty(user.User.UnconfirmedEmailAddress))
+            {
+                MessageService.SendNewAccountEmail(
+                    new MailAddress(user.User.UnconfirmedEmailAddress, user.User.Username),
+                    Url.ConfirmationUrl(
+                        "Confirm",
+                        "Users",
+                        user.User.Username,
+                        user.User.EmailConfirmationToken));
+            }
 
             // We're logging in!
             AuthService.CreateSession(OwinContext, user.User);

--- a/tests/NuGetGallery.Facts/Framework/TestContainer.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestContainer.cs
@@ -10,6 +10,7 @@ using Microsoft.Owin;
 using Moq;
 using Ninject;
 using Ninject.Modules;
+using NuGetGallery.Configuration;
 using Xunit.Extensions;
 
 namespace NuGetGallery.Framework
@@ -43,6 +44,7 @@ namespace NuGetGallery.Framework
             if (appCtrl != null)
             {
                 appCtrl.OwinContext = Kernel.Get<IOwinContext>();
+                appCtrl.NuGetContext.Config = Kernel.Get<ConfigurationService>();
             }
             
             return c;


### PR DESCRIPTION
Fixes #1791 
# Test Notes:

For NuGet.org, we need only test that confirmation emails are still sent (because we set ConfirmEmailAddresses to true). There is no need to spend cycles testing the ConfirmEmailAddresses=false case pre-deployment. We can circle back if necessary and follow up with those who were affected by this issue.
