### PR TITLE
Prevent overwriting of packages in blob storage

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -350,15 +350,17 @@ namespace NuGetGallery
                             {
                                 await PackageFileService.SavePackageFileAsync(package, uploadStream.AsSeekableStream());
                             }
-                            catch (InvalidOperationException)
+                            catch (InvalidOperationException ex)
                             {
+                                ex.Log();
+
                                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.Conflict, Strings.UploadPackage_IdVersionConflict);
                             }
-
-                            IndexingService.UpdatePackage(package);
                         }
 
                         await EntitiesContext.SaveChangesAsync();
+
+                        IndexingService.UpdatePackage(package);
 
                         // Write an audit record
                         await AuditingService.SaveAuditRecord(

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1169,7 +1169,15 @@ namespace NuGetGallery
 
                 // save package to blob storage
                 uploadFile.Position = 0;
-                await _packageFileService.SavePackageFileAsync(package, uploadFile.AsSeekableStream());
+                try
+                {
+                    await _packageFileService.SavePackageFileAsync(package, uploadFile.AsSeekableStream());
+                }
+                catch(InvalidOperationException)
+                {
+                    TempData["Message"] = Strings.UploadPackage_IdVersionConflict;
+                    return new RedirectResult(Url.UploadPackage());
+                }
 
                 // commit all changes to database as an atomic transaction
                 await _entitiesContext.SaveChangesAsync();

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1176,7 +1176,7 @@ namespace NuGetGallery
                 catch(InvalidOperationException)
                 {
                     TempData["Message"] = Strings.UploadPackage_IdVersionConflict;
-                    return new RedirectResult(Url.UploadPackage());
+                    return new RedirectResult(Url.VerifyPackage());
                 }
 
                 // commit all changes to database as an atomic transaction

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1173,8 +1173,9 @@ namespace NuGetGallery
                 {
                     await _packageFileService.SavePackageFileAsync(package, uploadFile.AsSeekableStream());
                 }
-                catch(InvalidOperationException)
+                catch (InvalidOperationException ex)
                 {
+                    ex.Log();
                     TempData["Message"] = Strings.UploadPackage_IdVersionConflict;
                     return new RedirectResult(Url.VerifyPackage());
                 }

--- a/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
+++ b/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
@@ -108,10 +108,12 @@ namespace NuGetGallery
             if (overwrite)
             {
                 await blob.DeleteIfExistsAsync();
-            } else if (await blob.ExistsAsync())
+            }
+            else if (await blob.ExistsAsync())
             {
                 throw new InvalidOperationException(
-                    String.Format(CultureInfo.CurrentCulture, "There is already a blob with name {0} in container {1}.", fileName, folderName));
+                    String.Format(CultureInfo.CurrentCulture, "There is already a blob with name {0} in container {1}.",
+                        fileName, folderName));
             }
 
             await blob.UploadFromStreamAsync(packageFile);

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -124,7 +124,7 @@ namespace NuGetGallery
             return Task.FromResult<IFileReference>(file.Exists ? new LocalFileReference(file) : null);
         }
 
-        public Task SaveFileAsync(string folderName, string fileName, Stream packageFile)
+        public Task SaveFileAsync(string folderName, string fileName, Stream packageFile, bool overwrite = true)
         {
             if (String.IsNullOrWhiteSpace(folderName))
             {
@@ -149,7 +149,15 @@ namespace NuGetGallery
 
             if (_fileSystemService.FileExists(filePath))
             {
-                _fileSystemService.DeleteFile(filePath);
+                if (overwrite)
+                {
+                    _fileSystemService.DeleteFile(filePath);
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        String.Format(CultureInfo.CurrentCulture, "There is already a file with name {0} in folder {1}.", fileName, folderName));
+                }
             }
 
             using (var file = _fileSystemService.OpenWrite(filePath))

--- a/src/NuGetGallery/Services/IFileStorageService.cs
+++ b/src/NuGetGallery/Services/IFileStorageService.cs
@@ -26,7 +26,7 @@ namespace NuGetGallery
         /// <returns>A <see cref="IFileReference"/> representing the file reference</returns>
         Task<IFileReference> GetFileReferenceAsync(string folderName, string fileName, string ifNoneMatch = null);
 
-        Task SaveFileAsync(string folderName, string fileName, Stream packageFile);
+        Task SaveFileAsync(string folderName, string fileName, Stream packageFile, bool overwrite = true);
 
         Task<bool> IsAvailableAsync();
     }

--- a/src/NuGetGallery/Services/PackageFileService.cs
+++ b/src/NuGetGallery/Services/PackageFileService.cs
@@ -56,7 +56,7 @@ namespace NuGetGallery
             }
 
             var fileName = BuildFileName(package);
-            return _fileStorageService.SaveFileAsync(Constants.PackagesFolderName, fileName, packageFile);
+            return _fileStorageService.SaveFileAsync(Constants.PackagesFolderName, fileName, packageFile, false);
         }
 
         public Task StorePackageFileInBackupLocationAsync(Package package, Stream packageFile)

--- a/src/NuGetGallery/Services/PackageFileService.cs
+++ b/src/NuGetGallery/Services/PackageFileService.cs
@@ -56,7 +56,7 @@ namespace NuGetGallery
             }
 
             var fileName = BuildFileName(package);
