### PR TITLE
Added latest version for packages in profile

### DIFF
--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -265,8 +265,7 @@ namespace NuGetGallery
                 .OrderByDescending(p => p.PackageRegistration.DownloadCount)
                 .Select(p => new PackageViewModel(p)
                 {
-                    DownloadCount = p.PackageRegistration.DownloadCount,
-                    Version = null
+                    DownloadCount = p.PackageRegistration.DownloadCount
                 }).ToList();
 
             var model = new UserProfileModel(user, packages, page - 1, Constants.DefaultPackageListPageSize, Url);

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -50,7 +50,7 @@
                     </a>
                 </div>
                 <div class="main">
-                    <h1><a href="@Url.Package(package.Id)">@package.Title</a></h1>
+                    <h1><a href="@Url.Package(package.Id)">@package.Title</a> <small>Latest version: @package.Version</small></h1>
                 
                     <p>
                         @if (String.IsNullOrEmpty(package.Description) || package.Description.Length < 350)


### PR DESCRIPTION
When we pushed Nancy 1.1 today, we wanted a way to see the latest version of all [nancyfx packages](https://www.nuget.org/profiles/nancyfx), to verify that all packages was uploaded successfully. Unfortunately there's no way to see this today, without checking each package individually.

This PR adds the latest version to the packages listing under the profile page. It might not be the sexiest placement, but it does the job :sparkles:

## Before
![2015-02-18_19-14-07](https://cloud.githubusercontent.com/assets/582487/6253587/dbe7d72e-b7a2-11e4-92fa-3043eaf8cf7f.png)


## After
![2015-02-18_19-13-19](https://cloud.githubusercontent.com/assets/582487/6253595/e58cf700-b7a2-11e4-8e92-cb6dd64ecc78.png)
