### PR TITLE
Fix #1749 by using word-wrap instead of word-break

### DIFF
--- a/src/NuGetGallery/Content/PageStylings.css
+++ b/src/NuGetGallery/Content/PageStylings.css
@@ -174,7 +174,8 @@ button.undo-button {
 
 .edit-root {
     display: inline-block;
-    word-break: break-all;
+    -ms-word-wrap: break-word;
+    word-wrap: break-word;
     font-size: 1.3em;
 }
 

--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -508,6 +508,11 @@ section.package {
     padding-top: 10px;
 }
 
+    section.package div.main header.package-list-header {
+        width: 820px;
+        overflow: hidden;
+    }
+
     section.package div.minimum-client-version {
         float: right;
     }
@@ -537,12 +542,13 @@ section.package {
     section.package ul,
     section.package li { display: inline; }
 
-section.package h1 {
-    font-size: 1.75em;
-    display: inline-block;
-    word-break: break-all;
-    margin: 0;
-}
+    section.package h1 {
+        font-size: 1.75em;
+        display: inline-block;
+        -ms-word-wrap: break-word;
+        word-wrap: break-word;
+        margin: 0;
+    }
 
     section.package p {
         line-height: 1.25em;

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -7,7 +7,7 @@
         </a>
     </div>
     <div class="main">
-        <header>
+        <header class="package-list-header">
             <h1><a href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)">@Model.Title</a></h1>
             <h2 id="owners-subheader">By:</h2>
             <ul class="owners">


### PR DESCRIPTION
Fixes #1749 

Turns out word-break is for CJK characters specifically. 'word-wrap' is the CSS property I wanted.

![image](https://f.cloud.github.com/assets/7574/2035275/b6deda12-8937-11e3-8429-7656d2e17790.png)

![image](https://f.cloud.github.com/assets/7574/2035279/c08687d6-8937-11e3-9c2c-300a529daead.png)

There's not much we can do if there are literally no spaces in the phrase unfortunately. The text will be clipped:
![image](https://f.cloud.github.com/assets/7574/2035304/0a5976b6-8938-11e3-8aa8-21b5acd8fb99.png)
