### PR TITLE
Allow tests to run against URLs not matching "nuget.org" pattern

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGetGallery.FunctionalTests
 {
@@ -18,6 +20,7 @@ namespace NuGetGallery.FunctionalTests
         private static string _testEmailServerHost;
         private static string _runFunctionalTests;
         private static string _readOnlyMode;
+        private static List<string> _trustedHttpsCertificates;
 
         /// <summary>
         /// Option to enable or disable functional tests from the current run.
@@ -211,6 +214,41 @@ namespace NuGetGallery.FunctionalTests
                     _testEmailServerHost = Environment.GetEnvironmentVariable("TestEmailServerHost");
                 }
                 return _testEmailServerHost;
+            }
+        }
+
+        public static IEnumerable<string> TrustedHttpsCertificates
+        {
+            get
+            {
+                if (_trustedHttpsCertificates == null)
+                {
+                    var unparsedValued = Environment.GetEnvironmentVariable("TrustedHttpsCertificates") ?? string.Empty;
+
+                    List<string> pieces;
+                    if (unparsedValued.Length == 0)
+                    {
+                        pieces = new List<string>
+                        {
+                            "8c11c16610b7a147d10bbcc6a65ce23d321c12c2", // *.nugettest.org
+                            "9d984f91f40d8b3a1fb29153179415523c4e64d1", // *.int.nugettest.org
+                            "3751cb513b93ee67ec9f18a1f2aec1eac87af9bc"  // *.nuget.org
+                        };
+                    }
+                    else
+                    {
+
+                        pieces = unparsedValued
+                            .Split(',')
+                            .Select(p => p.Trim())
+                            .Where(p => p.Length > 0)
+                            .ToList();
+                    }
+
+                    _trustedHttpsCertificates = pieces;
+                }
+
+                return _trustedHttpsCertificates;
             }
         }
     }