-            return _fileStorageService.SaveFileAsync(Constants.PackagesFolderName, fileName, packageFile, false);
+            return _fileStorageService.SaveFileAsync(Constants.PackagesFolderName, fileName, packageFile, overwrite: false);
         }
 
         public Task StorePackageFileInBackupLocationAsync(Package package, Stream packageFile)

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -618,7 +618,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A package with id &apos;{0}&apos; and version &apos;{1}&apos; already exists and cannot be modified..
+        ///   Looks up a localized string similar to A package with ID &apos;{0}&apos; and version &apos;{1}&apos; already exists and cannot be modified..
         /// </summary>
         public static string PackageExistsAndCannotBeModified {
             get {
@@ -654,7 +654,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A package with id &apos;{0}&apos; and version &apos;{1}&apos; does not exist..
+        ///   Looks up a localized string similar to A package with ID &apos;{0}&apos; and version &apos;{1}&apos; does not exist..
         /// </summary>
         public static string PackageWithIdAndVersionNotFound {
             get {
@@ -789,7 +789,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is a conflict with the id and version of your package and another package. Please change your package&apos;s id or version and try again..
+        ///   Looks up a localized string similar to There is a conflict with the ID and version of your package and another package. Please change your package&apos;s ID or version and try again..
         /// </summary>
         public static string UploadPackage_IdVersionConflict {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -789,6 +789,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There is a conflict with the id and version of your package and another package. Please change your package&apos;s id or version and try again..
+        /// </summary>
+        public static string UploadPackage_IdVersionConflict {
+            get {
+                return ResourceManager.GetString("UploadPackage_IdVersionConflict", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The NuGet package contains an invalid .nuspec file. The error encountered was: &apos;{0}&apos;. Correct the error and try again..
         /// </summary>
         public static string UploadPackage_InvalidNuspec {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -410,4 +410,7 @@ The {1} Team</value>
   <data name="UploadPackage_InvalidNuspecMultiple" xml:space="preserve">
     <value>The NuGet package contains an invalid .nuspec file. The errors encountered were: '{0}'. Correct the errors and try again.</value>
   </data>
+  <data name="UploadPackage_IdVersionConflict" xml:space="preserve">
+    <value>There is a conflict with the id and version of your package and another package. Please change your package's id or version and try again.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -130,7 +130,7 @@
     <value>The package ID '{0}' is not available.</value>
   </data>
   <data name="PackageWithIdAndVersionNotFound" xml:space="preserve">
-    <value>A package with id '{0}' and version '{1}' does not exist.</value>
+    <value>A package with ID '{0}' and version '{1}' does not exist.</value>
   </data>
   <data name="NuGetPackagePropertyTooLong" xml:space="preserve">
     <value>A nuget package's {0} property may not be more than {1} characters long.</value>
@@ -139,7 +139,7 @@
     <value>The specified API key is invalid, has expired, or does not have permission to access the specified package.</value>
   </data>
   <data name="PackageExistsAndCannotBeModified" xml:space="preserve">
-    <value>A package with id '{0}' and version '{1}' already exists and cannot be modified.</value>
+    <value>A package with ID '{0}' and version '{1}' already exists and cannot be modified.</value>
   </data>
   <data name="CurrentPasswordIncorrect" xml:space="preserve">
     <value>The current password you provided is incorrect.</value>
@@ -411,6 +411,6 @@ The {1} Team</value>
     <value>The NuGet package contains an invalid .nuspec file. The errors encountered were: '{0}'. Correct the errors and try again.</value>
   </data>
   <data name="UploadPackage_IdVersionConflict" xml:space="preserve">
-    <value>There is a conflict with the id and version of your package and another package. Please change your package's id or version and try again.</value>
+    <value>There is a conflict with the ID and version of your package and another package. Please change your package's ID or version and try again.</value>
   </data>
 </root>

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -19,6 +19,7 @@ using NuGetGallery.Configuration;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
 using Xunit;
+using System.Globalization;
 
 namespace NuGetGallery
 {
@@ -351,7 +352,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task WillReturnConflictIfSavingPackageBlobFails()
+            public async Task WillReturnConflictIfSavingPackageBlobFailsOnConflict()
             {
                 // Arrange
                 var user = new User { EmailAddress = "confirmed@email.com" };
@@ -786,21 +787,23 @@ namespace NuGetGallery
             public void VerifyPackageKeyReturns404IfPackageDoesNotExist()
             {
                 // Arrange
+                var id = "foo";
+                var version = "1.0.0";
                 var user = new User { EmailAddress = "confirmed@email.com" };
                 GetMock<IPackageService>()
-                    .Setup(s => s.FindPackageByIdAndVersion("foo", "1.0.0", true))
+                    .Setup(s => s.FindPackageByIdAndVersion(id, version, true))
                     .ReturnsNull();
                 var controller = GetController<ApiController>();
                 controller.SetCurrentUser(user);
 
                 // Act
-                var result = controller.VerifyPackageKey("foo", "1.0.0");
+                var result = controller.VerifyPackageKey(id, version);
 
                 // Assert
                 ResultAssert.IsStatusCode(
                     result,
                     HttpStatusCode.NotFound,
-                    "A package with id 'foo' and version '1.0.0' does not exist.");
+                    String.Format(CultureInfo.CurrentCulture, Strings.PackageWithIdAndVersionNotFound, id, version));
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -834,18 +834,20 @@ namespace NuGetGallery
             [Fact]
             public async Task WillRedirectToVerifyPackageActionWhenThereIsAlreadyAnUploadInProgress()
             {
-                var fakeFileStream = new MemoryStream();
-                var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                var controller = CreateController(
-                    uploadFileService: fakeUploadFileService);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    var fakeUploadFileService = new Mock<IUploadFileService>();
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key))
+                        .Returns(Task.FromResult<Stream>(fakeFileStream));
+                    var controller = CreateController(
+                        uploadFileService: fakeUploadFileService);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                var result = await controller.UploadPackage() as RedirectToRouteResult;
+                    var result = await controller.UploadPackage() as RedirectToRouteResult;
 
-                Assert.NotNull(result);
-                Assert.Equal(RouteName.VerifyPackage, result.RouteName);
-                fakeFileStream.Dispose();
+                    Assert.NotNull(result);
+                    Assert.Equal(RouteName.VerifyPackage, result.RouteName);
+                }
             }
 
             [Fact]
@@ -868,18 +870,19 @@ namespace NuGetGallery
             [Fact]
             public async Task WillReturn409WhenThereIsAlreadyAnUploadInProgress()
             {
-                var fakeFileStream = new MemoryStream();
-                var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                var controller = CreateController(
-                    uploadFileService: fakeUploadFileService);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    var fakeUploadFileService = new Mock<IUploadFileService>();
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    var controller = CreateController(
+                        uploadFileService: fakeUploadFileService);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                var result = await controller.UploadPackage(null) as HttpStatusCodeResult;
+                    var result = await controller.UploadPackage(null) as HttpStatusCodeResult;
 
-                Assert.NotNull(result);
-                Assert.Equal(409, result.StatusCode);
-                fakeFileStream.Dispose();
+                    Assert.NotNull(result);
+                    Assert.Equal(409, result.StatusCode);
+                }
             }
 
             [Fact]
@@ -1378,24 +1381,25 @@ namespace NuGetGallery
             public async Task WillCreateThePackage()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackageService = new Mock<IPackageService>();
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>())).Returns(
-                    Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageService = new Mock<IPackageService>();
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>())).Returns(
+                        Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
 
-                fakePackageService.Verify(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), TestUtility.FakeUser, false));
-                fakeFileStream.Dispose();
+                    fakePackageService.Verify(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), TestUtility.FakeUser, false));
+                }
             }
 
             [Fact]
