### PR TITLE
No more HTTP 500 when external search service calls fail

### DIFF
--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -131,6 +131,15 @@ namespace NuGetGallery.Infrastructure.Lucene
                         content.Data.Select(ReadPackage).AsQueryable());
                 }
             }
+            else
+            {
+                if (result.HttpResponse.Content != null)
+                {
+                    result.HttpResponse.Content.Dispose();
+                }
+
+                results = new SearchResults(0, null, Enumerable.Empty<Package>().AsQueryable());
+            }
 
             Trace.PerfEvent(
                 SearchRoundtripTimePerfCounter,
@@ -146,7 +155,6 @@ namespace NuGetGallery.Infrastructure.Lucene
                     {"Url", TryGetUrl()}
                 });
 
-            result.HttpResponse.EnsureSuccessStatusCode();
             return results;
         }
 

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1108,6 +1108,7 @@
     <Compile Include="Services\IDownloadCountService.cs" />
     <Compile Include="Services\IFileReference.cs" />
     <Compile Include="Services\IPackageDeleteService.cs" />
+    <Compile Include="Services\IRawSearchService.cs" />
     <Compile Include="Services\IStatusService.cs" />
     <Compile Include="Services\JsonStatisticsService.cs" />
     <Compile Include="Services\CloudReportService.cs" />
@@ -1138,6 +1139,7 @@
     <Compile Include="Filters\RequireSslAttribute.cs" />
     <Compile Include="Services\PackageSearchResults.cs" />
     <Compile Include="Services\JsonAggregateStatsService.cs" />
+    <Compile Include="Services\SearchResults.cs" />
     <Compile Include="Services\SqlAggregateStatsService.cs" />
     <Compile Include="Services\ReportPackageRequest.cs" />
     <Compile Include="Services\SearchFilter.cs" />

--- a/src/NuGetGallery/Services/IRawSearchService.cs
+++ b/src/NuGetGallery/Services/IRawSearchService.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGetGallery
+{
+    public interface IRawSearchService
+    {
+        /// <summary>
+        /// Executes a raw lucene query against the search index
+        /// </summary>
+        /// <param name="filter">The query to execute, with the search term interpreted as a raw lucene query</param>
+        /// <returns>The results of the query</returns>
+        Task<SearchResults> RawSearch(SearchFilter filter);
+    }
+}

--- a/src/NuGetGallery/Services/ISearchService.cs
+++ b/src/NuGetGallery/Services/ISearchService.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using System;
-using System.Linq;
+
 using System.Threading.Tasks;
 
 namespace NuGetGallery
@@ -19,34 +18,5 @@ namespace NuGetGallery
         /// Gets a boolean indicating if all versions of each package are stored in the index
         /// </summary>
         bool ContainsAllVersions { get; }
-    }
-
-    public interface IRawSearchService
-    {
-        /// <summary>
-        /// Executes a raw lucene query against the search index
-        /// </summary>
-        /// <param name="filter">The query to execute, with the search term interpreted as a raw lucene query</param>
-        /// <returns>The results of the query</returns>
-        Task<SearchResults> RawSearch(SearchFilter filter);
-    }
-
-    public class SearchResults
-    {
-        public int Hits { get; private set; }
-        public DateTime? IndexTimestampUtc { get; private set; }
-        public IQueryable<Package> Data { get; private set; }
-
-        public SearchResults(int hits, DateTime? indexTimestampUtc)
-            : this(hits, indexTimestampUtc, Enumerable.Empty<Package>().AsQueryable())
-        {
-        }
-
-        public SearchResults(int hits, DateTime? indexTimestampUtc, IQueryable<Package> data)
-        {
-            Hits = hits;
-            Data = data;
-            IndexTimestampUtc = indexTimestampUtc;
-        }
     }
 }

--- a/src/NuGetGallery/Services/SearchResults.cs
+++ b/src/NuGetGallery/Services/SearchResults.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace NuGetGallery
+{
+    public class SearchResults
+    {
+        public int Hits { get; private set; }
+        public DateTime? IndexTimestampUtc { get; private set; }
+        public IQueryable<Package> Data { get; private set; }
+
+        public SearchResults(int hits, DateTime? indexTimestampUtc)
+            : this(hits, indexTimestampUtc, Enumerable.Empty<Package>().AsQueryable())
+        {
+        }
+
+        public SearchResults(int hits, DateTime? indexTimestampUtc, IQueryable<Package> data)
+        {
+            Hits = hits;
+            Data = data;
+            IndexTimestampUtc = indexTimestampUtc;
+        }
+    }
+}


### PR DESCRIPTION
Relates to https://github.com/NuGet/NuGetGallery/issues/2781

This PR ensures the gallery no longer crashes with an HTTP 500 when the external search service call returns a non-200 HTTP status code.

cc @maartenba @joyhui 