### PR TITLE
Fix typos in comments, log messages and strings

### DIFF
--- a/src/NuGet.Services.Search.Client/Client/RetryingHttpClientWrapper.cs
+++ b/src/NuGet.Services.Search.Client/Client/RetryingHttpClientWrapper.cs
@@ -67,7 +67,7 @@ namespace NuGet.Services.Search.Client
             // Create requests queue
             var tasks = CreateRequestQueue(healthyEndpoints, httpClient, cancellationTokenSource);
 
-            // When the first succesful task comes in, return it. If no succesfull tasks are returned, throw an AggregateException.
+            // When the first successful task comes in, return it. If no successful tasks are returned, throw an AggregateException.
             var exceptions = new List<Exception>();
 
             var taskList = tasks.ToList();

--- a/src/NuGet.Services.Search.Client/Correlation/WebApiCorrelationHandler.cs
+++ b/src/NuGet.Services.Search.Client/Correlation/WebApiCorrelationHandler.cs
@@ -67,7 +67,7 @@ namespace NuGet.Services.Search.Client.Correlation
             if (response != null)
             {
                 // Do not allow overriding the header - if any code wants to set the correlation id
-                // it shoud set the request property instead.
+                // it should set the request property instead.
                 if (response.Headers.Contains(CorrelationIdHttpHeaderName))
                 {
                     response.Headers.Remove(CorrelationIdHttpHeaderName);

--- a/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
@@ -21,7 +21,7 @@ namespace NuGetGallery.Auditing
             Type = credential.Type;
             Identity = credential.Identity;
 
-            // Track the value for credentials that are definitely revokable (API Key, etc.) and have been removed
+            // Track the value for credentials that are definitely revocable (API Key, etc.) and have been removed
             if (removed && !CredentialTypes.IsPassword(credential.Type))
             {
                 Value = credential.Value;

--- a/src/NuGetGallery.Core/Auditing/PackageCreatedVia.cs
+++ b/src/NuGetGallery.Core/Auditing/PackageCreatedVia.cs
@@ -11,7 +11,7 @@ namespace NuGetGallery.Auditing
         public const string Api = "Created via API.";
 
         /// <summary>
-        /// Package has been created via Nuget web interface (browser)
+        /// Package has been created via NuGet web interface (browser)
         /// </summary>
         public const string Web = "Created via web.";
     }

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -72,7 +72,7 @@ namespace NuGetGallery
             return Database;
         }
 
-#pragma warning disable 618 // TODO: remove Package.Authors completely once prodution services definitely no longer need it
+#pragma warning disable 618 // TODO: remove Package.Authors completely once production services definitely no longer need it
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Credential>()

--- a/src/NuGetGallery.Core/Entities/Package.cs
+++ b/src/NuGetGallery.Core/Entities/Package.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery
         : IEntity
     {
 
-#pragma warning disable 618 // TODO: remove Package.Authors completely once prodution services definitely no longer need it
+#pragma warning disable 618 // TODO: remove Package.Authors completely once production services definitely no longer need it
         public Package()
         {
             Authors = new HashSet<PackageAuthor>();
@@ -142,7 +142,7 @@ namespace NuGetGallery
 
         public virtual ICollection<PackageLicenseReport> LicenseReports { get; set; }
 
-        // Pre-calcuated data for the feed
+        // Pre-calculated data for the feed
         public string LicenseNames { get; set; }
         public string LicenseReportUrl { get; set; }
 

--- a/src/NuGetGallery.Operations/Infrastructure/ImportExportHelper.cs
+++ b/src/NuGetGallery.Operations/Infrastructure/ImportExportHelper.cs
@@ -141,7 +141,7 @@ namespace WASDImportExport
                 }
                 catch (WebException responseException)
                 {
-                    _log.Error("Request Falied:{0}", responseException.Message);
+                    _log.Error("Request Failed:{0}", responseException.Message);
                     if (responseException.Response != null)
                     {
                         _log.Error("Status Code: {0}", ((HttpWebResponse)responseException.Response).StatusCode);
@@ -227,7 +227,7 @@ namespace WASDImportExport
         //    }
         //    catch (WebException responseException)
         //    {
-        //        Console.WriteLine("Request Falied: {0}", responseException.Message);
+        //        Console.WriteLine("Request Failed: {0}", responseException.Message);
         //        {
         //            Console.WriteLine("Status Code: {0}", ((HttpWebResponse)responseException.Response).StatusCode);
         //            Console.WriteLine("Status Description: {0}\n\r", ((HttpWebResponse)responseException.Response).StatusDescription);

--- a/src/NuGetGallery.Operations/Tasks/Backups/BackupPackageFileTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/Backups/BackupPackageFileTask.cs
@@ -59,7 +59,7 @@ namespace NuGetGallery.Operations
             var downloadedPackageFilePath = Path.Combine(Util.GetTempFolder(), packageFileName);
 
             // Why are we still downloading/uploading instead of using Async Blob Copy?
-            // Because it feels a little safer to ensure we know the copy is truely complete before continuing.
+            // Because it feels a little safer to ensure we know the copy is truly complete before continuing.
             // I could be convinced otherwise though 
             //  - anurse
             Log.Trace("Downloading package file '{0}' to temporary file '{1}'.", packageFileName, downloadedPackageFilePath);

--- a/src/NuGetGallery.Operations/Tasks/CreateWarehouseReportsTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/CreateWarehouseReportsTask.cs
@@ -191,7 +191,7 @@ namespace NuGetGallery.Operations
                 bag[index++] = packageId;
             }
 
-            // limit the potential concurrency becasue this is against SQL
+            // limit the potential concurrency because this is against SQL
 
             ParallelOptions options = new ParallelOptions() { MaxDegreeOfParallelism = 4 };
 

--- a/src/NuGetGallery.Operations/Tasks/DataManagement/DeleteDuplicatePackageVersionsTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/DataManagement/DeleteDuplicatePackageVersionsTask.cs
@@ -105,7 +105,7 @@ namespace NuGetGallery.Operations.Tasks
                 }
                 else
                 {
-                    // Select the most recent pacakge
+                    // Select the most recent package
                     var selected = packages.OrderByDescending(p => p.Published).FirstOrDefault();
                     if (selected == null)
                     {

--- a/src/NuGetGallery.Operations/Tasks/SendMailTask.cs
+++ b/src/NuGetGallery.Operations/Tasks/SendMailTask.cs
@@ -70,7 +70,7 @@ namespace NuGetGallery.Operations
             ServicePointManager.ServerCertificateValidationCallback = delegate(object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
             System.Net.Mail.MailMessage message = new System.Net.Mail.MailMessage();
 
-            //Set the from and to mail addressess.
+            //Set the from and to mail addresses.
             message.From = new MailAddress(UserAccount, "NuGet Gallery Support");
 
             string[] replyTo = ReplyToList.Split(new char[] { ',' });

--- a/src/NuGetGallery/Areas/Admin/Models/SupportRequestDbContext.cs
+++ b/src/NuGetGallery/Areas/Admin/Models/SupportRequestDbContext.cs
@@ -26,7 +26,7 @@ namespace NuGetGallery.Areas.Admin.Models
 
         /// <summary>
         /// The NuGet Gallery code should usually use this constructor,
-        /// so that we can configure the connection via the Cloud Service configuraton.
+        /// so that we can configure the connection via the Cloud Service configuration.
         /// </summary>
         public SupportRequestDbContext(string connectionString)
             : base(connectionString)

--- a/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
@@ -43,7 +43,7 @@
             <h2>
                 <a class="action-menu-link" href="@Url.Action(actionName: "Index", controllerName: "Lucene")">
                     <i class="icon-search action-menu-icon"></i>
-                    <span class="action-menu-text">Lucene Index Maintainance</span>
+                    <span class="action-menu-text">Lucene Index Maintenance</span>
                 </a>
             </h2>
             <p>

--- a/src/NuGetGallery/Areas/Admin/Views/Lucene/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Lucene/Index.cshtml
@@ -1,10 +1,10 @@
 ﻿@model NuGetGallery.Areas.Admin.Models.LuceneInfoModel
 @{
-    ViewBag.Title = "Lucene Maintainance";
+    ViewBag.Title = "Lucene Maintenance";
     TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
 }
 
-<h2>Lucene Maintainance</h2>
+<h2>Lucene Maintenance</h2>
 
 @if (Model.LastUpdated == null)
 {

--- a/src/NuGetGallery/Controllers/ODataV1FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV1FeedController.cs
@@ -170,7 +170,7 @@ namespace NuGetGallery.Controllers
                 }
             }
 
-            // Peform actual search
+            // Perform actual search
             var packages = _packagesRepository.GetAll()
                 .Include(p => p.PackageRegistration)
                 .Include(p => p.PackageRegistration.Owners)

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -198,7 +198,7 @@ namespace NuGetGallery.Controllers
                 }
             }
 
-            // Peform actual search
+            // Perform actual search
             var curatedFeed = _curatedFeedService.GetFeedByName(curatedFeedName, includePackages: false);
             var packages = _curatedFeedService.GetPackages(curatedFeedName)
                 .OrderBy(p => p.PackageRegistration.Id).ThenBy(p => p.Version);

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -222,7 +222,7 @@ namespace NuGetGallery.Controllers
                 }
             }
 