--- a/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
@@ -228,6 +228,9 @@ namespace NuGetGallery.FunctionalTests
                     List<string> pieces;
                     if (unparsedValued.Length == 0)
                     {
+                        // This list will need to be modified as DEV, INT, and PROD certificates change and are
+                        // renewed. These values are easily and publicly discoverable by inspecting the certificate
+                        // returned from HTTPS browser interactions with the gallery.
                         pieces = new List<string>
                         {
                             "8c11c16610b7a147d10bbcc6a65ce23d321c12c2", // *.nugettest.org
@@ -237,7 +240,6 @@ namespace NuGetGallery.FunctionalTests
                     }
                     else
                     {
-
                         pieces = unparsedValued
                             .Split(',')
                             .Select(p => p.Trim())

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/CommandlineHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/CommandlineHelper.cs
@@ -156,7 +156,15 @@ namespace NuGetGallery.FunctionalTests
             var nugetProcess = new Process();
             var pathToNugetExe = Path.Combine(Environment.CurrentDirectory, NugetExePath);
 
+            arguments.AddRange(new[]
+            {
+                "-TrustedHttpsCertificate", "8c11c16610b7a147d10bbcc6a65ce23d321c12c2", // *.nugettest.org
+                "-TrustedHttpsCertificate", "9d984f91f40d8b3a1fb29153179415523c4e64d1", // *.int.nugettest.org
+                "-TrustedHttpsCertificate", "3751cb513b93ee67ec9f18a1f2aec1eac87af9bc"  // *.nuget.org
+            });
+
             arguments.Add(NonInteractiveSwitchString);
+
             var argumentsString = string.Join(" ", arguments);
 
             WriteLine("The NuGet.exe command to be executed is: " + pathToNugetExe + " " + argumentsString);

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/CommandlineHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/CommandlineHelper.cs
@@ -156,12 +156,10 @@ namespace NuGetGallery.FunctionalTests
             var nugetProcess = new Process();
             var pathToNugetExe = Path.Combine(Environment.CurrentDirectory, NugetExePath);
 
-            arguments.AddRange(new[]
+            foreach (var trustedCertificate in EnvironmentSettings.TrustedHttpsCertificates)
             {
-                "-TrustedHttpsCertificate", "8c11c16610b7a147d10bbcc6a65ce23d321c12c2", // *.nugettest.org
-                "-TrustedHttpsCertificate", "9d984f91f40d8b3a1fb29153179415523c4e64d1", // *.int.nugettest.org
-                "-TrustedHttpsCertificate", "3751cb513b93ee67ec9f18a1f2aec1eac87af9bc"  // *.nuget.org
-            });
+                arguments.AddRange(new[] { "-TrustedHttpsCertificate", trustedCertificate });
+            }
 
             arguments.Add(NonInteractiveSwitchString);
 

--- a/tests/NuGetGallery.FunctionalTests/Commandline/NuGetCommandLineTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/Commandline/NuGetCommandLineTests.cs
@@ -13,8 +13,6 @@ namespace NuGetGallery.FunctionalTests.Commandline
     /// <summary>
     /// Tries to download and upload package from the gallery using NuGet.exe client.
     /// </summary>
-    // All the tests in this class fail due to the following error
-    // The package upload via Nuget.exe didn't succeed properly OR package download from V2 feed didn't work. Could not establish trust relationship for the SSL/TLS secure channel
     public class NugetCommandLineTests
         : GalleryTestBase
     {
@@ -36,17 +34,13 @@ namespace NuGetGallery.FunctionalTests.Commandline
         [Category("P0Tests")]
         public async Task DownloadPackageWithNuGetCommandLineTest()
         {
-            // Temporary work around for the SSL issue, which keeps the upload tests from working on sites with cloudapp.net
-            if (UrlHelper.BaseUrl.Contains("nugettest.org") || UrlHelper.BaseUrl.Contains("nuget.org"))
-            {
-                string packageId = Constants.TestPackageId; //try to download a pre-defined test package.
-                _clientSdkHelper.ClearLocalPackageFolder(packageId, ClientSdkHelper.GetLatestStableVersion(packageId));
+            string packageId = Constants.TestPackageId; //try to download a pre-defined test package.
+            _clientSdkHelper.ClearLocalPackageFolder(packageId, ClientSdkHelper.GetLatestStableVersion(packageId));
 
-                var result = await _commandlineHelper.InstallPackageAsync(packageId, UrlHelper.V2FeedRootUrl, Environment.CurrentDirectory);
+            var result = await _commandlineHelper.InstallPackageAsync(packageId, UrlHelper.V2FeedRootUrl, Environment.CurrentDirectory);
 
-                Assert.True(result.ExitCode == 0, Constants.PackageDownloadFailureMessage);
-                Assert.True(_clientSdkHelper.CheckIfPackageInstalled(packageId), Constants.PackageInstallFailureMessage);
-            }
+            Assert.True(result.ExitCode == 0, Constants.PackageDownloadFailureMessage);
+            Assert.True(_clientSdkHelper.CheckIfPackageInstalled(packageId), Constants.PackageInstallFailureMessage);
         }
 
         [Fact]
@@ -55,10 +49,7 @@ namespace NuGetGallery.FunctionalTests.Commandline
         [Category("P0Tests")]
         public async Task UploadPackageWithNuGetCommandLineTest()
         {
-            if (UrlHelper.BaseUrl.Contains("nugettest.org") || UrlHelper.BaseUrl.Contains("nuget.org"))
-            {
-                await _clientSdkHelper.UploadNewPackageAndVerify(DateTime.Now.Ticks.ToString());
-            }
+            await _clientSdkHelper.UploadNewPackageAndVerify(DateTime.Now.Ticks.ToString());
         }
 
         [Fact]
@@ -67,28 +58,25 @@ namespace NuGetGallery.FunctionalTests.Commandline
         [Category("P0Tests")]
         public async Task UploadAndDownLoadPackageWithMinClientVersion()
         {
-            if (UrlHelper.BaseUrl.Contains("nugettest.org") || UrlHelper.BaseUrl.Contains("nuget.org"))
+            string packageId = DateTime.Now.Ticks + "PackageWithDotCsNames.Cs";
+            string version = "1.0.0";
+            string packageFullPath = await _packageCreationHelper.CreatePackageWithMinClientVersion(packageId, version, "2.3");
+
+            var processResult = await _commandlineHelper.UploadPackageAsync(packageFullPath, UrlHelper.V2FeedPushSourceUrl);
+
+            Assert.True(processResult.ExitCode == 0, Constants.UploadFailureMessage);
+
+            var packageVersionExistsInSource = _clientSdkHelper.CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl);
+            var userMessage = string.Format(Constants.PackageNotFoundAfterUpload, packageId, UrlHelper.V2FeedRootUrl);
+            Assert.True(packageVersionExistsInSource, userMessage);
+
+            //Delete package from local disk so once it gets uploaded
+            if (File.Exists(packageFullPath))
             {
-                string packageId = DateTime.Now.Ticks + "PackageWithDotCsNames.Cs";
-                string version = "1.0.0";
-                string packageFullPath = await _packageCreationHelper.CreatePackageWithMinClientVersion(packageId, version, "2.3");
-
-                var processResult = await _commandlineHelper.UploadPackageAsync(packageFullPath, UrlHelper.V2FeedPushSourceUrl);
-
-                Assert.True(processResult.ExitCode == 0, Constants.UploadFailureMessage);
-
-                var packageVersionExistsInSource = _clientSdkHelper.CheckIfPackageVersionExistsInSource(packageId, version, UrlHelper.V2FeedRootUrl);
-                var userMessage = string.Format(Constants.PackageNotFoundAfterUpload, packageId, UrlHelper.V2FeedRootUrl);
-                Assert.True(packageVersionExistsInSource, userMessage);
-
-                //Delete package from local disk so once it gets uploaded
-                if (File.Exists(packageFullPath))
-                {
-                    File.Delete(packageFullPath);
-                    Directory.Delete(Path.GetFullPath(Path.GetDirectoryName(packageFullPath)), true);
-                }
-                _clientSdkHelper.DownloadPackageAndVerify(packageId);
+                File.Delete(packageFullPath);
+                Directory.Delete(Path.GetFullPath(Path.GetDirectoryName(packageFullPath)), true);
             }
+            _clientSdkHelper.DownloadPackageAndVerify(packageId);
         }
     }
 }

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/CuratedFeedTest.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/CuratedFeedTest.cs
@@ -48,51 +48,40 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
             Assert.True(responseText.ToLowerInvariant().Contains(packageUrl.ToLowerInvariant()));
         }
 
