### PR TITLE
Add auditing for all user actions #3078

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ src/NuGetGallery.Cloud/ecf/
 
 # Vs2015
 .vs/config/applicationhost.config
+src/NuGetGallery/App_Data/Files/auditing/

--- a/src/NuGetGallery.Core/Auditing/AuditActor.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditActor.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace NuGetGallery.Auditing
@@ -23,9 +23,11 @@ namespace NuGetGallery.Auditing
 
         public AuditActor(string machineName, string machineIP, string userName, string authenticationType, DateTime timeStampUtc)
             : this(machineName, machineIP, userName, authenticationType, timeStampUtc, null) { }
+
         public AuditActor(string machineName, string machineIP, string userName, string authenticationType, DateTime timeStampUtc, AuditActor onBehalfOf)
         {
             MachineName = machineName;
+            MachineIP = machineIP;
             UserName = userName;
             AuthenticationType = authenticationType;
             TimestampUtc = timeStampUtc;

--- a/src/NuGetGallery.Core/Auditing/AuditedAuthenticatedOperationAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedAuthenticatedOperationAction.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Auditing
+{
+    public enum AuditedAuthenticatedOperationAction
+    {
+        /// <summary>
+        /// Package push was attempted by a non-owner of the package
+        /// </summary>
+        PackagePushAttemptByNonOwner,
+
+        /// <summary>
+        /// Login failed, no such user
+        /// </summary>
+        FailedLoginNoSuchUser,
+
+        /// <summary>
+        /// Login failed, user exists but password is invalid
+        /// </summary>
+        FailedLoginInvalidPassword,
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/AuditedEntities/AuditedPackage.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedEntities/AuditedPackage.cs
@@ -1,0 +1,91 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery.Auditing.AuditedEntities
+{
+    public class AuditedPackage
+    {
+        public int PackageRegistrationKey { get; private set; }
+        public string Copyright { get; private set; }
+        public DateTime Created { get; private set; }
+        public string Description { get; private set; }
+        public string ReleaseNotes { get; private set; }
+        public int DownloadCount { get; private set; }
+        public string ExternalPackageUrl { get; private set; }
+        public string HashAlgorithm { get; private set; }
+        public string Hash { get; private set; }
+        public string IconUrl { get; private set; }
+        public bool IsLatest { get; private set; }
+        public bool IsLatestStable { get; private set; }
+        public DateTime LastUpdated { get; private set; }
+        public DateTime? LastEdited { get; private set; }
+        public string LicenseUrl { get; private set; }
+        public bool HideLicenseReport { get; private set; }
+        public string Language { get; private set; }
+        public DateTime Published { get; private set; }
+        public long PackageFileSize { get; private set; }
+        public string ProjectUrl { get; private set; }
+        public bool RequiresLicenseAcceptance { get; private set; }
+        public string Summary { get; private set; }
+        public string Tags { get; private set; }
+        public string Title { get; private set; }
+        public string Version { get; private set; }
+        public string NormalizedVersion { get; private set; }
+        public string LicenseNames { get; private set; }
+        public string LicenseReportUrl { get; private set; }
+        public bool Listed { get; private set; }
+        public bool IsPrerelease { get; private set; }
+        public string FlattenedAuthors { get; private set; }
+        public string FlattenedDependencies { get; private set; }
+        public int Key { get; private set; }
+        public string MinClientVersion { get; private set; }
+        public int? UserKey { get; private set; }
+        public bool Deleted { get; private set; }
+
+        public static AuditedPackage CreateFrom(Package package)
+        {
+            return new AuditedPackage
+            {
+                PackageRegistrationKey = package.PackageRegistrationKey,
+                Copyright = package.Copyright,
+                Created = package.Created,
+                Description = package.Description,
+                ReleaseNotes = package.ReleaseNotes,
+                DownloadCount = package.DownloadCount,
+#pragma warning disable 612
+#pragma warning restore 612
+                HashAlgorithm = package.HashAlgorithm,
+                Hash = package.Hash,
+                IconUrl = package.IconUrl,
+                IsLatest = package.IsLatest,
+                IsLatestStable = package.IsLatestStable,
+                LastUpdated = package.LastUpdated,
+                LastEdited = package.LastEdited,
+                LicenseUrl = package.LicenseUrl,
+                HideLicenseReport = package.HideLicenseReport,
+                Language = package.Language,
+                Published = package.Published,
+                PackageFileSize = package.PackageFileSize,
+                ProjectUrl = package.ProjectUrl,
+                RequiresLicenseAcceptance = package.RequiresLicenseAcceptance,
+                Summary = package.Summary,
+                Tags = package.Tags,
+                Title = package.Title,
+                Version = package.Version,
+                NormalizedVersion = package.NormalizedVersion,
+                LicenseNames = package.LicenseNames,
+                LicenseReportUrl = package.LicenseReportUrl,
+                Listed = package.Listed,
+                IsPrerelease = package.IsPrerelease,
+                FlattenedAuthors = package.FlattenedAuthors,
+                FlattenedDependencies = package.FlattenedDependencies,
+                Key = package.Key,
+                MinClientVersion = package.MinClientVersion,
+                UserKey = package.UserKey,
+                Deleted = package.Deleted
+            };
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/AuditedEntities/AuditedPackageIdentifier.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedEntities/AuditedPackageIdentifier.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Auditing.AuditedEntities
+{
+    public class AuditedPackageIdentifier
+    {
+        public string Id { get; }
+        public string Version { get; }
+
+        public AuditedPackageIdentifier(string id, string version)
+        {
+            Id = id;
+            Version = version;
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/AuditedEntities/AuditedPackageRegistration.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedEntities/AuditedPackageRegistration.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Auditing.AuditedEntities
+{
+    public class AuditedPackageRegistration
+    {
+        public string Id { get; private set; }
+        public int DownloadCount { get; private set; }
+        public int Key { get; private set; }
+
+        public static AuditedPackageRegistration CreateFrom(PackageRegistration packageRegistration)
+        {
+            return new AuditedPackageRegistration
+            {
+                Id = packageRegistration.Id,
+                DownloadCount = packageRegistration.DownloadCount,
+                Key = packageRegistration.Key
+            };
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/AuditedPackageAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedPackageAction.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Auditing
+{
+    public enum AuditedPackageAction
+    {
+        Delete,
+        SoftDelete,
+        Create,
+        List,
+        Unlist,
+        Edit,
+        UndoEdit,
+
+        
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/AuditedPackageRegistrationAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedPackageRegistrationAction.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Auditing
+{
+    public enum AuditedPackageRegistrationAction
+    {
+        AddOwner,
+        RemoveOwner
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/AuditedUserAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedUserAction.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Auditing
+{
+    public enum AuditedUserAction
+    {
+        Register,
+        AddCredential,
+        RemoveCredential,
+        RequestPasswordReset,
+        ChangeEmail,
+        CancelChangeEmail,
+        ConfirmEmail,
+        Login
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/AuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditingService.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -15,7 +12,7 @@ namespace NuGetGallery.Auditing
     {
         public static readonly AuditingService None = new NullAuditingService();
 
-        private static readonly JsonSerializerSettings _auditRecordSerializerSettings;
+        private static readonly JsonSerializerSettings AuditRecordSerializerSettings;
 
         static AuditingService()
         {
@@ -31,7 +28,7 @@ namespace NuGetGallery.Auditing
                 TypeNameHandling = TypeNameHandling.None
             };
             settings.Converters.Add(new StringEnumConverter());
-            _auditRecordSerializerSettings = settings;
+            AuditRecordSerializerSettings = settings;
         }
 
         public virtual async Task<Uri> SaveAuditRecord(AuditRecord record)
@@ -48,7 +45,7 @@ namespace NuGetGallery.Auditing
 
         public virtual string RenderAuditEntry(AuditEntry entry)
         {
-            return JsonConvert.SerializeObject(entry, _auditRecordSerializerSettings);
+            return JsonConvert.SerializeObject(entry, AuditRecordSerializerSettings);
         }
 
         /// <summary>
@@ -73,6 +70,7 @@ namespace NuGetGallery.Auditing
             {
                 var uriString = $"http://auditing.local/{resourceType}/{filePath}/{timestamp:s}-{action.ToLowerInvariant()}";
                 var uri = new Uri(uriString);
+
                 return Task.FromResult(uri);
             }
         }

--- a/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
@@ -5,8 +5,14 @@ namespace NuGetGallery.Auditing
 {
     public class CredentialAuditRecord
     {
+        public int Key { get; }
+        public string Type { get; }
+        public string Value { get; }
+        public string Identity { get; }
+
         public CredentialAuditRecord(Credential credential, bool removed)
         {
+            Key = credential.Key;
             Type = credential.Type;
             Identity = credential.Identity;
 
@@ -16,10 +22,5 @@ namespace NuGetGallery.Auditing
                 Value = credential.Value;
             }
         }
-
-        public string Type { get; set; }
-        public string Value { get; set; }
-        public string Identity { get; set; }
-
     }
 }

--- a/src/NuGetGallery.Core/Auditing/FailedAuthenticatedOperationAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/FailedAuthenticatedOperationAuditRecord.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetGallery.Auditing.AuditedEntities;
+
+namespace NuGetGallery.Auditing
+{
+    public class FailedAuthenticatedOperationAuditRecord 
+        : AuditRecord<AuditedAuthenticatedOperationAction>
+    {
+        public string UsernameOrEmail { get; }
+        public AuditedPackageIdentifier AttemptedPackage { get; }
+        public CredentialAuditRecord AttemptedCredential { get; }
+
+        public FailedAuthenticatedOperationAuditRecord(
+            string usernameOrEmail, 
+            AuditedAuthenticatedOperationAction action,
+            AuditedPackageIdentifier attemptedPackage = null,
+            Credential attemptedCredential = null) 
+            : base(action)
+        {
+            UsernameOrEmail = usernameOrEmail;
+
+            if (attemptedPackage != null)
+            {
+                AttemptedPackage = attemptedPackage;
+            }
+
+            if (attemptedCredential != null)
+            {
+                AttemptedCredential = new CredentialAuditRecord(attemptedCredential, removed: false);
+            }
+        }
+
+        public override string GetPath()
+        {
+            return string.Empty; // store in <auditpath>/failedauthenticatedoperation/
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/FileSystemAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/FileSystemAuditingService.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace NuGetGallery.Auditing
+{
+    /// <summary>
+    /// Writes audit records to a specific directory in the file system
+    /// </summary>
+    public class FileSystemAuditingService : AuditingService
+    {
+        public static readonly string DefaultContainerName = "auditing";
+
+        private readonly string _auditingPath;
+        private readonly Func<Task<AuditActor>> _getOnBehalfOf;
+        
+        public FileSystemAuditingService(string auditingPath, Func<Task<AuditActor>> getOnBehalfOf)
+        {
+            if (string.IsNullOrEmpty(auditingPath))
+            {
+                throw new ArgumentNullException(nameof(auditingPath));
+            }
+            
+            if (getOnBehalfOf == null)
+            {
+                throw new ArgumentNullException(nameof(getOnBehalfOf));
+            }
+
+            _auditingPath = auditingPath;
+            _getOnBehalfOf = getOnBehalfOf;
+        }
+
+        public static Task<AuditActor> GetAspNetOnBehalfOf()
+        {
+            // Use HttpContext to build an actor representing the user performing the action
+            var context = HttpContext.Current;
+            if (context == null)
+            {
+                return null;
+            }
+
+            // Try to identify the client IP using various server variables
+            var clientIpAddress = context.Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
+            if (string.IsNullOrEmpty(clientIpAddress)) // Try REMOTE_ADDR server variable
+            {
+                clientIpAddress = context.Request.ServerVariables["REMOTE_ADDR"];
+            }
+
+            if (string.IsNullOrEmpty(clientIpAddress)) // Try UserHostAddress property
+            {
+                clientIpAddress = context.Request.UserHostAddress;
+            }
+
+            if (!string.IsNullOrEmpty(clientIpAddress) && clientIpAddress.IndexOf(".", StringComparison.Ordinal) > 0)
+            {
+                clientIpAddress = clientIpAddress.Substring(0, clientIpAddress.LastIndexOf(".", StringComparison.Ordinal)) + ".0";
+            }
+
+            string user = null;
+            string authType = null;
+            if (context.User != null)
+            {
+                user = context.User.Identity.Name;
+                authType = context.User.Identity.AuthenticationType;
+            }
+
+            return Task.FromResult(new AuditActor(
+                null,
+                clientIpAddress,
+                user,
+                authType,
+                DateTime.UtcNow));
+        }
+
+        protected override async Task<AuditActor> GetActor()
+        {
+            // Construct an actor representing the user the service is acting on behalf of
+            AuditActor onBehalfOf = null;
+            if (_getOnBehalfOf != null)
+            {
+                onBehalfOf = await _getOnBehalfOf();
+            }
+
+            return await AuditActor.GetCurrentMachineActor(onBehalfOf);
+        }
+
+        protected override Task<Uri> SaveAuditRecord(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
+        {
+            // Build relative file path
+            var relativeFilePath = string.Concat(
+                resourceType.ToLowerInvariant(), Path.DirectorySeparatorChar, 
+                filePath, Path.DirectorySeparatorChar,
+                timestamp.ToString("s").Replace(":", string.Empty), "-", // Sortable DateTime format
+                action.ToLowerInvariant(), ".audit.v1.json");
+
+            // Build full file path
+            var fullFilePath = Path.Combine(_auditingPath, relativeFilePath);
+
+            // Ensure the directory exists
+            var directoryName = Path.GetDirectoryName(fullFilePath);
+            if (!Directory.Exists(directoryName))
+            {
+                Directory.CreateDirectory(directoryName);
+            }
+
+            // Write the data
+            File.WriteAllText(fullFilePath, auditData);
+
+            // Generate a local URL
+            var uri = new Uri($"https://auditing.local/{relativeFilePath.Replace(Path.DirectorySeparatorChar, '/')}");
+
+            return Task.FromResult(uri);
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/PackageAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/PackageAuditRecord.cs
@@ -1,23 +1,25 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Data;
+using NuGetGallery.Auditing.AuditedEntities;
 
 namespace NuGetGallery.Auditing
 {
-    public class PackageAuditRecord : AuditRecord<PackageAuditAction>
+    public class PackageAuditRecord : AuditRecord<AuditedPackageAction>
     {
-        public string Id { get; set; }
-        public string Version { get; set; }
-        public string Hash { get; set; }
+        public string Id { get; }
+        public string Version { get; }
+        public string Hash { get; }
 
-        public DataTable PackageRecord { get; set; }
-        public DataTable RegistrationRecord { get; set; }
+        public AuditedPackage PackageRecord { get; }
+        public AuditedPackageRegistration RegistrationRecord { get; }
 
-        public string Reason { get; set; }
+        public string Reason { get; }
 
-        public PackageAuditRecord(string id, string version, string hash, DataTable packageRecord, DataTable registrationRecord, PackageAuditAction action, string reason)
+        public PackageAuditRecord(
+            string id, string version, string hash,
+            AuditedPackage packageRecord, AuditedPackageRegistration registrationRecord, 
+            AuditedPackageAction action, string reason)
             : base(action)
         {
             Id = id;
@@ -28,21 +30,27 @@ namespace NuGetGallery.Auditing
             Reason = reason;
         }
 
-        public PackageAuditRecord(Package package, DataTable packageRecord, DataTable registrationRecord, PackageAuditAction action, string reason)
-            : this(package.PackageRegistration.Id, package.Version, package.Hash, packageRecord, registrationRecord, action, reason)
+        public PackageAuditRecord(
+            Package package, AuditedPackageAction action, string reason)
+            : this(package.PackageRegistration.Id, package.Version, package.Hash, 
+                  packageRecord: null, registrationRecord: null, action: action, reason: reason)
         {
+            PackageRecord = AuditedPackage.CreateFrom(package);
+            RegistrationRecord = AuditedPackageRegistration.CreateFrom(package.PackageRegistration);
         }
 
+        public PackageAuditRecord(Package package, AuditedPackageAction action)
+            : this(package.PackageRegistration.Id, package.Version, package.Hash, 
+                  packageRecord: null, registrationRecord: null, action: action, reason: null)
+        {
+            PackageRecord = AuditedPackage.CreateFrom(package);
+            RegistrationRecord = AuditedPackageRegistration.CreateFrom(package.PackageRegistration);
+        }
+        
         public override string GetPath()
         {
             return $"{Id}/{NuGetVersionNormalizer.Normalize(Version)}"
                 .ToLowerInvariant();
         }
-    }
-
-    public enum PackageAuditAction
-    {
-        Deleted,
-        SoftDeleted
     }
 }

--- a/src/NuGetGallery.Core/Auditing/PackageCreatedVia.cs
+++ b/src/NuGetGallery.Core/Auditing/PackageCreatedVia.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Auditing
+{
+    public static class PackageCreatedVia
+    {
+        /// <summary>
+        /// Package has been created via NuGet API (nuget.exe push)
+        /// </summary>
+        public const string Api = "Created via API.";
+
+        /// <summary>
+        /// Package has been created via Nuget web interface (browser)
+        /// </summary>
+        public const string Web = "Created via web.";
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/PackageRegistrationAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/PackageRegistrationAuditRecord.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetGallery.Auditing.AuditedEntities;
+
+namespace NuGetGallery.Auditing
+{
+    public class PackageRegistrationAuditRecord : AuditRecord<AuditedPackageRegistrationAction>
+    {
+        public string Id { get; }
+        public AuditedPackageRegistration RegistrationRecord { get; }
+        public string Owner { get; }
+
+        public PackageRegistrationAuditRecord(
+            string id, AuditedPackageRegistration registrationRecord, AuditedPackageRegistrationAction action, string owner)
+            : base(action)
+        {
+            Id = id;
+            RegistrationRecord = registrationRecord;
+            Owner = owner;
+        }
+
+        public PackageRegistrationAuditRecord(
+            PackageRegistration packageRegistration, AuditedPackageRegistrationAction action, string owner)
+            : this(packageRegistration.Id, AuditedPackageRegistration.CreateFrom(packageRegistration), action, owner)
+        {
+        }
+        
+        public override string GetPath()
+        {
+            return $"{Id}".ToLowerInvariant();
+        }
+    }
+}

--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -16,6 +16,7 @@ namespace NuGetGallery
             public static readonly string Pbkdf2 = Prefix + "pbkdf2";
             public static readonly string Sha1 = Prefix + "sha1";
         }
+
         public static readonly string ApiKeyV1 = "apikey.v1";
         public static readonly string ExternalPrefix = "external.";
 

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -135,12 +135,24 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Auditing\AuditedEntities\AuditedPackage.cs" />
+    <Compile Include="Auditing\AuditedEntities\AuditedPackageIdentifier.cs" />
+    <Compile Include="Auditing\AuditedAuthenticatedOperationAction.cs" />
     <Compile Include="Auditing\AuditEntry.cs" />
     <Compile Include="Auditing\AuditActor.cs" />
     <Compile Include="Auditing\AuditingService.cs" />
     <Compile Include="Auditing\AuditRecord.cs" />
+    <Compile Include="Auditing\FailedAuthenticatedOperationAuditRecord.cs" />
+    <Compile Include="Auditing\FileSystemAuditingService.cs" />
     <Compile Include="Auditing\CloudAuditingService.cs" />
+    <Compile Include="Auditing\CredentialAuditRecord.cs" />
+    <Compile Include="Auditing\AuditedPackageAction.cs" />
     <Compile Include="Auditing\PackageAuditRecord.cs" />
+    <Compile Include="Auditing\PackageCreatedVia.cs" />
+    <Compile Include="Auditing\AuditedPackageRegistrationAction.cs" />
+    <Compile Include="Auditing\AuditedEntities\AuditedPackageRegistration.cs" />
+    <Compile Include="Auditing\PackageRegistrationAuditRecord.cs" />
+    <Compile Include="Auditing\AuditedUserAction.cs" />
     <Compile Include="Auditing\UserAuditRecord.cs" />
     <Compile Include="CoreConstants.cs" />
     <Compile Include="CredentialTypes.cs" />

--- a/src/NuGetGallery.Operations/Tasks/DeletePackageVersionTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/DeletePackageVersionTask.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data;
 using System.Data.SqlClient;
 using AnglicanGeek.DbExecutor;
@@ -10,6 +11,7 @@ using NuGetGallery.Operations.Common;
 
 namespace NuGetGallery.Operations
 {
+    [Obsolete("This command should no longer be used.")]
     [Command("deletepackageversion", "Delete a specific package version", AltName = "dpv")]
     public class DeletePackageVersionTask : DatabasePackageVersionTask
     {
@@ -73,9 +75,9 @@ namespace NuGetGallery.Operations
                     package.Id,
                     package.Version,
                     package.Hash,
-                    packageRecord,
-                    registrationRecord,
-                    PackageAuditAction.Deleted,
+                    null,
+                    null,
+                    AuditedPackageAction.Delete,
                     Reason);
 
                 if (WhatIf)

--- a/src/NuGetGallery.Operations/Util.cs
+++ b/src/NuGetGallery.Operations/Util.cs
@@ -352,7 +352,7 @@ namespace NuGetGallery.Operations
             } while (token != null);
         }
 
-        internal static string GetPackageAuditBlobName(string id, string version, PackageAuditAction action)
+        internal static string GetPackageAuditBlobName(string id, string version, AuditedPackageAction action)
         {
             // Audit Blob Name:
             //  /auditing/package/[id]/[version]/[action]-at-[datetime]
@@ -367,7 +367,7 @@ namespace NuGetGallery.Operations
                 Environment.MachineName,
                 localIP,
                 storage.CreateCloudBlobClient().GetContainerReference("auditing"),
-                onBehalfOfThunk: null);
+                getOnBehalfOf: null);
             return await audit.SaveAuditRecord(auditRecord);
         }
 

--- a/src/NuGetGallery/Authentication/Providers/ApiKey/ApiKeyAuthenticationHandler.cs
+++ b/src/NuGetGallery/Authentication/Providers/ApiKey/ApiKeyAuthenticationHandler.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Owin;
 using Microsoft.Owin.Logging;
@@ -69,28 +67,28 @@ namespace NuGetGallery.Authentication.Providers.ApiKey
             Response.Write(message);
         }
 
-        protected override Task<AuthenticationTicket> AuthenticateCoreAsync()
+        protected override async Task<AuthenticationTicket> AuthenticateCoreAsync()
         {
             var apiKey = Request.Headers[TheOptions.ApiKeyHeaderName];
             if (!String.IsNullOrEmpty(apiKey))
             {
                 // Get the user
-                var authUser = Auth.Authenticate(CredentialBuilder.CreateV1ApiKey(apiKey));
+                var authUser = await Auth.Authenticate(CredentialBuilder.CreateV1ApiKey(apiKey));
                 if (authUser != null)
                 {
                     // Set the current user
                     Context.Set(Constants.CurrentUserOwinEnvironmentKey, authUser);
 
-                    return Task.FromResult(
-                        new AuthenticationTicket(
+                    return new AuthenticationTicket(
                             AuthenticationService.CreateIdentity(
                                 authUser.User, 
                                 AuthenticationTypes.ApiKey, 
                                 new Claim(NuGetClaims.ApiKey, apiKey)),
-                            new AuthenticationProperties()));
+                            new AuthenticationProperties());
                 }
                 else
                 {
+                    // No user was matched
                     Logger.WriteWarning("No match for API Key!");
                 }
             }
@@ -98,7 +96,8 @@ namespace NuGetGallery.Authentication.Providers.ApiKey
             {
                 Logger.WriteVerbose("No API Key Header found in request.");
             }
-            return Task.FromResult<AuthenticationTicket>(null);
+
+            return null;
         }
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -16,6 +16,8 @@ using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
+using NuGetGallery.Auditing;
+using NuGetGallery.Auditing.AuditedEntities;
 using NuGetGallery.Configuration;
 using NuGetGallery.Filters;
 using NuGetGallery.Packaging;
@@ -38,10 +40,12 @@ namespace NuGetGallery
         public IAutomaticallyCuratePackageCommand AutoCuratePackage { get; set; }
         public IStatusService StatusService { get; set; }
         public IMessageService MessageService { get; set; }
+        public AuditingService AuditingService { get; set; }
         public ConfigurationService ConfigurationService{ get; set; }
 
         protected ApiController()
         {
+            AuditingService = AuditingService.None;
         }
 
         public ApiController(
@@ -56,6 +60,7 @@ namespace NuGetGallery
             IAutomaticallyCuratePackageCommand autoCuratePackage,
             IStatusService statusService,
             IMessageService messageService,
+            AuditingService auditingService,
             ConfigurationService configurationService)
         {
             EntitiesContext = entitiesContext;
@@ -70,6 +75,7 @@ namespace NuGetGallery
             AutoCuratePackage = autoCuratePackage;
             StatusService = statusService;
             MessageService = messageService;
+            AuditingService = auditingService;
             ConfigurationService = configurationService;
         }
 
@@ -86,8 +92,9 @@ namespace NuGetGallery
             IStatusService statusService,
             IStatisticsService statisticsService,
             IMessageService messageService,
+            AuditingService auditingService,
             ConfigurationService configurationService)
-            : this(entitiesContext, packageService, packageFileService, userService, nugetExeDownloaderService, contentService, indexingService, searchService, autoCuratePackage, statusService, messageService, configurationService)
+            : this(entitiesContext, packageService, packageFileService, userService, nugetExeDownloaderService, contentService, indexingService, searchService, autoCuratePackage, statusService, messageService, auditingService, configurationService)
         {
             StatisticsService = statisticsService;
         }
@@ -273,6 +280,15 @@ namespace NuGetGallery
                         {
                             if (!packageRegistration.IsOwner(user))
                             {
+                                // Audit that a non-owner tried to push the package
+                                await AuditingService.SaveAuditRecord(
+                                    new FailedAuthenticatedOperationAuditRecord(
+                                        user.Username, 
+                                        AuditedAuthenticatedOperationAction.PackagePushAttemptByNonOwner, 
+                                        attemptedPackage: new AuditedPackageIdentifier(
+                                            nuspec.GetId(), nuspec.GetVersion().ToNormalizedStringSafe())));
+
+                                // User can not push this package
                                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.Forbidden,
                                     Strings.ApiKeyNotAuthorized);
                             }
@@ -317,6 +333,11 @@ namespace NuGetGallery
                             IndexingService.UpdatePackage(package);
                         }
 
+                        // Write an audit record
+                        await AuditingService.SaveAuditRecord(
+                            new PackageAuditRecord(package, AuditedPackageAction.Create, PackageCreatedVia.Api));
+
+                        // Notify user of push
                         MessageService.SendPackageAddedNotice(package,
                             Url.Action("DisplayPackage", "Packages", routeValues: new { id = package.PackageRegistration.Id, version = package.Version }, protocol: Request.Url.Scheme),
                             Url.Action("ReportMyPackage", "Packages", routeValues: new { id = package.PackageRegistration.Id, version = package.Version }, protocol: Request.Url.Scheme),

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -103,7 +103,7 @@ namespace NuGetGallery
             }
 
             // Create session
-            AuthService.CreateSession(OwinContext, user.User);
+            await AuthService.CreateSessionAsync(OwinContext, user);
             return SafeRedirect(returnUrl);
         }
 
@@ -215,7 +215,7 @@ namespace NuGetGallery
             }
 
             // Create session
-            AuthService.CreateSession(OwinContext, user.User);
+            await AuthService.CreateSessionAsync(OwinContext, user);
             return RedirectFromRegister(returnUrl);
         }
 
@@ -262,7 +262,7 @@ namespace NuGetGallery
                 }
 
                 // Create session
-                AuthService.CreateSession(OwinContext, result.Authentication.User);
+                await AuthService.CreateSessionAsync(OwinContext, result.Authentication);
                 return SafeRedirect(returnUrl);
             }
             else

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -11,7 +11,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Mail;
-using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Caching;
@@ -20,6 +19,7 @@ using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Areas.Admin;
 using NuGetGallery.AsyncFileUpload;
+using NuGetGallery.Auditing;
 using NuGetGallery.Configuration;
 using NuGetGallery.Filters;
 using NuGetGallery.Helpers;
@@ -50,6 +50,7 @@ namespace NuGetGallery
         private readonly EditPackageService _editPackageService;
         private readonly IPackageDeleteService _packageDeleteService;
         private readonly ISupportRequestService _supportRequestService;
+        private readonly AuditingService _auditingService;
 
         public PackagesController(
             IPackageService packageService,
@@ -64,7 +65,8 @@ namespace NuGetGallery
             ICacheService cacheService,
             EditPackageService editPackageService,
             IPackageDeleteService packageDeleteService,
-            ISupportRequestService supportRequestService)
+            ISupportRequestService supportRequestService,
+            AuditingService auditingService)
         {
             _packageService = packageService;
             _uploadFileService = uploadFileService;
@@ -79,6 +81,7 @@ namespace NuGetGallery
             _editPackageService = editPackageService;
             _packageDeleteService = packageDeleteService;
             _supportRequestService = supportRequestService;
+            _auditingService = auditingService;
         }
 
         [Authorize]
@@ -141,6 +144,8 @@ namespace NuGetGallery
             }
             else if (numOK > 0)
             {
+                await _auditingService.SaveAuditRecord(new PackageAuditRecord(package, AuditedPackageAction.UndoEdit));
+
                 TempData["Message"] = "Your pending edits for this package were successfully canceled.";
             }
             else
@@ -905,6 +910,10 @@ namespace NuGetGallery
                 {
                     _editPackageService.StartEditPackageRequest(package, formData.Edit, user);
                     await _entitiesContext.SaveChangesAsync();
+
+                    var packageWithEditsApplied = formData.Edit.ApplyTo(package);
+
+                    await _auditingService.SaveAuditRecord(new PackageAuditRecord(packageWithEditsApplied, AuditedPackageAction.Edit));
                 }
                 catch (EntityException ex)
                 {
@@ -1165,6 +1174,11 @@ namespace NuGetGallery
                 // tell Lucene to update index for the new package
                 _indexingService.UpdateIndex();
 
+                // write an audit record
+                await _auditingService.SaveAuditRecord(
+                    new PackageAuditRecord(package, AuditedPackageAction.Create, PackageCreatedVia.Web));
+
+                // notify user
                 _messageService.SendPackageAddedNotice(package,
                     Url.Action("DisplayPackage", "Packages", routeValues: new { id = package.PackageRegistration.Id, version = package.Version }, protocol: Request.Url.Scheme),
                     Url.Action("ReportMyPackage", "Packages", routeValues: new { id = package.PackageRegistration.Id, version = package.Version }, protocol: Request.Url.Scheme),

--- a/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Text;
+using NuGetGallery.Packaging;
 
 namespace NuGetGallery
 {
@@ -103,5 +108,27 @@ namespace NuGetGallery
 
         [Display(Name = RequiresLicenseAcceptanceStr)]
         public bool RequiresLicenseAcceptance { get; set; }
+
+        /// <summary>
+        /// Applied the edit to a package
+        /// </summary>
+        /// <param name="package">Package to apply edits to</param>
+        /// <returns>Edited package</returns>
+        public Package ApplyTo(Package package)
+        {
+            package.FlattenedAuthors = Authors;
+            package.Copyright = Copyright;
+            package.Description = Description;
+            package.IconUrl = IconUrl;
+            package.LicenseUrl = LicenseUrl;
+            package.ProjectUrl = ProjectUrl;
+            package.ReleaseNotes = ReleaseNotes;
+            package.RequiresLicenseAcceptance = RequiresLicenseAcceptance;
+            package.Summary = Summary;
+            package.Tags = Tags;
+            package.Title = VersionTitle;
+
+            return package;
+        }
     }
 }

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -181,7 +181,7 @@ namespace NuGetGallery
             return Path.Combine(fileStorageDirectory, folderName, fileName);
         }
 
-        private static string ResolvePath(string fileStorageDirectory)
+        public static string ResolvePath(string fileStorageDirectory)
         {
             if (fileStorageDirectory.StartsWith("~/", StringComparison.OrdinalIgnoreCase) && HostingEnvironment.IsHosted)
             {

--- a/src/NuGetGallery/Services/PackageDeleteService.cs
+++ b/src/NuGetGallery/Services/PackageDeleteService.cs
@@ -3,11 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Data.Entity;
 using System.Data.SqlClient;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Versioning;
@@ -90,7 +87,7 @@ namespace NuGetGallery
                     package.Deleted = true;
                     packageDelete.Packages.Add(package);
 
-                    await _auditingService.SaveAuditRecord(CreateAuditRecord(package, package.PackageRegistration, PackageAuditAction.SoftDeleted, reason));
+                    await _auditingService.SaveAuditRecord(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.SoftDelete, reason));
                 }
 
                 _packageDeletesRepository.InsertOnCommit(packageDelete);
@@ -138,7 +135,7 @@ namespace NuGetGallery
                         "DELETE pf FROM PackageFrameworks pf JOIN Packages p ON p.[Key] = pf.Package_Key WHERE p.[Key] = @key",
                         new SqlParameter("@key", package.Key));
 
-                    await _auditingService.SaveAuditRecord(CreateAuditRecord(package, package.PackageRegistration, PackageAuditAction.Deleted, reason));
+                    await _auditingService.SaveAuditRecord(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.Delete, reason));
 
                     package.PackageRegistration.Packages.Remove(package);
                     _packageRepository.DeleteOnCommit(package);
@@ -221,40 +218,9 @@ namespace NuGetGallery
             _indexingService.UpdateIndex(true);
         }
 
-        protected virtual PackageAuditRecord CreateAuditRecord(Package package, PackageRegistration packageRegistration, PackageAuditAction action, string reason)
+        protected virtual PackageAuditRecord CreateAuditRecord(Package package, PackageRegistration packageRegistration, AuditedPackageAction action, string reason)
         {
-            return new PackageAuditRecord(package, ConvertToDataTable(package), ConvertToDataTable(packageRegistration), action, reason);
-        }
-
-        public static DataTable ConvertToDataTable<T>(T instance)
-        {
-            PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(typeof(T));
-            DataTable table = new DataTable() { Locale = CultureInfo.CurrentCulture };
-
-            List<object> values = new List<object>();
-            for (int i = 0; i < properties.Count; i++)
-            {
-                var propertyDescriptor = properties[i];
-                var propertyType = Nullable.GetUnderlyingType(propertyDescriptor.PropertyType) ?? propertyDescriptor.PropertyType;
-                if (!IsComplexType(propertyType))
-                {
-                    table.Columns.Add(propertyDescriptor.Name, propertyType);
-                    values.Add(propertyDescriptor.GetValue(instance) ?? DBNull.Value);
-                }
-            }
-
-            table.Rows.Add(values.ToArray());
-
-            return table;
-        }
-
-        public static bool IsComplexType(Type type)
-        {
-            if (type.IsSubclassOf(typeof (ValueType)) || type == typeof (string))
-            {
-                return false;
-            }
-            return true;
+            return new PackageAuditRecord(package, action, reason);
         }
     }
 }

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -97,7 +97,7 @@ namespace NuGetGallery
                 throw new EntityException(Strings.EmailAddressBeingUsed, newEmailAddress);
             }
 
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, UserAuditAction.ChangeEmail, newEmailAddress));
+            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.ChangeEmail, newEmailAddress));
 
             user.UpdateEmailAddress(newEmailAddress, Crypto.GenerateToken);
             await UserRepository.CommitChangesAsync();
@@ -105,7 +105,7 @@ namespace NuGetGallery
 
         public async Task CancelChangeEmailAddress(User user)
         {
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, UserAuditAction.CancelChangeEmail, user.UnconfirmedEmailAddress));
+            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.CancelChangeEmail, user.UnconfirmedEmailAddress));
 
             user.CancelChangeEmailAddress();
             await UserRepository.CommitChangesAsync();
