### PR TITLE
Remove "The package was published as the wrong version” from "package delete reasons" (Issue #3117)

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Controllers/DeleteController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/DeleteController.cs
@@ -32,7 +32,6 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
         private static readonly ReportPackageReason[] ReportMyPackageReasons = {
             ReportPackageReason.ContainsPrivateAndConfidentialData,
-            ReportPackageReason.PublishedWithWrongVersion,
             ReportPackageReason.ReleasedInPublicByAccident,
             ReportPackageReason.ContainsMaliciousCode,
             ReportPackageReason.Other

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -500,7 +500,6 @@ namespace NuGetGallery
 
         private static readonly ReportPackageReason[] ReportMyPackageReasons = {
             ReportPackageReason.ContainsPrivateAndConfidentialData,
-            ReportPackageReason.PublishedWithWrongVersion,
             ReportPackageReason.ReleasedInPublicByAccident,
             ReportPackageReason.ContainsMaliciousCode,
             ReportPackageReason.Other

--- a/src/NuGetGallery/ViewModels/ReportPackageReason.cs
+++ b/src/NuGetGallery/ViewModels/ReportPackageReason.cs
@@ -25,9 +25,6 @@ namespace NuGetGallery
         [Description("The package contains private/confidential data")]
         ContainsPrivateAndConfidentialData,
 
-        [Description("The package was published as the wrong version")]
-        PublishedWithWrongVersion,
-
         [Description("The package was not intended to be published publically on nuget.org")]
         ReleasedInPublicByAccident,
     }


### PR DESCRIPTION
Issue #3117:

@alpaix wrote: As it was discussed offline “The package was published as the wrong version” is not a legitimate reason for package delete request anymore. Please update the support request web form to keep customers from submitting such requests. Otherwise support person has to apologize every time in response :(.

@skofman1 @xavierdecoster @maartenba 