### PR TITLE
Functional test that verifies the order of packages in the feed

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
@@ -117,7 +117,7 @@ namespace NuGetGallery.FunctionalTests
         {
             await UploadNewPackage(packageId, version, minClientVersion, title, tags, description, licenseUrl, dependencies);
 
-            VerifyPackage(packageId, version);
+            VerifyPackageExistsInSource(packageId, version);
         }
 
         public async Task UploadNewPackage(string packageId, string version = "1.0.0", string minClientVersion = null,
@@ -150,17 +150,17 @@ namespace NuGetGallery.FunctionalTests
         }
 
         /// <summary>
-        /// Deletes (unlists) a package with the specified Id and Version and checks if the delete has succeeded.
-        /// This will be used by test classes which tests scenarios on top of delete/unlist.
+        /// Unlists a package with the specified Id and Version and checks if the unlist has succeeded.
+        /// This will be used by test classes which tests scenarios on top of unlist.
         /// </summary>
-        public async Task DeletePackageAndVerify(string packageId, string version = "1.0.0")
+        public async Task UnlistPackageAndVerify(string packageId, string version = "1.0.0")
         {
-            await DeletePackage(packageId, version);
+            await UnlistPackage(packageId, version);
 
-            VerifyPackage(packageId, version);
+            VerifyPackageExistsInSource(packageId, version);
         }
 
-        public async Task DeletePackage(string packageId, string version = "1.0.0")
+        public async Task UnlistPackage(string packageId, string version = "1.0.0")
         {
             if (string.IsNullOrEmpty(packageId))
             {
@@ -177,7 +177,7 @@ namespace NuGetGallery.FunctionalTests
                 processResult.ExitCode + ". Error message: \"" + processResult.StandardError + "\"");
         }
 
