### PR TITLE
Updated .md Update-Database Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ website for the NuGet client. For information about the NuGet clients, visit htt
  5. Run the following command in the Package Manager Console:
  
     ```
-    Update-Database
+    Update-Database -StartUpProjectName NuGetGallery
     ```
 If this fails, you are likely to get more useful output by passing -Debug than -Verbose.
 


### PR DESCRIPTION
Updated the Update-Database command in the readme.md file to add -StartupProjectName parameter as NuGetGallery. (Without it it uses NuGetGallery.Operations as the Startup project which does not have the database connection string in its config...)