### PR TITLE
fixes #2747

### DIFF
--- a/src/NuGetGallery.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/src/NuGetGallery.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -21,6 +21,7 @@
       <Setting name="Gallery.Environment" value="LocalEmulator" />
       <Setting name="Gallery.FacebookAppId" value="" />
       <Setting name="Gallery.AppInsightsInstrumentationKey" value="" />
+      <Setting name="Gallery.AppInsightsSamplingPercentage" value="50" />
       <Setting name="Gallery.GoogleAnalyticsPropertyId" value="" />
       <Setting name="Gallery.AzureCdnHost" value="" />
       <Setting name="Gallery.SiteRoot" value="nuget.localtest.me" />

--- a/src/NuGetGallery.Cloud/ServiceConfiguration.Local.cscfg
+++ b/src/NuGetGallery.Cloud/ServiceConfiguration.Local.cscfg
@@ -21,6 +21,7 @@
       <Setting name="Gallery.Environment" value="LocalEmulator" />
       <Setting name="Gallery.FacebookAppId" value="" />
       <Setting name="Gallery.AppInsightsInstrumentationKey" value="" />
+      <Setting name="Gallery.AppInsightsSamplingPercentage" value="100" />
       <Setting name="Gallery.GoogleAnalyticsPropertyId" value="" />
       <Setting name="Gallery.AzureCdnHost" value="" />
       <Setting name="Gallery.SiteRoot" value="nuget.localtest.me" />

--- a/src/NuGetGallery.Cloud/ServiceDefinition.csdef
+++ b/src/NuGetGallery.Cloud/ServiceDefinition.csdef
@@ -19,6 +19,7 @@
       <Setting name="Gallery.SmtpUri" />
       <Setting name="Gallery.FacebookAppId" />
       <Setting name="Gallery.AppInsightsInstrumentationKey" />
+      <Setting name="Gallery.AppInsightsSamplingPercentage" />
       <Setting name="Gallery.SiteRoot" />
       <Setting name="Gallery.AzureCdnHost" />
       <Setting name="Gallery.LuceneIndexLocation" />

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -124,6 +124,7 @@
     // Get instrumentation key
     var config = DependencyResolver.Current.GetService<ConfigurationService>();
     var iKey = config == null ? string.Empty : config.Current.AppInsightsInstrumentationKey;
+    var samplingPct = config == null ? 100 : config.Current.AppInsightsSamplingPercentage;
 
     if (!string.IsNullOrEmpty(iKey))
     {
@@ -144,7 +145,8 @@
                     return s !== !0 && t["_" + i](config, r, f, e, o), s
                 }), t
             }({
-                instrumentationKey: '@(iKey)'
+                instrumentationKey: '@(iKey)',
+                samplingPercentage: @(samplingPct)
             });
 
             window.appInsights = appInsights;

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -11,6 +11,7 @@ using System.Web.Mvc;
 using Elmah;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Owin;
 using Microsoft.Owin.Logging;
 using Microsoft.Owin.Security;
@@ -56,6 +57,17 @@ namespace NuGetGallery
             if (!string.IsNullOrEmpty(instrumentationKey))
             {
                 TelemetryConfiguration.Active.InstrumentationKey = instrumentationKey;
+
+                // Note: sampling rate must be a factor 100/N where N is a whole number
+                // e.g.: 50 (= 100/2), 33.33 (= 100/3), 25 (= 100/4), ...
+                // https://azure.microsoft.com/en-us/documentation/articles/app-insights-sampling/
+                var instrumentationSamplingPercentage = config.Current.AppInsightsSamplingPercentage;
+                if (instrumentationSamplingPercentage > 0 && instrumentationSamplingPercentage < 100)
+                {
+                    var telemetryProcessorChainBuilder = TelemetryConfiguration.Active.GetTelemetryProcessorChainBuilder();
+                    telemetryProcessorChainBuilder.UseSampling(instrumentationSamplingPercentage);
+                    telemetryProcessorChainBuilder.Build();
+                }
             }
 
             // Configure logging

--- a/src/NuGetGallery/ApplicationInsights.config
+++ b/src/NuGetGallery/ApplicationInsights.config
@@ -7,8 +7,8 @@
     Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
   -->
   <TelemetryModules>
-    <Add Type="Microsoft.ApplicationInsights.Extensibility.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.ApplicationInsights.Extensibility.DependencyCollector"/>
-    <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector">
+    <Add Type="Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule, Microsoft.AI.DependencyCollector"/>
+    <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.PerformanceCollectorModule, Microsoft.AI.PerfCounterCollector">
       <!--
       Use the following syntax here to collect additional performance counters:
       
@@ -32,39 +32,25 @@
       -->
     </Add>
     <Add Type="Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule, Microsoft.ApplicationInsights"/>
