### PR TITLE
Fix build issue and missing setting.

### DIFF
--- a/src/NuGetGallery.Backend.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/src/NuGetGallery.Backend.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -8,6 +8,7 @@
       <Setting name="Operations.Storage.Backup" value="UseDevelopmentStorage=true" />
       <Setting name="Operations.Sql.Primary" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetGallery;Integrated Security=SSPI" />
       <Setting name="Operations.Sql.Warehouse" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetWarehouse;Integrated Security=SSPI" />
+      <Setting name="Operations.SqlDac" value="" />
       <Setting name="Queue.PollInterval" value="00:00:01" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />

--- a/src/NuGetGallery.Backend.Cloud/ServiceConfiguration.Local.cscfg
+++ b/src/NuGetGallery.Backend.Cloud/ServiceConfiguration.Local.cscfg
@@ -8,6 +8,7 @@
       <Setting name="Operations.Storage.Backup" value="UseDevelopmentStorage=true" />
       <Setting name="Operations.Sql.Primary" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetGallery;Integrated Security=SSPI" />
       <Setting name="Operations.Sql.Warehouse" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetWarehouse;Integrated Security=SSPI" />
+      <Setting name="Operations.SqlDac" value="" />
       <Setting name="Queue.PollInterval" value="00:00:01" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />

--- a/src/NuGetGallery.Backend.Cloud/ServiceDefinition.csdef
+++ b/src/NuGetGallery.Backend.Cloud/ServiceDefinition.csdef
@@ -11,6 +11,7 @@
       <Setting name="Operations.Storage.Backup" />
       <Setting name="Operations.Sql.Primary" />
       <Setting name="Operations.Sql.Warehouse" />
+      <Setting name="Operations.SqlDac" />
       <Setting name="Queue.PollInterval" />
     </ConfigurationSettings>
     <LocalResources>

--- a/src/NuGetGallery/DataServices/V2Feed.svc.cs
+++ b/src/NuGetGallery/DataServices/V2Feed.svc.cs
@@ -66,7 +66,6 @@ namespace NuGetGallery
                 // TODO: Async this when I can figure out OData async stuff...
                 .Result
                 .ToV2FeedPackageQuery(GetSiteRoot(), Configuration.Features.FriendlyLicenses);
-            var result = query.ToList();
             return query;
         }
 


### PR DESCRIPTION
The `Operations.SqlDac` setting is needed for SQL Azure. The `result` variable was not used which caused a build error.