### PR TITLE
Make functional tests output xml instead of html and use VSTest instead of MSTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,7 +175,7 @@ build/artifacts/
 tests/Scripts/TestResults[*].trx
 src/NuGetGallery.Cloud/ecf/
 *.trx
-tests/functionaltests*.html
+tests/functionaltests.*.xml
 Results.?.xml
 
 # Vs2015

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -9,11 +9,6 @@ param (
     [string]$AzureCertificateThumbprint
 )
 
-# Delete leftover tests
-Get-ChildItem "$PSScriptRoot\.." -Recurse | Where-Object {$_.Extension -eq '.trx' -Or $_.Name -match 'functionaltests.*.xml'} | ForEach-Object {
-    Remove-Item "$($_.FullName)"
-}
-
 # Determine the url to run the tests against
 if ($Slot -eq "Production")
 {

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -1,3 +1,9 @@
+# Delete leftover tests
+Get-ChildItem $env:Build_SourcesDirectory | Where-Object {$_.Extension -eq '.trx' -Or $_.Name -match 'functionaltests.*.xml'} | ForEach-Object {
+    Remove-Item $_
+}
+
+# Determine the url of the gallery we are testing.
 function GetUrl()
 {
 	param([string] $xmlString)
@@ -14,6 +20,7 @@ if($env:Slot -eq "Production")
 }
 else
 {
+    # Use the Azure management certificate to find the url of the desired slot
 	$dict = New-Object "System.Collections.Generic.Dictionary``2[System.String,System.String]"
 	$dict.Add('x-ms-version', ' 2014-02-01')
 	$uri =  "https://management.core.windows.net/$env:SubscriptionId/services/hostedservices/$env:CloudServiceName" + "?embed-detail=true"

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -25,7 +25,7 @@ else
     try
     {
         Write-Host "Logging into Azure as service principal."
-        Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -Tenant "$TenantId"
+        Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
         Write-Host "Fetching url of $Slot slot of $CloudServiceName."
         $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url
     }

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -33,7 +33,7 @@ else
         # Use the resource group name to construct the id of the slot resource
         $slotResource = Get-AzureRmResource -Id "/subscriptions/$SubscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.ClassicCompute/domainNames/$CloudServiceName/slots/$Slot"
         # Get the uri of the slot resource
-        $GalleryUrl = $slotResource.Properties.uri
+        $GalleryUrl = ($slotResource.Properties.uri).Replace("http", "https")
     }
     Catch [System.Exception]
     {

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -26,8 +26,10 @@ else
     {
         Write-Host "Logging into Azure as service principal."
         $login = Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
+        $subscriptionName = $login.Context.Subscription.SubscriptionName
+        Write-Host "Using $subscriptionName subscription."
+        Select-AzureSubscription -SubscriptionName "$subscriptionName"
         Write-Host "Fetching url of $Slot slot of $CloudServiceName."
-        Select-AzureSubscription -SubscriptionName "$($login.Context.Subscription.SubscriptionName)"
         $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url
     }
     catch [System.Exception]

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -1,0 +1,36 @@
+function GetUrl()
+{
+	param([string] $xmlString)
+	$stagingsectionindex = $xmlString.IndexOf("<DeploymentSlot>Staging</DeploymentSlot>")
+	$startindex =  $xmlString.IndexOf("<Url>",$stagingsectionindex)
+	$endindex = $xmlString.IndexOf("</Url>",$startindex)
+	$stagingUrl =  $xmlString.Substring($startindex+5, $endindex-($startindex +5))
+	return $stagingUrl
+}
+
+if($env:Slot -eq "Production")
+{
+    $GalleryUrl = $env:SERVICEROOT
+}
+else
+{
+	$dict = New-Object "System.Collections.Generic.Dictionary``2[System.String,System.String]"
+	$dict.Add('x-ms-version', ' 2014-02-01')
+	$uri =  "https://management.core.windows.net/$env:SubscriptionId/services/hostedservices/$env:CloudServiceName" + "?embed-detail=true"
+	$cert = dir "cert:\LocalMachine\My\$env:AzureCertificateThumbprint"
+    try
+    {
+	    $response = Invoke-WebRequest -Uri $uri -Certificate $cert -Headers $dict -Method GET -UseBasicParsing
+	    $url = GetUrl "$response.Content"
+	    $url = $url.Replace("http","https")
+        $GalleryUrl = $url
+    }
+    catch
+    {
+        Write-Host "Failed to retrieve URL for testing"
+        Exit 1
+    }
+}
+
+Write-Host "Using the following GalleryURL: " + $GalleryUrl
+Write-Host "##vso[task.setvariable variable=GalleryUrl;]$GalleryUrl"

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -32,7 +32,7 @@ else
         $resourceGroupName = (Find-AzureRmResource -ResourceNameEquals "$CloudServiceName").ResourceGroupName
         # Use the resource group name to construct the id of the slot resource
         $slotResource = Get-AzureRmResource -Id "/subscriptions/$SubscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.ClassicCompute/domainNames/$CloudServiceName/slots/$Slot"
-        # Get the uri of the slot resource
+        # Get the uri of the slot resource and make sure it is https
         $GalleryUrl = ($slotResource.Properties.uri).Replace("http", "https")
     }
     Catch [System.Exception]

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -25,8 +25,7 @@ else
     try
     {
         Write-Host "Logging into Azure as service principal."
-        Get-Help Add-AzureRmAccount
-        Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
+        Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -Tenant "$TenantId"
         Write-Host "Fetching url of $Slot slot of $CloudServiceName."
         $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url
     }

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -27,6 +27,7 @@ else
         Write-Host "Logging into Azure as service principal."
         Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
         Write-Host "Fetching url of $Slot slot of $CloudServiceName."
+        Select-AzureRmContext -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
         $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url
     }
     catch [System.Exception]

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -24,7 +24,9 @@ else
     # Use Azure PowerShell cmdlets to find the url of the desired slot
     try
     {
+        Write-Host "Logging into Azure as service principal."
         Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
+        Write-Host "Fetching url of $Slot slot of $CloudServiceName."
         $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url
     }
     catch [System.Exception]
