### PR TITLE
Don't gitignore Branding Views Packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ src/NuGetGallery/App_Data/Files/Uploads
 src/NuGetGallery/App_Data/Mail
 src/NuGetGallery/App_Data/Lucene
 !src/NuGetGallery/Views/Packages/
+!src/NuGetGallery/Branding/Views/Packages/
 !src/NuGetGallery.Operations/Tasks/Backups/
 !src/NuGetGallery.Cloud/*Content/bin
 


### PR DESCRIPTION
The 'Packages' folder in Branding was being ignored, making it hard to get files into git with the standard workflow. Now excluding it from gitignore like the 'Packages' folder in the normal Views.
