### PR TITLE
Prevent last updated date from wrapping

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -334,7 +334,7 @@ p.authors {
 }
 
 .stat-number {
-    font: 2.3em 'andale mono', 'lucida console', monospace;
+    font: 2em 'andale mono', 'lucida console', monospace;
     letter-spacing: 1px;
     line-height: 1.4em;
     margin: 0;

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -51,18 +51,15 @@
     <div id="stats">
         <div class="stat">
             <p class="stat-number">@Model.TotalDownloadCount.ToString("n0")</p>
-            <p class="stat-label">
-                @(Model.TotalDownloadCount == 1 ? "Download" : "Downloads")</p>
+            <p class="stat-label">@(Model.TotalDownloadCount == 1 ? "Download" : "Downloads")</p>
         </div>
         <div class="stat">
             <p class="stat-number">@Model.DownloadCount.ToString("n0")</p>
-            <p class="stat-label">
-                @(Model.DownloadCount == 1 ? "Download" : "Downloads") of v @Model.Version</p>
+            <p class="stat-label">@(Model.DownloadCount == 1 ? "Download" : "Downloads") of v @Model.Version</p>
         </div>
         <div class="stat">
             <p class="stat-number">@Model.LastUpdated.ToNuGetShortDateString()</p>
-            <p class="stat-label">
-                Last published</p>
+            <p class="stat-label">Last published</p>
         </div>
     </div>
     <nav>


### PR DESCRIPTION
Scaled down the font size on the `stat-number` class. The Newtonsoft.Json (as an example) page looks like a mess with the current size.

## Before
![2015-02-18_19-39-05](https://cloud.githubusercontent.com/assets/582487/6254050/f9647aac-b7a5-11e4-9327-bd315a178e0d.png)

## After
![2015-02-18_19-38-47](https://cloud.githubusercontent.com/assets/582487/6254054/fddd1f4e-b7a5-11e4-915a-d4fb4ade238e.png)
