### PR TITLE
Better support for running gallery in virtual directory

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Home.html
+++ b/src/NuGetGallery/App_Data/Files/Content/Home.html
@@ -5,11 +5,11 @@
         <a class="install" href="https://dist.nuget.org/visualstudio-2015-vsix/latest/NuGet.Tools.vsix"><i class="icon-download-alt icon-white"></i> Install NuGet</a>
         <div class="downloads">
             <a href="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe">latest nuget.exe</a> -
-            <a href="/downloads">all downloads</a> - 
+            <a href="~/downloads">all downloads</a> - 
             <a href="https://docs.nuget.org/docs/start-here/installing-nuget" target="_blank">documentation</a>
         </div>
     </div>
-    <img height="354" width="494" src="Content/Logos/hero.png" alt="Manage NuGet Packages Dialog Window" /> 
+    <img height="354" width="494" src="~/Content/Logos/hero.png" alt="Manage NuGet Packages Dialog Window" /> 
 </section> 
 
 <section class="aggstats">

--- a/src/NuGetGallery/Controllers/PagesController.cs
+++ b/src/NuGetGallery/Controllers/PagesController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Web;
 using System.Web.Mvc;
 using NuGetGallery.Areas.Admin;
 
@@ -91,9 +92,13 @@ namespace NuGetGallery
         {
             if (_contentService != null)
             {
-                ViewBag.Content = await _contentService.GetContentItemAsync(
-                    Constants.ContentNames.Home,
-                    TimeSpan.FromMinutes(1));
+                var homeContent = await _contentService.GetContentItemAsync(
+                     Constants.ContentNames.Home,
+                     TimeSpan.FromMinutes(1));
+
+                homeContent = new HtmlString(homeContent.ToString().Replace("~/", Url.Content("~/")));
+
+                ViewBag.Content = homeContent;
             }
             return View();
         }

--- a/src/NuGetGallery/Views/Shared/SiteMenu.cshtml
+++ b/src/NuGetGallery/Views/Shared/SiteMenu.cshtml
@@ -19,6 +19,6 @@
         <li class="@classes["Admin"]"><a href="@Url.Action("Index", "Home", new { area="Admin" })">Admin</a></li>
     }
     <li><a href="https://docs.nuget.org">Documentation</a></li>
-    <li><a href="/downloads">Downloads</a></li>
+    <li><a href="@Url.RouteUrl(RouteName.Downloads)">Downloads</a></li>
     <li><a href="http://blog.nuget.org">Blog</a></li>
 </ul>


### PR DESCRIPTION
This should fix https://github.com/NuGet/NuGetGallery/issues/2121

I removed all hard /downloads links and used the already existing route. For the hero image I used the UrlHelper - this part could be enhanced. 
I could move the logic into the ContentService, but then it would need access to the UrlHelper.

What do you think?