### PR TITLE
Fix functional tests

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
@@ -18,30 +18,7 @@ namespace NuGetGallery.FunctionalTests
         private static string _testAccountPassword;
         private static string _testAccountApiKey;
         private static string _testEmailServerHost;
-        private static bool? _runFunctionalTests;
         private static List<string> _trustedHttpsCertificates;
-
-        /// <summary>
-        /// Option to enable or disable functional tests from the current run.
-        /// </summary>
-        public static bool RunFunctionalTests
-        {
-            get
-            {
-                if (!_runFunctionalTests.HasValue)
-                {
-                    bool runFunctionalTests;
-                    if (!bool.TryParse(Environment.GetEnvironmentVariable("RunFunctionalTests"), out runFunctionalTests))
-                    {
-                        runFunctionalTests = false;
-                    }
-
-                    _runFunctionalTests = runFunctionalTests;
-                }
-
-                return _runFunctionalTests.Value;
-            }
-        }
 
         /// <summary>
         /// The environment against which the test has to be run. The value would be picked from env variable.

--- a/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
@@ -18,8 +18,31 @@ namespace NuGetGallery.FunctionalTests
         private static string _testAccountPassword;
         private static string _testAccountApiKey;
         private static string _testEmailServerHost;
+        private static bool? _runFunctionalTests;
         private static List<string> _trustedHttpsCertificates;
-        
+
+        /// <summary>
+        /// Option to enable or disable functional tests from the current run.
+        /// </summary>
+        public static bool RunFunctionalTests
+        {
+            get
+            {
+                if (!_runFunctionalTests.HasValue)
+                {
+                    bool runFunctionalTests;
+                    if (!bool.TryParse(Environment.GetEnvironmentVariable("RunFunctionalTests"), out runFunctionalTests))
+                    {
+                        runFunctionalTests = false;
+                    }
+
+                    _runFunctionalTests = runFunctionalTests;
+                }
+
+                return _runFunctionalTests.Value;
+            }
+        }
+
         /// <summary>
         /// The environment against which the test has to be run. The value would be picked from env variable.
         /// If nothing is specified, preview is used as default.

--- a/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
@@ -18,8 +18,6 @@ namespace NuGetGallery.FunctionalTests
         private static string _testAccountPassword;
         private static string _testAccountApiKey;
         private static string _testEmailServerHost;
-        private static string _runFunctionalTests;
-        private static bool? _readOnlyMode;
         private static List<string> _trustedHttpsCertificates;
         
         /// <summary>

--- a/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
@@ -19,45 +19,9 @@ namespace NuGetGallery.FunctionalTests
         private static string _testAccountApiKey;
         private static string _testEmailServerHost;
         private static string _runFunctionalTests;
-        private static string _readOnlyMode;
+        private static bool? _readOnlyMode;
         private static List<string> _trustedHttpsCertificates;
-
-        /// <summary>
-        /// Option to enable or disable functional tests from the current run.
-        /// </summary>
-        public static string RunFunctionalTests
-        {
-            get
-            {
-               if (string.IsNullOrEmpty(_runFunctionalTests))
-                {
-                    if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("RunFunctionalTests")))
-                        _runFunctionalTests = "False";
-                    else
-                        _runFunctionalTests = Environment.GetEnvironmentVariable("RunFunctionalTests");
-                }
-                return _runFunctionalTests;
-            }
-        }
-
-        /// <summary>
-        /// Option to enable or disable functional tests from the current run.
-        /// </summary>
-        public static string ReadOnlyMode
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(_readOnlyMode))
-                {
-                    if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ReadOnlyMode")))
-                        _readOnlyMode = "False";
-                    else
-                        _readOnlyMode = Environment.GetEnvironmentVariable("ReadOnlyMode");
-                }
-                return _readOnlyMode;
-            }
-        }
-
+        
         /// <summary>
         /// The environment against which the test has to be run. The value would be picked from env variable.
         /// If nothing is specified, preview is used as default.

--- a/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/GalleryTestFixture.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/GalleryTestFixture.cs
@@ -16,13 +16,13 @@ namespace NuGetGallery.FunctionalTests
             // Initialize the test collection shared context.
             // Check if functional tests is enabled.
             // If not, do an assert inconclusive.
