### PR TITLE
Autorun Database Migrations Proposal

### DIFF
--- a/src/NuGetGallery/App_Start/AppActivator.cs
+++ b/src/NuGetGallery/App_Start/AppActivator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Entity.Migrations;
 using System.Diagnostics;
 using System.IO;
 using System.Security.Claims;
@@ -22,6 +23,7 @@ using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
 using NuGetGallery.Infrastructure;
 using NuGetGallery.Infrastructure.Jobs;
+using NuGetGallery.Migrations;
 using WebBackgrounder;
 using WebActivatorEx;
 
@@ -66,6 +68,13 @@ namespace NuGetGallery
 
             // Get configuration from the kernel
             var config = DependencyResolver.Current.GetService<IAppConfiguration>();
+
+            if (config.RequireDatabaseMigration)
+            {
+                var migrationConfiguration = new MigrationsConfiguration();
+                var migrator = new DbMigrator(migrationConfiguration);
+                migrator.Update();
+            }
 
             BackgroundJobsPostStart(config);
             AppPostStart(config);

--- a/src/NuGetGallery/App_Start/AppActivator.cs
+++ b/src/NuGetGallery/App_Start/AppActivator.cs
@@ -73,7 +73,16 @@ namespace NuGetGallery
             {
                 var migrationConfiguration = new MigrationsConfiguration();
                 var migrator = new DbMigrator(migrationConfiguration);
-                migrator.Update();
+                try
+                {
+                    migrator.Update(config.TargetMigration);
+                }
+                catch (Exception)
+                {
+                    Trace.TraceWarning($"Migration to target {config.TargetMigration} failed.");
+                    Trace.TraceWarning("Defaulting to latest migration");
+                    migrator.Update();
+                }
             }
 
             BackgroundJobsPostStart(config);

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -168,6 +168,12 @@ namespace NuGetGallery.Configuration
         public bool AutoUpdateSearchIndex { get; set; }
 
         /// <summary>
+        /// Gets a boolean indicating if the database requires a migration for this release
+        /// </summary>
+        [DefaultValue(false)]
+        public bool RequireDatabaseMigration { get; set; }
+
+        /// <summary>
         /// Gets a string indicating which authentication provider(s) are supported for administrators. 
         /// When specified, the gallery will ensure admin users are logging in using any of the specified authentication providers.
         /// Blank means any authentication provider can be used by administrators.

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -174,6 +174,13 @@ namespace NuGetGallery.Configuration
         public bool RequireDatabaseMigration { get; set; }
 
         /// <summary>
+        /// Gets a string indicating the target migration for the database.
+        /// When unspecified, defaults to the latest migration.
+        /// </summary>
+        [DefaultValue("")]
+        public string TargetMigration { get; set; }
+
+        /// <summary>
         /// Gets a string indicating which authentication provider(s) are supported for administrators. 
         /// When specified, the gallery will ensure admin users are logging in using any of the specified authentication providers.
         /// Blank means any authentication provider can be used by administrators.

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -154,6 +154,11 @@ namespace NuGetGallery.Configuration
         bool AutoUpdateSearchIndex { get; set; }
 
         /// <summary>
+        /// Gets a boolean indicating if the database requires a migration for this release
+        /// </summary>
+        bool RequireDatabaseMigration { get; set; }
+
+        /// <summary>
         /// Gets a string indicating which authentication provider(s) are supported for administrators. 
         /// When specified, the gallery will ensure admin users are logging in using any of the specified authentication providers.
         /// Blank means any authentication provider can be used by administrators.

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -159,6 +159,12 @@ namespace NuGetGallery.Configuration
         bool RequireDatabaseMigration { get; set; }
 
         /// <summary>
+        /// Gets a string indicating the target migration for the database.
+        /// When unspecified, defaults to the latest migration.
+        /// </summary>
+        string TargetMigration { get; set; }
+
+        /// <summary>
         /// Gets a string indicating which authentication provider(s) are supported for administrators. 
         /// When specified, the gallery will ensure admin users are logging in using any of the specified authentication providers.
         /// Blank means any authentication provider can be used by administrators.

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -116,7 +116,7 @@
 
     <!-- This is also the default so you can remove this setting if you really want. -->
     <!-- Set this to true if the database requires a migration. -->
-    <add key="Gallery.RequireDatabaseMigration" value="true" />
+    <add key="Gallery.RequireDatabaseMigration" value="false" />
     
     <!-- Set this to the name of the target migration for the database. -->
     <!-- Leave unspecified to run all migrations -->

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -114,6 +114,10 @@
     <!-- Set this to false if you want to disable search indexing in the background. -->
     <add key="Gallery.AutoUpdateSearchIndex" value="true" />
 
+    <!-- This is also the default so you can remove this setting if you really want. -->
+    <!-- Set this to true if the database requires a migration. -->
+    <add key="Gallery.RequireDatabaseMigration" value="false" />
+
     <!-- Feature Configuration -->
     <add key="Feature.FriendlyLicenses" value="" />
     <add key="Feature.TrackPackageDownloadCountInLocalDatabase" value="false" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -116,7 +116,11 @@
 
     <!-- This is also the default so you can remove this setting if you really want. -->
     <!-- Set this to true if the database requires a migration. -->
-    <add key="Gallery.RequireDatabaseMigration" value="false" />
+    <add key="Gallery.RequireDatabaseMigration" value="true" />
+    
+    <!-- Set this to the name of the target migration for the database. -->
+    <!-- Leave unspecified to run all migrations -->
+    <add key="Gallery.TargetMigration" value="" />
 
     <!-- Feature Configuration -->
     <add key="Feature.FriendlyLicenses" value="" />


### PR DESCRIPTION
This PR adds the ability to specify if the database needs to be migrated at run time.
The proposed flow is as follows:
At deployment time, a new variable is set, Gallery.RequireDatabaseMigration, that indicates if this release requires a database migration. At app start, this setting is read, and if true, the migrations are run against the database.

In the case that we need to roll back, Gallery.TargetMigration can be set to target a previous migration, otherwise left empty to run to latest migration.

In most cases Gallery.RequireDatabaseMigration should be false, and is false by default. When the database requires an update, this should be a very conscious decision to update this flag to run the migrations.

@xavierdecoster @maartenba @skofman1 @scottbommarito @shishirx34 