-            // Peform actual search
+            // Perform actual search
             var packages = _packagesRepository.GetAll()
                 .Include(p => p.PackageRegistration)
                 .Include(p => p.PackageRegistration.Owners)
@@ -296,7 +296,7 @@ namespace NuGetGallery.Controllers
             // Workaround https://github.com/NuGet/NuGetGallery/issues/674 for NuGet 2.1 client.
             // Can probably eventually be retired (when nobody uses 2.1 anymore...)
             // Note - it was URI un-escaping converting + to ' ', undoing that is actually a pretty conservative substitution because
-            // space characters are never acepted as valid by VersionUtility.ParseFrameworkName.
+            // space characters are never accepted as valid by VersionUtility.ParseFrameworkName.
             if (!string.IsNullOrEmpty(targetFrameworks))
             {
                 targetFrameworks = targetFrameworks.Replace(' ', '+');

--- a/src/NuGetGallery/Diagnostics/PerfCounters.cs
+++ b/src/NuGetGallery/Diagnostics/PerfCounters.cs
@@ -73,7 +73,7 @@ namespace NuGetGallery.Diagnostics
                     double max = Double.MinValue;
 
                     // Start at _position-1 and work backwards. 
-                    // In order to avoid negative indicies, we do this by ADDING the distance between the end of ring and i, 
+                    // In order to avoid negative indices, we do this by ADDING the distance between the end of ring and i, 
                     //  then we use mod to get a real offset
                     for (int i = 0; i < _count; i++)
                     {

--- a/src/NuGetGallery/Helpers/TreeView.cs
+++ b/src/NuGetGallery/Helpers/TreeView.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery.Helpers
     }
 
     /// <summary>
-    /// Create an HTML tree from a resursive collection of items
+    /// Create an HTML tree from a recursive collection of items
     /// </summary>
     public class TreeView<T> : IHtmlString
     {

--- a/src/NuGetGallery/PackageCurators/WebMatrixPackageCurator.cs
+++ b/src/NuGetGallery/PackageCurators/WebMatrixPackageCurator.cs
@@ -62,7 +62,7 @@ namespace NuGetGallery
                     // Must have AspNetWebPages tag
                     ContainsAspNetWebPagesTag(galleryPackage) ||
 
-                    // OR: Must not contain powershell or T4
+                    // OR: Must not contain PowerShell or T4
                     DoesNotContainUnsupportedFiles(packageArchiveReader)
                 ) &&
 

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -126,7 +126,7 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(id));
             }
 
