### PR TITLE
Straight alignment for package detail page

### DIFF
--- a/src/NuGetGallery/Content/PageStylings.css
+++ b/src/NuGetGallery/Content/PageStylings.css
@@ -80,7 +80,7 @@
 
 .package-page h3 {
     font-size: 1.75em;
-    margin: 20px 0 6px -6px;
+    margin: 20px 0 6px 0px;
     margin-bottom: 6px;
     margin-top: 25px;
 }

--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -341,9 +341,9 @@ p.authors {
 }
 
 .stat-label {
-    font-size: 1.25em;
+    font-size: 1.0em;
     line-height: 1em;
-    margin: -7px 0 0 5px;
+    margin: -7px 0 0 0px;
 }
 
 /* License Gadget */


### PR DESCRIPTION
The uneven styling between the headers and the paragraphs and the label stats are a bit odd in my eyes, but design can always be discussed. So this PR removes the left margins to get a straight alignment. 
I also made the labels for the stats a bit smaller.

(The red lines are only to demonstrate it)

![image](https://cloud.githubusercontent.com/assets/756703/12002965/df9d47e0-ab0e-11e5-8d98-7ce8d9d3a658.png)

vs. current version:
![image](https://cloud.githubusercontent.com/assets/756703/12002966/f32be884-ab0e-11e5-8d67-bfc417280f49.png)
