### PR TITLE
Supported frameworks not always populated correctly (fixes #3215)

### DIFF
--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -509,17 +509,24 @@ namespace NuGetGallery
             }
 #pragma warning restore 618
 
-            var supportedFrameworks = GetSupportedFrameworks(packageArchive).Select(fn => fn.ToShortNameOrNull()).ToArray();
-            if (!supportedFrameworks.AnySafe(sf => sf == null))
-            {
-                ValidateSupportedFrameworks(supportedFrameworks);
+            var supportedFrameworks = GetSupportedFrameworks(packageArchive)
+                .ToArray();
 
-                foreach (var supportedFramework in supportedFrameworks)
+            if (!supportedFrameworks.Any(fx => fx != null && fx.IsAny))
+            {
+                var supportedFrameworkNames = supportedFrameworks
+                                .Select(fn => fn.ToShortNameOrNull())
+                                .Where(fn => fn != null)
+                                .ToArray();
+
+                ValidateSupportedFrameworks(supportedFrameworkNames);
+
+                foreach (var supportedFramework in supportedFrameworkNames)
                 {
-                    package.SupportedFrameworks.Add(new PackageFramework {TargetFramework = supportedFramework});
+                    package.SupportedFrameworks.Add(new PackageFramework { TargetFramework = supportedFramework });
                 }
             }
-
+            
             package.Dependencies = packageMetadata
                 .GetDependencyGroups()
                 .AsPackageDependencyEnumerable()

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -924,29 +924,7 @@ namespace NuGetGallery
                 Assert.Equal("net40", package.SupportedFrameworks.First().TargetFramework);
                 Assert.Equal("net35", package.SupportedFrameworks.ElementAt(1).TargetFramework);
             }
-
-            [Fact]
-            private async Task WillNotSaveAnySupportedFrameworksWhenThereIsANullTargetFramework()
-            {
-                var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
-                var service = CreateService(packageRegistrationRepository: packageRegistrationRepository, setup: mockPackageService =>
-                {
-                    mockPackageService.Setup(p => p.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
-                    mockPackageService.Setup(p => p.GetSupportedFrameworks(It.IsAny<PackageArchiveReader>())).Returns(
-                        new[]
-                        {
-                                           null,
-                                           NuGetFramework.Parse("net35")
-                        });
-                });
-                var nugetPackage = CreateNuGetPackage();
-                var currentUser = new User();
-
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser);
-
-                Assert.Empty(package.SupportedFrameworks);
-            }
-
+            
             [Fact]
             private async Task WillNotSaveAnySupportedFrameworksWhenThereIsAnAnyTargetFramework()
             {


### PR DESCRIPTION
Fixes #3215. Note that I did respect [this unit test](https://github.com/NuGet/NuGetGallery/blob/dbe578b69eefd03671977974d221d2ceb680df1e/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs#L951), hence the check for `IsAny`.

Please review and take over from me during vacation.

@skofman1 @ryuyu @shishirx34 @yishaigalatzer @xavierdecoster @qianjun22 

/cc @joelverhagen