### PR TITLE
Fix #2514 - Use optimistic concurrency to prevent multiple UpdateIsLatest calls on same package

### DIFF
--- a/src/NuGetGallery.Core/Entities/EntitiesConfiguration.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesConfiguration.cs
@@ -24,24 +24,24 @@ namespace NuGetGallery
         {
             get
             {
-                return (bool?)CallContext.LogicalGetData("UseRetriableExecutionStrategy") ?? false;
+                return (bool?)CallContext.LogicalGetData(nameof(UseRetriableExecutionStrategy)) ?? true;
             }
             set
             {
-                CallContext.LogicalSetData("UseRetriableExecutionStrategy", value);
+                CallContext.LogicalSetData(nameof(UseRetriableExecutionStrategy), value);
             }
         }
 
         public static IDisposable SuspendRetriableExecutionStrategy()
         {
-            return new ExecutionStrategySuspension();
+            return new RetriableExecutionStrategySuspension();
         }
 
-        private class ExecutionStrategySuspension : IDisposable
+        private class RetriableExecutionStrategySuspension : IDisposable
         {
             private readonly bool _originalValue;
 
-            internal ExecutionStrategySuspension()
+            internal RetriableExecutionStrategySuspension()
             {
                 _originalValue = UseRetriableExecutionStrategy;
 

--- a/src/NuGetGallery.Core/Entities/EntitiesConfiguration.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.SqlServer;
@@ -15,19 +16,41 @@ namespace NuGetGallery
         {
             // Configure Connection Resiliency / Retry Logic
             // See https://msdn.microsoft.com/en-us/data/dn456835.aspx and msdn.microsoft.com/en-us/data/dn307226
-            SetExecutionStrategy("System.Data.SqlClient", () => SuspendExecutionStrategy
-                ? (IDbExecutionStrategy)new DefaultExecutionStrategy() : new SqlAzureExecutionStrategy());
+            SetExecutionStrategy("System.Data.SqlClient", () => UseRetriableExecutionStrategy
+                ? new SqlAzureExecutionStrategy() : (IDbExecutionStrategy)new DefaultExecutionStrategy());
         }
 
-        public static bool SuspendExecutionStrategy
+        private static bool UseRetriableExecutionStrategy
         {
             get
             {
-                return (bool?)CallContext.LogicalGetData("SuspendExecutionStrategy") ?? false;
+                return (bool?)CallContext.LogicalGetData("UseRetriableExecutionStrategy") ?? false;
             }
             set
             {
-                CallContext.LogicalSetData("SuspendExecutionStrategy", value);
+                CallContext.LogicalSetData("UseRetriableExecutionStrategy", value);
+            }
+        }
+
+        public static IDisposable SuspendRetriableExecutionStrategy()
+        {
+            return new ExecutionStrategySuspension();
+        }
+
+        private class ExecutionStrategySuspension : IDisposable
+        {
+            private readonly bool _originalValue;
+
+            internal ExecutionStrategySuspension()
+            {
+                _originalValue = UseRetriableExecutionStrategy;
+
+                UseRetriableExecutionStrategy = false;
+            }
+
+            public void Dispose()
+            {
+                UseRetriableExecutionStrategy = _originalValue;
             }
         }
     }

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
@@ -66,6 +67,11 @@ namespace NuGetGallery
         public void SetCommandTimeout(int? seconds)
         {
             ObjectContext.CommandTimeout = seconds;
+        }
+
+        public DbChangeTracker GetChangeTracker()
+        {
+            return ChangeTracker;
         }
 
         public Database GetDatabase()

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
@@ -47,11 +46,6 @@ namespace NuGetGallery
         IDbSet<T> IEntitiesContext.Set<T>()
         {
             return base.Set<T>();
-        }
-
-        DbEntityEntry<T> IEntitiesContext.Entry<T>(T entry)
-        {
-            return base.Entry<T>(entry);
         }
 
         public override async Task<int> SaveChangesAsync()

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
@@ -46,6 +47,11 @@ namespace NuGetGallery
         IDbSet<T> IEntitiesContext.Set<T>()
         {
             return base.Set<T>();
+        }
+
+        DbEntityEntry<T> IEntitiesContext.Entry<T>(T entry)
+        {
+            return base.Entry<T>(entry);
         }
 
         public override async Task<int> SaveChangesAsync()

--- a/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
@@ -18,6 +19,7 @@ namespace NuGetGallery
         Task<int> SaveChangesAsync();
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Set", Justification="This is to match the EF terminology.")]
         IDbSet<T> Set<T>() where T : class;
+        DbEntityEntry<T> Entry<T>(T entry) where T : class;
         void DeleteOnCommit<T>(T entity) where T : class;
         void SetCommandTimeout(int? seconds);
         Database GetDatabase();

--- a/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data.Entity;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
 {
     public interface IEntitiesContext
+        : IDisposable
     {
         IDbSet<CuratedFeed> CuratedFeeds { get; set; }
         IDbSet<CuratedPackage> CuratedPackages { get; set; }

--- a/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
@@ -22,6 +23,8 @@ namespace NuGetGallery
         IDbSet<T> Set<T>() where T : class;
         void DeleteOnCommit<T>(T entity) where T : class;
         void SetCommandTimeout(int? seconds);
+
+        DbChangeTracker GetChangeTracker();
         Database GetDatabase();
     }
 }

--- a/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
@@ -19,7 +18,6 @@ namespace NuGetGallery
         Task<int> SaveChangesAsync();
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Set", Justification="This is to match the EF terminology.")]
         IDbSet<T> Set<T>() where T : class;
-        DbEntityEntry<T> Entry<T>(T entry) where T : class;
         void DeleteOnCommit<T>(T entity) where T : class;
         void SetCommandTimeout(int? seconds);
         Database GetDatabase();

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -393,7 +393,7 @@ namespace NuGetGallery
                             throw;
                         }
 
-                        // handle in separate transaction because of concurrency check with retry
+                        // Handle in separate transaction because of concurrency check with retry
                         await PackageService.UpdateIsLatestAsync(package.PackageRegistration);
 
                         IndexingService.UpdatePackage(package);

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -474,7 +474,7 @@ namespace NuGetGallery
 
             await PackageService.MarkPackageUnlistedAsync(package);
             
-            // handle in separate transaction because of concurrency check with retry
+            // Handle in separate transaction because of concurrency check with retry.
             if (package.IsLatest || package.IsLatestStable)
             {
                 await PackageService.UpdateIsLatestAsync(package.PackageRegistration);

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -473,12 +473,12 @@ namespace NuGetGallery
             }
 
             await PackageService.MarkPackageUnlistedAsync(package);
-            
-            // Handle in separate transaction because of concurrency check with retry.
-            if (package.IsLatest || package.IsLatestStable)
-            {
-                await PackageService.UpdateIsLatestAsync(package.PackageRegistration);
-            }
+
+            // Handle in separate transaction because of concurrency check with retry. Due to using
+            // separate transactions, we must always call UpdateIsLatest on delete/unlist. This is
+            // because a concurrent thread could be marking the package as latest before this thread
+            // is able to commit the delete /unlist.
+            await PackageService.UpdateIsLatestAsync(package.PackageRegistration);
 
             IndexingService.UpdatePackage(package);
             return new EmptyResult();

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -997,11 +997,11 @@ namespace NuGetGallery
                 action = "unlisted";
                 await _packageService.MarkPackageUnlistedAsync(package);
 