@@ -1403,32 +1407,33 @@ namespace NuGetGallery
             {
                 // Arrange
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackageService = new Mock<IPackageService>();
-                var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(fakePackage));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageService = new Mock<IPackageService>();
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(fakePackage));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var fakePackageFileService = new Mock<IPackageFileService>();
-                fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.FromResult(0)).Verifiable();
+                    var fakePackageFileService = new Mock<IPackageFileService>();
+                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.FromResult(0)).Verifiable();
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage,
-                    packageFileService: fakePackageFileService);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage,
+                        packageFileService: fakePackageFileService);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                // Act
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
+                    // Act
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
 
-                // Assert
-                fakePackageService.Verify(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), TestUtility.FakeUser, false));
-                fakePackageFileService.Verify();
-                fakeFileStream.Dispose();
+                    // Assert
+                    fakePackageService.Verify(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), TestUtility.FakeUser, false));
+                    fakePackageFileService.Verify();
+                }
             }
 
             [Fact]
@@ -1436,37 +1441,38 @@ namespace NuGetGallery
             {
                 // Arrange
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackageService = new Mock<IPackageService>();
-                var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(fakePackage));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageService = new Mock<IPackageService>();
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(fakePackage));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var fakePackageFileService = new Mock<IPackageFileService>();
-                fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>()))
-                    .Throws<InvalidOperationException>();
+                    var fakePackageFileService = new Mock<IPackageFileService>();
+                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>()))
+                        .Throws<InvalidOperationException>();
 
-                var fakeEntitiesContext = new Mock<IEntitiesContext>();
+                    var fakeEntitiesContext = new Mock<IEntitiesContext>();
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage,
-                    packageFileService: fakePackageFileService,
-                    entitiesContext: fakeEntitiesContext);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage,
+                        packageFileService: fakePackageFileService,
+                        entitiesContext: fakeEntitiesContext);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                // Act
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
+                    // Act
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
 
-                // Assert
-                fakePackageService.Verify(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), TestUtility.FakeUser, false));
-                Assert.Equal(Strings.UploadPackage_IdVersionConflict, controller.TempData["Message"]);
-                fakeEntitiesContext.VerifyCommitted(Times.Never());
-                fakeFileStream.Dispose();
+                    // Assert
+                    fakePackageService.Verify(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), TestUtility.FakeUser, false));
+                    Assert.Equal(Strings.UploadPackage_IdVersionConflict, controller.TempData["Message"]);
+                    fakeEntitiesContext.VerifyCommitted(Times.Never());
+                }
             }
 
             [Fact]
@@ -1474,34 +1480,35 @@ namespace NuGetGallery
             {
                 // Arrange
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackageService = new Mock<IPackageService>();
-                var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(fakePackage));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
-                var fakePackageFileService = new Mock<IPackageFileService>();
-                fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.FromResult(0)).Verifiable();
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageService = new Mock<IPackageService>();
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(fakePackage));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakePackageFileService = new Mock<IPackageFileService>();
+                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.FromResult(0)).Verifiable();
 
-                var fakeIndexingService = new Mock<IIndexingService>(MockBehavior.Strict);
-                fakeIndexingService.Setup(f => f.UpdateIndex()).Verifiable();
+                    var fakeIndexingService = new Mock<IIndexingService>(MockBehavior.Strict);
+                    fakeIndexingService.Setup(f => f.UpdateIndex()).Verifiable();
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage,
-                    packageFileService: fakePackageFileService,
-                    indexingService: fakeIndexingService);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage,
+                        packageFileService: fakePackageFileService,
+                        indexingService: fakeIndexingService);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                // Act
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
+                    // Act
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
 
