### PR TITLE
Title of newly uploaded package should not match existing package registration id

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -128,6 +128,11 @@ namespace NuGetGallery
                 .AsSelf()
                 .As<IUserService>()
                 .InstancePerLifetimeScope();
+            
+            builder.RegisterType<PackageNamingConflictValidator>()
+                .AsSelf()
+                .As<IPackageNamingConflictValidator>()
+                .InstancePerLifetimeScope();
 
             builder.RegisterType<PackageService>()
                 .AsSelf()

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -37,7 +37,7 @@
     <MvcProjectUpgradeChecked>true</MvcProjectUpgradeChecked>
     <UseGlobalApplicationHostFile />
     <MvcBuildViews Condition=" '$(MvcBuildViews)' == '' ">false</MvcBuildViews>
-</PropertyGroup>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -1185,6 +1185,8 @@
     <Compile Include="Services\PackageDeleteService.cs" />
     <Compile Include="Services\PackageFileService.cs" />
     <Compile Include="Filters\RequireSslAttribute.cs" />
+    <Compile Include="Services\PackageIdAndTitleValidationService.cs" />
+    <Compile Include="Services\PackageNamingConflictValidator.cs" />
     <Compile Include="Services\PackageSearchResults.cs" />
     <Compile Include="Services\JsonAggregateStatsService.cs" />
     <Compile Include="Services\SearchResults.cs" />
@@ -1622,7 +1624,6 @@
   <ItemGroup>
     <Folder Include="Areas\Admin\DynamicData\CustomPages\" />
     <Folder Include="Areas\Admin\Views\Shared\" />
-    <Folder Include="Packaging\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Services.Search.Client\NuGet.Services.Search.Client.csproj">

--- a/src/NuGetGallery/Services/PackageIdAndTitleValidationService.cs
+++ b/src/NuGetGallery/Services/PackageIdAndTitleValidationService.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public interface IPackageNamingConflictValidator
+    {
+        bool TitleConflictsWithExistingRegistrationId(string registrationId, string packageTitle);
+        bool IdConflictsWithExistingPackageTitle(string registrationId);
+    }
+}

