### PR TITLE
Fix for #1314 - Register/Sign Error Page & Style issue

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -984,12 +984,10 @@ fieldset.form {
 .field-hint-message,
 .field-validation-error {
     font-size: 1em;
-    left: 440px;
     line-height: 1.2em;
     padding: 5px;
-    position: absolute;
-    top: 30px;
-    width: 400px;
+    margin-top: 5px;
+    width: 416px;
     z-index: 550;
 }
 


### PR DESCRIPTION
Just checked this issue: https://github.com/NuGet/NuGetGallery/issues/1314

With Opera 21.9  this issue is obsolete, but I found a related issue, which occurs on all browsers:
![image](https://cloud.githubusercontent.com/assets/756703/3109458/b3181a96-e699-11e3-85db-3b80a3c4a879.png)

Reason for this is the fixed position of the validation messages via CSS. 

My simple solution: Delete the position: absolute rule plus some cosmetic and everything should be fine:
![image](https://cloud.githubusercontent.com/assets/756703/3109483/072a9f0a-e69a-11e3-9b1d-52bb7580a83e.png)

The style is also used on the Package Edit Page which now looks like this:
![image](https://cloud.githubusercontent.com/assets/756703/3109494/2c8c109e-e69a-11e3-8c66-dacea8740641.png)

And the support page:
![image](https://cloud.githubusercontent.com/assets/756703/3109507/4201194c-e69a-11e3-82ce-6a33da510b09.png)

The Account and VerifyPackage pages have similar forms as well.

As you can see the validation message has currently a fixed size, but with the redesign there might be a bigger change coming anyway and maybe there will be a "standard" size for inputs, thats why I leave it as is.
