### PR TITLE
Implemented a "show paged list" link in Profile UI

### DIFF
--- a/src/NuGetGallery/ViewModels/UserProfileModel.cs
+++ b/src/NuGetGallery/ViewModels/UserProfileModel.cs
@@ -8,6 +8,7 @@ namespace NuGetGallery
     {
         public UserProfileModel(User user, List<PackageViewModel> allPackages, int pageIndex, int pageSize, UrlHelper url)
         {
+            User = user;
             Username = user.Username;
             EmailAddress = user.EmailAddress;
             UnconfirmedEmailAddress = user.UnconfirmedEmailAddress;
@@ -29,6 +30,7 @@ namespace NuGetGallery
         }
 
         public int PackagePageTotalCount { get; private set; }
+        public User User { get; private set; }
         public string Username { get; private set; }
         public string EmailAddress { get; private set; }
         public string UnconfirmedEmailAddress { get; set; }

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -29,6 +29,10 @@
 {
     <small>(Page @(Model.PackagePage + 1) of @Model.PackagePageTotalCount) <a href="@Url.UserShowAllPackages(Model.Username)">Show all packages</a></small>
 }
+else if (Model.ShowAllPackages)
+{
+    <small><a href="@Url.User(Model.User)">Show paged package list</a></small>
+}
 </h2>
 <ul id="searchResults">
 @{


### PR DESCRIPTION
As suggested in this PR https://github.com/NuGet/NuGetGallery/pull/2215 I implemented a link back to the paged package list, so that a user can navigate from the paged package list to the full package list and back again. This is only visible if paging is necessary.

Screenshot:
![image](https://cloud.githubusercontent.com/assets/756703/3638600/2533d018-1055-11e4-83d5-f3df17e5d605.png)