-            // Optimization: Everytime we look at a package we almost always want to see
+            // Optimization: Every time we look at a package we almost always want to see
             // all the other packages with the same ID via the PackageRegistration property.
             // This resulted in a gnarly query.
             // Instead, we can always query for all packages with the ID.
@@ -502,7 +502,7 @@ namespace NuGetGallery
             package.ProjectUrl = packageMetadata.ProjectUrl.ToEncodedUrlStringOrNull();
             package.MinClientVersion = packageMetadata.MinClientVersion.ToStringOrNull();
 
-#pragma warning disable 618 // TODO: remove Package.Authors completely once prodution services definitely no longer need it
+#pragma warning disable 618 // TODO: remove Package.Authors completely once production services definitely no longer need it
             foreach (var author in packageMetadata.Authors)
             {
                 package.Authors.Add(new PackageAuthor { Name = author });

--- a/src/NuGetGallery/T4MVC.tt.settings.t4
+++ b/src/NuGetGallery/T4MVC.tt.settings.t4
@@ -34,7 +34,7 @@ const string ControllersFolder = "Controllers";
 // The folder under the project that contains the views
 const string ViewsRootFolder = "Views";
 
-// Views in DisplayTemplates and EditorTemplates folders shouldn't be fully qualifed as it breaks
+// Views in DisplayTemplates and EditorTemplates folders shouldn't be fully qualified as it breaks
 // the templated helper code
 readonly string[]  NonQualifiedViewFolders = new string[] {
   "DisplayTemplates",

--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -62,7 +62,7 @@ namespace NuGetGallery
 
     public class RegisterViewModel
     {
-        // Note: regexes must be tested to work in javascript
+        // Note: regexes must be tested to work in JavaScript
         // We do NOT follow strictly the RFCs at this time, and we choose not to support many obscure email address variants.
         // Specifically the following are not supported by-design:
         //  * Addresses containing () or []

--- a/src/NuGetGallery/ViewModels/StatisticsPivot.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPivot.cs
@@ -136,7 +136,7 @@ namespace NuGetGallery
             }
         }
 
-        // The count in the tree is the count of values. It is equivallent to the count of rows if we
+        // The count in the tree is the count of values. It is equivalent to the count of rows if we
         // were to represent this in a table.
 
         private static int Count(Level level)
@@ -223,7 +223,7 @@ namespace NuGetGallery
 
             public int Count { get; set; }
 
-            // Total is the sum Total of all the Amounts in all the decendents. (See Total function above.)
+            // Total is the sum Total of all the Amounts in all the descendants. (See Total function above.)
 
             public int Total { get; set; }
 

--- a/src/NuGetGallery/Web.Debug.config
+++ b/src/NuGetGallery/Web.Debug.config
@@ -6,7 +6,7 @@
   <!--
     In the example below, the "SetAttributes" transform will change the value of 
     "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
-    finds an atrribute "name" that has a value of "MyDB".
+    finds an attribute "name" that has a value of "MyDB".
     
     <connectionStrings>
       <add name="MyDB" 

--- a/src/NuGetGallery/Web.Release.config
+++ b/src/NuGetGallery/Web.Release.config
@@ -6,7 +6,7 @@
   <!--
     In the example below, the "SetAttributes" transform will change the value of 
     "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
-    finds an atrribute "name" that has a value of "MyDB".
+    finds an attribute "name" that has a value of "MyDB".
     
     <connectionStrings>
       <add name="MyDB" 

--- a/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
@@ -63,7 +63,7 @@ namespace NuGetGallery.Packaging
                 var metadataDescendants = nuspec.Xml.Document.Descendants().Where(d => d.Name.LocalName == PackageMetadataStrings.Metadata).Descendants();
                 foreach (var element in metadataDescendants)
                 {
-                    Assert.False(string.IsNullOrEmpty(element.Value), $"Nuspec contains a null or emtpy tag <{element.Name.LocalName}>");
+                    Assert.False(string.IsNullOrEmpty(element.Value), $"Nuspec contains a null or empty tag <{element.Name.LocalName}>");
                 }
             }
         }

