### PR TITLE
Fix NugetGallery.Core's NupkgRewriter

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Packaging\NupkgRewriter.cs" />
     <Compile Include="Packaging\PackageIdValidator.cs" />
     <Compile Include="Packaging\PackageMetadata.cs" />
+    <Compile Include="Packaging\PackageMetadataStrings.cs" />
     <Compile Include="Packaging\PackageStreamMetadata.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NuGetVersionExtensions.cs" />

--- a/src/NuGetGallery.Core/Packaging/ManifestEdit.cs
+++ b/src/NuGetGallery.Core/Packaging/ManifestEdit.cs
@@ -18,6 +18,7 @@ namespace NuGetGallery.Packaging
         public bool RequireLicenseAcceptance { get; set; }
         public string Summary { get; set; }
         public string Tags { get; set; }
+
         public object Clone()
         {
             return this.MemberwiseClone();

--- a/src/NuGetGallery.Core/Packaging/ManifestEdit.cs
+++ b/src/NuGetGallery.Core/Packaging/ManifestEdit.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 
 namespace NuGetGallery.Packaging

--- a/src/NuGetGallery.Core/Packaging/ManifestEdit.cs
+++ b/src/NuGetGallery.Core/Packaging/ManifestEdit.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace NuGetGallery.Packaging
 {
-    public class ManifestEdit
+    public class ManifestEdit : ICloneable
     {
         public string Title { get; set; }
         public string Authors { get; set; }
@@ -13,5 +15,9 @@ namespace NuGetGallery.Packaging
         public bool RequireLicenseAcceptance { get; set; }
         public string Summary { get; set; }
         public string Tags { get; set; }
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
     }
 }

--- a/src/NuGetGallery.Core/Packaging/NupkgRewriter.cs
+++ b/src/NuGetGallery.Core/Packaging/NupkgRewriter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -45,26 +46,26 @@ namespace NuGetGallery.Packaging
 
                 // Read <metadata> node from nuspec
                 var metadataNode = nuspecReader.Xml.Root.Elements()
-                    .FirstOrDefault(e => StringComparer.Ordinal.Equals(e.Name.LocalName, "metadata"));
+                    .FirstOrDefault(e => StringComparer.Ordinal.Equals(e.Name.LocalName, PackageMetadataStrings.Metadata));
                 if (metadataNode == null)
                 {
-                    throw new PackagingException("The package manifest is missing the 'metadata' node.");
+                    throw new PackagingException($"The package manifest is missing the '{PackageMetadataStrings.Metadata}' node.");
                 }
 
                 // Convert metadata into a ManifestEdit so that we can run it through the editing pipeline
                 var editableManifestElements = new ManifestEdit
                 {
-                    Title = ReadFromMetadata(metadataNode, "title"),
-                    Authors = ReadFromMetadata(metadataNode, "authors"),
-                    Copyright = ReadFromMetadata(metadataNode, "copyright"),
-                    Description = ReadFromMetadata(metadataNode, "description"),
-                    IconUrl = ReadFromMetadata(metadataNode, "iconUrl"),
-                    LicenseUrl = ReadFromMetadata(metadataNode, "licenseUrl"),
-                    ProjectUrl = ReadFromMetadata(metadataNode, "projectUrl"),
-                    ReleaseNotes = ReadFromMetadata(metadataNode, "releaseNotes"),
-                    RequireLicenseAcceptance = ReadBoolFromMetadata(metadataNode, "requireLicenseAcceptance"),
-                    Summary = ReadFromMetadata(metadataNode, "summary"),
-                    Tags = ReadFromMetadata(metadataNode, "tags")
+                    Title = ReadFromMetadata(metadataNode, PackageMetadataStrings.Title),
+                    Authors = ReadFromMetadata(metadataNode, PackageMetadataStrings.Authors),
+                    Copyright = ReadFromMetadata(metadataNode, PackageMetadataStrings.Copyright),
+                    Description = ReadFromMetadata(metadataNode, PackageMetadataStrings.Description),
+                    IconUrl = ReadFromMetadata(metadataNode, PackageMetadataStrings.IconUrl),
+                    LicenseUrl = ReadFromMetadata(metadataNode, PackageMetadataStrings.LicenseUrl),
+                    ProjectUrl = ReadFromMetadata(metadataNode, PackageMetadataStrings.ProjectUrl),
+                    ReleaseNotes = ReadFromMetadata(metadataNode, PackageMetadataStrings.ReleaseNotes),
+                    RequireLicenseAcceptance = ReadBoolFromMetadata(metadataNode, PackageMetadataStrings.RequireLicenseAcceptance),
+                    Summary = ReadFromMetadata(metadataNode, PackageMetadataStrings.Summary),
+                    Tags = ReadFromMetadata(metadataNode, PackageMetadataStrings.Tags)
                 };
 
                 var originalManifestElements = (ManifestEdit)editableManifestElements.Clone();
@@ -82,57 +83,57 @@ namespace NuGetGallery.Packaging
                 // Defined by spec here: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
                 if (originalManifestElements.Title != editableManifestElements.Title)
                 {
-                    WriteToMetadata(metadataNode, "title", editableManifestElements.Title, /*canBeRemoved*/ true);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.Title, editableManifestElements.Title, /*canBeRemoved*/ true);
                 }
 
                 if (originalManifestElements.Authors != editableManifestElements.Authors)
                 {
-                    WriteToMetadata(metadataNode, "authors", editableManifestElements.Authors);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.Authors, editableManifestElements.Authors);
                 }
 
                 if (originalManifestElements.Copyright != editableManifestElements.Copyright)
                 {
-                    WriteToMetadata(metadataNode, "copyright", editableManifestElements.Copyright, /*canBeRemoved*/ true);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.Copyright, editableManifestElements.Copyright, /*canBeRemoved*/ true);
                 }
 
                 if (originalManifestElements.Description != editableManifestElements.Description)
                 {
-                    WriteToMetadata(metadataNode, "description", editableManifestElements.Description);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.Description, editableManifestElements.Description);
                 }
 
                 if (originalManifestElements.IconUrl != editableManifestElements.IconUrl)
                 {
-                    WriteToMetadata(metadataNode, "iconUrl", editableManifestElements.IconUrl, /*canBeRemoved*/ true);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.IconUrl, editableManifestElements.IconUrl, /*canBeRemoved*/ true);
                 }
 
                 if (originalManifestElements.LicenseUrl != editableManifestElements.LicenseUrl)
                 {
-                    WriteToMetadata(metadataNode, "licenseUrl", editableManifestElements.LicenseUrl, /*canBeRemoved*/ true);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.LicenseUrl, editableManifestElements.LicenseUrl, /*canBeRemoved*/ true);
                 }
 
                 if (originalManifestElements.ProjectUrl != editableManifestElements.ProjectUrl)
                 {
-                    WriteToMetadata(metadataNode, "projectUrl", editableManifestElements.ProjectUrl, /*canBeRemoved*/ true);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.ProjectUrl, editableManifestElements.ProjectUrl, /*canBeRemoved*/ true);
                 }
 
                 if (originalManifestElements.ReleaseNotes != editableManifestElements.ReleaseNotes)
                 {
-                    WriteToMetadata(metadataNode, "releaseNotes", editableManifestElements.ReleaseNotes, /*canBeRemoved*/ true);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.ReleaseNotes, editableManifestElements.ReleaseNotes, /*canBeRemoved*/ true);
                 }
 
                 if (originalManifestElements.RequireLicenseAcceptance != editableManifestElements.RequireLicenseAcceptance)
                 {
-                    WriteToMetadata(metadataNode, "requireLicenseAcceptance", editableManifestElements.RequireLicenseAcceptance.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.RequireLicenseAcceptance, editableManifestElements.RequireLicenseAcceptance.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
                 }
 
                 if (originalManifestElements.Summary != editableManifestElements.Summary)
                 {
-                    WriteToMetadata(metadataNode, "summary", editableManifestElements.Summary, /*canBeRemoved*/ true);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.Summary, editableManifestElements.Summary, /*canBeRemoved*/ true);
                 }
 
                 if (originalManifestElements.Tags != editableManifestElements.Tags)
                 {
-                    WriteToMetadata(metadataNode, "tags", editableManifestElements.Tags, /*canBeRemoved*/ true);
+                    WriteToMetadata(metadataNode, PackageMetadataStrings.Tags, editableManifestElements.Tags, /*canBeRemoved*/ true);
                 }
 
                 // Update the package stream

