### PR TITLE
Contact-Page: Add Required-badge and use fieldset

### DIFF
--- a/src/NuGetGallery/Views/Pages/Contact.cshtml
+++ b/src/NuGetGallery/Views/Pages/Contact.cshtml
@@ -51,8 +51,8 @@
         </p>
         using (Html.BeginForm("Contact", "Pages"))
         {
-            @Html.AntiForgeryToken()
             <fieldset class="form">
+                @Html.AntiForgeryToken()
                 <div class="form-field">
                     @Html.LabelFor(m => m.SubjectLine)
                     @Html.TextAreaFor(m => m.SubjectLine, 1, 50, null)
@@ -66,7 +66,7 @@
                     @Html.CheckBoxFor(m => m.CopySender)
                     @Html.LabelFor(m => m.CopySender, new { @class = "checkbox" })
                 </div>
-                <img src="/Content/images/required.png" alt="Blue border on left means required.">
+                <img src="@Url.Content("~/Content/images/required.png")" alt="Blue border on left means required.">
                 <input id="form-submit" type="submit" value="Contact" title="Contact Support" />
             </fieldset>
         }

--- a/src/NuGetGallery/Views/Pages/Contact.cshtml
+++ b/src/NuGetGallery/Views/Pages/Contact.cshtml
@@ -52,20 +52,23 @@
         using (Html.BeginForm("Contact", "Pages"))
         {
             @Html.AntiForgeryToken()
-            <div class="form-field">
-                @Html.LabelFor(m => m.SubjectLine)
-                @Html.TextAreaFor(m => m.SubjectLine, 1, 50, null)
-            </div>
-            <div class="form-field">
-                @Html.LabelFor(m => m.Message)
-                @Html.TextAreaFor(m => m.Message, 10, 50, null)
-                @Html.ValidationMessageFor(m => m.Message, null, new { id = "contact-support-message" })
-            </div>
-            <div class="form-field">
-                @Html.CheckBoxFor(m => m.CopySender)
-                @Html.LabelFor(m => m.CopySender, new { @class = "checkbox" })
-            </div>
-            <input id="form-submit" type="submit" value="Contact" title="Contact Support" />
+            <fieldset class="form">
+                <div class="form-field">
+                    @Html.LabelFor(m => m.SubjectLine)
+                    @Html.TextAreaFor(m => m.SubjectLine, 1, 50, null)
+                </div>
+                <div class="form-field">
+                    @Html.LabelFor(m => m.Message)
+                    @Html.TextAreaFor(m => m.Message, 10, 50, null)
+                    @Html.ValidationMessageFor(m => m.Message, null, new { id = "contact-support-message" })
+                </div>
+                <div class="form-field">
+                    @Html.CheckBoxFor(m => m.CopySender)
+                    @Html.LabelFor(m => m.CopySender, new { @class = "checkbox" })
+                </div>
+                <img src="/Content/images/required.png" alt="Blue border on left means required.">
+                <input id="form-submit" type="submit" value="Contact" title="Contact Support" />
+            </fieldset>
         }
     }
     else


### PR DESCRIPTION
Related to this PR https://github.com/NuGet/NuGetGallery/pull/3415 

Currently the "Contact Us" page is also missing the required-badge icon. 

The contact-us form was also not using the normal <fieldset ...> container, which is needed to render the img as a block element.

With the PR applied:

![image](https://cloud.githubusercontent.com/assets/756703/21157213/ddf13a2e-c178-11e6-9cb6-47eb7d898cb0.png)

Current version:

![image](https://cloud.githubusercontent.com/assets/756703/21157228/eb001302-c178-11e6-9a3b-8bb86f06b675.png)

Nothing fancy, but a consistent UI is helpful.
