### PR TITLE
Fix for flickering red bar on ManagePackageOwners page

### DIFF
--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -5,7 +5,7 @@
 
 
 <h1 class="page-heading">Manage Owners for Package "@Model.Title.Abbreviate(50)"</h1>
-<div class="error message" data-bind="text: message, visible: message"></div>
+<div class="error message" style="display: none" data-bind="text: message, visible: message"></div>
 
 <h2>Current Owners</h2>
 <ul id="package-owner-list" data-bind="foreach: owners">


### PR DESCRIPTION
Issue: https://github.com/NuGet/NuGetGallery/issues/427

The flickering is a result of the knockout visible binding and that the intial display setting is block.
To prevent this I set it the error message element to display: none. Not very elegant, but works.

When knockout kicks in everything works as expected.