--- a/src/NuGetGallery.Core/Packaging/NupkgRewriter.cs
+++ b/src/NuGetGallery.Core/Packaging/NupkgRewriter.cs
@@ -81,19 +81,19 @@ namespace NuGetGallery.Packaging
                 // 2. Remove the empty/null elements from metadata after edit
                 // Apart from Authors, Description, Id and Version all other elements are optional.
                 // Defined by spec here: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
-                WriteToMetadata(metadataNode, PackageMetadataStrings.Title, originalManifestElements.Title, editableManifestElements.Title, /*canBeRemoved*/ true);
+                WriteToMetadata(metadataNode, PackageMetadataStrings.Title, originalManifestElements.Title, editableManifestElements.Title, canBeRemoved: true);
                 WriteToMetadata(metadataNode, PackageMetadataStrings.Authors, originalManifestElements.Authors, editableManifestElements.Authors);
-                WriteToMetadata(metadataNode, PackageMetadataStrings.Copyright, originalManifestElements.Copyright, editableManifestElements.Copyright, /*canBeRemoved*/ true);
+                WriteToMetadata(metadataNode, PackageMetadataStrings.Copyright, originalManifestElements.Copyright, editableManifestElements.Copyright, canBeRemoved: true);
                 WriteToMetadata(metadataNode, PackageMetadataStrings.Description, originalManifestElements.Description, editableManifestElements.Description);