-#if DEBUG
-#else
-            if (!EnvironmentSettings.RunFunctionalTests.Equals("True", System.StringComparison.OrdinalIgnoreCase))
+            if (!EnvironmentSettings.RunFunctionalTests)
             {
-                throw new System.InvalidOperationException("Functional tests are disabled in the current run. Please set environment variable RunFuntionalTests to True to enable them");
-            }
+#if !DEBUG
+                throw new InvalidOperationException("Functional tests are disabled in the current run. Please set environment variable RunFuntionalTests to True to enable them");
 #endif
+            }
+
 
             // suppress SSL validation for *.cloudapp.net
             ServicePointManagerInitializer.InitializeServerCertificateValidationCallback();

--- a/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/GalleryTestFixture.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/GalleryTestFixture.cs
@@ -16,13 +16,13 @@ namespace NuGetGallery.FunctionalTests
             // Initialize the test collection shared context.
             // Check if functional tests is enabled.
             // If not, do an assert inconclusive.
+#if DEBUG
+#else
             if (!EnvironmentSettings.RunFunctionalTests)
             {
-#if !DEBUG
                 throw new InvalidOperationException("Functional tests are disabled in the current run. Please set environment variable RunFuntionalTests to True to enable them");
-#endif
             }
-
+#endif
 
             // suppress SSL validation for *.cloudapp.net
             ServicePointManagerInitializer.InitializeServerCertificateValidationCallback();

--- a/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/GalleryTestFixture.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/GalleryTestFixture.cs
@@ -13,17 +13,6 @@ namespace NuGetGallery.FunctionalTests
     {
         public GalleryTestFixture()
         {
-            // Initialize the test collection shared context.
-            // Check if functional tests is enabled.
-            // If not, do an assert inconclusive.
-#if DEBUG
-#else
-            if (!EnvironmentSettings.RunFunctionalTests)
-            {
-                throw new InvalidOperationException("Functional tests are disabled in the current run. Please set environment variable RunFuntionalTests to True to enable them");
-            }
-#endif
-
             // suppress SSL validation for *.cloudapp.net
             ServicePointManagerInitializer.InitializeServerCertificateValidationCallback();
             Task.Run(async () =>

--- a/tests/NuGetGallery.WebUITests.P0/UploadAndDownload/UploadPackageFromUI.cs
+++ b/tests/NuGetGallery.WebUITests.P0/UploadAndDownload/UploadPackageFromUI.cs
@@ -33,6 +33,7 @@ namespace NuGetGallery.FunctionalTests.WebUITests.UploadAndDownload
             var uploadRequest = AssertAndValidationHelper.GetHttpRequestForUrl(UrlHelper.UploadPageUrl);
             yield return uploadRequest;
 
+            string packageId;
             if (LastResponse.ResponseUri.ToString().Contains("verify-upload"))
             {
                 // If there is a upload in progress, try to submit that upload instead of creating a new package (since we are just going to verify that upload goes through UI).
@@ -40,15 +41,13 @@ namespace NuGetGallery.FunctionalTests.WebUITests.UploadAndDownload
                 var response = LastResponse.BodyString;
                 var startIndex = response.IndexOf("<p>", StringComparison.Ordinal);
                 var endIndex = response.IndexOf("</p>", startIndex, StringComparison.Ordinal);
-                var packageId = response.Substring(startIndex + 3, endIndex - (startIndex + 3));
+                packageId = response.Substring(startIndex + 3, endIndex - (startIndex + 3));
                 AddCommentToResult(packageId);   //Adding the package ID to result for debugging.
-                var verifyUploadPostRequest = AssertAndValidationHelper.GetVerifyPackagePostRequestForPackage(this, packageId, "1.0.0", UrlHelper.VerifyUploadPageUrl, Constants.ReadOnlyModeError, 503);
-                yield return verifyUploadPostRequest;
             }
             else
             {
                 // The API key is part of the nuget.config file that is present under the solution dir.
-                var packageId = DateTime.Now.Ticks.ToString();
+                packageId = DateTime.Now.Ticks.ToString();
                 var packageCreationHelper = new PackageCreationHelper();
                 var packageFullPath = packageCreationHelper.CreatePackage(packageId).Result;
 
@@ -58,10 +57,10 @@ namespace NuGetGallery.FunctionalTests.WebUITests.UploadAndDownload
                 var verifyUploadRequest = new WebTestRequest(UrlHelper.VerifyUploadPageUrl);
                 verifyUploadRequest.ExtractValues += defaultExtractionRule.Extract;
                 yield return verifyUploadRequest;
-
-                var verifyUploadPostRequest = AssertAndValidationHelper.GetVerifyPackagePostRequestForPackage(this, packageId, "1.0.0", UrlHelper.GetPackagePageUrl(packageId, "1.0.0"), packageId);
-                yield return verifyUploadPostRequest;
             }
+
+            var verifyUploadPostRequest = AssertAndValidationHelper.GetVerifyPackagePostRequestForPackage(this, packageId, "1.0.0", UrlHelper.GetPackagePageUrl(packageId, "1.0.0"), packageId);
+            yield return verifyUploadPostRequest;
         }
     }
 }

