### PR TITLE
Code and tests for issue #2567

### DIFF
--- a/src/NuGetGallery/App_Start/VersionRouteConstraint.cs
+++ b/src/NuGetGallery/App_Start/VersionRouteConstraint.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
@@ -32,7 +33,12 @@ namespace NuGetGallery
             {
                 return true;
             }
-            
+
+            if (versionText.Equals("prerelease", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
+            }
+
             NuGetVersion ignored;
             return NuGetVersion.TryParse(versionText, out ignored);
         }

--- a/src/NuGetGallery/App_Start/VersionRouteConstraint.cs
+++ b/src/NuGetGallery/App_Start/VersionRouteConstraint.cs
@@ -34,7 +34,7 @@ namespace NuGetGallery
                 return true;
             }
 
-            if (versionText.Equals("prerelease", StringComparison.InvariantCultureIgnoreCase))
+            if (versionText.Equals(Constants.AbsoluteLatestUrlString, StringComparison.InvariantCultureIgnoreCase))
             {
                 return true;
             }

--- a/src/NuGetGallery/Constants.cs
+++ b/src/NuGetGallery/Constants.cs
@@ -47,6 +47,7 @@ namespace NuGetGallery
         public const string NuGetCommandLinePackageId = "NuGet.CommandLine";
 
         public static readonly string ReturnUrlViewDataKey = "ReturnUrl";
+        public const string AbsoluteLatestUrlString = "absoluteLatest";
 
         public const string UrlValidationRegEx = @"(https?):\/\/[^ ""]+$";
         public const string UrlValidationErrorMessage = "This doesn't appear to be a valid HTTP/HTTPS URL";

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -308,9 +308,9 @@ namespace NuGetGallery
             }
             
             Package package;
-            if (version.Equals("prerelease", StringComparison.InvariantCultureIgnoreCase))
+            if (version != null && version.Equals(Constants.AbsoluteLatestUrlString, StringComparison.InvariantCultureIgnoreCase))
             {
-                package = _packageService.FindPackageByLatestPrerelease(id);
+                package = _packageService.FindAbsoluteLatestPackageById(id);
             }
             else
             {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -306,8 +306,16 @@ namespace NuGetGallery
                 // Permanent redirect to the normalized one (to avoid multiple URLs for the same content)
                 return RedirectToActionPermanent("DisplayPackage", new { id = id, version = normalized });
             }
