### PR TITLE
Fix for static code analyzers

### DIFF
--- a/src/NuGetGallery.Core/Entities/Credential.cs
+++ b/src/NuGetGallery.Core/Entities/Credential.cs
@@ -54,14 +54,14 @@ namespace NuGetGallery
         public int UserKey { get; set; }
 
         [Required]
-        [StringLength(64)]
+        [StringLength(/*maximumLength*/ 64)]
         public string Type { get; set; }
 
         [Required]
-        [StringLength(256)]
+        [StringLength(/*maximumLength*/ 256)]
         public string Value { get; set; }
 
-        [StringLength(256)]
+        [StringLength(/*maximumLength*/ 256)]
         public string Identity { get; set; }
 
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]

--- a/src/NuGetGallery.Core/Entities/Credential.cs
+++ b/src/NuGetGallery.Core/Entities/Credential.cs
@@ -54,14 +54,14 @@ namespace NuGetGallery
         public int UserKey { get; set; }
 
         [Required]
-        [StringLength(maximumLength: 64)]
+        [StringLength(64)]
         public string Type { get; set; }
 
         [Required]
-        [StringLength(maximumLength: 256)]
+        [StringLength(256)]
         public string Value { get; set; }
 
-        [StringLength(maximumLength: 256)]
+        [StringLength(256)]
         public string Identity { get; set; }
 
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]

