### PR TITLE
Support Branded Layout.cshtml

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Views/_ViewStart.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/_ViewStart.cshtml
@@ -1,3 +1,5 @@
 ﻿@{
-    Layout = "~/Views/Shared/Layout.cshtml";
+    Layout = File.Exists(Server.MapPath("~/Branding/Views/Shared/Layout.cshtml"))
+        ? "~/Branding/Views/Shared/Layout.cshtml"
+        : "~/Views/Shared/Layout.cshtml";
 }

--- a/src/NuGetGallery/Views/_ViewStart.cshtml
+++ b/src/NuGetGallery/Views/_ViewStart.cshtml
@@ -1,3 +1,5 @@
 ﻿@{
-    Layout = "~/views/Shared/Layout.cshtml";
+    Layout = File.Exists(Server.MapPath("~/Branding/Views/Shared/Layout.cshtml"))
+        ? "~/Branding/Views/Shared/Layout.cshtml"
+        : "~/Views/Shared/Layout.cshtml";
 }


### PR DESCRIPTION
Currently you can override all views in Branding, except Layout.cshtml
because ViewStart refers to the one in the regular Views, ignoring the
one in Branding if it exists.

Added a check to see if Branding Layout exists and use that one if it's
present.
