### PR TITLE
Filter out unsupported credentials from account view and auditing

### DIFF
--- a/src/NuGetGallery.Core/Auditing/UserAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/UserAuditRecord.cs
@@ -33,7 +33,8 @@ namespace NuGetGallery.Auditing
             EmailAddress = user.EmailAddress;
             UnconfirmedEmailAddress = user.UnconfirmedEmailAddress;
             Roles = user.Roles.Select(r => r.Name).ToArray();
-            Credentials = user.Credentials.Where(c => CredentialTypes.IsSupportedCredential(c)).Select(c => new CredentialAuditRecord(c, removed: false)).ToArray();
+            Credentials = user.Credentials.Where(CredentialTypes.IsSupportedCredential)
+                                          .Select(c => new CredentialAuditRecord(c, removed: false)).ToArray();
 
             if (affected != null)
             {

--- a/src/NuGetGallery.Core/Auditing/UserAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/UserAuditRecord.cs
@@ -33,7 +33,7 @@ namespace NuGetGallery.Auditing
             EmailAddress = user.EmailAddress;
             UnconfirmedEmailAddress = user.UnconfirmedEmailAddress;
             Roles = user.Roles.Select(r => r.Name).ToArray();
-            Credentials = user.Credentials.Select(c => new CredentialAuditRecord(c, removed: false)).ToArray();
+            Credentials = user.Credentials.Where(c => CredentialTypes.IsSupportedCredential(c)).Select(c => new CredentialAuditRecord(c, removed: false)).ToArray();
 
             if (affected != null)
             {

--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -22,5 +22,20 @@ namespace NuGetGallery
         {
             return type.StartsWith(Password.Prefix, StringComparison.OrdinalIgnoreCase);
         }
+
+        /// <summary>
+        /// Forward compatibility - we support only the bellow subset of credentials in this code version.
+        /// Any unrecognized credential will be ignored.
+        /// </summary>
+        /// <param name="credential"></param>
+        /// <returns></returns>
+        public static bool IsSupportedCredential(Credential credential)
+        {
+            return string.Compare(credential.Type, Password.Pbkdf2, StringComparison.OrdinalIgnoreCase) == 0 ||
+                   string.Compare(credential.Type, Password.Sha1, StringComparison.OrdinalIgnoreCase) == 0 ||
+                   string.Compare(credential.Type, Password.V3, StringComparison.OrdinalIgnoreCase) == 0 ||
+                   string.Compare(credential.Type, ApiKeyV1, StringComparison.OrdinalIgnoreCase) == 0 ||
+                   credential.Type.StartsWith(ExternalPrefix, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGetGallery
 {
@@ -23,19 +25,18 @@ namespace NuGetGallery
             return type.StartsWith(Password.Prefix, StringComparison.OrdinalIgnoreCase);
         }
 
+        internal static List<string> SupportedCredentialTypes = new List<string> { Password.Sha1, Password.Pbkdf2, Password.V3, ApiKeyV1 };
+
         /// <summary>
-        /// Forward compatibility - we support only the bellow subset of credentials in this code version.
+        /// Forward compatibility - we support only the below subset of credentials in this code version.
         /// Any unrecognized credential will be ignored.
         /// </summary>
         /// <param name="credential"></param>
         /// <returns></returns>
         public static bool IsSupportedCredential(Credential credential)
         {
-            return string.Compare(credential.Type, Password.Pbkdf2, StringComparison.OrdinalIgnoreCase) == 0 ||
-                   string.Compare(credential.Type, Password.Sha1, StringComparison.OrdinalIgnoreCase) == 0 ||
-                   string.Compare(credential.Type, Password.V3, StringComparison.OrdinalIgnoreCase) == 0 ||
-                   string.Compare(credential.Type, ApiKeyV1, StringComparison.OrdinalIgnoreCase) == 0 ||
-                   credential.Type.StartsWith(ExternalPrefix, StringComparison.OrdinalIgnoreCase);
+            return SupportedCredentialTypes.Any(credType => string.Compare(credential.Type, credType, StringComparison.OrdinalIgnoreCase) == 0)
+                    || credential.Type.StartsWith(ExternalPrefix, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -572,7 +572,8 @@ namespace NuGetGallery
             // Load Credential info
             var user = GetCurrentUser();
             var curatedFeeds = _curatedFeedService.GetFeedsForManager(user.Key);
-            var creds = user.Credentials.Select(c => _authService.DescribeCredential(c)).ToList();
+            var creds = user.Credentials.Where(c => CredentialTypes.IsSupportedCredential(c))
+                                        .Select(c => _authService.DescribeCredential(c)).ToList();
 
             model.Credentials = creds;
             model.CuratedFeeds = curatedFeeds.Select(f => f.Name);

--- a/tests/NuGetGallery.Facts/Infrastructure/UserAuditRecordFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/UserAuditRecordFacts.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetGallery.Auditing;
+using NuGetGallery.Authentication;
+using NuGetGallery.Framework;
+using NuGetGallery.Infrastructure.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NuGetGallery.Infrastructure
+{
+    public class UserAuditRecordFacts
+    {
+        [Fact]
+        public void FiltersOutUnsupportedCredentials()
+        {
+            // Arrange
+            var credentialBuilder = new CredentialBuilder();
+            var credentials = new List<Credential> {
+                    credentialBuilder.CreatePasswordCredential("v3"),
+                    TestCredentialBuilder.CreatePbkdf2Password("pbkdf2"),
+                    TestCredentialBuilder.CreateSha1Password("sha1"),
+                    TestCredentialBuilder.CreateV1ApiKey(Guid.NewGuid(), Fakes.ExpirationForApiKeyV1),
+                    credentialBuilder.CreateExternalCredential("MicrosoftAccount", "blarg", "Bloog"),
+                    new Credential() { Type = "unsupported" }
+            };
+
+            var user = new User()
+            {
+                Username = "name",
+                Credentials = credentials
+            };
+
+            // Act 
+            var userAuditRecord = new UserAuditRecord(user, AuditedUserAction.AddCredential);
+
+            // Assert
+            var auditRecords = userAuditRecord.Credentials.ToDictionary(c => c.Type);
+            Assert.Equal(5, auditRecords.Count);
+            Assert.True(auditRecords.ContainsKey(credentials[0].Type));
+            Assert.True(auditRecords.ContainsKey(credentials[1].Type));
+            Assert.True(auditRecords.ContainsKey(credentials[2].Type));
+            Assert.True(auditRecords.ContainsKey(credentials[3].Type));
+            Assert.True(auditRecords.ContainsKey(credentials[4].Type));
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -404,6 +404,7 @@
     <Compile Include="Controllers\StatisticsControllerFacts.cs" />
     <Compile Include="Controllers\UsersControllerFacts.cs" />
     <Compile Include="Framework\TestGalleryConfigurationService.cs" />
+    <Compile Include="Infrastructure\UserAuditRecordFacts.cs" />
     <Compile Include="OData\Filter\ODataFilterFacts.cs" />
     <Compile Include="OData\SearchService\SearchHijackerFacts.cs" />
     <Compile Include="PasswordValidationRegexTests.cs" />


### PR DESCRIPTION
A change that needs to be deployed prior to scoped API keys, to prevent unexpected behavior in case of rollback.

@dtivel , @xavierdecoster 