### PR TITLE
3046 - allow for local tracking of download counts

### DIFF
--- a/src/NuGetGallery/Configuration/FeatureConfiguration.cs
+++ b/src/NuGetGallery/Configuration/FeatureConfiguration.cs
@@ -16,5 +16,12 @@ namespace NuGetGallery.Configuration
         [DefaultValue(true)] // Default: Enabled
         [Description("Displays reports on license data")]
         public virtual bool FriendlyLicenses { get; set; }
+
+        /// <summary>
+        /// Gets a boolean indicating if package download counts should be recorded in the local database.
+        /// </summary>
+        [DefaultValue(false)] // Default: Disabled
+        [Description("Indicates if package download counts should be recorded in the local database")]
+        public virtual bool TrackPackageDownloadCountInLocalDatabase { get; set; }
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -16,6 +16,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
+using NuGetGallery.Configuration;
 using NuGetGallery.Filters;
 using NuGetGallery.Packaging;
 using PackageIdValidator = NuGetGallery.Packaging.PackageIdValidator;
@@ -37,6 +38,7 @@ namespace NuGetGallery
         public IAutomaticallyCuratePackageCommand AutoCuratePackage { get; set; }
         public IStatusService StatusService { get; set; }
         public IMessageService MessageService { get; set; }
+        public ConfigurationService ConfigurationService{ get; set; }
 
         protected ApiController()
         {
@@ -53,7 +55,8 @@ namespace NuGetGallery
             ISearchService searchService,
             IAutomaticallyCuratePackageCommand autoCuratePackage,
             IStatusService statusService,
-            IMessageService messageService)
+            IMessageService messageService,
+            ConfigurationService configurationService)
         {
             EntitiesContext = entitiesContext;
             PackageService = packageService;
@@ -67,6 +70,7 @@ namespace NuGetGallery
             AutoCuratePackage = autoCuratePackage;
             StatusService = statusService;
             MessageService = messageService;
+            ConfigurationService = configurationService;
         }
 
         public ApiController(
@@ -81,8 +85,9 @@ namespace NuGetGallery
             IAutomaticallyCuratePackageCommand autoCuratePackage,
             IStatusService statusService,
             IStatisticsService statisticsService,
-            IMessageService messageService)
-            : this(entitiesContext, packageService, packageFileService, userService, nugetExeDownloaderService, contentService, indexingService, searchService, autoCuratePackage, statusService, messageService)
+            IMessageService messageService,
+            ConfigurationService configurationService)
+            : this(entitiesContext, packageService, packageFileService, userService, nugetExeDownloaderService, contentService, indexingService, searchService, autoCuratePackage, statusService, messageService, configurationService)
         {
             StatisticsService = statisticsService;
         }
@@ -138,7 +143,11 @@ namespace NuGetGallery
 			        // Database was unavailable and we don't have a version, return a 503
                     return new HttpStatusCodeWithBodyResult(HttpStatusCode.ServiceUnavailable, Strings.DatabaseUnavailable_TrySpecificVersion);
                 }
+            }
 
+            if (ConfigurationService.Features.TrackPackageDownloadCountInLocalDatabase)
+            {
+                await PackageService.IncrementDownloadCountAsync(id, version);
             }
 
             return await PackageFileService.CreateDownloadPackageActionResultAsync(

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -293,10 +293,11 @@ namespace NuGetGallery
                             Size = packageStream.Length,
                         };
 
-                        var package =
-                            await
-                                PackageService.CreatePackageAsync(packageToPush, packageStreamMetadata, user,
-                                    commitChanges: false);
+                        var package = await PackageService.CreatePackageAsync(
+                            packageToPush, 
+                            packageStreamMetadata,
+                            user,
+                            commitChanges: false);
                         await AutoCuratePackage.ExecuteAsync(package, packageToPush, commitChanges: false);
                         await EntitiesContext.SaveChangesAsync();
 

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1305,6 +1305,7 @@
     <Compile Include="RequestModels\ModifyCuratedPackageRequest.cs" />
     <Compile Include="RequestModels\CreateCuratedPackageRequest.cs" />
     <Compile Include="RequestModels\VerifyPackageRequest.cs" />