@@ -144,7 +144,7 @@ namespace NuGetGallery
                 throw new EntityException(Strings.EmailAddressBeingUsed, user.UnconfirmedEmailAddress);
             }
 
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, UserAuditAction.ConfirmEmail, user.UnconfirmedEmailAddress));
+            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.ConfirmEmail, user.UnconfirmedEmailAddress));
 
             user.ConfirmEmailAddress();
 

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -555,6 +555,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package created from API..
+        /// </summary>
+        public static string PackageCreatedFromApi {
+            get {
+                return ResourceManager.GetString("PackageCreatedFromApi", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package is invalid and cannot be uploaded. One or more files, such as &apos;{0}&apos; have a date in the future..
         /// </summary>
         public static string PackageEntryFromTheFuture {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -380,4 +380,7 @@ The {2} Team</value>
   <data name="AzureActiveDirectory_Caption" xml:space="preserve">
     <value>Azure Active Directory</value>
   </data>
+  <data name="PackageCreatedFromApi" xml:space="preserve">
+    <value>Package created from API.</value>
+  </data>
 </root>

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -14,6 +14,7 @@ using System.Web.Routing;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NuGet.Packaging;
+using NuGetGallery.Auditing;
 using NuGetGallery.Configuration;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
@@ -60,6 +61,8 @@ namespace NuGetGallery
             MockConfigurationService.SetupGet(s => s.Features.TrackPackageDownloadCountInLocalDatabase)
                 .Returns(false);
             ConfigurationService = MockConfigurationService.Object;
+
+            AuditingService = new TestAuditingService();
 
             TestUtility.SetupHttpContextMockForUrlGeneration(new Mock<HttpContextBase>(), this);
         }
@@ -115,6 +118,37 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public async Task WritesAnAuditRecord()
+            {
+                // Arrange
+                var user = new User { EmailAddress = "confirmed@email.com" };
+                var packageRegistration = new PackageRegistration();
+                packageRegistration.Id = "theId";
+                packageRegistration.Owners.Add(user);
+                var package = new Package();
+                package.PackageRegistration = packageRegistration;
+                package.Version = "1.0.42";
+                packageRegistration.Packages.Add(package);
+
+                var controller = new TestableApiController();
+                controller.SetCurrentUser(user);
+                controller.MockPackageService.Setup(p => p.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), false))
+                    .Returns(Task.FromResult(package));
+
+                var nuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.42");
+                controller.SetupPackageFromInputStream(nuGetPackage);
+
+                // Act
+                await controller.CreatePackagePut();
+
+                // Assert
+                Assert.True(controller.AuditingService.WroteRecord<PackageAuditRecord>(ar =>
+                    ar.Action == AuditedPackageAction.Create
+                    && ar.Id == package.PackageRegistration.Id
+                    && ar.Version == package.Version));
+            }
+
+            [Fact]
             public async Task CreatePackageWillSendPackageAddedNotice()
             {
                 // Arrange
@@ -167,6 +201,36 @@ namespace NuGetGallery
 
                 // Assert
                 ResultAssert.IsStatusCode(result, HttpStatusCode.BadRequest);
+            }
+
+            [Fact]
+            public async Task WillWriteAnAuditRecordIfUserIsNotPackageOwner()
+            {
+                // Arrange
+                var user = new User { EmailAddress = "confirmed@email.com" };
+                var packageRegistration = new PackageRegistration();
+                packageRegistration.Id = "theId";
+                var package = new Package();
+                package.PackageRegistration = packageRegistration;
+                package.Version = "1.0.42";
+                packageRegistration.Packages.Add(package);
+
+                var controller = new TestableApiController();
+                controller.SetCurrentUser(user);
+                controller.MockPackageService.Setup(p => p.FindPackageRegistrationById(It.IsAny<string>()))
+                    .Returns(packageRegistration);
+
+                var nuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.42");
+                controller.SetupPackageFromInputStream(nuGetPackage);
+
+                // Act
+                await controller.CreatePackagePut();
+
+                // Assert
+                Assert.True(controller.AuditingService.WroteRecord<FailedAuthenticatedOperationAuditRecord>(ar =>
+                    ar.Action == AuditedAuthenticatedOperationAction.PackagePushAttemptByNonOwner
+                    && ar.AttemptedPackage.Id == package.PackageRegistration.Id
+                    && ar.AttemptedPackage.Version == package.Version));
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -149,7 +149,8 @@ namespace NuGetGallery.Controllers
                     .CompletesWith(authUser);
                 var controller = GetController<AuthenticationController>();
                 GetMock<AuthenticationService>()
-                    .Setup(a => a.CreateSession(controller.OwinContext, authUser.User))
+                    .Setup(a => a.CreateSessionAsync(controller.OwinContext, authUser))
+                    .Returns(Task.FromResult(0))
                     .Verifiable();
 
                 // Act
@@ -177,7 +178,8 @@ namespace NuGetGallery.Controllers
                     .CompletesWith(authUser);
                 var controller = GetController<AuthenticationController>();
                 GetMock<AuthenticationService>()
-                    .Setup(a => a.CreateSession(controller.OwinContext, authUser.User))
+                    .Setup(a => a.CreateSessionAsync(controller.OwinContext, authUser))
+                    .Returns(Task.FromResult(0))
                     .Verifiable();
 
                 // Act
@@ -205,7 +207,8 @@ namespace NuGetGallery.Controllers
                     .CompletesWith(authUser);
                 var controller = GetController<AuthenticationController>();
                 GetMock<AuthenticationService>()
-                    .Setup(a => a.CreateSession(controller.OwinContext, authUser.User))
+                    .Setup(a => a.CreateSessionAsync(controller.OwinContext, authUser))
+                    .Returns(Task.FromResult(0))
                     .Verifiable();
 
                 // Act
@@ -250,7 +253,7 @@ namespace NuGetGallery.Controllers
                 // Assert
                 VerifyExternalLinkExpiredResult(controller, result);
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.CreateSession(It.IsAny<IOwinContext>(), It.IsAny<User>()), Times.Never());
+                    .Verify(x => x.CreateSessionAsync(It.IsAny<IOwinContext>(), It.IsAny<AuthenticatedUser>()), Times.Never());
             }
 
             [Fact]
