### PR TITLE
System.Spatial reference cleanup

### DIFF
--- a/src/NuGetGallery.Backend/NuGetGallery.Backend.csproj
+++ b/src/NuGetGallery.Backend/NuGetGallery.Backend.csproj
@@ -92,9 +92,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Rx-PlatformServices.2.1.30214.0\lib\Net45\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="System.Spatial, Version=5.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\System.Spatial.5.5.0\lib\net40\System.Spatial.dll</HintPath>
+    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/NuGetGallery.Backend/app.config
+++ b/src/NuGetGallery.Backend/app.config
@@ -24,7 +24,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.5.0.0" newVersion="5.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/src/NuGetGallery.Backend/packages.config
+++ b/src/NuGetGallery.Backend/packages.config
@@ -13,6 +13,6 @@
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-Main" version="2.1.30214.0" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.1.30214.0" targetFramework="net45" />
-  <package id="System.Spatial" version="5.5.0" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="2.1.0.3" targetFramework="net45" />
 </packages>

--- a/src/NuGetGallery.Operations/NuGetGallery.Operations.csproj
+++ b/src/NuGetGallery.Operations/NuGetGallery.Operations.csproj
@@ -14,7 +14,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>da05628d</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>946c4ba1</NuGetPackageImportStamp>
+	<SkipValidatePackageReferences>true</SkipValidatePackageReferences>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,11 +54,16 @@
     <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
@@ -107,11 +113,13 @@
       <Private>True</Private>
       <HintPath>..\..\packages\System.Net.Http.2.0.20126.16343\lib\net40\System.Net.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
       <Private>True</Private>
@@ -373,6 +381,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.props'))" />
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
   <Import Project="..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
 </Project>

--- a/src/NuGetGallery.Operations/packages.config
+++ b/src/NuGetGallery.Operations/packages.config
@@ -22,6 +22,6 @@
   <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.6" targetFramework="net45" developmentDependency="true" />
   <package id="System.Net.Http" version="2.0.20126.16343" targetFramework="net45" />
-  <package id="System.Spatial" version="5.5.0" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="2.1.0.3" targetFramework="net45" />
 </packages>

--- a/src/NuGetGallery.Operations/packages.config
+++ b/src/NuGetGallery.Operations/packages.config
@@ -5,12 +5,12 @@
   <package id="EntityFramework" version="5.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.20715.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Common" version="0.9.3-preview" targetFramework="net45" />

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -7,6 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>
     </ProductVersion>
+	<SkipValidatePackageReferences>true</SkipValidatePackageReferences>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{1DACF781-5CD0-4123-8BAC-CD385D864BE5}</ProjectGuid>
     <ProjectTypeGuids>{E3E379DF-F4C6-4180-9B81-6769533ABE47};{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
@@ -33,7 +34,7 @@
     <IISExpressWindowsAuthentication>disabled</IISExpressWindowsAuthentication>
     <IISExpressUseClassicPipelineMode>false</IISExpressUseClassicPipelineMode>
     <CodeContractsAssemblyMode>0</CodeContractsAssemblyMode>
-    <NuGetPackageImportStamp>13a692f4</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>14d46f63</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -304,16 +305,17 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Entity" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.0-rc\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.23.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
@@ -1453,7 +1455,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>80</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://nuget.localtest.me</IISUrl>
+          <IISUrl>http://localhost</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>
@@ -1469,11 +1471,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.props'))" />
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
   <Import Project="..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.6\build\NuGet.Services.Build.targets')" />
-  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
 </Project>

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -29,14 +29,14 @@
   <package id="Microsoft.AspNet.Web.Optimization" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.0-rc" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net40" />
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="2.0.30116.0" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.2.23-beta" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="2.0.2" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="2.0.2" targetFramework="net45" />

--- a/src/galops/packages.config
+++ b/src/galops/packages.config
@@ -6,6 +6,6 @@
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="NLog" version="2.0.0.2000" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.6" targetFramework="net45" developmentDependency="true" />
-  <package id="System.Spatial" version="5.5.0" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="2.1.0.3" targetFramework="net45" />
 </packages>

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -77,8 +77,8 @@
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Spatial, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.2.0\lib\net40\System.Spatial.dll</HintPath>
+    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />

--- a/tests/NuGetGallery.Core.Facts/packages.config
+++ b/tests/NuGetGallery.Core.Facts/packages.config
@@ -8,6 +8,7 @@
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.5" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.6" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
the most confusing part actually is  tests/NuGetGallery.Core.Facts/packages.config
system.spatial was missing there, so package didn't restore at build

5.5 --> 5.6 is a cosmetic change