### PR TITLE
Fix for issue #1844 - Email sent when removing package owner

### DIFF
--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -107,8 +107,15 @@ namespace NuGetGallery
             {
                 return new { success = false, message = "Owner not found" };
             }
+            var currentUser = _userService.FindByUsername(HttpContext.User.Identity.Name);
+            if (currentUser == null)
+            {
+                return new { success = false, message = "Current user not found" };
+            }
 
             _packageService.RemovePackageOwner(package, user);
+            _messageService.SendPackageOwnerRemovedNotice(currentUser, user, package);
+
             return new { success = true };
         }
 

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -15,6 +15,7 @@ namespace NuGetGallery
         void SendPasswordResetInstructions(User user, string resetPasswordUrl, bool forgotPassword);
         void SendEmailChangeNoticeToPreviousEmailAddress(User user, string oldEmailAddress);
         void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string confirmationUrl);
+        void SendPackageOwnerRemovedNotice(User fromUser, User toUser, PackageRegistration package);
         void SendCredentialRemovedNotice(User user, Credential removed);
         void SendCredentialAddedNotice(User user, Credential added);
     }

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -314,6 +314,35 @@ The {3} Team";
             }
         }
 
+        public void SendPackageOwnerRemovedNotice(User fromUser, User toUser, PackageRegistration package)
+        {
+            if (!toUser.EmailAllowed)
+            {
+                return;
+            }
+            
+            const string subject = "[{0}] The user '{1}' has removed you as an owner of the package '{2}'.";
+
+            string body = @"The user '{0}' removed you as an owner of the package '{1}'.
+
+If this was done incorrectly, we'd recommend contacting '{0}' at '{2}'.
+
+Thanks,
+The {3} Team";
+            body = String.Format(CultureInfo.CurrentCulture, body, fromUser.Username, package.Id, fromUser.EmailAddress, Config.GalleryOwner.DisplayName);
+            
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = String.Format(CultureInfo.CurrentCulture, subject, Config.GalleryOwner.DisplayName, fromUser.Username, package.Id);
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryOwner;
+                mailMessage.ReplyToList.Add(fromUser.ToMailAddress());
+
+                mailMessage.To.Add(toUser.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
         public void SendCredentialRemovedNotice(User user, Credential removed)
         {
             SendCredentialChangeNotice(

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -358,6 +358,40 @@ namespace NuGetGallery
             }
         }
 
+        public class TheSendPackageOwnerRemovedNoticeMethod
+        {
+            [Fact]
+            public void SendsPackageOwnerRemovedNotice()
+            {
+                var to = new User { Username = "Noob", EmailAddress = "old-owner@example.com", EmailAllowed = true };
+                var from = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
+                var package = new PackageRegistration { Id = "CoolStuff" };
+
+                var messageService = new TestableMessageService();
+                messageService.SendPackageOwnerRemovedNotice(from, to, package);
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal("old-owner@example.com", message.To[0].Address);
+                Assert.Equal(TestGalleryOwner.Address, message.From.Address);
+                Assert.Equal("existing-owner@example.com", message.ReplyToList.Single().Address);
+                Assert.Contains("The user 'Existing' has removed you as an owner of the package 'CoolStuff'.", message.Subject);
+                Assert.Contains("The user 'Existing' removed you as an owner of the package 'CoolStuff'", message.Body);
+            }
+
+            [Fact]
+            public void DoesNotSendRemovedNoticeIfUserDoesNotAllowEmails()
+            {
+                var to = new User { Username = "Noob", EmailAddress = "old-owner@example.com", EmailAllowed = false };
+                var from = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
+                var package = new PackageRegistration { Id = "CoolStuff" };
+
+                var messageService = new TestableMessageService();
+                messageService.SendPackageOwnerRemovedNotice(from, to, package);
+
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
         public class TheSendResetPasswordInstructionsMethod
         {
             [Fact]


### PR DESCRIPTION
This PR fixes issue #1844 by sending an email to the package owner when being removed from a package.

I have taken some liberties as I wasn't sure how to phrase the message - feedback on the code and the message would be much appreciated.