-                WriteToMetadata(metadataNode, PackageMetadataStrings.IconUrl, originalManifestElements.IconUrl, editableManifestElements.IconUrl, /*canBeRemoved*/ true);
-                WriteToMetadata(metadataNode, PackageMetadataStrings.LicenseUrl, originalManifestElements.LicenseUrl, editableManifestElements.LicenseUrl, /*canBeRemoved*/ true);
-                WriteToMetadata(metadataNode, PackageMetadataStrings.ProjectUrl, originalManifestElements.ProjectUrl, editableManifestElements.ProjectUrl, /*canBeRemoved*/ true);
-                WriteToMetadata(metadataNode, PackageMetadataStrings.ReleaseNotes, originalManifestElements.ReleaseNotes, editableManifestElements.ReleaseNotes, /*canBeRemoved*/ true);
+                WriteToMetadata(metadataNode, PackageMetadataStrings.IconUrl, originalManifestElements.IconUrl, editableManifestElements.IconUrl, canBeRemoved: true);
+                WriteToMetadata(metadataNode, PackageMetadataStrings.LicenseUrl, originalManifestElements.LicenseUrl, editableManifestElements.LicenseUrl, canBeRemoved: true);
+                WriteToMetadata(metadataNode, PackageMetadataStrings.ProjectUrl, originalManifestElements.ProjectUrl, editableManifestElements.ProjectUrl, canBeRemoved: true);
+                WriteToMetadata(metadataNode, PackageMetadataStrings.ReleaseNotes, originalManifestElements.ReleaseNotes, editableManifestElements.ReleaseNotes, canBeRemoved: true);
                 WriteToMetadata(metadataNode, PackageMetadataStrings.RequireLicenseAcceptance,
                     originalManifestElements.RequireLicenseAcceptance.ToString(CultureInfo.InvariantCulture).ToLowerInvariant(),
                     editableManifestElements.RequireLicenseAcceptance.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
-                WriteToMetadata(metadataNode, PackageMetadataStrings.Summary, originalManifestElements.Summary, editableManifestElements.Summary, /*canBeRemoved*/ true);
-                WriteToMetadata(metadataNode, PackageMetadataStrings.Tags, originalManifestElements.Tags, editableManifestElements.Tags, /*canBeRemoved*/ true);
+                WriteToMetadata(metadataNode, PackageMetadataStrings.Summary, originalManifestElements.Summary, editableManifestElements.Summary, canBeRemoved: true);
+                WriteToMetadata(metadataNode, PackageMetadataStrings.Tags, originalManifestElements.Tags, editableManifestElements.Tags, canBeRemoved: true);
 
                 // Update the package stream
                 using (var newManifestStream = new MemoryStream())

--- a/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
@@ -45,21 +45,21 @@ namespace NuGetGallery.Packaging
                 Version = nugetVersion;
             }
 