+    <Compile Include="Services\ReflowPackageService.cs" />
     <Compile Include="WebApi\PlainTextResult.cs" />
     <Compile Include="WebApi\QueryResult.cs" />
     <Compile Include="WebApi\QueryResultExtensions.cs" />

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -46,5 +46,7 @@ namespace NuGetGallery
         Task SetLicenseReportVisibilityAsync(Package package, bool visible, bool commitChanges = true);
 
         void EnsureValid(PackageArchiveReader packageArchiveReader);
+
+        Task IncrementDownloadCountAsync(string id, string version, bool commitChanges = true);
     }
 }

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -30,6 +30,8 @@ namespace NuGetGallery
         /// <returns>The created package entity.</returns>
         Task<Package> CreatePackageAsync(PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User user, bool commitChanges = true);
 
+        Package EnrichPackageFromNuGetPackage(Package package, PackageArchiveReader packageArchive, PackageMetadata packageMetadata, PackageStreamMetadata packageStreamMetadata, User user);
+
         Task PublishPackageAsync(string id, string version, bool commitChanges = true);
         Task PublishPackageAsync(Package package, bool commitChanges = true);
 

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -417,30 +417,41 @@ namespace NuGetGallery
                     "A package with identifier '{0}' and version '{1}' already exists.", packageRegistration.Id, package.Version);
             }
 
-            package = new Package
-            {
-                // Version must always be the exact string from the nuspec, which ToString will return to us.
-                // However, we do also store a normalized copy for looking up later.
-                Version = packageMetadata.Version.ToString(),
-                NormalizedVersion = packageMetadata.Version.ToNormalizedString(),
+            package = new Package();
+            package.PackageRegistration = packageRegistration;
 
-                Description = packageMetadata.Description,
-                ReleaseNotes = packageMetadata.ReleaseNotes,
-                HashAlgorithm = packageStreamMetadata.HashAlgorithm,
-                Hash = packageStreamMetadata.Hash,
-                PackageFileSize = packageStreamMetadata.Size,
-                Language = packageMetadata.Language,
-                Copyright = packageMetadata.Copyright,
-                FlattenedAuthors = packageMetadata.Authors.Flatten(),
-                IsPrerelease = packageMetadata.Version.IsPrerelease,
-                Listed = true,
-                PackageRegistration = packageRegistration,
-                RequiresLicenseAcceptance = packageMetadata.RequireLicenseAcceptance,
-                Summary = packageMetadata.Summary,
-                Tags = PackageHelper.ParseTags(packageMetadata.Tags),
-                Title = packageMetadata.Title,
-                User = user,
-            };
+            package = EnrichPackageFromNuGetPackage(package, nugetPackage, packageMetadata, packageStreamMetadata, user);
+
+            return package;
+        }
+
+        public virtual Package EnrichPackageFromNuGetPackage(
+            Package package, 
+            PackageArchiveReader packageArchive, 
+            PackageMetadata packageMetadata,
+            PackageStreamMetadata packageStreamMetadata,
+            User user)
+        {
+            // Version must always be the exact string from the nuspec, which ToString will return to us.
+            // However, we do also store a normalized copy for looking up later.
+            package.Version = packageMetadata.Version.ToString();
+            package.NormalizedVersion = packageMetadata.Version.ToNormalizedString();
+
+            package.Description = packageMetadata.Description;
+            package.ReleaseNotes = packageMetadata.ReleaseNotes;
+            package.HashAlgorithm = packageStreamMetadata.HashAlgorithm;
+            package.Hash = packageStreamMetadata.Hash;
+            package.PackageFileSize = packageStreamMetadata.Size;
+            package.Language = packageMetadata.Language;
+            package.Copyright = packageMetadata.Copyright;
+            package.FlattenedAuthors = packageMetadata.Authors.Flatten();
+            package.IsPrerelease = packageMetadata.Version.IsPrerelease;
+            package.Listed = true;
+            package.RequiresLicenseAcceptance = packageMetadata.RequireLicenseAcceptance;
+            package.Summary = packageMetadata.Summary;
+            package.Tags = PackageHelper.ParseTags(packageMetadata.Tags);
+            package.Title = packageMetadata.Title;
+            package.User = user;
 
             package.IconUrl = packageMetadata.IconUrl.ToEncodedUrlStringOrNull();
             package.LicenseUrl = packageMetadata.LicenseUrl.ToEncodedUrlStringOrNull();
@@ -454,14 +465,14 @@ namespace NuGetGallery
             }
 #pragma warning restore 618
 