-                // Assert
-                fakeIndexingService.Verify();
-                fakeFileStream.Dispose();
+                    // Assert
+                    fakeIndexingService.Verify();
+                }
             }
 
             [Fact]
@@ -1509,34 +1516,35 @@ namespace NuGetGallery
             {
                 // Arrange
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key))
-                    .Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key))
-                    .Returns(Task.CompletedTask);
-                var fakePackageService = new Mock<IPackageService>();
-                var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(fakePackage));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key))
+                        .Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key))
+                        .Returns(Task.CompletedTask);
+                    var fakePackageService = new Mock<IPackageService>();
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(fakePackage));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var entitiesContext = new Mock<IEntitiesContext>();
-                entitiesContext.Setup(e => e.SaveChangesAsync())
-                    .Returns(Task.FromResult(0)).Verifiable();
+                    var entitiesContext = new Mock<IEntitiesContext>();
+                    entitiesContext.Setup(e => e.SaveChangesAsync())
+                        .Returns(Task.FromResult(0)).Verifiable();
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage,
-                    entitiesContext: entitiesContext);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage,
+                        entitiesContext: entitiesContext);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                // Act
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
+                    // Act
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
 
-                // Assert
-                entitiesContext.Verify();
-                fakeFileStream.Dispose();
+                    // Assert
+                    entitiesContext.Verify();
+                }
             }
 
             [Fact]
@@ -1544,84 +1552,86 @@ namespace NuGetGallery
             {
                 // Arrange
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key))
-                    .Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key))
-                    .Returns(Task.CompletedTask);
-                var fakePackageService = new Mock<IPackageService>(MockBehavior.Strict);
-                var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), false))
-                    .Returns(Task.FromResult(fakePackage));
-                fakePackageService.Setup(x => x.PublishPackageAsync(fakePackage, false))
-                    .Returns(Task.CompletedTask);
-                fakePackageService.Setup(x => x.MarkPackageUnlistedAsync(fakePackage, false))
-                    .Returns(Task.CompletedTask);
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key))
+                        .Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key))
+                        .Returns(Task.CompletedTask);
+                    var fakePackageService = new Mock<IPackageService>(MockBehavior.Strict);
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), false))
+                        .Returns(Task.FromResult(fakePackage));
+                    fakePackageService.Setup(x => x.PublishPackageAsync(fakePackage, false))
+                        .Returns(Task.CompletedTask);
+                    fakePackageService.Setup(x => x.MarkPackageUnlistedAsync(fakePackage, false))
+                        .Returns(Task.CompletedTask);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                // Act
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
+                    // Act
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
 
-                // There's no assert. If the method completes, it means the test passed because we set MockBehavior to Strict
-                // for the fakePackageService. We verified that it only calls methods passing commitSettings = false.
-
-                fakeFileStream.Dispose();
+                    // There's no assert. If the method completes, it means the test passed because we set MockBehavior to Strict
+                    // for the fakePackageService. We verified that it only calls methods passing commitSettings = false.
+                }
             }
 
             [Fact]
             public async Task WillPublishThePackage()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                var fakePackageService = new Mock<IPackageService>();
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(fakePackage));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    var fakePackageService = new Mock<IPackageService>();
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(fakePackage));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Edit = null });
 
-                fakePackageService.Verify(x => x.PublishPackageAsync(fakePackage, false), Times.Once());
-                fakeFileStream.Dispose();
+                    fakePackageService.Verify(x => x.PublishPackageAsync(fakePackage, false), Times.Once());
+                }
             }
 
             [Fact]
             public async Task WillMarkThePackageUnlistedWhenListedArgumentIsFalse()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                var fakePackageService = new Mock<IPackageService>();
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    var fakePackageService = new Mock<IPackageService>();
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
 
-                fakePackageService.Verify(
-                    x => x.MarkPackageUnlistedAsync(It.Is<Package>(p => p.PackageRegistration.Id == "theId" && p.Version == "theVersion"), It.IsAny<bool>()));
-                fakeFileStream.Dispose();
+                    fakePackageService.Verify(
+                        x => x.MarkPackageUnlistedAsync(It.Is<Package>(p => p.PackageRegistration.Id == "theId" && p.Version == "theVersion"), It.IsAny<bool>()));
+                }
             }
 
             [Theory]
@@ -1630,24 +1640,25 @@ namespace NuGetGallery
             public async Task WillNotMarkThePackageUnlistedWhenListedArgumentIsNullorTrue(bool? listed)
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackageService = new Mock<IPackageService>();
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageService = new Mock<IPackageService>();
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = listed.GetValueOrDefault(true), Edit = null });
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = listed.GetValueOrDefault(true), Edit = null });
 
-                fakePackageService.Verify(x => x.MarkPackageUnlistedAsync(It.IsAny<Package>(), It.IsAny<bool>()), Times.Never());
-                fakeFileStream.Dispose();
+                    fakePackageService.Verify(x => x.MarkPackageUnlistedAsync(It.IsAny<Package>(), It.IsAny<bool>()), Times.Never());
+                }
             }
 
             [Fact]
@@ -1655,99 +1666,104 @@ namespace NuGetGallery
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
                 fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0)).Verifiable();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                var fakePackageService = new Mock<IPackageService>();
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(),  It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    var fakePackageService = new Mock<IPackageService>();
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
 
