### PR TITLE
Feature: Add message for AddOwner request

### DIFF
--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Web;
 using System.Web.Mvc;
 
 namespace NuGetGallery
@@ -59,8 +60,10 @@ namespace NuGetGallery
         }
 
         [HttpPost]
-        public async Task<JsonResult> AddPackageOwner(string id, string username)
+        public async Task<JsonResult> AddPackageOwner(string id, string username, string message)
         {
+            message = HttpUtility.HtmlEncode(message);
+
             var package = _packageService.FindPackageRegistrationById(id);
             if (package == null)
             {
@@ -89,7 +92,7 @@ namespace NuGetGallery
                 user.Username,
                 ownerRequest.ConfirmationCode,
                 new { id = package.Id });
-            _messageService.SendPackageOwnerRequest(currentUser, user, package, confirmationUrl);
+            _messageService.SendPackageOwnerRequest(currentUser, user, package, confirmationUrl, message);
 
             return Json(new { success = true, name = user.Username, pending = true });
         }

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
         void SendEmailChangeConfirmationNotice(MailAddress newEmailAddress, string confirmationUrl);
         void SendPasswordResetInstructions(User user, string resetPasswordUrl, bool forgotPassword);
         void SendEmailChangeNoticeToPreviousEmailAddress(User user, string oldEmailAddress);
-        void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string confirmationUrl);
+        void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string confirmationUrl, string message);
         void SendPackageOwnerRemovedNotice(User fromUser, User toUser, PackageRegistration package);
         void SendCredentialRemovedNotice(User user, Credential removed);
         void SendCredentialAddedNotice(User user, Credential added);

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -294,17 +294,23 @@ The {0} Team";
 
             const string subject = "[{0}] The user '{1}' wants to add you as an owner of the package '{2}'.";
 
-            string body = @"The user '{0}' wants to add you as an owner of the package '{1}'.
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{fromUser.Username}' wants to add you as an owner of the package '{package.Id}'.
 If you do not want to be listed as an owner of this package, simply delete this email.
 
 To accept this request and become a listed owner of the package, click the following URL:
 
-[{2}]({2})
+[{confirmationUrl}]({confirmationUrl})");
 
-Thanks,
-The {3} Team";
 