--- a/src/NuGetGallery/Services/PackageNamingConflictValidator.cs
+++ b/src/NuGetGallery/Services/PackageNamingConflictValidator.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace NuGetGallery
+{
+    public class PackageNamingConflictValidator 
+        : IPackageNamingConflictValidator
+    {
+        private readonly IEntityRepository<PackageRegistration> _packageRegistrationRepository;
+        private readonly IEntityRepository<Package> _packageRepository;
+
+        public PackageNamingConflictValidator(
+            IEntityRepository<PackageRegistration> packageRegistrationRepository,
+            IEntityRepository<Package> packageRepository)
+        {
+            _packageRegistrationRepository = packageRegistrationRepository;
+            _packageRepository = packageRepository;
+        }
+
+        public bool TitleConflictsWithExistingRegistrationId(string registrationId, string packageTitle)
+        {
+            if (string.IsNullOrEmpty(registrationId))
+            {
+                throw new ArgumentNullException("registrationId");
+            }
+
+            if (!string.IsNullOrEmpty(packageTitle))
+            {
+                var cleanedTitle = packageTitle.Trim().ToLowerInvariant();
+                if (!string.IsNullOrEmpty(cleanedTitle))
+                {
+                    var packageRegistration = _packageRegistrationRepository.GetAll()
+                        .SingleOrDefault(pr => pr.Id.ToLower() == cleanedTitle);
+
+                    if (packageRegistration != null 
+                        && !String.Equals(packageRegistration.Id, registrationId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public bool IdConflictsWithExistingPackageTitle(string registrationId)
+        {
+            if (string.IsNullOrEmpty(registrationId))
+            {
+                throw new ArgumentNullException("registrationId");
+            }
+
+            registrationId = registrationId.ToLowerInvariant();
+
+            return _packageRepository.GetAll()
+                .Any(p => p.Title.ToLower() == registrationId);
+        }
+    }
+}

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -474,6 +474,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The ID of your package, &apos;{0}&apos;, is similar to the title of an existing package, which can cause confusion with our users. Please modify the ID of your package and try uploading again..
+        /// </summary>
+        public static string NewRegistrationIdMatchesExistingPackageTitle {
+            get {
+                return ResourceManager.GetString("NewRegistrationIdMatchesExistingPackageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No.
         /// </summary>
         public static string No {
@@ -623,6 +632,15 @@ namespace NuGetGallery {
         public static string SuccessfullyUploadedPackage {
             get {
                 return ResourceManager.GetString("SuccessfullyUploadedPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The title of your package, &apos;{0}&apos;, is similar to the ID of an existing package, which can cause confusion with our users. Please modify the title of your package and try uploading again..
+        /// </summary>
+        public static string TitleMatchesExistingRegistration {
+            get {
+                return ResourceManager.GetString("TitleMatchesExistingRegistration", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -356,4 +356,10 @@ The {2} Team</value>
   <data name="No" xml:space="preserve">
     <value>No</value>
   </data>
+  <data name="TitleMatchesExistingRegistration" xml:space="preserve">
+    <value>The title of your package, '{0}', is similar to the ID of an existing package, which can cause confusion with our users. Please modify the title of your package and try uploading again.</value>
+  </data>
+  <data name="NewRegistrationIdMatchesExistingPackageTitle" xml:space="preserve">
+    <value>The ID of your package, '{0}', is similar to the title of an existing package, which can cause confusion with our users. Please modify the ID of your package and try uploading again.</value>
+  </data>
 </root>

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -291,6 +291,7 @@
     <Compile Include="Filters\ApiAuthorizeAttributeFacts.cs" />
     <Compile Include="Filters\RequiresAccountConfirmationAttributeFacts.cs" />
     <Compile Include="Filters\RequireSslAttributeFacts.cs" />
+    <Compile Include="Services\PackageNamingConflictValidatorFacts.cs" />
     <Compile Include="TestPackage.cs" />
     <Compile Include="Framework\AssertEx.cs" />
     <Compile Include="Framework\Fakes.cs" />

--- a/tests/NuGetGallery.Facts/Services/PackageNamingConflictValidatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageNamingConflictValidatorFacts.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NuGetGallery.Packaging;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class PackageNamingConflictValidatorFacts
+    {
+        [Theory]
+        [InlineData("Microsoft.FooBar", "Microsoft.FooBar", true)]
+        [InlineData("Microsoft.FooBar", "microsoft.foobar", true)]
+        [InlineData("Microsoft.FooBar", "Another.Package", false)]
+        [InlineData("Microsoft.FooBar", "another.package", false)]
+        [InlineData("Microsoft.FooBar", "Microsoft.FooBar contribution package", false)]
+        private void TitleConflictsWithExistingRegistrationIdTests(string existingRegistrationId, string newPackageTitle, bool shouldBeConflict)
+        {
+            // Arrange
+            var existingPackageRegistration = new PackageRegistration
+            {
+                Id = existingRegistrationId,
+                Owners = new HashSet<User>()
+            };
+
+            var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
+            packageRegistrationRepository.Setup(r => r.GetAll()).Returns(new[] { existingPackageRegistration }.AsQueryable());
+
+            var packageRepository = new Mock<IEntityRepository<Package>>();
+
+            var target = new PackageNamingConflictValidator(packageRegistrationRepository.Object, packageRepository.Object);
+
+            // Act
+            var result = target.TitleConflictsWithExistingRegistrationId("NewPackageId", newPackageTitle);
+
+            // Assert
+            Assert.True(result == shouldBeConflict);
+        }
+
+
+        [Theory]
+        [InlineData("ExistingPackageId", "ExistingPackageTitle", "NewPackageId", false)]
+        [InlineData("ExistingPackageId", "ExistingPackageTitle", "newpackageid", false)]
+        [InlineData("AnotherPackageTitle", "ExistingPackageTitle", "ExistingPackageTitle", true)]
+        [InlineData("AnotherPackageTitle", "ExistingPackageTitle", "EXISTingPACKAGETiTLE", true)]
+        public void IdConflictsWithExistingPackageTitleTests(string existingPackageId, string existingPackageTitle, string newPackageId, bool shouldBeConflict)
+        {
+            // Arrange
+            var existingPackageRegistration = new PackageRegistration
+            {
+                Id = existingPackageId,
+                Owners = new HashSet<User>()
+            };
+            var existingPackage = new Package
+            {
+                PackageRegistration = existingPackageRegistration,
+                Version = "1.0.0",
+                Title = existingPackageTitle
+            };
+
+            var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
+            packageRegistrationRepository.Setup(r => r.GetAll()).Returns(new[] { existingPackageRegistration }.AsQueryable());
+
+            var packageRepository = new Mock<IEntityRepository<Package>>();
+            packageRepository.Setup(r => r.GetAll()).Returns(new[] { existingPackage }.AsQueryable());
+
+            var target = new PackageNamingConflictValidator(packageRegistrationRepository.Object, packageRepository.Object);
+            
+            // Act
+            var result = target.IdConflictsWithExistingPackageTitle(newPackageId);
+
+            // Assert
+            Assert.True(result == shouldBeConflict);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2849

On upload/edit package:

* Title of newly uploaded package should not match existing package registration id
* New package registration id should not match an existing package title

/cc @yishaigalatzer @joyhui @joelverhagen 