### PR TITLE
Return 400 Bad Request instead of 500 Internal Server Error when NuGet.exe push encounters a validation error

### DIFF
--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -708,7 +708,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The NuGet is invalid. The error encountered was:&apos;{0}&apos;. Correct the error and try again..
+        ///   Looks up a localized string similar to The NuGet package is invalid. The error encountered was:&apos;{0}&apos;. Correct the error and try again..
         /// </summary>
         public static string UploadPackage_InvalidPackage {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -306,7 +306,7 @@ The {2} Team</value>
     <value>You canceled your email address change request.</value>
   </data>
   <data name="UploadPackage_InvalidPackage" xml:space="preserve">
-    <value>The NuGet is invalid. The error encountered was:'{0}'. Correct the error and try again.</value>
+    <value>The NuGet package is invalid. The error encountered was:'{0}'. Correct the error and try again.</value>
   </data>
   <data name="UploadPackage_InvalidNuspec" xml:space="preserve">
     <value>The NuGet package contains an invalid .nuspec file. The error encountered was:'{0}'. Correct the error and try again.</value>


### PR DESCRIPTION
Return 400 Bad Request instead of 500 Internal Server Error when
NuGet.exe push encounters a validation error.

@xavierdecoster @skofman1 