### PR TITLE
Allow package title reuse after package soft-deletion

### DIFF
--- a/src/NuGetGallery/Services/PackageNamingConflictValidator.cs
+++ b/src/NuGetGallery/Services/PackageNamingConflictValidator.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace NuGetGallery
 {
-    public class PackageNamingConflictValidator 
+    public class PackageNamingConflictValidator
         : IPackageNamingConflictValidator
     {
         private readonly IEntityRepository<PackageRegistration> _packageRegistrationRepository;
@@ -35,7 +35,7 @@ namespace NuGetGallery
                     var packageRegistration = _packageRegistrationRepository.GetAll()
                         .SingleOrDefault(pr => pr.Id.ToLower() == cleanedTitle);
 
-                    if (packageRegistration != null 
+                    if (packageRegistration != null
                         && !String.Equals(packageRegistration.Id, registrationId, StringComparison.OrdinalIgnoreCase))
                     {
                         return true;
@@ -56,7 +56,7 @@ namespace NuGetGallery
             registrationId = registrationId.ToLowerInvariant();
 
             return _packageRepository.GetAll()
-                .Any(p => p.Title.ToLower() == registrationId);
+                .Any(p => !p.Deleted && p.Title.ToLower() == registrationId);
         }
     }
 }


### PR DESCRIPTION
Fix #3456.

A package title should be available for reuse by another package if the title is not otherwise in use by any non-deleted package.  Before this change, a soft-deleted package's title was still reserved.

Added a few unit tests.  Verified the new experience from both the command line (nuget.exe) and from the gallery web site.