### PR TITLE
Prevent unconfirmed users from re-enabling password auth #3386

### DIFF
--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -370,7 +370,7 @@
                     }
                 }
             }
-            else
+            else if (CurrentUser.Confirmed)
             {
                 using (Html.BeginForm("ChangePassword", "Users", FormMethod.Post, new { @class = "form-inline" }))
                 {


### PR DESCRIPTION
Issue #3386: AuthenticationService.GeneratePasswordResetToken throws InvalidOperationException when unconfirmed user re-enables password auth in profile. Proposed fix is to only show Enable button when account is confirmed, to match check in AuthService.GeneratePasswordResetToken.

@skofman1 