### PR TITLE
Change defaults for Search and Metrics to true...

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -164,16 +164,7 @@
         
         @* A little quick-n-dirty code to display the current machine *@
         @* In Azure, we want the Instance ID. The Machine Name is total garbage *@
-        @try {
-            if(RoleEnvironment.IsAvailable) {
-                <text>You are on @RoleEnvironment.CurrentRoleInstance.Id.</text>
-            } else {
-                <text>You are on @Environment.MachineName.</text>
-            }
-        } catch(Exception) {
-            @* Azure SDK not installed so we can't even run RoleEnvironment.IsAvailable. Just use Machine Name *@
-            <text>You are on @Environment.MachineName.</text>
-        }
+        You are on @HostMachine.Name.
     </p>
 }
 

--- a/src/NuGetGallery/Helpers/HostMachine.cs
+++ b/src/NuGetGallery/Helpers/HostMachine.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using Microsoft.WindowsAzure.ServiceRuntime;
+
+namespace NuGetGallery.Helpers
+{
+    public static class HostMachine
+    {
+        private static Lazy<string> _name = new Lazy<string>(DetermineName);
+
+        public static string Name
+        {
+            get { return _name.Value; }
+        }
+
+        private static string DetermineName()
+        {
+            try
+            {
+                if (RoleEnvironment.IsAvailable)
+                {
+                    return RoleEnvironment.CurrentRoleInstance.Id;
+                }
+                else
+                {
+                    return Environment.MachineName;
+                }
+            }
+            catch // Can't even run RoleEnvironment.IsAvailable because Azure SDK is not installed.
+            {
+                return Environment.MachineName;
+            }
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -239,7 +239,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-        <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=2.1.0.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -420,6 +420,7 @@
     <Compile Include="Diagnostics\DiagnosticsGlimpseTab.cs" />
     <Compile Include="Diagnostics\DiagnosticsService.cs" />
     <Compile Include="Diagnostics\PerfEvent.cs" />
+    <Compile Include="Helpers\HostMachine.cs" />
     <Compile Include="Infrastructure\MessageQueue.cs" />
     <Compile Include="Diagnostics\NullDiagnosticsSource.cs" />
     <Compile Include="Diagnostics\TraceDiagnosticsSource.cs" />


### PR DESCRIPTION
...so that the status check endpoint skips checking them if they are not configured.
