### PR TITLE
Split AuthenticationController.Authenticate into a POST and a GET

### DIFF
--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -249,7 +249,8 @@ namespace NuGetGallery
             return ChallengeAuthentication(returnUrl, provider);
         }
 
-        private ActionResult ChallengeAuthentication(string returnUrl, string provider)
+        [NonAction]
+        public ActionResult ChallengeAuthentication(string returnUrl, string provider)
         {
             return AuthService.Challenge(
                 provider,

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -234,9 +234,22 @@ namespace NuGetGallery
             return SafeRedirect(returnUrl);
         }
 
+        [ActionName("Authenticate")]
+        [HttpGet]
+        public virtual ActionResult AuthenticateGet(string returnUrl, string provider)
+        {
+            return ChallengeAuthentication(returnUrl, provider);
+        }
+
+        [ActionName("Authenticate")]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public virtual ActionResult Authenticate(string returnUrl, string provider)
+        public virtual ActionResult AuthenticatePost(string returnUrl, string provider)
+        {
+            return ChallengeAuthentication(returnUrl, provider);
+        }
+
+        private ActionResult ChallengeAuthentication(string returnUrl, string provider)
         {
             return AuthService.Challenge(
                 provider,

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -709,7 +709,7 @@ namespace NuGetGallery.Controllers
                 var controller = GetController<AuthenticationController>();
 
                 // Act
-                var result = controller.Authenticate("/theReturnUrl", "MicrosoftAccount");
+                var result = controller.ChallengeAuthentication("/theReturnUrl", "MicrosoftAccount");
 
                 // Assert
                 ResultAssert.IsChallengeResult(result, "MicrosoftAccount", "/users/account/authenticate/return?ReturnUrl=%2FtheReturnUrl");


### PR DESCRIPTION
The route is used as both GET and POST, so in order for it to function correctly it needs to be split into two methods.