-        public void VerifyPackage(string packageId, string version = "1.0.0")
+        public void VerifyPackageExistsInSource(string packageId, string version = "1.0.0")
         {
             var packageExistsInSource = CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl);
             Assert.True(packageExistsInSource,

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
@@ -111,7 +111,7 @@ namespace NuGetGallery.FunctionalTests
 
         /// <summary>
         /// Creates a package with the specified Id and Version and uploads it and checks if the upload has succeeded.
-        /// This will be used by test classes which tests scenarios on top of upload.
+        /// Throws if the upload fails or cannot be verified in the source.
         /// </summary>
         public async Task UploadNewPackageAndVerify(string packageId, string version = "1.0.0", string minClientVersion = null, string title = null, string tags = null, string description = null, string licenseUrl = null, string dependencies = null)
         {
@@ -151,7 +151,7 @@ namespace NuGetGallery.FunctionalTests
 
         /// <summary>
         /// Unlists a package with the specified Id and Version and checks if the unlist has succeeded.
-        /// This will be used by test classes which tests scenarios on top of unlist.
+        /// Throws if the unlist fails or cannot be verified in the source.
         /// </summary>
         public async Task UnlistPackageAndVerify(string packageId, string version = "1.0.0")
         {
@@ -164,19 +164,24 @@ namespace NuGetGallery.FunctionalTests
         {
             if (string.IsNullOrEmpty(packageId))
             {
-                packageId = DateTime.Now.Ticks.ToString();
+                throw new ArgumentException($"{nameof(packageId)} cannot be null or empty!");
             }
 
-            WriteLine("Deleting package '{0}', version '{1}'", packageId, version);
+            WriteLine("Unlisting package '{0}', version '{1}'", packageId, version);
 
             var commandlineHelper = new CommandlineHelper(TestOutputHelper);
             var processResult = await commandlineHelper.DeletePackageAsync(packageId, version, UrlHelper.V2FeedPushSourceUrl);
 
             Assert.True(processResult.ExitCode == 0,
-                "The package delete via Nuget.exe did not succeed properly. Check the logs to see the process error and output stream.  Exit Code: " +
+                "The package unlist via Nuget.exe did not succeed properly. Check the logs to see the process error and output stream.  Exit Code: " +
                 processResult.ExitCode + ". Error message: \"" + processResult.StandardError + "\"");
         }
 
+        /// <summary>
+        /// Throws if the specified package cannot be found in the source.
+        /// </summary>
+        /// <param name="packageId">Id of the package.</param>
+        /// <param name="version">Version of the package.</param>
         public void VerifyPackageExistsInSource(string packageId, string version = "1.0.0")
         {
             var packageExistsInSource = CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl);

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
@@ -141,7 +141,7 @@ namespace NuGetGallery.FunctionalTests
                 "The package upload via Nuget.exe did not succeed properly. Check the logs to see the process error and output stream.  Exit Code: " +
                 processResult.ExitCode + ". Error message: \"" + processResult.StandardError + "\"");
 
-            // Delete package from local disk so once it gets uploaded
+            // Delete package from local disk once it gets uploaded
             if (File.Exists(packageFullPath))
             {
                 File.Delete(packageFullPath);

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
@@ -61,7 +61,7 @@ namespace NuGetGallery.FunctionalTests
         /// <summary>
         /// Checks if the given package version is present in the source.
         /// </summary>
-        public bool CheckIfPackageVersionExistsInSource(string packageId, string version, string sourceUrl, bool isListed)
+        public bool CheckIfPackageVersionExistsInSource(string packageId, string version, string sourceUrl)
         {
             var found = false;
             var repo = PackageRepositoryFactory.Default.CreateRepository(sourceUrl);
@@ -92,17 +92,7 @@ namespace NuGetGallery.FunctionalTests
                         found = package != null;
                         if (found)
                         {
-                            var packageIsListedCorrectly = true; // package.Listed == isListed;
-
-                            WriteLine(packageIsListedCorrectly
-                                ? "Found!"
-                                : $"Found but is {(package.Listed ? "" : "not ")}listed. Expected package to be {(isListed ? "" : "not ")}listed.");
-
-                            if (!packageIsListedCorrectly)
-                            {
-                                found = false;
-                                break;
-                            }
+                            WriteLine("Found!");
                         }
                         else
                         {
@@ -127,7 +117,7 @@ namespace NuGetGallery.FunctionalTests
         {
             await UploadNewPackage(packageId, version, minClientVersion, title, tags, description, licenseUrl, dependencies);
 
-            VerifyPackage(packageId, true, version);
+            VerifyPackage(packageId, version);
         }
 
         public async Task UploadNewPackage(string packageId, string version = "1.0.0", string minClientVersion = null,
@@ -167,7 +157,7 @@ namespace NuGetGallery.FunctionalTests
         {
             await DeletePackage(packageId, version);
 
-            VerifyPackage(packageId, false, version);
+            VerifyPackage(packageId, version);
         }
 
         public async Task DeletePackage(string packageId, string version = "1.0.0")
@@ -187,9 +177,9 @@ namespace NuGetGallery.FunctionalTests
                 processResult.ExitCode + ". Error message: \"" + processResult.StandardError + "\"");
         }
 
-        public void VerifyPackage(string packageId, bool listed, string version = "1.0.0")
+        public void VerifyPackage(string packageId, string version = "1.0.0")
         {
-            var packageExistsInSource = CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl, listed);
+            var packageExistsInSource = CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl);
             Assert.True(packageExistsInSource,
                 $"Package {packageId} with version {version} is not found on the site {UrlHelper.V2FeedRootUrl}.");
         }

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/CommandlineHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/CommandlineHelper.cs
@@ -20,6 +20,7 @@ namespace NuGetGallery.FunctionalTests
         internal static string PackCommandString = " pack ";
         internal static string UpdateCommandString = " update ";
         internal static string InstallCommandString = " install ";
+        internal static string DeleteCommandString = " delete ";
         internal static string PushCommandString = " push ";
         internal static string OutputDirectorySwitchString = " -OutputDirectory ";
         internal static string PreReleaseSwitchString = " -Prerelease ";
@@ -48,6 +49,19 @@ namespace NuGetGallery.FunctionalTests
             var arguments = string.Join(string.Empty, PushCommandString, @"""" + packageFullPath + @"""", SourceSwitchString, sourceName, ApiKeySwitchString, EnvironmentSettings.TestAccountApiKey);
             WriteLine("nuget.exe " + arguments);
 
+            return await InvokeNugetProcess(arguments);
+        }
+
+        /// <summary>
+        ///  Delete the specified package using Nuget.exe
+        /// </summary>
+        /// <param name="packageId">package to be deleted</param>
+        /// <param name="version">version of package to be deleted</param>
+        /// <param name="sourceName">source url</param>
+        /// <returns></returns>
+        public async Task<ProcessResult> DeletePackageAsync(string packageId, string version, string sourceName)
+        {
+            var arguments = string.Join(string.Empty, DeleteCommandString, packageId, " ", version, SourceSwitchString, sourceName, ApiKeySwitchString, EnvironmentSettings.TestAccountApiKey);
             return await InvokeNugetProcess(arguments);
         }
 

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
@@ -59,30 +59,31 @@ namespace NuGetGallery.FunctionalTests
             }
         }
 