-
-            var package = _packageService.FindPackageByIdAndVersion(id, version);
+            
+            Package package;
+            if (version.Equals("prerelease", StringComparison.InvariantCultureIgnoreCase))
+            {
+                package = _packageService.FindPackageByLatestPrerelease(id);
+            }
+            else
+            {
+                package = _packageService.FindPackageByIdAndVersion(id, version);
+            }
 
             if (package == null)
             {

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
     {
         PackageRegistration FindPackageRegistrationById(string id);
         Package FindPackageByIdAndVersion(string id, string version, bool allowPrerelease = true);
-        Package FindPackageByLatestPrerelease(string id);
+        Package FindAbsoluteLatestPackageById(string id);
         IEnumerable<Package> FindPackagesByOwner(User user, bool includeUnlisted);
         IEnumerable<PackageRegistration> FindPackageRegistrationsByOwner(User user);
         IEnumerable<Package> FindDependentPackages(Package package);

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -12,6 +12,7 @@ namespace NuGetGallery
     {
         PackageRegistration FindPackageRegistrationById(string id);
         Package FindPackageByIdAndVersion(string id, string version, bool allowPrerelease = true);
+        Package FindPackageByLatestPrerelease(string id);
         IEnumerable<Package> FindPackagesByOwner(User user, bool includeUnlisted);
         IEnumerable<PackageRegistration> FindPackageRegistrationsByOwner(User user);
         IEnumerable<Package> FindDependentPackages(Package package);

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -171,18 +171,17 @@ namespace NuGetGallery
             return package;
         }
 
-        public virtual Package FindPackageByLatestPrerelease(string id)
+        public virtual Package FindAbsoluteLatestPackageById(string id)
         {
             var packageVersions = _packageRepository.GetAll()
                 .Include(p => p.LicenseReports)
                 .Include(p => p.PackageRegistration)
-                .Where(p => (p.PackageRegistration.Id == id))
-                .Where(p => p.IsPrerelease)
+                .Where(p => p.PackageRegistration.Id == id)
                 .ToList();
 
             Package package = packageVersions.FirstOrDefault(p => p.IsLatest);
 
-            // If we couldn't find a package marked as latest, then return the most recent prerelease one 
+            // If we couldn't find a package marked as latest, then return the most recent one 
             if (package == null)
             {
                 package = packageVersions.OrderByDescending(p => p.Version).FirstOrDefault();

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -171,6 +171,26 @@ namespace NuGetGallery
             return package;
         }
 
+        public virtual Package FindPackageByLatestPrerelease(string id)
+        {
+            var packageVersions = _packageRepository.GetAll()
+                .Include(p => p.LicenseReports)
+                .Include(p => p.PackageRegistration)
+                .Where(p => (p.PackageRegistration.Id == id))
+                .Where(p => p.IsPrerelease)
+                .ToList();
+
+            Package package = packageVersions.FirstOrDefault(p => p.IsLatest);
+
+            // If we couldn't find a package marked as latest, then return the most recent prerelease one 
+            if (package == null)
+            {
+                package = packageVersions.OrderByDescending(p => p.Version).FirstOrDefault();
+            }
+
+            return package;
+        }
+
         public IEnumerable<Package> FindPackagesByOwner(User user, bool includeUnlisted)
         {
             // Like DisplayPackage we should prefer to show you information from the latest stable version,

--- a/tests/NuGetGallery.Facts/Routing/VersionRouteConstraintFacts.cs
+++ b/tests/NuGetGallery.Facts/Routing/VersionRouteConstraintFacts.cs
@@ -67,7 +67,7 @@ namespace NuGetGallery.Routing
             [Fact]
             public void ReturnsTrueIfVersionIsPrerelease()
             {
-                var routeValues = new RouteValueDictionary { { "version", "prerelease" } };
+                var routeValues = new RouteValueDictionary { { "version", Constants.AbsoluteLatestUrlString } };
                 var constraint = new VersionRouteConstraint();
 
                 var result = constraint.Match(null, null, "version", routeValues, RouteDirection.IncomingRequest);

--- a/tests/NuGetGallery.Facts/Routing/VersionRouteConstraintFacts.cs
+++ b/tests/NuGetGallery.Facts/Routing/VersionRouteConstraintFacts.cs
@@ -63,6 +63,17 @@ namespace NuGetGallery.Routing
 
                 Assert.True(result);
             }
+
+            [Fact]
+            public void ReturnsTrueIfVersionIsPrerelease()
+            {
+                var routeValues = new RouteValueDictionary { { "version", "prerelease" } };
+                var constraint = new VersionRouteConstraint();
+
+                var result = constraint.Match(null, null, "version", routeValues, RouteDirection.IncomingRequest);
+
+                Assert.True(result);
+            }
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1225,10 +1225,10 @@ namespace NuGetGallery
             }
         }
 
-        public class TheFindPackageByLatestPrereleaseMethod
-        { 
+        public class TheFindAbsoluteLatestPackageByIdMethod
+        {
             [Fact]
-            public void ReturnsTheLatestPrereleaseVersion()
+            public void ReturnsTheLatestVersion()
             {
                 // Arrange
                 var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
@@ -1242,7 +1242,7 @@ namespace NuGetGallery
                 var service = CreateService(packageRepository: repository);
 
                 // Act
-                var result = service.FindPackageByLatestPrerelease("theId");
+                var result = service.FindAbsoluteLatestPackageById("theId");
 
                 // Assert
                 Assert.NotNull(result);
@@ -1250,14 +1250,14 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void ReturnsTheMostRecentPrereleaseVersion()
+            public void ReturnsTheMostRecentVersion()
             {
                 // Arrange
                 var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
                 var packageRegistration = new PackageRegistration { Id = "theId" };
                 var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true };
                 var package2 = new Package { Version = "2.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true };
-                var package3 = new Package { Version = "2.0.0", PackageRegistration = packageRegistration, Listed = true, IsLatestStable = true, IsLatest = true };
+                var package3 = new Package { Version = "2.0.0", PackageRegistration = packageRegistration, Listed = true };
 
                 repository
                     .Setup(repo => repo.GetAll())
@@ -1265,7 +1265,7 @@ namespace NuGetGallery
                 var service = CreateService(packageRepository: repository);
 
                 // Act
-                var result = service.FindPackageByLatestPrerelease("theId");
+                var result = service.FindAbsoluteLatestPackageById("theId");
 
                 // Assert
                 Assert.NotNull(result);

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1225,6 +1225,54 @@ namespace NuGetGallery
             }
         }
 
+        public class TheFindPackageByLatestPrereleaseMethod
+        { 
+            [Fact]
+            public void ReturnsTheLatestPrereleaseVersion()
+            {
+                // Arrange
+                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
+                var packageRegistration = new PackageRegistration { Id = "theId" };
+                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true, IsLatestStable = true };
+                var package2 = new Package { Version = "2.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
+
+                repository
+                    .Setup(repo => repo.GetAll())
+                    .Returns(new[] { package1, package2 }.AsQueryable());
+                var service = CreateService(packageRepository: repository);
+
+                // Act
+                var result = service.FindPackageByLatestPrerelease("theId");
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("2.0.0a", result.Version);
+            }
+
+            [Fact]
+            public void ReturnsTheMostRecentPrereleaseVersion()
+            {
+                // Arrange
+                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
+                var packageRegistration = new PackageRegistration { Id = "theId" };
+                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true };
+                var package2 = new Package { Version = "2.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true };
+                var package3 = new Package { Version = "2.0.0", PackageRegistration = packageRegistration, Listed = true, IsLatestStable = true, IsLatest = true };
+
+                repository
+                    .Setup(repo => repo.GetAll())
+                    .Returns(new[] { package1, package2, package3 }.AsQueryable());
+                var service = CreateService(packageRepository: repository);
+
+                // Act
+                var result = service.FindPackageByLatestPrerelease("theId");
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("2.0.0a", result.Version);
+            }
+        }
+
         public class TheFindPackagesByOwnerMethod : TestContainer
         {
             [Fact]


### PR DESCRIPTION
URLs like `https://www.nuget.org/packages/PACKAGE/prerelease` will display the latest prereleased version. Will fall back to latest stable version if no pre-releases exist.