### PR TITLE
Enforce administrators to a specific authentication mechanism

### DIFF
--- a/src/NuGetGallery.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/src/NuGetGallery.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -15,6 +15,7 @@
       <!-- WARNING: This is an insecure default password. Change it before enabling remote desktop -->
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountEncryptedPassword" value="MIIBnQYJKoZIhvcNAQcDoIIBjjCCAYoCAQAxggFOMIIBSgIBADAyMB4xHDAaBgNVBAMME1dpbmRvd3MgQXp1cmUgVG9vbHMCEG870pHsz0GPRZ18ZHEVMyMwDQYJKoZIhvcNAQEBBQAEggEABCvdlx/fjNaMh+I4tdArjlmC/KhsVISFYKP+Tppd4LJM4J67FUcgSnnZLp/fII7gvd0X7XHRjV9a9gTj15b3lexRXp36oDLiRpw9Ld0EbxNMB1CBPNDqYRlV8iZBLeER3KOq7b+6iUywx1TWRf3UtaIZYI1BU6XJXWlKKartrKFl7g1MV6T506xN5a2m+r9Wi9dTApOYx3mBl1ZICDPTQX5dMWP6aRslapdOcyp+cMAgNjdE0TW0jw5eVEY0m3PqxuSSI99xtXLcVYrz6H7K3C8lNoxR9BlL89XOBh2VGsrsNeDF80cwuZkLYkqL3koehilh6b+iIC74yjcNboPRajAzBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECCGRjuJpsHCYgBDKJqr9G6xa5kT1yQHFHx5Y" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountExpiration" value="2014-10-12T23:59:59.0000000-07:00" />
+
       <!-- ******************** -->
       <!-- ENVIRONMENT SPECIFIC -->
       <!-- ******************** -->
@@ -32,6 +33,11 @@
       <Setting name="Auth.MicrosoftAccount.Enabled" value="false" />
       <Setting name="Auth.MicrosoftAccount.ClientId" value="" />
       <Setting name="Auth.MicrosoftAccount.ClientSecret" value="" />
+      <Setting name="Auth.AzureActiveDirectory.Enabled" value="false" />
+      <Setting name="Auth.AzureActiveDirectory.ClientId" value="" />
+      <Setting name="Auth.AzureActiveDirectory.Authority" value="" />
+      <Setting name="Auth.AzureActiveDirectory.Issuer" value="" />
+      <Setting name="Auth.AzureActiveDirectory.ShowOnLoginPage" value="false" />
       <Setting name="Gallery.PagerDutyAccountName" value="" />
       <Setting name="Gallery.PagerDutyAPIKey" value="" />
       <Setting name="Gallery.PagerDutyServiceKey" value="" />
@@ -52,6 +58,7 @@
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="true" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="nuget" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteForwarder.Enabled" value="true" />
+
       <!-- **************** -->
       <!-- RUNTIME SETTINGS -->
       <!-- **************** -->

--- a/src/NuGetGallery.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/src/NuGetGallery.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -41,6 +41,7 @@
       <Setting name="Gallery.PagerDutyAccountName" value="" />
       <Setting name="Gallery.PagerDutyAPIKey" value="" />
       <Setting name="Gallery.PagerDutyServiceKey" value="" />
+      <Setting name="Gallery.EnforcedAuthProviderForAdmin" value="" />
 
       <!-- *************** -->
       <!-- STABLE SETTINGS -->

--- a/src/NuGetGallery.Cloud/ServiceConfiguration.Local.cscfg
+++ b/src/NuGetGallery.Cloud/ServiceConfiguration.Local.cscfg
@@ -15,6 +15,7 @@
       <!-- WARNING: This is an insecure default password. Change it before enabling remote desktop -->
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountEncryptedPassword" value="MIIBnQYJKoZIhvcNAQcDoIIBjjCCAYoCAQAxggFOMIIBSgIBADAyMB4xHDAaBgNVBAMME1dpbmRvd3MgQXp1cmUgVG9vbHMCEG870pHsz0GPRZ18ZHEVMyMwDQYJKoZIhvcNAQEBBQAEggEABCvdlx/fjNaMh+I4tdArjlmC/KhsVISFYKP+Tppd4LJM4J67FUcgSnnZLp/fII7gvd0X7XHRjV9a9gTj15b3lexRXp36oDLiRpw9Ld0EbxNMB1CBPNDqYRlV8iZBLeER3KOq7b+6iUywx1TWRf3UtaIZYI1BU6XJXWlKKartrKFl7g1MV6T506xN5a2m+r9Wi9dTApOYx3mBl1ZICDPTQX5dMWP6aRslapdOcyp+cMAgNjdE0TW0jw5eVEY0m3PqxuSSI99xtXLcVYrz6H7K3C8lNoxR9BlL89XOBh2VGsrsNeDF80cwuZkLYkqL3koehilh6b+iIC74yjcNboPRajAzBgkqhkiG9w0BBwEwFAYIKoZIhvcNAwcECCGRjuJpsHCYgBDKJqr9G6xa5kT1yQHFHx5Y" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountExpiration" value="2014-10-12T23:59:59.0000000-07:00" />
+      
       <!-- ******************** -->
       <!-- ENVIRONMENT SPECIFIC -->
       <!-- ******************** -->
@@ -32,6 +33,11 @@
       <Setting name="Auth.MicrosoftAccount.Enabled" value="false" />
       <Setting name="Auth.MicrosoftAccount.ClientId" value="" />
       <Setting name="Auth.MicrosoftAccount.ClientSecret" value="" />
+      <Setting name="Auth.AzureActiveDirectory.Enabled" value="false" />
+      <Setting name="Auth.AzureActiveDirectory.ClientId" value="" />
+      <Setting name="Auth.AzureActiveDirectory.Authority" value="" />
+      <Setting name="Auth.AzureActiveDirectory.Issuer" value="" />
+      <Setting name="Auth.AzureActiveDirectory.ShowOnLoginPage" value="false" />
       <Setting name="Gallery.PagerDutyAccountName" value="" />
       <Setting name="Gallery.PagerDutyAPIKey" value="" />
       <Setting name="Gallery.PagerDutyServiceKey" value="" />
