### PR TITLE
Escape underscores in confirmation urls for new accounts or changes emai...

### DIFF
--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -179,7 +179,7 @@ The {0} Team";
                 CultureInfo.CurrentCulture,
                 body,
                 Config.GalleryOwner.DisplayName,
-                HttpUtility.UrlDecode(confirmationUrl),
+                HttpUtility.UrlDecode(confirmationUrl).Replace("_", "\\_"),
                 confirmationUrl);
 
             using (var mailMessage = new MailMessage())
@@ -208,7 +208,7 @@ The {0} Team";
                 CultureInfo.CurrentCulture,
                 body,
                 Config.GalleryOwner.DisplayName,
-                HttpUtility.UrlDecode(confirmationUrl),
+                HttpUtility.UrlDecode(confirmationUrl).Replace("_", "\\_"),
                 confirmationUrl);
 
             using (var mailMessage = new MailMessage())


### PR DESCRIPTION
...l addresses #2357

Markdown sees the underscore as italics indicator, so underscores are
stripped in the message. This prevents cut and pasting of the address or
the use of text only email readers.