### PR TITLE
 Align package id validation with the client

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -5,6 +5,6 @@ namespace NuGetGallery
 {
     public static class CoreConstants
     {
-        public const int MaxPackageIdLength = 128;
+        public const int MaxPackageIdLength = 100;
     }
 }

--- a/src/NuGetGallery.Core/Packaging/PackageIdValidator.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageIdValidator.cs
@@ -17,12 +17,6 @@ namespace NuGetGallery.Packaging
             {
                 throw new ArgumentNullException(nameof(packageId));
             }
-
-            if (String.Equals(packageId, "$id$", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
             return IdRegex.IsMatch(packageId);
         }
 


### PR DESCRIPTION
Synced up to be identical to
https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/PackageCreation/Utility/PackageIdValidator.cs

We have an extra null check but I think it's fine.

(Fixes https://github.com/NuGet/NuGetGallery/issues/3142)

@maartenba @xavierdecoster @emgarten 