### PR TITLE
Functional tests: Close all web responses after use

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
@@ -143,22 +143,25 @@ namespace NuGetGallery.FunctionalTests
         private async Task<string> GetResponseText(string url)
         {
             var request = WebRequest.Create(url);
-            var response = await request.GetResponseAsync();
-
-            string responseText;
-            using (var sr = new StreamReader(response.GetResponseStream()))
+            using (var response = await request.GetResponseAsync())
             {
-                responseText = await sr.ReadToEndAsync();
-            }
+                string responseText;
+                using (var sr = new StreamReader(response.GetResponseStream()))
+                {
+                    responseText = await sr.ReadToEndAsync();
+                }
 
-            return responseText;
+                return responseText;
+            }
         }
 
         public async Task<WebResponse> SendRequest(string url)
         {
             var request = WebRequest.Create(url);
-            var response = await request.GetResponseAsync().ConfigureAwait(false);
-            return response;
+            using (var response = await request.GetResponseAsync().ConfigureAwait(false))
+            {
+                return response;
+            }
         }
 
         public async Task DownloadPackageFromV2FeedWithOperation(string packageId, string version, string operation)

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
@@ -158,10 +158,7 @@ namespace NuGetGallery.FunctionalTests
         public async Task<WebResponse> SendRequest(string url)
         {
             var request = WebRequest.Create(url);
-            using (var response = await request.GetResponseAsync().ConfigureAwait(false))
-            {
-                return response;
-            }
+            return await request.GetResponseAsync().ConfigureAwait(false);
         }
 
         public async Task DownloadPackageFromV2FeedWithOperation(string packageId, string version, string operation)

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedTests.cs
@@ -91,7 +91,12 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         {
             //If the search engine will be changed to handle the types of requests passed as inputs; the test inputs need to be changed.
             var request = UrlHelper.V2FeedRootUrl + requestParametrs;
-            await Assert.ThrowsAsync<WebException>(async () => { await _odataHelper.SendRequest(request); });
+            await Assert.ThrowsAsync<WebException>(async () =>
+            {
+                using (await _odataHelper.SendRequest(request))
+                {
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Encountered some deadlocks with running groups of functional tests and this appeared to be the cause.