### PR TITLE
Remove hard coded base URL in functional tests

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery.FunctionalTests
     /// </summary>
     public class EnvironmentSettings
     {
-        private static string _baseurl = "https://dev.nugettest.org/";
+        private static string _baseurl;
         private static string _searchServiceBaseurl;
         private static string _testAccountName;
         private static string _testAccountPassword;


### PR DESCRIPTION
Not sure how this snuck in, but it was probably test code left over from the scoped API keys work. This prevents the environment variables set by the CI (in particular the staging slot URL) from sticking.