-            body = String.Format(CultureInfo.CurrentCulture, body, fromUser.Username, package.Id, confirmationUrl, Config.GalleryOwner.DisplayName);
+            if (!string.IsNullOrWhiteSpace(message))
+            {
+                body += Environment.NewLine + Environment.NewLine + string.Format(CultureInfo.CurrentCulture, $@"The user '{fromUser.Username}' added the following message for you:
+
+'{message}'");
+            }
+
+            body += Environment.NewLine + Environment.NewLine + $@"Thanks,
+The {Config.GalleryOwner.DisplayName} Team";
 
             using (var mailMessage = new MailMessage())
             {
@@ -440,15 +446,15 @@ The {3} Team";
                     var senderCopy = new MailMessage(
                         Config.GalleryOwner,
                         mailMessage.ReplyToList.First())
-                        {
-                            Subject = mailMessage.Subject + " [Sender Copy]",
-                            Body = String.Format(
+                    {
+                        Subject = mailMessage.Subject + " [Sender Copy]",
+                        Body = String.Format(
                                 CultureInfo.CurrentCulture,
                                 "You sent the following message via {0}: {1}{1}{2}",
                                 Config.GalleryOwner.DisplayName,
                                 Environment.NewLine,
                                 mailMessage.Body),
-                        };
+                    };
                     senderCopy.ReplyToList.Add(mailMessage.ReplyToList.First());
                     MailSender.Send(senderCopy);
                 }
@@ -479,8 +485,8 @@ The {3} Team";
             body = String.Format(
                 CultureInfo.CurrentCulture,
                 body,
-                Config.GalleryOwner.DisplayName, 
-                package.PackageRegistration.Id, 
+                Config.GalleryOwner.DisplayName,
+                package.PackageRegistration.Id,
                 package.Version,
                 packageUrl,
                 packageSupportUrl,

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -31,7 +31,11 @@
         <legend>Add Owner</legend>
         <div class="form-field">
             <label for="newOwnerUserName">Username</label>
-            <input type="text" id="newOwnerUserName" name="newOwnerUserName" data-bind="value: newOwnerUsername" />
+            <input type="text" id="newOwnerUserName" name="newOwnerUserName" data-bind="value: newOwnerUsername"/>
+        </div>
+        <div class="form-field">
+            <label for="newOwnerUserName">Message</label>
+            <textarea id="newOwnerMessage" name="newOwnerUserName" data-bind="value: newOwnerMessage"></textarea>
         </div>
         <input type="submit" value="Add" title="Add the user as an owner to @Model.Title" data-bind="click: addOwner" />
     </fieldset>
@@ -50,10 +54,13 @@
                 package: { id: '@Model.Id' },
                 owners: ko.observableArray([]),
                 newOwnerUsername: ko.observable(''),
+                newOwnerMessage: ko.observable(''),
+
                 message: ko.observable(''),
 
                 addOwner: function () {
                     var newUsername = viewModel.newOwnerUsername();
+                    var message = viewModel.newOwnerMessage();
 
                     if (!newUsername) {
                         viewModel.message("Please enter a valid user name.");
@@ -72,7 +79,8 @@
                     var ownerInputModel =
                     {
                         username: newUsername,
-                        id: viewModel.package.id
+                        id: viewModel.package.id,
+                        message: message
                     };
 
                     var headers = { '__RequestVerificationToken': $('input[name=""__RequestVerificationToken""]').val() };
@@ -92,6 +100,7 @@
 
                                 // reset the Username textbox
                                 viewModel.newOwnerUsername('');
+                                viewModel.newOwnerMessage('');
 
                                 // when an operation succeeds, always clear the error message
                                 viewModel.message('');

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -18,7 +18,7 @@ namespace NuGetGallery.Controllers
             {
                 var controller = GetController<JsonApiController>();
 
-                JsonResult result = await controller.AddPackageOwner("foo", "steve");
+                JsonResult result = await controller.AddPackageOwner("foo", "steve", "message");
                 dynamic data = result.Data;
 
                 Assert.False(data.success);
@@ -33,7 +33,7 @@ namespace NuGetGallery.Controllers
                     .Setup(svc => svc.FindPackageRegistrationById("foo"))
                     .Returns(new PackageRegistration());
 
-                JsonResult result = await controller.AddPackageOwner("foo", "steve");
+                JsonResult result = await controller.AddPackageOwner("foo", "steve", "message");
                 dynamic data = result.Data;
 
                 Assert.False(data.success);
@@ -49,7 +49,7 @@ namespace NuGetGallery.Controllers
                     .Setup(c => c.User)
                     .Returns(Fakes.ToPrincipal(fakes.Owner));
 
-                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, "notARealUser");
+                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, "notARealUser", "message");
                 dynamic data = result.Data;
 
                 Assert.False(data.success);
@@ -81,10 +81,11 @@ namespace NuGetGallery.Controllers
                         fakes.Owner,
                         fakes.User,
                         fakes.Package,
-                        "https://nuget.local/packages/FakePackage/owners/testUser/confirm/confirmation-code"))
+                        "https://nuget.local/packages/FakePackage/owners/testUser/confirm/confirmation-code",
+                        "Hello World! Html Encoded &lt;3"))
                     .Verifiable();
 
-                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username);
+                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, "Hello World! Html Encoded <3");
                 dynamic data = result.Data;
 
                 Assert.True(data.success);

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -332,17 +332,33 @@ namespace NuGetGallery
                 var from = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
                 var package = new PackageRegistration { Id = "CoolStuff" };
                 const string confirmationUrl = "http://example.com/confirmation-token-url";
-
+                const string userMessage = "Hello World!";
                 var messageService = new TestableMessageService();
-                messageService.SendPackageOwnerRequest(from, to, package, confirmationUrl);
+                messageService.SendPackageOwnerRequest(from, to, package, confirmationUrl, userMessage);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal("new-owner@example.com", message.To[0].Address);
                 Assert.Equal(TestGalleryNoReplyAddress.Address, message.From.Address);
                 Assert.Equal("existing-owner@example.com", message.ReplyToList.Single().Address);
                 Assert.Equal("[Joe Shmoe] The user 'Existing' wants to add you as an owner of the package 'CoolStuff'.", message.Subject);
