### PR TITLE
Verify package with language, devdep & deps

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -700,7 +700,7 @@ namespace NuGetGallery
                 // Get the packages to delete
                 foreach (var package in deletePackagesRequest.Packages)
                 {
-                    var split = package.Split(new[] {'|'}, StringSplitOptions.RemoveEmptyEntries);
+                    var split = package.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
                     if (split.Length == 2)
                     {
                         var packageToDelete = _packageService.FindPackageByIdAndVersion(split[0], split[1], allowPrerelease: true);
@@ -727,9 +727,9 @@ namespace NuGetGallery
                 }
 
                 // Redirect out
-                TempData["Message"] = 
+                TempData["Message"] =
                     "We're performing the package delete right now. It may take a while for this change to propagate through our system.";
-                
+
                 return Redirect("/");
             }
 
@@ -854,10 +854,10 @@ namespace NuGetGallery
             ConfirmOwnershipResult result = _packageService.ConfirmPackageOwner(package, user, token);
 
             var model = new PackageOwnerConfirmationModel
-                {
-                    Result = result,
-                    PackageId = package.Id
-                };
+            {
+                Result = result,
+                PackageId = package.Id
+            };
 
             return View(model);
         }
@@ -894,7 +894,7 @@ namespace NuGetGallery
             _indexingService.UpdatePackage(package);
             return Redirect(urlFactory(package));
         }
-        
+
         [Authorize]
         [RequiresAccountConfirmation("upload a package")]
         public virtual async Task<ActionResult> VerifyPackage()
@@ -927,12 +927,18 @@ namespace NuGetGallery
                 }
             }
 
+
             var model = new VerifyPackageRequest
             {
                 Id = packageMetadata.Id,
                 Version = packageMetadata.Version.ToNormalizedStringSafe(),
                 LicenseUrl = packageMetadata.LicenseUrl.ToEncodedUrlStringOrNull(),
                 Listed = true,
+                Language = packageMetadata.Language,
+                MinClientVersion = packageMetadata.MinClientVersion,
+                FrameworkReferenceGroups = packageMetadata.GetFrameworkReferenceGroups(),
+                DependencyGroups = packageMetadata.GetDependencyGroups(),
+                DevelopmentDependency = packageMetadata.GetValueFromMetadata("developmentDependency"),
                 Edit = new EditPackageVersionRequest
                 {
                     Authors = packageMetadata.Authors.Flatten(),
@@ -976,7 +982,7 @@ namespace NuGetGallery
                     return new RedirectResult(Url.UploadPackage());
                 }
                 Debug.Assert(nugetPackage != null);
-                
+
                 var packageMetadata = PackageMetadata.FromNuspecReader(
                     nugetPackage.GetNuspecReader());
 

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -1,5 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using NuGet.Packaging;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace NuGetGallery
 {
     public class VerifyPackageRequest
@@ -7,8 +13,12 @@ namespace NuGetGallery
         public string Id { get; set; }
         public string Version { get; set; }
         public string LicenseUrl { get; set; }
-
         public bool Listed { get; set; }
         public EditPackageVersionRequest Edit { get; set; }
+        public NuGetVersion MinClientVersion { get; set; }
+        public string Language { get; set; }
+        public string DevelopmentDependency { get; set; }
+        public IReadOnlyCollection<PackageDependencyGroup> DependencyGroups { get; set; }
+        public IReadOnlyCollection<FrameworkSpecificGroup> FrameworkReferenceGroups { get; set; }
     }
 }

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -80,7 +80,10 @@
     <ul id="packageDetails" style="border-bottom: 1px solid gray; margin-bottom: 1em;">
         <li>@ReadOnlyField("Package ID", "Id", Model.Id)</li>
         <li>@ReadOnlyField("Version", "Version", Model.Version)</li>
+        <li>@ReadOnlyField("Minimum NuGet Client Version", "MinClientVersion", Model.MinClientVersion.ToStringSafe())</li>
         <li>@ReadOnlyField("License URL", "LicenseUrl", Model.LicenseUrl, link: true)</li>
