### PR TITLE
Fix typo in SSL configuration

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -241,7 +241,7 @@
                 <add name="X-Frame-Options" value="deny" />
                 <add name="X-XSS-Protection" value="1; mode=block" />
                 <add name="X-Content-Type-Options" value="nosniff" />
-                <add name="Strict-Transport-Security" value="maxage=31536000; includeSubDomains" />
+                <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" />
             </customHeaders>
         </httpProtocol>
         <handlers>

--- a/tests/NuGetGallery.FunctionalTests/WebUITests/BasicPages/SecurityHeaderTest.cs
+++ b/tests/NuGetGallery.FunctionalTests/WebUITests/BasicPages/SecurityHeaderTest.cs
@@ -26,7 +26,7 @@ namespace NuGetGallery.FunctionalTests
  @"X-Frame-Options: deny
 X-XSS-Protection: 1; mode=block
 X-Content-Type-Options: nosniff
-Strict-Transport-Security: maxage=31536000; includeSubDomains");               
+Strict-Transport-Security: max-age=31536000; includeSubDomains");               
              homePageRequest.ValidateResponse += new EventHandler<ValidationEventArgs>(homePageTextValidationRule.Validate);         
              yield return homePageRequest;
              homePageRequest = null;
@@ -38,7 +38,7 @@ Strict-Transport-Security: maxage=31536000; includeSubDomains");
  @"X-Frame-Options: deny
 X-XSS-Protection: 1; mode=block
 X-Content-Type-Options: nosniff
-Strict-Transport-Security: maxage=31536000; includeSubDomains");    
+Strict-Transport-Security: max-age=31536000; includeSubDomains");    
             packagesPageRequest.ValidateResponse += new EventHandler<ValidationEventArgs>(packagesPageTextValidationRule.Validate);
             yield return packagesPageRequest;
             packagesPageRequest = null;


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security#Enabling_Strict_Transport_Security

Fixes https://github.com/NuGet/Home/issues/616