### PR TITLE
Update Octopus link

### DIFF
--- a/src/NuGetGallery/Views/Shared/LayoutFooter.cshtml
+++ b/src/NuGetGallery/Views/Shared/LayoutFooter.cshtml
@@ -30,7 +30,7 @@
         <a href="https://status.nuget.org">Service status</a>
     </p>
     <p>
-        Deployed using <a href="http://octopusdeploy.com/" target="referral">Octopus Deploy</a> | Uses <a href="http://fontawesome.io" target="referral">Font Awesome</a> by Dave Gandy
+        Deployed using <a href="https://octopus.com/" target="referral">Octopus Deploy</a> | Uses <a href="http://fontawesome.io" target="referral">Font Awesome</a> by Dave Gandy
     </p>
     @ViewHelpers.ReleaseTag()
 </div>


### PR DESCRIPTION
Hi NuGet team! We really appreciate the Octopus link in the footer. Mind if we update the URL? 

Git seems to really want a newline at the bottom of the file for some reason too. 