-        public async Task<DateTime> GetTimestampOfPackageFromResponse(string url, string propertyName, string packageId, string version = "1.0.0")
+        public async Task<DateTime?> GetTimestampOfPackageFromResponse(string url, string propertyName, string packageId, string version = "1.0.0")
         {
             WriteLine($"Getting '{propertyName}' timestamp of package '{packageId}' with version '{version}'.");
 
             var packageResponse = await GetPackageDataInResponse(url, packageId, version);
             if (string.IsNullOrEmpty(packageResponse))
             {
-                return DateTime.MinValue;
+                return null;
             }
 
             var timestampStartTag = "<d:" + propertyName + " m:type=\"Edm.DateTime\">";
             var timestampEndTag = "</d:" + propertyName + ">";
-            var timestampStartIndex = packageResponse.IndexOf(timestampStartTag) + timestampStartTag.Length;
 
-            if (timestampStartIndex < 0)
+            var timestampTagIndex = packageResponse.IndexOf(timestampStartTag);
+            if (timestampTagIndex < 0)
             {
                 WriteLine($"Package data does not contain '{propertyName}' timestamp!");
-                return DateTime.MinValue;
+                return null;
             }
 
-            var timestampEndIndex = packageResponse.IndexOf(timestampEndTag);
+            var timestampStartIndex = timestampTagIndex + timestampStartTag.Length;
+            var timestampLength = packageResponse.Substring(timestampStartIndex).IndexOf(timestampEndTag);
 
             var timestamp =
-                DateTime.Parse(packageResponse.Substring(timestampStartIndex, timestampEndIndex - timestampStartIndex));
+                DateTime.Parse(packageResponse.Substring(timestampStartIndex, timestampLength));
             WriteLine($"'{propertyName}' timestamp of package '{packageId}' with version '{version}' is '{timestamp}'");
             return timestamp;
         }

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
@@ -59,16 +59,59 @@ namespace NuGetGallery.FunctionalTests
             }
         }
 
