### PR TITLE
Use guid instead of timestamp in auditing files

### DIFF
--- a/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
@@ -92,11 +92,10 @@ namespace NuGetGallery.Auditing
 
         protected override async Task<Uri> SaveAuditRecord(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
         {
-            string fullPath = String.Concat(
-                resourceType.ToLowerInvariant(), "/", 
-                filePath.Replace(Path.DirectorySeparatorChar, '/'), "/",
-                timestamp.ToString("s"), "-", // Sortable DateTime format
-                action.ToLowerInvariant(), ".audit.v1.json");
+            string fullPath =
+                $"{resourceType.ToLowerInvariant()}/" +
+                $"{filePath.Replace(Path.DirectorySeparatorChar, '/')}/" +
+                $"{Guid.NewGuid().ToString("N")}-{action.ToLowerInvariant()}.audit.v1.json";
 
             var blob = _auditContainer.GetBlockBlobReference(fullPath);
             bool retry = false;

--- a/src/NuGetGallery.Core/Auditing/FileSystemAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/FileSystemAuditingService.cs
@@ -91,12 +91,11 @@ namespace NuGetGallery.Auditing
         protected override Task<Uri> SaveAuditRecord(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
         {
             // Build relative file path
-            var relativeFilePath = string.Concat(
-                resourceType.ToLowerInvariant(), Path.DirectorySeparatorChar, 
-                filePath, Path.DirectorySeparatorChar,
-                timestamp.ToString("s").Replace(":", string.Empty), "-", // Sortable DateTime format
-                action.ToLowerInvariant(), ".audit.v1.json");
-
+            var relativeFilePath = 
+               $"{resourceType.ToLowerInvariant()}{Path.DirectorySeparatorChar}" +
+               $"{filePath}{Path.DirectorySeparatorChar}" +
+               $"{Guid.NewGuid().ToString("N")}-{action.ToLowerInvariant()}.audit.v1.json";
+            
             // Build full file path
             var fullFilePath = Path.Combine(_auditingPath, relativeFilePath);
 


### PR DESCRIPTION
This PR fixes issue: https://github.com/NuGet/NuGetGallery/issues/3099

@maartenba @xavierdecoster @yishaigalatzer 