@@ -52,6 +58,7 @@
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="true" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="nuget" />
       <Setting name="Microsoft.WindowsAzure.Plugins.RemoteForwarder.Enabled" value="true" />
+      
       <!-- **************** -->
       <!-- RUNTIME SETTINGS -->
       <!-- **************** -->

--- a/src/NuGetGallery.Cloud/ServiceConfiguration.Local.cscfg
+++ b/src/NuGetGallery.Cloud/ServiceConfiguration.Local.cscfg
@@ -41,6 +41,7 @@
       <Setting name="Gallery.PagerDutyAccountName" value="" />
       <Setting name="Gallery.PagerDutyAPIKey" value="" />
       <Setting name="Gallery.PagerDutyServiceKey" value="" />
+      <Setting name="Gallery.EnforcedAuthProviderForAdmin" value="" />
 
       <!-- *************** -->
       <!-- STABLE SETTINGS -->

--- a/src/NuGetGallery.Cloud/ServiceDefinition.csdef
+++ b/src/NuGetGallery.Cloud/ServiceDefinition.csdef
@@ -36,6 +36,11 @@
       <Setting name="Auth.MicrosoftAccount.Enabled" />
       <Setting name="Auth.MicrosoftAccount.ClientId" />
       <Setting name="Auth.MicrosoftAccount.ClientSecret" />
+      <Setting name="Auth.AzureActiveDirectory.Enabled" />
+      <Setting name="Auth.AzureActiveDirectory.ClientId" />
+      <Setting name="Auth.AzureActiveDirectory.Authority" />
+      <Setting name="Auth.AzureActiveDirectory.Issuer" />
+      <Setting name="Auth.AzureActiveDirectory.ShowOnLoginPage" />
       <Setting name="Startup.BlockedIPs" />
       <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
     </ConfigurationSettings>

--- a/src/NuGetGallery.Cloud/ServiceDefinition.csdef
+++ b/src/NuGetGallery.Cloud/ServiceDefinition.csdef
@@ -33,6 +33,7 @@
       <Setting name="Gallery.PagerDutyAPIKey" />
       <Setting name="Gallery.PagerDutyServiceKey" />
       <Setting name="Gallery.WarningBanner" />
+      <Setting name="Gallery.EnforcedAuthProviderForAdmin" />
       <Setting name="Auth.MicrosoftAccount.Enabled" />
       <Setting name="Auth.MicrosoftAccount.ClientId" />
       <Setting name="Auth.MicrosoftAccount.ClientSecret" />

--- a/src/NuGetGallery.Core/Entities/User.cs
+++ b/src/NuGetGallery.Core/Entities/User.cs
@@ -109,5 +109,10 @@ namespace NuGetGallery
             return Credentials.Any(c =>
                 c.Type.StartsWith(CredentialTypes.Password.Prefix, StringComparison.OrdinalIgnoreCase));
         }