+                Assert.Contains("The user 'Existing' added the following message for you", message.Body);
+                Assert.Contains(userMessage, message.Body);
                 Assert.Contains(confirmationUrl, message.Body);
                 Assert.Contains("The user 'Existing' wants to add you as an owner of the package 'CoolStuff'.", message.Body);
+            }
+
+            [Fact]
+            public void SendsPackageOwnerRequestConfirmationUrlWithoutUserMessage()
+            {
+                var to = new User { Username = "Noob", EmailAddress = "new-owner@example.com", EmailAllowed = true };
+                var from = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
+                var package = new PackageRegistration { Id = "CoolStuff" };
+                const string confirmationUrl = "http://example.com/confirmation-token-url";
+                var messageService = new TestableMessageService();
+                messageService.SendPackageOwnerRequest(from, to, package, confirmationUrl, string.Empty);
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.DoesNotContain("The user 'Existing' added the following message for you", message.Body);
             }
 
             [Fact]
@@ -354,7 +370,7 @@ namespace NuGetGallery
                 const string confirmationUrl = "http://example.com/confirmation-token-url";
 
                 var messageService = new TestableMessageService();
-                messageService.SendPackageOwnerRequest(from, to, package, confirmationUrl);
+                messageService.SendPackageOwnerRequest(from, to, package, confirmationUrl, string.Empty);
 
                 Assert.Empty(messageService.MockMailSender.Sent);
             }
@@ -423,7 +439,8 @@ namespace NuGetGallery
                 var messageService = new TestableMessageService();
                 messageService.MockAuthService
                     .Setup(a => a.DescribeCredential(cred))
-                    .Returns(new CredentialViewModel {
+                    .Returns(new CredentialViewModel
+                    {
                         AuthUI = new AuthenticatorUI("sign in", "Microsoft Account", "Microsoft Account")
                     });
 
@@ -444,7 +461,8 @@ namespace NuGetGallery
                 var messageService = new TestableMessageService();
                 messageService.MockAuthService
                     .Setup(a => a.DescribeCredential(cred))
-                    .Returns(new CredentialViewModel() {
+                    .Returns(new CredentialViewModel()
+                    {
                         TypeCaption = "Password"
                     });
 
@@ -468,7 +486,8 @@ namespace NuGetGallery
                 var messageService = new TestableMessageService();
                 messageService.MockAuthService
                     .Setup(a => a.DescribeCredential(cred))
-                    .Returns(new CredentialViewModel {
+                    .Returns(new CredentialViewModel
+                    {
                         AuthUI = new AuthenticatorUI("sign in", "Microsoft Account", "Microsoft Account")
                     });
 
@@ -489,7 +508,8 @@ namespace NuGetGallery
                 var messageService = new TestableMessageService();
                 messageService.MockAuthService
                     .Setup(a => a.DescribeCredential(cred))
-                    .Returns(new CredentialViewModel {
+                    .Returns(new CredentialViewModel
+                    {
                         TypeCaption = "Password"
                     });
 


### PR DESCRIPTION
UI, message-service & tests enhanced for "message"

![image](https://cloud.githubusercontent.com/assets/756703/20409382/a8ebce52-ad19-11e6-93ac-a2d5abd097b8.png)

Email body will look like this:

```
The user 'admin' wants to add you as an owner of the package 'OpenXMLSDK-MOT'.
If you do not want to be listed as an owner of this package, simply delete this email.

To accept this request and become a listed owner of the package, click the following URL:

[https://nuget.localtest.me/packages/OpenXMLSDK-MOT/owners/tester1/confirm/hqVPnrJcMiOBD06SkBFOog2](https://nuget.localtest.me/packages/OpenXMLSDK-MOT/owners/tester1/confirm/hqVPnrJcMiOBD06SkBFOog2)

The user 'admin' added the following message for you:

'asda sd asd asd ,,, &lt; .&gt;&gt;'

Thanks,
The NuGet Gallery Team
```

`'asda sd asd asd ,,, &lt; .&gt;&gt;'` => the given message

The message itself will be html encoded and will be sent in the email.
The message will not be stored in the db, which is ok I think.
Related to this https://github.com/NuGet/NuGetGallery/issues/328