@@ -276,11 +279,12 @@ namespace NuGetGallery.Controllers
                 var controller = GetController<AuthenticationController>();
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                    .Setup(x => x.CreateSessionAsync(controller.OwinContext, It.IsAny<AuthenticatedUser>()))
+                    .Returns(Task.FromResult(0))
                     .Verifiable();
                 GetMock<AuthenticationService>()
                     .Setup(x => x.ReadExternalLoginCredential(controller.OwinContext))
-                    .CompletesWith(new AuthenticateExternalLoginResult()
+                    .CompletesWith(new AuthenticateExternalLoginResult
                     {
                         ExternalIdentity = new ClaimsIdentity(),
                         Credential = externalCred
@@ -353,7 +357,8 @@ namespace NuGetGallery.Controllers
                 else
                 {
                     GetMock<AuthenticationService>()
-                       .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                       .Setup(x => x.CreateSessionAsync(controller.OwinContext, It.IsAny<AuthenticatedUser>()))
+                       .Returns(Task.FromResult(0))
                        .Verifiable();
                 }
                 
@@ -444,7 +449,8 @@ namespace NuGetGallery.Controllers
                 var controller = GetController<AuthenticationController>();
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                    .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser))
+                    .Returns(Task.FromResult(0))
                     .Verifiable();
 
                 // Act
@@ -493,7 +499,8 @@ namespace NuGetGallery.Controllers
                 var controller = GetController<AuthenticationController>();
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                    .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser))
+                    .Returns(Task.FromResult(0))
                     .Verifiable();
 
                 // Act
