### PR TITLE
Chenriks/3316 o data

### DIFF
--- a/src/NuGetGallery/OData/SearchService/SearchHijacker.cs
+++ b/src/NuGetGallery/OData/SearchService/SearchHijacker.cs
@@ -127,6 +127,12 @@ namespace NuGetGallery.OData
 
         private static bool IsSubstringOfFunctionCall(SingleValueNode expression)
         {
+            // If necessary, unwrap SingleValueFunctionCall from ConvertNode
+            if (expression.Kind == QueryNodeKind.Convert)
+            {
+                expression = ((ConvertNode)expression).Source;
+            }
+
             if (expression.Kind == QueryNodeKind.SingleValueFunctionCall)
             {
                 var functionCallExpression = (SingleValueFunctionCallNode)expression;

--- a/src/NuGetGallery/OData/SearchService/SearchHijacker.cs
+++ b/src/NuGetGallery/OData/SearchService/SearchHijacker.cs
@@ -10,6 +10,7 @@ using System.Web.Http.OData.Query;
 using Microsoft.Data.Edm;
 using Microsoft.Data.OData;
 using Microsoft.Data.OData.Query;
+using Microsoft.Data.OData.Query.SemanticAst;
 using NuGetGallery.WebApi;
 
 namespace NuGetGallery.OData
@@ -102,21 +103,36 @@ namespace NuGetGallery.OData
             }
 
             // If the filter clause can be read, it may not be a valid expression tree.
-            // Verify "function cannot be applied to an enumeration-typed argument" type of errors.
-            // An example of such error: /api/v2/Packages?$filter=substringof(null,Id)
+            // Example is '/api/v2/Packages?$filter=substringof(null,Id)' which throws ODataException:
+            //     "The 'substringof' function cannot be applied to an enumeration-typed argument."
+            // Skip hijacking queries that use a substringof filter due to the cost of validating PropertyAccess nodes
             if (options.Filter?.FilterClause != null
-                && options.Filter.FilterClause.Expression.Kind == QueryNodeKind.SingleValueFunctionCall
                 && options.Filter.FilterClause.ItemType.Definition.TypeKind == EdmTypeKind.Entity)
             {
-                var functionCallExpression = (SingleValueFunctionCallNode) options.Filter.FilterClause.Expression;
-                if (string.Equals(functionCallExpression.Name, "substringof", StringComparison.OrdinalIgnoreCase))
+                var current = options.Filter.FilterClause.Expression;
+                while (current.Kind == QueryNodeKind.BinaryOperator)
                 {
-                    // The function cannot be applied to an enumeration-typed argument
-                    return false;
+                    var currentBinaryNode = ((BinaryOperatorNode)current);
+                    if (IsSubstringOfFunctionCall(currentBinaryNode.Right))
+                    {
+                        return false;
+                    }
+                    current = currentBinaryNode.Left;
                 }
+                return !IsSubstringOfFunctionCall(current);
             }
 
             return true;
+        }
+
+        private static bool IsSubstringOfFunctionCall(SingleValueNode expression)
+        {
+            if (expression.Kind == QueryNodeKind.SingleValueFunctionCall)
+            {
+                var functionCallExpression = (SingleValueFunctionCallNode)expression;
+                return string.Equals(functionCallExpression.Name, "substringof", StringComparison.OrdinalIgnoreCase);
+            }
+            return false;
         }
 
         private static IEnumerable<Tuple<Target, string>> ExtractComparison(MethodCallExpression outerWhere)

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -404,6 +404,7 @@
     <Compile Include="Controllers\StatisticsControllerFacts.cs" />
     <Compile Include="Controllers\UsersControllerFacts.cs" />
     <Compile Include="Framework\TestGalleryConfigurationService.cs" />
+    <Compile Include="OData\SearchService\SearchHijackerFacts.cs" />
     <Compile Include="PasswordValidationRegexTests.cs" />
     <Compile Include="SearchClient\CorrelatingHttpClientHandlerFacts.cs" />
     <Compile Include="SearchClient\RequestInspectingHandler.cs" />

--- a/tests/NuGetGallery.Facts/OData/SearchService/SearchHijackerFacts.cs
+++ b/tests/NuGetGallery.Facts/OData/SearchService/SearchHijackerFacts.cs
@@ -28,6 +28,12 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public void IsHijackableReturnsFalseWhenValidSubstringOfInBinaryOperatorWithConvertNode()
+            {
+                AssertIsNotHijackable("https://nuget.localtest.me/api/v2/Packages()?$filter=substringof(Id,%27MyPackage%27)%20and%20Id%20eq%20%27MyPackageId%27");
+            }
+
+            [Fact]
             public void IsHijackableReturnsFalseWhenInvalidSubstringOfInSingleValueExpression()
             {
                 AssertIsNotHijackable("https://localhost:8081/api/v2/Packages?$filter=substringof(null,Tags)");

--- a/tests/NuGetGallery.Facts/OData/SearchService/SearchHijackerFacts.cs
+++ b/tests/NuGetGallery.Facts/OData/SearchService/SearchHijackerFacts.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Web.Http.OData;
+using System.Web.Http.OData.Query;
+using NuGetGallery.OData;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class SearchHijackerFacts
+    {
+        protected static ODataQueryOptions<V2FeedPackage> GetODataQueryOptionsForTest(Uri requestUri)
+        {
+            return new ODataQueryOptions<V2FeedPackage>(
+                new ODataQueryContext(NuGetODataV2FeedConfig.GetEdmModel(), typeof(V2FeedPackage)),
+                new HttpRequestMessage(HttpMethod.Get, requestUri));
+        }
+
+        public class TheIsHijackableMethod
+        {
+            [Fact]
+            public void IsHijackableReturnsFalseWhenValidSubstringOfInSingleValueExpression()
+            {
+                AssertIsNotHijackable("https://nuget.localtest.me/api/v2/Packages()?$filter=substringof(Id,%27MyPackage%27)");
+            }
+
+            [Fact]
+            public void IsHijackableReturnsFalseWhenInvalidSubstringOfInSingleValueExpression()
+            {
+                AssertIsNotHijackable("https://localhost:8081/api/v2/Packages?$filter=substringof(null,Tags)");
+            }
+
+            [Fact]
+            public void IsHijackableReturnsFalseWhenInvalidSubstringOfInBinaryOperatorExpressionLeft()
+            {
+                AssertIsNotHijackable("https://nuget.localtest.me/api/v2/Packages()?$filter=substringof(null,Tags)%20and%20IsLatestVersion%20and%20IsLatestVersion");
+            }
+
+            [Fact]
+            public void IsHijackableReturnsFalseWhenInvalidSubstringOfInBinaryOperatorExpressionRight()
+            {
+                AssertIsNotHijackable("https://nuget.localtest.me/api/v2/Packages()?$filter=IsLatestVersion%20and%20substringof(null,Tags)");
+            }
+
+            private void AssertIsNotHijackable(string uri)
+            {
+                // Arrange
+                var requestUri = new Uri(uri);
+
+                // Act
+                HijackableQueryParameters hijackableQueryParameters = null;
+                var result = SearchHijacker.IsHijackable(GetODataQueryOptionsForTest(requestUri), out hijackableQueryParameters);
+
+                // Assert
+                Assert.False(result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
#3316 (partial; for logged ODataExceptions)

Update SearchHijacker.CanProcessFilterClause to also search for nested substringof calls in binary operator expressions. Hijacker is skipped when substringof is found, same as was done for non-nested (SingleValueFunctionCall) substringof calls.

Related to #2916 