+        <li>@ReadOnlyField("Language", "Language", Model.Language)</li>
+        <li>@ReadOnlyField("Development Dependency", "DevDependency", Model.DevelopmentDependency)</li>
         <li>@EditableField("Title", m => m.Edit.VersionTitle)</li>
         <li>@EditableField("Description", m => m.Edit.Description)</li>
         <li>@EditableField("Summary", m => m.Edit.Summary)</li>
@@ -90,6 +93,69 @@
         <li>@EditableField("Copyright", m => m.Edit.Copyright)</li>
         <li>@EditableField("Tags", m => m.Edit.Tags)</li>
         <li>@EditableField("Release Notes", m => m.Edit.ReleaseNotes, pre: true)</li>
+
+        @if (Model.DependencyGroups != null && Model.DependencyGroups.Any())
+        {
+            <li>
+                <h4>
+                    Dependencies
+                </h4>
+                <div style="position: relative">
+                    <ul>
+                        @foreach (var dependencyset in Model.DependencyGroups)
+                        {
+                            if (dependencyset.TargetFramework != null)
+                            {
+                                <li>
+                                    <b>@dependencyset.TargetFramework.DotNetFrameworkName</b>
+
+                                    <ul style="padding-left: 15px">
+                                        @foreach (var dependency in dependencyset.Packages)
+                                        {
+                                            <li>@dependency.Id @dependency.VersionRange.ToString()</li>
+                                        }
+                                    </ul>
+                                </li>
+                            }
+                            else
+                            {
+                                foreach (var dependency in dependencyset.Packages)
+                                {
+                                    <li>@dependency.Id @dependency.VersionRange.ToString()</li>
+                                }
+                            }
+                        }
+                    </ul>
+                </div>
+            </li>
+        }
+
+        @if (Model.FrameworkReferenceGroups.Any())
+        {
+            <li>
+                <h4>
+                    Framework Assembly References
+                </h4>
+                <div style="position: relative">
+                    <ul>
+                        @foreach (var framework in Model.FrameworkReferenceGroups)
+                        {
+                            <li>
+                                <b>@framework.TargetFramework</b>
+
+                                <ul style="padding-left: 15px">
+                                    @foreach (var assembly in framework.Items)
+                                    {
+                                        <li>@assembly</li>
+                                    }
+                                </ul>
+                            </li>
+                        }
+                    </ul>
+                </div>
+            </li>
+        }
+
 
         @if (!String.IsNullOrEmpty(Model.LicenseUrl))
         {


### PR DESCRIPTION
New PR with just the VerifyPackage enhancements (instead of https://github.com/NuGet/NuGetGallery/pull/2242) - just in read only mode.

The Verify Package Page now shows also:
- Language
- Minimum Client Version
- Dev Dependeny
- FrameworkAssemblies
- Other Dependencies

Sample 1:
![image](https://cloud.githubusercontent.com/assets/756703/11986238/8fcd1fca-a9cd-11e5-95a6-9377359837c7.png)

Sample 2 - with DevDependency:
![image](https://cloud.githubusercontent.com/assets/756703/11986245/9cf2d406-a9cd-11e5-8bc1-da1b6a5ae7d9.png)

Sample 3:
![image](https://cloud.githubusercontent.com/assets/756703/11986314/5a898a0a-a9ce-11e5-82b7-88e337e8c6b8.png)


Problems: 
The "PackageMetadata" doesn't read the MinimumClientVersion at all and a real DevelopmentDependency property is missing on the class. I could get the DevelopmentDependency Value via the key, but maybe a real property would be cleaner. 
If the DevelopmentDependency property is not found the default "not specified" appears, but this would be easy to change.

I noticed that the frameworkassembly/dependency stuff has changed - I just saw the visualization of the dependencies on the details page, maybe I should adapt this kind of style, right?

What do you think?