### PR TITLE
Fix P1 and P2 functional tests 

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
@@ -63,50 +63,57 @@ namespace NuGetGallery.FunctionalTests
         /// </summary>
         public bool CheckIfPackageVersionExistsInSource(string packageId, string version, string sourceUrl)
         {
-            var found = false;
             var repo = PackageRepositoryFactory.Default.CreateRepository(sourceUrl);
-            SemanticVersion semVersion;
-            var success = SemanticVersion.TryParse(version, out semVersion);
+            SemanticVersion semVersion = SemanticVersion.Parse(version);
+
+            return VerifyWithRetry(
+                $"checking if package {packageId} {version} exists on source {sourceUrl}",
+                () =>
+                {
+                    var package = repo.FindPackage(packageId, semVersion);
+
+                    return package != null;
+                });
+        }
+
+        private bool VerifyWithRetry(string actionName, Func<bool> action)
+        {
+            bool success = false;
             const int intervalSec = 30;
             const int maxAttempts = 30;
 
-            if (success)
+            try
             {
-                try
+                WriteLine($"Starting '{actionName}' ({maxAttempts} attempts, interval {intervalSec} seconds).");
+
+                for (var i = 0; i < maxAttempts && !success; i++)
                 {
-                    WriteLine("Starting package verification checks ({0} attempts, interval {1} seconds).", maxAttempts, intervalSec);
-                    // Wait for the search service to kick in, so that the package can be found via FindPackage(packageId, SemanticVersion)
-                    Thread.Sleep(5000);
-
-                    for (var i = 0; ((i < maxAttempts) && (!found)); i++)
+                    if (i != 0)
                     {
-                        WriteLine("[verification attempt {0}]: Waiting {1} seconds before next check...", i, intervalSec);
+                        WriteLine($"[verification attempt {i}]: Waiting {intervalSec} seconds before next check...");
+                        Thread.Sleep(intervalSec * 1000);
+                    }
 
-                        if (i != 0)
-                        {
-                            Thread.Sleep(intervalSec * 1000);
-                        }
+                    WriteLine($"[verification attempt {i}]: Executing... ");
+                    success = action();
 
-                        WriteLine("[verification attempt {0}]: Checking if package {1} with version {2} exists in source {3}... ", i, packageId, version, sourceUrl);
-                        IPackage package = repo.FindPackage(packageId, semVersion);
-                        found = package != null;
-                        if (found)
-                        {
-                            WriteLine("Found!");
-                        }
-                        else
-                        {
-                            WriteLine("NOT found!");
-                        }
+                    if (success)
+                    {
+                        WriteLine("Successful!");
+                    }
+                    else
+                    {
+                        WriteLine("NOT successful!");
                     }
                 }
-                catch (Exception ex)
-                {
-                    WriteLine("Exception thrown while checking the existence of package {0} with version {1}:\r\n {2}", packageId, version, ex.Message);
-                }
+            }
+            catch (Exception ex)
+            {
+                WriteLine($"Exception thrown while executing '{actionName}'.{Environment.NewLine}{ex}");
+                return false;
             }
 
-            return found;
+            return success;
         }
 
         /// <summary>
@@ -203,17 +210,27 @@ namespace NuGetGallery.FunctionalTests
             return version.ToString();
         }
 
-        /// <summary>
-        /// Returns the count of versions available for the given package
-        /// </summary>
-        public int GetVersionCount(string packageId, bool allowPreRelease = true)
+        public void VerifyVersionCount(string packageId, int expectedCount, bool allowPreRelease = true)
         {
             var repo = PackageRepositoryFactory.Default.CreateRepository(SourceUrl);
-            var packages = repo.FindPackagesById(packageId).ToList();
-            if (!allowPreRelease)
-                packages = packages.Where(item => item.IsReleaseVersion()).ToList();
-            return packages.Count;
+
+            Assert.True(VerifyWithRetry(
+                $"verifying count of {packageId} packages is {expectedCount}",
+                () =>
+                {
+                    var packages = repo.FindPackagesById(packageId).ToList();
+                    if (!allowPreRelease)
+                    {
+                        packages = packages.Where(item => item.IsReleaseVersion()).ToList();
+                    }
+                    var actualCount = packages.Count;
+
+                    var versionsDisplay = string.Join(", ", packages.Select(p => p.Version));
+                    WriteLine($"{actualCount} versions of {packageId} found: {versionsDisplay}");
+                    return actualCount == expectedCount;
+                }));
         }
