### PR TITLE
3316: Filter out 400 and 404 response codes from telemetry logs

### DIFF
--- a/src/NuGetGallery/Helpers/TelemetryResponseCodeFilter.cs
+++ b/src/NuGetGallery/Helpers/TelemetryResponseCodeFilter.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace NuGetGallery.Helpers
+{
+    public class TelemetryResponseCodeFilter : ITelemetryProcessor
+    {
+        public TelemetryResponseCodeFilter(ITelemetryProcessor next)
+        {
+            Next = next;
+        }
+        
+        private ITelemetryProcessor Next { get; set; }
+
+        public void Process(ITelemetry item)
+        {
+            var request = item as RequestTelemetry;
+            int responseCode;
+
+            if (request != null && int.TryParse(request.ResponseCode, out responseCode))
+            {
+                if (responseCode == 400 || responseCode == 404)
+                {
+                    request.Success = true;
+                }
+            }
+
+            this.Next.Process(item);
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -747,6 +747,7 @@
     <Compile Include="Controllers\ErrorsController.cs" />
     <Compile Include="Controllers\PagesController.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Helpers\TelemetryResponseCodeFilter.cs" />
     <Compile Include="Infrastructure\Authentication\CredentialBuilder.cs" />
     <Compile Include="Infrastructure\Authentication\CredentialValidator.cs" />
     <Compile Include="Infrastructure\Authentication\ICredentialBuilder.cs" />


### PR DESCRIPTION
#3316 prevent logging of 400 and 404 responses