### PR TITLE
Fixed default configuration in Web.config

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -75,7 +75,7 @@
         <add key="Gallery.ServiceDiscoveryUri" value="https://api.nuget.org/v3/index.json" />
         <add key="Gallery.SearchServiceResourceType" value="SearchGalleryQueryService/3.0.0-rc" />
         -->
-    <add key="Gallery.ServiceDiscoveryUri" value="n" />
+    <add key="Gallery.ServiceDiscoveryUri" value="" />
     <add key="Gallery.SearchServiceResourceType" value="" />
     <add key="Gallery.Brand" value="NuGet Gallery" />
     <add key="Gallery.GalleryOwner" value="NuGet Gallery &lt;support@nuget.org&gt;" />


### PR DESCRIPTION
It seems that this "n" was introduced as a typo, but now the site is crashing with the default configuration