### PR TITLE
Fix the last 3 functional test failures:

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Helpers/ClientSDKHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Helpers/ClientSDKHelper.cs
@@ -209,7 +209,9 @@ namespace NuGetGallery.FunctionTests.Helpers
         {
             string packageVersion = ClientSDKHelper.GetLatestStableVersion(packageId);
             string expectedDownloadedNupkgFileName = packageId + "." + packageVersion;
-            if(Directory.Exists(Path.Combine(Environment.CurrentDirectory, expectedDownloadedNupkgFileName)))
+            string pathToNupkgFolder = Path.Combine(Environment.CurrentDirectory, expectedDownloadedNupkgFileName);
+            Console.WriteLine("Path to the downloaded Nupkg file for clearing local package folder is: " + pathToNupkgFolder);
+            if(Directory.Exists(pathToNupkgFolder))
                 Directory.Delete(expectedDownloadedNupkgFileName, true);
         }
 
@@ -236,6 +238,7 @@ namespace NuGetGallery.FunctionTests.Helpers
             string expectedDownloadedNupkgFileName = packageId + "." + packageVersion;
             //check if the nupkg file exists on the expected path post install
             string expectedNupkgFilePath = Path.Combine(Environment.CurrentDirectory, expectedDownloadedNupkgFileName, expectedDownloadedNupkgFileName + ".nupkg");
