### PR TITLE
Fixed issue #1976 - invalid date time format in Enable-LocalTestMe.ps1

### DIFF
--- a/tools/Enable-LocalTestMe.ps1
+++ b/tools/Enable-LocalTestMe.ps1
@@ -95,7 +95,7 @@ if($cert.Length -eq 0) {
 if($cert.Length -eq 0) {
     Write-Host "Generating a Self-Signed SSL Certificate for $Subdomain.localtest.me"
     # Generate one
-    & $MakeCertPath -r -pe -n "CN=$Subdomain.localtest.me" -b `"$([DateTime]::Now.ToString("MM/dd/yyy"))`" -e `"$([DateTime]::Now.AddYears(10).ToString("MM/dd/yyy"))`" -eku 1.3.6.1.5.5.7.3.1 -ss root -sr localMachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12
+    & $MakeCertPath -r -pe -n "CN=$Subdomain.localtest.me" -b `"$([DateTime]::Now.ToString("MM\/dd\/yyy"))`" -e `"$([DateTime]::Now.AddYears(10).ToString("MM\/dd\/yyy"))`" -eku 1.3.6.1.5.5.7.3.1 -ss root -sr localMachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12
     $cert = @(dir -l "Cert:\LocalMachine\Root" | where {$_.Subject -eq "CN=$Subdomain.localtest.me"})
 }
 


### PR DESCRIPTION
The "/" character is seen as the date separator and thus on systems, where the date separator is set to some other character `.ToString("MM/dd/yyy")` produces the date in a wrong format.
