### PR TITLE
Remove social network JS-bloat and move social buttons to sidebar

### DIFF
--- a/src/NuGetGallery/Content/Layout.css
+++ b/src/NuGetGallery/Content/Layout.css
@@ -1,6 +1,25 @@
 ﻿/* This CSS file contains elements specific to the SHARED LAYOUT [Layout.cshtml, TwoColumnLayout.cshtml etc] 
    that are used across the whole site */
 
+ul.share-buttons{
+  list-style: none;
+  padding: 0;
+}
+
+ul.share-buttons li{
+  display: inline;
+}
+
+ul.share-buttons a {
+    text-decoration: none;
+    margin-right: 8px;
+}
+
+ul.share-buttons i {
+    font-size: 1.6em;
+}
+
+
 /* Service Alert */
 
 #service-alert {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -27,25 +27,6 @@
         <meta name="robots" content="noindex">
     }
 }
-@section BottomScripts {
-    @* Facebook SDK *@
-    <div id="fb-root"></div>
-    <script>
-        (function (d, s, id) {
-            var js, fjs = d.getElementsByTagName(s)[0];
-            if (d.getElementById(id)) return;
-            js = d.createElement(s); js.id = id;
-            @if(!String.IsNullOrWhiteSpace(ViewBag.FacebookAppID)) {
-        @:js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId=@ViewBag.FacebookAppID";
-                                } else {
-        @:js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
-                                }
-            fjs.parentNode.insertBefore(js, fjs);
-        }(document, 'script', 'facebook-jssdk'));</script>
-
-    @* Twitter SDK *@
-    <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = "//platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs); } }(document, "script", "twitter-wjs");</script>
-}
 @section SideColumn {
     <img class="logo" src="@(Model.IconUrl ?? Url.Absolute("~/Content/Images/packageDefaultIcon.png"))" alt="Icon for package @Model.Id" onerror="this.src = '@Url.Absolute("~/Content/Images/packageDefaultIcon.png")';" />
     <div id="stats">
@@ -116,6 +97,18 @@
             }
         </ul>
     </nav>
+
+    <div class="stat">
+        <ul class="share-buttons">
+            @{
+                var encodedText = Url.Encode(string.Format("Check out {0} on #NuGet.", Model.Id));
+            }
+            <li><a href="https://www.facebook.com/sharer/sharer.php?u=@absolutePackageUrl&t=@encodedText" target="_blank" title="Share on Facebook"><i class="icon-facebook"></i></a></li>
+            <li><a href="https://twitter.com/intent/tweet?url=@absolutePackageUrl&text=@encodedText" target="_blank" title="Tweet this package"><i class="icon-twitter"></i></a></li>
+        </ul>
+        <p class="stat-label">Share on Social Networks</p>
+    </div>
+
 
     @* ** FEATURE: License Reports ** *@
     @if (Config.Features.FriendlyLicenses || User.IsAdministrator())
@@ -273,12 +266,6 @@
         {
             <p>Requires NuGet @Model.MinClientVersion or higher.</p>
         }
-        <div id="socialbuttons" style="height: 60px; display: block;">
-            <div>
-                <a href="https://twitter.com/share" class="twitter-share-button" data-url="@absolutePackageUrl" data-text="Check out @Model.Id on #NuGet!">Tweet</a>
-            </div>
-            <div class="fb-like" data-href="@absolutePackageUrl" data-send="false" data-width="450" data-show-faces="true"></div>
-        </div>
     }
 
     @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))


### PR DESCRIPTION
Instead of linking those heavy JS-libraries from Facebook or Twitter, I used the simple link-method.

The buttons should work the same way as before and are represented as the logos from FontAwesome.

The "downside": It's a pretty simple integration, so there is no "37 friends of you already likes this"-FB message shown.

On the pro-side:

* No more privacy issues.
* Cleaner looking page
* Faster rendering, because no JS is involved
* Saves client bandwith
* easier styling

... and because of the last point I moved this part to the sidebar:

![image](https://cloud.githubusercontent.com/assets/756703/14366907/665dd756-fd15-11e5-9520-d64422d6de15.png)
