### PR TITLE
Add ability to remove "myself" from the owner list

### DIFF
--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -12,7 +12,7 @@
     <li>
         <span data-bind="text: name"></span> <em data-bind="visible: current">(that&#8217;s you!)</em>
         <em data-bind="visible: pending">(pending approval)</em>
-        <a href="#" title="Remove as owner of @Model.Title" data-bind="visible: !current, click: $root.removeOwner">Remove</a>
+        <a href="#" title="Remove as owner of @Model.Title" data-bind="visible: !current  || $parent.hasMoreThanOneOwner, click: $root.removeOwner">Remove</a>
     </li>
 </ul>
 
@@ -51,6 +51,10 @@
                 owners: ko.observableArray([]),
                 newOwnerUsername: ko.observable(''),
                 message: ko.observable(''),
+
+                hasMoreThanOneOwner: function() {
+                    return true;
+                },
 
                 addOwner: function () {
                     var newUsername = viewModel.newOwnerUsername();
@@ -108,6 +112,15 @@
                     var package = viewModel.package;
                     var headers = { '__RequestVerificationToken': $('input[name=""__RequestVerificationToken""]').val() };
 
+                    var proceedToRemoveFunction = true;
+
+                    if (item.current) {
+                        proceedToRemoveFunction = confirm("Are you sure you want to remove yourself from the owners?");
+                    }
+
+                    if (proceedToRemoveFunction === false)
+                        return;
+
                     $.ajax({
                         url: '@Url.Action("RemovePackageOwner", "JsonApi")?id=' + package.id + '&username=' + item.name(),
                         cache: false,
@@ -117,6 +130,10 @@
                         contentType: 'application/json; charset=utf-8',
                         success: function (data) {
                             if (data.success) {
+                                if (item.current) {
+                                    window.location.href = '@Url.Package(Model.Id)';
+                                }
+
                                 viewModel.owners.remove(item);
 
                                 // when an operation succeeds, always clear the error message
@@ -129,6 +146,24 @@
                     .error(failHandler);
                 }
             };
+
+            viewModel.hasMoreThanOneOwner = ko.computed(function () {
+
+                if (this.owners().length < 2)
+                    return false;
+
+                var approvedOwner = 0;
+
+                ko.utils.arrayForEach(this.owners(), function (owner) {
+                    if (owner.pending() === false)
+                        approvedOwner++;
+                });
+
+                if (approvedOwner >= 2)
+                    return true;
+
+                return false;
+            }, viewModel);
 
             ko.applyBindings(viewModel);
 


### PR DESCRIPTION
I noticed this issue https://github.com/NuGet/NuGetGallery/issues/3356 and found that the main "blocker" for this is based in the knockout.js viewmodel.

I changed the view logic so that someone could remove his account from the owner list if there are other "non-pending" owners.

The logic is: 
If I'm the only owner, I can't remove myself.
If there are other non-pending owners, than I could remove myself, but I can always remove others.

When I try to remove myself from the owners the user will get this warning:
![image](https://cloud.githubusercontent.com/assets/756703/20685748/f12d25b8-b5b5-11e6-85aa-18492c10a89b.png)

When the operation is completed the user will be redirected to the package page (because he is not an owner anymore).

"normal" view:

![image](https://cloud.githubusercontent.com/assets/756703/20685771/0cd14556-b5b6-11e6-986f-fd21aa0ebb71.png)