--- a/tests/NuGetGallery.WebUITests.ReadOnlyMode/AccountManagement/AccountManagementInReadOnlyModeTest.cs
+++ b/tests/NuGetGallery.WebUITests.ReadOnlyMode/AccountManagement/AccountManagementInReadOnlyModeTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.WebTesting;
 using NuGetGallery.FunctionalTests.Helpers;
@@ -9,7 +8,7 @@ using NuGetGallery.FunctionalTests.Helpers;
 namespace NuGetGallery.FunctionalTests.WebUITests.ReadOnlyMode
 {
     /// <summary>
-    /// Go Account management activities like "Unsunscribe" notications and "Reset" Api key in read-only mode and check for error.
+    /// Go Account management activities like "Unsubscribe" notications and "Reset" Api key in read-only mode and check for error.
     /// </summary>
     public class AccountManagementInReadOnlyModeTest : WebTest
     {
@@ -20,47 +19,43 @@ namespace NuGetGallery.FunctionalTests.WebUITests.ReadOnlyMode
 
         public override IEnumerator<WebTestRequest> GetRequestEnumerator()
         {
-            // Run this test only if read-only mode is set. This is to avoid false failures while doing Run all tests locally.
-            if (EnvironmentSettings.ReadOnlyMode.Equals("True", StringComparison.OrdinalIgnoreCase))
-            {
-                // Do initial login to be able to perform package management.
-                var logonGet = AssertAndValidationHelper.GetLogonGetRequest();
-                yield return logonGet;
+            // Do initial login to be able to perform package management.
+            var logonGet = AssertAndValidationHelper.GetLogonGetRequest();
+            yield return logonGet;
 
-                var logonPost = AssertAndValidationHelper.GetLogonPostRequest(this);
-                yield return logonPost;
+            var logonPost = AssertAndValidationHelper.GetLogonPostRequest(this);
+            yield return logonPost;
 
-                var accountPageRequest = new WebTestRequest(UrlHelper.AccountPageUrl);
-                var extractionRule1 = AssertAndValidationHelper.GetDefaultExtractHiddenFields();
-                accountPageRequest.ExtractValues += extractionRule1.Extract;
-                yield return accountPageRequest;
+            var accountPageRequest = new WebTestRequest(UrlHelper.AccountPageUrl);
+            var extractionRule1 = AssertAndValidationHelper.GetDefaultExtractHiddenFields();
+            accountPageRequest.ExtractValues += extractionRule1.Extract;
+            yield return accountPageRequest;
 
 
-                var unsubscribeRequest = new WebTestRequest(UrlHelper.AccountUnscribeUrl);
-                unsubscribeRequest.Method = "POST";
-                unsubscribeRequest.ExpectedHttpStatusCode = 503;
-                var unsubscribeRequestBody = new FormPostHttpBody();
-                unsubscribeRequestBody.FormPostParameters.Add("__RequestVerificationToken", Context["$HIDDEN1.__RequestVerificationToken"].ToString());
-                unsubscribeRequestBody.FormPostParameters.Add("emailAllowed", "false");
-                unsubscribeRequest.Body = unsubscribeRequestBody;
+            var unsubscribeRequest = new WebTestRequest(UrlHelper.AccountUnscribeUrl);
+            unsubscribeRequest.Method = "POST";
+            unsubscribeRequest.ExpectedHttpStatusCode = 503;
+            var unsubscribeRequestBody = new FormPostHttpBody();
+            unsubscribeRequestBody.FormPostParameters.Add("__RequestVerificationToken", Context["$HIDDEN1.__RequestVerificationToken"].ToString());
+            unsubscribeRequestBody.FormPostParameters.Add("emailAllowed", "false");
+            unsubscribeRequest.Body = unsubscribeRequestBody;
 
-                // Check for read-only status.
-                var readonlyValidationRule = AssertAndValidationHelper.GetValidationRuleForFindText(Constants.ReadOnlyModeError);
-                unsubscribeRequest.ValidateResponse += readonlyValidationRule.Validate;
-                yield return unsubscribeRequest;
+            // Check for read-only status.
+            var readonlyValidationRule = AssertAndValidationHelper.GetValidationRuleForFindText(Constants.ReadOnlyModeError);
+            unsubscribeRequest.ValidateResponse += readonlyValidationRule.Validate;
+            yield return unsubscribeRequest;
 
-                var resetApiKeyRequest = new WebTestRequest(UrlHelper.AccountApiKeyResetUrl);
-                resetApiKeyRequest.Method = "POST";
-                resetApiKeyRequest.ExpectedHttpStatusCode = 503;
+            var resetApiKeyRequest = new WebTestRequest(UrlHelper.AccountApiKeyResetUrl);
+            resetApiKeyRequest.Method = "POST";
+            resetApiKeyRequest.ExpectedHttpStatusCode = 503;
 
-                var resetApiKeyRequestBody = new FormPostHttpBody();
-                resetApiKeyRequestBody.FormPostParameters.Add("__RequestVerificationToken", Context["$HIDDEN1.__RequestVerificationToken"].ToString());
-                resetApiKeyRequest.Body = resetApiKeyRequestBody;
+            var resetApiKeyRequestBody = new FormPostHttpBody();
+            resetApiKeyRequestBody.FormPostParameters.Add("__RequestVerificationToken", Context["$HIDDEN1.__RequestVerificationToken"].ToString());
+            resetApiKeyRequest.Body = resetApiKeyRequestBody;
 
-                // Check for read-only error
-                resetApiKeyRequest.ValidateResponse += readonlyValidationRule.Validate;
-                yield return resetApiKeyRequest;
-            }
+            // Check for read-only error
+            resetApiKeyRequest.ValidateResponse += readonlyValidationRule.Validate;
+            yield return resetApiKeyRequest;
         }
     }
 }