-                // handle in separate transaction because of concurrency check with retry
-                if (package.IsLatest || package.IsLatestStable)
-                {
-                    await _packageService.UpdateIsLatestAsync(package.PackageRegistration);
-                }
+                // Handle in separate transaction because of concurrency check with retry. Due to using
+                // separate transactions, we must always call UpdateIsLatest on delete/unlist. This is
+                // because a concurrent thread could be marking the package as latest before this thread
+                // is able to commit the delete /unlist.
+                await _packageService.UpdateIsLatestAsync(package.PackageRegistration);
             }
             else
             {

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -19,23 +19,9 @@ namespace NuGetGallery
         /// <summary>
         /// Updates IsLatest/IsLatestStable flags after a package create, update or delete operation.
         /// 
-        /// Optimistic concurrency was added to this update to prevent multiple threads (in the same
-        /// or different gallery instance) from setting the IsLatest/IsLatestStable flag to true on
-        /// different package versions. The concurrency check is manual, avoiding EF's ConcurrencyCheck
-        /// attribute, because we only want to reject concurrent updates to the IsLatest/IsLatestStable
-        /// columns and not package deletes or updates of other columns.
-        /// 
-        /// When concurrency is detected, UpdateIsLatest will fetch the latest from the database and
-        /// retry just in case the concurrent update didn't have the latest. More than likely the other
-        /// update did have the latest since package updates are committed in a separate transaction,
-        /// and the retry will detect that no changes are necessary.
-        /// 
-        /// Since EF contexts are short-lived and do not really support refresh, UpdateIsLatest will
-        /// use a different context than the request when retrying to avoid putting the request context
-        /// in a bad state. The request context will be updated with the original (non-retry)
-        /// IsLatest/IsLatestStable values for use by the remainder of the request. These updates should
-        /// not be committed, therefore UpdateIsLatestAsync should only be called after all other commits
-        /// are complete.
+        /// Due to the manual optimistic concurrency check added to the underlying implementation,
+        /// IsLatest/IsLatestStable changes will be applied in memory and should not be committed with EF.
+        /// Callers should ensure that all other commits are complete before calling UpdateIsLatestAsync.
         /// </summary>
         /// <param name="packageRegistration"></param>
         /// <returns></returns>

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -16,7 +16,7 @@ namespace NuGetGallery
         IEnumerable<PackageRegistration> FindPackageRegistrationsByOwner(User user);
         IEnumerable<Package> FindDependentPackages(Package package);
 
-        Task UpdateIsLatestAsync(PackageRegistration packageRegistration, bool commitChanges = true);
+        Task UpdateIsLatestAsync(PackageRegistration packageRegistration);
 
         /// <summary>
         /// Populate the related database tables to create the specified package for the specified user.

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -16,6 +16,17 @@ namespace NuGetGallery
         IEnumerable<PackageRegistration> FindPackageRegistrationsByOwner(User user);
         IEnumerable<Package> FindDependentPackages(Package package);
 
+        /// <summary>
+        /// Updates IsLatest/IsLatestStable flags after a package CUD operation.
+        /// 
+        /// Database updates are applied on a separate context to better control refresh of entities when
+        /// concurrency conflicts are detected without affecting the current request.
+        /// 
+        /// Updates are also applied (but not committed) to entities in memory, for the remainder of the current
+        /// request. For this reason, UpdateIsLatestAsync should only be called after other commits are complete.
+        /// </summary>
+        /// <param name="packageRegistration"></param>
+        /// <returns></returns>
         Task UpdateIsLatestAsync(PackageRegistration packageRegistration);
 
         /// <summary>

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -17,13 +17,25 @@ namespace NuGetGallery
         IEnumerable<Package> FindDependentPackages(Package package);
 
         /// <summary>
-        /// Updates IsLatest/IsLatestStable flags after a package CUD operation.
+        /// Updates IsLatest/IsLatestStable flags after a package create, update or delete operation.
         /// 
-        /// Database updates are applied on a separate context to better control refresh of entities when
-        /// concurrency conflicts are detected without affecting the current request.
+        /// Optimistic concurrency was added to this update to prevent multiple threads (in the same
+        /// or different gallery instance) from setting the IsLatest/IsLatestStable flag to true on
+        /// different package versions. The concurrency check is manual, avoiding EF's ConcurrencyCheck
+        /// attribute, because we only want to reject concurrent updates to the IsLatest/IsLatestStable
+        /// columns and not package deletes or updates of other columns.
         /// 
-        /// Updates are also applied (but not committed) to entities in memory, for the remainder of the current
-        /// request. For this reason, UpdateIsLatestAsync should only be called after other commits are complete.
+        /// When concurrency is detected, UpdateIsLatest will fetch the latest from the database and
+        /// retry just in case the concurrent update didn't have the latest. More than likely the other
+        /// update did have the latest since package updates are committed in a separate transaction,
+        /// and the retry will detect that no changes are necessary.
+        /// 
+        /// Since EF contexts are short-lived and do not really support refresh, UpdateIsLatest will
+        /// use a different context than the request when retrying to avoid putting the request context
+        /// in a bad state. The request context will be updated with the original (non-retry)
+        /// IsLatest/IsLatestStable values for use by the remainder of the request. These updates should
+        /// not be committed, therefore UpdateIsLatestAsync should only be called after all other commits
+        /// are complete.
         /// </summary>
         /// <param name="packageRegistration"></param>
         /// <returns></returns>

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -34,6 +34,7 @@ namespace NuGetGallery
         /// </summary>
         /// <remarks>
         /// This method doesn't upload the package binary to the blob storage. The caller must do it after this call.
+        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
         /// </remarks>
         /// <param name="nugetPackage">The package to be created.</param>
         /// <param name="packageStreamMetadata">The package stream's metadata.</param>
@@ -44,10 +45,49 @@ namespace NuGetGallery
 
         Package EnrichPackageFromNuGetPackage(Package package, PackageArchiveReader packageArchive, PackageMetadata packageMetadata, PackageStreamMetadata packageStreamMetadata, User user);
 
+        /// <summary>
+        /// Publishes a package by listing it.
+        /// </summary>
+        /// <remarks>
+        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
+        /// </remarks>
+        /// <param name="id">ID for the package to publish</param>
+        /// <param name="version">Package version</param>
+        /// <param name="commitChanges">Whether to commit changes to the database.</param>
+        /// <returns></returns>
         Task PublishPackageAsync(string id, string version, bool commitChanges = true);
+
+        /// <summary>
+        /// Publishes a package by listing it.
+        /// </summary>
+        /// <remarks>
+        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
+        /// </remarks>
+        /// <param name="package">The package to publish</param>
+        /// <param name="commitChanges">Whether to commit changes to the database.</param>
+        /// <returns></returns>
         Task PublishPackageAsync(Package package, bool commitChanges = true);
 
+        /// <summary>
+        /// Mark a package as unlisted.
+        /// </summary>
+        /// <remarks>
+        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
+        /// </remarks>
+        /// <param name="package">The package to unlist</param>
+        /// <param name="commitChanges">Whether to commit changes to the database.</param>
+        /// <returns></returns>
         Task MarkPackageUnlistedAsync(Package package, bool commitChanges = true);
+
+        /// <summary>
+        /// Mark a package as listed.
+        /// </summary>
+        /// <remarks>
+        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
+        /// </remarks>
+        /// <param name="package">The package to list.</param>
+        /// <param name="commitChanges">Whether to commit changes to the database.</param>
+        /// <returns></returns>
         Task MarkPackageListedAsync(Package package, bool commitChanges = true);
 
         Task<PackageOwnerRequest> CreatePackageOwnerRequestAsync(PackageRegistration package, User currentOwner, User newOwner);

--- a/src/NuGetGallery/Services/PackageDeleteService.cs
+++ b/src/NuGetGallery/Services/PackageDeleteService.cs
@@ -58,7 +58,8 @@ namespace NuGetGallery
         {
             List<PackageRegistration> packageRegistrations;
 
-            using (var retrySuspension = EntitiesConfiguration.SuspendRetriableExecutionStrategy())
+            // Must suspend the retry execution strategy in order to use transactions.
+            using (EntitiesConfiguration.SuspendRetriableExecutionStrategy())
             {
                 using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())
                 {
@@ -113,7 +114,8 @@ namespace NuGetGallery
         {
             List<PackageRegistration> packageRegistrations;
 
-            using (var retrySuspension = EntitiesConfiguration.SuspendRetriableExecutionStrategy())
+            // Must suspend the retry execution strategy in order to use transactions.
+            using (EntitiesConfiguration.SuspendRetriableExecutionStrategy())
             {
                 using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())
                 {

--- a/src/NuGetGallery/Services/PackageDeleteService.cs
+++ b/src/NuGetGallery/Services/PackageDeleteService.cs
@@ -99,11 +99,10 @@ namespace NuGetGallery
                 await _packageDeletesRepository.CommitChangesAsync();
                 transaction.Commit();
             }
-            
+            EntitiesConfiguration.SuspendExecutionStrategy = false;
+
             // handle in separate transaction because of concurrency check with retry
             await UpdateIsLatestAsync(packageRegistrations);
-
-            EntitiesConfiguration.SuspendExecutionStrategy = false;
 
             // Force refresh the index
             UpdateSearchIndex();
@@ -157,11 +156,10 @@ namespace NuGetGallery
                 // Commit transaction
                 transaction.Commit();
             }
+            EntitiesConfiguration.SuspendExecutionStrategy = false;
 
             // handle in separate transaction because of concurrency check with retry
             await UpdateIsLatestAsync(packageRegistrations);
-
-            EntitiesConfiguration.SuspendExecutionStrategy = false;
 
             // Force refresh the index
             UpdateSearchIndex();

--- a/src/NuGetGallery/Services/PackageDeleteService.cs
+++ b/src/NuGetGallery/Services/PackageDeleteService.cs
@@ -58,48 +58,49 @@ namespace NuGetGallery
         {
             List<PackageRegistration> packageRegistrations;
 
-            EntitiesConfiguration.SuspendExecutionStrategy = true;
-            using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())
+            using (var retrySuspension = EntitiesConfiguration.SuspendRetriableExecutionStrategy())
             {
-                // Increase command timeout
-                _entitiesContext.SetCommandTimeout(seconds: 300);
-
-                // Keep package registrations
-                packageRegistrations = packages
-                    .GroupBy(p => p.PackageRegistration)
-                    .Select(g => g.First().PackageRegistration)
-                    .ToList();
-
-                // Backup the package binaries and remove from main storage
-                // We're doing this early in the process as we need the metadata to still exist in the DB.
-                await BackupPackageBinaries(packages);
-
-                // Store the soft delete in the database
-                var packageDelete = new PackageDelete
+                using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())
                 {
-                    DeletedOn = DateTime.UtcNow,
-                    DeletedBy = deletedBy,
-                    Reason = reason,
-                    Signature = signature
-                };
+                    // Increase command timeout
+                    _entitiesContext.SetCommandTimeout(seconds: 300);
 
-                foreach (var package in packages)
-                {
-                    package.Listed = false;
-                    package.Deleted = true;
-                    packageDelete.Packages.Add(package);
+                    // Keep package registrations
+                    packageRegistrations = packages
+                        .GroupBy(p => p.PackageRegistration)
+                        .Select(g => g.First().PackageRegistration)
+                        .ToList();
 
-                    await _auditingService.SaveAuditRecordAsync(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.SoftDelete, reason));
+                    // Backup the package binaries and remove from main storage
+                    // We're doing this early in the process as we need the metadata to still exist in the DB.
+                    await BackupPackageBinaries(packages);
+
+                    // Store the soft delete in the database
+                    var packageDelete = new PackageDelete
+                    {
+                        DeletedOn = DateTime.UtcNow,
+                        DeletedBy = deletedBy,
+                        Reason = reason,
+                        Signature = signature
+                    };
+
+                    foreach (var package in packages)
+                    {
+                        package.Listed = false;
+                        package.Deleted = true;
+                        packageDelete.Packages.Add(package);
+
+                        await _auditingService.SaveAuditRecordAsync(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.SoftDelete, reason));
+                    }
+
+                    _packageDeletesRepository.InsertOnCommit(packageDelete);
+
+                    // Commit changes
+                    await _packageRepository.CommitChangesAsync();
+                    await _packageDeletesRepository.CommitChangesAsync();
+                    transaction.Commit();
                 }
-
-                _packageDeletesRepository.InsertOnCommit(packageDelete);
-
-                // Commit changes
-                await _packageRepository.CommitChangesAsync();
-                await _packageDeletesRepository.CommitChangesAsync();
-                transaction.Commit();
             }
