### PR TITLE
Functional tests: nuget.exe spec -f fails after nuget.exe update to 3.5

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/CommandlineHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/CommandlineHelper.cs
@@ -16,7 +16,7 @@ namespace NuGetGallery.FunctionalTests
         : HelperBase
     {
         internal static string AnalyzeCommandString = " analyze ";
-        internal static string SpecCommandString = " spec -f ";
+        internal static string SpecCommandString = " spec -force ";
         internal static string PackCommandString = " pack ";
         internal static string UpdateCommandString = " update ";
         internal static string InstallCommandString = " install ";


### PR DESCRIPTION
Change -f to -force. We get "ambiguous option" error when using only -f.