### PR TITLE
Allow passwords with HTML chars

### DIFF
--- a/src/NuGetGallery/ViewModels/AccountViewModel.cs
+++ b/src/NuGetGallery/ViewModels/AccountViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Web.Mvc;
 using NuGetGallery.Authentication.Providers;
 
 namespace NuGetGallery
@@ -27,6 +28,7 @@ namespace NuGetGallery
         [DataType(DataType.Password)]
         [Display(Name = "Current Password (for verification)")]
         [StringLength(64)]
+        [AllowHtml]
         public string Password { get; set; }
     }
 
@@ -34,10 +36,12 @@ namespace NuGetGallery
     {
         [Required]
         [Display(Name = "Old Password")]
+        [AllowHtml]
         public string OldPassword { get; set; }
 
         [Required]
         [Display(Name = "New Password")]
+        [AllowHtml]
         public string NewPassword { get; set; }
     }
 

--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
+using System.Web.Mvc;
 using NuGetGallery.Authentication.Providers;
 
 namespace NuGetGallery
@@ -48,6 +49,7 @@ namespace NuGetGallery
         [Required]
         [DataType(DataType.Password)]
         [Hint("Passwords must be at least 7 characters long.")]
+        [AllowHtml]
         public string Password { get; set; }
 
         public SignInViewModel() { }
@@ -106,6 +108,7 @@ namespace NuGetGallery
         [DataType(DataType.Password)]
         [StringLength(64, MinimumLength = 7)]
         [Hint("Passwords must be at least 7 characters long.")]
+        [AllowHtml]
         public string Password { get; set; }
     }
 


### PR DESCRIPTION
Allow passwords with HTML chars, like `'yj^0b]'nh*'l{}*=;=^W{<Y`. Fixes #2438.

The problem was not only at registering, but also at logon and change profile/password.

Without `[AllowHtml]` ASP.net throws: 
 [HttpRequestValidationException (0x80004005): A potentially
dangerous Request.Form value was detected from the client. 

Is the password ever printed somewhere? (confirmation or recover mail?) - if so, we need maybe also an escape there. 

NB: PR to DEV branch, but let me know if it should be to another branch. 

@maartenba Thanks for the proposed solution. 

