### PR TITLE
Added "Api" to the action names for DeletePackage and PublishPackage in ...

### DIFF
--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -288,12 +288,12 @@ namespace NuGetGallery
             routes.MapRoute(
                 "v1" + RouteName.DeletePackageApi,
                 "v1/Packages/{apiKey}/{id}/{version}",
-                new { controller = "Api", action = "DeletePackages" });
+                new { controller = "Api", action = "DeletePackagesApi" });
 
             routes.MapRoute(
                 "v1" + RouteName.PublishPackageApi,
                 "v1/PublishedPackages/Publish",
-                new { controller = "Api", action = "PublishPackage" });
+                new { controller = "Api", action = "PublishPackageApi" });
 
             // Redirected Legacy Routes
 


### PR DESCRIPTION
The routing configuration was missing the "Api" appendix, so deleting packages was failing with HTTP 404.

You can reproduce it by calling:
nuget.exe delete 'Your package id ' [VERSION] [Your API Key] ...
