### PR TITLE
target msbuild.exe directly

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,12 @@
-@msbuild build.msbuild /tv:14.0 /p:VisualStudioVersion=14.0 /p:ToolsVersion=14.0 %*
+:CheckOS
+IF EXIST "%PROGRAMFILES(X86)%" (GOTO 64BIT) ELSE (GOTO 32BIT)
+
+:64BIT
+"%programfiles(x86)%\MSBuild\14.0\Bin\msbuild.exe" build.msbuild /tv:14.0 /p:VisualStudioVersion=14.0 /p:ToolsVersion=14.0 %*
+GOTO END
+
+:32BIT
+"%programfiles%\MSBuild\14.0\Bin\msbuild.exe" build.msbuild /tv:14.0 /p:VisualStudioVersion=14.0 /p:ToolsVersion=14.0 %*
+GOTO END
+
+:END


### PR DESCRIPTION
This is more or less a cosmetic change, but the goal is to reduce the effort to clone and build (and run) the Gallery on a fresh PC.

Instead of relying on the correct PATH-Setup (which might be not in place), I enhanced the build.cmd to directly target the msbuild.exe which ships with VS2015. 

With this in place you can just open a command promt and hit build. With the previous "@msbuild" it didn't work for me.