### PR TITLE
Implement auto linking URLs on Package Details - Fix #67

### DIFF
--- a/src/NuGetGallery/Helpers/HtmlExtensions.cs
+++ b/src/NuGetGallery/Helpers/HtmlExtensions.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Mvc.Html;
@@ -34,9 +36,59 @@ namespace NuGetGallery.Helpers
             return self.DropDownListFor(expression, items);
         }
 
-        public static IHtmlString PreFormattedText(this HtmlHelper self, string text)
+        /// <summary>
+        /// RegEx Source: http://stackoverflow.com/a/1112171
+        /// Sample: https://regex101.com/r/kI9xT9/2
+        /// </summary>
+        private static Regex regExHttpLinks = new Regex(@"(?<=\()\b(https?://|www\.)[-A-Za-z0-9+&@#/%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%=~_()|](?=\))|(?<=(?<wrap>[=~|_#]))\b(https?://|www\.)[-A-Za-z0-9+&@#/%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%=~_()|](?=\k<wrap>)|\b(https?://|www\.)[-A-Za-z0-9+&@#/%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%=~_()|]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static IHtmlString PreFormattedTextWithClickableLinks(this HtmlHelper self, string html, bool newLineAsNewParagraph = false)
         {
-            return self.Raw(HttpUtility.HtmlEncode(text).Replace("\n", "<br />").Replace("  ", "&nbsp; "));
+            if (string.IsNullOrEmpty(html))
+            {
+                return new HtmlString(string.Empty);
+            }
+
+            html = self.Encode(html);
+
+            if (newLineAsNewParagraph)
+            {
+                var splittedParagraphs = html.Split('\n');
+
+                html = string.Empty;
+                foreach (var splittedParagraph in splittedParagraphs)
+                {
+                    html += "<p>" + splittedParagraph + "</p>";
+                }
+            }
+            else
+            {
+                html = html.Replace("\n", "<br />");
+                html = html.Replace("  ", "&nbsp; ");
+            }
+
+            // replace periods on numeric values that appear to be valid domain names
+            var periodReplacement = "[[[replace:period]]]";
+            html = Regex.Replace(html, @"(?<=\d)\.(?=\d)", periodReplacement);
+
+            // create links for matches
+            var linkMatches = regExHttpLinks.Matches(html);
+            for (int i = 0; i < linkMatches.Count; i++)
+            {
+                var temp = linkMatches[i].ToString();
+
+                if (!temp.Contains("://"))
+                {
+                    temp = "http://" + temp;
+                }
+
+                html = html.Replace(linkMatches[i].ToString(), String.Format("<a href=\"{0}\" title=\"{0}\">{1}</a>", temp.Replace(".", periodReplacement).ToLower(), linkMatches[i].ToString().Replace(".", periodReplacement)));
+            }
+
+            // Clear out period replacement
+            html = html.Replace(periodReplacement, ".");
+
+            return self.Raw(html);
         }
 
         public static IHtmlString ValidationSummaryFor(this HtmlHelper html, string key)

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -216,10 +216,8 @@
         <h1 title="@Model.Title">@Model.Title.Abbreviate(40)</h1>
         <h2>@Model.Version</h2>
     </div>
-    @foreach (var line in Model.Description.ToStringSafe().Split('\n'))
-    {
-        <p>@line</p>
-    }
+    @Html.PreFormattedTextWithClickableLinks(Model.Description, true)
+
 
     @if (!Model.Listed && !Model.Deleted)
     {
@@ -272,8 +270,7 @@
     {
         <h3>Release Notes</h3>
 
-        // Not actually using <pre/> because its better to have wrapping text
-        <p>@Html.PreFormattedText(Model.ReleaseNotes)</p>
+        <p>@Html.PreFormattedTextWithClickableLinks(Model.ReleaseNotes)</p>
     }
 
     <h3>Owners</h3>

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -54,8 +54,7 @@
             }
             else if (pre)
             {
-                // Not actually using <pre/> because its better to have wrapping text
-                <p>@Html.PreFormattedText(value)</p>
+                <p>@Html.PreFormattedTextWithClickableLinks(value)</p>
             }
             else if (link)
             {


### PR DESCRIPTION
This PR should implement the (pretty old) feature idea from this issue https://github.com/NuGet/NuGetGallery/issues/67

I used a RegEx that seems to identify URLs fine and it wraps them in a a-tag. As far as I tested, there shouldn't be any XSS attacks possible, because the first step is to HtmlEncode the content, which is the same way as before.

Some screenshots from my tests (with modified packages - the real authors didn't inject the xss stuff ;))

![image](https://cloud.githubusercontent.com/assets/756703/15629965/6c5099ba-2528-11e6-8e50-22637fefb0ca.png)

![image](https://cloud.githubusercontent.com/assets/756703/15629966/7e69cfd6-2528-11e6-86bc-4428eebb463a.png)

![image](https://cloud.githubusercontent.com/assets/756703/15629972/a4f35172-2528-11e6-8fbd-537769357c68.png)

![image](https://cloud.githubusercontent.com/assets/756703/15629977/b1e5658c-2528-11e6-8f04-46dd919edf06.png)

The RegEx seems to be "clever" in the sense that only urls that start with http will be catched - so JSON.NET is just fine. 
If you need to test some other combinations: https://regex101.com/r/kI9xT9/2

