### PR TITLE
Enable angle brackets search queries (AllowHtml vs. ASP.NET Req Validation)

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -385,8 +385,11 @@ namespace NuGetGallery
             return View(model);
         }
 
-        public virtual async Task<ActionResult> ListPackages(string q, int page = 1)
+        public virtual async Task<ActionResult> ListPackages(PackageListSearchViewModel searchAndListModel)
         {
+            var page = searchAndListModel.Page;
+            var q = searchAndListModel.Q;
+
             if (page < 1)
             {
                 page = 1;

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1400,6 +1400,7 @@
     <Compile Include="Infrastructure\Authentication\LegacyHasher.cs" />
     <Compile Include="Infrastructure\Authentication\V3Hasher.cs" />
     <Compile Include="Services\ReflowPackageService.cs" />
+    <Compile Include="ViewModels\PackageListSearchViewModel.cs" />
     <Compile Include="WebApi\PlainTextResult.cs" />
     <Compile Include="WebApi\QueryResult.cs" />
     <Compile Include="WebApi\QueryResultExtensions.cs" />

--- a/src/NuGetGallery/ViewModels/PackageListSearchViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageListSearchViewModel.cs
@@ -1,0 +1,11 @@
+using System.Web.Mvc;
+
+namespace NuGetGallery
+{
+    public class PackageListSearchViewModel
+    {
+        [AllowHtml]
+        public string Q { get; set; }
+        public int Page { get; set; }
+    }
+}

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -609,7 +609,7 @@ namespace NuGetGallery
                 var controller = CreateController(searchService: searchService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
 
-                var result = (await controller.ListPackages(" test ")) as ViewResult;
+                var result = (await controller.ListPackages(new PackageListSearchViewModel() { Q = " test "})) as ViewResult;
 
                 var model = result.Model as PackageListViewModel;
                 Assert.Equal("test", model.SearchTerm);


### PR DESCRIPTION
This PR should fix this behavior: https://github.com/NuGet/NuGetGallery/issues/1191

Background:
Currently NuGet.org doesn't allow "potentially dangerous content", e.g. < helloworld > because of the ASP.NET Request Validation.

My fix:
To suppress this I needed to introduce a new "viewmodel" in order to decorate the "query" parameter with the AllowHtml attribute.

After that everything worked as expected. The searchterm itself is html encoded displayed and shouldn't be a threat.

![image](https://cloud.githubusercontent.com/assets/756703/20728133/a78d498e-b67c-11e6-8ba2-e49a0db830aa.png)

![image](https://cloud.githubusercontent.com/assets/756703/20728136/ab1c6666-b67c-11e6-8268-52a44208d5a0.png)

With this fix the NuGet.org website can trigger the search engine with those angle brackets.
