### PR TITLE
Show indexing status next to new package versions #2522

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -250,7 +250,7 @@ namespace NuGetGallery
             return RedirectToRoute(RouteName.VerifyPackage);
         }
 
-        public virtual ActionResult DisplayPackage(string id, string version)
+        public virtual async Task<ActionResult> DisplayPackage(string id, string version)
         {
             string normalized = SemanticVersionExtensions.Normalize(version);
             if (!String.Equals(version, normalized))
@@ -281,6 +281,8 @@ namespace NuGetGallery
                     model.SetPendingMetadata(pendingMetadata);
                 }
             }
+
+            model.IndexLastWriteTime = await _indexingService.GetLastWriteTime();
 
             ViewBag.FacebookAppID = _config.FacebookAppId;
             return View(model);

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -24,6 +24,7 @@ namespace NuGetGallery
                                   select new DisplayPackageViewModel(p, isVersionHistory: true);
             }
             DownloadCount = package.DownloadCount;
+            LastEdited = package.LastEdited;
         }
 
         public void SetPendingMetadata(PackageEdit pendingMetadata)
@@ -54,6 +55,7 @@ namespace NuGetGallery
 
         public bool HasPendingMetadata { get; private set; }
         public bool IsLastEditFailed { get; private set; }
+        public DateTime? LastEdited { get; set; }
 
         public bool HasNewerPrerelease
         {
@@ -62,5 +64,14 @@ namespace NuGetGallery
                 return PackageVersions.Any(pv => pv.LatestVersion && !pv.LatestStableVersion);
             }
         }
+
+        public bool IsProbablyIndexed(DateTime? indexLastWriteTime)
+        {
+            return (indexLastWriteTime.HasValue 
+                && LastUpdated <= indexLastWriteTime 
+                && (!LastEdited.HasValue || LastEdited <= indexLastWriteTime));
+        }
+
+        public DateTime? IndexLastWriteTime { get; set; }
     }
 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -187,6 +187,15 @@
             There is a newer prerelease version of this package available. See the version list below for details.
         </p>
     }
+
+    @if (Model.Listed && !Model.IsProbablyIndexed(Model.IndexLastWriteTime))
+    {
+        <p class="message warning">
+            <strong>This package has not been indexed yet.</strong> It will appear in search results and will be available for install/restore after indexing is completed.<br/><br/>
+            Search index last updated <time class="timeago" datetime="@Model.IndexLastWriteTime.Value.ToJavaScriptUTC()">@Model.IndexLastWriteTime.Value.ToNuGetShortDateTimeString() UTC</time>.
+        </p>
+    }
+
     <div class="package-page-heading">
         <h1>@Model.Title</h1>
         <h2>@Model.Version</h2>
@@ -303,48 +312,52 @@
                 </th>
                 @if (Model.IsOwner(User))
                 {
-                    <th class="last">
-                        Listed
-                    </th>
+                    <th class="last">Listed</th>
                 }
             </tr>
         </thead>
         <tbody>
-            @foreach (var packageVersion in Model.PackageVersions)
+        @foreach (var packageVersion in Model.PackageVersions)
+        {
+            var rowClass = packageVersion.LatestStableVersion ? "recommended" : null;
+            var cellTitle = packageVersion.LatestStableVersion ? "Latest Stable Version" : null;
+            if (packageVersion.Listed || Model.IsOwner(User))
             {
-                var rowClass = packageVersion.LatestStableVersion ? "recommended" : null;
-                var cellTitle = packageVersion.LatestStableVersion ? "Latest Stable Version" : null;
-                if (packageVersion.Listed || Model.IsOwner(User))
-                {
-                    <tr class="versionTableRow @rowClass">
-                        <td class="version" title="@cellTitle">
-                            @if (!packageVersion.IsCurrent(Model))
-                            {
-                                <a href="@Url.Package(packageVersion)">
-                                    @packageVersion.Title 
-                                    @packageVersion.Version
-                                    @if(packageVersion.LatestStableVersion) {
-                                        @:(latest stable)
-                                    }
-                                </a>
-                            }
-                            else
-                            {
-                                <span>@packageVersion.Title @packageVersion.Version (this version)</span>
-                            }
-                        </td>
-                        <td>@packageVersion.DownloadCount
-                        </td>
-                        <td>@packageVersion.LastUpdated.ToNuGetLongDateString()
-                        </td>
-                        @if (Model.IsOwner(User))
+                <tr class="versionTableRow @rowClass">
+                    <td class="version" title="@cellTitle">
+                        @if (!packageVersion.IsCurrent(Model))
                         {
-                            <td><a href="@Url.DeletePackage(packageVersion)" class="delete">@(packageVersion.Listed ? "yes" : "no")</a>
-                            </td>
+                            <a href="@Url.Package(packageVersion)">
+                                @packageVersion.Title
+                                @packageVersion.Version
+                                @if (packageVersion.LatestStableVersion)
+                                {
+                                    @:(latest stable)
+                                }
+                            </a>
                         }
-                    </tr>
-                }
+                        else
+                        {
+                            <span>@packageVersion.Title @packageVersion.Version (this version)</span>
+                        }
+
+                        @if (!packageVersion.IsProbablyIndexed(Model.IndexLastWriteTime))
+                        {
+                            <span title="This package has not been indexed yet. It will appear in search results and will be available for install/restore after indexing is completed.">pending</span>
+                        }
+                    </td>
+                    <td>@packageVersion.DownloadCount
+                    </td>
+                    <td>@packageVersion.LastUpdated.ToNuGetLongDateString()
+                    </td>
+                    @if (Model.IsOwner(User))
+                    {
+                        <td><a href="@Url.DeletePackage(packageVersion)" class="delete">@(packageVersion.Listed ? "yes" : "no")</a>
+                        </td>
+                    }
+                </tr>
             }
+        }
         </tbody>
     </table>
 </div>

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -151,7 +151,7 @@ namespace NuGetGallery
                 var controller = CreateController();
 
                 // Act