-            IconUrl = GetValue("iconUrl", (Uri) null);
-            ProjectUrl = GetValue("projectUrl", (Uri) null);
-            LicenseUrl = GetValue("licenseUrl", (Uri) null);
-            Copyright = GetValue("copyright", (string) null);
-            Description = GetValue("description", (string) null);
-            ReleaseNotes = GetValue("releaseNotes", (string) null);
-            RequireLicenseAcceptance = GetValue("requireLicenseAcceptance", false);
-            Summary = GetValue("summary", (string) null);
-            Title = GetValue("title", (string) null);
-            Tags = GetValue("tags", (string) null);
-            Language = GetValue("language", (string) null);
+            IconUrl = GetValue(PackageMetadataStrings.IconUrl, (Uri) null);
+            ProjectUrl = GetValue(PackageMetadataStrings.ProjectUrl, (Uri) null);
+            LicenseUrl = GetValue(PackageMetadataStrings.LicenseUrl, (Uri) null);
+            Copyright = GetValue(PackageMetadataStrings.Copyright, (string) null);
+            Description = GetValue(PackageMetadataStrings.Description, (string) null);
+            ReleaseNotes = GetValue(PackageMetadataStrings.ReleaseNotes, (string) null);
+            RequireLicenseAcceptance = GetValue(PackageMetadataStrings.RequireLicenseAcceptance, false);
+            Summary = GetValue(PackageMetadataStrings.Summary, (string) null);
+            Title = GetValue(PackageMetadataStrings.Title, (string) null);
+            Tags = GetValue(PackageMetadataStrings.Tags, (string) null);
+            Language = GetValue(PackageMetadataStrings.Language, (string) null);
 
-            Owners = GetValue("owners", (string) null);
+            Owners = GetValue(PackageMetadataStrings.Owners, (string) null);
 
-            var authorsString = GetValue("authors", Owners ?? string.Empty);
+            var authorsString = GetValue(PackageMetadataStrings.Authors, Owners ?? string.Empty);
             Authors = new List<string>(authorsString.Split(',').Select(author => author.Trim()));
         }
 

--- a/src/NuGetGallery.Core/Packaging/PackageMetadataStrings.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageMetadataStrings.cs
@@ -3,7 +3,7 @@
 
 namespace NuGetGallery.Packaging
 {
-    static class PackageMetadataStrings
+    public static class PackageMetadataStrings
     {
         public const string Authors = "authors";
         public const string Copyright = "copyright";

--- a/src/NuGetGallery.Core/Packaging/PackageMetadataStrings.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageMetadataStrings.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Packaging
+{
+    static class PackageMetadataStrings
+    {
+        public const string Authors = "authors";
+        public const string Copyright = "copyright";
+        public const string Description = "description";
+        public const string IconUrl = "iconUrl";
+        public const string Language = "language";
+        public const string LicenseUrl = "licenseUrl";
+        public const string Metadata = "metadata";
+        public const string Owners = "owners";
+        public const string ProjectUrl = "projectUrl";
+        public const string ReleaseNotes = "releaseNotes";
+        public const string RequireLicenseAcceptance = "requireLicenseAcceptance";
+        public const string Summary = "summary";
+        public const string Tags = "tags";
+        public const string Title = "title";
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
@@ -36,9 +36,9 @@ namespace NuGetGallery.Packaging
 
                 Assert.Equal("TestPackage", nuspec.GetId());
                 Assert.Equal(NuGetVersion.Parse("0.0.0.1"), nuspec.GetVersion());
-                Assert.Equal("Me and You", nuspec.GetMetadata().First(kvp => kvp.Key == "authors").Value);
-                Assert.Equal("Peas In A Pod", nuspec.GetMetadata().First(kvp => kvp.Key == "tags").Value);
-                Assert.Equal("In perfect harmony", nuspec.GetMetadata().First(kvp => kvp.Key == "releaseNotes").Value);
+                Assert.Equal("Me and You", nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.Authors).Value);
+                Assert.Equal("Peas In A Pod", nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.Tags).Value);
+                Assert.Equal("In perfect harmony", nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.ReleaseNotes).Value);
             }
         }
 
