### PR TITLE
Footer always at bottom

### DIFF
--- a/src/NuGetGallery/Content/Layout.css
+++ b/src/NuGetGallery/Content/Layout.css
@@ -203,7 +203,10 @@ nav.main {
     color: #3e483c;
     padding-bottom: 1em;
     padding-top: 0px;
-    position: relative;
+    position: absolute;
+    width: 100%;
+    bottom: 0px;
+    min-height: 220px;
 }
 
 footer#footer {
@@ -274,12 +277,15 @@ footer#footer {
 
 #outer-wrapper {
     background: url('../Content/Images/headerbackground.png') repeat-x top left #fff;
+    position: relative;
+    min-height: 100%;
 }
 
 #content-wrapper {
     margin: 0 auto;
     min-width: 960px;
     width: 960px;
+    padding-bottom: 250px;
 }
 
 /* Columns (For Two-Column Layout) */


### PR DESCRIPTION
Currently on sites with few content the footer is somewhere in the middle of the screen:

![image](https://cloud.githubusercontent.com/assets/756703/12223856/df3d7230-b7e2-11e5-9eec-1448694b91ba.png)

For most people this will be the case on the upload package page and on the Manage Package page, so I made a few CSS changes.

The good part:
It should work in all browers. The only issue: If the NuGet Websites shows the yellow warning bar the scrollbar might be displayed, because the warning bar is not part of the overall container.

Result:
![image](https://cloud.githubusercontent.com/assets/756703/12223882/689cdb6a-b7e3-11e5-8ff9-427e0144aa21.png)