+
         /// <summary>
         /// Returns the download count of the given package as a formatted string as it would appear in the gallery UI.
         /// </summary>

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
@@ -110,7 +110,6 @@ namespace NuGetGallery.FunctionalTests
             catch (Exception ex)
             {
                 WriteLine($"Exception thrown while executing '{actionName}'.{Environment.NewLine}{ex}");
-                return false;
             }
 
             return success;

--- a/tests/NuGetGallery.FunctionalTests/Commandline/PackageVersionTest.cs
+++ b/tests/NuGetGallery.FunctionalTests/Commandline/PackageVersionTest.cs
@@ -22,19 +22,19 @@ namespace NuGetGallery.FunctionalTests.Commandline
 
         [Fact]
         [Description("Upload multiple versions of a package and see if it gets uploaded properly")]
-        [Priority(0)]
+        [Priority(1)]
         [Category("P1Tests")]
         public async Task UploadMultipleVersionOfPackage()
         {
             var packageId = string.Format("TestMultipleVersion.{0}", DateTime.Now.Ticks);
 
-            await _clientSdkHelper.UploadNewPackageAndVerify(packageId);
-            await _clientSdkHelper.UploadNewPackageAndVerify(packageId, "2.0.0");
+            await _clientSdkHelper.UploadNewPackage(packageId, "1.0.0");
+            await _clientSdkHelper.UploadNewPackage(packageId, "2.0.0");
 
-            int actualCount = _clientSdkHelper.GetVersionCount(packageId);
+            _clientSdkHelper.VerifyPackageExistsInSource(packageId, "1.0.0");
+            _clientSdkHelper.VerifyPackageExistsInSource(packageId, "2.0.0");
 
-            var userMessage = string.Format(" 2 versions of package {0} not found after uploading. Actual versions found {1}", packageId, actualCount);
-            Assert.True(actualCount.Equals(2), userMessage);
+            _clientSdkHelper.VerifyVersionCount(packageId, 2);
         }
     }
 }

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -154,8 +155,28 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
 
             Assert.True((processResult.ExitCode == 0), Constants.UploadFailureMessage + "Exit Code: " + processResult.ExitCode + ". Error message: \"" + processResult.StandardError + "\"");
 
+            var packagesList = new List<string>
+            {
+                packageName,
+                "Microsoft.Bcl.Build",
+                "Microsoft.Bcl",
+                "Microsoft.Net.Http"
+            };
+            var versionsList = new List<string>
+            {
+                version1,
+                "1.0.6",
+                "1.0.19",
+                "2.1.6-rc"
+            };
             var url = UrlHelper.V2FeedRootUrl +