@@ -525,7 +532,7 @@ namespace NuGetGallery.Controllers
                 var controller = GetController<AuthenticationController>();
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                    .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser))
                     .Verifiable();
                 GetMock<AuthenticationService>()
                     .Setup(x => x.ReadExternalLoginCredential(controller.OwinContext))
@@ -545,7 +552,7 @@ namespace NuGetGallery.Controllers
                 // Assert
                 VerifyExternalLinkExpiredResult(controller, result);
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.CreateSession(It.IsAny<IOwinContext>(), It.IsAny<User>()), Times.Never());
+                    .Verify(x => x.CreateSessionAsync(It.IsAny<IOwinContext>(), It.IsAny<AuthenticatedUser>()), Times.Never());
                 GetMock<AuthenticationService>()
                     .Verify(x => x.Register("theUsername", "theEmailAddress", It.IsAny<Credential>()), Times.Never());
             }
@@ -570,7 +577,8 @@ namespace NuGetGallery.Controllers
                 var controller = GetController<AuthenticationController>();
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                    .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser))
+                    .Returns(Task.FromResult(0))
                     .Verifiable();
                 GetMock<AuthenticationService>()
                     .Setup(x => x.ReadExternalLoginCredential(controller.OwinContext))
@@ -652,7 +660,8 @@ namespace NuGetGallery.Controllers
                 else
                 {
                     GetMock<AuthenticationService>()
-                       .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                       .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser))
+                       .Returns(Task.FromResult(0))
                        .Verifiable();
                 }
 
