### PR TITLE
Fix elmah error for Object reference not set to an instance of object

### DIFF
--- a/src/NuGetGallery/OData/SearchService/SearchAdaptor.cs
+++ b/src/NuGetGallery/OData/SearchService/SearchAdaptor.cs
@@ -99,7 +99,7 @@ namespace NuGetGallery.OData
             // We can only use Lucene if:
             //  a) The Index contains all versions of each package
             //  b) The sort order is something Lucene can handle
-            if (TryReadSearchFilter(searchService.ContainsAllVersions, request.RawUrl, searchService.ContainsAllVersions, out searchFilter))
+            if (TryReadSearchFilter(searchService.ContainsAllVersions, request.RawUrl, searchService.ContainsAllVersions, out searchFilter) && !string.IsNullOrWhiteSpace(id))
             {
                 var normalizedRegistrationId = id.Normalize(NormalizationForm.FormC);
 


### PR DESCRIPTION
Fixes issue #3267. If id were null would throw the exception and log it in Elmah. The behaviour however is correct and responds with a 404 as expected.