### PR TITLE
Fix for #858: Remove Version Param in ManagePackageOwner Url

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -565,9 +565,9 @@ namespace NuGetGallery
         }
 
         [Authorize]
-        public virtual ActionResult ManagePackageOwners(string id, string version)
+        public virtual ActionResult ManagePackageOwners(string id)
         {
-            var package = _packageService.FindPackageByIdAndVersion(id, version);
+            var package = _packageService.FindPackageByIdAndVersion(id, string.Empty);
             if (package == null)
             {
                 return HttpNotFound();

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -236,8 +236,7 @@ namespace NuGetGallery
                 controllerName: "Packages",
                 routeValues: new
                 {
-                    id = package.Id,
-                    version = package.Version
+                    id = package.Id
                 });
         }
 


### PR DESCRIPTION
Issue: https://github.com/NuGet/NuGetGallery/issues/858

I removed the unnecessary version parameter from the action. Old URLs are still valid, but now the UI will render just "http://nuget.localtest.me/packages/{package}/ManagePackageOwners"

If there is a more elegant way to get a "Package"-Object from the PackageService just let me know. String.Empty is a bit... well... ;)