--- a/tests/NuGetGallery.Facts/Authentication/TestCredentialBuilder.cs
+++ b/tests/NuGetGallery.Facts/Authentication/TestCredentialBuilder.cs
@@ -8,7 +8,7 @@ using NuGetGallery.Services.Authentication;
 namespace NuGetGallery.Authentication
 {
     /// <summary>
-    /// Builds all kinds of supported credentials for test puposes.
+    /// Builds all kinds of supported credentials for test purposes.
     /// </summary>
     public class TestCredentialBuilder
     {

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -581,7 +581,7 @@ namespace NuGetGallery
                 var package = new Package();
                 var actionResult = new EmptyResult();
                 var controller = new TestableApiController(MockBehavior.Strict);
-                controller.MockPackageService.Setup(x => x.FindPackageByIdAndVersion("Baz", "", false)).Throws(new DataException("Oh noes, database broked!"));
+                controller.MockPackageService.Setup(x => x.FindPackageByIdAndVersion("Baz", "", false)).Throws(new DataException("Oh noes, database broken!"));
  		        controller.MockPackageFileService.Setup(s => s.CreateDownloadPackageActionResultAsync(HttpRequestUrl, packageId, package.NormalizedVersion))
                              .Returns(Task.FromResult<ActionResult>(actionResult))
                              .Verifiable();

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -383,7 +383,7 @@ namespace NuGetGallery
                                     {
                                         { "ClientName", "NuGet" },
                                         { "ClientVersion", "2.1" },
-                                        { "Operation", "unknow" },
+                                        { "Operation", "unknown" },
                                         { "Downloads", 301 }
                                     }
                                 }
@@ -465,7 +465,7 @@ namespace NuGetGallery
                                     {
                                         { "ClientName", "NuGet" },
                                         { "ClientVersion", "2.1" },
-                                        { "Operation", "unknow" },
+                                        { "Operation", "unknown" },
                                         { "Downloads", 301 }
                                     }
                                 }