-    <Add Type="Microsoft.ApplicationInsights.Extensibility.Web.RequestTrackingTelemetryModule, Microsoft.ApplicationInsights.Extensibility.Web"/>
-    <Add Type="Microsoft.ApplicationInsights.Extensibility.Web.ExceptionTrackingTelemetryModule, Microsoft.ApplicationInsights.Extensibility.Web"/>
-    <Add Type="Microsoft.ApplicationInsights.Extensibility.Web.DeveloperModeWithDebuggerAttachedTelemetryModule, Microsoft.ApplicationInsights.Extensibility.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.DeveloperModeWithDebuggerAttachedTelemetryModule, Microsoft.AI.WindowsServer"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.UnhandledExceptionTelemetryModule, Microsoft.AI.WindowsServer"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.UnobservedExceptionTelemetryModule, Microsoft.AI.WindowsServer"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule, Microsoft.AI.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.ExceptionTrackingTelemetryModule, Microsoft.AI.Web"/>
   </TelemetryModules>
-<!-- 
-    Learn more about Application Insights configuration with ApplicationInsights.config here: 
-    http://go.microsoft.com/fwlink/?LinkID=513840
-    
-    Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
-  --><!-- 
-    Learn more about Application Insights configuration with ApplicationInsights.config here: 
-    http://go.microsoft.com/fwlink/?LinkID=513840
-    
-    Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
-  -->
-<TelemetryChannel Type="Microsoft.ApplicationInsights.Extensibility.Web.TelemetryChannel, Microsoft.ApplicationInsights.Web.TelemetryChannel"/>
-<!-- 
-    Learn more about Application Insights configuration with ApplicationInsights.config here: 
-    http://go.microsoft.com/fwlink/?LinkID=513840
-    
-    Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
-  -->
-<TelemetryInitializers>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.SyntheticTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.ClientIpHeaderTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.UserAgentTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.OperationNameTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.OperationIdTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.UserTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.SessionTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.AzureRoleEnvironmentTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.DomainNameRoleInstanceTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.BuildInfoConfigComponentVersionTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-<Add Type="Microsoft.ApplicationInsights.Extensibility.Web.DeviceTelemetryInitializer, Microsoft.ApplicationInsights.Extensibility.Web"/>
-</TelemetryInitializers>
+  <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
+  <TelemetryInitializers>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureRoleEnvironmentTelemetryInitializer, Microsoft.AI.WindowsServer"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.DomainNameRoleInstanceTelemetryInitializer, Microsoft.AI.WindowsServer"/>
+    <Add Type="Microsoft.ApplicationInsights.WindowsServer.BuildInfoConfigComponentVersionTelemetryInitializer, Microsoft.AI.WindowsServer"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.SyntheticTelemetryInitializer, Microsoft.AI.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.ClientIpHeaderTelemetryInitializer, Microsoft.AI.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.UserAgentTelemetryInitializer, Microsoft.AI.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.OperationNameTelemetryInitializer, Microsoft.AI.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.OperationIdTelemetryInitializer, Microsoft.AI.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.UserTelemetryInitializer, Microsoft.AI.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.AuthenticatedUserIdTelemetryInitializer, Microsoft.AI.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.AccountIdTelemetryInitializer, Microsoft.AI.Web"/>
+    <Add Type="Microsoft.ApplicationInsights.Web.SessionTelemetryInitializer, Microsoft.AI.Web"/>
+  </TelemetryInitializers>
 </ApplicationInsights>

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -132,6 +132,11 @@ namespace NuGetGallery.Configuration
         public string AppInsightsInstrumentationKey { get; set; }
 
         /// <summary>
+        /// Gets the Application Insights sampling percentage associated with this deployment.
+        /// </summary>
+        public double AppInsightsSamplingPercentage { get; set; }
+
+        /// <summary>
         /// Gets the protocol-independent site root
         /// </summary>
         public string SiteRoot { get; set; }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -124,6 +124,11 @@ namespace NuGetGallery.Configuration
         string AppInsightsInstrumentationKey { get; set; }
 
         /// <summary>
+        /// Gets the Application Insights sampling percentage associated with this deployment.
+        /// </summary>
+        double AppInsightsSamplingPercentage { get; set; }
+
+        /// <summary>
         /// Gets the protocol-independent site root
         /// </summary>
         string SiteRoot { get; set; }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -200,23 +200,34 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=1.0.0.4220, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.AI.Agent.Intercept">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.1.2.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.AI.DependencyCollector">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.0.0-beta2\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.AI.PerfCounterCollector">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.0.0-beta2\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.AI.ServerTelemetryChannel">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.0.0-beta2\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.AI.Web">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.Web.2.0.0-beta2\lib\net45\Microsoft.AI.Web.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.AI.WindowsServer">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.WindowsServer.2.0.0-beta2\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.0.0.4189, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.1.0.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights.Extensibility.DependencyCollector">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.DependencyCollector.1.0.0\lib\net45\Microsoft.ApplicationInsights.Extensibility.DependencyCollector.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector">
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.1.0.0\lib\net45\Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights.Extensibility.Web, Version=1.0.0.4227, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.Web.1.0.0\lib\net45\Microsoft.ApplicationInsights.Extensibility.Web.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights.Web.TelemetryChannel, Version=1.0.0.4227, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.Web.TelemetryChannel.1.0.0\lib\net45\Microsoft.ApplicationInsights.Web.TelemetryChannel.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.0.0-beta2\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationServer.Caching.Client, Version=101.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\WindowsAzure.Caching.1.7.0.0\lib\net35-full\Microsoft.ApplicationServer.Caching.Client.dll</HintPath>
@@ -253,10 +264,6 @@
     <Reference Include="Microsoft.Data.Services.Client, Version=5.6.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.5-beta\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Diagnostics.Instrumentation.Extensions.Intercept, Version=0.17.0.194, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.0.17.0\lib\net45\Microsoft.Diagnostics.Instrumentation.Extensions.Intercept.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -1070,7 +1077,9 @@
     <Compile Include="RequestModels\CreateCuratedPackageRequest.cs" />
     <Compile Include="RequestModels\VerifyPackageRequest.cs" />
     <Content Include="App_Data\Files\Content\ReadOnly.md" />
