### PR TITLE
Fix for issue #2038 (part 1 of 2)

### DIFF
--- a/build.msbuild
+++ b/build.msbuild
@@ -40,7 +40,7 @@
         <PropertyGroup>
             <NuGetExeDir>$(MSBuildThisFileDirectory)\.nuget</NuGetExeDir>
             <NuGetExePath>$(NuGetExeDir)\nuget.exe</NuGetExePath>
-            <RestoreCommand>$(NuGetExePath) restore -Source "@(PackageSource)" "@(SolutionFile)" -NonInteractive</RestoreCommand>
+            <RestoreCommand>"$(NuGetExePath)" restore -Source "@(PackageSource)" "@(SolutionFile)" -NonInteractive</RestoreCommand>
         </PropertyGroup>
         <MakeDir Directories="$(NuGetExeDir)" Condition="!Exists('$(NuGetExeDir)')" />
         <Message Text="Restoring packages ... " Importance="high" />


### PR DESCRIPTION
Fix for issue #2038 ("build.md fails when path contains spaces").

Note that the same bug exists in the NuGet.Services.Build project.  In
order to completely fix this issue, both NuGetGallery and
NuGet.Services.Build will need to be patched.

I'll create a pull request for NuGet.Services.Build as well.