### PR TITLE
Gallery UTs fail sporadically in CI

### DIFF
--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -26,7 +26,8 @@ namespace NuGetGallery.Controllers
             {
                 // Arrange
                 var controller = GetController<AuthenticationController>();
-                controller.SetCurrentUser(Fakes.User);
+                var fakes = Get<Fakes>();
+                controller.SetCurrentUser(fakes.User);
 
                 // Act
                 var result = controller.LogOn("/foo/bar/baz");
@@ -96,7 +97,8 @@ namespace NuGetGallery.Controllers
             {
                 // Arrange
                 var controller = GetController<AuthenticationController>();
-                controller.SetCurrentUser(Fakes.User);
+                var fakes = Get<Fakes>();
+                controller.SetCurrentUser(fakes.User);
 
                 // Act
                 var result = await controller.SignIn(new LogOnViewModel(), "/foo/bar/baz", linkingAccount: false);
@@ -737,11 +739,12 @@ namespace NuGetGallery.Controllers
             public async Task GivenAssociatedLocalUser_ItCreatesASessionAndSafeRedirectsToReturnUrl()
             {
                 // Arrange
+                var fakes = Get<Fakes>();
                 GetMock<AuthenticationService>(); // Force a mock to be created
                 var controller = GetController<AuthenticationController>();
                 var cred = CredentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "Bloog");
                 var authUser = new AuthenticatedUser(
-                    Fakes.CreateUser("test", cred),
+                    fakes.CreateUser("test", cred),
                     cred);
                 GetMock<AuthenticationService>()
                     .Setup(x => x.AuthenticateExternalLogin(controller.OwinContext))
@@ -775,11 +778,12 @@ namespace NuGetGallery.Controllers
                     EnforcedAuthProviderForAdmin = enforcedProvider
                 };
 
+                var fakes = Get<Fakes>();
                 GetMock<AuthenticationService>(); // Force a mock to be created
                 var controller = GetController<AuthenticationController>();
                 var cred = CredentialBuilder.CreateExternalCredential(providerUsedForLogin, "blorg", "Bloog");
                 var authUser = new AuthenticatedUser(
-                    Fakes.CreateUser("test", cred),
+                    fakes.CreateUser("test", cred),
                     cred);
 
                 authUser.User.Roles.Add(new Role { Name = Constants.AdminRoleName });
@@ -925,12 +929,13 @@ namespace NuGetGallery.Controllers
             public async Task GivenNoLinkButEmailMatchingLocalUser_ItDisplaysLogOnViewPresetForSignIn()
             {
                 // Arrange
+                var fakes = Get<Fakes>();
                 var existingUser = new User("existingUser") { EmailAddress = "existing@example.com" };
                 var cred = CredentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "Bloog");
                 var msAuther = new MicrosoftAccountAuthenticator();
                 var msaUI = msAuther.GetUI();
                 var authUser = new AuthenticatedUser(
-                    Fakes.CreateUser("test", cred),
+                    fakes.CreateUser("test", cred),
                     cred);
 
                 GetMock<AuthenticationService>(); // Force a mock to be created

--- a/tests/NuGetGallery.Facts/Controllers/CuratedFeedsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/CuratedFeedsControllerFacts.cs
@@ -17,8 +17,12 @@ namespace NuGetGallery
     {
         public class TestableCuratedFeedsController : CuratedFeedsController
         {
+            public Fakes Fakes { get; }
+
             public TestableCuratedFeedsController()
             {
+                Fakes = new Fakes();
+
                 StubCuratedFeed = new CuratedFeed
                     { Key = 0, Name = "aName", Managers = new HashSet<User>(new[] { Fakes.User }) };
                 StubCuratedFeedService = new Mock<ICuratedFeedService>();
@@ -73,7 +77,7 @@ namespace NuGetGallery
             public void WillReturn403IfTheCurrentUsersIsNotAManagerOfTheCuratedFeed()
             {
                 var controller = new TestableCuratedFeedsController();
-                controller.SetCurrentUser(Fakes.Owner);
+                controller.SetCurrentUser(controller.Fakes.Owner);
 
                 var result = controller.CuratedFeed("aName") as HttpStatusCodeResult;
 
@@ -100,7 +104,7 @@ namespace NuGetGallery
                 var viewModel = (controller.CuratedFeed("aName") as ViewResult).Model as CuratedFeedViewModel;
 
                 Assert.NotNull(viewModel);
-                Assert.Equal(Fakes.User.Username, viewModel.Managers.First());
+                Assert.Equal(controller.Fakes.User.Username, viewModel.Managers.First());
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/CuratedPackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/CuratedPackagesControllerFacts.cs
@@ -16,8 +16,12 @@ namespace NuGetGallery
     {
         public class TestableCuratedPackagesController : CuratedPackagesController
         {
+            public Fakes Fakes { get; }
+
             public TestableCuratedPackagesController()
             {
+                Fakes = new Fakes();
+
                 StubCuratedFeed = new CuratedFeed
                     { Key = 0, Name = "aFeedName", Managers = new HashSet<User>(new[] { Fakes.User }) };
                 StubPackageRegistration = new PackageRegistration { Key = 0, Id = "anId" };
@@ -52,7 +56,7 @@ namespace NuGetGallery
             public async Task WillReturn404IfTheCuratedFeedDoesNotExist()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 var result = await controller.DeleteCuratedPackage("aStrangeCuratedFeedName", "anId");
 
@@ -63,7 +67,7 @@ namespace NuGetGallery
             public async Task WillReturn404IfTheCuratedPackageDoesNotExist()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
                 controller.StubCuratedFeed.Packages = new[] { new CuratedPackage { PackageRegistration = new PackageRegistration() } };
 
                 var result = await controller.DeleteCuratedPackage("aFeedName", "aStrangeCuratedPackageId");
@@ -75,7 +79,7 @@ namespace NuGetGallery
             public async Task WillReturn403IfTheUserNotAManager()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.Owner);
+                controller.SetCurrentUser(controller.Fakes.Owner);
 
                 controller.StubCuratedFeed.Packages.Add(
                     new CuratedPackage
@@ -96,7 +100,7 @@ namespace NuGetGallery
             public async Task WillDeleteTheCuratedPackageWhenRequestIsValid()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 controller.StubCuratedFeed.Packages.Add(
                     new CuratedPackage
@@ -120,7 +124,7 @@ namespace NuGetGallery
             public async Task WillReturn204AfterDeletingTheCuratedPackage()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 controller.StubCuratedFeed.Packages.Add(
                     new CuratedPackage
@@ -144,7 +148,7 @@ namespace NuGetGallery
             public void WillReturn404IfTheCuratedFeedDoesNotExist()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 var result = controller.GetCreateCuratedPackageForm("aWrongFeedName");
 
@@ -155,7 +159,7 @@ namespace NuGetGallery
             public void WillReturn403IfTheCurrentUsersIsNotAManagerOfTheCuratedFeed()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.Owner);
+                controller.SetCurrentUser(controller.Fakes.Owner);
 
                 var result = controller.GetCreateCuratedPackageForm("aFeedName") as HttpStatusCodeResult;
 
@@ -167,7 +171,7 @@ namespace NuGetGallery
             public void WillPushTheCuratedFeedNameIntoTheViewBag()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
                 controller.StubCuratedFeed.Name = "theCuratedFeedName";
 
                 var result = controller.GetCreateCuratedPackageForm("theCuratedFeedName") as ViewResult;
@@ -183,7 +187,7 @@ namespace NuGetGallery
             public async Task WillReturn404IfTheCuratedFeedDoesNotExist()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 var result = await controller.PatchCuratedPackage("aWrongFeedName", "anId",
                     new ModifyCuratedPackageRequest());
@@ -195,7 +199,7 @@ namespace NuGetGallery
             public async Task WillReturn404IfTheCuratedPackageDoesNotExist()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 var result = await controller.PatchCuratedPackage("aFeedName", "aWrongId", new ModifyCuratedPackageRequest());
 
@@ -206,7 +210,7 @@ namespace NuGetGallery
             public async Task WillReturn403IfNotAFeedManager()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.Owner);
+                controller.SetCurrentUser(controller.Fakes.Owner);
                 controller.StubCuratedFeed.Packages.Add(
                     new CuratedPackage
                     {
@@ -227,7 +231,7 @@ namespace NuGetGallery
             public async Task WillReturn400IfTheModelStateIsInvalid()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
                 controller.StubCuratedFeed.Packages.Add(
                     new CuratedPackage
                     {
@@ -251,7 +255,7 @@ namespace NuGetGallery
             public async Task WillModifyTheCuratedPackageWhenRequestIsValid()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
                 controller.StubCuratedFeed.Packages.Add(
                     new CuratedPackage
                     {
@@ -278,7 +282,7 @@ namespace NuGetGallery
             public async Task WillReturn204AfterModifyingTheCuratedPackage()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
                 controller.StubCuratedFeed.Packages.Add(
                     new CuratedPackage
                     {
@@ -303,7 +307,7 @@ namespace NuGetGallery
             public async Task WillReturn404IfTheCuratedFeedDoesNotExist()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 var result = await controller.PostCuratedPackages(
                     "aWrongFeedName",
@@ -316,7 +320,7 @@ namespace NuGetGallery
             public async Task WillReturn403IfTheCurrentUsersIsNotAManagerOfTheCuratedFeed()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.Owner);
+                controller.SetCurrentUser(controller.Fakes.Owner);
 
                 var result = await controller.PostCuratedPackages(
                     "aFeedName",
@@ -331,7 +335,7 @@ namespace NuGetGallery
             public async Task WillPushTheCuratedFeedNameIntoTheViewBagAndShowTheCreateCuratedPackageFormWithErrorsWhenModelStateIsInvalid()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
                 controller.StubCuratedFeed.Name = "theCuratedFeedName";
                 controller.ModelState.AddModelError("", "anError");
 
@@ -347,7 +351,7 @@ namespace NuGetGallery
             public async Task WillPushTheCuratedFeedNameIntoTheViewBagAndShowTheCreateCuratedPackageFormWithErrorsWhenThePackageIdDoesNotExist()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 var result = await controller.PostCuratedPackages("aFeedName",
                     new CreateCuratedPackageRequest { PackageId = "aWrongId" }) as ViewResult;
@@ -362,7 +366,7 @@ namespace NuGetGallery
             public async Task WillCreateTheCuratedPackage()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 await controller.PostCuratedPackages(
                     "aFeedName",
@@ -383,7 +387,7 @@ namespace NuGetGallery
             public async Task WillRedirectToTheCuratedFeedRouteAfterCreatingTheCuratedPackage()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
 
                 var result = await controller.PostCuratedPackages(
                     "aFeedName", new CreateCuratedPackageRequest { PackageId = "anId" })
@@ -397,7 +401,7 @@ namespace NuGetGallery
             public async Task WillShowAnErrorWhenThePackageHasAlreadyBeenCurated()
             {
                 var controller = new TestableCuratedPackagesController();
-                controller.SetCurrentUser(Fakes.User);
+                controller.SetCurrentUser(controller.Fakes.User);
                 controller.StubCuratedFeed.Packages.Add(
                     new CuratedPackage {
                         CuratedFeed = controller.StubCuratedFeed,

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -53,7 +53,8 @@ namespace NuGetGallery
             public void LoadsDescriptionsOfCredentialsInToViewModel()
             {
                 // Arrange
-                var user = Fakes.CreateUser(
+                var fakes = Get<Fakes>();
+                var user = fakes.CreateUser(
                     "test",
                     CredentialBuilder.CreatePbkdf2Password("hunter2"),
                     CredentialBuilder.CreateV1ApiKey(Guid.NewGuid(), Fakes.ExpirationForApiKeyV1),
@@ -741,7 +742,8 @@ namespace NuGetGallery
             public async Task GivenNoOldPassword_ItSendsAPasswordSetEmail()
             {
                 // Arrange
-                var user = Fakes.CreateUser("test");
+                var fakes = Get<Fakes>();
+                var user = fakes.CreateUser("test");
                 user.EmailAddress = "confirmed@example.com";
 
                 GetMock<AuthenticationService>()
@@ -773,7 +775,8 @@ namespace NuGetGallery
             public async Task GivenNoOtherLoginCredentials_ItRedirectsBackWithAnErrorMessage()
             {
                 // Arrange
-                var user = Fakes.CreateUser("test",
+                var fakes = Get<Fakes>();
+                var user = fakes.CreateUser("test",
                     CredentialBuilder.CreatePbkdf2Password("password"));
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
@@ -791,7 +794,8 @@ namespace NuGetGallery
             public async Task GivenNoPassword_ItRedirectsBackWithNoChangesMade()
             {
                 // Arrange
-                var user = Fakes.CreateUser("test",
+                var fakes = Get<Fakes>();
+                var user = fakes.CreateUser("test",
                     CredentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "bloog"));
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
@@ -809,8 +813,9 @@ namespace NuGetGallery
             public async Task GivenValidRequest_ItRemovesCredAndSendsNotificationToUser()
             {
                 // Arrange
+                var fakes = Get<Fakes>();
                 var cred = CredentialBuilder.CreatePbkdf2Password("password");
-                var user = Fakes.CreateUser("test",
+                var user = fakes.CreateUser("test",
                     cred,
                     CredentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "bloog"));
 
@@ -841,8 +846,9 @@ namespace NuGetGallery
             public async Task GivenNoOtherLoginCredentials_ItRedirectsBackWithAnErrorMessage()
             {
                 // Arrange
+                var fakes = Get<Fakes>();
                 var cred = CredentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "bloog");
-                var user = Fakes.CreateUser("test", cred);
+                var user = fakes.CreateUser("test", cred);
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
@@ -859,7 +865,8 @@ namespace NuGetGallery
             public async Task GivenNoCredential_ItRedirectsBackWithNoChangesMade()
             {
                 // Arrange
-                var user = Fakes.CreateUser("test",
+                var fakes = Get<Fakes>();
+                var user = fakes.CreateUser("test",
                     CredentialBuilder.CreatePbkdf2Password("password"));
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
@@ -877,8 +884,9 @@ namespace NuGetGallery
             public async Task GivenValidRequest_ItRemovesCredAndSendsNotificationToUser()
             {
                 // Arrange
+                var fakes = Get<Fakes>();
                 var cred = CredentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "bloog");
-                var user = Fakes.CreateUser("test",
+                var user = fakes.CreateUser("test",
                     cred,
                     CredentialBuilder.CreatePbkdf2Password("password"));
 

--- a/tests/NuGetGallery.Facts/Framework/Fakes.cs
+++ b/tests/NuGetGallery.Facts/Framework/Fakes.cs
@@ -11,56 +11,76 @@ using Moq;
 
 namespace NuGetGallery.Framework
 {
-    public static class Fakes
+    public class Fakes
     {
         public static TimeSpan ExpirationForApiKeyV1 =  TimeSpan.FromDays(90);
 
         public static readonly string Password = "p@ssw0rd!";
-
-        public static readonly User User = new User("testUser")
+        
+        public Fakes()
         {
-            Key = 42,
-            EmailAddress = "confirmed1@example.com",
-            Credentials = new List<Credential>() {
-                CredentialBuilder.CreatePbkdf2Password(Password),
-                CredentialBuilder.CreateV1ApiKey(Guid.Parse("519e180e-335c-491a-ac26-e83c4bd31d65"), ExpirationForApiKeyV1)
-            }
-        };
+            User = new User("testUser")
+            {
+                Key = 42,
+                EmailAddress = "confirmed1@example.com",
+                Credentials = new List<Credential>
+                {
+                    CredentialBuilder.CreatePbkdf2Password(Password),
+                    CredentialBuilder.CreateV1ApiKey(Guid.Parse("519e180e-335c-491a-ac26-e83c4bd31d65"),
+                        ExpirationForApiKeyV1)
+                }
+            };
 
-        public static readonly User ShaUser = new User("testShaUser")
-        {
-            Key = 42,
-            EmailAddress = "confirmed2@example.com",
-            Credentials = new List<Credential>() {
-                CredentialBuilder.CreateSha1Password(Password),
-                CredentialBuilder.CreateV1ApiKey(Guid.Parse("b9704a41-4107-4cd2-bcfa-70d84e021ab2"), ExpirationForApiKeyV1)
-            }
-        };
+            ShaUser = new User("testShaUser")
+            {
+                Key = 42,
+                EmailAddress = "confirmed2@example.com",
+                Credentials = new List<Credential>
+                {
+                    CredentialBuilder.CreateSha1Password(Password),
+                    CredentialBuilder.CreateV1ApiKey(Guid.Parse("b9704a41-4107-4cd2-bcfa-70d84e021ab2"),
+                        ExpirationForApiKeyV1)
+                }
+            };
 
-        public static readonly User Admin = new User("testAdmin") {
-            Key = 43,
-            EmailAddress = "confirmed3@example.com",
-            Credentials = new List<Credential>() { CredentialBuilder.CreatePbkdf2Password(Password) },
-            Roles = new List<Role>() { new Role() { Name = Constants.AdminRoleName } }
-        };
+            Admin = new User("testAdmin")
+            {
+                Key = 43,
+                EmailAddress = "confirmed3@example.com",
+                Credentials = new List<Credential> {CredentialBuilder.CreatePbkdf2Password(Password)},
+                Roles = new List<Role> {new Role {Name = Constants.AdminRoleName}}
+            };
 
-        public static readonly User Owner = new User("testPackageOwner") {
-            Key = 44,
-            Credentials = new List<Credential>() { CredentialBuilder.CreatePbkdf2Password(Password) },
-            EmailAddress = "confirmed@example.com" //package owners need confirmed email addresses, obviously.
-        };
+            Owner = new User("testPackageOwner")
+            {
+                Key = 44,
+                Credentials = new List<Credential> {CredentialBuilder.CreatePbkdf2Password(Password)},
+                EmailAddress = "confirmed@example.com" //package owners need confirmed email addresses, obviously.
+            };
 
-        public static readonly PackageRegistration Package = new PackageRegistration()
-        {
-            Id = "FakePackage",
-            Owners = new List<User>() { Owner },
-            Packages = new List<Package>() {
-                new Package() { Version = "1.0" },
-                new Package() { Version = "2.0" }
-            }
-        };
+            Package = new PackageRegistration
+            {
+                Id = "FakePackage",
+                Owners = new List<User> {Owner},
+                Packages = new List<Package>
+                {
+                    new Package {Version = "1.0"},
+                    new Package {Version = "2.0"}
+                }
+            };
+        }
 
-        public static User CreateUser(string userName, params Credential[] credentials)
+        public User User { get; }
+
+        public User ShaUser { get; }
+
+        public User Admin { get; }
+
+        public User Owner { get; }
+
+        public PackageRegistration Package { get; }
+
+        public User CreateUser(string userName, params Credential[] credentials)
         {
             return new User(userName)
             {
@@ -69,7 +89,7 @@ namespace NuGetGallery.Framework
             };
         }
 
-        public static ClaimsPrincipal ToPrincipal(this User user)
+        public static ClaimsPrincipal ToPrincipal(User user)
         {
             ClaimsIdentity identity = new ClaimsIdentity(
                 claims: Enumerable.Concat(new[] {
@@ -82,12 +102,12 @@ namespace NuGetGallery.Framework
             return new ClaimsPrincipal(identity);
         }
 
-        public static IIdentity ToIdentity(this User user)
+        public static IIdentity ToIdentity(User user)
         {
              return new GenericIdentity(user.Username);
         }
 
-        internal static void ConfigureEntitiesContext(FakeEntitiesContext ctxt)
+        internal void ConfigureEntitiesContext(FakeEntitiesContext ctxt)
         {
             // Add Users
             var users = ctxt.Set<User>();

--- a/tests/NuGetGallery.Facts/Framework/TestContainer.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestContainer.cs
@@ -65,7 +65,12 @@ namespace NuGetGallery.Framework
 
         protected FakeEntitiesContext GetFakeContext()
         {
-            var fakeContext = new FakeEntitiesContext();
+            var fakeContext = Container.Resolve<IEntitiesContext>() as FakeEntitiesContext;
+
+            if (fakeContext == null)
+            {
+                fakeContext = new FakeEntitiesContext();
+            }
 
             var updater = new ContainerBuilder();
             updater.RegisterInstance(fakeContext).As<IEntitiesContext>();
@@ -86,9 +91,10 @@ namespace NuGetGallery.Framework
 
         protected T Get<T>()
         {
-            if(typeof(Controller).IsAssignableFrom(typeof(T))) {
+            if (typeof(Controller).IsAssignableFrom(typeof(T))) {
                 throw new InvalidOperationException("Use GetController<T> to get a controller instance");
             }
+
             return Container.Resolve<T>();
         }
 

--- a/tests/NuGetGallery.Facts/Framework/UnitTestBindings.cs
+++ b/tests/NuGetGallery.Facts/Framework/UnitTestBindings.cs
@@ -34,6 +34,12 @@ namespace NuGetGallery.Framework
 
         protected override void Load(ContainerBuilder builder)
         {
+            var fakes = new Fakes();
+
+            builder.RegisterInstance(fakes)
+                .As<Fakes>()
+                .SingleInstance();
+
             builder.RegisterType<TestAuditingService>()
                 .As<AuditingService>();
 
@@ -52,8 +58,8 @@ namespace NuGetGallery.Framework
                     {
                         var mockService = new Mock<IPackageService>();
                         mockService
-                            .Setup(p => p.FindPackageRegistrationById(Fakes.Package.Id))
-                            .Returns(Fakes.Package);
+                            .Setup(p => p.FindPackageRegistrationById(fakes.Package.Id))
+                            .Returns(fakes.Package);
                         return mockService.Object;
                     })
                 .As<IPackageService>()
@@ -62,9 +68,9 @@ namespace NuGetGallery.Framework
             builder.Register(_ =>
             {
                 var mockService = new Mock<IUserService>();
-                mockService.Setup(u => u.FindByUsername(Fakes.User.Username)).Returns(Fakes.User);
-                mockService.Setup(u => u.FindByUsername(Fakes.Owner.Username)).Returns(Fakes.Owner);
-                mockService.Setup(u => u.FindByUsername(Fakes.Admin.Username)).Returns(Fakes.Admin);
+                mockService.Setup(u => u.FindByUsername(fakes.User.Username)).Returns(fakes.User);
+                mockService.Setup(u => u.FindByUsername(fakes.Owner.Username)).Returns(fakes.Owner);
+                mockService.Setup(u => u.FindByUsername(fakes.Admin.Username)).Returns(fakes.Admin);
                 return mockService.Object;
             })
                 .As<IUserService>()
@@ -73,7 +79,7 @@ namespace NuGetGallery.Framework
             builder.Register(_ =>
                     {
                         var ctxt = new FakeEntitiesContext();
-                        Fakes.ConfigureEntitiesContext(ctxt);
+                        fakes.ConfigureEntitiesContext(ctxt);
                         return ctxt;
                     })
                 .As<IEntitiesContext>()


### PR DESCRIPTION
The `Fakes` object used by our tests was static, and thus shared across tests. When a test would remove, for example, a credential from this static object, other tests would fail when depending on that credential being there.

This PR makes the `Fakes` object non-static, so that each test uses a fresh copy of test data.

Ran this build a number of times, seems to fix the sporadic failures properly. (https://github.com/NuGet/NuGetGallery/issues/3105)

@skofman1 @ryuyu @scottbommarito @xavierdecoster 