### PR TITLE
Issue #431 - moved owner names out of disabled textbox and into paragraph

### DIFF
--- a/src/NuGetGallery/Views/Packages/ContactOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ContactOwners.cshtml
@@ -17,8 +17,8 @@
             <legend>Contact Owners</legend>
             @Html.AntiForgeryToken()
             <div class="form-field">
-                <label for="NotUsed">To</label>
-                <input name="NotUsed" type="text" value="@owners" disabled="disabled" />
+                <label>To</label>
+                <p class="authors"><strong>@owners</strong></p>
             </div>
             <div class="form-field">
                 @Html.LabelFor(m => m.Message)


### PR DESCRIPTION
Address issue #431 by taking owner names out of input box (which is NotUsed for input anyway) and into a plain paragraph to improve contrast. Threw in `<strong />` just for good measure.
