### PR TITLE
Handle case where $filter makes Package(Id=...,Version=...) yield an empty result

### DIFF
--- a/src/NuGetGallery/WebApi/QueryResult.cs
+++ b/src/NuGetGallery/WebApi/QueryResult.cs
@@ -176,11 +176,23 @@ namespace NuGetGallery.WebApi
                     // Handle single result
                     if (modelQueryResults != null)
                     {
-                        return NegotiatedContentResult(modelQueryResults.FirstOrDefault());
+                        var model = modelQueryResults.FirstOrDefault();
+                        if (model == null)
+                        {
+                            return NotFoundResult();
+                        }
+
+                        return NegotiatedContentResult(model);
                     }
                     else if (projectedQueryResults != null)
                     {
-                        return NegotiatedContentResult(projectedQueryResults.AsEnumerable().FirstOrDefault());
+                        var model = projectedQueryResults.AsEnumerable().FirstOrDefault();
+                        if (model == null)
+                        {
+                            return NotFoundResult();
+                        }
+
+                        return NegotiatedContentResult(model);
                     }
                 }
             }

--- a/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -114,6 +115,8 @@ namespace NuGetGallery
 
                 [Theory]
                 [InlineData("https://nuget.org/api/v2/Packages(Id='NoFoo',Version='1.0.0')")]
+                [InlineData("https://nuget.org/api/v2/Packages(Id='Foo',Version='1.0.0')?$filter=Id%20eq%20%27SomethingElse%27")]
+                [InlineData("https://nuget.org/api/v2/Packages(Id='Foo',Version='1.0.0')?$filter=Id%20eq%20%27SomethingElse%27&$select=Id")]
                 public async Task Return404NotFoundForUnexistingPackage(string requestUrl)
                 {
                     using (var server = FeedServiceHelpers.SetupODataServer())
@@ -121,7 +124,7 @@ namespace NuGetGallery
                         var client = new HttpClient(server);
                         var response = await client.GetAsync(requestUrl);
 
-                        Assert.False(response.IsSuccessStatusCode);
+                        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
                     }
                 }
 


### PR DESCRIPTION
Before this change, an HTTP `500 Internal Server Error` was being thrown.

Fixes https://github.com/NuGet/NuGetGallery/issues/3435