@@ -551,7 +551,7 @@ namespace NuGetGallery
                                     {
                                         { "ClientName", "NuGet" },
                                         { "ClientVersion", "2.1" },
-                                        { "Operation", "unknow" },
+                                        { "Operation", "unknown" },
                                         { "Downloads", 301 }
                                     }
                                 }
@@ -616,7 +616,7 @@ namespace NuGetGallery
                     // Act
                     var result = await controller.Totals() as JsonResult;
 
-                    // Asssert
+                    // Assert
                     Assert.NotNull(result);
                     dynamic data = result.Data;
 
@@ -652,7 +652,7 @@ namespace NuGetGallery
 
                 var result = await InvokeAction(() => (controller.Totals()), controller) as JsonResult;
 
-                // Asssert
+                // Assert
                 Assert.NotNull(result);
                 dynamic data = result.Data;
 

--- a/tests/NuGetGallery.Facts/OData/Interceptors/PackageExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/OData/Interceptors/PackageExtensionsFacts.cs
@@ -51,7 +51,7 @@ namespace NuGetGallery.OData.Interceptors
                 Assert.Equal("Mostly Harmless", actual.ReleaseNotes);
                 Assert.True(actual.RequireLicenseAcceptance);
                 Assert.Equal(new DateTime(1979, 10, 12), actual.Published);
-                Assert.Equal("A truely remarkable book", actual.Summary);
+                Assert.Equal("A truly remarkable book", actual.Summary);
                 Assert.Equal("Guide, Harmless, Mostly", actual.Tags);
                 Assert.Equal("The Hitchhiker's Guide to the Galaxy", actual.Title);
                 Assert.Equal(421, actual.VersionDownloadCount);
@@ -158,7 +158,7 @@ namespace NuGetGallery.OData.Interceptors
                 ReleaseNotes = "Mostly Harmless",
                 RequiresLicenseAcceptance = true,
                 Published = new DateTime(1979, 10, 12),
-                Summary = "A truely remarkable book",
+                Summary = "A truly remarkable book",
                 Tags = "Guide, Harmless, Mostly",
                 Title = "The Hitchhiker's Guide to the Galaxy",
                 DownloadCount = 421,

--- a/tests/NuGetGallery.Facts/PasswordValidationRegexTests.cs
+++ b/tests/NuGetGallery.Facts/PasswordValidationRegexTests.cs
@@ -39,7 +39,7 @@ namespace NuGetGallery
         [InlineData("89984214214")] // Just numbers
         [InlineData("%*`~&*()%#@$!@<>?\"")] // Special characters
         [InlineData("aaAAaaAAaaAA")] // No digit
-        [InlineData("12345678a")] // No upperscase letter
+        [InlineData("12345678a")] // No uppercase letter
         [InlineData("12345678A")] // No lowercase letter
         [InlineData("1aA")] // Too short
         public void DoesNotAccept(string password)


### PR DESCRIPTION
List of fixed words:
- successful
- should
- revocable
- NuGet
- production
- pre-calculated
- failed
- truly
- because
- unknown
- package
- PowerShell
- addresses
- configuration
- maintenance
- perform
- accepted
- indices
- recursive
- uppercase
- broken
- purposes
- empty