-                $@"/GetUpdates()?packageIds='{packageName}%7COwin%7CMicrosoft.Web.Infrastructure%7CMicrosoft.AspNet.Identity.Core%7CMicrosoft.AspNet.Identity.EntityFramework%7CMicrosoft.AspNet.Identity.Owin%7CMicrosoft.AspNet.Web.Optimization%7CRespond%7CWebGrease%7CjQuery%7CjQuery.Validation%7CMicrosoft.Owin.Security.Twitter%7CMicrosoft.Owin.Security.OAuth%7CMicrosoft.Owin.Security.MicrosoftAccount%7CMicrosoft.Owin.Security.Google%7CMicrosoft.Owin.Security.Facebook%7CMicrosoft.Owin.Security.Cookies%7CMicrosoft.Owin%7CMicrosoft.Owin.Host.SystemWeb%7CMicrosoft.Owin.Security%7CModernizr%7CMicrosoft.jQuery.Unobtrusive.Validation%7CMicrosoft.AspNet.WebPages%7CMicrosoft.AspNet.Razor%7Cbootstrap%7CAntlr%7CMicrosoft.AspNet.Mvc%7CNewtonsoft.Json%7CEntityFramework'&versions='" + version1 + "%7C1.0%7C1.0.0.0%7C1.0.0%7C1.0.0%7C1.0.0%7C1.1.1%7C1.2.0%7C1.5.2%7C1.10.2%7C1.11.1%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.6.2%7C3.0.0%7C3.0.0%7C3.0.0%7C3.0.0%7C3.4.1.9004%7C5.0.0%7C5.0.6%7C6.0.0'&includePrerelease=false&includeAllVersions=false&targetFrameworks='net45'&versionConstraints='%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C'";
+                @"/GetUpdates()?packageIds='" +
+                string.Join("%7C", packagesList) +
+                @"'&versions='" +
+                string.Join("%7C", versionsList) +
+                @"'&includePrerelease=false&includeAllVersions=false&targetFrameworks='net45'&versionConstraints='" +
+                string.Join("%7C", Enumerable.Repeat(string.Empty, packagesList.Count)) +
+                @"'";
             string[] expectedTexts =
             {
                 $@"<title type=""text"">{packageName}</title>",

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -139,7 +139,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         public async Task GetUpdates1199RegressionTest()
         {
             // Use the same package name, but force the version to be unique.
-            var packageName = "NuGetGallery.FunctionalTests.ODataTests.GetUpdates1199RegressionTest";
+            var packageName = "GetUpdates1199RegressionTest";
             var ticks = DateTime.Now.Ticks.ToString();
             var version1 = new Version(ticks.Substring(0, 6) + "." + ticks.Substring(6, 6) + "." + ticks.Substring(12, 6)).ToString();
             var version2 = new Version(Convert.ToInt32(ticks.Substring(0, 6) + 1) + "." + ticks.Substring(6, 6) + "." + ticks.Substring(12, 6)).ToString();
@@ -154,11 +154,12 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
 
             Assert.True((processResult.ExitCode == 0), Constants.UploadFailureMessage + "Exit Code: " + processResult.ExitCode + ". Error message: \"" + processResult.StandardError + "\"");
 
-            var url = UrlHelper.V2FeedRootUrl + @"/GetUpdates()?packageIds='NuGetGallery.FunctionalTests.ODataTests.GetUpdates1199RegressionTest%7COwin%7CMicrosoft.Web.Infrastructure%7CMicrosoft.AspNet.Identity.Core%7CMicrosoft.AspNet.Identity.EntityFramework%7CMicrosoft.AspNet.Identity.Owin%7CMicrosoft.AspNet.Web.Optimization%7CRespond%7CWebGrease%7CjQuery%7CjQuery.Validation%7CMicrosoft.Owin.Security.Twitter%7CMicrosoft.Owin.Security.OAuth%7CMicrosoft.Owin.Security.MicrosoftAccount%7CMicrosoft.Owin.Security.Google%7CMicrosoft.Owin.Security.Facebook%7CMicrosoft.Owin.Security.Cookies%7CMicrosoft.Owin%7CMicrosoft.Owin.Host.SystemWeb%7CMicrosoft.Owin.Security%7CModernizr%7CMicrosoft.jQuery.Unobtrusive.Validation%7CMicrosoft.AspNet.WebPages%7CMicrosoft.AspNet.Razor%7Cbootstrap%7CAntlr%7CMicrosoft.AspNet.Mvc%7CNewtonsoft.Json%7CEntityFramework'&versions='" + version1 + "%7C1.0%7C1.0.0.0%7C1.0.0%7C1.0.0%7C1.0.0%7C1.1.1%7C1.2.0%7C1.5.2%7C1.10.2%7C1.11.1%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.6.2%7C3.0.0%7C3.0.0%7C3.0.0%7C3.0.0%7C3.4.1.9004%7C5.0.0%7C5.0.6%7C6.0.0'&includePrerelease=false&includeAllVersions=false&targetFrameworks='net45'&versionConstraints='%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C'";
+            var url = UrlHelper.V2FeedRootUrl +
+                $@"/GetUpdates()?packageIds='{packageName}%7COwin%7CMicrosoft.Web.Infrastructure%7CMicrosoft.AspNet.Identity.Core%7CMicrosoft.AspNet.Identity.EntityFramework%7CMicrosoft.AspNet.Identity.Owin%7CMicrosoft.AspNet.Web.Optimization%7CRespond%7CWebGrease%7CjQuery%7CjQuery.Validation%7CMicrosoft.Owin.Security.Twitter%7CMicrosoft.Owin.Security.OAuth%7CMicrosoft.Owin.Security.MicrosoftAccount%7CMicrosoft.Owin.Security.Google%7CMicrosoft.Owin.Security.Facebook%7CMicrosoft.Owin.Security.Cookies%7CMicrosoft.Owin%7CMicrosoft.Owin.Host.SystemWeb%7CMicrosoft.Owin.Security%7CModernizr%7CMicrosoft.jQuery.Unobtrusive.Validation%7CMicrosoft.AspNet.WebPages%7CMicrosoft.AspNet.Razor%7Cbootstrap%7CAntlr%7CMicrosoft.AspNet.Mvc%7CNewtonsoft.Json%7CEntityFramework'&versions='" + version1 + "%7C1.0%7C1.0.0.0%7C1.0.0%7C1.0.0%7C1.0.0%7C1.1.1%7C1.2.0%7C1.5.2%7C1.10.2%7C1.11.1%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.0.0%7C2.6.2%7C3.0.0%7C3.0.0%7C3.0.0%7C3.0.0%7C3.4.1.9004%7C5.0.0%7C5.0.6%7C6.0.0'&includePrerelease=false&includeAllVersions=false&targetFrameworks='net45'&versionConstraints='%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C%7C'";
             string[] expectedTexts =
             {
-                @"<title type=""text"">NuGetGallery.FunctionalTests.ODataTests.GetUpdates1199RegressionTest</title>",
-                @"<d:Version>" + version2 + "</d:Version><d:NormalizedVersion>" + version2 + "</d:NormalizedVersion>"
+                $@"<title type=""text"">{packageName}</title>",
+                $@"<d:Version>{version2}</d:Version><d:NormalizedVersion>{version2}</d:NormalizedVersion>"
             };
             var containsResponseText = await _odataHelper.ContainsResponseText(url, expectedTexts);
 

--- a/tests/NuGetGallery.LoadTests/NuGetGallery.LoadTests.csproj
+++ b/tests/NuGetGallery.LoadTests/NuGetGallery.LoadTests.csproj
@@ -31,7 +31,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/tests/NuGetGallery.WebUITests.P1/BasicPages/StatisticsPageTest.cs
+++ b/tests/NuGetGallery.WebUITests.P1/BasicPages/StatisticsPageTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Web.UI;
 using Microsoft.VisualStudio.TestTools.WebTesting;
 using NuGetGallery.FunctionalTests.Helpers;
 
@@ -23,10 +22,10 @@ namespace NuGetGallery.FunctionalTests.WebUITests.BasicPages
         {
             var statsPageRequest = new WebTestRequest(UrlHelper.StatsPageUrl);
 
-            // Checks for the presence of a link to jquery package. It is harded to Jquery for now as there is no API exposed for stats
-            // and also Jquery is going to be one of the top 10 for now.
-            var jQueryPackageValidationRule = AssertAndValidationHelper.GetValidationRuleForHtmlTagInnerText(HtmlTextWriterTag.A.ToString(), HtmlTextWriterAttribute.Href.ToString(), "/packages/EntityFramework/", "EntityFramework");
-            statsPageRequest.ValidateResponse += jQueryPackageValidationRule.Validate;
+            // Checks for the presence of the rank element. This means there is at least one package in the list.
+            var validationRule = AssertAndValidationHelper.GetValidationRuleForFindText(
+                @"<td class=""statistics-rank"">1</td>");
+            statsPageRequest.ValidateResponse += validationRule.Validate;
 
             // Validation rule to check for the default text in stats page.
             var statsPageDefaultTextValidationRule = AssertAndValidationHelper.GetValidationRuleForFindText(Constants.StatsPageDefaultText);

--- a/tests/NuGetGallery.WebUITests.P2/BasicPages/SecurityHeaderTest.cs
+++ b/tests/NuGetGallery.WebUITests.P2/BasicPages/SecurityHeaderTest.cs
@@ -19,27 +19,23 @@ namespace NuGetGallery.FunctionalTests.WebUITests.BasicPages
          }
 
         public override IEnumerator<WebTestRequest> GetRequestEnumerator()
-         {
-             //send a request to home page and check for security headers.
-             var homePageRequest = new WebTestRequest(UrlHelper.BaseUrl);
-             homePageRequest.ParseDependentRequests = false;
-             var homePageTextValidationRule = new ValidationRuleFindHeaderText(
- @"X-Frame-Options: deny
-X-XSS-Protection: 1; mode=block
-X-Content-Type-Options: nosniff
-Strict-Transport-Security: max-age=31536000");
-             homePageRequest.ValidateResponse += homePageTextValidationRule.Validate;
-             yield return homePageRequest;
+        {
+            // Send a request to home page and check for security headers.
+            var homePageRequest = new WebTestRequest(UrlHelper.BaseUrl);
+            homePageRequest.ParseDependentRequests = false;
+            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Frame-Options: deny").Validate;
+            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-XSS-Protection: 1; mode=block").Validate;
+            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Content-Type-Options: nosniff").Validate;
+            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("Strict-Transport-Security: max-age=31536000").Validate;
+            yield return homePageRequest;
 
-             //send a request to Packages page and check for security headers.
-             var packagesPageRequest = new WebTestRequest(UrlHelper.PackagesPageUrl);
-             packagesPageRequest.ParseDependentRequests = false;
-             var packagesPageTextValidationRule = new ValidationRuleFindHeaderText(
- @"X-Frame-Options: deny
-X-XSS-Protection: 1; mode=block
-X-Content-Type-Options: nosniff
-Strict-Transport-Security: max-age=31536000");
-            packagesPageRequest.ValidateResponse += packagesPageTextValidationRule.Validate;
+            // Send a request to Packages page and check for security headers.
+            var packagesPageRequest = new WebTestRequest(UrlHelper.PackagesPageUrl);
+            packagesPageRequest.ParseDependentRequests = false;
+            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Frame-Options: deny").Validate;
+            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-XSS-Protection: 1; mode=block").Validate;
+            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Content-Type-Options: nosniff").Validate;
+            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("Strict-Transport-Security: max-age=31536000").Validate;
             yield return packagesPageRequest;
         }
     }

--- a/tests/NuGetGallery.WebUITests.P2/BasicPages/SecurityHeaderTest.cs
+++ b/tests/NuGetGallery.WebUITests.P2/BasicPages/SecurityHeaderTest.cs
@@ -32,10 +32,10 @@ namespace NuGetGallery.FunctionalTests.WebUITests.BasicPages
             // Send a request to Packages page and check for security headers.
             var packagesPageRequest = new WebTestRequest(UrlHelper.PackagesPageUrl);
             packagesPageRequest.ParseDependentRequests = false;
-            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Frame-Options: deny").Validate;
-            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-XSS-Protection: 1; mode=block").Validate;
-            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Content-Type-Options: nosniff").Validate;
-            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("Strict-Transport-Security: max-age=31536000").Validate;
+            packagesPageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Frame-Options: deny").Validate;
+            packagesPageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-XSS-Protection: 1; mode=block").Validate;
+            packagesPageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Content-Type-Options: nosniff").Validate;
+            packagesPageRequest.ValidateResponse += new ValidationRuleFindHeaderText("Strict-Transport-Security: max-age=31536000").Validate;
             yield return packagesPageRequest;
         }
     }

--- a/tests/Scripts/RunP1Tests.bat
+++ b/tests/Scripts/RunP1Tests.bat
@@ -21,6 +21,9 @@ if exist resultsfile.trx (
 if exist TestResults (
 	rd TestResults /S /Q
 )
+if exist loadtests-resultsfile.trx (
+	del loadtests-resultsfile.trx
+)
 
 REM Restore packages
 if not exist nuget (

--- a/tests/Scripts/RunP2Tests.bat
+++ b/tests/Scripts/RunP2Tests.bat
@@ -21,6 +21,9 @@ if exist resultsfile.trx (
 if exist TestResults (
 	rd TestResults /S /Q
 )
+if exist loadtests-resultsfile.trx (
+	del loadtests-resultsfile.trx
+)
 
 REM Restore packages
 if not exist nuget (


### PR DESCRIPTION
1. Retry calls to `FindPackagesById` since it delegates to search service.
1. Delete tests than take > 10 minutes. Two of the three of that type were already skipped.
1. Fix statistics page web UI test to not depend on a specific package ID.

After this, P1 and P2 tests work just fine against DEV, INT, and PROD.

The whole suite takes 30 - 40 minutes to run.