-            EntitiesConfiguration.SuspendExecutionStrategy = false;
 
             // handle in separate transaction because of concurrency check with retry
             await UpdateIsLatestAsync(packageRegistrations);
@@ -112,51 +113,52 @@ namespace NuGetGallery
         {
             List<PackageRegistration> packageRegistrations;
 
-            EntitiesConfiguration.SuspendExecutionStrategy = true;
-            using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())
+            using (var retrySuspension = EntitiesConfiguration.SuspendRetriableExecutionStrategy())
             {
-                // Increase command timeout
-                _entitiesContext.SetCommandTimeout(seconds: 300);
-
-                // Keep package registrations
-                packageRegistrations = packages.GroupBy(p => p.PackageRegistration).Select(g => g.First().PackageRegistration).ToList();
-
-                // Backup the package binaries and remove from main storage
-                // We're doing this early in the process as we need the metadata to still exist in the DB.
-                await BackupPackageBinaries(packages);
-
-                // Remove the package and related entities from the database
-                foreach (var package in packages)
+                using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())
                 {
-                    await ExecuteSqlCommandAsync(_entitiesContext.GetDatabase(),
-                        "DELETE pa FROM PackageAuthors pa JOIN Packages p ON p.[Key] = pa.PackageKey WHERE p.[Key] = @key",
-                        new SqlParameter("@key", package.Key));
-                    await ExecuteSqlCommandAsync(_entitiesContext.GetDatabase(),
-                        "DELETE pd FROM PackageDependencies pd JOIN Packages p ON p.[Key] = pd.PackageKey WHERE p.[Key] = @key",
-                        new SqlParameter("@key", package.Key));
-                    await ExecuteSqlCommandAsync(_entitiesContext.GetDatabase(),
-                        "DELETE pf FROM PackageFrameworks pf JOIN Packages p ON p.[Key] = pf.Package_Key WHERE p.[Key] = @key",
-                        new SqlParameter("@key", package.Key));
+                    // Increase command timeout
+                    _entitiesContext.SetCommandTimeout(seconds: 300);
 
-                    await _auditingService.SaveAuditRecordAsync(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.Delete, reason));
+                    // Keep package registrations
+                    packageRegistrations = packages.GroupBy(p => p.PackageRegistration).Select(g => g.First().PackageRegistration).ToList();
 
