### PR TITLE
Fix #2295 by reading the $top variable from the Query String.

### DIFF
--- a/src/NuGetGallery/DataServices/SearchAdaptor.cs
+++ b/src/NuGetGallery/DataServices/SearchAdaptor.cs
@@ -14,7 +14,7 @@ namespace NuGetGallery
         /// <summary>
         ///     Determines the maximum number of packages returned in a single page of an OData result.
         /// </summary>
-        internal const int MaxPageSize = 40;
+        internal const int MaxPageSize = 100;
 
         public static SearchFilter GetSearchFilter(string q, int page, string sortOrder, string context)
         {


### PR DESCRIPTION
Fixes #2295.
Fixes #2299.

The client sends $top=30, but we were ignoring it and returning 40 items. When the code went through an OData filter, OData would ensure only 30 items were returned but as part of the Target Framework code, I had to bypass that code and strip out OData expressions. Thus, we were returning 40 items even though only 30 were requested. This caused problems with paging on the client.

The fix was to honour the $top variable and emit only 30 items.