-                fakeUploadFileService.Verify();
-                fakeFileStream.Dispose();
+                    fakeUploadFileService.Verify();
+                }
             }
 
             [Fact]
             public async Task WillSetAFlashMessage()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackageService = new Mock<IPackageService>();
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(),  It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageService = new Mock<IPackageService>();
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
 
-                Assert.Equal(String.Format(Strings.SuccessfullyUploadedPackage, "theId", "theVersion"), controller.TempData["Message"]);
-                fakeFileStream.Dispose();
+                    Assert.Equal(String.Format(Strings.SuccessfullyUploadedPackage, "theId", "theVersion"), controller.TempData["Message"]);
+                }
             }
 
             [Fact]
             public async Task WillRedirectToPackagePage()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackageService = new Mock<IPackageService>();
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(),  It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageService = new Mock<IPackageService>();
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                var result = await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null }) as RedirectToRouteResult;
+                    var result = await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null }) as RedirectToRouteResult;
 
-                Assert.NotNull(result);
-                Assert.Equal(RouteName.DisplayPackage, result.RouteName);
-                fakeFileStream.Dispose();
+                    Assert.NotNull(result);
+                    Assert.Equal(RouteName.DisplayPackage, result.RouteName);
+                }
             }
 
             [Fact]
             public async Task WillCurateThePackage()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackageService = new Mock<IPackageService>();
-                var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(),  It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(fakePackage));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageService = new Mock<IPackageService>();
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(fakePackage));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var fakeAutoCuratePackageCmd = new Mock<IAutomaticallyCuratePackageCommand>();
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage,
-                    autoCuratePackageCmd: fakeAutoCuratePackageCmd);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var fakeAutoCuratePackageCmd = new Mock<IAutomaticallyCuratePackageCommand>();
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage,
+                        autoCuratePackageCmd: fakeAutoCuratePackageCmd);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
+                    await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Edit = null });
 
-                fakeAutoCuratePackageCmd.Verify(fake => fake.ExecuteAsync(fakePackage, It.IsAny<PackageArchiveReader>(), false));
+                    fakeAutoCuratePackageCmd.Verify(fake => fake.ExecuteAsync(fakePackage, It.IsAny<PackageArchiveReader>(), false));
+                }
             }
 
             [Fact]
@@ -1755,32 +1771,34 @@ namespace NuGetGallery
             {
                 // Arrange
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                var fakeFileStream = new MemoryStream();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                var fakePackageService = new Mock<IPackageService>();
-                var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(fakePackage));
-                var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageService = new Mock<IPackageService>();
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
+                        .Returns(Task.FromResult(fakePackage));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
-                var auditingService = new TestAuditingService();
+                    var auditingService = new TestAuditingService();
 
-                var controller = CreateController(
-                    packageService: fakePackageService,
-                    uploadFileService: fakeUploadFileService,
-                    fakeNuGetPackage: fakeNuGetPackage,
-                    auditingService: auditingService);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        packageService: fakePackageService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage,
+                        auditingService: auditingService);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                // Act
-                await controller.VerifyPackage(new VerifyPackageRequest { Listed = true, Edit = null });
+                    // Act
+                    await controller.VerifyPackage(new VerifyPackageRequest { Listed = true, Edit = null });
 
-                // Assert
-                Assert.True(auditingService.WroteRecord<PackageAuditRecord>(ar =>
-                    ar.Action == AuditedPackageAction.Create 
-                    && ar.Id == fakePackage.PackageRegistration.Id
-                    && ar.Version == fakePackage.Version));
+                    // Assert
+                    Assert.True(auditingService.WroteRecord<PackageAuditRecord>(ar =>
+                        ar.Action == AuditedPackageAction.Create
+                        && ar.Id == fakePackage.PackageRegistration.Id
+                        && ar.Version == fakePackage.Version));
+                }
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
@@ -471,7 +471,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task WillThrowIfBlobExistsAndNotOverwriteFalse()
+            public async Task WillThrowIfBlobExistsAndOverwriteFalse()
             {
                 var fakeBlobClient = new Mock<ICloudBlobClient>();
                 var fakeBlobContainer = new Mock<ICloudBlobContainer>();

--- a/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
@@ -486,7 +486,7 @@ namespace NuGetGallery
                 fakeBlob.Setup(x => x.Uri).Returns(new Uri("http://theUri"));
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 
-                await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.SaveFileAsync(Constants.PackagesFolderName, "theFileName", new MemoryStream(), false));
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.SaveFileAsync(Constants.PackagesFolderName, "theFileName", new MemoryStream(), overwrite: false));
 
                 fakeBlob.Verify();
             }

