### PR TITLE
Fix 3107 - Gallery UTs take a long time to finish.

### DIFF
--- a/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
+++ b/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
@@ -14,7 +14,7 @@ namespace NuGetGallery.SearchClient
     public class RetryingHttpClientWrapperFacts
     {
         private static readonly Uri ValidUri1 = new Uri("http://www.microsoft.com");
-        private static readonly Uri ValidUri2 = new Uri("http://www.bing.com");
+        private static readonly Uri ValidUri2 = new Uri("http://www.nuget.org");
         private static readonly Uri InvalidUri1 = new Uri("http://nonexisting.domain.atleast.ihope");
         private static readonly Uri InvalidUri2 = new Uri("http://nonexisting.domain.atleast.ihope/foo");
         private static readonly Uri InvalidUri3 = new Uri("http://www.nuget.org/com/ibm/mq/com.ibm.mq.soap/7.0.1.10/com.ibm.mq.soap-7.0.1.10");
@@ -83,7 +83,7 @@ namespace NuGetGallery.SearchClient
             bool hasHitUri2 = false;
 
             int numRequests = 0;
-            while (!hasHitUri1 || !hasHitUri2 || numRequests < 25)
+            while ((!hasHitUri1 || !hasHitUri2) && numRequests < 25)
             {
                 numRequests++;
                 var result = await client.GetStringAsync(new[] { ValidUri1, ValidUri2 });
@@ -107,7 +107,7 @@ namespace NuGetGallery.SearchClient
             bool hasHitUri2 = false;
 
             int numRequests = 0;
-            while (!hasHitUri1 || !hasHitUri2 || numRequests < 25)
+            while ((!hasHitUri1 || !hasHitUri2) && numRequests < 25)
             {
                 numRequests++;
                 var result = await client.GetAsync(new[] { ValidUri1, ValidUri2 });


### PR DESCRIPTION
Fixes #3107 - Gallery UTs take a long time to finish.

The tests were hanging in an infinite loop due to condition check failure plus a url redirection causing failure of tests.

It looks like the requestUri for `http://www.bing.com` is redirected to `https://www.bing.com/?toHttps=1&redig=414F637CC2A1431BACF5E4B0D0F90FF0` probably an SSL change on bing. I think just changing the url should be sufficient for validating tests.

Validation: All UTs passed in under 1 minute, also command line build would hang for gallery which now finishes in under 2 minutes.