### PR TITLE
Fix api key add/remove e-mail message

### DIFF
--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -487,7 +487,7 @@ namespace NuGetGallery.Authentication
                                               !credential.HasBeenUsedInLastDays(_config.ExpirationInDaysForApiKeyV1));
 
             credentialViewModel.Description = credentialViewModel.IsNonScopedV1ApiKey
-                ? Strings.NonScopedApiKeyDesciption : credentialViewModel.Description;
+                ? Strings.NonScopedApiKeyDescription : credentialViewModel.Description;
 
             return credentialViewModel;
         }

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -486,6 +486,9 @@ namespace NuGetGallery.Authentication
                                              (credentialViewModel.IsNonScopedV1ApiKey &&
                                               !credential.HasBeenUsedInLastDays(_config.ExpirationInDaysForApiKeyV1));
 
+            credentialViewModel.Description = credentialViewModel.IsNonScopedV1ApiKey
+                ? Strings.NonScopedApiKeyDesciption : credentialViewModel.Description;
+
             return credentialViewModel;
         }
 

--- a/src/NuGetGallery/Authentication/Providers/AuthenticatorUI.cs
+++ b/src/NuGetGallery/Authentication/Providers/AuthenticatorUI.cs
@@ -1,10 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Microsoft.Owin;
 
 namespace NuGetGallery.Authentication.Providers
 {

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -355,20 +355,61 @@ The {3} Team";
 
         public void SendCredentialRemovedNotice(User user, Credential removed)
         {
-            SendCredentialChangeNotice(
-                user,
-                removed,
-                Strings.Emails_CredentialRemoved_Body,
-                Strings.Emails_CredentialRemoved_Subject);
+            if (CredentialTypes.IsApiKey(removed.Type))
+            {
+                SendApiKeyChangeNotice(
+                    user,
+                    removed,
+                    Strings.Emails_ApiKeyRemoved_Body,
+                    Strings.Emails_CredentialRemoved_Subject);
+            }
+            else
+            {
+                SendCredentialChangeNotice(
+                    user,
+                    removed,
+                    Strings.Emails_CredentialRemoved_Body,
+                    Strings.Emails_CredentialRemoved_Subject);
+            }
+            
         }
 
         public void SendCredentialAddedNotice(User user, Credential added)
         {
-            SendCredentialChangeNotice(
-                user,
-                added,
-                Strings.Emails_CredentialAdded_Body,
-                Strings.Emails_CredentialAdded_Subject);
+            if (CredentialTypes.IsApiKey(added.Type))
+            {
+                SendApiKeyChangeNotice(
+                    user,
+                    added,
+                    Strings.Emails_ApiKeyAdded_Body,
+                    Strings.Emails_CredentialAdded_Subject);
+            }
+            else
+            {
+                SendCredentialChangeNotice(
+                    user,
+                    added,
+                    Strings.Emails_CredentialAdded_Body,
+                    Strings.Emails_CredentialAdded_Subject);
+            }
+        }
+
+        private void SendApiKeyChangeNotice(User user, Credential changed, string bodyTemplate, string subjectTemplate)
+        {
+            var credViewModel = AuthService.DescribeCredential(changed);
+
+            string body = String.Format(
+                CultureInfo.CurrentCulture,
+                bodyTemplate,
+                credViewModel.Description);
+
+            string subject = String.Format(
+                CultureInfo.CurrentCulture,
+                subjectTemplate,
+                Config.GalleryOwner.DisplayName,
+                Strings.CredentialType_ApiKey);
+
+            SendSupportMessage(user, body, subject);
         }
 
         private void SendCredentialChangeNotice(User user, Credential changed, string bodyTemplate, string subjectTemplate)
@@ -381,11 +422,13 @@ The {3} Team";
                 CultureInfo.CurrentCulture,
                 bodyTemplate,
                 name);
+
             string subject = String.Format(
                 CultureInfo.CurrentCulture,
                 subjectTemplate,
                 Config.GalleryOwner.DisplayName,
                 name);
