### PR TITLE
Add ServiceDiscovery support to Gallery.

### DIFF
--- a/src/NuGetGallery.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/src/NuGetGallery.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -22,7 +22,7 @@
       <Setting name="Gallery.GoogleAnalyticsPropertyId" value="" />
       <Setting name="Gallery.AzureCdnHost" value="" />
       <Setting name="Gallery.SiteRoot" value="nuget.localtest.me" />
-      <Setting name="Gallery.SearchServiceUri" value="" />
+      <Setting name="Gallery.ServiceDiscoveryUri" value="" />
       <Setting name="Gallery.MetricsServiceUri" value="" />
       <Setting name="Auth.MicrosoftAccount.Enabled" value="false" />
       <Setting name="Auth.MicrosoftAccount.ClientId" value="" />

--- a/src/NuGetGallery.Cloud/ServiceConfiguration.Local.cscfg
+++ b/src/NuGetGallery.Cloud/ServiceConfiguration.Local.cscfg
@@ -22,7 +22,7 @@
       <Setting name="Gallery.GoogleAnalyticsPropertyId" value="" />
       <Setting name="Gallery.AzureCdnHost" value="" />
       <Setting name="Gallery.SiteRoot" value="nuget.localtest.me" />
-      <Setting name="Gallery.SearchServiceUri" value="" />
+      <Setting name="Gallery.ServiceDiscoveryUri" value="" />
       <Setting name="Gallery.MetricsServiceUri" value="" />
       <Setting name="Auth.MicrosoftAccount.Enabled" value="false" />
       <Setting name="Auth.MicrosoftAccount.ClientId" value="" />

--- a/src/NuGetGallery.Cloud/ServiceDefinition.csdef
+++ b/src/NuGetGallery.Cloud/ServiceDefinition.csdef
@@ -21,7 +21,7 @@
       <Setting name="Gallery.LuceneIndexLocation" />
       <Setting name="Gallery.GoogleAnalyticsPropertyId" />
       <Setting name="Gallery.HasWorker" />
-      <Setting name="Gallery.SearchServiceUri" />
+      <Setting name="Gallery.ServiceDiscoveryUri" />
       <Setting name="Gallery.MetricsServiceUri" />
       <Setting name="Gallery.AutoUpdateSearchIndex" />
       <Setting name="Gallery.CollectPerfLogs" />