@@ -60,7 +60,7 @@ namespace NuGetGallery.Packaging
             using (var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false))
             {
                 var nuspec = nupkg.GetNuspecReader();
-                var metadataDescendants = nuspec.Xml.Document.Descendants().Where(d => d.Name.LocalName == "metadata").Descendants();
+                var metadataDescendants = nuspec.Xml.Document.Descendants().Where(d => d.Name.LocalName == PackageMetadataStrings.Metadata).Descendants();
                 foreach (var element in metadataDescendants)
                 {
                     Assert.False(string.IsNullOrEmpty(element.Value), $"Nuspec contains a null or emtpy tag <{element.Name.LocalName}>");
@@ -76,7 +76,7 @@ namespace NuGetGallery.Packaging
             using (var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
             {
                 var nuspec = nupkg.GetNuspecReader();
-                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == "projectUrl"), false);
+                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == PackageMetadataStrings.LicenseUrl), false);
             }
 
             // Act
@@ -85,7 +85,8 @@ namespace NuGetGallery.Packaging
                     {
                         metadata => { metadata.Authors = "Me and You"; },
                         metadata => { metadata.Tags = "Peas In A Pod"; },
-                        metadata => { metadata.ProjectUrl = "http://myget.org"; }
+                        metadata => { metadata.LicenseUrl = "http://myget.org"; },
+                        metadata => { metadata.RequireLicenseAcceptance = true; }
                     });
 
             // Assert
@@ -94,8 +95,9 @@ namespace NuGetGallery.Packaging
                 var nuspec = nupkg.GetNuspecReader();
                 Assert.Equal("TestPackage", nuspec.GetId());
                 Assert.Equal(NuGetVersion.Parse("0.0.0.1"), nuspec.GetVersion());
-                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == "projectUrl"), true);
-                Assert.Equal(nuspec.GetMetadata().First(kvp => kvp.Key == "projectUrl").Value, "http://myget.org");
+                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == PackageMetadataStrings.LicenseUrl), true);
+                Assert.Equal(nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.LicenseUrl).Value, "http://myget.org");
+                Assert.Equal(nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.RequireLicenseAcceptance).Value, "true");
             }
         }
 
@@ -107,7 +109,7 @@ namespace NuGetGallery.Packaging
             using (var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
             {
                 var nuspec = nupkg.GetNuspecReader();
-                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == "title"), true);
+                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == PackageMetadataStrings.Title), true);
             }
 
             // Act
@@ -121,7 +123,7 @@ namespace NuGetGallery.Packaging
             using (var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false))
             {
                 var nuspec = nupkg.GetNuspecReader();
-                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == "title"), false);
+                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == PackageMetadataStrings.Title), false);
             }
         }
 
@@ -152,8 +154,8 @@ namespace NuGetGallery.Packaging
 
                 Assert.Equal("TestPackage", nuspec.GetId());
                 Assert.Equal(NuGetVersion.Parse("0.0.0.1"), nuspec.GetVersion());
-                Assert.Equal(longValue, nuspec.GetMetadata().First(kvp => kvp.Key == "description").Value);
-                Assert.Equal(longValue, nuspec.GetMetadata().First(kvp => kvp.Key == "summary").Value);
+                Assert.Equal(longValue, nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.Description).Value);
+                Assert.Equal(longValue, nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.Summary).Value);
             }
 
             // Act 2 - Make the stream smaller
@@ -174,8 +176,8 @@ namespace NuGetGallery.Packaging
 
                 Assert.Equal("TestPackage", nuspec.GetId());
                 Assert.Equal(NuGetVersion.Parse("0.0.0.1"), nuspec.GetVersion());
-                Assert.Equal(shortValue, nuspec.GetMetadata().First(kvp => kvp.Key == "description").Value);
-                Assert.Equal(shortValue, nuspec.GetMetadata().First(kvp => kvp.Key == "summary").Value);
+                Assert.Equal(shortValue, nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.Description).Value);
+                Assert.Equal(shortValue, nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.Summary).Value);
             }
         }
         


### PR DESCRIPTION
This fixes the nupkg rewriter's packaging of nuspec to not add empty elements for metadata.
The way it works:
- If there is an existing element which is optional, defined by the nuspec schema, and the edit removes the value(by setting null/empty), we remove the element from the <metadata>.
- If there is no existing element which is optional and the edit adds a new value, this would create a new element in the <metadata> node.
- If there is a change of value(not null or empty)  to the optional element, we will update the value.

Also added test coverage. I checked with @emgarten and it looks like the client mostly cares to not have null/empty value for URI(licenseUrl, projectUrl, iconUrl). It doesnt matter if the optional fields are not present in the nuspec, this shouldn't break the clients.

/cc @maartenba @skofman1 @ryuyu 