+            Console.WriteLine("The expected Nupkg file path after package install is: " + expectedNupkgFilePath);
             if ((!File.Exists(expectedNupkgFilePath)))
             {
                 Console.WriteLine(" Package file {0} not present after download", expectedDownloadedNupkgFileName);

--- a/tests/NuGetGallery.FunctionalTests.Helpers/CmdLineHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Helpers/CmdLineHelper.cs
@@ -37,8 +37,8 @@ namespace NuGetGallery.FunctionTests.Helpers
         /// <param name="sourceName"></param>
         /// <returns></returns>
         public static int UploadPackage(string packageFullPath, string sourceName, out string standardOutput, out string standardError)
-        {            
-            return InvokeNugetProcess(string.Join(string.Empty, new string[] { PushCommandString, @"""" + packageFullPath + @"""",SourceSwitchString, sourceName }), out standardError, out standardOutput);            
+        {
+            return InvokeNugetProcess(string.Join(string.Empty, new string[] { PushCommandString, @"""" + packageFullPath + @"""", SourceSwitchString, sourceName }), out standardError, out standardOutput);         
         }
 
         /// <summary>
@@ -52,6 +52,20 @@ namespace NuGetGallery.FunctionTests.Helpers
             string standardOutput = string.Empty;
             string standardError = string.Empty;
             return InvokeNugetProcess(string.Join(string.Empty, new string[] { InstallCommandString, packageId, SourceSwitchString, sourceName}), out standardError, out standardOutput);
+        }
+
+        /// <summary>
+        ///  Install the specified package using Nuget.exe, specifying the output directory
+        /// </summary>
+        /// <param name="packageId">package to be installed</param>
+        /// <param name="sourceName">source url</param>
+        /// <param name="outputDirectory">outputDirectory</param>
+        /// <returns></returns>
+        public static int InstallPackage(string packageId, string sourceName, string outputDirectory)
+        {
+            string standardOutput = string.Empty;
+            string standardError = string.Empty;
+            return InvokeNugetProcess(string.Join(string.Empty, new string[] { InstallCommandString, packageId, SourceSwitchString, sourceName, OutputDirectorySwitchString, outputDirectory }), out standardError, out standardOutput);
         }
 
         /// <summary>
@@ -81,6 +95,7 @@ namespace NuGetGallery.FunctionTests.Helpers
         {
             Process nugetProcess = new Process();
             string pathToNugetExe = Path.Combine(Environment.CurrentDirectory, NugetExePath);
+            Console.WriteLine("The NuGet.exe command to be executed is: " + pathToNugetExe + " " + arguments);
 
             // During the actual test run, a script will copy the latest NuGet.exe and overwrite the existing one
             ProcessStartInfo nugetProcessStartInfo = new ProcessStartInfo(pathToNugetExe);

--- a/tests/NuGetGallery.FunctionalTests.Helpers/UrlHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Helpers/UrlHelper.cs
@@ -119,6 +119,11 @@ namespace NuGetGallery.FunctionTests.Helpers
             get { return UrlHelper.V2FeedRootUrl + WebMatrixCuratedFeedUrlSuffix; }
         }
 
+        public static string DotnetCuratedFeedUrl
+        {
+            get { return UrlHelper.V2FeedRootUrl + DotnetCuratedFeedUrlSuffix; }
+        }
+
         public static string AccountPageUrl
         {
             get { return UrlHelper.BaseUrl + AccountPageUrlSuffix; }
@@ -165,6 +170,7 @@ namespace NuGetGallery.FunctionTests.Helpers
         private const string VerifyUploadPageUrlSuffix = "/packages/verify-upload";
         private const string Windows8CuratedFeedUrlSuffix = "curated-feeds/windows8-packages/";
         private const string WebMatrixCuratedFeedUrlSuffix = "curated-feeds/webmatrix/";
+        private const string DotnetCuratedFeedUrlSuffix = "curated-feeds/microsoftdotnet/";
         private const string AccountPageUrlSuffix = "/account";
         private const string ManageMyPackagesUrlSuffix = "/account/Packages";
         #endregion UrlSuffix

--- a/tests/NuGetGallery.FunctionalTests/ClientIntegrationTests/NuGetCommandLineTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ClientIntegrationTests/NuGetCommandLineTests.cs
@@ -37,7 +37,7 @@ namespace NuGetGallery.FunctionalTests.ClientIntegrationTests
         {
            string packageId = Constants.TestPackageId; //try to down load a pre-defined test package.          
            ClientSDKHelper.ClearLocalPackageFolder(packageId);
-           int exitCode = CmdLineHelper.InstallPackage(packageId, UrlHelper.V2FeedRootUrl);
+           int exitCode = CmdLineHelper.InstallPackage(packageId, UrlHelper.V2FeedRootUrl, Environment.CurrentDirectory);
            Assert.IsTrue((exitCode == 0), "The package install via Nuget.exe didnt suceed properly. Check the logs to see the process error and output stream");
            Assert.IsTrue(ClientSDKHelper.CheckIfPackageInstalled(packageId), "Package install failed. Either the file is not present on disk or it is corrupted. Check logs for details");
 

--- a/tests/NuGetGallery.FunctionalTests/Features/CuratedFeedTest.cs
+++ b/tests/NuGetGallery.FunctionalTests/Features/CuratedFeedTest.cs
@@ -255,13 +255,13 @@ namespace NuGetGallery.FunctionalTests.Features
         public void SearchMicrosoftDotNetCuratedFeed()
         {
             string packageId = "microsoft.aspnet.webpages";
-            WebRequest request = WebRequest.Create(UrlHelper.V2FeedRootUrl + @"curated-feeds/microsoftdotnet/Packages()?$filter=tolower(Id)%20eq%20'" + packageId + "'&$orderby=Id&$skip=0&$top=30");
+            WebRequest request = WebRequest.Create(UrlHelper.DotnetCuratedFeedUrl + @"Packages()?$filter=tolower(Id)%20eq%20'" + packageId + "'&$orderby=Id&$skip=0&$top=30");
             // Get the response.          
             WebResponse response = request.GetResponse();
             StreamReader sr = new StreamReader(response.GetResponseStream());
             string responseText = sr.ReadToEnd();
-            Assert.IsTrue(responseText.Contains(@"<id>" + UrlHelper.V2FeedRootUrl + "Packages(Id='" + packageId));          
-
+            string packageURL = @"<id>" + UrlHelper.DotnetCuratedFeedUrl + "Packages(Id='" + packageId;
+            Assert.IsTrue(responseText.ToLowerInvariant().Contains(packageURL.ToLowerInvariant()));          
         }
     }
 }

--- a/tests/NuGetGallery.FunctionalTests/WebUITests/UploadAndDownload/AggregateStatsAfterDownload.cs
+++ b/tests/NuGetGallery.FunctionalTests/WebUITests/UploadAndDownload/AggregateStatsAfterDownload.cs
@@ -36,7 +36,7 @@
             //wait either the download count changes or till 5 minutes which ever is earlier.
             int waittime = 0;
             int aggregateStatsAfterDownload = aggregateStatsBeforeDownload;
-            while (aggregateStatsAfterDownload == aggregateStatsBeforeDownload && waittime <= 300)
+            while (aggregateStatsAfterDownload == aggregateStatsBeforeDownload && waittime <= 600)
             {
                 //send a request stats to keep polling the new download count.
                 statsRequestBeforeDownload = GetWebRequestForAggregateStats();


### PR DESCRIPTION
1. increase the timeout for verifying aggregatestats after uploading and then downloading a package
2. fixed the dotnetcuratedsearchtest by comparing strings all using lower cases
3. fixed the downloadusingNuGetcommandline tests by explicitly specifying the outputdirectory for nuget.exe install
