### PR TITLE
/api/status should check storage availability in general, not "one specific file availablity"

### DIFF
--- a/src/NuGetGallery/Services/CloudBlobContainerWrapper.cs
+++ b/src/NuGetGallery/Services/CloudBlobContainerWrapper.cs
@@ -32,5 +32,10 @@ namespace NuGetGallery
         {
             return new CloudBlobWrapper(_blobContainer.GetBlockBlobReference(blobAddressUri));
         }
+
+        public Task<bool> ExistsAsync()
+        {
+            return _blobContainer.ExistsAsync();
+        }
     }
 }

--- a/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
+++ b/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
@@ -110,6 +110,12 @@ namespace NuGetGallery
             await blob.SetPropertiesAsync();
         }
 
+        public async Task<bool> IsAvailableAsync()
+        {
+            var container = await GetContainer(Constants.PackagesFolderName);
+            return await container.ExistsAsync();
+        }
+
         private async Task<ICloudBlobContainer> GetContainer(string folderName)
         {
             ICloudBlobContainer container;

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
-using System.Web;
 using System.Web.Hosting;
 using System.Web.Mvc;
 using NuGetGallery.Configuration;
@@ -157,6 +157,11 @@ namespace NuGetGallery
             }
 
             return Task.FromResult(0);
+        }
+
+        public Task<bool> IsAvailableAsync()
+        {
+            return Task.FromResult(Directory.Exists(_configuration.FileStorageDirectory));
         }
 
         private static string BuildPath(string fileStorageDirectory, string folderName, string fileName)

--- a/src/NuGetGallery/Services/ICloudBlobContainer.cs
+++ b/src/NuGetGallery/Services/ICloudBlobContainer.cs
@@ -10,5 +10,6 @@ namespace NuGetGallery
         Task CreateIfNotExistAsync();
         Task SetPermissionsAsync(BlobContainerPermissions permissions);
         ISimpleCloudBlob GetBlobReference(string blobAddressUri);
+        Task<bool> ExistsAsync();
     }
 }

--- a/src/NuGetGallery/Services/IFileStorageService.cs
+++ b/src/NuGetGallery/Services/IFileStorageService.cs
@@ -4,7 +4,6 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using System.Web.Mvc;
-using NuGetGallery;
 
 namespace NuGetGallery
 {
@@ -28,5 +27,7 @@ namespace NuGetGallery
         Task<IFileReference> GetFileReferenceAsync(string folderName, string fileName, string ifNoneMatch = null);
 
         Task SaveFileAsync(string folderName, string fileName, Stream packageFile);
+
+        Task<bool> IsAvailableAsync();
     }
 }

--- a/src/NuGetGallery/Services/StatusService.cs
+++ b/src/NuGetGallery/Services/StatusService.cs
@@ -95,7 +95,7 @@ namespace NuGetGallery
             try
             {
                 // Check Storage Availability
-                storageAvailable = await _fileStorageService.FileExistsAsync(Constants.DownloadsFolderName, "nuget.exe");
+                storageAvailable = await _fileStorageService.IsAvailableAsync();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Now checks if /packages is available as a container. No longer requires nuget.exe to be present in a given folder.

@xavierdecoster Can you review?