-                    package.PackageRegistration.Packages.Remove(package);
-                    _packageRepository.DeleteOnCommit(package);
+                    // Backup the package binaries and remove from main storage
+                    // We're doing this early in the process as we need the metadata to still exist in the DB.
+                    await BackupPackageBinaries(packages);
+
+                    // Remove the package and related entities from the database
+                    foreach (var package in packages)
+                    {
+                        await ExecuteSqlCommandAsync(_entitiesContext.GetDatabase(),
+                            "DELETE pa FROM PackageAuthors pa JOIN Packages p ON p.[Key] = pa.PackageKey WHERE p.[Key] = @key",
+                            new SqlParameter("@key", package.Key));
+                        await ExecuteSqlCommandAsync(_entitiesContext.GetDatabase(),
+                            "DELETE pd FROM PackageDependencies pd JOIN Packages p ON p.[Key] = pd.PackageKey WHERE p.[Key] = @key",
+                            new SqlParameter("@key", package.Key));
+                        await ExecuteSqlCommandAsync(_entitiesContext.GetDatabase(),
+                            "DELETE pf FROM PackageFrameworks pf JOIN Packages p ON p.[Key] = pf.Package_Key WHERE p.[Key] = @key",
+                            new SqlParameter("@key", package.Key));
+
+                        await _auditingService.SaveAuditRecordAsync(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.Delete, reason));
+
+                        package.PackageRegistration.Packages.Remove(package);
+                        _packageRepository.DeleteOnCommit(package);
+                    }
+
+                    // Commit changes to package repository
+                    await _packageRepository.CommitChangesAsync();
+
+                    // Remove package registrations that have no more packages?
+                    if (deleteEmptyPackageRegistration)
+                    {
+                        await RemovePackageRegistrationsWithoutPackages(packageRegistrations);
+                    }
+
+                    // Commit transaction
+                    transaction.Commit();
                 }
-
-                // Commit changes to package repository
-                await _packageRepository.CommitChangesAsync();
-
-                // Remove package registrations that have no more packages?
-                if (deleteEmptyPackageRegistration)
-                {
-                    await RemovePackageRegistrationsWithoutPackages(packageRegistrations);
-                }
-
-                // Commit transaction
-                transaction.Commit();
             }
-            EntitiesConfiguration.SuspendExecutionStrategy = false;
 
             // handle in separate transaction because of concurrency check with retry
             await UpdateIsLatestAsync(packageRegistrations);

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -795,6 +795,7 @@ namespace NuGetGallery
                 int retryCount = 1;
                 do
                 {
+                    await Task.Delay(retryCount * 250);
                     _trace.Information(String.Format("Retrying {0} for package '{1}' ({2}/{3})",
                         nameof(UpdateIsLatestAsync), packageRegistration.Id, retryCount, UpdateIsLatestMaxRetries));
 

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -21,6 +21,8 @@ namespace NuGetGallery
     {
         private const int UpdateIsLatestMaxRetries = 3;
 
+        private static readonly Lazy<Random> _randomGenerator = new Lazy<Random>();
+
         private readonly IIndexingService _indexingService;
         private readonly IEntitiesContext _entitiesContext;
         private readonly IEntityRepository<PackageOwnerRequest> _packageOwnerRequestRepository;
@@ -795,7 +797,8 @@ namespace NuGetGallery
                 int retryCount = 1;
                 do
                 {
-                    await Task.Delay(retryCount * 250);
+                    await Task.Delay(_randomGenerator.Value.Next(0, 1000));
+
                     _trace.Information(String.Format("Retrying {0} for package '{1}' ({2}/{3})",
                         nameof(UpdateIsLatestAsync), packageRegistration.Id, retryCount, UpdateIsLatestMaxRetries));
 
@@ -815,7 +818,7 @@ namespace NuGetGallery
                     }
                     retryCount++;
                 }
-                while (retryCount < UpdateIsLatestMaxRetries);
+                while (retryCount <= UpdateIsLatestMaxRetries);
             }
         }
 

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -705,11 +705,11 @@ namespace NuGetGallery
                 // that we don't update rows where IsLatest/IsLatestStable hasn't changed.
                 packageEntry.Entity.LastUpdated = DateTime.UtcNow;
 
-                var isLatest = packageEntry.Entity.IsLatest;
-                var isLatestStable = packageEntry.Entity.IsLatestStable;
+                var isLatest = packageEntry.Entity.IsLatest ? 1 : 0;
+                var isLatestStable = packageEntry.Entity.IsLatestStable ? 1 : 0;
                 var key = packageEntry.Entity.Key;
-                var originalIsLatest= packageEntry.OriginalValues["IsLatest"];
-                var originalIsLatestStable = packageEntry.OriginalValues["IsLatestStable"];
+                var originalIsLatest = Boolean.Parse(packageEntry.OriginalValues["IsLatest"].ToString()) ? 1 : 0;
+                var originalIsLatestStable = Boolean.Parse(packageEntry.OriginalValues["IsLatestStable"].ToString()) ? 1 : 0;
 
                 query.AppendLine($"UPDATE [dbo].[Packages]");
                 query.AppendLine($"SET [IsLatest] = {isLatest}, [IsLatestStable] = {isLatestStable}, [LastUpdated] = GETUTCDATE()");

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -371,7 +371,7 @@ namespace NuGetGallery
             // NOTE: LastEdited will be overwritten by a trigger defined in the migration named "AddTriggerForPackagesLastEdited".
             package.LastEdited = DateTime.UtcNow;
 
