### PR TITLE
Fix #1784 by updating owner link styles

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -88,7 +88,8 @@
             @GravatarImage(owner.EmailAddress, owner.Username, size)
         }
         @if (showName)
-        {<text>@owner.Username</text>
+        {
+            <span class="owner-name">@owner.Username</span>
         }
     </a>
 }

--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -339,10 +339,19 @@ ul.owners {
 
 ul.owners li { margin-bottom: 12px; }
 
+a.owner {
+    font-size: 1.4em;
+}
+
+    a.owner span.owner-name {
+        display: inline-block;
+        position: relative;
+        top: -0.5em;
+    }
+
 a.owner:hover {
     text-decoration: none;
     color: #333;
-    font-size: 1.4em;
 }
 
 .owner-image { margin-right: 5px; }


### PR DESCRIPTION
Fixes #1784

![image](https://f.cloud.github.com/assets/7574/2035062/f6f0f12e-8934-11e3-88bd-350473594918.png)

Looks the same on hover except the font color turns black (as it did before). Font size remains constant.
