### PR TITLE
Fixed the action names for "DeletePackageApi" and "PublishPackageApi"

### DIFF
--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -377,13 +377,13 @@ namespace NuGetGallery
             routes.MapRoute(
                 "v2" + RouteName.DeletePackageApi,
                 "api/v2/package/{id}/{version}",
-                new { controller = "Api", action = "DeletePackage" },
+                new { controller = "Api", action = "DeletePackageApi" },
                 constraints: new { httpMethod = new HttpMethodConstraint("DELETE") });
 
             routes.MapRoute(
                 "v2" + RouteName.PublishPackageApi,
                 "api/v2/package/{id}/{version}",
-                new { controller = "Api", action = "PublishPackage" },
+                new { controller = "Api", action = "PublishPackageApi" },
                 constraints: new { httpMethod = new HttpMethodConstraint("POST") });
 
             routes.MapRoute(


### PR DESCRIPTION
which are endpoints to unlist and list a package in V2Gallery

This was broken by a 'Find-Replace' commit
e9313fed53aa1569a3841d650f0d67dd8ca55472 made on 04-08-2014

I would like to spend some time fixing any other possible misses from the
old commit. But, given the high importance of this fix, sending this
separately
