### PR TITLE
Fix broken test case after validation PR

### DIFF
--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -765,12 +765,19 @@ namespace NuGetGallery
             {
                 var service = CreateService();
                 var versionSpec = VersionRange.Parse("[1.0]");
+
+                var numDependencies = 5000;
+                var packageDependencies = new List<NuGet.Packaging.Core.PackageDependency>();
+                for (int i = 0; i < numDependencies; i++)
+                {
+                    packageDependencies.Add(new NuGet.Packaging.Core.PackageDependency("dependency" + i, versionSpec));
+                }
+
                 var nugetPackage = CreateNuGetPackage(packageDependencyGroups: new[]
                 {
                     new PackageDependencyGroup(
                         new NuGetFramework("net40"),
-                        Enumerable.Repeat(
-                            new NuGet.Packaging.Core.PackageDependency("theFirstDependency", versionSpec), 5000)),
+                        packageDependencies),
                 });
 
                 var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));


### PR DESCRIPTION
I think using the newer `NuGet.Client` library broke this test case (it consolidated every "theFirstDependency" into a single dependency).