### PR TITLE
View: Misc. fixes for listing page

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -72,10 +72,10 @@ small {
 }
 
 
-    h1 img, h2 img, h3 img,
-    h4 img, h5 img, h6 img {
-        margin: 0;
-    }
+h1 img, h2 img, h3 img,
+h4 img, h5 img, h6 img {
+    margin: 0;
+}
 
 /* Page Headings*/
 
@@ -487,7 +487,17 @@ section.package {
         overflow: hidden;
     }
 
-    section.package div.minimum-client-version {
+    section.package article > :first-child {
+        font-style: italic;
+    }
+
+        section.package article > :first-child small:last-child {
+            padding-left: 10px;
+            margin-left: 10px;
+            border-left: 1px solid #ccc;
+        }
+
+    section.package article > .minimum-client-version {
         float: right;
     }
 

--- a/src/NuGetGallery/Helpers/StringHelper.cs
+++ b/src/NuGetGallery/Helpers/StringHelper.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Globalization;
 
 namespace NuGetGallery.Helpers
 {
-    internal static class StringHelper
+    public static class StringHelper
     {
         public static string[] SplitSafe(this string s, char[] separator, StringSplitOptions stringSplitOptions)
         {
@@ -12,6 +13,19 @@ namespace NuGetGallery.Helpers
             }
 
             return s.Split(separator, stringSplitOptions);
+        }
+
+        public static string TruncateAtWordBoundary(this string input, int length = 300, string ommission = "...", string morText = "")
+        {
+            if (string.IsNullOrEmpty(input) || input.Length < length)
+                return input;
+
+            int nextSpace = input.LastIndexOf(" ", length);
+
+            return string.Format(CultureInfo.CurrentCulture, "{2}{1}{0}",
+                                 morText,
+                                 ommission,
+                                 input.Substring(0, (nextSpace > 0) ? nextSpace : length).Trim());
         }
     }
 }

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -17,24 +17,34 @@
             </ul>
         </header>
 
-        <p>
-            @if (String.IsNullOrEmpty(Model.Description) || Model.Description.Length < 350)
-            {
-                @Model.Description
-            }
-            else
-            {
-                @Model.Description.Substring(0, 350)<text>... </text>
-                <a href="@Url.Package(Model)">More information</a>
-            }
-        </p>
+        <article>
+            <p>
+                <small>
+                    Last  Published: <time datetime="@Model.LastUpdated.ToJavaScriptUTC()" pubdate>@Model.LastUpdated.ToNuGetShortDateString()</time>
+                </small>
+                <small>
+                    Latest Version: @Model.Version @(Model.Prerelease ? "(prerelease)" : "")
+                </small>
+            </p>
+            <p>
+                @if (String.IsNullOrEmpty(Model.Description) || Model.Description.Length < 350)
+                {
+                    @Model.Description
+                }
+                else
+                {
+                    @Model.Description.Substring(0, 350)<text>... </text>
+                    <a href="@Url.Package(Model)">More information</a>
+                }
+            </p>
 
-        @if (!String.IsNullOrEmpty(Model.MinClientVersion)) 
-        {
-            <div class="minimum-client-version">
-                Requires NuGet @Model.MinClientVersion or higher.
-            </div>
-        }
+            @if (!String.IsNullOrEmpty(Model.MinClientVersion))
+            {
+                <p class="minimum-client-version">
+                    Requires NuGet @Model.MinClientVersion or higher.
+                </p>
+            }
+        </article>
     
         <footer>
             <p class="downloads">

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -27,15 +27,7 @@
                 </small>
             </p>
             <p>
-                @if (String.IsNullOrEmpty(Model.Description) || Model.Description.Length < 350)
-                {
-                    @Model.Description
-                }
-                else
-                {
-                    @Model.Description.Substring(0, 350)<text>... </text>
-                    <a href="@Url.Package(Model)">More information</a>
-                }
+                @Model.Description.TruncateAtWordBoundary(350, "<text>... </text>", string.Format(System.Globalization.CultureInfo.CurrentCulture, "<a href=\"{0}\">More information</a>", @Url.Package(Model)))
             </p>
 
             @if (!String.IsNullOrEmpty(Model.MinClientVersion))


### PR DESCRIPTION
* Listing page to show at-the-glance `Last Published` and `Latest Version` info: 2731fe6 
  * For instance, on http://www.nuget.org/packages?q=casablanca result listing page, if the user is looking for the most recent package or checking if the newer Version of certain package has arrived, with this change its possible without navigating to the details page.
* Adds helper to truncate description at word boundary: 34ae737 
