### PR TITLE
PageSpeed Fix: Height&Width on Images & Async GA

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -184,7 +184,7 @@
         var propertyId = config.Current.GoogleAnalyticsPropertyId;
         if (propertyId != null)
         {
-            @Analytics.GetGoogleHtml(propertyId)
+            @Analytics.GetGoogleAsyncHtml(propertyId)
         }
     }
 }

--- a/src/NuGetGallery/App_Data/Files/Content/Home.html
+++ b/src/NuGetGallery/App_Data/Files/Content/Home.html
@@ -4,7 +4,7 @@
         <p>NuGet is the package manager for the Microsoft development platform including .NET. The NuGet client tools provide the ability to produce and consume packages. The NuGet Gallery is the central package repository used by all package authors and consumers.</p>
         <a class="install" href="http://docs.nuget.org/docs/start-here/installing-nuget">Install NuGet</a>
     </div>
-    <img src="Content/Logos/hero.png" alt="Manage NuGet Packages Dialog Window" /> 
+    <img height="352" width="494" src="Content/Logos/hero.png" alt="Manage NuGet Packages Dialog Window" /> 
 </section> 
 
 <section class="aggstats">

--- a/src/NuGetGallery/Views/Shared/LayoutFooter.cshtml
+++ b/src/NuGetGallery/Views/Shared/LayoutFooter.cshtml
@@ -21,7 +21,7 @@
     </li>
 </ul>
 <div class="license">
-    <a title="Outercurve Foundation" href="http://outercurve.org"><img src="@Href("~/Content/Logos/outercurve.png")" alt="Outercurve Foundation" /></a>
+    <a title="Outercurve Foundation" href="http://outercurve.org"><img height="30" width="125" src="@Href("~/Content/Logos/outercurve.png")" alt="Outercurve Foundation" /></a>
     <p>
         &copy; @DateTime.UtcNow.Year Outercurve Foundation -
         <a href="@Url.Action("Terms", "Pages")">Terms of Use</a> -


### PR DESCRIPTION
Should fix 2 pagespeed issues on the nuget.org:

- SpecifyImageDimensions for outercurve and nuget image
- Include Google Analytics via the Async Helper

Didn't made an end to end test with the Google Analytics stuff, but the scripts seems proper and didn't found anything bad about the async helper.