+
             SendSupportMessage(user, body, subject);
         }
 

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -242,7 +242,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to API Key.
+        ///   Looks up a localized string similar to API key.
         /// </summary>
         public static string CredentialType_ApiKey {
             get {
@@ -305,7 +305,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to API Key &apos;{0}&apos; was added to your account and can now be used. If you did not request this change, please reply to this email to contact support..
+        ///   Looks up a localized string similar to API key &apos;{0}&apos; was added to your account and can now be used. If you did not request this change, please reply to this email to contact support..
         /// </summary>
         public static string Emails_ApiKeyAdded_Body {
             get {
@@ -314,7 +314,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to API Key &apos;{0}&apos; was removed from your account and can no longer be used. If you did not request this change, please reply to this email to contact support..
+        ///   Looks up a localized string similar to API key &apos;{0}&apos; was removed from your account and can no longer be used. If you did not request this change, please reply to this email to contact support..
         /// </summary>
         public static string Emails_ApiKeyRemoved_Body {
             get {
@@ -602,9 +602,9 @@ namespace NuGetGallery {
         /// <summary>
         ///   Looks up a localized string similar to Full access API key.
         /// </summary>
-        public static string NonScopedApiKeyDesciption {
+        public static string NonScopedApiKeyDescription {
             get {
-                return ResourceManager.GetString("NonScopedApiKeyDesciption", resourceCulture);
+                return ResourceManager.GetString("NonScopedApiKeyDescription", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -305,6 +305,24 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to API Key &apos;{0}&apos; was added to your account and can now be used. If you did not request this change, please reply to this email to contact support..
+        /// </summary>
+        public static string Emails_ApiKeyAdded_Body {
+            get {
+                return ResourceManager.GetString("Emails_ApiKeyAdded_Body", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to API Key &apos;{0}&apos; was removed from your account and can no longer be used. If you did not request this change, please reply to this email to contact support..
+        /// </summary>
+        public static string Emails_ApiKeyRemoved_Body {
+            get {
+                return ResourceManager.GetString("Emails_ApiKeyRemoved_Body", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A {0} was added to your account and can now be used to log in. If you did not request this change, please reply to this email to contact support..
         /// </summary>
         public static string Emails_CredentialAdded_Body {
@@ -578,6 +596,15 @@ namespace NuGetGallery {
         public static string No {
             get {
                 return ResourceManager.GetString("No", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Full access API key.
+        /// </summary>
+        public static string NonScopedApiKeyDesciption {
+            get {
+                return ResourceManager.GetString("NonScopedApiKeyDesciption", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -434,4 +434,13 @@ The {1} Team</value>
   <data name="UploadPackage_IdVersionConflict" xml:space="preserve">
     <value>There is a conflict with the ID and version of your package and another package. Please change your package's ID or version and try again.</value>
   </data>
+  <data name="Emails_ApiKeyAdded_Body" xml:space="preserve">
+    <value>API Key '{0}' was added to your account and can now be used. If you did not request this change, please reply to this email to contact support.</value>
+  </data>
+  <data name="Emails_ApiKeyRemoved_Body" xml:space="preserve">
+    <value>API Key '{0}' was removed from your account and can no longer be used. If you did not request this change, please reply to this email to contact support.</value>
+  </data>
+  <data name="NonScopedApiKeyDesciption" xml:space="preserve">
+    <value>Full access API key</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -211,7 +211,7 @@
     <value>Microsoft account</value>
   </data>
   <data name="CredentialType_ApiKey" xml:space="preserve">
-    <value>API Key</value>
+    <value>API key</value>
   </data>
   <data name="CredentialType_Password" xml:space="preserve">
     <value>Password</value>
@@ -435,12 +435,12 @@ The {1} Team</value>
     <value>There is a conflict with the ID and version of your package and another package. Please change your package's ID or version and try again.</value>
   </data>
   <data name="Emails_ApiKeyAdded_Body" xml:space="preserve">
-    <value>API Key '{0}' was added to your account and can now be used. If you did not request this change, please reply to this email to contact support.</value>
+    <value>API key '{0}' was added to your account and can now be used. If you did not request this change, please reply to this email to contact support.</value>
   </data>
   <data name="Emails_ApiKeyRemoved_Body" xml:space="preserve">
-    <value>API Key '{0}' was removed from your account and can no longer be used. If you did not request this change, please reply to this email to contact support.</value>
+    <value>API key '{0}' was removed from your account and can no longer be used. If you did not request this change, please reply to this email to contact support.</value>
   </data>
-  <data name="NonScopedApiKeyDesciption" xml:space="preserve">
+  <data name="NonScopedApiKeyDescription" xml:space="preserve">
     <value>Full access API key</value>
   </data>
 </root>

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -120,15 +120,7 @@
                                             }
                                         </td>
                                         <td>
-                                            @if (apiKey.IsNonScopedV1ApiKey)
-                                            {
-                                                <strong>Full access API key</strong>
-                                                <br />
-                                            }
-                                            else
-                                            {
-                                                <strong title="@apiKey.Description">@apiKey.Description</strong><br />
-                                            }
+                                            <strong title="@apiKey.Description">@apiKey.Description</strong><br />
                                             <span>
                                                 <b>Expires:</b>
                                                 @if (!apiKey.Expires.HasValue)

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -1275,7 +1275,7 @@ namespace NuGetGallery.Authentication
                 Assert.Equal(CredentialKind.Token, description.Kind);
                 Assert.Null(description.AuthUI);
                 Assert.Equal(cred.Value, description.Value);
-                Assert.Equal(Strings.NonScopedApiKeyDesciption, description.Description);
+                Assert.Equal(Strings.NonScopedApiKeyDescription, description.Description);
                 Assert.Equal(expectedHasExpired, description.HasExpired);
             }
 

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -1275,7 +1275,7 @@ namespace NuGetGallery.Authentication
                 Assert.Equal(CredentialKind.Token, description.Kind);
                 Assert.Null(description.AuthUI);
                 Assert.Equal(cred.Value, description.Value);
-                Assert.Equal(null, description.Description);
+                Assert.Equal(Strings.NonScopedApiKeyDesciption, description.Description);
                 Assert.Equal(expectedHasExpired, description.HasExpired);
             }
 

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -475,6 +476,29 @@ namespace NuGetGallery
                 Assert.Equal("[Joe Shmoe] Password removed from your account", message.Subject);
                 Assert.Contains("A Password was removed from your account", message.Body);
             }
+
+            [Fact]
+            public void ApiKeyRemovedMessageIsCorrect()
+            {
+                var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
+                var cred = new CredentialBuilder().CreateApiKey(TimeSpan.FromDays(1));
+                cred.Description = "new api key";
+                var messageService = new TestableMessageService();
+                messageService.MockAuthService
+                    .Setup(a => a.DescribeCredential(cred))
+                    .Returns(new CredentialViewModel
+                    {
+                        Description = cred.Description
+                    });
+
+                messageService.SendCredentialRemovedNotice(user, cred);
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(user.ToMailAddress(), message.To[0]);
+                Assert.Equal(TestGalleryOwner, message.From);
+                Assert.Equal("[Joe Shmoe] API Key removed from your account", message.Subject);
+                Assert.Contains("API Key 'new api key' was removed from your account and can no longer be used. If you did not request this change, please reply to this email to contact support.", message.Body);
+            }
         }
 
         public class TheSendCredentialAddedNoticeMethod
@@ -521,6 +545,29 @@ namespace NuGetGallery
                 Assert.Equal(TestGalleryOwner, message.From);
                 Assert.Equal("[Joe Shmoe] Password added to your account", message.Subject);
                 Assert.Contains("A Password was added to your account", message.Body);
+            }
+
+            [Fact]
+            public void ApiKeyAddedMessageIsCorrect()
+            {
+                var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
+                var cred = new CredentialBuilder().CreateApiKey(TimeSpan.FromDays(1));
+                cred.Description = "new api key";
+                var messageService = new TestableMessageService();
+                messageService.MockAuthService
+                    .Setup(a => a.DescribeCredential(cred))
+                    .Returns(new CredentialViewModel
+                    {
+                        Description = cred.Description
+                    });
+
+                messageService.SendCredentialAddedNotice(user, cred);
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(user.ToMailAddress(), message.To[0]);
+                Assert.Equal(TestGalleryOwner, message.From);
+                Assert.Equal("[Joe Shmoe] API Key added to your account", message.Subject);
+                Assert.Contains("API Key 'new api key' was added to your account and can now be used. If you did not request this change, please reply to this email to contact support.", message.Body);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -438,12 +438,13 @@ namespace NuGetGallery
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
                 var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "abc123", "Test User");
+                const string MicrosoftAccountCredentialName = "Microsoft Account";
                 var messageService = new TestableMessageService();
                 messageService.MockAuthService
                     .Setup(a => a.DescribeCredential(cred))
                     .Returns(new CredentialViewModel
                     {
-                        AuthUI = new AuthenticatorUI("sign in", "Microsoft Account", "Microsoft Account")
+                        AuthUI = new AuthenticatorUI("sign in", MicrosoftAccountCredentialName, MicrosoftAccountCredentialName)
                     });
 
                 messageService.SendCredentialRemovedNotice(user, cred);
@@ -451,8 +452,8 @@ namespace NuGetGallery
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
                 Assert.Equal(TestGalleryOwner, message.From);
-                Assert.Equal("[Joe Shmoe] Microsoft Account removed from your account", message.Subject);
-                Assert.Contains("A Microsoft Account was removed from your account", message.Body);
+                Assert.Equal(string.Format(Strings.Emails_CredentialRemoved_Subject, TestGalleryOwner.DisplayName, MicrosoftAccountCredentialName), message.Subject);
+                Assert.Contains(string.Format(Strings.Emails_CredentialRemoved_Body, MicrosoftAccountCredentialName), message.Body);
             }
 
             [Fact]
@@ -465,7 +466,7 @@ namespace NuGetGallery
                     .Setup(a => a.DescribeCredential(cred))
                     .Returns(new CredentialViewModel()
                     {
-                        TypeCaption = "Password"
+                        TypeCaption = Strings.CredentialType_Password
                     });
 
                 messageService.SendCredentialRemovedNotice(user, cred);
@@ -473,8 +474,8 @@ namespace NuGetGallery
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
                 Assert.Equal(TestGalleryOwner, message.From);
-                Assert.Equal("[Joe Shmoe] Password removed from your account", message.Subject);
-                Assert.Contains("A Password was removed from your account", message.Body);
+                Assert.Equal(string.Format(Strings.Emails_CredentialRemoved_Subject, TestGalleryOwner.DisplayName, Strings.CredentialType_Password), message.Subject);
+                Assert.Contains(string.Format(Strings.Emails_CredentialRemoved_Body, Strings.CredentialType_Password), message.Body);
             }
 
             [Fact]
@@ -496,8 +497,8 @@ namespace NuGetGallery
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
                 Assert.Equal(TestGalleryOwner, message.From);
-                Assert.Equal("[Joe Shmoe] API Key removed from your account", message.Subject);
-                Assert.Contains("API Key 'new api key' was removed from your account and can no longer be used. If you did not request this change, please reply to this email to contact support.", message.Body);
+                Assert.Equal(string.Format(Strings.Emails_CredentialRemoved_Subject, TestGalleryOwner.DisplayName, Strings.CredentialType_ApiKey), message.Subject);
+                Assert.Contains(string.Format(Strings.Emails_ApiKeyRemoved_Body, cred.Description), message.Body);
             }
         }
 
@@ -508,12 +509,14 @@ namespace NuGetGallery
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
                 var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "abc123", "Test User");
+                const string MicrosoftAccountCredentialName = "Microsoft Account";
+
                 var messageService = new TestableMessageService();
                 messageService.MockAuthService
                     .Setup(a => a.DescribeCredential(cred))
                     .Returns(new CredentialViewModel
                     {
-                        AuthUI = new AuthenticatorUI("sign in", "Microsoft Account", "Microsoft Account")
+                        AuthUI = new AuthenticatorUI("sign in", MicrosoftAccountCredentialName, MicrosoftAccountCredentialName)
                     });
 
                 messageService.SendCredentialAddedNotice(user, cred);
@@ -521,8 +524,8 @@ namespace NuGetGallery
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
                 Assert.Equal(TestGalleryOwner, message.From);
-                Assert.Equal("[Joe Shmoe] Microsoft Account added to your account", message.Subject);
-                Assert.Contains("A Microsoft Account was added to your account", message.Body);
+                Assert.Equal(string.Format(Strings.Emails_CredentialAdded_Subject, TestGalleryOwner.DisplayName, MicrosoftAccountCredentialName), message.Subject);
+                Assert.Contains(string.Format(Strings.Emails_CredentialAdded_Body, MicrosoftAccountCredentialName), message.Body);
             }
 
             [Fact]
@@ -543,8 +546,8 @@ namespace NuGetGallery
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
                 Assert.Equal(TestGalleryOwner, message.From);
-                Assert.Equal("[Joe Shmoe] Password added to your account", message.Subject);
-                Assert.Contains("A Password was added to your account", message.Body);
+                Assert.Equal(string.Format(Strings.Emails_CredentialAdded_Subject, TestGalleryOwner.DisplayName, Strings.CredentialType_Password), message.Subject);
+                Assert.Contains(string.Format(Strings.Emails_CredentialAdded_Body, Strings.CredentialType_Password), message.Body);
             }
 
             [Fact]
@@ -566,8 +569,8 @@ namespace NuGetGallery
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
                 Assert.Equal(TestGalleryOwner, message.From);
-                Assert.Equal("[Joe Shmoe] API Key added to your account", message.Subject);
-                Assert.Contains("API Key 'new api key' was added to your account and can now be used. If you did not request this change, please reply to this email to contact support.", message.Body);
+                Assert.Equal(string.Format(Strings.Emails_CredentialAdded_Subject, TestGalleryOwner.DisplayName, Strings.CredentialType_ApiKey), message.Subject);
+                Assert.Contains(string.Format(Strings.Emails_ApiKeyAdded_Body, cred.Description), message.Body);
             }
         }
 


### PR DESCRIPTION
Fix for: https://github.com/NuGet/NuGetGallery/issues/3525

The message will be similar to this:
API Key 'blabla' was added to your account and can now be used. If you did not request this change, please reply to this email to contact support.

API Key 'blabla' was removed from your account and can no longer be used. If you did not request this change, please reply to this email to contact support.
