### PR TITLE
Fix opensearch for usage with Firefox

### DIFF
--- a/src/NuGetGallery/Public/opensearch.xml
+++ b/src/NuGetGallery/Public/opensearch.xml
@@ -1,4 +1,4 @@
-<OpenSearchDescription>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>NuGet packages</ShortName>
   <Description>Search NuGet packages</Description>
   <Tags>nuget package component</Tags>


### PR DESCRIPTION
There's apparently a problem with opensearch on NuGet gallery when used with current versions of Mozilla Firefox / Firefox Developer Edition.
I am the person who contributed opensearch functionality (PR: #2833, deployed in #2685), and now I suggest this fix to solve the issue with Firefox-based browsers.