### PR TITLE
added a basic RSS feed on the package detail site for issue 541

### DIFF
--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -96,6 +96,12 @@ namespace NuGetGallery
                 "packages/{id}/owners/{username}/confirm/{token}",
                 new { controller = "Packages", action = "ConfirmOwner" });
 
+            routes.MapRoute(
+                RouteName.DisplayPackageFeed,
+                "packages/{id}/feed",
+                new { controller = "Packages", action = "Feed" });
+
+
             // We need the following two routes (rather than just one) due to Routing's 
             // Consecutive Optional Parameter bug. :(
             var packageDisplayRoute = routes.MapRoute(

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -965,6 +965,7 @@
     <None Include="Scripts\jquery-1.11.0.intellisense.js" />
     <Content Include="Scripts\jquery-1.11.0.js" />
     <Content Include="Scripts\jquery-1.11.0.min.js" />
+    <Compile Include="Results\FeedResult.cs" />
     <Compile Include="Services\ConfirmOwnershipResult.cs" />
     <Compile Include="Services\CuratedFeedService.cs" />
     <Compile Include="Services\ICuratedFeedService.cs" />

--- a/src/NuGetGallery/Results/FeedResult.cs
+++ b/src/NuGetGallery/Results/FeedResult.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel.Syndication;
+using System.Web;
+using System.Web.Mvc;
+using System.Xml;
+
+namespace NuGetGallery.Results
+{
+    public class RssResult : FileResult
+    {
+        private readonly SyndicationFeed _feed;
+
+        /// <summary>
+        /// Creates a new instance of RssResult
+        /// based on this sample 
+        /// http://www.developerzen.com/2009/01/11/aspnet-mvc-rss-feed-action-result/
+        /// </summary>
+        /// <param name="feed">The feed to return the user.</param>
+        public RssResult(SyndicationFeed feed)
+            : base("application/rss+xml")
+        {
+            _feed = feed;
+        }
+
+        /// <summary>
+        /// Creates a new instance of RssResult
+        /// </summary>
+        /// <param name="title">The title for the feed.</param>
+        /// <param name="feedItems">The items of the feed.</param>
+        public RssResult(string title, List<SyndicationItem> feedItems)
+            : base("application/rss+xml")
+        {
+            _feed = new SyndicationFeed(title, title, HttpContext.Current.Request.Url) { Items = feedItems };
+        }
+
+        protected override void WriteFile(HttpResponseBase response)
+        {
+            using (XmlWriter writer = XmlWriter.Create(response.OutputStream))
+            {
+                _feed.GetRss20Formatter().WriteTo(writer);
+            }
+        }
+    } 
+}

--- a/src/NuGetGallery/RouteNames.cs
+++ b/src/NuGetGallery/RouteNames.cs
@@ -9,6 +9,7 @@
         public const string Account = "Account";
         public const string Profile = "Profile";
         public const string DisplayPackage = "package-route";
+        public const string DisplayPackageFeed = "DisplayPackageFeed";
         public const string DownloadPackage = "DownloadPackage";
         public const string DownloadNuGetExe = "DownloadNuGetExe";
         public const string Home = "Home";

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -80,6 +80,11 @@ namespace NuGetGallery
             return url.Action(actionName: "UndoPendingEdits", controllerName: "Packages", routeValues: new { id = package.Id, version = package.Version });
         }
 
+        public static string PackageFeed(this UrlHelper url, string id)
+        {
+            return url.RouteUrl(RouteName.DisplayPackageFeed, new { id }, protocol: null);
+        }
+
         public static string Package(this UrlHelper url, string id)
         {
             return url.Package(id, null, scheme: null);

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -21,6 +21,7 @@
     {
     <meta name="robots" content="noindex">
     }
+    <link rel="alternate" type="application/rss+xml" title="Package Feed" href="@Url.PackageFeed(Model.Id)">
 }
 @section BottomScripts {
     @* Facebook SDK *@
@@ -100,6 +101,7 @@
             {
                 <li><a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics">Package Statistics</a></li>
             }
+            <li><a href="@Url.PackageFeed(Model.Id)" title="Subscribe to the Package Feed">Package Feed</a></li>
         </ul>
     </nav>
 


### PR DESCRIPTION
I added a very basic feed to the package detail site. It uses the SyndicationItem/SyndicationFeed APIs, but doesn't use the existing NuGet OData Feed System. With this the "public feed syndication" feature would be independent to any API changes. 

RSS might be a bit "old school", but there are some pretty cool scenarios possible in combination with IFTTT etc.

Related issue: https://github.com/NuGet/NuGetGallery/issues/541