-            await _auditingService.SaveAuditRecord(new PackageAuditRecord(package, AuditedPackageAction.Unlist));
+            await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(package, AuditedPackageAction.Unlist));
 
             if (commitChanges)
             {

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -772,7 +772,7 @@ namespace NuGetGallery
                             if (retryCount++ < UpdateIsLatestMaxRetries)
                             {
                                 await Task.Delay(retryCount * 500);
-                                await UpdateIsLatestAsync(packageRegistration);
+                                await UpdateIsLatestAsync(packageRegistration, retryCount);
                             }
                             else
                             {
@@ -802,6 +802,11 @@ namespace NuGetGallery
         }
 
         public Task UpdateIsLatestAsync(PackageRegistration packageRegistration)
+        {
+            return UpdateIsLatestAsync(packageRegistration, retryCount: 0);
+        }
+
+        private Task UpdateIsLatestAsync(PackageRegistration packageRegistration, int retryCount)
         {
             if (!packageRegistration.Packages.Any())
             {

--- a/src/NuGetGallery/Services/ReflowPackageService.cs
+++ b/src/NuGetGallery/Services/ReflowPackageService.cs
@@ -34,6 +34,7 @@ namespace NuGetGallery
                 return null;
             }
 
+            // Must suspend the retry execution strategy in order to use transactions.
             using (EntitiesConfiguration.SuspendRetriableExecutionStrategy())
             {
                 using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())

--- a/src/NuGetGallery/Services/ReflowPackageService.cs
+++ b/src/NuGetGallery/Services/ReflowPackageService.cs
@@ -34,51 +34,52 @@ namespace NuGetGallery
                 return null;
             }
 
-            EntitiesConfiguration.SuspendExecutionStrategy = true;
-            using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())
+            using (EntitiesConfiguration.SuspendRetriableExecutionStrategy())
             {
-                // 1) Download package binary to memory
-                using (var packageStream = await _packageFileService.DownloadPackageFileAsync(package))
+                using (var transaction = _entitiesContext.GetDatabase().BeginTransaction())
                 {
-                    using (var packageArchive = new PackageArchiveReader(packageStream, leaveStreamOpen: false))
+                    // 1) Download package binary to memory
+                    using (var packageStream = await _packageFileService.DownloadPackageFileAsync(package))
                     {
-                        // 2) Determine package metadata from binary
-                        var packageStreamMetadata = new PackageStreamMetadata
+                        using (var packageArchive = new PackageArchiveReader(packageStream, leaveStreamOpen: false))
                         {
-                            HashAlgorithm = Constants.Sha512HashAlgorithmId,
-                            Hash = CryptographyService.GenerateHash(packageStream.AsSeekableStream()),
-                            Size = packageStream.Length,
-                        };
+                            // 2) Determine package metadata from binary
+                            var packageStreamMetadata = new PackageStreamMetadata
+                            {
+                                HashAlgorithm = Constants.Sha512HashAlgorithmId,
+                                Hash = CryptographyService.GenerateHash(packageStream.AsSeekableStream()),
+                                Size = packageStream.Length,
+                            };
 
-                        var packageMetadata = PackageMetadata.FromNuspecReader(packageArchive.GetNuspecReader());
+                            var packageMetadata = PackageMetadata.FromNuspecReader(packageArchive.GetNuspecReader());
 
-                        // 3) Clear referenced objects that will be reflowed
-                        ClearSupportedFrameworks(package);
-                        ClearAuthors(package);
-                        ClearDependencies(package);
+                            // 3) Clear referenced objects that will be reflowed
+                            ClearSupportedFrameworks(package);
+                            ClearAuthors(package);
+                            ClearDependencies(package);
 
-                        // 4) Reflow the package
-                        var listed = package.Listed;
+                            // 4) Reflow the package
+                            var listed = package.Listed;
 
-                        package = _packageService.EnrichPackageFromNuGetPackage(
-                            package,
-                            packageArchive,
-                            packageMetadata,
-                            packageStreamMetadata,
-                            package.User);
+                            package = _packageService.EnrichPackageFromNuGetPackage(
+                                package,
+                                packageArchive,
+                                packageMetadata,
+                                packageStreamMetadata,
+                                package.User);
 
-                        package.LastEdited = DateTime.UtcNow;
-                        package.Listed = listed;
+                            package.LastEdited = DateTime.UtcNow;
+                            package.Listed = listed;
 
-                        // 5) Save and profit
-                        await _entitiesContext.SaveChangesAsync();
+                            // 5) Save and profit
+                            await _entitiesContext.SaveChangesAsync();
+                        }
                     }
-                }
 
-                // Commit transaction
-                transaction.Commit();
+                    // Commit transaction
+                    transaction.Commit();
+                }
             }
-            EntitiesConfiguration.SuspendExecutionStrategy = false;
 
             return package;
         }

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -580,6 +580,8 @@ namespace NuGetGallery
                     .Throws(new Exception("Shouldn't be called"));
                 packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0", true))
                     .Returns(package).Verifiable();
+                packageService.Setup(svc => svc.UpdateIsLatestAsync(It.IsAny<PackageRegistration>()))
+                    .Returns(Task.FromResult(0)).Verifiable();
 
                 var indexingService = new Mock<IIndexingService>();
 
@@ -1606,6 +1608,8 @@ namespace NuGetGallery
                         .Returns(Task.CompletedTask);
                     fakePackageService.Setup(x => x.MarkPackageUnlistedAsync(fakePackage, false))
                         .Returns(Task.CompletedTask);
+                    fakePackageService.Setup(x => x.UpdateIsLatestAsync(It.IsAny<PackageRegistration>()))
+                        .Returns(Task.FromResult(0));
                     var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
                     var controller = CreateController(

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -544,6 +544,8 @@ namespace NuGetGallery
                     .Returns(Task.CompletedTask).Verifiable();
                 packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0", true))
                     .Returns(package).Verifiable();
+                packageService.Setup(svc => svc.UpdateIsLatestAsync(It.IsAny<PackageRegistration>()))
+                    .Returns(Task.CompletedTask).Verifiable();
 
                 var indexingService = new Mock<IIndexingService>();
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -10,18 +10,18 @@ using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
+using Xunit;
 using Moq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
+using NuGetGallery.Areas.Admin;
 using NuGetGallery.AsyncFileUpload;
+using NuGetGallery.Auditing;
 using NuGetGallery.Configuration;
 using NuGetGallery.Framework;
 using NuGetGallery.Helpers;
 using NuGetGallery.Packaging;
-using NuGetGallery.Areas.Admin;
-using NuGetGallery.Auditing;
-using Xunit;
 
 namespace NuGetGallery
 {
@@ -50,9 +50,9 @@ namespace NuGetGallery
             if (uploadFileService == null)
             {
                 uploadFileService = new Mock<IUploadFileService>();
-                uploadFileService.Setup(x => x.DeleteUploadFileAsync(It.IsAny<int>())).Returns(Task.FromResult(0));
+                uploadFileService.Setup(x => x.DeleteUploadFileAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
                 uploadFileService.Setup(x => x.GetUploadFileAsync(42)).Returns(Task.FromResult<Stream>(null));
-                uploadFileService.Setup(x => x.SaveUploadFileAsync(42, It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                uploadFileService.Setup(x => x.SaveUploadFileAsync(42, It.IsAny<Stream>())).Returns(Task.CompletedTask);
             }
             messageService = messageService ?? new Mock<IMessageService>();
             searchService = searchService ?? CreateSearchService();
@@ -62,7 +62,7 @@ namespace NuGetGallery
             if (packageFileService == null)
             {
                 packageFileService = new Mock<IPackageFileService>();
-                packageFileService.Setup(p => p.SavePackageFileAsync(It.IsAny<Package>(), It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                packageFileService.Setup(p => p.SavePackageFileAsync(It.IsAny<Package>(), It.IsAny<Stream>())).Returns(Task.CompletedTask);
             }
 
             entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
@@ -133,7 +133,7 @@ namespace NuGetGallery
             public async Task DeletesTheInProgressPackageUpload()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(42)).Returns(Task.FromResult(0));
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(42)).Returns(Task.CompletedTask);
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
@@ -147,7 +147,7 @@ namespace NuGetGallery
             public async Task RedirectsToUploadPageAfterDelete()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(42)).Returns(Task.FromResult(0));
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(42)).Returns(Task.CompletedTask);
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
@@ -541,7 +541,7 @@ namespace NuGetGallery
                 packageService.Setup(svc => svc.MarkPackageListedAsync(It.IsAny<Package>(), It.IsAny<bool>()))
                     .Throws(new Exception("Shouldn't be called"));
                 packageService.Setup(svc => svc.MarkPackageUnlistedAsync(It.IsAny<Package>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(0)).Verifiable();
+                    .Returns(Task.CompletedTask).Verifiable();
                 packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0", true))
                     .Returns(package).Verifiable();
 
@@ -575,13 +575,13 @@ namespace NuGetGallery
 
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
                 packageService.Setup(svc => svc.MarkPackageListedAsync(It.IsAny<Package>(), It.IsAny<bool>()))
-                    .Returns(Task.FromResult(0)).Verifiable();
+                    .Returns(Task.CompletedTask).Verifiable();
                 packageService.Setup(svc => svc.MarkPackageUnlistedAsync(It.IsAny<Package>(), It.IsAny<bool>()))
                     .Throws(new Exception("Shouldn't be called"));
                 packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0", true))
                     .Returns(package).Verifiable();
                 packageService.Setup(svc => svc.UpdateIsLatestAsync(It.IsAny<PackageRegistration>()))
-                    .Returns(Task.FromResult(0)).Verifiable();
+                    .Returns(Task.CompletedTask).Verifiable();
 
                 var indexingService = new Mock<IIndexingService>();
 
@@ -1041,9 +1041,9 @@ namespace NuGetGallery
                 fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
 
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                 fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(null));
-                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.CompletedTask);
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService,
                     fakeNuGetPackage: fakeFileStream);
@@ -1063,9 +1063,9 @@ namespace NuGetGallery
                 var fakeFileStream = TestPackage.CreateTestPackageStream("thePackageId", "1.0.0");
                 fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                 fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(null));