-    <Content Include="ApplicationInsights.config" />
+    <Content Include="ApplicationInsights.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="NuGetGallery.dll.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <SubType>Designer</SubType>
@@ -1600,12 +1609,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.0.17.0\build\Microsoft.ApplicationInsights.Agent.Intercept.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.0.17.0\build\Microsoft.ApplicationInsights.Agent.Intercept.targets'))" />
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.9\build\NuGet.Services.Build.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.9\build\NuGet.Services.Build.props'))" />
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.9\build\NuGet.Services.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.9\build\NuGet.Services.Build.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Import Project="..\..\packages\Microsoft.ApplicationInsights.0.17.0\tools\net40\Microsoft.ApplicationInsights.targets" Condition="Exists('..\..\packages\Microsoft.ApplicationInsights.0.16.1-build00418\tools\net40\Microsoft.ApplicationInsights.targets')" />
-  <Import Project="..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.0.17.0\build\Microsoft.ApplicationInsights.Agent.Intercept.targets" Condition="Exists('..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.0.17.0\build\Microsoft.ApplicationInsights.Agent.Intercept.targets')" />
   <Import Project="..\..\packages\NuGet.Services.Build.3.0.9\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.9\build\NuGet.Services.Build.targets')" />
 </Project>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -41,6 +41,8 @@
     <add key="Gallery.FacebookAppId" value="" />
     <!-- Set this if you have a Application Insights instrumentation key to use for your gallery deployment -->
     <add key="Gallery.AppInsightsInstrumentationKey" value="" />
+    <!-- Set this if you have a Application Insights instrumentation key to use for your gallery deployment and want to apply sampling-->
+    <add key="Gallery.AppInsightsSamplingPercentage" value="100" />
     <!-- Set this if you have a Facebook App ID you want to use for the Like button -->
     <add key="Gallery.GoogleAnalyticsPropertyId" value="" />
     <!-- Set this if you have a Google Analytics property for the site -->
@@ -230,8 +232,8 @@
       <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" />
       <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" />
       <add name="AsyncFileUpload" type="NuGetGallery.AsyncFileUpload.AsyncFileUploadModule, NuGetGallery" />
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Extensibility.Web.ApplicationInsightsHttpModule, Microsoft.ApplicationInsights.Extensibility.Web" />
       <add name="Glimpse" type="Glimpse.AspNet.HttpModule, Glimpse.AspNet" />
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
     </httpModules>
     <httpHandlers>
       <!-- Remove Default HTTP Handler -->
@@ -279,7 +281,7 @@
       <add name="Glimpse" type="Glimpse.AspNet.HttpModule, Glimpse.AspNet" preCondition="integratedMode" />
       <remove name="RoleManager" />
       <remove name="ApplicationInsightsWebTracking" />
-      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Extensibility.Web.ApplicationInsightsHttpModule, Microsoft.ApplicationInsights.Extensibility.Web" preCondition="managedHandler" />
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
     </modules>
     <validation validateIntegratedModeConfiguration="false" />
     <httpErrors errorMode="DetailedLocalOnly">
@@ -425,6 +427,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.4189" newVersion="2.0.0.4189" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -25,12 +25,13 @@
   <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
   <package id="Lucene.Net.Contrib" version="3.0.3" targetFramework="net45" />
   <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="0.17.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.Web" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.ApplicationInsights.Web.TelemetryChannel" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.ApplicationInsights" version="2.0.0-beta2" targetFramework="net452" />
+  <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.0" targetFramework="net452" />
+  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.0.0-beta2" targetFramework="net452" />
+  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.0.0-beta2" targetFramework="net452" />
+  <package id="Microsoft.ApplicationInsights.Web" version="2.0.0-beta2" targetFramework="net452" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.0.0-beta2" targetFramework="net452" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.0.0-beta2" targetFramework="net452" />
   <package id="Microsoft.AspNet.DynamicData.EFProvider" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.EntityDataSource" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.Identity.Core" version="1.0.0" targetFramework="net45" />


### PR DESCRIPTION
This PR fixes #2747:
* Upgrades Application Insights SDK to 2.0.0-beta2
* Adds support for telemetry sampling through new configuration setting `Gallery.AppInsightsSamplingPercentage`, which has default value of 100 (effectively disabling sampling by default)

cc @maartenba @joyhui @yishaigalatzer @johnataylor 