### PR TITLE
Added "Required"-badge on Edit Package Page

### DIFF
--- a/src/NuGetGallery/Views/Packages/Edit.cshtml
+++ b/src/NuGetGallery/Views/Packages/Edit.cshtml
@@ -276,6 +276,9 @@
                     </li>
                 }
             }
+            <li>
+                <img src="@Url.Content("~/Content/images/required.png")" alt="Blue border on left means required." />
+            </li>
         </ul>
         <input type="submit" value="Save" title="Save Changes" />
         <a class="cancel" href="@Url.Package(Model.PackageId, Model.Version)" title="Cancel Changes and go back to package page.">Cancel</a>


### PR DESCRIPTION
I noticed that on nearly all NuGet forms, e.g. create user form, change password, change email, contact support form there is this little "[blue border] = required" image - but currently it is missing from the Edit-Package page.

This PR will just add the little image to the edit page, resulting in this:

![image](https://cloud.githubusercontent.com/assets/756703/21115157/45c6aa18-c0b0-11e6-8ad5-d9b33e150e29.png)

Currently it looks like this:

![image](https://cloud.githubusercontent.com/assets/756703/21115201/6759890c-c0b0-11e6-8e36-8f024c5f8e97.png)