-        // This test fails due to the following error
-        // The package upload via Nuget.exe didnt succeed properly. Could not establish trust relationship for the SSL/TLS secure channel
         [Fact]
         [Description("Performs a querystring-based search of the Windows 8 curated feed. Confirms expected packages are returned.")]
         [Priority(0)]
         [Category("P0Tests")]
         public async Task SearchWindows8CuratedFeed()
         {
-            // Temporary workaround for the SSL issue, which keeps the upload test from working with cloudapp.net sites
-            if (UrlHelper.BaseUrl.Contains("nugettest.org") || UrlHelper.BaseUrl.Contains("nuget.org"))
-            {
-                string packageName = "NuGetGallery.FunctionalTests.SearchWindows8CuratedFeed";
-                string ticks = DateTime.Now.Ticks.ToString();
-                string version = new Version(ticks.Substring(0, 6) + "." + ticks.Substring(6, 6) + "." + ticks.Substring(12, 6)).ToString();
+            string packageName = "NuGetGallery.FunctionalTests.SearchWindows8CuratedFeed";
+            string ticks = DateTime.Now.Ticks.ToString();
+            string version = new Version(ticks.Substring(0, 6) + "." + ticks.Substring(6, 6) + "." + ticks.Substring(12, 6)).ToString();
 
-                int exitCode = await UploadPackageToCuratedFeed(packageName, version, FeedType.Windows8CuratedFeed);
-                Assert.True((exitCode == 0), Constants.UploadFailureMessage);
+            int exitCode = await UploadPackageToCuratedFeed(packageName, version, FeedType.Windows8CuratedFeed);
+            Assert.True((exitCode == 0), Constants.UploadFailureMessage);
 
-                bool applied = CheckPackageExistInCuratedFeed(packageName, FeedType.Windows8CuratedFeed);
-                var userMessage = string.Format(Constants.PackageNotFoundAfterUpload, packageName, UrlHelper.Windows8CuratedFeedUrl);
-                Assert.True(applied, userMessage);
-            }
+            bool applied = CheckPackageExistInCuratedFeed(packageName, FeedType.Windows8CuratedFeed);
+            var userMessage = string.Format(Constants.PackageNotFoundAfterUpload, packageName, UrlHelper.Windows8CuratedFeedUrl);
+            Assert.True(applied, userMessage);
         }
 
