### PR TITLE
'Search Packages' for Search Button for Accessibility  #1187

### DIFF
--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -33,7 +33,7 @@
                         <div id="searchBox" role="search">
                             <form action="@Url.PackageList()" method="get">
                                 <input name="q" id="searchBoxInput" class="expanding-search" placeholder="Search Packages" value="@(String.IsNullOrEmpty(ViewBag.SearchTerm) ? "" : ViewBag.SearchTerm)" autocomplete="off" />
-                                <input id="searchBoxSubmit" type="submit" value="Search Packages" />
+                                <input id="searchBoxSubmit" type="submit" value="Submit" />
                             </form>
                         </div>
                         @Html.Partial("UserDisplay")


### PR DESCRIPTION
Should fix this: https://github.com/NuGet/NuGetGallery/issues/1187

I just changed the value to 'Search Packages' and didn't notice any negative impact in Chrome and IE11.
