### PR TITLE
Resolve path before exists-or-create dir handling

### DIFF
--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -141,20 +141,15 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(packageFile));
             }
 
-            if (!_fileSystemService.DirectoryExists(_configuration.FileStorageDirectory))
-            {
-                _fileSystemService.CreateDirectory(_configuration.FileStorageDirectory);
-            }
-
             var filePath = BuildPath(_configuration.FileStorageDirectory, folderName, fileName);
-            var folderPath = Path.GetDirectoryName(filePath);
+
+            var dirPath = System.IO.Path.GetDirectoryName(filePath);
+
+            _fileSystemService.CreateDirectory(dirPath);
+
             if (_fileSystemService.FileExists(filePath))
             {
                 _fileSystemService.DeleteFile(filePath);
-            }
-            else
-            {
-                _fileSystemService.CreateDirectory(folderPath);
             }
 
             using (var file = _fileSystemService.OpenWrite(filePath))


### PR DESCRIPTION
I noticed a bug when uploading a new package via the web ui without setting absolute filepath as FileStorageDirectory. The default value is "~/App_Data/Files", which will lead to this exception when you try to upload a new package:
![image](https://cloud.githubusercontent.com/assets/756703/20022836/b0a82c7c-a2dc-11e6-9fd3-ce2c7371909e.png)

The actual resolvepath method was called below the CreateDirectory-Call. I just moved the ResolvePath stuff up and make sure that the actual directoy exists. 
