### PR TITLE
Adding accept attr for .nupkg upload to guide the user

### DIFF
--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -20,7 +20,7 @@
 
         <div class="form-field">
             <label for="PackageFile">Choose a package...</label>
-            <input type="file" name="UploadFile" />
+            <input type="file" name="UploadFile" accept=".nupkg" />
         </div>
 
         <input type="submit" value="Upload" title="Upload the package." />


### PR DESCRIPTION
I noticed that the manual package upload will accept anything and will fail after the postback if the file extension is not a .nupkg:

![image](https://cloud.githubusercontent.com/assets/756703/14157983/fcef28b2-f6cd-11e5-87db-335e521ba32e.png)

To guide the user to their own luck I added the accept attribute, which will work on most browsers:
http://caniuse.com/#search=accept

This is not a security feature - the security part is already handled on the server - it's just cosmetic. The result (in supported browsers) is this:
![image](https://cloud.githubusercontent.com/assets/756703/14158041/53df2a6e-f6ce-11e5-8012-aaa937d0c367.png)
