### PR TITLE
Fix #1635 - Escape underscores in packages for markdown

### DIFF
--- a/src/NuGetGallery/App_Start/ContainerBindings.cs
+++ b/src/NuGetGallery/App_Start/ContainerBindings.cs
@@ -5,7 +5,6 @@ using System.Security.Principal;
 using System.Web;
 using System.Web.Hosting;
 using System.Web.Mvc;
-using AnglicanGeek.MarkdownMailer;
 using Elmah;
 using Microsoft.WindowsAzure.ServiceRuntime;
 using Ninject;
@@ -16,6 +15,7 @@ using NuGetGallery.Infrastructure;
 using System.Diagnostics;
 using NuGetGallery.Auditing;
 using NuGetGallery.Infrastructure.Lucene;
+using NuGetGallery.Services;
 
 namespace NuGetGallery
 {

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -970,6 +970,7 @@
     <Compile Include="Services\IContentService.cs" />
     <Compile Include="Services\IFileReference.cs" />
     <Compile Include="Services\IMailSender.cs" />
+    <Compile Include="Services\ISmtpClient.cs" />
     <Compile Include="Services\IStatusService.cs" />
     <Compile Include="Services\JsonStatisticsService.cs" />
     <Compile Include="Services\CloudReportService.cs" />
@@ -999,6 +1000,7 @@
     <Compile Include="Filters\RequireSslAttribute.cs" />
     <Compile Include="Services\PackageSearchResults.cs" />
     <Compile Include="Services\JsonAggregateStatsService.cs" />
+    <Compile Include="Services\SmtpClientWrapper.cs" />
     <Compile Include="Services\SqlAggregateStatsService.cs" />
     <Compile Include="Services\ReportPackageRequest.cs" />
     <Compile Include="Services\SearchFilter.cs" />

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -93,10 +93,6 @@
     <CodeAnalysisRuleSet>..\Frontend.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AnglicanGeek.MarkdownMailer, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\AnglicanGeek.MarkdownMailer.1.2\lib\net40\AnglicanGeek.MarkdownMailer.dll</HintPath>
-    </Reference>
     <Reference Include="Antlr3.Runtime, Version=3.3.1.7705, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\WebGrease.1.1.0\lib\Antlr3.Runtime.dll</HintPath>
@@ -973,6 +969,7 @@
     <Compile Include="Services\ContentService.cs" />
     <Compile Include="Services\IContentService.cs" />
     <Compile Include="Services\IFileReference.cs" />
+    <Compile Include="Services\IMailSender.cs" />
     <Compile Include="Services\IStatusService.cs" />
     <Compile Include="Services\JsonStatisticsService.cs" />
     <Compile Include="Services\CloudReportService.cs" />
@@ -995,6 +992,8 @@
     <Compile Include="Services\ISearchService.cs" />
     <Compile Include="Services\IUploadFileService.cs" />
     <Compile Include="Services\LocalFileReference.cs" />
+    <Compile Include="Services\MailSender.cs" />
+    <Compile Include="Services\MailSenderConfiguration.cs" />
     <Compile Include="Services\NuGetExeDownloaderService.cs" />
     <Compile Include="Services\PackageFileService.cs" />
     <Compile Include="Filters\RequireSslAttribute.cs" />

--- a/src/NuGetGallery/Services/IMailSender.cs
+++ b/src/NuGetGallery/Services/IMailSender.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Net.Mail;
+
+namespace NuGetGallery.Services
+{
+    public interface IMailSender : IDisposable
+    {
+        void Send(
+            string fromAddress,
+            string toAddress,
+            string subject,
+            string markdownBody);
+
+        void Send(
+            MailAddress fromAddress,
+            MailAddress toAddress,
+            string subject,
+            string markdownBody);
+
+        void Send(MailMessage mailMessage);
+    }
+}

--- a/src/NuGetGallery/Services/ISmtpClient.cs
+++ b/src/NuGetGallery/Services/ISmtpClient.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Net;
+using System.Net.Mail;
+
+namespace NuGetGallery.Services
+{
+    public interface ISmtpClient : IDisposable
+    {
+        ICredentialsByHost Credentials { get; set; }
+        SmtpDeliveryMethod DeliveryMethod { get; set; }
+        bool EnableSsl { get; set; }
+        string Host { get; set; }
+        string PickupDirectoryLocation { get; set; }
+        int Port { get; set; }
+        void Send(MailMessage message);
+        bool UseDefaultCredentials { get; set; }
+    }
+}

--- a/src/NuGetGallery/Services/MailSender.cs
+++ b/src/NuGetGallery/Services/MailSender.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using System.Net.Mail;
+using System.Net.Mime;
+using MarkdownSharp;
+
+namespace NuGetGallery.Services
+{
+    public class MailSender : IMailSender
+    {
+        readonly SmtpClient smtpClient;
+
+        public MailSender()
+        {
+        }
+
+        public MailSender(MailSenderConfiguration configuration)
+        {
+        }
+
+        internal MailSender(
+            SmtpClient smtpClient,
+            MailSenderConfiguration configuration)
+        {
+            if (smtpClient == null)
+                throw new ArgumentNullException("smtpClient");
+
+            if (configuration != null)
+                ConfigureSmtpClient(smtpClient, configuration);
+
+            this.smtpClient = smtpClient;
+        }
+
+        static internal void ConfigureSmtpClient(
+            SmtpClient smtpClient,
+            MailSenderConfiguration configuration)
+        {
+            if (configuration.Host != null)
+                smtpClient.Host = configuration.Host;
+            if (configuration.Port.HasValue)
+                smtpClient.Port = configuration.Port.Value;
+            if (configuration.EnableSsl.HasValue)
+                smtpClient.EnableSsl = configuration.EnableSsl.Value;
+            if (configuration.DeliveryMethod.HasValue)
+                smtpClient.DeliveryMethod = configuration.DeliveryMethod.Value;
+            if (configuration.UseDefaultCredentials.HasValue)
+                smtpClient.UseDefaultCredentials = configuration.UseDefaultCredentials.Value;
+            if (configuration.Credentials != null)
+                smtpClient.Credentials = configuration.Credentials;
+            if (configuration.PickupDirectoryLocation != null)
+                smtpClient.PickupDirectoryLocation = configuration.PickupDirectoryLocation;
+        }
+
+        public void Send(
+            string fromAddress,
+            string toAddress,
+            string subject,
+            string markdownBody)
+        {
+            Send(
+                new MailAddress(fromAddress),
+                new MailAddress(toAddress),
+                subject,
+                markdownBody);
+        }
+
+        public void Send(
+            MailAddress fromAddress,
+            MailAddress toAddress,
+            string subject,
+            string markdownBody)
+        {
+            var mailMessage = new MailMessage(fromAddress, toAddress)
+            {
+                Subject = subject,
+                Body = markdownBody
+            };
+
+            Send(mailMessage);
+        }
+
+        public void Send(MailMessage mailMessage)
+        {
+            if (smtpClient.DeliveryMethod == SmtpDeliveryMethod.SpecifiedPickupDirectory
+                && !Directory.Exists(smtpClient.PickupDirectoryLocation))
+                Directory.CreateDirectory(smtpClient.PickupDirectoryLocation);
+
+            string markdownBody = mailMessage.Body;
+            string htmlBody = new Markdown().Transform(markdownBody);
+
+            AlternateView textView = AlternateView.CreateAlternateViewFromString(
+                markdownBody,
+                null,
+                MediaTypeNames.Text.Plain);
+            mailMessage.AlternateViews.Add(textView);
+
+            AlternateView htmlView = AlternateView.CreateAlternateViewFromString(
+                htmlBody,
+                null,
+                MediaTypeNames.Text.Html);
+            mailMessage.AlternateViews.Add(htmlView);
+
+            smtpClient.Send(mailMessage);
+        }
+
+        public void Dispose()
+        {
+            smtpClient.Dispose();
+        }
+    }
+}

--- a/src/NuGetGallery/Services/MailSender.cs
+++ b/src/NuGetGallery/Services/MailSender.cs
@@ -8,18 +8,25 @@ namespace NuGetGallery.Services
 {
     public class MailSender : IMailSender
     {
-        readonly SmtpClient smtpClient;
+        readonly ISmtpClient smtpClient;
 
         public MailSender()
+            : this(new SmtpClientWrapper(new SmtpClient()), null)
         {
         }
 
         public MailSender(MailSenderConfiguration configuration)
+            : this(new SmtpClientWrapper(new SmtpClient()), configuration)
+        {
+        }
+
+        public MailSender(SmtpClient smtpClient)
+            : this(new SmtpClientWrapper(smtpClient), null)
         {
         }
 
         internal MailSender(
-            SmtpClient smtpClient,
+            ISmtpClient smtpClient,
             MailSenderConfiguration configuration)
         {
             if (smtpClient == null)
@@ -32,7 +39,7 @@ namespace NuGetGallery.Services
         }
 
         static internal void ConfigureSmtpClient(
-            SmtpClient smtpClient,
+            ISmtpClient smtpClient,
             MailSenderConfiguration configuration)
         {
             if (configuration.Host != null)

--- a/src/NuGetGallery/Services/MailSenderConfiguration.cs
+++ b/src/NuGetGallery/Services/MailSenderConfiguration.cs
@@ -1,0 +1,16 @@
+using System.Net;
+using System.Net.Mail;
+
+namespace NuGetGallery.Services
+{
+    public class MailSenderConfiguration
+    {
+        public ICredentialsByHost Credentials { get; set; }
+        public SmtpDeliveryMethod? DeliveryMethod { get; set; }
+        public bool? EnableSsl { get; set; }
+        public string Host { get; set; }
+        public string PickupDirectoryLocation { get; set; }
+        public int? Port { get; set; }
+        public bool? UseDefaultCredentials { get; set; }
+    }
+}

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -4,11 +4,10 @@ using System.Linq;
 using System.Net.Mail;
 using System.Text;
 using System.Web;
-using AnglicanGeek.MarkdownMailer;
 using Elmah;
 using NuGetGallery.Authentication;
-using Glimpse.AspNet.AlternateType;
 using NuGetGallery.Configuration;
+using NuGetGallery.Services;
 
 namespace NuGetGallery
 {

--- a/src/NuGetGallery/Services/ReportPackageRequest.cs
+++ b/src/NuGetGallery/Services/ReportPackageRequest.cs
@@ -23,8 +23,10 @@ namespace NuGetGallery
             // note, format blocks {xxx} are matched by ordinal-case-sensitive comparison
             var builder = new StringBuilder(subject);
             
+            string packageIdMarkdownEscaped = Package.PackageRegistration.Id.Replace("_", "\\_");
+
             Substitute(builder, "{GalleryOwnerName}", config.GalleryOwner.DisplayName);
-            Substitute(builder, "{Id}", Package.PackageRegistration.Id);
+            Substitute(builder, "{Id}", packageIdMarkdownEscaped);
             Substitute(builder, "{Version}", Package.Version);
             Substitute(builder, "{Reason}", Reason);
             if (RequestingUser != null)
@@ -44,8 +46,9 @@ namespace NuGetGallery
             Substitute(builder, "{Name}", FromAddress.DisplayName);
             Substitute(builder, "{Address}", FromAddress.Address);
             Substitute(builder, "{AlreadyContactedOwners}", AlreadyContactedOwners ? "Yes" : "No");
-            Substitute(builder, "{PackageUrl}", Url.Package(Package.PackageRegistration.Id, null, scheme: "http"));
-            Substitute(builder, "{VersionUrl}", Url.Package(Package.PackageRegistration.Id, Package.Version, scheme: "http"));
+            // Fix for Markdown Mailer compatible urls containing _
+            Substitute(builder, "{PackageUrl}", Url.Package(packageIdMarkdownEscaped, null, scheme: "http").Replace("%5C", "\\"));
+            Substitute(builder, "{VersionUrl}", Url.Package(packageIdMarkdownEscaped, Package.Version, scheme: "http").Replace("%5C", "\\"));
             Substitute(builder, "{Reason}", Reason);
             Substitute(builder, "{Message}", Message);
 

--- a/src/NuGetGallery/Services/SmtpClientWrapper.cs
+++ b/src/NuGetGallery/Services/SmtpClientWrapper.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using System.Net.Mail;
+
+namespace NuGetGallery.Services
+{
+    public class SmtpClientWrapper : ISmtpClient
+    {
+        readonly SmtpClient smtpClient;
+
+        public SmtpClientWrapper(SmtpClient smtpClient)
+        {
+            this.smtpClient = smtpClient;
+        }
+
+        public ICredentialsByHost Credentials
+        {
+            get { return smtpClient.Credentials; }
+            set { smtpClient.Credentials = value; }
+        }
+
+        public SmtpDeliveryMethod DeliveryMethod
+        {
+            get { return smtpClient.DeliveryMethod; }
+            set { smtpClient.DeliveryMethod = value; }
+        }
+
+        public bool EnableSsl
+        {
+            get { return smtpClient.EnableSsl; }
+            set { smtpClient.EnableSsl = value; }
+        }
+
+        public void Dispose()
+        {
+            smtpClient.Dispose();
+        }
+
+        public string Host
+        {
+            get { return smtpClient.Host; }
+            set { smtpClient.Host = value; }
+        }
+
+        public string PickupDirectoryLocation
+        {
+            get { return smtpClient.PickupDirectoryLocation; }
+            set { smtpClient.PickupDirectoryLocation = value; }
+        }
+
+        public int Port
+        {
+            get { return smtpClient.Port; }
+            set { smtpClient.Port = value; }
+        }
+
+        public void Send(MailMessage message)
+        {
+            smtpClient.Send(message);
+        }
+
+        public bool UseDefaultCredentials
+        {
+            get { return smtpClient.UseDefaultCredentials; }
+            set { smtpClient.UseDefaultCredentials = value; }
+        }
+    }
+}

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AnglicanGeek.MarkdownMailer" version="1.2" />
   <package id="AnglicanGeek.WindowsAzure.ServiceRuntime" version="1.6" targetFramework="net45" />
   <package id="d3" version="3.0.2" targetFramework="net45" />
   <package id="DynamicData.EFCodeFirstProvider" version="0.3.0.0" />

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -40,10 +40,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AnglicanGeek.MarkdownMailer, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\AnglicanGeek.MarkdownMailer.1.2\lib\net40\AnglicanGeek.MarkdownMailer.dll</HintPath>
-    </Reference>
     <Reference Include="EntityFramework, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\EntityFramework.5.0.0\lib\net45\EntityFramework.dll</HintPath>

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Collections.ObjectModel;
 using System.Net.Mail;
-using AnglicanGeek.MarkdownMailer;
 using Moq;
 using NuGetGallery.Areas.Admin.DynamicData;
+using NuGetGallery.Services;
 using Xunit;
 using NuGetGallery.Configuration;
 using NuGetGallery.Framework;
@@ -505,6 +505,10 @@ namespace NuGetGallery
             public void Send(string fromAddress, string toAddress, string subject, string markdownBody)
             {
                 Send(new MailMessage(fromAddress, toAddress, subject, markdownBody));
+            }
+
+            public void Dispose()
+            {
             }
         }
     }

--- a/tests/NuGetGallery.Facts/packages.config
+++ b/tests/NuGetGallery.Facts/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AnglicanGeek.MarkdownMailer" version="1.2" />
   <package id="EntityFramework" version="5.0.0" targetFramework="net45" />
   <package id="Glimpse" version="1.8.0" targetFramework="net45" />
   <package id="Glimpse.AspNet" version="1.6.0" targetFramework="net45" />


### PR DESCRIPTION
Should fix this issue https://github.com/NuGet/NuGetGallery/issues/1635

I tested it with this package https://www.nuget.org/packages/JQueryFileUpload_Demo_with_Backload/

Now he ReportPackageRequest creates such an MailBody with correct escapted underscore. Poor mans solution, but should work.

**Email:** admin (...)

**Package:** JQueryFileUpload_Demo_with_Backload
http://nuget.localtest.me/packages/JQueryFileUpload\_Demo\_with\_Backload/

**Version:** 1.9.2.4
http://nuget.localtest.me/packages/JQueryFileUpload\_Demo\_with\_Backload/1.9.2.4

**User:** admin (...)
http://nuget.localtest.me/profiles/admin

**Reason:**
The package was published as the wrong version

**Message:**
test

_Message sent from NuGet Gallery_

---

Only problem: The escaped PackageID is now also displayed in the mail subject - but I guess this is a very rare case and with this PR the link and the ID is correct in the mail body.