-            var supportedFrameworks = GetSupportedFrameworks(nugetPackage).Select(fn => fn.ToShortNameOrNull()).ToArray();
+            var supportedFrameworks = GetSupportedFrameworks(packageArchive).Select(fn => fn.ToShortNameOrNull()).ToArray();
             if (!supportedFrameworks.AnySafe(sf => sf == null))
             {
                 ValidateSupportedFrameworks(supportedFrameworks);
 
                 foreach (var supportedFramework in supportedFrameworks)
                 {
-                    package.SupportedFrameworks.Add(new PackageFramework { TargetFramework = supportedFramework });
+                    package.SupportedFrameworks.Add(new PackageFramework {TargetFramework = supportedFramework});
                 }
             }
 
@@ -469,6 +480,7 @@ namespace NuGetGallery
                 .GetDependencyGroups()
                 .AsPackageDependencyEnumerable()
                 .ToList();
+
             package.FlattenedDependencies = package.Dependencies.Flatten();
 
             return package;

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -688,7 +688,6 @@ namespace NuGetGallery
             _indexingService.UpdateIndex();
         }
 
-
         public async Task SetLicenseReportVisibilityAsync(Package package, bool visible, bool commitChanges = true)
         {
             if (package == null)
@@ -700,7 +699,20 @@ namespace NuGetGallery
             {
                 await _packageRepository.CommitChangesAsync();
             }
-            await _packageRepository.CommitChangesAsync();
+        }
+
+        public async Task IncrementDownloadCountAsync(string id, string version, bool commitChanges = true)
+        {
+            var package = FindPackageByIdAndVersion(id, version);
+            if (package != null)
+            {
+                package.DownloadCount++;
+                package.PackageRegistration.DownloadCount++;
+                if (commitChanges)
+                {
+                    await _packageRepository.CommitChangesAsync();
+                }
+            }
         }
     }
 }