+
+        public bool IsInRole(string roleName)
+        {
+            return Roles.Any(r => String.Equals(r.Name, roleName, StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/NuGetGallery/Authentication/AuthenticatedUser.cs
+++ b/src/NuGetGallery/Authentication/AuthenticatedUser.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace NuGetGallery.Authentication
 {

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -293,6 +293,7 @@ namespace NuGetGallery.Authentication
         public virtual ActionResult Challenge(string providerName, string redirectUrl)
         {
             Authenticator provider;
+
             if (!Authenticators.TryGetValue(providerName, out provider))
             {
                 throw new InvalidOperationException(String.Format(
@@ -300,6 +301,7 @@ namespace NuGetGallery.Authentication
                     Strings.UnknownAuthenticationProvider,
                     providerName));
             }
+
             if (!provider.BaseConfig.Enabled)
             {
                 throw new InvalidOperationException(String.Format(

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -376,9 +376,17 @@ namespace NuGetGallery.Authentication
             string emailSuffix = emailClaim == null ? String.Empty : (" <" + emailClaim.Value + ">");
 
             Authenticator auther;
+            string authenticationType = idClaim.Issuer;
             if (!Authenticators.TryGetValue(idClaim.Issuer, out auther))
             {
-                auther = null;
+                foreach (var authenticator in Authenticators.Values)
+                {
+                    if (authenticator.TryMapIssuerToAuthenticationType(idClaim.Issuer, out authenticationType))
+                    {
+                        auther = authenticator;
+                        break;
+                    }
+                }
             }
 
             return new AuthenticateExternalLoginResult()
@@ -386,7 +394,7 @@ namespace NuGetGallery.Authentication
                 Authentication = null,
                 ExternalIdentity = result.Identity,
                 Authenticator = auther,
-                Credential = CredentialBuilder.CreateExternalCredential(idClaim.Issuer, idClaim.Value, nameClaim.Value + emailSuffix)
+                Credential = CredentialBuilder.CreateExternalCredential(authenticationType, idClaim.Value, nameClaim.Value + emailSuffix)
             };
         }
 

--- a/src/NuGetGallery/Authentication/Providers/Authenticator.cs
+++ b/src/NuGetGallery/Authentication/Providers/Authenticator.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery.Authentication.Providers
 {
     public abstract class Authenticator
     {
-        private static readonly Regex _nameShortener = new Regex(@"^(?<shortname>[A-Za-z0-9_]*)Authenticator$");
+        private static readonly Regex NameShortener = new Regex(@"^(?<shortname>[A-Za-z0-9_]*)Authenticator$");
         private static readonly string AuthPrefix = "Auth.";
 
         public AuthenticatorConfiguration BaseConfig { get; private set; }
@@ -49,7 +49,7 @@ namespace NuGetGallery.Authentication.Providers
         public static string GetName(Type authenticator)
         {
             var name = authenticator.Name;
-            var match = _nameShortener.Match(name);
+            var match = NameShortener.Match(name);
             if (match.Success)
             {
                 name = match.Groups["shortname"].Value;
@@ -92,17 +92,17 @@ namespace NuGetGallery.Authentication.Providers
         {
             return new HttpUnauthorizedResult();
         }
-    }
 
-    public abstract class Authenticator<TConfig> : Authenticator
-        where TConfig : AuthenticatorConfiguration, new()
-    {
-        public TConfig Config { get; private set; }
-
-        protected internal override AuthenticatorConfiguration CreateConfigObject()
+        public virtual bool TryMapIssuerToAuthenticationType(string issuer, out string authenticationType)
         {
-            Config = new TConfig();
-            return Config;
+            if (string.Equals(issuer, BaseConfig.AuthenticationType, StringComparison.OrdinalIgnoreCase))
+            {
+                authenticationType = BaseConfig.AuthenticationType;
+                return true;
+            }
+
+            authenticationType = null;
+            return false;
         }
     }
 }

--- a/src/NuGetGallery/Authentication/Providers/AuthenticatorT.cs
+++ b/src/NuGetGallery/Authentication/Providers/AuthenticatorT.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Authentication.Providers
+{
+    public abstract class Authenticator<TConfig> : Authenticator
+        where TConfig : AuthenticatorConfiguration, new()
+    {
+        public TConfig Config { get; private set; }
+
+        protected internal override AuthenticatorConfiguration CreateConfigObject()
+        {
+            Config = new TConfig();
+            return Config;
+        }
+    }
+}

--- a/src/NuGetGallery/Authentication/Providers/AuthenticatorUI.cs
+++ b/src/NuGetGallery/Authentication/Providers/AuthenticatorUI.cs
@@ -14,12 +14,16 @@ namespace NuGetGallery.Authentication.Providers
         public string AccountNoun { get; private set; }
         public string Caption { get; private set; }
         public string IconCssClass { get; set; }
+        public bool ShowOnLoginPage { get; set; }
+        public string SignInInfo { get; set; }
 
         public AuthenticatorUI(string signInMessage, string accountNoun, string caption)
         {
             SignInMessage = signInMessage;
             AccountNoun = accountNoun;
             Caption = caption;
+
+            ShowOnLoginPage = true;
         }
     }
 }

--- a/src/NuGetGallery/Authentication/Providers/AzureActiveDirectory/AzureActiveDirectoryAuthenticator.cs
+++ b/src/NuGetGallery/Authentication/Providers/AzureActiveDirectory/AzureActiveDirectoryAuthenticator.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.Owin.Security.OpenIdConnect;
+using NuGetGallery.Configuration;
+using Owin;
+
+namespace NuGetGallery.Authentication.Providers.AzureActiveDirectory
+{
+    public class AzureActiveDirectoryAuthenticator : Authenticator<AzureActiveDirectoryAuthenticatorConfiguration>
+    {
+        public static readonly string DefaultAuthenticationType = "AzureActiveDirectory";
+
+        protected override void AttachToOwinApp(ConfigurationService config, IAppBuilder app)
+        {
+            // Fetch site root from configuration
+            var siteRoot = config.Current.SiteRoot.TrimEnd('/') + "/";
+            
+            // We *always* require SSL for Azure Active Directory
+            if (siteRoot.StartsWith("http://", StringComparison.OrdinalIgnoreCase)) 
+            {
+                siteRoot = siteRoot.Replace("http://", "https://");
+            }
+
+            // Configure OpenIdConnect
+            var options = new OpenIdConnectAuthenticationOptions(BaseConfig.AuthenticationType)
+            {
+                RedirectUri = siteRoot + "users/account/authenticate/return",
+                PostLogoutRedirectUri = siteRoot,
+                Notifications = new OpenIdConnectAuthenticationNotifications
+                {
+                    RedirectToIdentityProvider = notification =>
+                    {
+                        if (notification.ProtocolMessage.RequestType == OpenIdConnectRequestType.LogoutRequest)
+                        {
+                            // We never intend to sign out at the federated identity. Suppress the redirect.
+                            notification.HandleResponse();
+                        }
+
+                        return Task.FromResult(0);
+                    } 
+                }
+            };
+            Config.ApplyToOwinSecurityOptions(options);
+
+            app.UseOpenIdConnectAuthentication(options);
+        }
+        
+        public override AuthenticatorUI GetUI()
+        {
+            return new AuthenticatorUI(
+                Strings.AzureActiveDirectory_SignInMessage,
+                Strings.AzureActiveDirectory_AccountNoun, 
+                Strings.AzureActiveDirectory_Caption)
+            {
+                ShowOnLoginPage = Config.ShowOnLoginPage
+            };
+        }
+
+        public override ActionResult Challenge(string redirectUrl)
+        {
+            return new ChallengeResult(BaseConfig.AuthenticationType, redirectUrl);
+        }
+
+        public override bool TryMapIssuerToAuthenticationType(string issuer, out string authenticationType)
+        {
+            if (string.Equals(issuer, Config.Issuer, StringComparison.OrdinalIgnoreCase))
+            {
+                authenticationType = Config.AuthenticationType;
+                return true;
+            }
+
+            return base.TryMapIssuerToAuthenticationType(issuer, out authenticationType);
+        }
+    }
+}

--- a/src/NuGetGallery/Authentication/Providers/AzureActiveDirectory/AzureActiveDirectoryAuthenticatorConfiguration.cs
+++ b/src/NuGetGallery/Authentication/Providers/AzureActiveDirectory/AzureActiveDirectoryAuthenticatorConfiguration.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Configuration;
+using System.Globalization;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.OpenIdConnect;
+
+namespace NuGetGallery.Authentication.Providers.AzureActiveDirectory
+{
+    public class AzureActiveDirectoryAuthenticatorConfiguration : AuthenticatorConfiguration
+    {
+        public string ClientId { get; set; }
+        public string Authority { get; set; }
+        public string Issuer { get; set; }
+        public bool ShowOnLoginPage { get; set; }
+
+        public AzureActiveDirectoryAuthenticatorConfiguration()
+        {
+            AuthenticationType = AzureActiveDirectoryAuthenticator.DefaultAuthenticationType;
+        }
+
+        public override void ApplyToOwinSecurityOptions(AuthenticationOptions options)
+        {
+            base.ApplyToOwinSecurityOptions(options);
+
+            var opts = options as OpenIdConnectAuthenticationOptions;
+            if (opts != null)
+            {
+                // Set passive so that a HTTP 401 does not automatically trigger
+                // Azure AD authentication. NuGet uses an explicit challenge to trigger
+                // the auth flow.
+                opts.AuthenticationMode = AuthenticationMode.Passive;
+
+                // Make sure ClientId is configured
+                if (String.IsNullOrEmpty(ClientId))
+                {
+                    throw new ConfigurationErrorsException(String.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.MissingRequiredConfigurationValue,
+                        "Auth.AzureActiveDirectory.ClientId"));
+                }
+
+                opts.ClientId = ClientId;
+
+                // Make sure Authority is configured
+                if (String.IsNullOrEmpty(Authority))
+                {
+                    throw new ConfigurationErrorsException(String.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.MissingRequiredConfigurationValue,
+                        "Auth.AzureActiveDirectory.Authority"));
+                }
+
+                opts.Authority = Authority;
+
+                // Make sure Issuer is configured
+                if (String.IsNullOrEmpty(Issuer))
+                {
+                    throw new ConfigurationErrorsException(String.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.MissingRequiredConfigurationValue,
+                        "Auth.AzureActiveDirectory.Issuer"));
+                }
+            }
+        }
+    }
+}

--- a/src/NuGetGallery/Authentication/Providers/LocalUser/LocalUserAuthenticator.cs
+++ b/src/NuGetGallery/Authentication/Providers/LocalUser/LocalUserAuthenticator.cs
@@ -33,7 +33,7 @@ namespace NuGetGallery.Authentication.Providers.Cookie
 
         protected internal override AuthenticatorConfiguration CreateConfigObject()
         {
-            return new AuthenticatorConfiguration()
+            return new AuthenticatorConfiguration
             {
                 AuthenticationType = AuthenticationTypes.LocalUser,
                 Enabled = false

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -162,6 +162,13 @@ namespace NuGetGallery.Configuration
         public bool AutoUpdateSearchIndex { get; set; }
 
         /// <summary>
+        /// Gets a string indicating which authentication provider(s) are supported for administrators. 
+        /// When specified, the gallery will ensure admin users are logging in using any of the specified authentication providers.
+        /// Blank means any authentication provider can be used by administrators.
+        /// </summary>
+        public string EnforcedAuthProviderForAdmin { get; set; }
+
+        /// <summary>
         /// Gets a string containing the PagerDuty account name.
         /// </summary>
         public string PagerDutyAccountName { get; set; }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -149,6 +149,13 @@ namespace NuGetGallery.Configuration
         bool AutoUpdateSearchIndex { get; set; }
 
         /// <summary>
+        /// Gets a string indicating which authentication provider(s) are supported for administrators. 
+        /// When specified, the gallery will ensure admin users are logging in using any of the specified authentication providers.
+        /// Blank means any authentication provider can be used by administrators.
+        /// </summary>
+        string EnforcedAuthProviderForAdmin { get; set; }
+
+        /// <summary>
         /// Gets a string containing the PagerDuty account name.
         /// </summary>
         string PagerDutyAccountName { get; set; }

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -182,6 +182,12 @@ namespace NuGetGallery
         public virtual ActionResult LogOff(string returnUrl)
         {
             OwinContext.Authentication.SignOut();
+
+            if (returnUrl.Contains("account"))
+            {
+                returnUrl = null;
+            }
+
             return SafeRedirect(returnUrl);
         }
 
@@ -284,7 +290,7 @@ namespace NuGetGallery
             return (from p in AuthService.Authenticators.Values
                     where p.BaseConfig.Enabled
                     let ui = p.GetUI()
-                    where ui != null
+                    where ui != null && ui.ShowOnLoginPage
                     select new AuthenticationProviderViewModel()
                     {
                         ProviderName = p.Name,

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -25,7 +25,6 @@ namespace NuGetGallery
         public IUserService UserService { get; protected set; }
         public IMessageService MessageService { get; protected set; }
 
-
         public AuthenticationController(
             AuthenticationService authService,
             IUserService userService,
@@ -83,7 +82,7 @@ namespace NuGetGallery
 
                 return LogOnView(model);
             }
-
+            
             if (linkingAccount)
             {
                 // Link with an external account
@@ -94,9 +93,43 @@ namespace NuGetGallery
                 }
             }
 
-            // Now log in!
+            // If we are an administrator and Gallery.EnforcedAuthProviderForAdmin is set
+            // to require a specific authentication provider, challenge that provider if needed.
+            ActionResult challenge;
+            if (ShouldChallengeEnforcedProvider(
+                NuGetContext.Config.Current.EnforcedAuthProviderForAdmin, user, returnUrl, out challenge))
+            {
+                return challenge;
+            }
+
+            // Create session
             AuthService.CreateSession(OwinContext, user.User);
             return SafeRedirect(returnUrl);
+        }
+
+        internal bool ShouldChallengeEnforcedProvider(string enforcedProviders, AuthenticatedUser authenticatedUser, string returnUrl, out ActionResult challenge)
+        {
+            if (!string.IsNullOrEmpty(enforcedProviders)
+                && authenticatedUser.CredentialUsed.Type != null
+                && authenticatedUser.User.IsInRole(Constants.AdminRoleName))
+            {
+                // Seems we *need* a specific authentication provider. Check if we logged in using one...
+                var providers = enforcedProviders.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
+
+                if (!providers.Any(p => string.Equals(p, authenticatedUser.CredentialUsed.Type, StringComparison.OrdinalIgnoreCase))
+                    && !providers.Any(p => string.Equals(CredentialTypes.ExternalPrefix + p, authenticatedUser.CredentialUsed.Type, StringComparison.OrdinalIgnoreCase)))
+                {
+                    // Challenge authentication using the first required authentication provider
+                    challenge = AuthService.Challenge(
+                        providers.First(),
+                        Url.Action("LinkExternalAccount", "Authentication", new { ReturnUrl = returnUrl }));
+
+                    return true;
+                }
+            }
+
+            challenge = null;
+            return false;
         }
 
         [HttpGet]
@@ -133,7 +166,6 @@ namespace NuGetGallery
             AuthenticatedUser user;
             try
             {
-
                 if (linkingAccount)
                 {
                     var result = await AuthService.ReadExternalLoginCredential(OwinContext);
@@ -162,7 +194,7 @@ namespace NuGetGallery
             }
 
             // Send a new account email
-            if(NuGetContext.Config.Current.ConfirmEmailAddresses && !String.IsNullOrEmpty(user.User.UnconfirmedEmailAddress))
+            if (NuGetContext.Config.Current.ConfirmEmailAddresses && !String.IsNullOrEmpty(user.User.UnconfirmedEmailAddress))
             {
                 MessageService.SendNewAccountEmail(
                     new MailAddress(user.User.UnconfirmedEmailAddress, user.User.Username),
@@ -173,9 +205,17 @@ namespace NuGetGallery
                         user.User.EmailConfirmationToken));
             }
 
-            // We're logging in!
-            AuthService.CreateSession(OwinContext, user.User);
+            // If we are an administrator and Gallery.EnforcedAuthProviderForAdmin is set
+            // to require a specific authentication provider, challenge that provider if needed.
+            ActionResult challenge;
+            if (ShouldChallengeEnforcedProvider(
+                NuGetContext.Config.Current.EnforcedAuthProviderForAdmin, user, returnUrl, out challenge))
+            {
+                return challenge;
+            }
 
+            // Create session
+            AuthService.CreateSession(OwinContext, user.User);
             return RedirectFromRegister(returnUrl);
         }
 
@@ -183,7 +223,8 @@ namespace NuGetGallery
         {
             OwinContext.Authentication.SignOut();
 
-            if (returnUrl.Contains("account"))
+            if (!string.IsNullOrEmpty(returnUrl) 
+                && returnUrl.Contains("account"))
             {
                 returnUrl = null;
             }
@@ -211,6 +252,16 @@ namespace NuGetGallery
 
             if (result.Authentication != null)
             {
+                // If we are an administrator and Gallery.EnforcedAuthProviderForAdmin is set
+                // to require a specific authentication provider, challenge that provider if needed.
+                ActionResult challenge;
+                if (ShouldChallengeEnforcedProvider(
+                    NuGetContext.Config.Current.EnforcedAuthProviderForAdmin, result.Authentication, returnUrl, out challenge))
+                {
+                    return challenge;
+                }
+
+                // Create session
                 AuthService.CreateSession(OwinContext, result.Authentication.User);
                 return SafeRedirect(returnUrl);
             }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -306,6 +306,10 @@
       <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.5-beta\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.0\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -329,6 +333,10 @@
     <Reference Include="Microsoft.Owin.Security.MicrosoftAccount, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Owin.Security.MicrosoftAccount.3.0.1\lib\net45\Microsoft.Owin.Security.MicrosoftAccount.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OpenIdConnect">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.OpenIdConnect.3.0.1\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.DistributedCache, Version=101.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -456,6 +464,12 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.4.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
@@ -645,6 +659,9 @@
     <Compile Include="Areas\Admin\ViewModels\SupportRequestsViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\SupportRequestViewModel.cs" />
     <Compile Include="Authentication\FeedOnlyModeException.cs" />
+    <Compile Include="Authentication\Providers\AuthenticatorT.cs" />
+    <Compile Include="Authentication\Providers\AzureActiveDirectory\AzureActiveDirectoryAuthenticator.cs" />
+    <Compile Include="Authentication\Providers\AzureActiveDirectory\AzureActiveDirectoryAuthenticatorConfiguration.cs" />
     <Compile Include="Controllers\NuGetContext.cs" />
     <Compile Include="Extensions\DateTimeExtensions.cs" />
     <Compile Include="Controllers\ODataV1FeedController.cs" />
@@ -724,7 +741,9 @@
     <Compile Include="Diagnostics\IDiagnosticsService.cs" />
     <Compile Include="Diagnostics\IDiagnosticsSource.cs" />
     <Compile Include="Configuration\StorageType.cs" />
-    <Content Include="bin\NuGetGallery.dll.config" />
+    <Content Include="bin\NuGetGallery.dll.config">
+      <SubType>Designer</SubType>
+    </Content>
     <Compile Include="Areas\Admin\AdminAreaRegistration.cs" />
     <Compile Include="Areas\Admin\Controllers\AdminControllerBase.cs" />
     <Compile Include="Areas\Admin\Controllers\HomeController.cs" />

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -116,6 +116,33 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Azure Active Directory Account.
+        /// </summary>
+        public static string AzureActiveDirectory_AccountNoun {
+            get {
+                return ResourceManager.GetString("AzureActiveDirectory_AccountNoun", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Azure Active Directory.
+        /// </summary>
+        public static string AzureActiveDirectory_Caption {
+            get {
+                return ResourceManager.GetString("AzureActiveDirectory_Caption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sign in with Azure Active Directory.
+        /// </summary>
+        public static string AzureActiveDirectory_SignInMessage {
+            get {
+                return ResourceManager.GetString("AzureActiveDirectory_SignInMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You canceled your email address change request..
         /// </summary>
         public static string CancelEmailAddress {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -371,4 +371,13 @@ The {2} Team</value>
   <data name="PackageEntryFromTheFuture" xml:space="preserve">
     <value>The package is invalid and cannot be uploaded. One or more files, such as '{0}' have a date in the future.</value>
   </data>
+  <data name="AzureActiveDirectory_SignInMessage" xml:space="preserve">
+    <value>Sign in with Azure Active Directory</value>
+  </data>
+  <data name="AzureActiveDirectory_AccountNoun" xml:space="preserve">
+    <value>Azure Active Directory Account</value>
+  </data>
+  <data name="AzureActiveDirectory_Caption" xml:space="preserve">
+    <value>Azure Active Directory</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Views/Authentication/LogOn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/LogOn.cshtml
@@ -13,7 +13,7 @@
                 <p>
                     We found an account with this email address. Sign in with your password to link with this account. 
                     Don't have a password? Sorry, you'll have to log in using an existing credential and 
-                    set a password to associate a Microsoft Account. If you're still having trouble, you can 
+                    set a password to associate a @Model.External.ProviderAccountNoun. If you're still having trouble, you can 
                     <a href="mailto:@Config.Current.GalleryOwner.Address">contact support.</a>
                 </p>
                 <div id="signIn-solo-form">
@@ -55,30 +55,36 @@
     }
     else
     {
-        if (Model.Providers.Count > 0)
+        foreach (var provider in Model.Providers)
         {
             <div id="logon-external">
-                <h1>Sign in with a Microsoft account</h1>
+                <h1>@provider.UI.SignInMessage</h1>
                 <p id="logon-external-info">
-                    We recommend using a Microsoft account to log in to NuGet.org.
-                    If you already have a NuGet.org account, click the button to the right to associate it
-                    with your Microsoft account. If not, click the button anyway and we'll create a new NuGet.org 
-                    account for you!
+                    @if (!string.IsNullOrEmpty(provider.UI.SignInInfo))
+                    {
+                        @provider.UI.SignInInfo
+                    }
+                    else
+                    {
+                        <text>
+                            We recommend using a @(provider.UI.AccountNoun ?? "external account") to log in to NuGet.org.
+                            If you already have a NuGet.org account, click the button to the right to associate it with your @(provider.UI.AccountNoun ?? "external account").
+                            If not, click the button anyway and we'll create a new NuGet.org account for you!
+                        </text>
+                    }
                 </p>
                 <ul id="signin-providerlist">
-                    @foreach (var provider in Model.Providers)
-                    {
-                        <li class="signin-authprovider">
-                            <a class="btn btn-big signin-external-link" href="@Url.Action("Authenticate", new { provider = provider.ProviderName, returnUrl = ViewData[Constants.ReturnUrlViewDataKey] })">
-                                <i class="@provider.UI.IconCssClass signin-authprovider-icon"></i>
-                                @provider.UI.SignInMessage
-                            </a>
-                        </li>
-                    }
+                    <li class="signin-authprovider">
+                        <a class="btn btn-big signin-external-link" href="@Url.Action("Authenticate", new {provider = provider.ProviderName, returnUrl = ViewData[Constants.ReturnUrlViewDataKey]})">
+                            <i class="@provider.UI.IconCssClass signin-authprovider-icon"></i>
+                            @provider.UI.SignInMessage
+                        </a>
+                    </li>
                 </ul>
             </div>
             <p id="logon-separator">&mdash; or &mdash;</p>
         }
+
         <h2>Sign in or register with a username and password</h2>
         <div id="register">
             <h3>Register</h3>

--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -301,8 +301,8 @@
 @if (hasPassword && credGroups.ContainsKey(CredentialKind.External) && credGroups[CredentialKind.External].Any())
 {
     <p class="message">
-        Because you have a Microsoft account registered you can remove your password below and use
-        that account to sign in to NuGet.org. No more passwords to forget!
+        Because you have an external account registered you can remove your password below and use
+        that account to sign in to @Config.Current.Brand. No more passwords to forget!
     </p>
 }
     
@@ -334,7 +334,7 @@
                     }
                 </text>,
                 content: @<p>
-                    You can use this Microsoft account to sign in to NuGet.org
+                    You can use this @cred.AuthUI.AccountNoun to sign in to @Config.Current.Brand
                 </p>)
         }
     }

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -66,9 +66,17 @@
     <!-- Enabling/Disabling and configuring auth providers -->
     <add key="Auth.LocalUser.Enabled" value="true" />
     <add key="Auth.ApiKey.Enabled" value="true" />
+    
     <add key="Auth.MicrosoftAccount.Enabled" value="false" />
     <add key="Auth.MicrosoftAccount.ClientId" value="" />
     <add key="Auth.MicrosoftAccount.ClientSecret" value="" />
+
+    <add key="Auth.AzureActiveDirectory.Enabled" value="false" />
+    <add key="Auth.AzureActiveDirectory.ClientId" value="" />
+    <add key="Auth.AzureActiveDirectory.Authority" value="" />
+    <add key="Auth.AzureActiveDirectory.Issuer" value="" />
+    <add key="Auth.AzureActiveDirectory.ShowOnLoginPage" value="true" />
+    
     <!-- *************** -->
     <!-- STABLE SETTINGS -->
     <!-- *************** -->

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -77,6 +77,8 @@
     <add key="Auth.AzureActiveDirectory.Issuer" value="" />
     <add key="Auth.AzureActiveDirectory.ShowOnLoginPage" value="true" />
     
+    <add key="Gallery.EnforcedAuthProviderForAdmin" value="" />
+    
     <!-- *************** -->
     <!-- STABLE SETTINGS -->
     <!-- *************** -->

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -52,6 +52,7 @@
   <package id="Microsoft.Data.OData" version="5.6.5-beta" targetFramework="net452" />
   <package id="Microsoft.Data.Services" version="5.6.5-beta" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.6.5-beta" targetFramework="net452" />
+  <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="2.0.30116.0" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
@@ -59,6 +60,7 @@
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security.MicrosoftAccount" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Security.OpenIdConnect" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net452" />
@@ -83,6 +85,7 @@
   <package id="RouteMagic" version="1.1.3" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />
   <package id="Strathweb.CacheOutput.WebApi2" version="0.9.0" targetFramework="net452" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.5-beta" targetFramework="net452" />
   <package id="WebActivator" version="1.4.4" targetFramework="net452" />
   <package id="WebActivatorEx" version="2.0.6" targetFramework="net452" />

--- a/tests/NuGetGallery.Core.Facts/Entities/UserFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Entities/UserFacts.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class UserFacts
+    {
+        [Theory]
+        [InlineData("Admins", true)]
+        [InlineData("OtherRole", false)]
+        public void IsInRoleReturnsCorrectValue(string expectedRole, bool isInRole)
+        {
+            // Arrange
+            var user = new User("testuser");
+            user.Roles.Add(new Role { Key = 1, Name = "Admins" });
+
+            // Act
+            var result = user.IsInRole(expectedRole);
+
+            // Assert
+            Assert.True(result == isInRole);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -148,6 +148,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Entities\PackageFacts.cs" />
+    <Compile Include="Entities\UserFacts.cs" />
     <Compile Include="Packaging\ManifestValidatorFacts.cs" />
     <Compile Include="Packaging\PackageIdValidatorTest.cs" />
     <Compile Include="Packaging\PackageMetadataFacts.cs" />

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -299,6 +299,92 @@ namespace NuGetGallery.Controllers
                 GetMock<AuthenticationService>().VerifyAll();
                 GetMock<IMessageService>().VerifyAll();
             }
+
+            [Theory]
+            [InlineData("MicrosoftAccount", true)]
+            [InlineData("AzureActiveDirectory", false)]
+            public async Task GivenAdminLogsInWithValidExternalAuth_ItChallengesWhenNotUsingRequiredExternalProvider(string providerUsedForLogin, bool shouldChallenge)
+            {
+                var enforcedProvider = "AzureActiveDirectory";
+
+                var config = Get<ConfigurationService>();
+                config.Current = new AppConfiguration()
+                {
+                    ConfirmEmailAddresses = false,
+                    EnforcedAuthProviderForAdmin = enforcedProvider
+                };
+
+                var externalCred = CredentialBuilder.CreateExternalCredential(providerUsedForLogin, "blorg", "Bloog");
+
+                var authUser = new AuthenticatedUser(
+                    new User("theUsername")
+                    {
+                        UnconfirmedEmailAddress = "confirmed@example.com",
+                        Roles =
+                        {
+                            new Role { Name = Constants.AdminRoleName }
+                        }
+                    },
+                    externalCred);
+                
+                GetMock<AuthenticationService>()
+                    .Setup(x => x.Authenticate(authUser.User.Username, "thePassword"))
+                    .CompletesWith(authUser);
+
+                GetMock<AuthenticationService>()
+                    .Setup(x => x.AddCredential(authUser.User, externalCred))
+                    .Completes()
+                    .Verifiable();
+
+                GetMock<IMessageService>()
+                    .Setup(x => x.SendCredentialAddedNotice(authUser.User, externalCred))
+                    .Verifiable();
+
+                EnableAllAuthenticators(Get<AuthenticationService>());
+                var controller = GetController<AuthenticationController>();
+
+                if (shouldChallenge)
+                {
+                    GetMock<AuthenticationService>()
+                        .Setup(x => x.Challenge(enforcedProvider, It.IsAny<string>()))
+                        .Returns(new ChallengeResult(enforcedProvider, null))
+                        .Verifiable();
+                }
+                else
+                {
+                    GetMock<AuthenticationService>()
+                       .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                       .Verifiable();
+                }
+                
+                GetMock<AuthenticationService>()
+                    .Setup(x => x.ReadExternalLoginCredential(controller.OwinContext))
+                    .CompletesWith(new AuthenticateExternalLoginResult()
+                    {
+                        ExternalIdentity = new ClaimsIdentity(),
+                        Credential = externalCred
+                    });
+
+                // Act
+                var result = await controller.SignIn(
+                    new LogOnViewModel(
+                        new SignInViewModel(
+                            authUser.User.Username,
+                            "thePassword")),
+                    "theReturnUrl", linkingAccount: true);
+
+                // Assert
+                if (shouldChallenge)
+                {
+                    ResultAssert.IsChallengeResult(result, enforcedProvider);
+                }
+                else
+                {
+                    ResultAssert.IsSafeRedirectTo(result, "theReturnUrl");
+                }
+                GetMock<AuthenticationService>().VerifyAll();
+                GetMock<IMessageService>().VerifyAll();
+            }
         }
 
         public class TheRegisterAction : TestContainer
@@ -494,7 +580,7 @@ namespace NuGetGallery.Controllers
                         Credential = externalCred
                     });
 
-                // Simulate the model state error that will be added when doing an extenral account registration (since password is not present)
+                // Simulate the model state error that will be added when doing an external account registration (since password is not present)
                 controller.ModelState.AddModelError("Register.Password", "Password is required");
 
                 // Act
@@ -516,7 +602,89 @@ namespace NuGetGallery.Controllers
                     .Verify(x => x.SendNewAccountEmail(
                         expectedAddress,
                         "https://nuget.local/account/confirm/theUsername/t0k3n"));
+
                 ResultAssert.IsSafeRedirectTo(result, "/theReturnUrl");
+            }
+
+            [Theory]
+            [InlineData("MicrosoftAccount", true)]
+            [InlineData("AzureActiveDirectory", false)]
+            public async Task GivenAdminLogsInWithExternalIdentity_ItChallengesWhenNotUsingRequiredExternalProvider(string providerUsedForLogin, bool shouldChallenge)
+            {
+                // Arrange
+                var enforcedProvider = "AzureActiveDirectory";
+
+                var config = Get<ConfigurationService>();
+                config.Current = new AppConfiguration()
+                {
+                    ConfirmEmailAddresses = false,
+                    EnforcedAuthProviderForAdmin = enforcedProvider
+                };
+
+                var externalCred = CredentialBuilder.CreateExternalCredential(providerUsedForLogin, "blorg", "Bloog");
+
+                var authUser = new AuthenticatedUser(
+                    new User("theUsername")
+                    {
+                        UnconfirmedEmailAddress = "unconfirmed@example.com",
+                        EmailConfirmationToken = "t0k3n",
+                        Roles =
+                        {
+                            new Role { Name = Constants.AdminRoleName }
+                        }
+                    },
+                    externalCred);
+
+                GetMock<AuthenticationService>()
+                    .Setup(x => x.Register("theUsername", "theEmailAddress", externalCred))
+                    .CompletesWith(authUser);
+
+                EnableAllAuthenticators(Get<AuthenticationService>());
+                var controller = GetController<AuthenticationController>();
+
+                if (shouldChallenge)
+                {
+                    GetMock<AuthenticationService>()
+                        .Setup(x => x.Challenge(enforcedProvider, It.IsAny<string>()))
+                        .Returns(new ChallengeResult(enforcedProvider, null))
+                        .Verifiable();
+                }
+                else
+                {
+                    GetMock<AuthenticationService>()
+                       .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                       .Verifiable();
+                }
+
+                GetMock<AuthenticationService>()
+                    .Setup(x => x.ReadExternalLoginCredential(controller.OwinContext))
+                    .CompletesWith(new AuthenticateExternalLoginResult()
+                    {
+                        ExternalIdentity = new ClaimsIdentity(),
+                        Credential = externalCred
+                    });
+
+                // Act
+                var result = await controller.Register(
+                    new LogOnViewModel()
+                    {
+                        Register = new RegisterViewModel
+                        {
+                            Username = "theUsername",
+                            EmailAddress = "theEmailAddress",
+                        }
+                    }, "/theReturnUrl", linkingAccount: true);
+
+                // Assert
+                if (shouldChallenge)
+                {
+                    ResultAssert.IsChallengeResult(result, enforcedProvider);
+                }
+                else
+                {
+                    ResultAssert.IsSafeRedirectTo(result, "/theReturnUrl");
+                }
+                GetMock<AuthenticationService>().VerifyAll();
             }
         }
 
@@ -583,6 +751,67 @@ namespace NuGetGallery.Controllers
                     .Verify(x => x.CreateSession(controller.OwinContext, authUser.User));
             }
 
+            [Theory]
+            [InlineData("MicrosoftAccount", true)]
+            [InlineData("AzureActiveDirectory", false)]
+            public async Task GivenAssociatedLocalAdminUser_ItChallengesWhenNotUsingRequiredExternalProvider(string providerUsedForLogin, bool shouldChallenge)
+            {
+                // Arrange
+                var enforcedProvider = "AzureActiveDirectory";
+
+                var config = Get<ConfigurationService>();
+                config.Current = new AppConfiguration()
+                {
+                    ConfirmEmailAddresses = false,
+                    EnforcedAuthProviderForAdmin = enforcedProvider
+                };
+
+                GetMock<AuthenticationService>(); // Force a mock to be created
+                var controller = GetController<AuthenticationController>();
+                var cred = CredentialBuilder.CreateExternalCredential(providerUsedForLogin, "blorg", "Bloog");
+                var authUser = new AuthenticatedUser(
+                    Fakes.CreateUser("test", cred),
+                    cred);
+
+                authUser.User.Roles.Add(new Role { Name = Constants.AdminRoleName });
+
+                GetMock<AuthenticationService>()
+                    .Setup(x => x.AuthenticateExternalLogin(controller.OwinContext))
+                    .CompletesWith(new AuthenticateExternalLoginResult()
+                    {
+                        ExternalIdentity = new ClaimsIdentity(),
+                        Authentication = authUser
+                    });
+
+                if (shouldChallenge)
+                {
+                    GetMock<AuthenticationService>()
+                        .Setup(x => x.Challenge(enforcedProvider, It.IsAny<string>()))
+                        .Returns(new ChallengeResult(enforcedProvider, null))
+                        .Verifiable();
+                }
+                else
+                {
+                    GetMock<AuthenticationService>()
+                       .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                       .Verifiable();
+                }
+
+                // Act
+                var result = await controller.LinkExternalAccount("theReturnUrl");
+
+                // Assert
+                if (shouldChallenge)
+                {
+                    ResultAssert.IsChallengeResult(result, enforcedProvider);
+                }
+                else
+                {
+                    ResultAssert.IsSafeRedirectTo(result, "theReturnUrl");
+                    GetMock<AuthenticationService>().VerifyAll();
+                }
+            }
+
             [Fact]
             public async Task GivenNoLinkAndNoClaimData_ItDisplaysLogOnViewWithNoPrefilledData()
             {
@@ -619,7 +848,6 @@ namespace NuGetGallery.Controllers
             public async Task GivenNoLinkAndNameClaim_ItDisplaysLogOnViewWithExternalAccountName()
             {
                 // Arrange
-                var cred = CredentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "Bloog");
                 var msAuther = new MicrosoftAccountAuthenticator();
                 var msaUI = msAuther.GetUI();
 
@@ -722,6 +950,43 @@ namespace NuGetGallery.Controllers
                 Assert.True(model.External.FoundExistingUser);
                 Assert.Equal(existingUser.EmailAddress, model.SignIn.UserNameOrEmail);
                 Assert.Equal(existingUser.EmailAddress, model.Register.EmailAddress);
+            }
+        }
+
+        public class TheShouldChallengeEnforcedProviderMethod : TestContainer
+        {
+            [Theory]
+            [InlineData("Foo", true)]
+            [InlineData("AzureActiveDirectory", false)]
+            public void VerifyShouldChallenge(string providerUsedForLogin, bool shouldChallenge)
+            {
+                // Arrange
+                var enforcedProvider = "AzureActiveDirectory";
+
+                EnableAllAuthenticators(Get<AuthenticationService>());
+
+                var controller = GetController<AuthenticationController>();
+                var authUser = new AuthenticatedUser(
+                    new User("theUsername")
+                    {
+                        EmailAddress = "confirmed@example.com",
+                        Roles =
+                        {
+                            new Role { Name = Constants.AdminRoleName }
+                        }
+                    },
+                    new Credential { Type = providerUsedForLogin });
+
+                // Act
+                ActionResult challengeResult;
+                var result = controller.ShouldChallengeEnforcedProvider(enforcedProvider, authUser, null, out challengeResult);
+
+                // Assert
+                Assert.Equal(shouldChallenge, result);
+                if (shouldChallenge)
+                {
+                    ResultAssert.IsChallengeResult(challengeResult, enforcedProvider);
+                }
             }
         }
 

--- a/tests/NuGetGallery.Facts/TestUtils/ResultAssert.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/ResultAssert.cs
@@ -127,6 +127,13 @@ namespace NuGetGallery
             return Assert.IsType<EmptyResult>(result);
         }
 
+        public static ChallengeResult IsChallengeResult(ActionResult result, string provider)
+        {
+            var challenge = Assert.IsType<ChallengeResult>(result);
+            Assert.Equal(provider, challenge.LoginProvider);
+            return challenge;
+        }
+
         public static ChallengeResult IsChallengeResult(ActionResult result, string provider, string redirectUrl)
         {
             var challenge = Assert.IsType<ChallengeResult>(result);


### PR DESCRIPTION
Enforce administrators to a specific authentication mechanism. For example, admins can be required to have Azure AD authentication setup and used as the sign-in mechanism.

* Adds Azure AD support
* Adds enforcement mechanism which will require the admin to login using the configured mechanism

/cc @xavierdecoster @skofman1 @blowdart 