### PR TITLE
Fix for #1186 - Title Attribute for Outercurve Foundation Image Link

### DIFF
--- a/src/NuGetGallery/Views/Shared/LayoutFooter.cshtml
+++ b/src/NuGetGallery/Views/Shared/LayoutFooter.cshtml
@@ -21,7 +21,7 @@
     </li>
 </ul>
 <div class="license">
-    <a href="http://outercurve.org"><img src="@Href("~/Content/Logos/outercurve.png")" alt="Outercurve Foundation" /></a>
+    <a title="Outercurve Foundation" href="http://outercurve.org"><img src="@Href("~/Content/Logos/outercurve.png")" alt="Outercurve Foundation" /></a>
     <p>
         &copy; @DateTime.UtcNow.Year Outercurve Foundation -
         <a href="~/policies/Terms">Terms of Use</a> -


### PR DESCRIPTION
Should fix this issue by providing a simple title attribute: https://github.com/NuGet/NuGetGallery/issues/1186
