### PR TITLE
moved X-Frame-Options, X-XSS-Protection from Web.config to MVC views

### DIFF
--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -1,4 +1,8 @@
-﻿<!DOCTYPE html> 
+﻿@{
+    Response.AddHeader("X-Frame-Options", "deny");
+    Response.AddHeader("X-XSS-Protection", "1; mode=block");
+}
+<!DOCTYPE html> 
 <html lang="en" class="static " data-root="@Href("~/")">
     <head>
         <meta charset="utf-8" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -262,8 +262,6 @@
     <httpProtocol>
       <customHeaders>
         <remove name="X-Powered-By" />
-        <add name="X-Frame-Options" value="deny" />
-        <add name="X-XSS-Protection" value="1; mode=block" />
         <add name="X-Content-Type-Options" value="nosniff" />
         <add name="Strict-Transport-Security" value="max-age=31536000" />
       </customHeaders>


### PR DESCRIPTION
I beleive that headers  X-Frame-Options, X-XSS-Protection  are not usefull for all http responses, particularly css, js, feeds.

So, I suggest to move them from web.config to Razor view