### PR TITLE
Add correlation id's to enable E2E tracing of requests

### DIFF
--- a/.vs/config/applicationhost.config
+++ b/.vs/config/applicationhost.config
@@ -155,7 +155,7 @@
         <sites>
             <site name="NuGet Gallery (nuget.localtest.me)" id="2">
                 <application path="/">
-                    <virtualDirectory path="/" physicalPath="..\..\src\NuGetGallery" />
+                    <virtualDirectory path="/" physicalPath="C:\Nuget\NuGetGallery\src\NuGetGallery" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:80:nuget.localtest.me" />

--- a/src/NuGet.Services.Search.Client/Correlation/CorrelationIdProvider.cs
+++ b/src/NuGet.Services.Search.Client/Correlation/CorrelationIdProvider.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Correlator.Extensions;
+using System;
+using System.Net.Http;
+
+namespace NuGet.Services.Search.Client.Correlation
+{
+    public class CorrelationIdProvider
+    {
+        public Guid CorrelationId { get; private set; }
+
+        public CorrelationIdProvider()
+        {
+            CorrelationId = Guid.NewGuid();
+        }
+
+        public CorrelationIdProvider(HttpRequestMessage request)
+        {
+            CorrelationId = request.GetClientCorrelationId();
+
+            if (CorrelationId == Guid.Empty)
+            {
+                CorrelationId = Guid.NewGuid();
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.Search.Client/Correlation/ICorrelated.cs
+++ b/src/NuGet.Services.Search.Client/Correlation/ICorrelated.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.Search.Client.Correlation
+{
+    /// <summary>
+    /// Indicated that the implementing class supports correlation id propogation, and thus excepts CorrelationIdProvider.
+    /// </summary>
+    public interface ICorrelated
+    {
+         CorrelationIdProvider CorrelationIdProvider { get; set; }
+    }
+}

--- a/src/NuGet.Services.Search.Client/NuGet.Services.Search.Client.csproj
+++ b/src/NuGet.Services.Search.Client/NuGet.Services.Search.Client.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Correlator">
+      <HintPath>..\..\packages\WebApiCorrelator.1.1.0.0\lib\net452\Correlator.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -68,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Client\BaseUrlHealthIndicatorStore.cs" />
+    <Compile Include="Correlation\CorrelationIdProvider.cs" />
     <Compile Include="Client\IEndpointHealthIndicatorStore.cs" />
     <Compile Include="Client\IHealthIndicatorLogger.cs" />
     <Compile Include="Client\NullHealthIndicatorLogger.cs" />
@@ -75,13 +80,19 @@
     <Compile Include="Client\SearchClient.cs" />
     <Compile Include="Client\ServiceDiscovery.cs" />
     <Compile Include="Client\ServiceDiscoveryClient.cs" />
+    <Compile Include="Correlation\ICorrelated.cs" />
     <Compile Include="Models\SearchResults.cs" />
     <Compile Include="Models\SortOrder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Scripts\jquery.ajax.correlator.min.js" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />

--- a/src/NuGet.Services.Search.Client/Scripts/jquery.ajax.correlator.min.js
+++ b/src/NuGet.Services.Search.Client/Scripts/jquery.ajax.correlator.min.js
@@ -1,0 +1,5 @@
+﻿/*
+* Author: Lenny Granovsky 
+* License: MIT license
+*/
+;if(typeof jQuery==="undefined"){throw new Error("AJAX correlation JavaScript plugin requires jQuery")}(function(b){var g="correlator";var a="ajax.correlation.id";var j=false;try{j=("sessionStorage" in window)&&window.sessionStorage!==null}catch(c){}var f={create:function(m){function k(){return Math.floor((1+Math.random())*65536).toString(16).substring(1)}var l=(m=="N")?k()+k()+k()+k()+k()+k()+k()+k():k()+k()+"-"+k()+"-"+k()+"-"+k()+"-"+k()+k()+k();return l},empty:function(k){if(k=="N"){return"00000000000000000000000000000000"}else{return"00000000-0000-0000-0000-000000000000"}}};function d(){if(j){var k=window.sessionStorage.getItem(a);if(k!=null&&k!="null"&&k.length>0){return k}}return null}function h(k){if(j){window.sessionStorage.setItem(a,k)}}var e=d();if(e===null){e=f.create();h(e)}var i={getCorrelationId:function(){return e},setCorrelationId:function(k){e=k;h(e);b.ajaxSetup({headers:{"X-CorrelationId":e}})},renewCorrelationId:function(){var k=f.create();i.setCorrelationId(k);return e}};b[g]=i;b.ajaxSetup({headers:{"X-CorrelationId":e}})})(jQuery);

--- a/src/NuGet.Services.Search.Client/app.config
+++ b/src/NuGet.Services.Search.Client/app.config
@@ -10,6 +10,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/NuGet.Services.Search.Client/packages.config
+++ b/src/NuGet.Services.Search.Client/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="NuGet.Services.Platform.Client" version="3.0.29-r-master" targetFramework="net452" />
+  <package id="WebApiCorrelator" version="1.1.0.0" targetFramework="net452" />
 </packages>

--- a/src/NuGetGallery/App_Start/AppActivator.cs
+++ b/src/NuGetGallery/App_Start/AppActivator.cs
@@ -172,6 +172,10 @@ namespace NuGetGallery
             WebApiConfig.Register(GlobalConfiguration.Configuration);
             NuGetODataConfig.Register(GlobalConfiguration.Configuration);
 
+            // Attach correlator
+            var correlatorHnd = new Correlator.Handlers.ClientCorrelationHandler { InitializeIfEmpty = true, TraceCorrelation = true };
+            GlobalConfiguration.Configuration.MessageHandlers.Add(correlatorHnd);
+
             Routes.RegisterRoutes(RouteTable.Routes, configuration.FeedOnlyMode);
             AreaRegistration.RegisterAllAreas();
 

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -115,6 +115,12 @@ namespace NuGetGallery
                 auther.Startup(config, app);
             }
 
+            // Attach correlator
+            HttpConfiguration httpConfig = new HttpConfiguration();
+
+            var correlatorHnd = new Correlator.Handlers.ClientCorrelationHandler { InitializeIfEmpty = true, TraceCorrelation = true };
+            httpConfig.MessageHandlers.Add(correlatorHnd);
+
             // Catch unobserved exceptions from threads before they cause IIS to crash:
             TaskScheduler.UnobservedTaskException += (sender, exArgs) =>
             {

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -115,12 +115,6 @@ namespace NuGetGallery
                 auther.Startup(config, app);
             }
 
-            // Attach correlator
-            HttpConfiguration httpConfig = new HttpConfiguration();
-
-            var correlatorHnd = new Correlator.Handlers.ClientCorrelationHandler { InitializeIfEmpty = true, TraceCorrelation = true };
-            httpConfig.MessageHandlers.Add(correlatorHnd);
-
             // Catch unobserved exceptions from threads before they cause IIS to crash:
             TaskScheduler.UnobservedTaskException += (sender, exArgs) =>
             {

--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -11,12 +11,13 @@ using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json.Linq;
 using NuGet.Services.Search.Client;
+using NuGet.Services.Search.Client.Correlation;
 using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
 
 namespace NuGetGallery.Infrastructure.Lucene
 {
-    public class ExternalSearchService : ISearchService, IIndexingService, IRawSearchService
+    public class ExternalSearchService : ISearchService, IIndexingService, IRawSearchService, ICorrelated
     {
         public static readonly string SearchRoundtripTimePerfCounter = "SearchRoundtripTime";
 
@@ -313,6 +314,12 @@ namespace NuGetGallery.Infrastructure.Lucene
         public void RegisterBackgroundJobs(IList<WebBackgrounder.IJob> jobs, IAppConfiguration configuration)
         {
             // No background jobs to register!
+        }
+
+        public CorrelationIdProvider CorrelationIdProvider
+        {
+            get { return _client.CorrelationIdProvider; }
+            set { _client.CorrelationIdProvider = value; }
         }
     }
 }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -131,6 +131,10 @@
       <HintPath>..\..\packages\Autofac.WebApi2.3.4.0\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Correlator">
+      <HintPath>..\..\packages\WebApiCorrelator.1.1.0.0\lib\net452\Correlator.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="DynamicData.EFCodeFirstProvider, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\DynamicData.EFCodeFirstProvider.0.3.0.0\lib\net40\DynamicData.EFCodeFirstProvider.dll</HintPath>
@@ -1490,6 +1494,7 @@
     <Content Include="Scripts\jquery-1.11.0.min.js" />
     <Content Include="Scripts\jquery-ui-1.10.3.js" />
     <Content Include="Scripts\jquery-ui-1.10.3.min.js" />
+    <Content Include="Scripts\jquery.ajax.correlator.min.js" />
     <Content Include="Scripts\jquery.timeago.js" />
     <None Include="Scripts\jquery.validate-vsdoc.js" />
     <Content Include="Scripts\jquery.validate.js" />
@@ -1607,7 +1612,9 @@
     <Content Include="Content\font\fontawesome-webfont.ttf" />
     <Content Include="Content\font\fontawesome-webfont.woff" />
     <Content Include="Content\font\FontAwesome.otf" />
-    <Content Include="packages.config" />
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
     <None Include="Properties\PublishProfiles\nuget-staging-frontend.pubxml" />
     <Content Include="Scripts\perpackagestatsgraphs.js" />
     <Content Include="Scripts\statsgraphs.js" />

--- a/src/NuGetGallery/Scripts/jquery.ajax.correlator.min.js
+++ b/src/NuGetGallery/Scripts/jquery.ajax.correlator.min.js
@@ -1,0 +1,5 @@
+﻿/*
+* Author: Lenny Granovsky 
+* License: MIT license
+*/
+;if(typeof jQuery==="undefined"){throw new Error("AJAX correlation JavaScript plugin requires jQuery")}(function(b){var g="correlator";var a="ajax.correlation.id";var j=false;try{j=("sessionStorage" in window)&&window.sessionStorage!==null}catch(c){}var f={create:function(m){function k(){return Math.floor((1+Math.random())*65536).toString(16).substring(1)}var l=(m=="N")?k()+k()+k()+k()+k()+k()+k()+k():k()+k()+"-"+k()+"-"+k()+"-"+k()+"-"+k()+k()+k();return l},empty:function(k){if(k=="N"){return"00000000000000000000000000000000"}else{return"00000000-0000-0000-0000-000000000000"}}};function d(){if(j){var k=window.sessionStorage.getItem(a);if(k!=null&&k!="null"&&k.length>0){return k}}return null}function h(k){if(j){window.sessionStorage.setItem(a,k)}}var e=d();if(e===null){e=f.create();h(e)}var i={getCorrelationId:function(){return e},setCorrelationId:function(k){e=k;h(e);b.ajaxSetup({headers:{"X-CorrelationId":e}})},renewCorrelationId:function(){var k=f.create();i.setCorrelationId(k);return e}};b[g]=i;b.ajaxSetup({headers:{"X-CorrelationId":e}})})(jQuery);

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -25,9 +25,9 @@
     <!-- DEPLOYMENT SPECIFIC -->
     <!-- ******************* -->
     <!-- These should change on every deployment (to rotate credentials, etc.) -->
-    <add key="Gallery.StorageType" value="FileSystem" />
+    <add key="Gallery.StorageType" value="AzureStorage" />
     <!-- The storage type to use. Can be FileSystem (default) or AzureStorage -->
-    <add key="Gallery.AzureStorageConnectionString" value="" />
+    <add key="Gallery.AzureStorageConnectionString" value="DefaultEndpointsProtocol=https;AccountName=skofmanstore;AccountKey=tO4NaeGNdmbslm2ZGX4lAK0SMyGl+ssaRejiP1JajySvme4019cgiYk/LgX1O9gUF46Sr3wMhNDYQLrAlz0RRw==" />
     <!-- The connection string for the Azure Storage Account used for Package Storage IF Gallery.StorageType is AzureStorage -->
     <add key="Gallery.AzureStorageReadAccessGeoRedundant" value="false" />
     <!-- If the storage account has to fall-back to a secondary (when Read Access Geo Redundant is enabled in Azure storage), change Gallery.AzureStorageReadAccessGeoRedundant to true -->
@@ -75,14 +75,15 @@
     <add key="Gallery.RequireSSL" value="false" />
 
     <!-- Set this value to use a remote search service. This overrides ALL other Lucene-related settings and disables indexing jobs. -->
-    <!-- Example:
-        <add key="Gallery.ServiceDiscoveryUri" value="https://api.nuget.org/v3/index.json" />
-        <add key="Gallery.SearchServiceResourceType" value="SearchGalleryQueryService/3.0.0-rc" />
-        <add key="Gallery.AutocompleteServiceResourceType" value="SearchAutocompleteService/3.0.0-rc" />
-        -->
-    <add key="Gallery.ServiceDiscoveryUri" value="" />
+   
+    <add key="Gallery.ServiceDiscoveryUri" value="https://api.dev.nugettest.org/v3-index/index.json" />
+    <add key="Gallery.SearchServiceResourceType" value="SearchGalleryQueryService/3.0.0-rc" />
+    <add key="Gallery.AutocompleteServiceResourceType" value="SearchAutocompleteService/3.0.0-rc" />
+      
+    <!-- <add key="Gallery.ServiceDiscoveryUri" value="" />
     <add key="Gallery.SearchServiceResourceType" value="" />
     <add key="Gallery.AutocompleteServiceResourceType" value="" />
+    -->
     <add key="Gallery.Brand" value="NuGet Gallery" />
     <add key="Gallery.GalleryOwner" value="NuGet Gallery &lt;support@nuget.org&gt;" />
     <add key="Gallery.ConfirmEmailAddresses" value="true" />
@@ -109,7 +110,7 @@
     <add key="enableSimpleMembership" value="false" />
   </appSettings>
   <connectionStrings>
-    <add name="Gallery.SqlServer" connectionString="Data Source=(localdb)\v11.0; Integrated Security=True; Initial Catalog=NuGetGallery; MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />
+    <add name="Gallery.SqlServer" connectionString="Server=tcp:szy5udivcd.database.windows.net,1433;Database=skofman;User ID=skofman@szy5udivcd;Password=9ol.^YHN;Trusted_Connection=False;Encrypt=True;Connection Timeout=30;" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <elmah>
     <security allowRemoteAccess="true" />

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -90,6 +90,7 @@
   <package id="System.Spatial" version="5.6.5-beta" targetFramework="net452" />
   <package id="WebActivator" version="1.4.4" targetFramework="net452" />
   <package id="WebActivatorEx" version="2.0.6" targetFramework="net452" />
+  <package id="WebApiCorrelator" version="1.1.0.0" targetFramework="net452" />
   <package id="WebBackgrounder" version="0.2.0" targetFramework="net452" />
   <package id="WebBackgrounder.EntityFramework" version="0.1" targetFramework="net452" />
   <package id="WebGrease" version="1.1.0" targetFramework="net452" />


### PR DESCRIPTION
Propagate a correlation id from NuGet client, to Gallery, to search service. If the client does not provide a correlation id, one will be created for him and sent back in the response.