-                var result = controller.DisplayPackage("Foo", "01.01.01");
+                var result = controller.DisplayPackage("Foo", "01.01.01").Result;
 
                 // Assert
                 ResultAssert.IsRedirectToRoute(result, new
@@ -173,7 +173,7 @@ namespace NuGetGallery
                               .ReturnsNull();
 
                 // Act
-                var result = controller.DisplayPackage("Foo", "1.1.1");
+                var result = controller.DisplayPackage("Foo", "1.1.1").Result;
 
                 // Assert
                 ResultAssert.IsNotFound(result);
@@ -184,8 +184,9 @@ namespace NuGetGallery
             {
                 // Arrange
                 var packageService = new Mock<IPackageService>();
+                var indexingService = new Mock<IIndexingService>();
                 var controller = CreateController(
-                    packageService: packageService);
+                    packageService: packageService, indexingService: indexingService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
 
                 packageService.Setup(p => p.FindPackageByIdAndVersion("Foo", "1.1.1", true))
@@ -201,8 +202,10 @@ namespace NuGetGallery
                                   Title = "A test package!"
                               });
 
+                indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
+
                 // Act
-                var result = controller.DisplayPackage("Foo", "1.1.1");
+                var result = controller.DisplayPackage("Foo", "1.1.1").Result;
 
                 // Assert
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
@@ -259,12 +262,14 @@ namespace NuGetGallery
             {
                 // Arrange
                 var packageService = new Mock<IPackageService>();
+                var indexingService = new Mock<IIndexingService>();
                 var editPackageService = new Mock<EditPackageService>();
                 var httpContext = new Mock<HttpContextBase>();
                 var httpCachePolicy = new Mock<HttpCachePolicyBase>();
                 var controller = CreateController(
                     packageService: packageService,
                     editPackageService: editPackageService,
+                    indexingService: indexingService,
                     httpContext: httpContext);
                 controller.SetCurrentUser(TestUtility.FakeUser);
                 httpContext.Setup(c => c.Response.Cache).Returns(httpCachePolicy.Object);
@@ -288,8 +293,10 @@ namespace NuGetGallery
                     .Setup(e => e.GetPendingMetadata(package))
                     .ReturnsNull();
 
+                indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
+
                 // Act
-                var result = controller.DisplayPackage("Foo", "1.1.1");
+                var result = controller.DisplayPackage("Foo", "1.1.1").Result;
 
                 // Assert
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
@@ -303,12 +310,14 @@ namespace NuGetGallery
             {
                 // Arrange
                 var packageService = new Mock<IPackageService>();
+                var indexingService = new Mock<IIndexingService>();
                 var editPackageService = new Mock<EditPackageService>();
                 var httpContext = new Mock<HttpContextBase>();
                 var httpCachePolicy = new Mock<HttpCachePolicyBase>();
                 var controller = CreateController(
                     packageService: packageService,
                     editPackageService: editPackageService,
+                    indexingService: indexingService,
                     httpContext: httpContext);
                 controller.SetCurrentUser(TestUtility.FakeUser);
                 httpContext.Setup(c => c.Response.Cache).Returns(httpCachePolicy.Object);
@@ -334,8 +343,10 @@ namespace NuGetGallery
                         Title = "A modified package!"
                     });
 
+                indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
+
                 // Act
-                var result = controller.DisplayPackage("Foo", "1.1.1");
+                var result = controller.DisplayPackage("Foo", "1.1.1").Result;
 
                 // Assert
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);


### PR DESCRIPTION
This PR fixes #2522 and:
* Shows a message on top of the package details page if it has not yet been indexed
* Shows "Indexed = yes / no" in the package version history

Screenshot for a package that is not yet in the index:

![screenshot](https://cloud.githubusercontent.com/assets/485230/7956384/cffdb5ac-09df-11e5-8bca-54e62c5ebddc.png)
