### PR TITLE
Version validation should use the original NuGet.Core regex to ensure compat #3226

### DIFF
--- a/src/NuGetGallery.Core/NuGetVersionExtensions.cs
+++ b/src/NuGetGallery.Core/NuGetVersionExtensions.cs
@@ -37,7 +37,7 @@ namespace NuGetGallery
             return self.ReleaseLabels.Count() > 1 || self.HasMetadata;
         }
 
-        public static bool IsValidVersion(this NuGetVersion self)
+        public static bool IsValidVersionForLegacyClients(this NuGetVersion self)
         {
             var match = SemanticVersionRegex.Match(self.ToString().Trim());
 

--- a/src/NuGetGallery.Core/NuGetVersionExtensions.cs
+++ b/src/NuGetGallery.Core/NuGetVersionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NuGet.Versioning;
 
 namespace NuGetGallery
@@ -23,6 +24,9 @@ namespace NuGetGallery
 
     public static class NuGetVersionExtensions
     {
+        private const RegexOptions Flags = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
+        private static readonly Regex SemanticVersionRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$", Flags);
+
         public static string ToNormalizedStringSafe(this NuGetVersion self)
         {
             return self != null ? self.ToNormalizedString() : String.Empty;
@@ -31,6 +35,13 @@ namespace NuGetGallery
         public static bool IsSemVer200(this NuGetVersion self)
         {
             return self.ReleaseLabels.Count() > 1 || self.HasMetadata;
+        }
+
+        public static bool IsValidVersion(this NuGetVersion self)
+        {
+            var match = SemanticVersionRegex.Match(self.ToString().Trim());
+
+            return match.Success;
         }
     }
 }

--- a/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
+++ b/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
@@ -79,9 +79,10 @@ namespace NuGetGallery.Packaging
                     version));
             }
 
-            foreach (var validationResult in ValidateVersion(packageMetadata.Version))
+            var versionValidationResult = ValidateVersion(packageMetadata.Version);
+            if (versionValidationResult != null)
             {
-                yield return validationResult;
+                yield return versionValidationResult;
             }
 
             // Check framework reference groups
@@ -145,18 +146,20 @@ namespace NuGetGallery.Packaging
                         // Versions
                         if (dependency.VersionRange.MinVersion != null)
                         {
-                            foreach (var validationResult in ValidateVersion(dependency.VersionRange.MinVersion))
+                            var versionRangeValidationResult = ValidateVersion(dependency.VersionRange.MinVersion);
+                            if (versionRangeValidationResult != null)
                             {
-                                yield return validationResult;
+                                yield return versionRangeValidationResult;
                             }
                         }
 
                         if (dependency.VersionRange.MaxVersion != null 
                             && dependency.VersionRange.MaxVersion != dependency.VersionRange.MinVersion)
                         {
-                            foreach (var validationResult in ValidateVersion(dependency.VersionRange.MaxVersion))
+                            var versionRangeValidationResult = ValidateVersion(dependency.VersionRange.MaxVersion);
+                            if (versionRangeValidationResult != null)
                             {
-                                yield return validationResult;
+                                yield return versionRangeValidationResult;
                             }
                         }
                     }
@@ -164,22 +167,24 @@ namespace NuGetGallery.Packaging
             }
         }
 
-        private static IEnumerable<ValidationResult> ValidateVersion(NuGetVersion version)
+        private static ValidationResult ValidateVersion(NuGetVersion version)
         {
             if (version.IsSemVer200())
             {
-                yield return new ValidationResult(string.Format(
+                return new ValidationResult(string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.Manifest_InvalidVersionSemVer200,
                     version.ToFullString()));
             }
             else if (!version.IsValidVersion())
             {
-                yield return new ValidationResult(string.Format(
+                return new ValidationResult(string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.Manifest_InvalidVersion,
                     version));
             }
+
+            return null;
         }
 
         private static IEnumerable<ValidationResult> CheckUrls(params string[] urls)

--- a/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
+++ b/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
@@ -176,7 +176,7 @@ namespace NuGetGallery.Packaging
                     Strings.Manifest_InvalidVersionSemVer200,
                     version.ToFullString()));
             }
-            else if (!version.IsValidVersion())
+            else if (!version.IsValidVersionForLegacyClients())
             {
                 return new ValidationResult(string.Format(
                     CultureInfo.CurrentCulture,

--- a/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
@@ -102,6 +102,40 @@ namespace NuGetGallery.Packaging
                       </metadata>
                     </package>";
 
+        private const string NuSpecDependencyVersionPlaceholder = @"<?xml version=""1.0""?>
+                    <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                      <metadata>
+                        <id>valid</id>
+                        <version>2.0.0</version>
+                        <title>Package A</title>
+                        <authors>ownera, ownerb</authors>
+                        <owners>ownera, ownerb</owners>
+                        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+                        <description>package A description.</description>
+                        <language>en-US</language>
+                        <dependencies>
+                            <group targetFramework=""net40"">
+                              <dependency id=""Dep"" version=""{0}"" />
+                            </group>
+                        </dependencies>
+                      </metadata>
+                    </package>";
+
+        private const string NuSpecPlaceholderVersion = @"<?xml version=""1.0""?>
+                    <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                      <metadata>
+                        <id>valid</id>
+                        <version>{0}</version>
+                        <title>Package A</title>
+                        <authors>ownera, ownerb</authors>
+                        <owners>ownera, ownerb</owners>
+                        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+                        <description>package A description.</description>
+                        <language>en-US</language>
+                        <dependencies />
+                      </metadata>
+                    </package>";
+
         private const string NuSpecIconUrlInvalid = @"<?xml version=""1.0""?>
                     <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
                       <metadata>
@@ -397,6 +431,39 @@ namespace NuGetGallery.Packaging
             var nuspecStream = CreateNuspecStream(NuSpecSemVer200);
 
             Assert.Equal(new[] { String.Format(Strings.Manifest_InvalidVersionSemVer200, "2.0.0+123") }, GetErrors(nuspecStream));
+        }
+
+        [Theory]
+        [InlineData("1.0.0-beta.1")]
+        [InlineData("3.0.0-beta+12")]
+        public void ReturnsErrorIfDependencyVersionIsSemVer200(string version)
+        {
+            var nuspecStream = CreateNuspecStream(string.Format(NuSpecDependencyVersionPlaceholder, version));
+
+            Assert.Equal(new[] { String.Format(Strings.Manifest_InvalidVersionSemVer200, version) }, GetErrors(nuspecStream));
+        }
+
+        [Theory]
+        [InlineData("1.0.0-10")]
+        [InlineData("1.0.0--")]
+        public void ReturnsErrorIfVersionIsInvalid(string version)
+        {
+            // https://github.com/NuGet/NuGetGallery/issues/3226
+
+            var nuspecStream = CreateNuspecStream(string.Format(NuSpecPlaceholderVersion, version));
+
+            Assert.Equal(new[] { String.Format(Strings.Manifest_InvalidVersion, version) }, GetErrors(nuspecStream));
+        }
+
+
+        [Theory]
+        [InlineData("1.0.0-10")]
+        [InlineData("1.0.0--")]
+        public void ReturnsErrorIfDependencyVersionIsInvalid(string version)
+        {
+            var nuspecStream = CreateNuspecStream(string.Format(NuSpecDependencyVersionPlaceholder, version));
+
+            Assert.Equal(new[] { String.Format(Strings.Manifest_InvalidVersion, version) }, GetErrors(nuspecStream));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/3226

@skofman1 @scottbommarito @ryuyu @xavierdecoster 

@emgarten can you have a look as well if this is the intended course?