--- a/src/NuGetGallery/OData/V1FeedPackage.cs
+++ b/src/NuGetGallery/OData/V1FeedPackage.cs
@@ -8,10 +8,10 @@ namespace NuGetGallery.OData
 {
     [HasStream]
     [DataServiceKey("Id", "Version")]
-    [EntityPropertyMapping("Title", SyndicationItemProperty.Title, SyndicationTextContentKind.Plaintext, true)]
-    [EntityPropertyMapping("Authors", SyndicationItemProperty.AuthorName, SyndicationTextContentKind.Plaintext, true)]
-    [EntityPropertyMapping("LastUpdated", SyndicationItemProperty.Updated, SyndicationTextContentKind.Plaintext, true)]
-    [EntityPropertyMapping("Summary", SyndicationItemProperty.Summary, SyndicationTextContentKind.Plaintext, true)]
+    [EntityPropertyMapping("Title", SyndicationItemProperty.Title, SyndicationTextContentKind.Plaintext, /*keepInContent*/ true)]
+    [EntityPropertyMapping("Authors", SyndicationItemProperty.AuthorName, SyndicationTextContentKind.Plaintext, /*keepInContent*/ true)]
+    [EntityPropertyMapping("LastUpdated", SyndicationItemProperty.Updated, SyndicationTextContentKind.Plaintext, /*keepInContent*/ true)]
+    [EntityPropertyMapping("Summary", SyndicationItemProperty.Summary, SyndicationTextContentKind.Plaintext, /*keepInContent*/ true)]
     public class V1FeedPackage
     {
         public string Id { get; set; }

--- a/src/NuGetGallery/OData/V1FeedPackage.cs
+++ b/src/NuGetGallery/OData/V1FeedPackage.cs
@@ -8,10 +8,10 @@ namespace NuGetGallery.OData
 {
     [HasStream]
     [DataServiceKey("Id", "Version")]
-    [EntityPropertyMapping("Title", SyndicationItemProperty.Title, SyndicationTextContentKind.Plaintext, keepInContent: true)]
-    [EntityPropertyMapping("Authors", SyndicationItemProperty.AuthorName, SyndicationTextContentKind.Plaintext, keepInContent: true)]
-    [EntityPropertyMapping("LastUpdated", SyndicationItemProperty.Updated, SyndicationTextContentKind.Plaintext, keepInContent: true)]
-    [EntityPropertyMapping("Summary", SyndicationItemProperty.Summary, SyndicationTextContentKind.Plaintext, keepInContent: true)]
+    [EntityPropertyMapping("Title", SyndicationItemProperty.Title, SyndicationTextContentKind.Plaintext, true)]
+    [EntityPropertyMapping("Authors", SyndicationItemProperty.AuthorName, SyndicationTextContentKind.Plaintext, true)]
+    [EntityPropertyMapping("LastUpdated", SyndicationItemProperty.Updated, SyndicationTextContentKind.Plaintext, true)]
+    [EntityPropertyMapping("Summary", SyndicationItemProperty.Summary, SyndicationTextContentKind.Plaintext, true)]
     public class V1FeedPackage
     {
         public string Id { get; set; }

--- a/src/NuGetGallery/OData/V2FeedPackage.cs
+++ b/src/NuGetGallery/OData/V2FeedPackage.cs
@@ -8,10 +8,10 @@ namespace NuGetGallery.OData
 {
     [HasStream]
     [DataServiceKey("Id", "Version")]
-    [EntityPropertyMapping("Id", SyndicationItemProperty.Title, SyndicationTextContentKind.Plaintext, false)]
-    [EntityPropertyMapping("Authors", SyndicationItemProperty.AuthorName, SyndicationTextContentKind.Plaintext, false)]
-    [EntityPropertyMapping("LastUpdated", SyndicationItemProperty.Updated, SyndicationTextContentKind.Plaintext, false)]
-    [EntityPropertyMapping("Summary", SyndicationItemProperty.Summary, SyndicationTextContentKind.Plaintext, false)]
+    [EntityPropertyMapping("Id", SyndicationItemProperty.Title, SyndicationTextContentKind.Plaintext, /*keepInContent*/ false)]
+    [EntityPropertyMapping("Authors", SyndicationItemProperty.AuthorName, SyndicationTextContentKind.Plaintext, /*keepInContent*/ false)]
+    [EntityPropertyMapping("LastUpdated", SyndicationItemProperty.Updated, SyndicationTextContentKind.Plaintext, /*keepInContent*/ false)]
+    [EntityPropertyMapping("Summary", SyndicationItemProperty.Summary, SyndicationTextContentKind.Plaintext, /*keepInContent*/ false)]
     public class V2FeedPackage
     {
         public string Id { get; set; }

--- a/src/NuGetGallery/OData/V2FeedPackage.cs
+++ b/src/NuGetGallery/OData/V2FeedPackage.cs
@@ -8,10 +8,10 @@ namespace NuGetGallery.OData
 {
     [HasStream]
     [DataServiceKey("Id", "Version")]
-    [EntityPropertyMapping("Id", SyndicationItemProperty.Title, SyndicationTextContentKind.Plaintext, keepInContent: false)]
-    [EntityPropertyMapping("Authors", SyndicationItemProperty.AuthorName, SyndicationTextContentKind.Plaintext, keepInContent: false)]
-    [EntityPropertyMapping("LastUpdated", SyndicationItemProperty.Updated, SyndicationTextContentKind.Plaintext, keepInContent: false)]
-    [EntityPropertyMapping("Summary", SyndicationItemProperty.Summary, SyndicationTextContentKind.Plaintext, keepInContent: false)]
+    [EntityPropertyMapping("Id", SyndicationItemProperty.Title, SyndicationTextContentKind.Plaintext, false)]
+    [EntityPropertyMapping("Authors", SyndicationItemProperty.AuthorName, SyndicationTextContentKind.Plaintext, false)]
+    [EntityPropertyMapping("LastUpdated", SyndicationItemProperty.Updated, SyndicationTextContentKind.Plaintext, false)]
+    [EntityPropertyMapping("Summary", SyndicationItemProperty.Summary, SyndicationTextContentKind.Plaintext, false)]
     public class V2FeedPackage
     {
         public string Id { get; set; }

--- a/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
@@ -146,7 +146,7 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [FolderNamesData(includePermissions: true)]
+            [FolderNamesData(true)]
             public async Task WillSetPermissionsForDemandedFolderInBlobContainers(string folderName, bool isPublic)
             {
                 var fakeBlobContainer = new Mock<ICloudBlobContainer>();

--- a/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
@@ -146,7 +146,7 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [FolderNamesData(true)]
+            [FolderNamesData(/*includePermissions*/ true)]
             public async Task WillSetPermissionsForDemandedFolderInBlobContainers(string folderName, bool isPublic)
             {
                 var fakeBlobContainer = new Mock<ICloudBlobContainer>();


### PR DESCRIPTION
Some static code analyzers fail on named arguments in attributes. This PR removes all of them to fix the issue.