### PR TITLE
Change routes from packages/<action> to packages/manage/<action> to avoid conflicts with package ids

### DIFF
--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -101,22 +101,22 @@ namespace NuGetGallery
 
             var uploadPackageRoute = routes.MapRoute(
                 RouteName.UploadPackage,
-                "packages/upload",
+                "packages/manage/upload",
                 new { controller = "Packages", action = "UploadPackage" });
 
             routes.MapRoute(
                 RouteName.UploadPackageProgress,
-                "packages/upload-progress",
+                "packages/manage/upload-progress",
                 new { controller = "Packages", action = "UploadPackageProgress" });
 
             routes.MapRoute(
                 RouteName.VerifyPackage,
-                "packages/verify-upload",
+                "packages/manage/verify-upload",
                 new { controller = "Packages", action = "VerifyPackage" });
 
             routes.MapRoute(
                 RouteName.CancelUpload,
-                "packages/cancel-upload",
+                "packages/manage/cancel-upload",
                 new { controller = "Packages", action = "CancelUpload" });
 
             routes.MapRoute(

--- a/src/NuGetGallery/Public/Blocked.html
+++ b/src/NuGetGallery/Public/Blocked.html
@@ -18,7 +18,7 @@
                     <li><a href="/">Home</a></li>
                     <li><a href="/Packages">Packages</a></li>
                     <li><a href="http://docs.nuget.org">Documentation</a></li>
-                    <li><a href="/packages/upload" class="upload">Upload Package</a></li>
+                    <li><a href="/packages/manage/upload" class="upload">Upload Package</a></li>
                 </ul>
             </nav>
             <div id="body">

--- a/src/NuGetGallery/Public/Error.html
+++ b/src/NuGetGallery/Public/Error.html
@@ -18,7 +18,7 @@
                     <li><a href="../">Home</a></li>
                     <li><a href="../Packages">Packages</a></li>
                     <li><a href="https://docs.nuget.org">Documentation</a></li>
-                    <li><a href="../packages/upload" class="upload">Upload Package</a></li>
+                    <li><a href="../packages/manage/upload" class="upload">Upload Package</a></li>
                 </ul>
             </nav>
             <div id="body">

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/UrlHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/UrlHelper.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery.FunctionalTests
     {
         private const string _logonPageUrlSuffix = "/users/account/LogOn";
         private const string _editUrlSuffix = "/packages/{0}/{1}/Edit";
-        private const string _cancelUrlSuffix = "packages/cancel-upload";
+        private const string _cancelUrlSuffix = "packages/manage/cancel-upload";
         private const string _signInPageUrlSuffix = "/users/account/SignIn";
         private const string _logOffPageUrlSuffix = "/users/account/LogOff?returnUrl=%2F";
         private const string _logonPageUrlOnPackageUploadSuffix = "Users/Account/LogOn?ReturnUrl=%2fpackages%2fupload";
@@ -21,8 +21,8 @@ namespace NuGetGallery.FunctionalTests
         private const string _registrationPendingPageUrlSuffix = "account/Thanks";
         private const string _statsPageUrlSuffix = "stats";
         private const string _aggregateStatsPageUrlSuffix = "/stats/totals";
-        private const string _uploadPageUrlSuffix = "/packages/Upload";
-        private const string _verifyUploadPageUrlSuffix = "/packages/verify-upload";
+        private const string _uploadPageUrlSuffix = "/packages/manage/Upload";
+        private const string _verifyUploadPageUrlSuffix = "/packages/manage/verify-upload";
         private const string _windows8CuratedFeedUrlSuffix = "curated-feeds/windows8-packages/";
         private const string _webMatrixCuratedFeedUrlSuffix = "curated-feeds/webmatrix/";
         private const string _dotnetCuratedFeedUrlSuffix = "curated-feeds/microsoftdotnet/";

--- a/tests/NuGetGallery.FunctionalTests.Fluent/ExtensionMethods.cs
+++ b/tests/NuGetGallery.FunctionalTests.Fluent/ExtensionMethods.cs
@@ -23,7 +23,7 @@ namespace NuGetGallery.FunctionalTests.Fluent
             I.Open(string.Format(UrlHelper.UploadPageUrl));
             try
             {
-                I.Expect.Url(x => x.AbsoluteUri.Contains("/packages/Upload"));
+                I.Expect.Url(x => x.AbsoluteUri.Contains("/packages/manage/Upload"));
             }
             catch
             {

--- a/tests/NuGetGallery.FunctionalTests.Fluent/Pages.csv
+++ b/tests/NuGetGallery.FunctionalTests.Fluent/Pages.csv
@@ -1,7 +1,7 @@
 ﻿Page
 /
 /packages
-/packages/upload
+/packages/manage/upload
 /stats
 /policies/Contact
 /policies/Terms


### PR DESCRIPTION
Currently, if someone creates a package with an id of "upload", "upload-progress", "verify-upload", or "cancel-upload", they can potentially run into conflicts with our routing scheme. In other words, a package with an id of "upload" would be impossible to view through `packages/<id>`, because MVC would route it to our upload package path route, `packages/upload`.

To avoid conflicts with our system, this PR changes those routes to `packages/manage/upload` and so on. Since `packages/<id>` and `packages/manage/<action>` are now completely distinct routes, users can upload a package with an id equal to any of our actions and view it without any issues. Note that a package id of "manage" is also still supported.

Will be making some additional PRs in different repos to update the references to the old route URLs.

@maartenba @skofman1 @xavierdecoster 

(Fixes #3130)