--- a/src/NuGetGallery/App_Start/ContainerBindings.cs
+++ b/src/NuGetGallery/App_Start/ContainerBindings.cs
@@ -217,7 +217,7 @@ namespace NuGetGallery
 
         private void ConfigureSearch(ConfigurationService configuration)
         {
-            if (configuration.Current.SearchServiceUri == null)
+            if (configuration.Current.ServiceDiscoveryUri == null)
             {
                 Bind<ISearchService>()
                     .To<LuceneSearchService>()

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -38,7 +38,7 @@ namespace NuGetGallery.Configuration
         /// <summary>
         /// Gets the URI to the search service
         /// </summary>
-        public Uri SearchServiceUri { get; set; }
+        public Uri ServiceDiscoveryUri { get; set; }
 
         /// <summary>
         /// Gets the URI to the metrics service

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -38,7 +38,7 @@ namespace NuGetGallery.Configuration
         /// <summary>
         /// Gets the URI to the search service
         /// </summary>
-        Uri SearchServiceUri { get; set; }
+        Uri ServiceDiscoveryUri { get; set; }
 
         /// <summary>
         /// Gets the URI to the metrics service

--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery.Infrastructure.Lucene
         
         private SearchClient _client;
         private JObject _diagCache;
-        
+
         public Uri ServiceUri { get; private set; }
         
         protected IDiagnosticsSource Trace { get; private set; }
@@ -43,7 +43,8 @@ namespace NuGetGallery.Infrastructure.Lucene
 
         public ExternalSearchService(IAppConfiguration config, IDiagnosticsService diagnostics)
         {
-            ServiceUri = config.SearchServiceUri;
+            ServiceUri = config.ServiceDiscoveryUri;
+
             Trace = diagnostics.SafeGetSource("ExternalSearchService");
 
             // Extract credentials
@@ -104,7 +105,7 @@ namespace NuGetGallery.Infrastructure.Lucene
                 explain: false,
                 getAllVersions: filter.IncludeAllVersions,
                 supportedFramework: filter.SupportedFramework);
-			sw.Stop();
+            sw.Stop();
 
             SearchResults results = null;
             if (result.IsSuccessStatusCode)

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -304,9 +304,16 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Entity" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.0-rc1\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.0-rc\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.23.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
@@ -1464,4 +1471,9 @@
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets'))" />
   </Target>
   <Import Project="..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
 </Project>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -273,13 +273,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Nuget.Core.2.8.3-alpha0001\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.11.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.29.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.11-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.29-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Search.Client">
-      <HintPath>..\..\packages\NuGet.Services.Search.Client.3.0.42-r-master\lib\portable-net45+win+wp80\NuGet.Services.Search.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Services.Search.Client, Version=3.0.53.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NuGet.Services.Search.Client.3.0.53-r-master\lib\portable-net45+win+wp80\NuGet.Services.Search.Client.dll</HintPath>
     </Reference>
     <Reference Include="ODataNullPropagationVisitor">
       <HintPath>..\..\packages\ODataNullPropagationVisitor.0.5.4237.2641\lib\net40\ODataNullPropagationVisitor.dll</HintPath>

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -302,6 +302,7 @@ namespace NuGetGallery
 
             package.Listed = true;
             package.LastUpdated = DateTime.UtcNow;
+            package.LastEdited = DateTime.UtcNow;
 
             UpdateIsLatest(package.PackageRegistration);
 

--- a/src/NuGetGallery/Services/StatusService.cs
+++ b/src/NuGetGallery/Services/StatusService.cs
@@ -108,12 +108,12 @@ namespace NuGetGallery
 
         private async Task<bool?> IsSearchServiceAvailable()
         {
-            if (_config == null || _config.SearchServiceUri == null)
+            if (_config == null || _config.ServiceDiscoveryUri == null)
             {
                 return null;
             }
 
-            return await IsGetSuccessful(_config.SearchServiceUri);
+            return await IsGetSuccessful(_config.ServiceDiscoveryUri);
         }
 
         private async Task<bool?> IsMetricsServiceAvailable()

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -71,7 +71,8 @@
         <add key="Gallery.RequireSSL" value="false" />
 
         <!-- Set this value to use a remote search service. This overrides ALL other Lucene-related settings and disables indexing jobs. -->
-        <add key="Gallery.SearchServiceUri" value="https://api-search.nuget.org" />
+        <add key="Gallery.ServiceDiscoveryUri" value="https://api.nuget.org/v3/index.json" />
+
 
         <add key="Gallery.Brand" value="NuGet Gallery" />
         <add key="Gallery.GalleryOwner" value="NuGet Gallery &lt;support@nuget.org&gt;" />

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -27,14 +27,17 @@
   <package id="Microsoft.AspNet.Razor" version="2.0.20715.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Web.Helpers.Mvc" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.0-rc1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.0-rc" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="2.0.30116.0" targetFramework="net45" />
-  <package id="Microsoft.Owin" version="2.0.2" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.23-beta" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.Cookies" version="2.0.2" targetFramework="net45" />

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -51,8 +51,8 @@
   <package id="Ninject.Web.Common" version="3.0.0.7" targetFramework="net45" />
   <package id="Nuget.Core" version="2.8.3-alpha0001" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.6" targetFramework="net45" developmentDependency="true" />
-  <package id="NuGet.Services.Platform.Client" version="3.0.11-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Search.Client" version="3.0.42-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform.Client" version="3.0.29-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Search.Client" version="3.0.53-r-master" targetFramework="net45" />
   <package id="ODataNullPropagationVisitor" version="0.5.4237.2641" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="PoliteCaptcha" version="0.4.0.0" targetFramework="net45" />


### PR DESCRIPTION
Make the gallery read and respect search service configuration from
api.nuget.org/v3/index.json so that we can straightforwardly re-point it
later.