@@ -35,6 +37,6 @@ else
     }
 }
 
-Write-Host "Using the following GalleryURL: " + $GalleryUrl
+Write-Host "Using the following GalleryURL: " $GalleryUrl
 $env:GalleryUrl = $GalleryUrl
 Write-Host "##vso[task.setvariable variable=GalleryUrl;]$GalleryUrl"

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -25,6 +25,7 @@ else
     try
     {
         Write-Host "Logging into Azure as service principal."
+        Get-Help Add-AzureRmAccount
         Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
         Write-Host "Fetching url of $Slot slot of $CloudServiceName."
         $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -25,9 +25,9 @@ else
     try
     {
         Write-Host "Logging into Azure as service principal."
-        Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
+        $login = Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
         Write-Host "Fetching url of $Slot slot of $CloudServiceName."
-        Select-AzureSubscription -SubscriptionId "$SubscriptionId"
+        Select-AzureSubscription -SubscriptionName "$($login.Context.Subscription.SubscriptionName)"
         $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url
     }
     catch [System.Exception]

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -27,7 +27,7 @@ else
         Write-Host "Logging into Azure as service principal."
         Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
         Write-Host "Fetching url of $Slot slot of $CloudServiceName."
-        Set-AzureRmContext -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
+        Select-AzureSubscription -SubscriptionId "$SubscriptionId"
         $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url
     }
     catch [System.Exception]

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -27,7 +27,7 @@ else
         Write-Host "Logging into Azure as service principal."
         Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
         Write-Host "Fetching url of $Slot slot of $CloudServiceName."
