### PR TITLE
Update DownloadReport_NuGetClientVersion.sql

### DIFF
--- a/src/NuGetGallery.Operations/Scripts/DownloadReport_NuGetClientVersion.sql
+++ b/src/NuGetGallery.Operations/Scripts/DownloadReport_NuGetClientVersion.sql
@@ -7,6 +7,6 @@ WHERE Dimension_Date.[Date] >= CONVERT(DATE, DATEADD(day, -42, GETDATE()))
   AND Dimension_Date.[Date] < CONVERT(DATE, GETDATE())
   AND Dimension_UserAgent.ClientCategory = 'NuGet'
   AND Dimension_UserAgent.ClientMajorVersion <= 2
-  AND Dimension_UserAgent.ClientMinorVersion <= 7
+  AND Dimension_UserAgent.ClientMinorVersion <= 8
 GROUP BY Dimension_UserAgent.ClientMajorVersion, Dimension_UserAgent.ClientMinorVersion
 ORDER BY Dimension_UserAgent.ClientMajorVersion, Dimension_UserAgent.ClientMinorVersion


### PR DESCRIPTION
We need to update this code too if we want to see new versions of NuGet client. (This is intentional to offer a little protection from false versions appearing in results.)
