### PR TITLE
Issue #1019 - Deeplink to NuGet Package Explorer

### DIFF
--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -132,6 +132,19 @@ namespace NuGetGallery
             return version == null ? EnsureTrailingSlash(result) : result;
         }
 
+        public static string ExplorerDeepLink(this UrlHelper url, int feedVersion, string id, string version)
+        {
+            string routeName = "v" + feedVersion + RouteName.DownloadPackage;
+            string protocol = url.RequestContext.HttpContext.Request.IsSecureConnection ? "https" : "http";
+            string urlResult = url.RouteUrl(routeName, new { Id = id }, protocol: protocol);
+
+            urlResult = EnsureTrailingSlash(urlResult);
+
+            string explorerDeepLink = @"https://npe.codeplex.com/releases/clickonce/NuGetPackageExplorer.application?url={0}&id={1}&version={2}";
+
+            return string.Format(explorerDeepLink, urlResult, id, version);
+        }
+
         public static string LogOn(this UrlHelper url)
         {
             return url.RouteUrl(RouteName.Authentication, new { action = "LogOn" });

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -78,6 +78,7 @@
             @if (User.Identity.IsAuthenticated)
             {
                 <li><a href="@Url.PackageDownload(2, Model.Id, Model.Version)" title="Download the raw nupkg file.">Download</a></li>
+                <li><a href="@Url.ExplorerDeepLink(2, Model.Id, Model.Version)" title="Explore the nupkg with the NuGet Package Explorer (IE only)">Package Explorer</a></li>
             }
             else
             {


### PR DESCRIPTION
Basic implemetation for https://github.com/NuGet/NuGetGallery/issues/1019

Currently the NPE Addess is hardcoded - could be moved to the web.config.

Another issue: Deeplinking with Chrome seems to be buggy (see http://stackoverflow.com/questions/13670030/why-is-activationuri-null-by-using-chrome)
