### PR TITLE
Fix broken migration from #2933

### DIFF
--- a/src/NuGetGallery/Migrations/201210312150156_AggregateStatistics_TotalDownloadCount.cs
+++ b/src/NuGetGallery/Migrations/201210312150156_AggregateStatistics_TotalDownloadCount.cs
@@ -4,11 +4,11 @@ namespace NuGetGallery.Migrations
 {
     using System.Data.Entity.Migrations;
     
-    public partial class AggregateStatistics_TotalDownloadCount : SqlResourceMigration
+    public partial class AggregateStatistics_TotalDownloadCount : DbMigration
     {
-        public AggregateStatistics_TotalDownloadCount()
-            : base("NuGetGallery.Infrastructure.AggregateStatistics.sql")
+        public override void Up()
         {
+            // This migration is now a no-op. The script it used to reference has been removed.
         }
     }
 }


### PR DESCRIPTION
In #2933, `AggregateStatistics.sql` was removed. Making the actual migration be a no-op was overlooked and that causes fresh environments to break when migrating.

References issue #2932.