### PR TITLE
Fix broken About Page - Readded Route for Team Api

### DIFF
--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -347,6 +347,12 @@ namespace NuGetGallery
         {
             // V2 routes
             routes.MapRoute(
+                RouteName.Team,
+                "api/v2/team",
+                defaults: new { controller = "Api", action = "Team" },
+                constraints: new { httpMethod = new HttpMethodConstraint("GET") });
+
+            routes.MapRoute(
                 "v2" + RouteName.VerifyPackageKey,
                 "api/v2/verifykey/{id}/{version}",
                 new {


### PR DESCRIPTION
Should fix this issue: https://github.com/NuGet/NuGetGallery/issues/2229

Problem: The route to the team api was missing. I guess it was accidentally deleted in this commit https://github.com/NuGet/NuGetGallery/commit/7d35cc0d8d12f0a5da0681f995877fcc9970afb9