### PR TITLE
Remove SQL Enterprise only feature on migration

### DIFF
--- a/src/NuGetGallery/Migrations/201603151731262_AddIndexForPackageDeletes.cs
+++ b/src/NuGetGallery/Migrations/201603151731262_AddIndexForPackageDeletes.cs
@@ -6,7 +6,7 @@ namespace NuGetGallery.Migrations
     {
         public override void Up()
         {
-            Sql("IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'nci_wi_Packages_Deleted' AND object_id = OBJECT_ID('Packages')) CREATE NONCLUSTERED INDEX [nci_wi_Packages_Deleted] ON [dbo].[Packages] ([Deleted], [Listed]) INCLUDE ([Description], [FlattenedDependencies], [IsPrerelease], [PackageRegistrationKey], [Tags], [Version]) WITH (ONLINE = ON)");
+            Sql("IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'nci_wi_Packages_Deleted' AND object_id = OBJECT_ID('Packages')) CREATE NONCLUSTERED INDEX [nci_wi_Packages_Deleted] ON [dbo].[Packages] ([Deleted], [Listed]) INCLUDE ([Description], [FlattenedDependencies], [IsPrerelease], [PackageRegistrationKey], [Tags], [Version])");
         }
 
         public override void Down()


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/2997

I'm not sure if the WITH (ONLINE = ON) is needed on your production server, but at least for non-enterprise SQL Server this seems problematic. 
And of course: @maartenba encouraged me to submit this PR :sunglasses: 