-                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.CompletedTask);
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
@@ -1084,7 +1084,7 @@ namespace NuGetGallery
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
                 fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns<Stream>(null);
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                 fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(null));
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService);
@@ -1385,7 +1385,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>())).Returns(
                         Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
@@ -1411,7 +1411,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1419,7 +1419,7 @@ namespace NuGetGallery
                     var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
                     var fakePackageFileService = new Mock<IPackageFileService>();
-                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.FromResult(0)).Verifiable();
+                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.CompletedTask).Verifiable();
 
                     var controller = CreateController(
                         packageService: fakePackageService,
@@ -1447,7 +1447,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = packageId }, Version = packageVersion };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1486,7 +1486,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1525,14 +1525,14 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
                         .Returns(Task.FromResult(fakePackage));
                     var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
                     var fakePackageFileService = new Mock<IPackageFileService>();
-                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.FromResult(0)).Verifiable();
+                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.CompletedTask).Verifiable();
 
                     var fakeIndexingService = new Mock<IIndexingService>(MockBehavior.Strict);
                     fakeIndexingService.Setup(f => f.UpdateIndex()).Verifiable();
@@ -1609,7 +1609,7 @@ namespace NuGetGallery
                     fakePackageService.Setup(x => x.MarkPackageUnlistedAsync(fakePackage, false))
                         .Returns(Task.CompletedTask);
                     fakePackageService.Setup(x => x.UpdateIsLatestAsync(It.IsAny<PackageRegistration>()))
-                        .Returns(Task.FromResult(0));
+                        .Returns(Task.CompletedTask);
                     var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
                     var controller = CreateController(
@@ -1633,7 +1633,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1658,7 +1658,7 @@ namespace NuGetGallery
                 var fakeUploadFileService = new Mock<IUploadFileService>();
                 using (var fakeFileStream = new MemoryStream())
                 {
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1687,7 +1687,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
                         .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
@@ -1709,7 +1709,7 @@ namespace NuGetGallery
             public async Task WillDeleteTheUploadFile()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0)).Verifiable();
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask).Verifiable();
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
@@ -1737,8 +1737,8 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
                         .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
@@ -1763,7 +1763,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
                         .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
@@ -1789,7 +1789,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1818,7 +1818,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))

--- a/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
@@ -173,7 +173,7 @@ namespace NuGetGallery
 
                 await service.SoftDeletePackagesAsync(new[] { package }, user, string.Empty, string.Empty);
 
-                packageService.Verify(x => x.UpdateIsLatestAsync(packageRegistration, false));
+                packageService.Verify(x => x.UpdateIsLatestAsync(packageRegistration));
             }
 
             [Fact]
@@ -351,7 +351,7 @@ namespace NuGetGallery
 
                 await service.HardDeletePackagesAsync(new[] { package }, user, string.Empty, string.Empty, false);
 
-                packageService.Verify(x => x.UpdateIsLatestAsync(packageRegistration, false));
+                packageService.Verify(x => x.UpdateIsLatestAsync(packageRegistration));
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1071,7 +1071,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task WillUpdateIsLatest1()
+            public async Task UpdateIsLatestAsync_DifferentLatestAndLatestStableVersions()
             {
                 // Arrange
                 var packages = new HashSet<Package>();
@@ -1097,7 +1097,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task WillUpdateIsLatest2()
+            public async Task UpdateIsLatestAsync_SameLatestAndLatestStableVersions()
             {
                 // Arrange
                 var packages = new HashSet<Package>();
@@ -1127,7 +1127,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task WillUpdateIsLatest3()
+            public async Task UpdateIsLatestAsync_SameLatestAndLatestStableVersionsWithClear()
             {
                 // Arrange
                 var packages = new HashSet<Package>();

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -136,6 +136,7 @@ namespace NuGetGallery
             var dbContext = new Mock<DbContext>();
             entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
             entitiesContext.Setup(m => m.GetDatabase()).Returns(dbContext.Object.Database);
+            entitiesContext.Setup(m => m.GetChangeTracker()).Returns(dbContext.Object.ChangeTracker);
 
             diagnosticsService = diagnosticsService ?? new Mock<IDiagnosticsService>();
             indexingService = indexingService ?? new Mock<IIndexingService>();
@@ -158,8 +159,7 @@ namespace NuGetGallery
                 packageNamingConflictValidator,
                 auditingService);
 
-            packageService.Setup(s => s.TryUpdateIsLatestInDatabase(
-                It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()))
+            packageService.Setup(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()))
                 .Returns(Task.FromResult(true));
             packageService.Setup(s => s.CreateNewEntitiesContext()).Returns(entitiesContext.Object);
 
@@ -617,20 +617,6 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task WillSetTheNewPackagesLastUpdatedTimes()
-            {
-                var service = CreateService(setup:
-                        mockPackageService => { mockPackageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null); });
-                var nugetPackage = CreateNuGetPackage();
-                var currentUser = new User();
-
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser);
-                await service.UpdateIsLatestAsync(package.PackageRegistration);
-
-                Assert.NotEqual(DateTime.MinValue, package.LastUpdated);
-            }
-
-            [Fact]
             public async Task WillSaveThePackageFileAndSetThePackageFileSize()
             {
                 var service = CreateService(setup:
@@ -1068,8 +1054,7 @@ namespace NuGetGallery
                 await service.Object.UpdateIsLatestAsync(packageRegistration);
 
                 // Assert
-                service.Verify(s => s.TryUpdateIsLatestInDatabase(
-                    It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()), Times.Once);
+                service.Verify(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()), Times.Once);
             }
 
             [Fact]
@@ -1095,8 +1080,7 @@ namespace NuGetGallery
                 Assert.False(package09.IsLatest);
                 Assert.True(package09.IsLatestStable);
 
-                service.Verify(s => s.TryUpdateIsLatestInDatabase(
-                    It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()), Times.Once);
+                service.Verify(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()), Times.Once);
             }
 
             [Fact]
@@ -1126,8 +1110,7 @@ namespace NuGetGallery
                 Assert.False(package09.IsLatest);
                 Assert.False(package09.IsLatestStable);
 
-                service.Verify(s => s.TryUpdateIsLatestInDatabase(
-                    It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()), Times.Once);
+                service.Verify(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()), Times.Once);
             }
 
             [Fact]
@@ -1161,8 +1144,7 @@ namespace NuGetGallery
                 Assert.False(package09.IsLatest);
                 Assert.False(package09.IsLatestStable);
 
-                service.Verify(s => s.TryUpdateIsLatestInDatabase(
-                    It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()), Times.Once);
+                service.Verify(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()), Times.Once);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -158,8 +158,9 @@ namespace NuGetGallery
                 packageNamingConflictValidator,
                 auditingService);
 
