### PR TITLE
Change default value of Gallery.ServiceDiscoveryUri application key

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -75,6 +75,7 @@
         <add key="Gallery.ServiceDiscoveryUri" value="https://api.nuget.org/v3/index.json" />
         <add key="Gallery.SearchServiceResourceType" value="SearchGalleryQueryService/3.0.0-rc" />
         -->
+    <add key="Gallery.ServiceDiscoveryUri" value="" />
     <add key="Gallery.SearchServiceResourceType" value="" />
     <add key="Gallery.Brand" value="NuGet Gallery" />
     <add key="Gallery.GalleryOwner" value="NuGet Gallery &lt;support@nuget.org&gt;" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -75,7 +75,6 @@
         <add key="Gallery.ServiceDiscoveryUri" value="https://api.nuget.org/v3/index.json" />
         <add key="Gallery.SearchServiceResourceType" value="SearchGalleryQueryService/3.0.0-rc" />
         -->
-    <add key="Gallery.ServiceDiscoveryUri" value="n" />
     <add key="Gallery.SearchServiceResourceType" value="" />
     <add key="Gallery.Brand" value="NuGet Gallery" />
     <add key="Gallery.GalleryOwner" value="NuGet Gallery &lt;support@nuget.org&gt;" />


### PR DESCRIPTION
Fixes #2615 - duplicate app key which causes application not to load up since it's not a URI