### PR TITLE
set cacheability to public and return $count from cached search results

### DIFF
--- a/src/NuGetGallery/DataServices/V2Feed.svc.cs
+++ b/src/NuGetGallery/DataServices/V2Feed.svc.cs
@@ -75,10 +75,10 @@ namespace NuGetGallery
                 }
             }
 
-            // Check if the caller is requesting packages or calling an aggregate operation.
-            bool requestingPackages = !HttpContext.Request.RawUrl.Contains("$count");
+            // Check if the caller is requesting packages or calling the count operation.
+            bool requestingCount = HttpContext.Request.RawUrl.Contains("$count");
 
-            if (requestingPackages && string.IsNullOrEmpty(searchTerm))
+            if (requestingCount || string.IsNullOrEmpty(searchTerm))
             {
                 // Fetch the cache key for the empty search query.
                 string cacheKey = GetCacheKeyForEmptySearchQuery(targetFramework, includePrerelease);
@@ -119,7 +119,7 @@ namespace NuGetGallery
 
                 // Clients should cache twice as long.
                 // This way, they won't notice differences in the short-lived per instance cache.
-                HttpContext.Response.Cache.SetCacheability(HttpCacheability.Private);
+                HttpContext.Response.Cache.SetCacheability(HttpCacheability.Public);
                 HttpContext.Response.Cache.SetMaxAge(TimeSpan.FromSeconds(60));
                 HttpContext.Response.Cache.SetExpires(currentDateTime.AddSeconds(ServerCacheExpirationInSeconds * 2));
                 HttpContext.Response.Cache.SetLastModified(lastModified);

--- a/src/NuGetGallery/DataServices/V2Feed.svc.cs
+++ b/src/NuGetGallery/DataServices/V2Feed.svc.cs
@@ -78,7 +78,8 @@ namespace NuGetGallery
             // Check if the caller is requesting packages or calling the count operation.
             bool requestingCount = HttpContext.Request.RawUrl.Contains("$count");
 
-            if (requestingCount || string.IsNullOrEmpty(searchTerm))
+            var isEmptySearchTerm = string.IsNullOrEmpty(searchTerm);
+            if ((requestingCount && isEmptySearchTerm) || isEmptySearchTerm)
             {
                 // Fetch the cache key for the empty search query.
                 string cacheKey = GetCacheKeyForEmptySearchQuery(targetFramework, includePrerelease);


### PR DESCRIPTION
These changes should properly enable caching on search results for the empty query (cacheability = public), and also return the $count from the cached resultset.

These changes should be merged in and go live once we have some app-insights data collected from today's deployment, so we can compare the data before and after this change.