### PR TITLE
Fix inconsistent number style + replaced `clientCulture` with currentCulture (code *was* inconsistent)

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -668,6 +668,10 @@ ul.pager {
             padding: 2px 5px;
         }
 
+        .sexy-table tbody td.package-version-downloads {
+           text-align: right
+        }
+
     /* footer */
 
     .sexy-table tfoot {

--- a/src/NuGetGallery/Controllers/AppController.cs
+++ b/src/NuGetGallery/Controllers/AppController.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Security.Claims;
+using System.Threading;
 using System.Web;
 using System.Web.Mvc;
 using Microsoft.Owin;
@@ -44,6 +45,23 @@ namespace NuGetGallery
         protected internal virtual ActionResult SafeRedirect(string returnUrl)
         {
             return new SafeRedirectResult(returnUrl, Url.Home());
+        }
+
+
+        /// <summary>
+        /// Called before the action method is invoked.
+        /// </summary>
+        /// <param name="filterContext">Information about the current request and action.</param>
+        protected override void OnActionExecuting(ActionExecutingContext filterContext)
+        {
+            if (!filterContext.IsChildAction)
+            {
+                //no need to do the hassle for a child action
+                //set the culture from the request headers
+                Thread.CurrentThread.CurrentCulture = filterContext.RequestContext.HttpContext.Request.DetermineClientLocale();
+            }
+
+            base.OnActionExecuting(filterContext);
         }
     }
 }

--- a/src/NuGetGallery/Controllers/AppController.cs
+++ b/src/NuGetGallery/Controllers/AppController.cs
@@ -58,7 +58,7 @@ namespace NuGetGallery
             {
                 //no need to do the hassle for a child action
                 //set the culture from the request headers
-                Thread.CurrentThread.CurrentCulture = filterContext.RequestContext.HttpContext.Request.DetermineClientLocale();
+                Thread.CurrentThread.CurrentCulture = Request.DetermineClientLocale();
             }
 
             base.OnActionExecuting(filterContext);

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -42,7 +42,7 @@ namespace NuGetGallery
             var stats = await _aggregateStatsService.GetAggregateStats();
 
             // if we fail to detect client locale from the Languages header, fall back to server locale
-            CultureInfo clientCulture = DetermineClientLocale() ?? CultureInfo.CurrentCulture;
+            CultureInfo clientCulture = Request.DetermineClientLocale() ?? CultureInfo.CurrentCulture;
             return Json(
                 new
                 {
@@ -54,49 +54,7 @@ namespace NuGetGallery
                 JsonRequestBehavior.AllowGet);
         }
 
-        private CultureInfo DetermineClientLocale()
-        {
-            if (Request == null)
-            {
-                return null;
-            }
-
-            string[] languages = Request.UserLanguages;
-            if (languages == null)
-            {
-                return null;
-            }
-
-            foreach (string language in languages)
-            {
-                string lang = language.ToLowerInvariant().Trim();
-                try
-                {
-                    return CultureInfo.GetCultureInfo(lang);
-                }
-                catch (CultureNotFoundException)
-                {
-                }
-            }
-
-            foreach (string language in languages)
-            {
-                string lang = language.ToLowerInvariant().Trim();
-                if (lang.Length > 2)
-                {
-                    string lang2 = lang.Substring(0, 2);
-                    try
-                    {
-                        return CultureInfo.GetCultureInfo(lang2);
-                    }
-                    catch (CultureNotFoundException)
-                    {
-                    }
-                }
-            }
-
-            return null;
-        }
+      
 
         //
         // GET: /stats
@@ -131,7 +89,7 @@ namespace NuGetGallery
                     .FirstOrDefault()
             };
 
-            model.ClientCulture = DetermineClientLocale();
+            model.ClientCulture = Request.DetermineClientLocale();
 
             model.Update();
 
@@ -156,7 +114,7 @@ namespace NuGetGallery
             {
                 IsDownloadPackageAvailable = result.Loaded,
                 DownloadPackagesAll = _statisticsService.DownloadPackagesAll,
-                ClientCulture = DetermineClientLocale(),
+                ClientCulture = Request.DetermineClientLocale(),
                 LastUpdatedUtc = result.LastUpdatedUtc
             };
 
