### PR TITLE
Fix issue 2252 - Hidden File Writing bug

### DIFF
--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -141,25 +141,17 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(packageFile));
             }
 
-            var storageDirectory = ResolvePath(_configuration.FileStorageDirectory);
-
-            if (!_fileSystemService.DirectoryExists(storageDirectory))
-            {
-                _fileSystemService.CreateDirectory(storageDirectory);
-            }
-
-            var folderPath = Path.Combine(storageDirectory, folderName);
-            if (!_fileSystemService.DirectoryExists(folderPath))
-            {
-                _fileSystemService.CreateDirectory(folderPath);
-            }
-
             var filePath = BuildPath(_configuration.FileStorageDirectory, folderName, fileName);
-            folderPath = Path.GetDirectoryName(filePath);
-            if (!_fileSystemService.DirectoryExists(folderPath))
+            var folderPath = Path.GetDirectoryName(filePath);
+            if (_fileSystemService.FileExists(filePath))
+            {
+                _fileSystemService.DeleteFile(filePath);
+            }
+            else
             {
                 _fileSystemService.CreateDirectory(folderPath);
             }
+
             using (var file = _fileSystemService.OpenWrite(filePath))
             {
                 packageFile.CopyTo(file);


### PR DESCRIPTION
Addresses issue https://github.com/NuGet/NuGetGallery/issues/2252

The core of the issue here was that when we were saving a file, we would write to the stream returned by the given file path. However, if the file already existed, it was not cleared before writing. In the case where the existing file was larger than the one we were trying to write, it would overwrite a portion of the file and leave the remainder, essentially corrupting both files.

This change simple removes the file if it already exists on the file system when we attempt to write to it.

@maartenba @yishaigalatzer @skofman1 