+        public async Task<DateTime> GetTimestampOfPackageFromResponse(string url, string propertyName, string packageId, string version = "1.0.0")
+        {
+            WriteLine($"Getting '{propertyName}' timestamp of package '{packageId}' with version '{version}'.");
+
+            var packageResponse = await GetPackageDataInResponse(url, packageId, version);
+            if (string.IsNullOrEmpty(packageResponse))
+            {
+                return DateTime.MinValue;
+            }
+
+            var timestampStartTag = "<d:" + propertyName + " m:type=\"Edm.DateTime\">";
+            var timestampEndTag = "</d:" + propertyName + ">";
+            var timestampStartIndex = packageResponse.IndexOf(timestampStartTag) + timestampStartTag.Length;
+
+            if (timestampStartIndex < 0)
+            {
+                WriteLine($"Package data does not contain '{propertyName}' timestamp!");
+                return DateTime.MinValue;
+            }
+
+            var timestampEndIndex = packageResponse.IndexOf(timestampEndTag);
+
+            var timestamp =
+                DateTime.Parse(packageResponse.Substring(timestampStartIndex, timestampEndIndex - timestampStartIndex));
+            WriteLine($"'{propertyName}' timestamp of package '{packageId}' with version '{version}' is '{timestamp}'");
+            return timestamp;
+        }
+
+        public async Task<string> GetPackageDataInResponse(string url, string packageId, string version = "1.0.0")
+        {
+            WriteLine($"Getting data for package '{packageId}' with version '{version}'.");
+
+            var responseText = await GetResponseText(url);
+
+            var packageString = @"<id>" + UrlHelper.V2FeedRootUrl + @"Packages(Id='" + packageId + @"',Version='" + (string.IsNullOrEmpty(version) ? "" : version + "')</id>");
+            var endEntryTag = "</entry>";
+
+            var startingIndex = responseText.IndexOf(packageString);
+
+            if (startingIndex < 0)
+            {
+                WriteLine("Package not found in response text!");
+                return null;
+            }
+
+            var endingIndex = responseText.IndexOf(endEntryTag, startingIndex);
+
+            return responseText.Substring(startingIndex, endingIndex - startingIndex);
+        }
+
         public async Task<bool> ContainsResponseText(string url, params string[] expectedTexts)
         {
-            var request = WebRequest.Create(url);
-            var response = await request.GetResponseAsync().ConfigureAwait(false);
-
-            string responseText;
-            using (var sr = new StreamReader(response.GetResponseStream()))
-            {
-                responseText = await sr.ReadToEndAsync().ConfigureAwait(false);
-            }
+            var responseText = await GetResponseText(url);
 
             foreach (string s in expectedTexts)
             {
@@ -83,14 +126,7 @@ namespace NuGetGallery.FunctionalTests
 
         public async Task<bool> ContainsResponseTextIgnoreCase(string url, params string[] expectedTexts)
         {
-            var request = WebRequest.Create(url);
-            var response = await request.GetResponseAsync();
-
-            string responseText;
-            using (var sr = new StreamReader(response.GetResponseStream()))
-            {
-                responseText = (await sr.ReadToEndAsync()).ToLowerInvariant();
-            }
+            var responseText = (await GetResponseText(url)).ToLowerInvariant();
 
             foreach (string s in expectedTexts)
             {
@@ -103,15 +139,29 @@ namespace NuGetGallery.FunctionalTests
             return true;
         }
 
+        private async Task<string> GetResponseText(string url)
+        {
+            var request = WebRequest.Create(url);
+            var response = await request.GetResponseAsync();
+
+            string responseText;
+            using (var sr = new StreamReader(response.GetResponseStream()))
+            {
+                responseText = await sr.ReadToEndAsync().ConfigureAwait(false);
+            }
+
+            return responseText;
+        }
+
         public async Task DownloadPackageFromV2FeedWithOperation(string packageId, string version, string operation)
         {
             string filename = await DownloadPackageFromFeed(packageId, version, operation);
 
-            //check if the file exists.
+            // Check if the file exists.
             Assert.True(File.Exists(filename), Constants.PackageDownloadFailureMessage);
             var clientSdkHelper = new ClientSdkHelper(TestOutputHelper);
             string downloadedPackageId = clientSdkHelper.GetPackageIdFromNupkgFile(filename);
-            //Check that the downloaded Nupkg file is not corrupt and it indeed corresponds to the package which we were trying to download.
+            // Check that the downloaded Nupkg file is not corrupt and it indeed corresponds to the package which we were trying to download.
             Assert.True(downloadedPackageId.Equals(packageId), Constants.UnableToZipError);
         }
 

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
@@ -148,7 +148,7 @@ namespace NuGetGallery.FunctionalTests
             string responseText;
             using (var sr = new StreamReader(response.GetResponseStream()))
             {
-                responseText = await sr.ReadToEndAsync().ConfigureAwait(false);
+                responseText = await sr.ReadToEndAsync();
             }
 
             return responseText;

--- a/tests/NuGetGallery.FunctionalTests/Commandline/NuGetCommandLineTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/Commandline/NuGetCommandLineTests.cs
@@ -77,7 +77,7 @@ namespace NuGetGallery.FunctionalTests.Commandline
 
                 Assert.True(processResult.ExitCode == 0, Constants.UploadFailureMessage);
 
-                var packageVersionExistsInSource = _clientSdkHelper.CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl, true);
+                var packageVersionExistsInSource = _clientSdkHelper.CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl);
                 var userMessage = string.Format(Constants.PackageNotFoundAfterUpload, packageId, UrlHelper.V2FeedRootUrl);
                 Assert.True(packageVersionExistsInSource, userMessage);
 

--- a/tests/NuGetGallery.FunctionalTests/Commandline/NuGetCommandLineTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/Commandline/NuGetCommandLineTests.cs
@@ -77,7 +77,7 @@ namespace NuGetGallery.FunctionalTests.Commandline
 
                 Assert.True(processResult.ExitCode == 0, Constants.UploadFailureMessage);
 
-                var packageVersionExistsInSource = _clientSdkHelper.CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl);
+                var packageVersionExistsInSource = _clientSdkHelper.CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl, true);
                 var userMessage = string.Format(Constants.PackageNotFoundAfterUpload, packageId, UrlHelper.V2FeedRootUrl);
                 Assert.True(packageVersionExistsInSource, userMessage);
 

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -60,7 +60,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         }
 
         private const int PackagesInOrderNumPackages = 10;
