### PR TITLE
Fix the run test scripts. 

### DIFF
--- a/tests/Scripts/RunEverythingy.cmd
+++ b/tests/Scripts/RunEverythingy.cmd
@@ -1,8 +1,4 @@
 @echo off
-SETLOCAL ENABLEDELAYEDEXPANSION
-
-Echo Set environment variable RunFuntionalTests to True to enable running the functional tests
-set RunFuntionalTests=true
 
 Echo Clear previulsly defined GalleryUrl
 set GalleryURl=
@@ -16,7 +12,7 @@ SET GalleryUrl=%Param%
 REM If GalleryUrl is still not defined, the default is to use int.nugettest.org
 if "%GalleryUrl%"=="" (
 ECHO Setting GalleryUrl to the default - int.nugettest.org
-SET GalleryUrl=https://int.nugettest.org
+SET GalleryUrl=https://int.nugettest.org/
 )
 ECHO The NuGet gallery tests are running against %GalleryUrl%
 
@@ -43,5 +39,4 @@ Echo Finished running NuGet Gallery Functional tests...
 Echo Exit.
 
 :End
-endlocal
 exit /b 0

--- a/tests/Scripts/TestRunSetupScript.cmd
+++ b/tests/Scripts/TestRunSetupScript.cmd
@@ -1,5 +1,4 @@
 @echo off
-SETLOCAL ENABLEDELAYEDEXPANSION
 
 set RunFunctionalTests=true
 set TestAccountName=testnuget@gmail.com
@@ -15,7 +14,7 @@ Echo Set the gallery Url...
 set galleryUrl=%1
 if "%galleryUrl%" == "" (
 Echo Setting galleryUrl to the default - int.nugettest.org
-set galleryUrl=https://int.nugettest.org
+set galleryUrl=https://int.nugettest.org/
 )
 Echo The gallery Url was set to %galleryUrl%
 Echo.
@@ -34,8 +33,7 @@ copy /y \\nuget-ci\drops\%branch%\latest-successful\nuget.exe .\..\.nuget\
 Echo.
 
 Echo Set APIKey for the gallery...
-.\..\.nuget\nuget.exe setAPIKey 0f9b12ee-876a-408b-bf27-3f5392c24ae1 -Source %galleryUrl%/api/v2/package/
+.\..\.nuget\nuget.exe setAPIKey 0f9b12ee-876a-408b-bf27-3f5392c24ae1 -Source %galleryUrl%api/v2/package/
 Echo Done.
 
-endlocal
 exit /b 0


### PR DESCRIPTION
The tests use environmental variable such as RunFunctionalTests etc. Remove setlocal so that the environmental variables take longer effect.

Also unify the format of URL, for the use of script parameters.
