### PR TITLE
Only NuGet Admins should see the reflow link

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -89,9 +89,13 @@
             {
                 <li><a href="@Url.EditPackage(Model.Id, Model.Version)">Edit Package</a></li>
                 <li><a href="@Url.ManagePackageOwners(Model)">Manage Owners</a></li>
-                <li><a href="@Url.ReflowPackage(Model)">Reflow Package</a></li>
+                if (User.IsAdministrator())
+                {
+                    <li><a href="@Url.ReflowPackage(Model)">Reflow Package</a></li>
+                }
                 <li><a href="@Url.DeletePackage(Model)" class="delete">Delete Package</a></li>
             }
+
             @if (StatisticsHelper.IsStatisticsPageAvailable)
             {
                 <li><a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics">Package Statistics</a></li>


### PR DESCRIPTION
I noticed a new link "Reflow" on the package detail page that shouldn't be visible for non admins - at least the control action is only accessable for NuGet Admins:

(the screenshot is from prod NuGet.org)

![image](https://cloud.githubusercontent.com/assets/756703/16745868/2570ee7a-47b8-11e6-95f2-ff9d912377af.png)

With this PR the link shouldn't be visible for normal NuGet users. 

If a normal NuGet user should do a "reflow" (whatever that means), then the Authorize("Admin") attribute should be removed.
