### PR TITLE
Added minimal twitter card integration for Issue 2067

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -5,16 +5,22 @@
     Layout = "~/Views/Shared/TwoColumnLayout.cshtml";
     var absolutePackageUrl = Url.Absolute(Url.Package(Model.Id));
 }
-@section OpenGraph {
+@section SocialMeta {
     @if(!String.IsNullOrWhiteSpace(ViewBag.FacebookAppID)) {
         <meta property="fb:app_id" content="@ViewBag.FacebookAppID" /> 
     }
+    
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:site" content="@("@nuget")"> 
+
     <meta property="og:title"       content="@Model.Title" />
     <meta property="og:type"        content="nugetgallery:package" /> 
     <meta property="og:url"         content="@absolutePackageUrl" /> 
     <meta property="og:description" content="@Model.Description" /> 
     <meta property="og:determiner"  content="a" />
     <meta property="og:image"       content="@(Model.IconUrl ?? Url.Absolute("~/Content/Images/packageDefaultIcon.png"))" />
+    
+
 }
 @section Meta {
     @if (!Model.Listed)

--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        @RenderSection("OpenGraph", required: false)
+        @RenderSection("SocialMeta", required: false)
         @RenderSection("Meta", required: false)
 
         <title>

--- a/src/NuGetGallery/Views/Shared/TwoColumnLayout.cshtml
+++ b/src/NuGetGallery/Views/Shared/TwoColumnLayout.cshtml
@@ -2,8 +2,8 @@
     Layout = "Layout.cshtml";
 }
 
-@section OpenGraph {
-    @RenderSection("OpenGraph", required: false)
+@section SocialMeta {
+    @RenderSection("SocialMeta", required: false)
 }
 @section Meta {
     @RenderSection("Meta", required: false)


### PR DESCRIPTION
PR for this issue https://github.com/NuGet/NuGetGallery/issues/2067

To get a nice Twitter card preview the site needs the mandatory "twitter:card" meta tag, but Twitter can also read the Open Graph meta tags, so I added only 2 more meta tags. I decided to rename the section, because it now contains not only the Open Graph stuff.

The bad part: Twitter has no testing tool and to verify you need to "apply" for the Twitter cards and do it in "production": https://dev.twitter.com/cards
It is a pretty easy and quick registration, but it needs to be done. But even if the registration is not in place, the addional meta tags should do no harm.

If you need more information about those tags: http://moz.com/blog/meta-data-templates-123

Just as an future idea: If the NuGet Gallery would know the Twitter Handles from the package manager it could serve it as well to promote the author.
