### PR TITLE
3046 - allow for local tracking of download counts (rebased)

### DIFF
--- a/src/NuGetGallery/Configuration/FeatureConfiguration.cs
+++ b/src/NuGetGallery/Configuration/FeatureConfiguration.cs
@@ -16,5 +16,12 @@ namespace NuGetGallery.Configuration
         [DefaultValue(true)] // Default: Enabled
         [Description("Displays reports on license data")]
         public virtual bool FriendlyLicenses { get; set; }
+
+        /// <summary>
+        /// Gets a boolean indicating if package download counts should be recorded in the local database.
+        /// </summary>
+        [DefaultValue(false)] // Default: Disabled
+        [Description("Indicates if package download counts should be recorded in the local database")]
+        public virtual bool TrackPackageDownloadCountInLocalDatabase { get; set; }
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -16,6 +16,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
+using NuGetGallery.Configuration;
 using NuGetGallery.Filters;
 using NuGetGallery.Packaging;
 using PackageIdValidator = NuGetGallery.Packaging.PackageIdValidator;
@@ -37,6 +38,7 @@ namespace NuGetGallery
         public IAutomaticallyCuratePackageCommand AutoCuratePackage { get; set; }
         public IStatusService StatusService { get; set; }
         public IMessageService MessageService { get; set; }
+        public ConfigurationService ConfigurationService{ get; set; }
 
         protected ApiController()
         {
@@ -53,7 +55,8 @@ namespace NuGetGallery
             ISearchService searchService,
             IAutomaticallyCuratePackageCommand autoCuratePackage,
             IStatusService statusService,
-            IMessageService messageService)
+            IMessageService messageService,
+            ConfigurationService configurationService)
         {
             EntitiesContext = entitiesContext;
             PackageService = packageService;
@@ -67,6 +70,7 @@ namespace NuGetGallery
             AutoCuratePackage = autoCuratePackage;
             StatusService = statusService;
             MessageService = messageService;
+            ConfigurationService = configurationService;
         }
 
         public ApiController(
@@ -81,8 +85,9 @@ namespace NuGetGallery
             IAutomaticallyCuratePackageCommand autoCuratePackage,
             IStatusService statusService,
             IStatisticsService statisticsService,
-            IMessageService messageService)
-            : this(entitiesContext, packageService, packageFileService, userService, nugetExeDownloaderService, contentService, indexingService, searchService, autoCuratePackage, statusService, messageService)
+            IMessageService messageService,
+            ConfigurationService configurationService)
+            : this(entitiesContext, packageService, packageFileService, userService, nugetExeDownloaderService, contentService, indexingService, searchService, autoCuratePackage, statusService, messageService, configurationService)
         {
             StatisticsService = statisticsService;
         }
@@ -138,7 +143,11 @@ namespace NuGetGallery
 			        // Database was unavailable and we don't have a version, return a 503
                     return new HttpStatusCodeWithBodyResult(HttpStatusCode.ServiceUnavailable, Strings.DatabaseUnavailable_TrySpecificVersion);
                 }
+            }
 
+            if (ConfigurationService.Features.TrackPackageDownloadCountInLocalDatabase)
+            {
+                await PackageService.IncrementDownloadCountAsync(id, version);
             }
 
             return await PackageFileService.CreateDownloadPackageActionResultAsync(

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -46,5 +46,7 @@ namespace NuGetGallery
         Task SetLicenseReportVisibilityAsync(Package package, bool visible, bool commitChanges = true);
 
         void EnsureValid(PackageArchiveReader packageArchiveReader);
+
+        Task IncrementDownloadCountAsync(string id, string version, bool commitChanges = true);
     }
 }

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -688,7 +688,6 @@ namespace NuGetGallery
             _indexingService.UpdateIndex();
         }
 
-
         public async Task SetLicenseReportVisibilityAsync(Package package, bool visible, bool commitChanges = true)
         {
             if (package == null)
@@ -700,7 +699,20 @@ namespace NuGetGallery
             {
                 await _packageRepository.CommitChangesAsync();
             }
-            await _packageRepository.CommitChangesAsync();
+        }
+
+        public async Task IncrementDownloadCountAsync(string id, string version, bool commitChanges = true)
+        {
+            var package = FindPackageByIdAndVersion(id, version);
+            if (package != null)
+            {
+                package.DownloadCount++;
+                package.PackageRegistration.DownloadCount++;
+                if (commitChanges)
+                {
+                    await _packageRepository.CommitChangesAsync();
+                }
+            }
         }
     }
 }

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -113,6 +113,7 @@
 
     <!-- Feature Configuration -->
     <add key="Feature.FriendlyLicenses" value="" />
+    <add key="Feature.TrackPackageDownloadCountInLocalDatabase" value="false" />
     <!-- Default is enabled. -->
     <!-- ***************** -->
     <!-- ASP.Net settings. -->


### PR DESCRIPTION
As noted in issue #3046 download counts for packages are not being saved to the database for standalone galleries.  This PR (re-?)implements that based on an appSetting of `Feature.TrackPackageDownloadCountInLocalDatabase`.