--- a/tests/NuGetGallery.WebUITests.ReadOnlyMode/AccountManagement/RegisterNewUserInReadOnlyModeTest.cs
+++ b/tests/NuGetGallery.WebUITests.ReadOnlyMode/AccountManagement/RegisterNewUserInReadOnlyModeTest.cs
@@ -20,31 +20,27 @@ namespace NuGetGallery.FunctionalTests.WebUITests.ReadOnlyMode
 
         public override IEnumerator<WebTestRequest> GetRequestEnumerator()
         {
-            //run this test only if read-only mode is set. This is to avoid false failures while doing Run all tests locally.
-            if (EnvironmentSettings.ReadOnlyMode.Equals("True", StringComparison.OrdinalIgnoreCase))
-            {
-                var registerPageRequest = AssertAndValidationHelper.GetHttpRequestForUrl(UrlHelper.LogonPageUrl);
-                yield return registerPageRequest;
+            var registerPageRequest = AssertAndValidationHelper.GetHttpRequestForUrl(UrlHelper.LogonPageUrl);
+            yield return registerPageRequest;
 
-                var registerPagePostRequest = new WebTestRequest(UrlHelper.RegisterPageUrl);
-                registerPagePostRequest.Method = "POST";
-                registerPagePostRequest.ExpectedResponseUrl = UrlHelper.RegistrationPendingPageUrl;
+            var registerPagePostRequest = new WebTestRequest(UrlHelper.RegisterPageUrl);
+            registerPagePostRequest.Method = "POST";
+            registerPagePostRequest.ExpectedResponseUrl = UrlHelper.RegistrationPendingPageUrl;
 
-                // Create a form and set the UserName, Email and password as form post parameters.
-                // We just need to set some unique user name and Email.
-                var registerNewUserFormPost = new FormPostHttpBody();
-                registerNewUserFormPost.FormPostParameters.Add("__RequestVerificationToken", Context["$HIDDEN1.__RequestVerificationToken"].ToString());
-                registerNewUserFormPost.FormPostParameters.Add("LinkingAccount", "false");
-                registerNewUserFormPost.FormPostParameters.Add(Constants.EmailAddressFormField, DateTime.Now.Ticks + "@live.com"); //add a dummy mail account. This will be fixed once we incorporate the logic to delete user.
-                registerNewUserFormPost.FormPostParameters.Add(Constants.UserNameFormField, DateTime.Now.Ticks + "NewAccount");
-                registerNewUserFormPost.FormPostParameters.Add(Constants.RegisterPasswordFormField, "xxXxx1xx");
-                registerPagePostRequest.Body = registerNewUserFormPost;
-                registerPagePostRequest.ExpectedHttpStatusCode = 503;
-                // Validate the response to make sure that it shows the error message for read-only mode.
-                var readOnlyModeTextRule = AssertAndValidationHelper.GetValidationRuleForFindText(Constants.ReadOnlyModeError);
-                registerPagePostRequest.ValidateResponse += readOnlyModeTextRule.Validate;
-                yield return registerPagePostRequest;
-            }
+            // Create a form and set the UserName, Email and password as form post parameters.
+            // We just need to set some unique user name and Email.
+            var registerNewUserFormPost = new FormPostHttpBody();
+            registerNewUserFormPost.FormPostParameters.Add("__RequestVerificationToken", Context["$HIDDEN1.__RequestVerificationToken"].ToString());
+            registerNewUserFormPost.FormPostParameters.Add("LinkingAccount", "false");
+            registerNewUserFormPost.FormPostParameters.Add(Constants.EmailAddressFormField, DateTime.Now.Ticks + "@live.com"); //add a dummy mail account. This will be fixed once we incorporate the logic to delete user.
+            registerNewUserFormPost.FormPostParameters.Add(Constants.UserNameFormField, DateTime.Now.Ticks + "NewAccount");
+            registerNewUserFormPost.FormPostParameters.Add(Constants.RegisterPasswordFormField, "xxXxx1xx");
+            registerPagePostRequest.Body = registerNewUserFormPost;
+            registerPagePostRequest.ExpectedHttpStatusCode = 503;
+            // Validate the response to make sure that it shows the error message for read-only mode.
+            var readOnlyModeTextRule = AssertAndValidationHelper.GetValidationRuleForFindText(Constants.ReadOnlyModeError);
+            registerPagePostRequest.ValidateResponse += readOnlyModeTextRule.Validate;
+            yield return registerPagePostRequest;
         }
     }
 }

