### PR TITLE
Fix 2029: 150% Zoom & IE = Thinner Searchbox

### DIFF
--- a/src/NuGetGallery/Content/Layout.css
+++ b/src/NuGetGallery/Content/Layout.css
@@ -148,6 +148,7 @@ nav.main {
     width: 690px;
     padding-left: 5px;
     padding-right: 4px;
+    padding-top: 1px;
     vertical-align: top;
 }
 


### PR DESCRIPTION
I'm not sure what caused this and I couldn't reproduce it when the "div id="service-alert"" had some content in it ("... Development Environment... "), but in production this div is empty.

The padding-top should fix the issue and I didn't notice any visual changes in IE/Chrome (besides the fix ;) ).

Issue: https://github.com/NuGet/NuGetGallery/issues/2029