-        Select-AzureRmContext -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
+        Set-AzureRmContext -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
         $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url
     }
     catch [System.Exception]

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -6,30 +6,30 @@ Get-ChildItem $env:Build_SourcesDirectory | Where-Object {$_.Extension -eq '.trx
 # Determine the url of the gallery we are testing.
 function GetUrl()
 {
-	param([string] $xmlString)
-	$stagingsectionindex = $xmlString.IndexOf("<DeploymentSlot>Staging</DeploymentSlot>")
-	$startindex =  $xmlString.IndexOf("<Url>",$stagingsectionindex)
-	$endindex = $xmlString.IndexOf("</Url>",$startindex)
-	$stagingUrl =  $xmlString.Substring($startindex+5, $endindex-($startindex +5))
-	return $stagingUrl
+    param([string] $xmlString)
+    $stagingsectionindex = $xmlString.IndexOf("<DeploymentSlot>Staging</DeploymentSlot>")
+    $startindex =  $xmlString.IndexOf("<Url>",$stagingsectionindex)
+    $endindex = $xmlString.IndexOf("</Url>",$startindex)
+    $stagingUrl =  $xmlString.Substring($startindex+5, $endindex-($startindex +5))
+    return $stagingUrl
 }
 
-if($env:Slot -eq "Production")
+if ($env:Slot -eq "Production")
 {
     $GalleryUrl = $env:SERVICEROOT
 }
 else
 {
     # Use the Azure management certificate to find the url of the desired slot
-	$dict = New-Object "System.Collections.Generic.Dictionary``2[System.String,System.String]"
-	$dict.Add('x-ms-version', ' 2014-02-01')
-	$uri =  "https://management.core.windows.net/$env:SubscriptionId/services/hostedservices/$env:CloudServiceName" + "?embed-detail=true"
-	$cert = dir "cert:\LocalMachine\My\$env:AzureCertificateThumbprint"
+    $dict = New-Object "System.Collections.Generic.Dictionary``2[System.String,System.String]"
+    $dict.Add('x-ms-version', ' 2014-02-01')
+    $uri =  "https://management.core.windows.net/$env:SubscriptionId/services/hostedservices/$env:CloudServiceName" + "?embed-detail=true"
+    $cert = dir "cert:\LocalMachine\My\$env:AzureCertificateThumbprint"
     try
     {
-	    $response = Invoke-WebRequest -Uri $uri -Certificate $cert -Headers $dict -Method GET -UseBasicParsing
-	    $url = GetUrl "$response.Content"
-	    $url = $url.Replace("http","https")
+        $response = Invoke-WebRequest -Uri $uri -Certificate $cert -Headers $dict -Method GET -UseBasicParsing
+        $url = GetUrl "$response.Content"
+        $url = $url.Replace("http","https")
         $GalleryUrl = $url
     }
     catch

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -17,22 +17,25 @@ Get-ChildItem "$PSScriptRoot\.." -Recurse | Where-Object {$_.Extension -eq '.trx
 # Determine the url to run the tests against
 if ($Slot -eq "Production")
 {
+    # If the slot is 'Production', then we can assume that we are testing the same url as the service root. 
     $GalleryUrl = $ServiceRoot
 }
 else
 {
     # Use Azure PowerShell cmdlets to find the url of the desired slot
-    try
+    Try
     {
         Write-Host "Logging into Azure as service principal."
+        # Log into Azure using a service principal with a certificate
         $login = Add-AzureRmAccount -ApplicationId "$ApplicationId" -CertificateThumbprint "$AzureCertificateThumbprint" -ServicePrincipal -SubscriptionId "$SubscriptionId" -TenantId "$TenantId"
-        $subscriptionName = $login.Context.Subscription.SubscriptionName
-        Write-Host "Using $subscriptionName subscription."
-        Select-AzureSubscription -SubscriptionName "$subscriptionName"
-        Write-Host "Fetching url of $Slot slot of $CloudServiceName."
-        $GalleryUrl = (Get-AzureDeployment -ServiceName "$CloudServiceName" -Slot "$Slot").Url
+        # Get the resource group name of the cloud service resource
+        $resourceGroupName = (Find-AzureRmResource -ResourceNameEquals "$CloudServiceName").ResourceGroupName
+        # Use the resource group name to construct the id of the slot resource
+        $slotResource = Get-AzureRmResource -Id "/subscriptions/$SubscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.ClassicCompute/domainNames/$CloudServiceName/slots/$Slot"
+        # Get the uri of the slot resource
+        $GalleryUrl = $slotResource.Properties.uri
     }
-    catch [System.Exception]
+    Catch [System.Exception]
     {
         Write-Host "Failed to retrieve URL for testing!"
         Write-Host $_.Exception.Message

--- a/tests/Scripts/Configure-FunctionalTests.ps1
+++ b/tests/Scripts/Configure-FunctionalTests.ps1
@@ -32,9 +32,10 @@ else
         $url = $url.Replace("http","https")
         $GalleryUrl = $url
     }
-    catch
+    catch [System.Exception]
     {
-        Write-Host "Failed to retrieve URL for testing"
+        Write-Host "Failed to retrieve URL for testing!"
+        Write-Host $_.Exception.Message
         Exit 1
     }
 }

--- a/tests/Scripts/RunEverything.cmd
+++ b/tests/Scripts/RunEverything.cmd
@@ -13,9 +13,13 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
+set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
+if exist functionaltests.*.xml (
+    del functionaltests.*.xml
+)
 if exist resultsfile.trx (
 	del resultsfile.trx
 )
@@ -46,15 +50,15 @@ call %xunit% "%fluentTestDir%\NuGetGallery.FunctionalTests.Fluent.dll" -xml func
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %vstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /logger:trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %vstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /logger:trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %vstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P2.dll" /logger:trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests

--- a/tests/Scripts/RunEverything.cmd
+++ b/tests/Scripts/RunEverything.cmd
@@ -11,7 +11,7 @@ set solutionPath="NuGetGallery.FunctionalTests.sln"
 
 REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
-set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
+set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
@@ -21,15 +21,15 @@ if exist functionaltests.*.xml (
     del functionaltests.*.xml
 )
 if exist resultsfile.trx (
-	del resultsfile.trx
+    del resultsfile.trx
 )
 if exist TestResults (
-	rd TestResults /S /Q
+    rd TestResults /S /Q
 )
 
 REM Restore packages
 if not exist nuget (
-	call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
+    call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
 )
 call %nuget% restore "%solutionPath%" -NonInteractive
 if not "%errorlevel%"=="0" goto failure

--- a/tests/Scripts/RunEverything.cmd
+++ b/tests/Scripts/RunEverything.cmd
@@ -13,7 +13,7 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
-set mstest="C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\mstest.exe"
+set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist resultsfile.trx (
@@ -38,27 +38,27 @@ REM Run functional tests
 set testDir="NuGetGallery.FunctionalTests\bin\%config%"
 set fluentTestDir="NuGetGallery.FunctionalTests.Fluent\bin\%config%"
 copy %nuget% %testDir%
-call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -teamcity
+call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -xml functionaltests.everything.xml
 if not "%errorlevel%"=="0" set exitCode=-1
 
 copy %nuget% %fluentTestDir%
-call %xunit% "%fluentTestDir%\NuGetGallery.FunctionalTests.Fluent.dll" -teamcity -html functionaltestseverything.html
+call %xunit% "%fluentTestDir%\NuGetGallery.FunctionalTests.Fluent.dll" -xml functionaltests.fluent.xml
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfileP0.trx
+call %vstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /logger:trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfileP1.trx
+call %vstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /logger:trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P2.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfileP2.trx
+call %vstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P2.dll" /logger:trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
-call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:loadtests-resultsfile.trx /category:%testCategory%
+call %vstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
 if not "%errorlevel%"=="0" set exitCode=-1
 
 goto end

--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -11,7 +11,7 @@ set exitCode=0
 
 REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
-set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
+set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"

--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -12,7 +12,7 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
-set mstest="C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\mstest.exe"
+set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
@@ -40,7 +40,6 @@ copy %nuget% %testDir%
 call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.P0.xml
 
 REM Run web UI tests
-call %vstest% "NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /logger:trx
 call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
 if not "%errorlevel%"=="0" goto failure
 

--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -7,6 +7,7 @@ REM Configuration
 set config=Release
 set testCategory="P0Tests"
 set solutionPath="NuGetGallery.FunctionalTests.sln"
+set exitCode=0
 
 REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
@@ -41,17 +42,17 @@ REM Run functional tests
 set testDir="NuGetGallery.FunctionalTests\bin\%config%"
 copy %nuget% %testDir%
 call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.P0.xml
+if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
 call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
-if not "%errorlevel%"=="0" goto failure
+if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
 call %vstest% "NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
-if not "%errorlevel%"=="0" goto failure
+if not "%errorlevel%"=="0" set exitCode=-1
 
-:success
-exit 0
+exit /B %exitCode%
 
 :failure
 exit -1

--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -12,6 +12,7 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
+set mstest="C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
@@ -40,6 +41,7 @@ call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%test
 
 REM Run web UI tests
 call %vstest% "NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /logger:trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
 if not "%errorlevel%"=="0" goto failure
 
 REM Run Load tests

--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -12,7 +12,7 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
-set mstest="C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\mstest.exe"
+set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist resultsfile.trx (
@@ -36,14 +36,14 @@ if not "%errorlevel%"=="0" goto failure
 REM Run functional tests
 set testDir="NuGetGallery.FunctionalTests\bin\%config%"
 copy %nuget% %testDir%
-call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -teamcity -html functionaltestsP0.html
+call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.P0.xml
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %vstest% "NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /logger:trx
 if not "%errorlevel%"=="0" goto failure
 
 REM Run Load tests
-call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:loadtests-resultsfile.trx /category:%testCategory%
+call %vstest% "NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
 if not "%errorlevel%"=="0" goto failure
 
 :success

--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -16,15 +16,15 @@ set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Comm
 
 REM Clean previous test results
 if exist resultsfile.trx (
-	del resultsfile.trx
+    del resultsfile.trx
 )
 if exist TestResults (
-	rd TestResults /S /Q
+    rd TestResults /S /Q
 )
 
 REM Restore packages
 if not exist nuget (
-	call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
+    call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
 )
 call %nuget% restore "%solutionPath%" -NonInteractive
 if not "%errorlevel%"=="0" goto failure

--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -16,6 +16,9 @@ set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mste
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
+if exist functionaltests.*.xml (
+    del functionaltests.*.xml
+)
 if exist resultsfile.trx (
     del resultsfile.trx
 )

--- a/tests/Scripts/RunP1Tests.bat
+++ b/tests/Scripts/RunP1Tests.bat
@@ -11,7 +11,7 @@ set exitCode=0
 
 REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
-set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
+set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"

--- a/tests/Scripts/RunP1Tests.bat
+++ b/tests/Scripts/RunP1Tests.bat
@@ -12,9 +12,13 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
+set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
+if exist functionaltests.*.xml (
+    del functionaltests.*.xml
+)
 if exist resultsfile.trx (
     del resultsfile.trx
 )
@@ -39,7 +43,7 @@ copy %nuget% %testDir%
 call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.P1.xml
 
 REM Run web UI tests
-call %vstest% "NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /logger:trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
 if not "%errorlevel%"=="0" goto failure
 
 REM Run Load tests

--- a/tests/Scripts/RunP1Tests.bat
+++ b/tests/Scripts/RunP1Tests.bat
@@ -12,7 +12,7 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
-set mstest="C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\mstest.exe"
+set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist resultsfile.trx (
@@ -36,14 +36,14 @@ if not "%errorlevel%"=="0" goto failure
 REM Run functional tests
 set testDir="NuGetGallery.FunctionalTests\bin\%config%"
 copy %nuget% %testDir%
-call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -teamcity -html functionaltestsP1.html
+call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.P1.xml
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %vstest% "NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /logger:trx
 if not "%errorlevel%"=="0" goto failure
 
 REM Run Load tests
-call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:loadtests-resultsfile.trx /category:%testCategory%
+call %vstest% "NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
 if not "%errorlevel%"=="0" goto failure
 
 :success

--- a/tests/Scripts/RunP1Tests.bat
+++ b/tests/Scripts/RunP1Tests.bat
@@ -7,6 +7,7 @@ REM Configuration
 set config=Release
 set testCategory="P1Tests"
 set solutionPath="NuGetGallery.FunctionalTests.sln"
+set exitCode=0
 
 REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
@@ -41,17 +42,17 @@ REM Run functional tests
 set testDir="NuGetGallery.FunctionalTests\bin\%config%"
 copy %nuget% %testDir%
 call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.P1.xml
+if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
 call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
-if not "%errorlevel%"=="0" goto failure
+if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
 call %vstest% "NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
-if not "%errorlevel%"=="0" goto failure
+if not "%errorlevel%"=="0" set exitCode=-1
 
-:success
-exit 0
+exit /B %exitCode%
 
 :failure
 exit -1

--- a/tests/Scripts/RunP1Tests.bat
+++ b/tests/Scripts/RunP1Tests.bat
@@ -16,15 +16,15 @@ set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Comm
 
 REM Clean previous test results
 if exist resultsfile.trx (
-	del resultsfile.trx
+    del resultsfile.trx
 )
 if exist TestResults (
-	rd TestResults /S /Q
+    rd TestResults /S /Q
 )
 
 REM Restore packages
 if not exist nuget (
-	call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
+    call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
 )
 call %nuget% restore "%solutionPath%" -NonInteractive
 if not "%errorlevel%"=="0" goto failure

--- a/tests/Scripts/RunP2Tests.bat
+++ b/tests/Scripts/RunP2Tests.bat
@@ -11,7 +11,7 @@ set exitCode=0
 
 REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
-set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
+set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"

--- a/tests/Scripts/RunP2Tests.bat
+++ b/tests/Scripts/RunP2Tests.bat
@@ -12,9 +12,13 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
+set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
+if exist functionaltests.*.xml (
+    del functionaltests.*.xml
+)
 if exist resultsfile.trx (
     del resultsfile.trx
 )
@@ -39,7 +43,7 @@ copy %nuget% %testDir%
 call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.P2.xml
 
 REM Run web UI and load tests
-call %vstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /logger:trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
 if not "%errorlevel%"=="0" goto failure
 
 REM Run Load tests

--- a/tests/Scripts/RunP2Tests.bat
+++ b/tests/Scripts/RunP2Tests.bat
@@ -16,15 +16,15 @@ set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Comm
 
 REM Clean previous test results
 if exist resultsfile.trx (
-	del resultsfile.trx
+    del resultsfile.trx
 )
 if exist TestResults (
-	rd TestResults /S /Q
+    rd TestResults /S /Q
 )
 
 REM Restore packages
 if not exist nuget (
-	call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
+    call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
 )
 call %nuget% restore "%solutionPath%" -NonInteractive
 if not "%errorlevel%"=="0" goto failure

--- a/tests/Scripts/RunP2Tests.bat
+++ b/tests/Scripts/RunP2Tests.bat
@@ -7,6 +7,7 @@ REM Configuration
 set config=Release
 set testCategory="P2Tests"
 set solutionPath="NuGetGallery.FunctionalTests.sln"
+set exitCode=0
 
 REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
@@ -41,17 +42,17 @@ REM Run functional tests
 set testDir="NuGetGallery.FunctionalTests\bin\%config%"
 copy %nuget% %testDir%
 call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.P2.xml
+if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI and load tests
 call %mstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
-if not "%errorlevel%"=="0" goto failure
+if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
 call %vstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
-if not "%errorlevel%"=="0" goto failure
+if not "%errorlevel%"=="0" set exitCode=-1
 
-:success
-exit 0
+exit /B %exitCode%
 
 :failure
 exit -1

--- a/tests/Scripts/RunP2Tests.bat
+++ b/tests/Scripts/RunP2Tests.bat
@@ -12,7 +12,7 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
-set mstest="C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\mstest.exe"
+set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist resultsfile.trx (
@@ -36,14 +36,14 @@ if not "%errorlevel%"=="0" goto failure
 REM Run functional tests
 set testDir="NuGetGallery.FunctionalTests\bin\%config%"
 copy %nuget% %testDir%
-call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -teamcity -html functionaltestsP2.html
+call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.P2.xml
 
 REM Run web UI and load tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %vstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /logger:trx
 if not "%errorlevel%"=="0" goto failure
 
 REM Run Load tests
-call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:loadtests-resultsfile.trx /category:%testCategory%
+call %vstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
 if not "%errorlevel%"=="0" goto failure
 
 :success

--- a/tests/Scripts/RunReadonlyModeTests.bat
+++ b/tests/Scripts/RunReadonlyModeTests.bat
@@ -10,7 +10,7 @@ set solutionPath="NuGetGallery.FunctionalTests.sln"
 
 REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
-set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
+set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 

--- a/tests/Scripts/RunReadonlyModeTests.bat
+++ b/tests/Scripts/RunReadonlyModeTests.bat
@@ -12,7 +12,7 @@ REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
-set mstest="C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\mstest.exe"
+set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist resultsfile.trx (
@@ -36,14 +36,14 @@ if not "%errorlevel%"=="0" goto failure
 REM Run functional tests
 set testDir="NuGetGallery.FunctionalTests\bin\%config%"
 copy %nuget% %testDir%
-call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -teamcity -html functionaltestsreadonly.html
+call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.readonly.xml
 
 REM Run web UI and load tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.ReadOnlyMode\bin\%config%\NuGetGallery.WebUITests.ReadOnlyMode.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %vstest% /TestContainer:"NuGetGallery.WebUITests.ReadOnlyMode\bin\%config%\NuGetGallery.WebUITests.ReadOnlyMode.dll" /logger:trx
 if not "%errorlevel%"=="0" goto failure
 
 REM Run Load tests
-call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:loadtests-resultsfile.trx /category:%testCategory%
+call %vstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
 if not "%errorlevel%"=="0" goto failure
 
 :success

--- a/tests/Scripts/RunReadonlyModeTests.bat
+++ b/tests/Scripts/RunReadonlyModeTests.bat
@@ -16,15 +16,15 @@ set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\Comm
 
 REM Clean previous test results
 if exist resultsfile.trx (
-	del resultsfile.trx
+    del resultsfile.trx
 )
 if exist TestResults (
-	rd TestResults /S /Q
+    rd TestResults /S /Q
 )
 
 REM Restore packages
 if not exist nuget (
-	call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
+    call PowerShell -NoProfile -ExecutionPolicy Bypass -File %cd%\Scripts\DownloadLatestNuGetExeRelease.ps1
 )
 call %nuget% restore "%solutionPath%" -NonInteractive
 if not "%errorlevel%"=="0" goto failure


### PR DESCRIPTION
Changed the outputs of our test scripts to output `xml` instead of `html` and to use `VSTest` instead of `MSTest` (when possible).

Also added a script to determine the url of the gallery being tested using an Azure service principal.