--- a/src/NuGetGallery/Services/ReflowPackageService.cs
+++ b/src/NuGetGallery/Services/ReflowPackageService.cs
@@ -1,0 +1,115 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Packaging;
+using NuGetGallery.Packaging;
+
+namespace NuGetGallery
+{
+    public class ReflowPackageService
+    {
+        private readonly IEntitiesContext _entitiesContext;
+        private readonly IPackageService _packageService;
+        private readonly IPackageFileService _packageFileService;
+
+        public ReflowPackageService(
+            IEntitiesContext entitiesContext,
+            IPackageService packageService,
+            IPackageFileService packageFileService)
+        {
+            _entitiesContext = entitiesContext;
+            _packageService = packageService;
+            _packageFileService = packageFileService;
+        }
+
+        public async Task<Package> ReflowAsync(string id, string version)
+        {
+            var package = _packageService.FindPackageByIdAndVersion(id, version);
+
+            if (package == null)
+            {
+                return null;
+            }
+
+            EntitiesConfiguration.SuspendExecutionStrategy = true;
+            using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())
+            {
+                // 1) Download package binary to memory
+                using (var packageStream = await _packageFileService.DownloadPackageFileAsync(package))
+                {
+                    using (var packageArchive = new PackageArchiveReader(packageStream, leaveStreamOpen: false))
+                    {
+                        // 2) Determine package metadata from binary
+                        var packageStreamMetadata = new PackageStreamMetadata
+                        {
+                            HashAlgorithm = Constants.Sha512HashAlgorithmId,
+                            Hash = CryptographyService.GenerateHash(packageStream.AsSeekableStream()),
+                            Size = packageStream.Length,
+                        };
+
+                        var packageMetadata = PackageMetadata.FromNuspecReader(packageArchive.GetNuspecReader());
+
+                        // 3) Clear referenced objects that will be reflowed
+                        ClearSupportedFrameworks(package);
+                        ClearAuthors(package);
+                        ClearDependencies(package);
+
+                        // 4) Reflow the package
+                        var listed = package.Listed;
+
+                        package = _packageService.EnrichPackageFromNuGetPackage(
+                            package,
+                            packageArchive,
+                            packageMetadata,
+                            packageStreamMetadata,
+                            package.User);
+
+                        package.LastEdited = DateTime.UtcNow;
+                        package.Listed = listed;
+
+                        // 5) Save and profit
+                        await _entitiesContext.SaveChangesAsync();
+                    }
+                }
+
+                // Commit transaction
+                transaction.Commit();
+            }
+            EntitiesConfiguration.SuspendExecutionStrategy = false;
+
+            return package;
+        }
+        
+        private void ClearSupportedFrameworks(Package package)
+        {
+            foreach (var supportedFramework in package.SupportedFrameworks.ToList())
+            {
+                _entitiesContext.Set<PackageFramework>().Remove(supportedFramework);
+            }
+            package.SupportedFrameworks.Clear();
+        }
+
+        private void ClearAuthors(Package package)
+        {
+#pragma warning disable 618
+            foreach (var packageAuthor in package.Authors.ToList())
+            {
+                _entitiesContext.Set<PackageAuthor>().Remove(packageAuthor);
+            }
+            package.Authors.Clear();
+#pragma warning restore 618
+        }
+
+        private void ClearDependencies(Package package)
+        {
+            foreach (var packageDependency in package.Dependencies.ToList())
+            {
+                _entitiesContext.Set<PackageDependency>().Remove(packageDependency);
+            }
+            package.Dependencies.Clear();
+        }
+    }
+}

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -244,6 +244,18 @@ namespace NuGetGallery
             return url.RouteUrl(RouteName.PackageVersionAction, new { action = "Edit", id, version });
         }
 
