### PR TITLE
Fix #1482 Account Link in Admin Area

### DIFF
--- a/src/NuGetGallery/Views/Shared/UserDisplay.cshtml
+++ b/src/NuGetGallery/Views/Shared/UserDisplay.cshtml
@@ -8,7 +8,7 @@
     }
     else
     {
-        <span class="welcome"><a href="@Url.Action(actionName: "Account", controllerName: "Users")">@(User.Identity.Name)</a></span>
+        <span class="welcome"><a href="@Url.Action("Account", "Users", new { area = "" })">@(User.Identity.Name)</a></span>
         <text>/</text>
         <span class="user-actions">
             <a href="@Url.LogOff()">Sign out</a>


### PR DESCRIPTION
Issue: https://github.com/NuGet/NuGetGallery/issues/1482

Did resolve a) - b/c seems to work.
a. The link to your account in the header,
b. The "Contact Us" link in the footer, or
c. The "Terms of Use" or "Privacy Policy" links in the footer.
