### PR TITLE
Copy API key to clipboard with key been invisible

### DIFF
--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -449,8 +449,8 @@
                     }
                     else
                     {
-                        <text>(hidden for security purposes)</text>
-                    }
+                        <text>(hidden for security purposes) <button class="btn btn-small" title="Copy API key to clipboard" type="button" onclick="copyTextToClipboard('@apiKey.Value')"><i class="icon-copy"></i></button></text>
+    }
 
                     @item.ExpandLink("Show details", "Hide details")
                 }


### PR DESCRIPTION
I talked with a workmate about visible passwords or keys in different systems and noticed that you currently need to display your NuGet key to copy it and this could be a problem if you want to do a screenrecording or doing demos in public.
The PR will just add a button in the header-bar a will copy the API key in the clipboard, but without been visible on the screen.

![image](https://cloud.githubusercontent.com/assets/756703/16746621/6eda1c5a-47bb-11e6-8f66-a8e8ac94ef19.png)

To be fair: I guess most NuGet clients make the API key somewhat visible for the enduser (e.g. you can see the NuGet API key in AppVeyor), but I don't think that this is a super clever idea.