### PR TITLE
remove fixed with and force 100% width for input fields

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -911,7 +911,7 @@ fieldset.form {
         font-size: 1.25em;
         padding: 5px 0 5px 10px;
         vertical-align: middle;
-        width: 400px;
+        width: 100%;
         /* This won't work in IE7, but it will only produce a minor layout quirk */
         -moz-box-sizing: border-box;
         -webkit-box-sizing: border-box;


### PR DESCRIPTION
I noticed this old issue https://github.com/NuGet/NuGetGallery/issues/1446 and always thought that those small input boxes are pretty stupid for a package management website.

So I did a quick experiment and removed the fixed with of 400px for input/textareas and the results are IMHO not bad (tested in IE11 and Chrome):

Current version:

![image](https://cloud.githubusercontent.com/assets/756703/20729224/5abdebc2-b681-11e6-85fd-c33a98564545.png)

100% version:

![image](https://cloud.githubusercontent.com/assets/756703/20729242/6c0f8052-b681-11e6-9911-23699a273fbd.png)

or the upload page:

![image](https://cloud.githubusercontent.com/assets/756703/20729297/b08d581c-b681-11e6-813a-f4766526201c.png)

Be aware that there are still a few glitches, but if you think it's a good change I would see if I can fix those as well.

![image](https://cloud.githubusercontent.com/assets/756703/20729333/dac4aaea-b681-11e6-873f-980382883998.png)