@@ -748,7 +757,7 @@ namespace NuGetGallery.Controllers
                 // Assert
                 ResultAssert.IsSafeRedirectTo(result, "theReturnUrl");
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.CreateSession(controller.OwinContext, authUser.User));
+                    .Verify(x => x.CreateSessionAsync(controller.OwinContext, authUser));
             }
 
             [Theory]
@@ -793,7 +802,8 @@ namespace NuGetGallery.Controllers
                 else
                 {
                     GetMock<AuthenticationService>()
-                       .Setup(x => x.CreateSession(controller.OwinContext, authUser.User))
+                       .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser))
+                       .Returns(Task.FromResult(0))
                        .Verifiable();
                 }
 

--- a/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
@@ -79,7 +79,7 @@ namespace NuGetGallery
                 return Task.FromResult(0);
             }
 
-            protected override PackageAuditRecord CreateAuditRecord(Package package, PackageRegistration packageRegistration, PackageAuditAction action, string reason)
+            protected override PackageAuditRecord CreateAuditRecord(Package package, PackageRegistration packageRegistration, AuditedPackageAction action, string reason)
             {
                 LastAuditRecord = base.CreateAuditRecord(package, packageRegistration, action, reason);
                 return LastAuditRecord;

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Packaging;
+using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
 using Xunit;
 
@@ -285,13 +286,15 @@ namespace NuGetGallery
             var packageNamingConflictValidator = new PackageNamingConflictValidator(
                     packageRegistrationRepository.Object,
                     packageRepository.Object);
+            var auditingService = new TestAuditingService();
 
             var packageService = new Mock<PackageService>(
                 packageRegistrationRepository.Object,
                 packageRepository.Object,
                 packageOwnerRequestRepo.Object,
                 indexingService.Object,
-                packageNamingConflictValidator);
+                packageNamingConflictValidator,
+                auditingService);
 
             packageService.CallBase = true;
 

