### PR TITLE
add OpenSearch feature for easy in-browser search of packages

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1427,6 +1427,7 @@
     <Content Include="DataServices\V2Feed.svc" />
     <Content Include="Public\Error.html" />
     <Content Include="Public\favicon.ico" />
+    <Content Include="Public\opensearch.xml" />
     <EmbeddedResource Include="Infrastructure\Elmah.SqlServer.sql" />
     <EmbeddedResource Include="Infrastructure\AggregateStatistics.sql" />
     <EmbeddedResource Include="Infrastructure\AddPackageLicenseReport.sql" />

--- a/src/NuGetGallery/Public/opensearch.xml
+++ b/src/NuGetGallery/Public/opensearch.xml
@@ -1,0 +1,10 @@
+<OpenSearchDescription>
+  <ShortName>NuGet packages</ShortName>
+  <Description>Search NuGet packages</Description>
+  <Tags>nuget package component</Tags>
+  <Contact>support@nuget.org</Contact>
+  <Developer>The NuGet team</Developer>
+  <Url type="text/html" method="get" template="https://www.nuget.org/packages?q={searchTerms}"/>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image height="16" width="16" type="image/ico">https://www.nuget.org/favicon.ico</Image>
+</OpenSearchDescription>

--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -18,7 +18,7 @@
 
         <link href="@Url.Content("~/favicon.ico")" rel="shortcut icon" type="image/x-icon" />
 
-        <link title="NuGet.org" type="application/opensearchdescription+xml" href="https://www.nuget.org/opensearch.xml" rel="search">
+        <link title="NuGet.org" type="application/opensearchdescription+xml" href="@Url.Content("~/opensearch.xml")" rel="search">
 
         @Scripts.Render("~/Scripts/modernizr")
         @ViewHelpers.AnalyticsScript()

--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -18,6 +18,8 @@
 
         <link href="@Url.Content("~/favicon.ico")" rel="shortcut icon" type="image/x-icon" />
 
+        <link title="NuGet.org" type="application/opensearchdescription+xml" href="https://www.nuget.org/opensearch.xml" rel="search">
+
         @Scripts.Render("~/Scripts/modernizr")
         @ViewHelpers.AnalyticsScript()
         @RenderSection("TopScripts", required: false)


### PR DESCRIPTION
With this, people could directly use the browser search-engine bar to search NuGet packages. It would be the same behavior shown below happening on NPM, but for NuGet:

![npm-opensearch](https://cloud.githubusercontent.com/assets/1469638/11977378/57ab9298-a982-11e5-8b7f-48ca706c4fc6.gif)
