### PR TITLE
Invoke Gallery Publishing via MSBuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ x64/
 #build/ # We use this folder for our Build Scripts
 [Bb]in/
 [Oo]bj/
+[Aa]rtifacts/
+
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,5 @@
+IF "%~1"=="LocalGalleryPublish" GOTO LocalGalleryPublish
+
 :CheckOS
 IF EXIST "%PROGRAMFILES(X86)%" (GOTO 64BIT) ELSE (GOTO 32BIT)
 
@@ -8,5 +10,10 @@ GOTO END
 :32BIT
 "%programfiles%\MSBuild\14.0\Bin\msbuild.exe" build.msbuild /tv:14.0 /p:VisualStudioVersion=14.0 /p:ToolsVersion=14.0 %*
 GOTO END
+
+:LocalGalleryPublish
+"%programfiles(x86)%\MSBuild\14.0\Bin\msbuild.exe" build.msbuild /t:LocalGalleryPublish /tv:14.0 /p:VisualStudioVersion=14.0 /p:ToolsVersion=14.0 
+GOTO END
+
 
 :END

--- a/build.msbuild
+++ b/build.msbuild
@@ -73,4 +73,12 @@
     </Target>
 
     <Target Name="Build" DependsOnTargets="CheckForMultipleSolutions;RestorePackages;CoreBuild" />
+	
+	<Target Name="LocalGalleryPublish" DependsOnTargets="RestorePackages">
+	  <Copy SourceFiles="$(MSBuildThisFileDirectory)src\NuGetGallery\NuGetGallery.dll.config" DestinationFolder="$(MSBuildThisFileDirectory)src\NuGetGallery\bin\" ContinueOnError="true" />
+
+	
+	  <MsBuild Projects="$(MSBuildThisFileDirectory)src\NuGetGallery\NuGetGallery.csproj" Targets="Package" Properties="PackageLocation=$(MSBuildThisFileDirectory)artifacts\NuGetGallery.zip;_PackageTempDir=$(MSBuildThisFileDirectory)artifacts\NuGetGallery;OutputPath=$(MSBuildThisFileDirectory)artifacts\temp\NuGetGallery-build;Configuration=Release;Platform=Any CPU;VisualStudioVersion=14.0;LocalGalleryPublish=true" />
+    </Target>
+
 </Project>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1918,5 +1918,5 @@
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.13\build\NuGet.Services.Build.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.13\build\NuGet.Services.Build.props'))" />
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.13\build\NuGet.Services.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.13\build\NuGet.Services.Build.targets'))" />
   </Target>
-  <Import Project="..\..\packages\NuGet.Services.Build.3.0.13\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.13\build\NuGet.Services.Build.targets')" />
+  <Import Project="..\..\packages\NuGet.Services.Build.3.0.13\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.13\build\NuGet.Services.Build.targets') And '$(LocalGalleryPublish)' == ''" />
 </Project>


### PR DESCRIPTION
This PR should made the process easier to get a "local" Gallery from source.

I added an optinal argument in the build.cmd that will trigger the publishing process from the NuGetGallery project.

There are some pieces of the current build that I don't 100% understand - especially the NuGet.Services.Build package, which contains MSBuild stuff and is linked in the NuGetGallery.csproj. Unfortunatly this package contains a target called "Package", which overlaps with the normal "Package" target from ASP.NET, so I needed to disable it via my publishing build.

__The good parts:__

You just need to invoke

    build.cmd LocalGalleryPublish

and it will produce the following output (builded with "Release"/"Any CPU")

Building from VS or just invoke build.cmd will behave the same way as before.

![image](https://cloud.githubusercontent.com/assets/756703/16170351/0df4dfb0-3550-11e6-9b71-b857d46067ff.png)

Now the user could just xcopy the NuGetGallery folder or use WebDeploy.

__The bad part:__

The NuGet.Services.Build MsBuild stuff will produce some nice Version Hints - if you are running my build, this will be seen:

![image](https://cloud.githubusercontent.com/assets/756703/16170357/5f8d67c0-3550-11e6-916d-04358a8b88b5.png)

But this behavior is not super bad, because even when you try to publish from VS the version hint is also not very helpful:

![image](https://cloud.githubusercontent.com/assets/756703/16170369/a8ca4070-3550-11e6-93af-bf68cb346040.png)

I didn't test everything with my build, but it seems to work, but I'm unsure if I missed something when I not include the NuGet.Services.Build stuff.