--- a/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
@@ -166,7 +166,7 @@ namespace NuGetGallery
                 var confirmed = await service.ConfirmEmailAddress(user, "secret");
 
                 Assert.True(service.Auditing.WroteRecord<UserAuditRecord>(ar =>
-                    ar.Action == UserAuditAction.ConfirmEmail &&
+                    ar.Action == AuditedUserAction.ConfirmEmail &&
                     ar.AffectedEmailAddress == "new@example.com"));
             }
         }
@@ -298,7 +298,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.True(service.Auditing.WroteRecord<UserAuditRecord>(ar =>
-                    ar.Action == UserAuditAction.ChangeEmail &&
+                    ar.Action == AuditedUserAction.ChangeEmail &&
                     ar.AffectedEmailAddress == "new@example.org" &&
                     ar.EmailAddress == "old@example.org"));
             }
@@ -353,7 +353,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.True(service.Auditing.WroteRecord<UserAuditRecord>(ar =>
-                    ar.Action == UserAuditAction.CancelChangeEmail &&
+                    ar.Action == AuditedUserAction.CancelChangeEmail &&
                     ar.AffectedEmailAddress == "unconfirmedEmail@example.org" &&
                     ar.EmailAddress == "confirmedEmail@example.org"));
             }

--- a/tests/NuGetGallery.Facts/TestUtils/MockExtensions.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/MockExtensions.cs
@@ -76,7 +76,7 @@ namespace NuGetGallery
             return self.Setup(us => us.Authenticate(It.Is<Credential>(c =>
                 String.Equals(c.Type, cred.Type, StringComparison.OrdinalIgnoreCase) &&
                 String.Equals(c.Value, cred.Value, StringComparison.Ordinal))))
-                .Returns(user == null ? null : new AuthenticatedUser(user, cred));
+                .Returns(Task.FromResult(user == null ? null : new AuthenticatedUser(user, cred)));
         }
     }
 }


### PR DESCRIPTION
Thuis PR ensures the following operations are audited:

* User audit actions:
  * Registered
  * AddedCredential
  * RemovedCredential
  * RequestedPasswordReset
  * ChangeEmail
  * CancelChangeEmail
  * ConfirmEmail
  * Login
  * Failed logins
* Package audit actions:
  * Deleted
  * SoftDeleted
  * Publish
  * List/Unlist
  * Edit metadata
  * Failed push due to invalid credential
* Package registration audit actions:
  * Add/remove owner

Please have a look @skofman1 @xavierdecoster 