### PR TITLE
Update Enable-LocalTestMe.ps1 to find makecert

### DIFF
--- a/tools/Enable-LocalTestMe.ps1
+++ b/tools/Enable-LocalTestMe.ps1
@@ -33,6 +33,15 @@ if(!$MakeCertPath) {
         $xArch = "x64"
     }
     $MakeCertPath = Join-Path $WinSDKDir "bin\$xArch\makecert.exe"
+    
+    # If registry scan finds wrong path, try the Azure extension's makecert
+    if(!(Test-Path $MakeCertPath)) {
+        if($xArch = "x64"){
+	    $MakeCertPath = ${env:ProgramFiles(x86)}/"Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\Microsoft Azure Data Lake Tools for Visual Studio 2015\2.0.6000.0\CppSDK\SDK\bin\makecert.exe"
+    } else {
+    	    $MakeCertPath = ${env:ProgramFiles}/"Microsoft Visual Studio 14.0\Common7\IDE\Extensions\Microsoft\Microsoft Azure Data Lake Tools for Visual Studio 2015\2.0.6000.0\CppSDK\SDK\bin\makecert.exe"
+        }
+    }
 }
 
 if(!(Test-Path $MakeCertPath)) {


### PR DESCRIPTION
Following the current readme, makecert is located in a Visual Studio extension folder installed by Azure SDK, instead of the Windows SDK that the script previously scanned the registry for.  The scan is still there, but if the scan doesn't find the makecert properly, then the extension folder is tested instead.