### PR TITLE
Fix for #658 - noindex and message for unlisted packages

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -16,6 +16,12 @@
     <meta property="og:determiner"  content="a" />
     <meta property="og:image"       content="@(Model.IconUrl ?? Url.Absolute("~/Content/Images/packageDefaultIcon.png"))" />
 }
+@section Meta {
+    @if (!Model.Listed)
+    {
+    <meta name="robots" content="noindex">
+    }
+}
 @section BottomScripts {
     @* Facebook SDK *@
     <div id="fb-root"></div>
@@ -192,13 +198,23 @@
         <p>@line</p>
     }
 
-    @if (!Model.Listed && Model.IsOwner(User))
+    @if (!Model.Listed)
     {
-        <p  class="message warning">
-            This package is unlisted and hidden from package listings.
-            You can see the package because you are one of its owners. To list the package again, 
-            <a href="@Url.DeletePackage(Model)">change its listing setting</a>.
-        </p>
+        if(Model.IsOwner(User))
+        { 
+            <p  class="message warning">
+                This package is unlisted and hidden from package listings.
+                You can see the package because you are one of its owners. To list the package again, 
+                <a href="@Url.DeletePackage(Model)">change its listing setting</a>.
+            </p>
+        }
+        else
+        {
+            <p  class="message warning">
+                The owner has unlisted this package. 
+                This could mean that the package is deprecated or shouldn't be used anymore.
+            </p>
+        }
     }
     <p>
         To install @Model.Title, run the following command in the <a href="http://docs.nuget.org/docs/start-here/using-the-package-manager-console">

--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -4,6 +4,8 @@
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         @RenderSection("OpenGraph", required: false)
+        @RenderSection("Meta", required: false)
+
         <title>
             @(Config.Current.Brand) 
             @(String.IsNullOrWhiteSpace(ViewBag.Title) ? "" : "| " + ViewBag.Title)</title>

--- a/src/NuGetGallery/Views/Shared/TwoColumnLayout.cshtml
+++ b/src/NuGetGallery/Views/Shared/TwoColumnLayout.cshtml
@@ -5,6 +5,9 @@
 @section OpenGraph {
     @RenderSection("OpenGraph", required: false)
 }
+@section Meta {
+    @RenderSection("Meta", required: false)
+}
 
 <div id="sideColumn">
     @RenderSection("SideColumn")


### PR DESCRIPTION
Fix for issue https://github.com/NuGet/NuGetGallery/issues/658

I added a new section "Meta" to the layout pages and if the package is unlisted the noindex meta tag is rendered. 
Because unlisted packages can still be found via Google and co. or if someone know the exact url I also added a visible warning box for non-owners as well ("The owner has unlisted this package. This could mean that the package is deprecated or shouldn't be used anymore.").