@@ -179,7 +137,7 @@ namespace NuGetGallery
             {
                 IsDownloadPackageDetailAvailable = result.Loaded,
                 DownloadPackageVersionsAll = _statisticsService.DownloadPackageVersionsAll,
-                ClientCulture = DetermineClientLocale(),
+                ClientCulture = Request.DetermineClientLocale(),
                 LastUpdatedUtc = result.LastUpdatedUtc
             };
 
@@ -198,7 +156,7 @@ namespace NuGetGallery
 
             StatisticsPackagesReport report = await _statisticsService.GetPackageDownloadsByVersion(id);
 
-            ProcessReport(report, groupby, new string[] { "Version", "ClientName", "ClientVersion", "Operation" }, id, DetermineClientLocale());
+            ProcessReport(report, groupby, new string[] { "Version", "ClientName", "ClientVersion", "Operation" }, id, Request.DetermineClientLocale());
 
             if (report != null)
             {
@@ -226,7 +184,7 @@ namespace NuGetGallery
 
             StatisticsPackagesReport report = await _statisticsService.GetPackageVersionDownloadsByClient(id, version);
 
-            ProcessReport(report, groupby, new[] { "ClientName", "ClientVersion", "Operation" }, null, DetermineClientLocale());
+            ProcessReport(report, groupby, new[] { "ClientName", "ClientVersion", "Operation" }, null, Request.DetermineClientLocale());
 
             if (report != null)
             {

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -261,7 +261,7 @@ namespace NuGetGallery
                 }
 
                 report.Table = null;
-                report.Total = report.Facts.Sum(fact => fact.Amount).ToString("n0", clientCulture);
+                report.Total = report.Facts.Sum(fact => fact.Amount).ToNuGetNumberString();
             }
         }
 

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -88,8 +87,6 @@ namespace NuGetGallery
                     .FirstOrDefault()
             };
 
-            model.ClientCulture = Request.DetermineClientLocale();
-
             model.Update();
 
             model.UseD3 = UseD3();
@@ -113,7 +110,6 @@ namespace NuGetGallery
             {
                 IsDownloadPackageAvailable = result.Loaded,
                 DownloadPackagesAll = _statisticsService.DownloadPackagesAll,
-                ClientCulture = Request.DetermineClientLocale(),
                 LastUpdatedUtc = result.LastUpdatedUtc
             };
 
@@ -136,7 +132,6 @@ namespace NuGetGallery
             {
                 IsDownloadPackageDetailAvailable = result.Loaded,
                 DownloadPackageVersionsAll = _statisticsService.DownloadPackageVersionsAll,
-                ClientCulture = Request.DetermineClientLocale(),
                 LastUpdatedUtc = result.LastUpdatedUtc
             };
 
@@ -155,7 +150,7 @@ namespace NuGetGallery
 
             StatisticsPackagesReport report = await _statisticsService.GetPackageDownloadsByVersion(id);
 
