### PR TITLE
Don't return MvcHtmlString in TruncateAtWordBoundary (#3124)

### DIFF
--- a/src/NuGetGallery/Helpers/StringExtensions.cs
+++ b/src/NuGetGallery/Helpers/StringExtensions.cs
@@ -43,17 +43,17 @@ namespace NuGetGallery.Helpers
             return text.Substring(0, length - 3) + "...";
         }
 
-        public static MvcHtmlString TruncateAtWordBoundary(this string input, int length = 300, string ommission = "...", string moreText = "")
+        public static string TruncateAtWordBoundary(this string input, int length = 300, string ommission = "...", string moreText = "")
         {
             if (string.IsNullOrEmpty(input) || input.Length < length)
-                return new MvcHtmlString(input);
+                return input;
 
             int nextSpace = input.LastIndexOf(" ", length, StringComparison.Ordinal);
 
-            return new MvcHtmlString(string.Format(CultureInfo.CurrentCulture, "{2}{1}{0}",
-                                 moreText,
-                                 ommission,
-                                 HttpUtility.HtmlEncode(input.Substring(0, (nextSpace > 0) ? nextSpace : length).Trim())));
+            return string.Format(CultureInfo.CurrentCulture, "{2}{1}{0}",
+                                moreText,
+                                ommission,
+                                input.Substring(0, (nextSpace > 0) ? nextSpace : length).Trim());
         }
     }
 }


### PR DESCRIPTION
Our package list view is displaying the description of each package by truncating it with a method called `TruncateAtWordBoundary`.

Razor normally HTML encodes every string in an `@`-tag; however, to avoid double-encoding, Razor does not encode `MvcHtmlString`s because it assumes that they are already encoded.

`TruncateAtWordBoundary` was returning an `MvcHtmlString` but not encoding the string when it was shorter than the truncate length. As a result, if the description of a package included HTML that was shorter than 300 characters, the HTML would be run in the browser.

To prevent this, I've modified `TruncateAtWordBoundary` to return a regular string, since it had no real reason to return a `MvcHtmlString` anyway. This encodes the description as usual.

(Fixes #3124)