### PR TITLE
Remove "Add MSBuild to Path" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ website for the NuGet client. For information about the NuGet project, visit the
     cd NuGetGallery
     .\build
     ```
-    
-    You may have to add the directory containing msbuild.exe to your PATH variable, %programfiles(x86)%\MSBuild\14.0\Bin\amd64 on 64-bit machines.
 4. Set up the website in IIS Express!
  1. We highly recommend using IIS Express. Use the [Web Platform Installer](http://microsoft.com/web) to install it if you don't have it already (it comes with recent versions of VS and WebMatrix though). Make sure to at least once run IIS Express as an administrator.
  2. In an ADMIN powershell prompt, run the `.\tools\Enable-LocalTestMe.ps1` file. It allows non-admins to host websites at: `http(s)://nuget.localtest.me`, it configures an IIS Express site at that URL and creates a self-signed SSL certificate. For more information on `localtest.me`, check out [readme.localtest.me](http://readme.localtest.me).


### PR DESCRIPTION
Because of this change, it is not needed anymore https://github.com/NuGet/NuGetGallery/pull/3051