--- a/tests/NuGetGallery.WebUITests.ReadOnlyMode/UploadAndDownload/UploadPackageFromInUIInReadOnlyMode.cs
+++ b/tests/NuGetGallery.WebUITests.ReadOnlyMode/UploadAndDownload/UploadPackageFromInUIInReadOnlyMode.cs
@@ -20,12 +20,6 @@ namespace NuGetGallery.FunctionalTests.WebUITests.ReadOnlyMode
 
         public override IEnumerator<WebTestRequest> GetRequestEnumerator()
         {
-            //run this test only if read-only mode is set. This is to avoid false failures while doing Run all tests locally.
-            if (!EnvironmentSettings.ReadOnlyMode.Equals("True", StringComparison.OrdinalIgnoreCase))
-            {
-                yield break;
-            }
-
             var defaultExtractionRule = AssertAndValidationHelper.GetDefaultExtractHiddenFields();
 
             // Do initial login


### PR DESCRIPTION
1. `UploadPackageFromUI` was improperly asserting 503 against a non-read-only server.
1. Remove checks that skipped test logic based on `ReadOnly` flag. This is the wrong way to skip tests.

Addresses https://github.com/NuGet/Engineering/issues/188.

Found https://github.com/NuGet/Engineering/issues/200 in the process. Will address separately.