### PR TITLE
fixes upload and prevent doubleclick for #430

### DIFF
--- a/src/NuGetGallery/Scripts/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/async-file-upload.js
@@ -1,16 +1,18 @@
 ﻿var AsyncFileUploadManager = new function () {
-    var _isWebkitBrowser = $.browser.webkit;
+    var _isWebkitBrowser = false; // $.browser.webkit is not longer supported on jQuery
     var _iframeId = '__fileUploadFrame';
     var _pollingInterval = 200;
     var _pingUrl;
     var _failureCount;
     var _isUploadInProgress;
-    
+
     this.init = function (pingUrl, formId, jQueryUrl) {
         _pingUrl = pingUrl;
 
         // attach the sumbit event to the form
         $('#' + formId).submit(function () {
+            $('#' + formId).find(':submit').attr('disabled', 'disabled');
+            $('#' + formId).find(':submit').val('Uploading...');
             submitForm(this);
             return false;
         });
@@ -72,7 +74,7 @@
         if (!result.FileName) {
             return;
         }
-        
+
         setProgressIndicator(percent, result.FileName);
         if (percent < 100) {
             setTimeout(getProgress, _pollingInterval);


### PR DESCRIPTION
The issue https://github.com/NuGet/NuGetGallery/issues/430 is very old and apart from the original issue text the complete AsyncFileUploadManager had a major bug in this line.
var _isWebkitBrowser = $.browser.webkit; 

The $.browser was deprecaded in jQuery 1.9 and this line prevent the async file upload. The same error can be seen on NuGet.org.

In the PR I set the isWebkitBrowser to false but I think the code could be removed.

With this in place I disabled the submit button on "submit" to prevent doubleclicking and the async file upload works again.
Tested in Chrome and IE11.

As far as I know the iFrame Workaround is not needed with modern browsers. Let me know if I should delete the _isWebkitBrowser reference and the iFrame building code.