-            ProcessReport(report, groupby, new string[] { "Version", "ClientName", "ClientVersion", "Operation" }, id, Request.DetermineClientLocale());
+            ProcessReport(report, groupby, new string[] { "Version", "ClientName", "ClientVersion", "Operation" }, id);
 
             if (report != null)
             {
@@ -183,7 +178,7 @@ namespace NuGetGallery
 
             StatisticsPackagesReport report = await _statisticsService.GetPackageVersionDownloadsByClient(id, version);
 
-            ProcessReport(report, groupby, new[] { "ClientName", "ClientVersion", "Operation" }, null, Request.DetermineClientLocale());
+            ProcessReport(report, groupby, new[] { "ClientName", "ClientVersion", "Operation" }, null);
 
             if (report != null)
             {
@@ -199,7 +194,7 @@ namespace NuGetGallery
             return View(model);
         }
 
-        private void ProcessReport(StatisticsPackagesReport report, string[] groupby, string[] dimensions, string id, CultureInfo clientCulture)
+        private void ProcessReport(StatisticsPackagesReport report, string[] groupby, string[] dimensions, string id)
         {
             if (report == null)
             {
@@ -228,7 +223,7 @@ namespace NuGetGallery
                     Array.Resize(ref pivot, dim);
                 }
 
-                Tuple<StatisticsPivot.TableEntry[][], string> result = StatisticsPivot.GroupBy(report.Facts, pivot, clientCulture);
+                Tuple<StatisticsPivot.TableEntry[][], string> result = StatisticsPivot.GroupBy(report.Facts, pivot);
 
                 if (id != null)
                 {

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -41,14 +41,13 @@ namespace NuGetGallery
         {
             var stats = await _aggregateStatsService.GetAggregateStats();
 
-            // if we fail to detect client locale from the Languages header, fall back to server locale
-            CultureInfo clientCulture = Request.DetermineClientLocale() ?? CultureInfo.CurrentCulture;
+       
             return Json(
                 new
                 {
-                    Downloads = stats.Downloads.ToString("n0", clientCulture),
-                    UniquePackages = stats.UniquePackages.ToString("n0", clientCulture),
-                    TotalPackages = stats.TotalPackages.ToString("n0", clientCulture),
+                    Downloads = stats.Downloads.ToNuGetNumberString(),
+                    UniquePackages = stats.UniquePackages.ToNuGetNumberString(),
+                    TotalPackages = stats.TotalPackages.ToNuGetNumberString(),
                     LastUpdatedDateUtc = stats.LastUpdateDateUtc
                 },
                 JsonRequestBehavior.AllowGet);

--- a/src/NuGetGallery/Extensions/HttpRequestExtensions.cs
+++ b/src/NuGetGallery/Extensions/HttpRequestExtensions.cs
@@ -9,7 +9,7 @@ namespace NuGetGallery
     /// <summary>
     /// Extensions on <see cref="HttpRequest"/> and <see cref="HttpRequestBase"/>
     /// </summary>
-    public static class RequestExtensions
+    public static class HttpRequestExtensions
     {
         /// <summary>
         /// Retrieve culture of client. 

--- a/src/NuGetGallery/Extensions/NumberExtensions.cs
+++ b/src/NuGetGallery/Extensions/NumberExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Web;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Extensions for int, long etc
+    /// </summary>
+    public static class NumberExtensions
+    {
+        /// <summary>
+        /// Format the number by client culture
+        /// </summary>
+        /// <param name="self"></param>
+        /// <returns></returns>
+        /// <remarks>Analogous name and signature as <see cref="DateTimeExtensions"/></remarks>
+        public static string ToNuGetNumberString(this int self)
+        {
+            return ToNuGetNumberString((long)self);
+        }
+
+        /// <summary>
+        /// Format the number by client culture
+        /// </summary>
+        /// <param name="self"></param>
+        /// <returns></returns>
+        /// <remarks>Analogous name and signature as <see cref="DateTimeExtensions"/></remarks>
+        public static string ToNuGetNumberString(this long self)
+        {
+            var httpContext = HttpContext.Current;
+            // if we fail to detect client locale from the Languages header, fall back to server locale
+            
+            CultureInfo clientCulture = (httpContext == null ? null : httpContext.Request.DetermineClientLocale()) ?? CultureInfo.CurrentCulture;
+            return self.ToString("n0", clientCulture);
+        }
+
+    }
+}

--- a/src/NuGetGallery/Extensions/NumberExtensions.cs
+++ b/src/NuGetGallery/Extensions/NumberExtensions.cs
@@ -33,11 +33,7 @@ namespace NuGetGallery
         /// <remarks>Analogous name and signature as <see cref="DateTimeExtensions"/></remarks>
         public static string ToNuGetNumberString(this long self)
         {
-            var httpContext = HttpContext.Current;
-            // if we fail to detect client locale from the Languages header, fall back to server locale
-            
-            CultureInfo clientCulture = (httpContext == null ? null : httpContext.Request.DetermineClientLocale()) ?? CultureInfo.CurrentCulture;
-            return self.ToString("n0", clientCulture);
+            return self.ToString("n0", CultureInfo.CurrentCulture);
         }
 
     }

--- a/src/NuGetGallery/Extensions/RequestExtensions.cs
+++ b/src/NuGetGallery/Extensions/RequestExtensions.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Web;
+
+namespace NuGetGallery
+{
+    public static class RequestExtensions
+    {
+        public static CultureInfo DetermineClientLocale(this HttpRequest request)
+        {
+            return DetermineClientLocale(new HttpRequestWrapper(request));
+        }
+
+        public static CultureInfo DetermineClientLocale(this HttpRequestBase request)
+        {
+            if (request == null)
+            {
+                return null;
+            }
+
+            string[] languages = request.UserLanguages;
+            if (languages == null)
+            {
+                return null;
+            }
+
+            foreach (string language in languages)
+            {
+                string lang = language.ToLowerInvariant().Trim();
+                try
+                {
+                    return CultureInfo.GetCultureInfo(lang);
+                }
+                catch (CultureNotFoundException)
+                {
+                }
+            }
+
+            foreach (string language in languages)
+            {
+                string lang = language.ToLowerInvariant().Trim();
+                if (lang.Length > 2)
+                {
+                    string lang2 = lang.Substring(0, 2);
+                    try
+                    {
+                        return CultureInfo.GetCultureInfo(lang2);
+                    }
+                    catch (CultureNotFoundException)
+                    {
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NuGetGallery/Extensions/RequestExtensions.cs
+++ b/src/NuGetGallery/Extensions/RequestExtensions.cs
@@ -6,13 +6,26 @@ using System.Web;
 
 namespace NuGetGallery
 {
+    /// <summary>
+    /// Extensions on <see cref="HttpRequest"/> and <see cref="HttpRequestBase"/>
+    /// </summary>
     public static class RequestExtensions
     {
+        /// <summary>
+        /// Retrieve culture of client. 
+        /// </summary>
+        /// <param name="request">Current request.</param>
+        /// <returns><c>null</c> if not to be determined.</returns>
         public static CultureInfo DetermineClientLocale(this HttpRequest request)
         {
             return DetermineClientLocale(new HttpRequestWrapper(request));
         }
-
+        
+        /// <summary>
+        /// Retrieve culture of client. 
+        /// </summary>
+        /// <param name="request">Current request.</param>
+        /// <returns><c>null</c> if not to be determined.</returns>
         public static CultureInfo DetermineClientLocale(this HttpRequestBase request)
         {
             if (request == null)
@@ -26,6 +39,7 @@ namespace NuGetGallery
                 return null;
             }
 
+            //first try parse of full langcodes. Stop with first success.
             foreach (string language in languages)
             {
                 string lang = language.ToLowerInvariant().Trim();
@@ -38,6 +52,7 @@ namespace NuGetGallery
                 }
             }
 
+            //try parse again with first 2 chars.  Stop with first success.
             foreach (string language in languages)
             {
                 string lang = language.ToLowerInvariant().Trim();

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -492,6 +492,7 @@
     <Compile Include="Diagnostics\DiagnosticsService.cs" />
     <Compile Include="Diagnostics\PerfEvent.cs" />
     <Compile Include="Diagnostics\SendErrorsToTelemetryAttribute.cs" />
+    <Compile Include="Extensions\RequestExtensions.cs" />
     <Compile Include="GlimpseSecurityPolicy.cs" />
     <Compile Include="Helpers\HostMachine.cs" />
     <Compile Include="Helpers\AppInsightsHealthIndicatorLogger.cs" />
@@ -1560,7 +1561,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>80</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://nuget.localtest.me</IISUrl>
+          <IISUrl>https://nuget.localtest.me</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -495,7 +495,7 @@
     <Compile Include="Extensions\NumberExtensions.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Extensions\RequestExtensions.cs" />
+    <Compile Include="Extensions\HttpRequestExtensions.cs" />
     <Compile Include="GlimpseSecurityPolicy.cs" />
     <Compile Include="Helpers\HostMachine.cs" />
     <Compile Include="Helpers\AppInsightsHealthIndicatorLogger.cs" />

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -492,6 +492,9 @@
     <Compile Include="Diagnostics\DiagnosticsService.cs" />
     <Compile Include="Diagnostics\PerfEvent.cs" />
     <Compile Include="Diagnostics\SendErrorsToTelemetryAttribute.cs" />
+    <Compile Include="Extensions\NumberExtensions.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Extensions\RequestExtensions.cs" />
     <Compile Include="GlimpseSecurityPolicy.cs" />
     <Compile Include="Helpers\HostMachine.cs" />

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -72,7 +72,7 @@ namespace NuGetGallery
 
         public string DisplayDownloads(int downloads)
         {
-            return downloads.ToString("n0", ClientCulture);
+            return downloads.ToNuGetNumberString();
         }
 
         public void Update()

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -29,8 +29,6 @@ namespace NuGetGallery
 
         public IEnumerable<StatisticsMonthlyUsageItem> Last6Months { get; set; }
 
-        public CultureInfo ClientCulture { get; set; }
-
         public StatisticsPackagesReport Report { get; private set; }
 
         public bool IsDownloadPackageAvailable { get; set; }
@@ -89,12 +87,12 @@ namespace NuGetGallery
             {
                 return string.Empty;
             }
-            return string.Format(ClientCulture, "{0} {1}", year, _months[monthOfYear]);
+            return string.Format(CultureInfo.CurrentCulture, "{0} {1}", year, _months[monthOfYear]);
         }
 
         public string DisplayPercentage(float amount, float total)
         {
-            return (amount / total).ToString("P0", ClientCulture);
+            return (amount / total).ToString("P0", CultureInfo.CurrentCulture);
         }
     }
 }

--- a/src/NuGetGallery/ViewModels/StatisticsPivot.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPivot.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 
 //  The implementation here is generic with respect to the specific properties in the data
 //  if can produce any pivot from any data. The result of the pivot is a 2-d array because
@@ -15,7 +14,7 @@ namespace NuGetGallery
 {
     public class StatisticsPivot
     {
-        public static Tuple<TableEntry[][], string> GroupBy(IList<StatisticsFact> facts, string[] pivot, CultureInfo clientCulture)
+        public static Tuple<TableEntry[][], string> GroupBy(IList<StatisticsFact> facts, string[] pivot)
         {
             // Firstly take the facts and the pivot vector and produce a tree structure
 
@@ -35,7 +34,7 @@ namespace NuGetGallery
                 table[i] = new TableEntry[pivot.Length + 1];
             }
 
-            PopulateTable(level, table, clientCulture);
+            PopulateTable(level, table);
 
             return new Tuple<TableEntry[][], string>(table, level.Total.ToNuGetNumberString());
         }
@@ -55,7 +54,7 @@ namespace NuGetGallery
             }
         }
 
-        private static void InnerPopulateTable(Level level, TableEntry[][] table, ref int row, int col, CultureInfo clientCulture)
+        private static void InnerPopulateTable(Level level, TableEntry[][] table, ref int row, int col)
         {
             foreach (KeyValuePair<string, Level> item in level.OrderedNext)
             {
@@ -68,15 +67,15 @@ namespace NuGetGallery
                 else
                 {
                     table[row][col] = new TableEntry { Data = item.Key, Rowspan = item.Value.Count };
-                    InnerPopulateTable(item.Value, table, ref row, col + 1, clientCulture);
+                    InnerPopulateTable(item.Value, table, ref row, col + 1);
                 }
             }
         }
 
-        private static void PopulateTable(Level level, TableEntry[][] table, CultureInfo clientCulture)
+        private static void PopulateTable(Level level, TableEntry[][] table)
         {
             int row = 0;
-            InnerPopulateTable(level, table, ref row, 0, clientCulture);
+            InnerPopulateTable(level, table, ref row, 0);
         }
 
         private static Level InnerGroupBy(IList<StatisticsFact> facts, string[] groupBy)

--- a/src/NuGetGallery/ViewModels/StatisticsPivot.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPivot.cs
@@ -37,7 +37,7 @@ namespace NuGetGallery
 
             PopulateTable(level, table, clientCulture);
 
-            return new Tuple<TableEntry[][], string>(table, level.Total.ToString("n0", clientCulture));
+            return new Tuple<TableEntry[][], string>(table, level.Total.ToNuGetNumberString());
         }
 
         private static void AddOrderedNext(Level level)
@@ -62,7 +62,7 @@ namespace NuGetGallery
                 if (item.Value.Next == null)
                 {
                     table[row][col] = new TableEntry { Data = item.Key };
-                    table[row][col + 1] = new TableEntry { Data = item.Value.Amount.ToString("n0", clientCulture), IsNumeric = true };
+                    table[row][col + 1] = new TableEntry { Data = item.Value.Amount.ToNuGetNumberString(), IsNumeric = true };
                     row++;
                 }
                 else

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -50,11 +50,11 @@
     <img class="logo" src="@(Model.IconUrl ?? Url.Absolute("~/Content/Images/packageDefaultIcon.png"))" alt="Icon for package @Model.Id" onerror="this.src = '@Url.Absolute("~/Content/Images/packageDefaultIcon.png")';" />
     <div id="stats">
         <div class="stat">
-            <p class="stat-number">@Model.TotalDownloadCount.ToString("n0")</p>
+            <p class="stat-number">@Model.TotalDownloadCount.ToNuGetNumberString()</p>
             <p class="stat-label">@(Model.TotalDownloadCount == 1 ? "Download" : "Downloads")</p>
         </div>
         <div class="stat">
-            <p class="stat-number">@Model.DownloadCount.ToString("n0")</p>
+            <p class="stat-number">@Model.DownloadCount.ToNuGetNumberString()</p>
             <p class="stat-label">@(Model.DownloadCount == 1 ? "Download" : "Downloads") of v @Model.Version</p>
         </div>
         <div class="stat">

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -360,7 +360,7 @@
                                 </a>
                             }
                         </td>
-                        <td>
+                        <td class="package-version-downloads">
                             @packageVersion.DownloadCount.ToNuGetNumberString()
                         </td>
                         <td>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -361,7 +361,7 @@
                             }
                         </td>
                         <td>
-                            @packageVersion.DownloadCount
+                            @packageVersion.DownloadCount.ToNuGetNumberString()
                         </td>
                         <td>
                             @packageVersion.LastUpdated.ToNuGetLongDateString()

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -21,17 +21,17 @@
     {
         <h1>@if (Model.TotalCount == 1)
             {
-                <text>There is @Model.TotalCount package</text>
+                <text>There is 1 package</text>
             }
             else
             {
-                <text>There are @Model.TotalCount packages</text>
+                <text>There are @Model.TotalCount.ToNuGetNumberString() packages</text>
             }</h1>
     }
     <span class="sorted-by">Sorted by @ViewBag.SortText</span>
     @if (Model.LastResultIndex > 0)
     {
-        <h2>Displaying results @Model.FirstResultIndex - @Model.LastResultIndex.</h2>
+        <h2>Displaying results @Model.FirstResultIndex.ToNuGetNumberString() - @Model.LastResultIndex.ToNuGetNumberString().</h2>
     }
     @if(Model.IndexTimestampUtc.HasValue)
     {

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -38,7 +38,7 @@
 
         <footer>
             <p class="downloads">
-                @Model.TotalDownloadCount.ToString("n0") total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
+                @Model.TotalDownloadCount.ToNuGetNumberString() total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
             </p>
 
             @if (@Model.Tags.AnySafe())

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -14,11 +14,11 @@
     }
     <div id="stats">
         <div class="stat">
-            <p class="stat-number">@Model.AllPackages.Count.ToString("n0")</p>
+            <p class="stat-number">@Model.AllPackages.Count.ToNuGetNumberString()</p>
             <p class="stat-label">@(Model.AllPackages.Count == 1 ? "Package" : "Packages")</p>
         </div>
         <div class="stat">
-            <p class="stat-number">@Model.TotalPackageDownloadCount.ToString("n0")</p>
+            <p class="stat-number">@Model.TotalPackageDownloadCount.ToNuGetNumberString()</p>
             <p class="stat-label">@(Model.TotalPackageDownloadCount == 1 ? "Download" : "Downloads") of @Model.Username's packages</p>
         </div>
     </div>
@@ -72,7 +72,7 @@ else if (Model.ShowAllPackages)
 
                     <footer>
                         <p class="downloads">
-                            @package.TotalDownloadCount.ToString("n0") @(package.TotalDownloadCount == 1 ? "download" : "downloads")
+                            @package.TotalDownloadCount.ToNuGetNumberString() @(package.TotalDownloadCount == 1 ? "download" : "downloads")
                         </p>
                     </footer>
                 </div>


### PR DESCRIPTION
fixes #2710 

Created C# extensions for:

- `DetermineClientLocale` => `HttpRequestExtensions`
- Formatting number with client culture: `NumberExtensions.ToNuGetNumberString`

TODO:

- [x] unit test `UseClientCultureIfLanguageHeadersIsPresent` fails because I use `httpcontext.current`. Ways to fix this: 

  1. pass `Request` to the method everywhere instead of `httpcontext.current`, 
  2. mock `httpcontext.current`. 
  3. change unit test.
  4. remove the usage of `HttpRequest` in `ToString` (see 
 https://github.com/NuGet/NuGetGallery/pull/2716#issuecomment-145242154)   -  I think 1 isn't good, because we're changing code solely for an unit test. 
- [x] alignment of downloads at package versions (should by right) 