--- a/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
@@ -449,7 +449,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task WillDeleteTheBlobIfItExists()
+            public async Task WillDeleteBlobIfItExistsAndOverwriteTrue()
             {
                 var fakeBlobClient = new Mock<ICloudBlobClient>();
                 var fakeBlobContainer = new Mock<ICloudBlobContainer>();
@@ -466,6 +466,27 @@ namespace NuGetGallery
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 
                 await service.SaveFileAsync(Constants.PackagesFolderName, "theFileName", new MemoryStream());
+
+                fakeBlob.Verify();
+            }
+
+            [Fact]
+            public async Task WillThrowIfBlobExistsAndNotOverwriteFalse()
+            {
+                var fakeBlobClient = new Mock<ICloudBlobClient>();
+                var fakeBlobContainer = new Mock<ICloudBlobContainer>();
+                var fakeBlob = new Mock<ISimpleCloudBlob>();
+                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                fakeBlob.Setup(x => x.ExistsAsync()).Returns(Task.FromResult(true)).Verifiable();
+                fakeBlobClient.Setup(x => x.GetContainerReference(It.IsAny<string>())).Returns(fakeBlobContainer.Object);
+                fakeBlobContainer.Setup(x => x.GetBlobReference(It.IsAny<string>())).Returns(fakeBlob.Object);
+                fakeBlobContainer.Setup(x => x.SetPermissionsAsync(It.IsAny<BlobContainerPermissions>())).Returns(Task.FromResult(0));
+                fakeBlobContainer.Setup(x => x.CreateIfNotExistAsync()).Returns(Task.FromResult(0));
+                fakeBlob.Setup(x => x.Properties).Returns(new BlobProperties());
+                fakeBlob.Setup(x => x.Uri).Returns(new Uri("http://theUri"));
+                var service = CreateService(fakeBlobClient: fakeBlobClient);
+
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.SaveFileAsync(Constants.PackagesFolderName, "theFileName", new MemoryStream(), false));
 
                 fakeBlob.Verify();
             }

--- a/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery
 
         private static MemoryStream CreateFileStream()
         {
-            return new MemoryStream(new byte[] { 0, 0, 1, 0, 1, 0, 1, 0 }, 0, 8, true, true);
+            return new MemoryStream(new byte[] { 0, 0, 1, 0, 1, 0, 1, 0 }, index: 0, count: 8, writable: true, publiclyVisible: true);
         }
 
         private static FileSystemFileStorageService CreateService(
@@ -261,13 +261,15 @@ namespace NuGetGallery
                     "theFileName");
                 var fakeFileSystemService = new Mock<IFileSystemService>();
                 fakeFileSystemService.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
-                var fakeFileStream = new MemoryStream();
-                fakeFileSystemService.Setup(x => x.OpenRead(expectedPath)).Returns(fakeFileStream);
-                var service = CreateService(fileSystemService: fakeFileSystemService);
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    fakeFileSystemService.Setup(x => x.OpenRead(expectedPath)).Returns(fakeFileStream);
+                    var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                var fileStream = await service.GetFileAsync("theFolderName", "theFileName");
+                    var fileStream = await service.GetFileAsync("theFolderName", "theFileName");
 
-                Assert.Same(fakeFileStream, fileStream);
+                    Assert.Same(fakeFileStream, fileStream);
+                }
             }
 
             [Fact]
@@ -292,9 +294,12 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.SaveFileAsync(folderName, "theFileName", CreateFileStream()));
+                using (var fakeFileStream = CreateFileStream())
+                {
+                    var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.SaveFileAsync(folderName, "theFileName", fakeFileStream));
 
-                Assert.Equal("folderName", ex.ParamName);
+                    Assert.Equal("folderName", ex.ParamName);
+                }
             }
 
             [Theory]
@@ -304,9 +309,12 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.SaveFileAsync("theFolderName", fileName, CreateFileStream()));
+                using (var fakeFileStream = CreateFileStream())
+                {
+                    var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.SaveFileAsync("theFolderName", fileName, fakeFileStream));
 
-                Assert.Equal("fileName", ex.ParamName);
+                    Assert.Equal("fileName", ex.ParamName);
+                }
             }
 
             [Fact]
@@ -325,12 +333,18 @@ namespace NuGetGallery
                 const string folderName = "theFolderName";
                 var fakeFileSystemService = new Mock<IFileSystemService>();
                 fakeFileSystemService.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(false);
-                fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(new MemoryStream(new byte[8]));
-                var service = CreateService(fileSystemService: fakeFileSystemService);
+                using (var fakeMemoryStream = CreateFileStream())
+                {
+                    fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(fakeMemoryStream);
+                    var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                await service.SaveFileAsync("theFolderName", "theFileName", CreateFileStream());
+                    using (var fakePackageStream = CreateFileStream())
+                    {
+                        await service.SaveFileAsync("theFolderName", "theFileName", fakePackageStream);
+                    }
 
-                fakeFileSystemService.Verify(x => x.CreateDirectory($"{FakeConfiguredFileStorageDirectory}\\{folderName}"));
+                    fakeFileSystemService.Verify(x => x.CreateDirectory($"{FakeConfiguredFileStorageDirectory}\\{folderName}"));
+                }
             }
 
             [Fact]
@@ -338,12 +352,18 @@ namespace NuGetGallery
             {
                 var fakeFileSystemService = new Mock<IFileSystemService>();
                 fakeFileSystemService.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(false);
-                fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(new MemoryStream(new byte[8]));
-                var service = CreateService(fileSystemService: fakeFileSystemService);
+                using (var fakeMemoryStream = CreateFileStream())
+                {
+                    fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(fakeMemoryStream);
+                    var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                await service.SaveFileAsync("theFolderName", "theFileName", CreateFileStream());
+                    using (var fakePackageStream = CreateFileStream())
+                    {
+                        await service.SaveFileAsync("theFolderName", "theFileName", fakePackageStream);
+                    }
 
-                fakeFileSystemService.Verify(x => x.CreateDirectory(Path.Combine(FakeConfiguredFileStorageDirectory, "theFolderName")));
+                    fakeFileSystemService.Verify(x => x.CreateDirectory(Path.Combine(FakeConfiguredFileStorageDirectory, "theFolderName")));
+                }
             }
 
             [Fact]
