### PR TITLE
Fix casing for release notes metadata tag in NupkgRewriter

### DIFF
--- a/src/NuGetGallery.Core/Packaging/NupkgRewriter.cs
+++ b/src/NuGetGallery.Core/Packaging/NupkgRewriter.cs
@@ -61,12 +61,12 @@ namespace NuGetGallery.Packaging
                     IconUrl = ReadFromMetadata(metadataNode, "iconUrl"),
                     LicenseUrl = ReadFromMetadata(metadataNode, "licenseUrl"),
                     ProjectUrl = ReadFromMetadata(metadataNode, "projectUrl"),
-                    ReleaseNotes = ReadFromMetadata(metadataNode, "releasenotes"),
+                    ReleaseNotes = ReadFromMetadata(metadataNode, "releaseNotes"),
                     RequireLicenseAcceptance = ReadBoolFromMetadata(metadataNode, "requireLicenseAcceptance"),
                     Summary = ReadFromMetadata(metadataNode, "summary"),
                     Tags = ReadFromMetadata(metadataNode, "tags")
                 };
-                
+
                 // Perform edits
                 foreach (var edit in edits)
                 {
@@ -81,11 +81,11 @@ namespace NuGetGallery.Packaging
                 WriteToMetadata(metadataNode, "iconUrl", editableManifestElements.IconUrl);
                 WriteToMetadata(metadataNode, "licenseUrl", editableManifestElements.LicenseUrl);
                 WriteToMetadata(metadataNode, "projectUrl", editableManifestElements.ProjectUrl);
-                WriteToMetadata(metadataNode, "releasenotes", editableManifestElements.ReleaseNotes);
+                WriteToMetadata(metadataNode, "releaseNotes", editableManifestElements.ReleaseNotes);
                 WriteToMetadata(metadataNode, "requireLicenseAcceptance", editableManifestElements.RequireLicenseAcceptance.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
                 WriteToMetadata(metadataNode, "summary", editableManifestElements.Summary);
                 WriteToMetadata(metadataNode, "tags", editableManifestElements.Tags);
-                
+
                 // Update the package stream
                 using (var newManifestStream = new MemoryStream())
                 {

--- a/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
@@ -24,7 +24,8 @@ namespace NuGetGallery.Packaging
                     new List<Action<ManifestEdit>>
                     {
                         metadata => { metadata.Authors = "Me and You"; },
-                        metadata => { metadata.Tags = "Peas In A Pod"; }
+                        metadata => { metadata.Tags = "Peas In A Pod"; },
+                        metadata => { metadata.ReleaseNotes = "In perfect harmony we're bobbing our heads to the groove"; }
                     });
 
             // Assert
@@ -36,6 +37,7 @@ namespace NuGetGallery.Packaging
                 Assert.Equal(NuGetVersion.Parse("0.0.0.1"), nuspec.GetVersion());
                 Assert.Equal("Me and You", nuspec.GetMetadata().First(kvp => kvp.Key == "authors").Value);
                 Assert.Equal("Peas In A Pod", nuspec.GetMetadata().First(kvp => kvp.Key == "tags").Value);
+                Assert.Equal("In perfect harmony we're bobbing our heads to the groove", nuspec.GetMetadata().First(kvp => kvp.Key == "releaseNotes").Value);
             }
         }
 

--- a/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
@@ -25,7 +25,7 @@ namespace NuGetGallery.Packaging
                     {
                         metadata => { metadata.Authors = "Me and You"; },
                         metadata => { metadata.Tags = "Peas In A Pod"; },
-                        metadata => { metadata.ReleaseNotes = "In perfect harmony we're bobbing our heads to the groove"; }
+                        metadata => { metadata.ReleaseNotes = "In perfect harmony"; }
                     });
 
             // Assert
@@ -37,7 +37,7 @@ namespace NuGetGallery.Packaging
                 Assert.Equal(NuGetVersion.Parse("0.0.0.1"), nuspec.GetVersion());
                 Assert.Equal("Me and You", nuspec.GetMetadata().First(kvp => kvp.Key == "authors").Value);
                 Assert.Equal("Peas In A Pod", nuspec.GetMetadata().First(kvp => kvp.Key == "tags").Value);
-                Assert.Equal("In perfect harmony we're bobbing our heads to the groove", nuspec.GetMetadata().First(kvp => kvp.Key == "releaseNotes").Value);
+                Assert.Equal("In perfect harmony", nuspec.GetMetadata().First(kvp => kvp.Key == "releaseNotes").Value);
             }
         }
 


### PR DESCRIPTION
The NugetGallery.Core's repackaging would rewrite the package manifest with incorrect tag for release notes (HandlePackageEdits uses this functionality). This fails to open up the package in 'Nuget Package Explorer'. This PR simply fixes the tag.