-        private const int PackagesInOrderNumRetries = 50;
+        private const int PackagesInOrderNumRetries = 60;
         private const int PackagesInOrderRefreshTimeSec = 30*1000;
 
         [Fact]

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -136,7 +136,6 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         private static string GetPackageUrl(string packageId, string version = "1.0.0")
         {
             return UrlHelper.V2FeedRootUrl + @"/Packages(Id='" + packageId + "',Version='" + version + "')";
-            // return UrlHelper.V2FeedRootUrl + @"/FindPackagesById()?id='" + packageId + "'";
         }
 
         /// <summary>

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -66,7 +66,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
 
         private const int PackagesInOrderNumPackages = 100;
         private const int PackagesInOrderNumRetries = 12;
-        private const int PackagesInOrderRefreshTimeSec = 10*1000;
+        private const int PackagesInOrderRefreshTimeMs = 10*1000;
 
         [Fact]
         [Description("Upload multiple packages and verify that they appear in the feed in the correct order")]
@@ -80,7 +80,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 var packageIds = new List<string>(PackagesInOrderNumPackages);
                 var startingTime = DateTime.UtcNow;
 
-                // We set a maximum amount of tries so that we never wait more than PackagesInOrderNumRetries * PackagesInOrderRefreshTimeSec on this test case.
+                // We set a maximum amount of tries so that we never wait more than (PackagesInOrderNumRetries * PackagesInOrderRefreshTimeMs) milliseconds on this test case.
                 var triesAvailable = PackagesInOrderNumRetries;
 
                 // Upload the packages.
@@ -110,7 +110,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                         Assert.True(createdTimestamp.Value > lastCreatedTimestamp,
                             $"Package #{i} was uploaded after package #{i - 1} but has an earlier Created timestamp ({createdTimestamp} should be greater than {lastCreatedTimestamp}).");
                         lastCreatedTimestamp = createdTimestamp.Value;
-                    }, triesAvailable, PackagesInOrderRefreshTimeSec);
+                    }, triesAvailable, PackagesInOrderRefreshTimeMs);
                 }
 
                 // Unlist the packages in order.
@@ -138,7 +138,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                         Assert.True(lastEditedTimestamp.Value > lastLastEditedTimestamp,
                             $"Package #{i} was edited after package #{i - 1} but has an earlier LastEdited timestamp ({lastEditedTimestamp} should be greater than {lastLastEditedTimestamp}).");
                         lastLastEditedTimestamp = lastEditedTimestamp.Value;
-                    }, triesAvailable, PackagesInOrderRefreshTimeSec);
+                    }, triesAvailable, PackagesInOrderRefreshTimeMs);
                 }
             }
         }

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -4,14 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace NuGetGallery.FunctionalTests.ODataFeeds
 {


### PR DESCRIPTION
Idea behind the test case is this:

1. Upload `x` packages synchronously (wait for each request to finish before starting the next one).
2. Verify that the `Created` timestamps of the packages in the feed are in the correct order.
3. Unlist the packages synchronously (wait for each request to finish before starting the next one).
4. Verify that the `LastEdited` timestamps of the packages in the feed are in the correct order.

Had to make some modifications to the framework behind the tests because a number of things were not supported that were necessary for the test case (i.e. getting timestamps from the feed, deleting packages using nuget.exe).