-        // This test fails due to the following error
-        // The package upload via Nuget.exe didnt succeed properly. Could not establish trust relationship for the SSL/TLS secure channel
         [Fact]
         [Description("Performs a querystring-based search of the WebMatrix curated feed.  Confirms expected packages are returned.")]
         [Priority(0)]
         [Category("P0Tests")]
         public async Task SearchWebMatrixCuratedFeed()
         {
-            if (UrlHelper.BaseUrl.Contains("nugettest.org") || UrlHelper.BaseUrl.Contains("nuget.org"))
-            {
-                string packageName = "NuGetGallery.FunctionalTests.SearchWebMatrixCuratedFeed";
-                string ticks = DateTime.Now.Ticks.ToString();
-                string version = new Version(ticks.Substring(0, 6) + "." + ticks.Substring(6, 6) + "." + ticks.Substring(12, 6)).ToString();
+            string packageName = "NuGetGallery.FunctionalTests.SearchWebMatrixCuratedFeed";
+            string ticks = DateTime.Now.Ticks.ToString();
+            string version = new Version(ticks.Substring(0, 6) + "." + ticks.Substring(6, 6) + "." + ticks.Substring(12, 6)).ToString();
 
-                int exitCode = await UploadPackageToCuratedFeed(packageName, version, FeedType.WebMatrixCuratedFeed);
-                Assert.True((exitCode == 0), Constants.UploadFailureMessage);
+            int exitCode = await UploadPackageToCuratedFeed(packageName, version, FeedType.WebMatrixCuratedFeed);
+            Assert.True((exitCode == 0), Constants.UploadFailureMessage);
 
-                bool applied = CheckPackageExistInCuratedFeed(packageName, FeedType.WebMatrixCuratedFeed);
-                var userMessage = string.Format(Constants.PackageNotFoundAfterUpload, packageName, UrlHelper.WebMatrixCuratedFeedUrl);
-                Assert.True(applied, userMessage);
-            }
+            bool applied = CheckPackageExistInCuratedFeed(packageName, FeedType.WebMatrixCuratedFeed);
+            var userMessage = string.Format(Constants.PackageNotFoundAfterUpload, packageName, UrlHelper.WebMatrixCuratedFeedUrl);
+            Assert.True(applied, userMessage);
         }
 
         [Fact]

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/SearchTest.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/SearchTest.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         [Category("P0Tests")]
         public async Task SearchV1Feed()
         {
-            await SearchFeedAsync(UrlHelper.V1FeedRootUrl, "Json NET");
+            await SearchFeedAsync(UrlHelper.V1FeedRootUrl, "Json.NET");
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         [Category("P0Tests")]
         public async Task SearchV2Feed()
         {
-            await SearchFeedAsync(UrlHelper.V2FeedRootUrl, "Json NET");
+            await SearchFeedAsync(UrlHelper.V2FeedRootUrl, "Json.NET");
         }
 
         private async Task SearchFeedAsync(string feedRootUrl, string title)

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/SearchTest.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/SearchTest.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         [Category("P0Tests")]
         public async Task SearchV1Feed()
         {
-            await SearchFeedAsync(UrlHelper.V1FeedRootUrl, "Json.NET");
+            await SearchFeedAsync(UrlHelper.V1FeedRootUrl, "Json NET");
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         [Category("P0Tests")]
         public async Task SearchV2Feed()
         {
-            await SearchFeedAsync(UrlHelper.V2FeedRootUrl, "Json.NET");
+            await SearchFeedAsync(UrlHelper.V2FeedRootUrl, "Json NET");
         }
 
         private async Task SearchFeedAsync(string feedRootUrl, string title)

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/SearchTest.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/SearchTest.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         [Category("P0Tests")]
         public async Task SearchV1Feed()
         {
-            await SearchFeedAsync(UrlHelper.V1FeedRootUrl, "ASP.NET Web Helpers Library");
+            await SearchFeedAsync(UrlHelper.V1FeedRootUrl, "Json.NET");
         }
 
         [Fact]
@@ -33,12 +33,12 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         [Category("P0Tests")]
         public async Task SearchV2Feed()
         {
-            await SearchFeedAsync(UrlHelper.V2FeedRootUrl, "ASP.NET Web Helpers Library");
+            await SearchFeedAsync(UrlHelper.V2FeedRootUrl, "Json.NET");
         }
 
         private async Task SearchFeedAsync(string feedRootUrl, string title)
         {
-            var requestUrl = feedRootUrl + @"Search()?$filter=IsLatestVersion&$skip=0&$top=25&searchTerm='web%20helpers'&targetFramework='net40'&includePrerelease=false";
+            var requestUrl = feedRootUrl + @"Search()?$filter=IsLatestVersion&$skip=0&$top=25&searchTerm='newtonsoft%20json'&targetFramework='net40'&includePrerelease=false";
             TestOutputHelper.WriteLine("Request: GET " + requestUrl);
 
             var request = WebRequest.Create(requestUrl);
@@ -52,7 +52,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 responseText = await sr.ReadToEndAsync();
             }
 
-            var expectedUrl = feedRootUrl + "package/Microsoft.AspNet.WebHelpers/";
+            var expectedUrl = feedRootUrl + "package/Newtonsoft.Json/";
 
             Assert.True(responseText.Contains(@"<title type=""text"">" + title + @"</title>")
                      || responseText.Contains(@"<d:Title>" + title + @"</d:Title>"), "The expected package title '" + title + "' wasn't found in the feed. Feed contents: " + responseText);

--- a/tests/NuGetGallery.WebUITests.P0/UploadAndDownload/UploadPackageFromUI.cs
+++ b/tests/NuGetGallery.WebUITests.P0/UploadAndDownload/UploadPackageFromUI.cs
@@ -21,10 +21,6 @@ namespace NuGetGallery.FunctionalTests.WebUITests.UploadAndDownload
 
         public override IEnumerator<WebTestRequest> GetRequestEnumerator()
         {
-            // Temporary workaround for the SSL issue, which keeps the upload test from working with cloudapp.net sites
-            if (!UrlHelper.BaseUrl.Contains("nugettest.org") && !UrlHelper.BaseUrl.Contains("nuget.org"))
-                yield break;
-
             var defaultExtractionRule = AssertAndValidationHelper.GetDefaultExtractHiddenFields();
 
             // Do initial login

--- a/tests/Scripts/DownloadLatestNuGetExeRelease.ps1
+++ b/tests/Scripts/DownloadLatestNuGetExeRelease.ps1
@@ -1,4 +1,11 @@
-$sourceNugetExe = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
-$targetNugetExe = ".\nuget.exe"
+$sourceNugetExeUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$sourceNuGetExePath = Join-Path $PSScriptRoot "nuget.exe"
+$targetNugetExePath = ".\nuget.exe"
 
-Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
+if (-Not (Test-Path $targetNugetExePath)) {
+    if (Test-Path $sourceNuGetExePath) {
+        Copy-Item $sourceNuGetExePath $targetNugetExePath
+    } else {
+        Invoke-WebRequest $sourceNugetExeUrl -OutFile $targetNugetExePath
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/3483.

When testing the staging instance before deploying the gallery, the URL being tested is some random string (dot) cloudapp (dot) .net. This URL does not match the SSL certificate so nuget.exe rejects pushing.

This change adds a custom build of nuget.exe based off of this branch:
https://github.com/NuGet/NuGet.Client/tree/dev-jver-trust-https

This nuget.exe has a feature to trust the fingerprint (a.k.a. thumbprint) of specific certificates. 

In short, this PR:

1. Uses this custom nuget.exe for functional tests.
1. Removes code that was causing some P0 tests to no-op (!!!).
1. Fix one test that depended on a package being in the first page of search results.

As a side note, the feature request for nuget.exe supporting this certificate trust option is here:
https://github.com/NuGet/Home/issues/4387