+        public static string ReflowPackage(this UrlHelper url, IPackageVersionModel package)
+        {
+            return url.Action(
+                actionName: "Reflow",
+                controllerName: "Packages",
+                routeValues: new
+                {
+                    id = package.Id,
+                    version = package.Version
+                });
+        }
+
         public static string DeletePackage(this UrlHelper url, IPackageVersionModel package)
         {
             return url.Action(

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -89,6 +89,7 @@
             {
                 <li><a href="@Url.EditPackage(Model.Id, Model.Version)">Edit Package</a></li>
                 <li><a href="@Url.ManagePackageOwners(Model)">Manage Owners</a></li>
+                <li><a href="@Url.ReflowPackage(Model)">Reflow Package</a></li>
                 <li><a href="@Url.DeletePackage(Model)" class="delete">Delete Package</a></li>
             }
             @if (StatisticsHelper.IsStatisticsPageAvailable)

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -113,6 +113,7 @@
 
     <!-- Feature Configuration -->
     <add key="Feature.FriendlyLicenses" value="" />
+    <add key="Feature.TrackPackageDownloadCountInLocalDatabase" value="false" />
     <!-- Default is enabled. -->
     <!-- ***************** -->
     <!-- ASP.Net settings. -->

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -351,6 +351,7 @@
     <Compile Include="SearchClient\RequestInspectingHandler.cs" />
     <Compile Include="SearchClient\WebApiCorrelationHandlerFacts.cs" />
     <Compile Include="Services\PagerDutyClientFacts.cs" />
+    <Compile Include="Services\ReflowPackageServiceFacts.cs" />
     <Compile Include="Services\SearchAdaptorFacts.cs" />
     <Compile Include="TestUtils\Infrastructure\TestableV1Feed.cs" />
     <Compile Include="TestUtils\Infrastructure\TestableV2Feed.cs" />

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -1,0 +1,390 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Packaging;
+using NuGetGallery.Packaging;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class ReflowPackageServiceFacts
+    {
+        private static readonly string _packageHashForTests = "NzMzMS1QNENLNEczSDQ1SA==";
+
+        private static ReflowPackageService CreateService(
+            Mock<IEntitiesContext> entitiesContext = null,
+            Mock<PackageService> packageService = null,
+            Mock<IPackageFileService> packageFileService = null,
+            Action<Mock<ReflowPackageService>> setup = null)
+        {
+            var dbContext = new Mock<DbContext>();
+            entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
+            entitiesContext.Setup(m => m.GetDatabase()).Returns(dbContext.Object.Database);
+
+            packageService = packageService ?? new Mock<PackageService>();
+            packageFileService = packageFileService ?? new Mock<IPackageFileService>();
+
+            var reflowPackageService = new Mock<ReflowPackageService>(
+                entitiesContext.Object,
+                packageService.Object,
+                packageFileService.Object);
+
+            reflowPackageService.CallBase = true;
+
+            if (setup != null)
+            {
+                setup(reflowPackageService);
+            }
+
+            return reflowPackageService.Object;
+        }
+
+        public class TheReflowAsyncMethod
+        {
+            [Fact]
+            public async Task ReturnsNullWhenPackageNotFound()
+            {
+                // Arrange
+                var package = CreateTestPackage();
+
+                var packageService = SetupPackageService(package);
+                var entitiesContext = SetupEntitiesContext();
+                var packageFileService = SetupPackageFileService(package);
+
+                var service = CreateService(
+                    packageService: packageService,
+                    entitiesContext: entitiesContext,
+                    packageFileService: packageFileService);
+
+                // Act
+                var result = await service.ReflowAsync("unknownpackage", "1.0.0");
+
+                // Assert
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public async Task RetrievesOriginalPackageBinary()
+            {
+                // Arrange
+                var package = CreateTestPackage();
+
+                var packageService = SetupPackageService(package);
+                var entitiesContext = SetupEntitiesContext();
+                var packageFileService = SetupPackageFileService(package);
+
+                var service = CreateService(
+                    packageService: packageService,
+                    entitiesContext: entitiesContext,
+                    packageFileService: packageFileService);
+
+                // Act
+                await service.ReflowAsync("test", "1.0.0");
+
+                // Assert
+                packageFileService.Verify();
+            }
+
+            [Fact]
+            public async Task RetrievesOriginalPackageMetadata()
+            {
+                // Arrange
+                var package = CreateTestPackage();
+
+                var packageService = SetupPackageService(package);
+                var entitiesContext = SetupEntitiesContext();
+                var packageFileService = SetupPackageFileService(package);
+
+                var service = CreateService(
+                    packageService: packageService,
+                    entitiesContext: entitiesContext,
+                    packageFileService: packageFileService);
+
+                // Act
+                await service.ReflowAsync("test", "1.0.0");
+
+                // Assert
+                packageService.Verify();
+            }
+
+            [Fact]
+            public async Task RemovesOriginalFrameworks_Authors_Dependencies()
+            {
+                // Arrange
+                var package = CreateTestPackage();
+
+                var packageService = SetupPackageService(package);
+                var entitiesContext = SetupEntitiesContext();
+                var packageFileService = SetupPackageFileService(package);
+
+                var service = CreateService(
+                    packageService: packageService,
+                    entitiesContext: entitiesContext,
+                    packageFileService: packageFileService);
+
+                // Act
+                await service.ReflowAsync("test", "1.0.0");
+
+                // Assert
+                entitiesContext.Verify();
+            }
+
+            [Fact]
+            public async Task UpdatesPackageMetadata()
+            {
+                // Arrange
+                var package = CreateTestPackage();
+
+                var packageService = SetupPackageService(package);
+                var entitiesContext = SetupEntitiesContext();
+                var packageFileService = SetupPackageFileService(package);
+
+                var service = CreateService(
+                    packageService: packageService,
+                    entitiesContext: entitiesContext,
+                    packageFileService: packageFileService);
+
+                // Act
+                var result = await service.ReflowAsync("test", "1.0.0");
+
+                // Assert
+                Assert.Equal("test", result.PackageRegistration.Id);
+                Assert.Equal("1.0.0", result.Version);
+                Assert.Equal("1.0.0", result.NormalizedVersion);
+                Assert.Equal("Test package", result.Title);
+
+                Assert.Equal(2, result.Authors.Count);
+                Assert.True(result.Authors.Any(a => a.Name == "authora"));
+                Assert.True(result.Authors.Any(a => a.Name == "authorb"));
+                Assert.Equal("authora, authorb", result.FlattenedAuthors);
+
+                Assert.Equal(false, result.RequiresLicenseAcceptance);
+                Assert.Equal("package A description.", result.Description);
+                Assert.Equal("en-US", result.Language);
+
+                Assert.Equal("WebActivator:[1.1.0, ):net40|PackageC:[1.1.0, 2.0.1):net40|jQuery:(, ):net451", result.FlattenedDependencies);
+                Assert.Equal(3, result.Dependencies.Count);
+
+                Assert.True(result.Dependencies.Any(d =>
+                    d.Id == "WebActivator"
+                    && d.VersionSpec == "[1.1.0, )"
+                    && d.TargetFramework == "net40"));
+
+                Assert.True(result.Dependencies.Any(d =>
+                    d.Id == "PackageC"
+                    && d.VersionSpec == "[1.1.0, 2.0.1)"
+                    && d.TargetFramework == "net40"));
+
+                Assert.True(result.Dependencies.Any(d =>
+                    d.Id == "jQuery"
+                    && d.VersionSpec == "(, )"
+                    && d.TargetFramework == "net451"));
+
+                Assert.Equal(0, result.SupportedFrameworks.Count);
+            }
+
+            [Fact]
+            public async Task UpdatesPackageLastEdited()
+            {
+                // Arrange
+                var package = CreateTestPackage();
+                var lastEdited = package.LastEdited;
+
+                var packageService = SetupPackageService(package);
+                var entitiesContext = SetupEntitiesContext();
+                var packageFileService = SetupPackageFileService(package);
+
+                var service = CreateService(
+                    packageService: packageService,
+                    entitiesContext: entitiesContext,
+                    packageFileService: packageFileService);
+
+                // Act
+                var result = await service.ReflowAsync("test", "1.0.0");
+
+                // Assert
+                Assert.NotEqual(lastEdited, result.LastEdited);
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public async Task DoesNotUpdatePackageListed(bool listed)
+            {
+                // Arrange
+                var package = CreateTestPackage();
+                package.Listed = listed;
+
+                var packageService = SetupPackageService(package);
+                var entitiesContext = SetupEntitiesContext();
+                var packageFileService = SetupPackageFileService(package);
+
+                var service = CreateService(
+                    packageService: packageService,
+                    entitiesContext: entitiesContext,
+                    packageFileService: packageFileService);
+
+                // Act
+                var result = await service.ReflowAsync("test", "1.0.0");
+
+                // Assert
+                Assert.Equal(listed, result.Listed);
+            }
+        }
+
+        private static Package CreateTestPackage()
+        {
+            var packageRegistration = new PackageRegistration();
+            packageRegistration.Id = "test";
+
+            var framework = new PackageFramework();
+            var author = new PackageAuthor { Name = "maarten" };
+            var dependency = new PackageDependency { Id = "other" };
+
+            var package = new Package
+            {
+                Key = 123,
+                PackageRegistration = packageRegistration,
+                Version = "1.0.0",
+                Hash = _packageHashForTests,
+                SupportedFrameworks = new List<PackageFramework>
+                {
+                    framework
+                },
+                FlattenedAuthors = "maarten",
+                Authors = new List<PackageAuthor>
+                {
+                    author
+                },
+                Dependencies = new List<PackageDependency>
+                {
+                    dependency
+                },
+                User = new User("test")
+            };
+
+            packageRegistration.Packages.Add(package);
+
+            return package;
+        }
+
+        private static Mock<PackageService> SetupPackageService(Package package)
+        {
+            var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
+            var packageRepository = new Mock<IEntityRepository<Package>>();
+            var packageOwnerRequestRepo = new Mock<IEntityRepository<PackageOwnerRequest>>();
+            var indexingService = new Mock<IIndexingService>();
+            var packageNamingConflictValidator = new PackageNamingConflictValidator(
+                    packageRegistrationRepository.Object,
+                    packageRepository.Object);
+
+            var packageService = new Mock<PackageService>(
+                packageRegistrationRepository.Object,
+                packageRepository.Object,
+                packageOwnerRequestRepo.Object,
+                indexingService.Object,
+                packageNamingConflictValidator);
+
+            packageService.CallBase = true;
+
+            packageService
+                .Setup(s => s.FindPackageByIdAndVersion("test", "1.0.0", true))
+                .Returns(package)
+                .Verifiable();
+
+            packageService
+              .Setup(s => s.EnrichPackageFromNuGetPackage(
+                  It.IsAny<Package>(),
+                  It.IsAny<PackageArchiveReader>(),
+                  It.IsAny<PackageMetadata>(),
+                  It.IsAny<PackageStreamMetadata>(),
+                  It.IsAny<User>()))
+              .CallBase()
+              .Verifiable();
+
+            return packageService;
+        }
+
+        private static Mock<IEntitiesContext> SetupEntitiesContext()
+        {
+            var entitiesContext = new Mock<IEntitiesContext>();
+
+            entitiesContext
+                .Setup(s => s.Set<PackageFramework>().Remove(It.IsAny<PackageFramework>()))
+                .Verifiable();
+
+            entitiesContext
+                .Setup(s => s.Set<PackageAuthor>().Remove(It.IsAny<PackageAuthor>()))
+                .Verifiable();
+
+            entitiesContext
+                .Setup(s => s.Set<PackageDependency>().Remove(It.IsAny<PackageDependency>()))
+                .Verifiable();
+
+            return entitiesContext;
+        }
+
+        private static Mock<IPackageFileService> SetupPackageFileService(Package package)
+        {
+            var packageFileService = new Mock<IPackageFileService>();
+
+            packageFileService
+                .Setup(s => s.DownloadPackageFileAsync(package))
+                .Returns(Task.FromResult(CreateTestPackageStream()))
+                .Verifiable();
+
+            return packageFileService;
+        }
+
+        private static Stream CreateTestPackageStream()
+        {
+            var packageStream = new MemoryStream();
+            using (var packageArchive = new ZipArchive(packageStream, ZipArchiveMode.Create, true))
+            {
+                var nuspecEntry = packageArchive.CreateEntry("TestPackage.nuspec", CompressionLevel.Fastest);
+                using (var streamWriter = new StreamWriter(nuspecEntry.Open()))
+                {
+                    streamWriter.WriteLine(@"<?xml version=""1.0""?>
+                    <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                      <metadata>
+                        <id>test</id>
+                        <version>1.0.0</version>
+                        <title>Test package</title>
+                        <authors>authora, authorb</authors>
+                        <owners>ownera</owners>
+                        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+                        <description>package A description.</description>
+                        <language>en-US</language>
+                        <projectUrl>http://www.nuget.org/</projectUrl>
+                        <iconUrl>http://www.nuget.org/</iconUrl>
+                        <licenseUrl>http://www.nuget.org/</licenseUrl>
+                        <dependencies>
+                            <group targetFramework=""net40"">
+                              <dependency id=""WebActivator"" version=""1.1.0"" />
+                              <dependency id=""PackageC"" version=""[1.1.0, 2.0.1)"" />
+                            </group>
+                            <group targetFramework=""net451"">
+                              <dependency id=""jQuery"" />
+                            </group>
+                        </dependencies>
+                      </metadata>
+                    </package>");
+                }
+
+                packageArchive.CreateEntry("content\\HelloWorld.cs", CompressionLevel.Fastest);
+            }
+
+            packageStream.Position = 0;
+
+            return packageStream;
+        }
+    }
+}


### PR DESCRIPTION
As noted in issue #3046 download counts for packages are not being saved to the database for standalone galleries.  This PR (re-?)implements that based on an appSetting of `Feature.TrackPackageDownloadCountInLocalDatabase`.