### PR TITLE
"UI" Paging in Profilepage - WIP

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -66,6 +66,12 @@ h6 {
     font-size: 1em;
 }
 
+
+small {
+    font-size: 0.5em;
+}
+
+
     h1 img, h2 img, h3 img,
     h4 img, h5 img, h6 img {
         margin: 0;

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -253,7 +253,7 @@ namespace NuGetGallery
             return View(model);
         }
 
-        public virtual ActionResult Profiles(string username, int page = 1)
+        public virtual ActionResult Profiles(string username, int page = 1, bool showAllPackages = false)
         {
             var user = UserService.FindByUsername(username);
             if (user == null)
@@ -270,6 +270,7 @@ namespace NuGetGallery
                 }).ToList();
 
             var model = new UserProfileModel(user, packages, page - 1, Constants.DefaultPackageListPageSize, Url);
+            model.ShowAllPackages = showAllPackages;
 
             return View(model);
         }

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -222,6 +222,16 @@ namespace NuGetGallery
             return result;
         }
 
+        public static string UserShowAllPackages(this UrlHelper url, string username, string scheme = null)
+        {
+            string result;
+                result = url.Action(actionName: "Profiles",
+                                    controllerName: "Users",
+                                    routeValues: new { username = username, showAllPackages = true },
+                                    protocol: scheme);
+            return result;
+        }
+
         public static string EditPackage(this UrlHelper url, string id, string version)
         {
             if (String.IsNullOrEmpty(version))

--- a/src/NuGetGallery/ViewModels/UserProfileModel.cs
+++ b/src/NuGetGallery/ViewModels/UserProfileModel.cs
@@ -39,6 +39,6 @@ namespace NuGetGallery
         public int PackagePage { get; private set; }
         public int PackagePageSize { get; private set; }
         public IPreviousNextPager Pager { get; private set; }
-
+        public bool ShowAllPackages { get; set; }
     }
 }

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -25,12 +25,22 @@
 <h1 class="page-heading">@Model.Username's Profile</h1>
 
 <h2>Packages
-     @if (Model.PackagePageTotalCount > 1)
+@if (Model.PackagePageTotalCount > 1 && Model.ShowAllPackages == false)
 {
-    <small>(Page @(Model.PackagePage + 1) of @Model.PackagePageTotalCount)</small>
-}</h2>
+    <small>(Page @(Model.PackagePage + 1) of @Model.PackagePageTotalCount) <a href="@Url.UserShowAllPackages(Model.Username)">Show all packages</a></small>
+}
+</h2>
 <ul id="searchResults">
-    @foreach (var package in Model.PagedPackages)
+@{
+    var allOrPagedPackages = Model.PagedPackages;
+
+    if (Model.ShowAllPackages)
+    {
+        allOrPagedPackages = Model.AllPackages;
+    }
+}
+
+    @foreach (var package in allOrPagedPackages)
     {
         <li>
             <section class="package">
@@ -65,4 +75,8 @@
     }
 </ul>
 
-@ViewHelpers.PreviousNextPager(Model.Pager)
+@if (Model.ShowAllPackages == false)
+{
+    @ViewHelpers.PreviousNextPager(Model.Pager)    
+}
+


### PR DESCRIPTION
Implemented a paging on the profile page for issue https://github.com/NuGet/NuGetGallery/issues/144

Screenshot with "DefaultPackageListPageSize=3" 

![capture](https://cloud.githubusercontent.com/assets/756703/3304635/54d949aa-f64d-11e3-809f-25fd25b84292.PNG)

The bad part is that the UserController is still using the current "PackageService.FindPackagesByOwner" method - so on each page ALL packages of the user will be loaded from the database. To calculate the "TotalDownload" number the code iterates over all packages. If there would be a more clever way to get the "TotalDownload" number the paging could be implemented inside the PackageService as well.

This is one of the oldest open issue (or the oldest?) - so before I rewrite more I wanted to show my current implementation. 
