### PR TITLE
Delete uploaded package from blob storage if saving changes to DB fails

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -364,7 +364,7 @@ namespace NuGetGallery
                         }
                         catch
                         {
-                            // If we are in read-only mode, saving to the DB will throw, so we need to delete the package from blob storage.
+                            // If saving to the DB fails for any reason, we need to delete the package we just saved.
                             await PackageFileService.DeletePackageFileAsync(nuspec.GetId(), nuspec.GetVersion().ToNormalizedString());
                             throw;
                         }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -358,7 +358,16 @@ namespace NuGetGallery
                             }
                         }
 
-                        await EntitiesContext.SaveChangesAsync();
+                        try
+                        {
+                            await EntitiesContext.SaveChangesAsync();
+                        }
+                        catch
+                        {
+                            // If we are in read-only mode, saving to the DB will throw, so we need to delete the package from blob storage.
+                            await PackageFileService.DeletePackageFileAsync(nuspec.GetId(), nuspec.GetVersion().ToNormalizedString());
+                            throw;
+                        }
 
                         IndexingService.UpdatePackage(package);
 

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1180,8 +1180,17 @@ namespace NuGetGallery
                     return new RedirectResult(Url.VerifyPackage());
                 }
 
-                // commit all changes to database as an atomic transaction
-                await _entitiesContext.SaveChangesAsync();
+                try
+                {
+                    // commit all changes to database as an atomic transaction
+                    await _entitiesContext.SaveChangesAsync();
+                }
+                catch
+                {
+                    // If we are in read-only mode, saving to the DB will throw, so we need to delete the package from blob storage.
+                    await _packageFileService.DeletePackageFileAsync(packageMetadata.Id, packageMetadata.Version.ToNormalizedString());
+                    throw;
+                }
 
                 // tell Lucene to update index for the new package
                 _indexingService.UpdateIndex();

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1187,7 +1187,7 @@ namespace NuGetGallery
                 }
                 catch
                 {
-                    // If we are in read-only mode, saving to the DB will throw, so we need to delete the package from blob storage.
+                    // If saving to the DB fails for any reason we need to delete the package we just saved.
                     await _packageFileService.DeletePackageFileAsync(packageMetadata.Id, packageMetadata.Version.ToNormalizedString());
                     throw;
                 }


### PR DESCRIPTION
The package is saved to blob storage before saving changes to the database. When the DB is in read-only mode (or there is some other failure when saving to the database), the saved package is not cleaned up from the database. [With overwriting packages in blob storage now disallowed](https://github.com/NuGet/NuGetGallery/pull/3457), this can lead to some strange failures when uploading packages.