-            packageService.Setup(s => s.ExecuteSqlCommandAsync(It.IsAny<Database>(), It.IsAny<string>(), It.IsAny<object[]>()))
-                .Returns(Task.FromResult(1));
+            packageService.Setup(s => s.TryUpdateIsLatestInDatabase(
+                It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()))
+                .Returns(Task.FromResult(true));
             packageService.Setup(s => s.CreateNewEntitiesContext()).Returns(entitiesContext.Object);
 
             packageService.CallBase = true;
@@ -1052,7 +1053,7 @@ namespace NuGetGallery
         public class TheUpdateIsLatestMethod
         {
             [Fact]
-            public async Task CommitIfCommitChangesIsTrue()
+            public async Task AlwaysCommitChanges()
             {
                 // Arrange
                 var packageRegistration = new PackageRegistration();
@@ -1067,7 +1068,8 @@ namespace NuGetGallery
                 await service.Object.UpdateIsLatestAsync(packageRegistration);
 
                 // Assert
-                service.Verify(s => s.ExecuteSqlCommandAsync(It.IsAny<Database>(), It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+                service.Verify(s => s.TryUpdateIsLatestInDatabase(
+                    It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()), Times.Once);
             }
 
             [Fact]
@@ -1093,7 +1095,8 @@ namespace NuGetGallery
                 Assert.False(package09.IsLatest);
                 Assert.True(package09.IsLatestStable);
 
-                service.Verify(s => s.ExecuteSqlCommandAsync(It.IsAny<Database>(), It.IsAny<string>(), It.IsAny<object[]>()), Times.Exactly(2));
+                service.Verify(s => s.TryUpdateIsLatestInDatabase(
+                    It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()), Times.Once);
             }
 
             [Fact]
@@ -1123,7 +1126,8 @@ namespace NuGetGallery
                 Assert.False(package09.IsLatest);
                 Assert.False(package09.IsLatestStable);
 
-                service.Verify(s => s.ExecuteSqlCommandAsync(It.IsAny<Database>(), It.IsAny<string>(), It.IsAny<object[]>()), Times.Once);
+                service.Verify(s => s.TryUpdateIsLatestInDatabase(
+                    It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()), Times.Once);
             }
 
             [Fact]
@@ -1157,7 +1161,8 @@ namespace NuGetGallery
                 Assert.False(package09.IsLatest);
                 Assert.False(package09.IsLatestStable);
 
-                service.Verify(s => s.ExecuteSqlCommandAsync(It.IsAny<Database>(), It.IsAny<string>(), It.IsAny<object[]>()), Times.Exactly(3));
+                service.Verify(s => s.TryUpdateIsLatestInDatabase(
+                    It.IsAny<IEntitiesContext>(), It.IsAny<List<PackageService.UpdateIsLatestPackageEdit>>()), Times.Once);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -160,6 +160,7 @@ namespace NuGetGallery
 
             packageService.Setup(s => s.ExecuteSqlCommandAsync(It.IsAny<Database>(), It.IsAny<string>(), It.IsAny<object[]>()))
                 .Returns(Task.FromResult(1));
+            packageService.Setup(s => s.CreateNewEntitiesContext()).Returns(entitiesContext.Object);
 
             packageService.CallBase = true;
 

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1114,7 +1114,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task UpdateIsLatestAsync_SameLatestAndLatestStableVersionsWithClear()
+            public async Task UpdateIsLatestAsync_SameNewLatestAndLatestStableVersions()
             {
                 // Arrange
                 var packages = new HashSet<Package>();

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Packaging;
+using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
 using Xunit;
@@ -282,6 +283,8 @@ namespace NuGetGallery
             var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
             var packageRepository = new Mock<IEntityRepository<Package>>();
             var packageOwnerRequestRepo = new Mock<IEntityRepository<PackageOwnerRequest>>();
+            var diagnosticsService = new Mock<IDiagnosticsService>();
+            var entitiesContext = new Mock<IEntitiesContext>();
             var indexingService = new Mock<IIndexingService>();
             var packageNamingConflictValidator = new PackageNamingConflictValidator(
                     packageRegistrationRepository.Object,
@@ -292,6 +295,8 @@ namespace NuGetGallery
                 packageRegistrationRepository.Object,
                 packageRepository.Object,
                 packageOwnerRequestRepo.Object,
+                entitiesContext.Object,
+                diagnosticsService.Object,
                 indexingService.Object,
                 packageNamingConflictValidator,
                 auditingService);

--- a/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -113,10 +112,6 @@ namespace NuGetGallery
             }
 
             return (IDbSet<T>)(dbSets[typeof(T)]);
-        }
-        public DbEntityEntry<T> Entry<T>(T entry) where T : class
-        {
-            throw new NotSupportedException(); // todo
         }
 
         public void DeleteOnCommit<T>(T entity) where T : class

--- a/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
@@ -134,6 +134,10 @@ namespace NuGetGallery
         {
             throw new NotSupportedException();
         }
+
+        public void Dispose()
+        {
+        }
     }
 }
 

--- a/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -126,6 +127,11 @@ namespace NuGetGallery
 
 
         public void SetCommandTimeout(int? seconds)
+        {
+            throw new NotSupportedException();
+        }
+
+        public DbChangeTracker GetChangeTracker()
         {
             throw new NotSupportedException();
         }

--- a/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -112,6 +113,10 @@ namespace NuGetGallery
             }
 
             return (IDbSet<T>)(dbSets[typeof(T)]);
+        }
+        public DbEntityEntry<T> Entry<T>(T entry) where T : class
+        {
+            throw new NotSupportedException(); // todo
         }
 
         public void DeleteOnCommit<T>(T entity) where T : class

--- a/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
+++ b/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
@@ -48,6 +48,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.XML" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -97,7 +97,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         [Category("P0Tests")]
         public async Task PackageLatestSetCorrectlyOnConcurrentPushes()
         {
-            var packageId = $"TestV2FeedPackageLatestSetCorrectlyOnConcurrentPushes.{DateTime.UtcNow.Ticks}"; ;
+            var packageId = $"TestV2FeedPackageLatestSetCorrectlyOnConcurrentPushes.{DateTime.UtcNow.Ticks}";
             var packageVersions = new List<string>()
             {
                  "1.0.0-a",  "1.0.0-b",  "1.0.0",  "1.0.1",  "1.0.2-abc",

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -79,7 +79,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 packageIds.Add(packageId);
             }
 
-            await CheckPackageTimestampsInOrder(packageIds, "Created", uploadStartTimestamp);
+            await CheckPackageTimestampsInOrder(packageIds, "Created", uploadStartTimestamp, packagesListed: true);
 
             // Unlist the packages in order.
             var unlistStartTimestamp = DateTime.UtcNow.AddMinutes(-1);
@@ -88,7 +88,56 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 await _clientSdkHelper.UnlistPackage(packageIds[i]);
             }
 