@@ -351,73 +371,92 @@ namespace NuGetGallery
             {
                 var fakeFileSystemService = new Mock<IFileSystemService>();
                 fakeFileSystemService.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
-                fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(new MemoryStream(new byte[8]));
-                var service = CreateService(fileSystemService: fakeFileSystemService);
+                using (var fakeMemoryStream = CreateFileStream())
+                {
+                    fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(fakeMemoryStream);
+                    var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                await service.SaveFileAsync("theFolderName", "theFileName", CreateFileStream());
+                    using (var fakePackageStream = CreateFileStream())
+                    {
+                        await service.SaveFileAsync("theFolderName", "theFileName", fakePackageStream);
+                    }
 
-                fakeFileSystemService.Verify(
-                    x =>
-                    x.OpenWrite(
-                        Path.Combine(
-                            FakeConfiguredFileStorageDirectory,
-                            "theFolderName",
-                            "theFileName")));
+                    fakeFileSystemService.Verify(
+                        x =>
+                        x.OpenWrite(
+                            Path.Combine(
+                                FakeConfiguredFileStorageDirectory,
+                                "theFolderName",
+                                "theFileName")));
+                }
             }
 
             [Fact]
             public async Task WillSaveThePackageFileBytes()
             {
-                var fakePackageFile = CreateFileStream();
-                var fakeFileStream = new MemoryStream(new byte[8], 0, 8, true, true);
-                var fakeFileSystemService = new Mock<IFileSystemService>();
-                fakeFileSystemService.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
-                fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(fakeFileStream);
-                var service = CreateService(fileSystemService: fakeFileSystemService);
-
-                await service.SaveFileAsync("theFolderName", "theFileName", CreateFileStream());
-
-                for (var i = 0; i < fakePackageFile.Length; i++)
+                using (var fakePackageFile = CreateFileStream())
                 {
-                    Assert.Equal(fakePackageFile.GetBuffer()[i], fakeFileStream.GetBuffer()[i]);
+                    using (var fakeFileStream = CreateFileStream())
+                    {
+                        var fakeFileSystemService = new Mock<IFileSystemService>();
+                        fakeFileSystemService.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
+                        fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(fakeFileStream);
+                        var service = CreateService(fileSystemService: fakeFileSystemService);
+
+                        using (var fakePackageStream = CreateFileStream())
+                        {
+                            await service.SaveFileAsync("theFolderName", "theFileName", fakePackageStream);
+                        }
+
+                        for (var i = 0; i < fakePackageFile.Length; i++)
+                        {
+                            Assert.Equal(fakePackageFile.GetBuffer()[i], fakeFileStream.GetBuffer()[i]);
+                        }
+                    }
                 }
             }
 
             [Fact]
             public async Task WillOverwriteFileIfOverwriteTrue()
             {
-                var fakePackageFile = CreateFileStream();
-                var fakeFileStream = new MemoryStream(new byte[8], 0, 8, true, true);
-                var fakeFileSystemService = new Mock<IFileSystemService>();
-                fakeFileSystemService.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
-                fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(fakeFileStream);
-                fakeFileSystemService.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
-                fakeFileSystemService.Setup(x => x.DeleteFile(It.IsAny<string>())).Verifiable();
-                var service = CreateService(fileSystemService: fakeFileSystemService);
-
-                await service.SaveFileAsync("theFolderName", "theFileName", CreateFileStream());
-
-                for (var i = 0; i < fakePackageFile.Length; i++)
+                using (var fakePackageFile = CreateFileStream())
                 {
-                    Assert.Equal(fakePackageFile.GetBuffer()[i], fakeFileStream.GetBuffer()[i]);
-                }
+                    using (var fakeFileStream = CreateFileStream())
+                    {
+                        var fakeFileSystemService = new Mock<IFileSystemService>();
+                        fakeFileSystemService.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
+                        fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(fakeFileStream);
+                        fakeFileSystemService.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+                        fakeFileSystemService.Setup(x => x.DeleteFile(It.IsAny<string>())).Verifiable();
+                        var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                fakeFileSystemService.Verify();
+                        await service.SaveFileAsync("theFolderName", "theFileName", fakePackageFile);
+
+                        for (var i = 0; i < fakePackageFile.Length; i++)
+                        {
+                            Assert.Equal(fakePackageFile.GetBuffer()[i], fakeFileStream.GetBuffer()[i]);
+                        }
+
+                        fakeFileSystemService.Verify();
+                    }
+                }
             }
 
             [Fact]
             public async Task WillThrowIfFileExistsAndOverwriteFalse()
             {
-                var fakeFileStream = new MemoryStream(new byte[8], 0, 8, true, true);
-                var fakeFileSystemService = new Mock<IFileSystemService>();
-                fakeFileSystemService.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
-                fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(fakeFileStream);
-                fakeFileSystemService.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
-                var service = CreateService(fileSystemService: fakeFileSystemService);
+                using (var fakeFileStream = CreateFileStream())
+                {
+                    var fakeFileSystemService = new Mock<IFileSystemService>();
+                    fakeFileSystemService.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
+                    fakeFileSystemService.Setup(x => x.OpenWrite(It.IsAny<string>())).Returns(fakeFileStream);
+                    fakeFileSystemService.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+                    var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.SaveFileAsync("theFolderName", "theFileName", CreateFileStream(), false));
+                    await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.SaveFileAsync("theFolderName", "theFileName", fakeFileStream, false));
 
-                fakeFileSystemService.Verify();
+                    fakeFileSystemService.Verify();
+                }
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
@@ -246,7 +246,7 @@ namespace NuGetGallery
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
                 var packageRegistraion = new PackageRegistration { Id = "theId" };
                 var package = new Package { PackageRegistration = packageRegistraion, NormalizedVersion = null, Version = "01.01.01" };
