### PR TITLE
Fix the EditPackage tests. 

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Fluent/EditPackageAsPartOfUploadTest.cs
+++ b/tests/NuGetGallery.FunctionalTests.Fluent/EditPackageAsPartOfUploadTest.cs
@@ -77,7 +77,8 @@ namespace NuGetGallery.FunctionalTests.Fluent
             string expectedDescription = @"p:contains('" + newDescription + "')";
             string unexpectedSummary = @"contains('" + newSummary + "')";
             string unexpectedIconUrl = "img[src='" + newIconUrl + "']";
-            string expectedIconUrl = "img[src='/Content/Images/packageDefaultIcon.png']";
+            string defaultIconUrl = UrlHelper.BaseUrl + "Content/Images/packageDefaultIcon.png";
+            string expectedIconUrl = "img[src='" + defaultIconUrl + "']";
             string expectedHomePageUrl = "a[href='" + newHomePageUrl + "']";
             string unexpectedCopyright = @"contains('" + newCopyright + "')";
             string expectedReleaseNotes = @"p:contains('" + newReleaseNotes + "')";

--- a/tests/NuGetGallery.FunctionalTests.Fluent/EditPackageTest.cs
+++ b/tests/NuGetGallery.FunctionalTests.Fluent/EditPackageTest.cs
@@ -68,7 +68,8 @@ namespace NuGetGallery.FunctionalTests.Fluent
             string expectedDescription = @"p:contains('" + newDescription + "')";
             string unexpectedSummary = @"contains('" + newSummary + "')";
             string unexpectedIconUrl = "img[src='" + newIconUrl + "']";
-            string expectedIconUrl = "img[src='/Content/Images/packageDefaultIcon.png']";
+            string defaultIconUrl = UrlHelper.BaseUrl + "Content/Images/packageDefaultIcon.png";
+            string expectedIconUrl = "img[src='" + defaultIconUrl + "']";
             string expectedHomePageUrl = "a[href='" + newHomePageUrl + "']";
             string unexpectedCopyright = @"contains('" + newCopyright + "')";
             string expectedReleaseNotes = @"p:contains('" + newReleaseNotes + "')";


### PR DESCRIPTION
Failures was due to unmatching URL in expected and actual page source. 