-            await CheckPackageTimestampsInOrder(packageIds, "LastEdited", unlistStartTimestamp);
+            await CheckPackageTimestampsInOrder(packageIds, "LastEdited", unlistStartTimestamp, packagesListed: false);
+        }
+
+        [Fact]
+        [Description("Verifies that the IsLatest/IsLatestStable flags are set correctly when different package versions are pushed concurrently")]
+        [Priority(1)]
+        [Category("P0Tests")]
+        public async Task PackageLatestSetCorrectlyOnConcurrentPushes()
+        {
+            var packageId = $"TestV2FeedPackageLatestSetCorrectlyOnConcurrentPushes.{DateTime.UtcNow.Ticks}"; ;
+            var packageVersions = new List<string>()
+            {
+                 "1.0.0-a",  "1.0.0-b",  "1.0.0",  "1.0.1",  "1.0.2-abc",
+                 "2.0.0-a",  "2.0.0-b",  "2.0.0",  "2.0.1",  "2.0.2-abc",
+                 "3.0.0-a",  "3.0.0-b",  "3.0.0",  "3.0.1",  "3.0.2-abc",
+                 "4.0.0-a",  "4.0.0-b",  "4.0.0",  "4.0.1",  "4.0.2-abc",
+                 "6.0.0-a",  "6.0.0-b",  "6.0.0",  "6.0.1",  "6.0.2-abc",
+                 "7.0.0-a",  "7.0.0-b",  "7.0.0",  "7.0.1",  "7.0.2-abc"
+            };
+
+            // push all and verify; ~15-20 concurrency conflicts seen in testing
+            var concurrentTasks = new Task[packageVersions.Count];
+            for (int i = 0; i < concurrentTasks.Length; i++)
+            {
+                var packageVersion = packageVersions[i];
+                concurrentTasks[i] = Task.Run(() => _clientSdkHelper.UploadNewPackage(packageId, version: packageVersion));
+            }
+            Task.WaitAll(concurrentTasks);
+            
+            await CheckPackageLatestVersions(packageId, packageVersions, expectedLatest: "7.0.2-abc", expectedLatestStable: "7.0.1");
+
+            // unlist last half and verify; ~1-2 concurrency conflicts seen in testing
+            for (int i = concurrentTasks.Length - 1; i >= 15; i--)
+            {
+                var packageVersion = packageVersions[i];
+                concurrentTasks[i] = Task.Run(() => _clientSdkHelper.UnlistPackage(packageId, version: packageVersion));
+            }
+            Task.WaitAll(concurrentTasks);
+
+            await CheckPackageLatestVersions(packageId, packageVersions, expectedLatest: "3.0.2-abc", expectedLatestStable: "3.0.1");
+
+            // unlist remaining and verify; ~1-2 concurrency conflicts seen in testing
+            for (int i = 14; i >= 0; i--)
+            {
+                var packageVersion = packageVersions[i];
+                concurrentTasks[i] = Task.Run(() => _clientSdkHelper.UnlistPackage(packageId, version: packageVersion));
+            }
+            Task.WaitAll(concurrentTasks);
+
+            await CheckPackageLatestVersions(packageId, packageVersions, string.Empty, string.Empty);
         }
 
         private static string GetPackagesAppearInFeedInOrderPackageId(DateTime startingTime, int i)
@@ -98,7 +147,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
 
         private static string GetPackagesAppearInFeedInOrderUrl(DateTime time, string timestamp)
         {
-            return $"{UrlHelper.V2FeedRootUrl}/Packages?$filter={timestamp} gt DateTime'{time:o}'&$orderby={timestamp} desc&$select={timestamp}";
+            return $"{UrlHelper.V2FeedRootUrl}/Packages?$filter={timestamp} gt DateTime'{time:o}'&$orderby={timestamp} desc&$select={timestamp},IsLatestVersion,IsAbsoluteLatestVersion";
         }
 
         /// <summary>
@@ -107,8 +156,9 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         /// <param name="packageIds">An ordered list of package ids. Each package id in the list must have a timestamp in the feed earlier than all package ids after it.</param>
         /// <param name="timestampPropertyName">The timestamp property to test the ordering of. For example, "Created" or "LastEdited".</param>
         /// <param name="operationStartTimestamp">A timestamp that is before all of the timestamps expected to be found in the feed. This is used in a request to the feed.</param>
+        /// <param name="packagesListed">Whether packages are listed, used to verify if latest flags are set properly.</param>
         private async Task CheckPackageTimestampsInOrder(List<string> packageIds, string timestampPropertyName,
-            DateTime operationStartTimestamp)
+            DateTime operationStartTimestamp, bool packagesListed)
         {
             var lastTimestamp = DateTime.MinValue;
             for (var i = 0; i < PackagesInOrderNumPackages; i++)
@@ -116,17 +166,51 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 var packageId = packageIds[i];
                 TestOutputHelper.WriteLine($"Attempting to check order of package #{i} {timestampPropertyName} timestamp in feed.");
 
-                var newTimestamp =
-                    await
-                        _odataHelper.GetTimestampOfPackageFromResponse(
-                            GetPackagesAppearInFeedInOrderUrl(operationStartTimestamp, timestampPropertyName),
-                            timestampPropertyName,
-                            packageId);
+                var feedUrl = GetPackagesAppearInFeedInOrderUrl(operationStartTimestamp, timestampPropertyName);
+                var packageDetails = await _odataHelper.GetPackagePropertiesFromResponse(feedUrl, packageId);
+                Assert.NotNull(packageDetails);
+                
+                var newTimestamp = (DateTime?)(packageDetails.ContainsKey(timestampPropertyName)
+                    ? packageDetails[timestampPropertyName]
+                    : null);
 
                 Assert.True(newTimestamp.HasValue);
                 Assert.True(newTimestamp.Value > lastTimestamp,
                     $"Package #{i} was last modified after package #{i - 1} but has an earlier {timestampPropertyName} timestamp ({newTimestamp} should be greater than {lastTimestamp}).");
                 lastTimestamp = newTimestamp.Value;
+
+                var isLatest = packageDetails["IsAbsoluteLatestVersion"] as bool?;
+                Assert.NotNull(isLatest);
+                Assert.Equal(isLatest, packagesListed);
+
+                var isLatestStable = packageDetails["IsLatestVersion"] as bool?;
+                Assert.NotNull(isLatestStable);
+                Assert.Equal(isLatestStable, packagesListed);
+            }
+        }
+        
+        private async Task CheckPackageLatestVersions(string packageId, List<string> versions, string expectedLatest, string expectedLatestStable)
+        {
+            foreach (var version in versions)
+            {
+                var feedUrl = $"{UrlHelper.V2FeedRootUrl}/Packages?$filter=Id eq '{packageId}' and Version eq '{version}'" +
+                    "&$select=Id,Version,IsLatestVersion,IsAbsoluteLatestVersion";
+                var packageDetails = await _odataHelper.GetPackagePropertiesFromResponse(feedUrl, packageId, version);
+                Assert.NotNull(packageDetails);
+
+                var actualId = packageDetails["Id"] as string;
+                Assert.True(packageId.Equals(actualId, StringComparison.InvariantCultureIgnoreCase));
+
+                var actualVersion = packageDetails["Version"] as string;
+                Assert.True(version.Equals(actualVersion, StringComparison.InvariantCultureIgnoreCase));
+
+                var isLatest = packageDetails["IsAbsoluteLatestVersion"] as bool?;
+                Assert.NotNull(isLatest);
+                Assert.Equal(isLatest, expectedLatest.Equals(version, StringComparison.InvariantCultureIgnoreCase));
+
+                var isLatestStable = packageDetails["IsLatestVersion"] as bool?;
+                Assert.NotNull(isLatestStable);
+                Assert.Equal(isLatestStable, expectedLatestStable.Equals(version, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 


### PR DESCRIPTION
Approach is same as discussed, but implementation is more complex due to our need to restrict the optimistic concurrency check to CUD operations only on specific columns - which EF doesn't support.