-                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), BuildFileName("theId", "1.1.1"), It.IsAny<Stream>()))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), BuildFileName("theId", "1.1.1"), It.IsAny<Stream>(), It.Is<bool>(b => !b)))
                     .Completes()
                     .Verifiable();
 
@@ -260,7 +260,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.SaveFileAsync(Constants.PackagesFolderName, It.IsAny<string>(), It.IsAny<Stream>()))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(Constants.PackagesFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => !b)))
                     .Completes()
                     .Verifiable();
 
@@ -274,7 +274,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), BuildFileName("theId", "theNormalizedVersion"), It.IsAny<Stream>()))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), BuildFileName("theId", "theNormalizedVersion"), It.IsAny<Stream>(), It.Is<bool>(b => !b)))
                     .Completes()
                     .Verifiable();
 
@@ -289,7 +289,7 @@ namespace NuGetGallery
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var fakeStream = new MemoryStream();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), fakeStream))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), fakeStream, It.Is<bool>(b => !b)))
                     .Completes()
                     .Verifiable();
 
@@ -370,7 +370,7 @@ namespace NuGetGallery
                 var package = new Package { PackageRegistration = packageRegistraion, NormalizedVersion = null, Version = "01.01.01", Hash = packageHashForTests};
                 package.Hash = packageHashForTests;
 
-                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), BuildBackupFileName("theId", "1.1.1", packageHashForTests), It.IsAny<Stream>()))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), BuildBackupFileName("theId", "1.1.1", packageHashForTests), It.IsAny<Stream>(), It.Is<bool>(b => b)))
                     .Completes()
                     .Verifiable();
 
@@ -384,7 +384,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.SaveFileAsync(Constants.PackageBackupsFolderName, It.IsAny<string>(), It.IsAny<Stream>()))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(Constants.PackageBackupsFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => b)))
                     .Completes()
                     .Verifiable();
 
@@ -401,7 +401,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), BuildBackupFileName("theId", "theNormalizedVersion", packageHashForTests), It.IsAny<Stream>()))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), BuildBackupFileName("theId", "theNormalizedVersion", packageHashForTests), It.IsAny<Stream>(), It.Is<bool>(b => b)))
                     .Completes()
                     .Verifiable();
 
@@ -419,7 +419,7 @@ namespace NuGetGallery
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var fakeStream = new MemoryStream();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), fakeStream))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), fakeStream, It.Is<bool>(b => b)))
                     .Completes()
                     .Verifiable();
 

--- a/tests/NuGetGallery.Facts/Services/UploadFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UploadFileServiceFacts.cs
@@ -137,7 +137,7 @@ namespace NuGetGallery
 
                 service.SaveUploadFileAsync(1, new MemoryStream());
 
-                fakeFileStorageService.Verify(x => x.SaveFileAsync(Constants.UploadsFolderName, It.IsAny<string>(), It.IsAny<Stream>()));
+                fakeFileStorageService.Verify(x => x.SaveFileAsync(Constants.UploadsFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => b)));
             }
 
             [Fact]
@@ -149,7 +149,7 @@ namespace NuGetGallery
 
                 service.SaveUploadFileAsync(1, new MemoryStream());
 
-                fakeFileStorageService.Verify(x => x.SaveFileAsync(It.IsAny<string>(), expectedFileName, It.IsAny<Stream>()));
+                fakeFileStorageService.Verify(x => x.SaveFileAsync(It.IsAny<string>(), expectedFileName, It.IsAny<Stream>(), It.Is<bool>(b => b)));
             }
 
             [Fact]
@@ -161,7 +161,7 @@ namespace NuGetGallery
 
                 service.SaveUploadFileAsync(1, fakeUploadFileStream);
 
-                fakeFileStorageService.Verify(x => x.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), fakeUploadFileStream));
+                fakeFileStorageService.Verify(x => x.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), fakeUploadFileStream, It.Is<bool>(b => b)));
             }
         }
     }

--- a/tests/NuGetGallery.Facts/TestUtils/MockExtensions.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/MockExtensions.cs
@@ -63,12 +63,23 @@ namespace NuGetGallery
         public static void VerifyCommitted<T>(this Mock<IEntityRepository<T>> self)
             where T : class, IEntity, new()
         {
-            self.Verify(e => e.CommitChangesAsync());
+            self.VerifyCommitted(Times.AtLeastOnce());
+        }
+
+        public static void VerifyCommitted<T>(this Mock<IEntityRepository<T>> self, Times times)
+            where T : class, IEntity, new()
+        {
+            self.Verify(e => e.CommitChangesAsync(), times);
         }
 
         public static void VerifyCommitted(this Mock<IEntitiesContext> self)
         {
-            self.Verify(e => e.SaveChangesAsync());
+            self.VerifyCommitted(Times.AtLeastOnce());
+        }
+
+        public static void VerifyCommitted(this Mock<IEntitiesContext> self, Times times)
+        {
+            self.Verify(e => e.SaveChangesAsync(), times);
         }
 
         public static IReturnsResult<AuthenticationService> SetupAuth(this Mock<AuthenticationService> self, Credential cred, User user)


### PR DESCRIPTION
Added an `overwrite` parameter to `IFileStorageService.SaveFileAsync`. If `overwrite` is false, the file storage service will not overwrite existing files.

Added logic to the `ApiController` and `PackagesController` upload flows to surface a UI message.

Added unit testing to verify that overwriting is handled correctly.