### PR TITLE
Refactor AuditingService base class for external use

### DIFF
--- a/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
@@ -20,6 +20,11 @@ namespace NuGetGallery.Auditing
 
         public CredentialAuditRecord(Credential credential, bool removed)
         {
+            if (credential == null)
+            {
+                throw new ArgumentNullException(nameof(credential));
+            }
+
             Key = credential.Key;
             Type = credential.Type;
             Description = credential.Description;

--- a/src/NuGetGallery.Core/Auditing/FileSystemAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/FileSystemAuditingService.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace NuGetGallery.Auditing
 {
@@ -17,14 +16,14 @@ namespace NuGetGallery.Auditing
 
         private readonly string _auditingPath;
         private readonly Func<Task<AuditActor>> _getOnBehalfOf;
-        
+
         public FileSystemAuditingService(string auditingPath, Func<Task<AuditActor>> getOnBehalfOf)
         {
             if (string.IsNullOrEmpty(auditingPath))
             {
                 throw new ArgumentNullException(nameof(auditingPath));
             }
-            
+
             if (getOnBehalfOf == null)
             {
                 throw new ArgumentNullException(nameof(getOnBehalfOf));
@@ -34,49 +33,7 @@ namespace NuGetGallery.Auditing
             _getOnBehalfOf = getOnBehalfOf;
         }
 
-        public static Task<AuditActor> GetAspNetOnBehalfOf()
-        {
-            // Use HttpContext to build an actor representing the user performing the action
-            var context = HttpContext.Current;
-            if (context == null)
-            {
-                return null;
-            }
-
-            // Try to identify the client IP using various server variables
-            var clientIpAddress = context.Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
-            if (string.IsNullOrEmpty(clientIpAddress)) // Try REMOTE_ADDR server variable
-            {
-                clientIpAddress = context.Request.ServerVariables["REMOTE_ADDR"];
-            }
-
-            if (string.IsNullOrEmpty(clientIpAddress)) // Try UserHostAddress property
-            {
-                clientIpAddress = context.Request.UserHostAddress;
-            }
-
-            if (!string.IsNullOrEmpty(clientIpAddress) && clientIpAddress.IndexOf(".", StringComparison.Ordinal) > 0)
-            {
-                clientIpAddress = clientIpAddress.Substring(0, clientIpAddress.LastIndexOf(".", StringComparison.Ordinal)) + ".0";
-            }
-
-            string user = null;
-            string authType = null;
-            if (context.User != null)
-            {
-                user = context.User.Identity.Name;
-                authType = context.User.Identity.AuthenticationType;
-            }
-
-            return Task.FromResult(new AuditActor(
-                null,
-                clientIpAddress,
-                user,
-                authType,
-                DateTime.UtcNow));
-        }
-
-        protected override async Task<AuditActor> GetActor()
+        protected override async Task<AuditActor> GetActorAsync()
         {
             // Construct an actor representing the user the service is acting on behalf of
             AuditActor onBehalfOf = null;
@@ -85,17 +42,17 @@ namespace NuGetGallery.Auditing
                 onBehalfOf = await _getOnBehalfOf();
             }
 
-            return await AuditActor.GetCurrentMachineActor(onBehalfOf);
+            return await AuditActor.GetCurrentMachineActorAsync(onBehalfOf);
         }
 
-        protected override Task<Uri> SaveAuditRecord(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
+        protected override Task<Uri> SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
         {
             // Build relative file path
-            var relativeFilePath = 
+            var relativeFilePath =
                $"{resourceType.ToLowerInvariant()}{Path.DirectorySeparatorChar}" +
                $"{filePath}{Path.DirectorySeparatorChar}" +
                $"{Guid.NewGuid().ToString("N")}-{action.ToLowerInvariant()}.audit.v1.json";
-            
+
             // Build full file path
             var fullFilePath = Path.Combine(_auditingPath, relativeFilePath);
 

--- a/src/NuGetGallery.Core/Auditing/UserAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/UserAuditRecord.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -29,6 +30,11 @@ namespace NuGetGallery.Auditing
         public UserAuditRecord(User user, AuditedUserAction action, IEnumerable<Credential> affected)
             : base(action)
         {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
             Username = user.Username;
             EmailAddress = user.EmailAddress;
             UnconfirmedEmailAddress = user.UnconfirmedEmailAddress;

--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -28,6 +28,11 @@ namespace NuGetGallery
 
         public static bool IsPassword(string type)
         {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
             return type.StartsWith(Password.Prefix, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/NuGetGallery.Operations/Util.cs
+++ b/src/NuGetGallery.Operations/Util.cs
@@ -362,13 +362,13 @@ namespace NuGetGallery.Operations
 
         internal static async Task<Uri> SaveAuditRecord(CloudStorageAccount storage, AuditRecord auditRecord)
         {
-            string localIP = await AuditActor.GetLocalIP();
+            string localIP = await AuditActor.GetLocalIpAddressAsync();
             CloudAuditingService audit = new CloudAuditingService(
                 Environment.MachineName,
                 localIP,
                 storage.CreateCloudBlobClient().GetContainerReference("auditing"),
                 getOnBehalfOf: null);
-            return await audit.SaveAuditRecord(auditRecord);
+            return await audit.SaveAuditRecordAsync(auditRecord);
         }
 
         public static string GenerateStatusString(int total, ref int counter)

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -372,7 +372,7 @@ namespace NuGetGallery
                 FileSystemFileStorageService.ResolvePath(configuration.Current.FileStorageDirectory),
                 FileSystemAuditingService.DefaultContainerName);
 
-            builder.RegisterInstance(new FileSystemAuditingService(auditingPath, FileSystemAuditingService.GetAspNetOnBehalfOf))
+            builder.RegisterInstance(new FileSystemAuditingService(auditingPath, AuditActor.GetAspNetOnBehalfOfAsync))
                 .AsSelf()
                 .As<AuditingService>()
                 .SingleInstance();
@@ -431,9 +431,9 @@ namespace NuGetGallery
                 instanceId = Environment.MachineName;
             }
 
-            var localIp = AuditActor.GetLocalIP().Result;
+            var localIp = AuditActor.GetLocalIpAddressAsync().Result;
 
-            builder.RegisterInstance(new CloudAuditingService(instanceId, localIp, configuration.Current.AzureStorageConnectionString, CloudAuditingService.GetAspNetOnBehalfOf))
+            builder.RegisterInstance(new CloudAuditingService(instanceId, localIp, configuration.Current.AzureStorageConnectionString, AuditActor.GetAspNetOnBehalfOfAsync))
                 .AsSelf()
                 .As<AuditingService>()
                 .SingleInstance();

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -120,7 +120,7 @@ namespace NuGetGallery.Authentication
                 {
                     _trace.Information("No such user: " + userNameOrEmail);
                     
-                    await Auditing.SaveAuditRecord(
+                    await Auditing.SaveAuditRecordAsync(
                         new FailedAuthenticatedOperationAuditRecord(
                             userNameOrEmail, AuditedAuthenticatedOperationAction.FailedLoginNoSuchUser));
 
@@ -145,7 +145,7 @@ namespace NuGetGallery.Authentication
 
                     await UpdateFailedLoginAttempt(user);
 
-                    await Auditing.SaveAuditRecord(
+                    await Auditing.SaveAuditRecordAsync(
                         new FailedAuthenticatedOperationAuditRecord(
                             userNameOrEmail, AuditedAuthenticatedOperationAction.FailedLoginInvalidPassword));
 
@@ -200,7 +200,7 @@ namespace NuGetGallery.Authentication
                 {
                     _trace.Information("No user matches credential of type: " + credential.Type);
 
-                    await Auditing.SaveAuditRecord(
+                    await Auditing.SaveAuditRecordAsync(
                         new FailedAuthenticatedOperationAuditRecord(null, AuditedAuthenticatedOperationAction.FailedLoginNoSuchUser, attemptedCredential: credential));
 
                     return null;
@@ -217,7 +217,7 @@ namespace NuGetGallery.Authentication
                     && !matched.HasBeenUsedInLastDays(_config.ExpirationInDaysForApiKeyV1))
                 {
                     // API key credential was last used a long, long time ago - expire it
-                    await Auditing.SaveAuditRecord(
+                    await Auditing.SaveAuditRecordAsync(
                         new UserAuditRecord(matched.User, AuditedUserAction.ExpireCredential, matched));
 
                     matched.Expires = _dateTimeProvider.UtcNow;
@@ -252,7 +252,7 @@ namespace NuGetGallery.Authentication
             owinContext.Authentication.SignOut(AuthenticationTypes.External);
             
             // Write an audit record
-            await Auditing.SaveAuditRecord(
+            await Auditing.SaveAuditRecordAsync(
                 new UserAuditRecord(user.User, AuditedUserAction.Login, user.CredentialUsed));
         }
 
@@ -295,7 +295,7 @@ namespace NuGetGallery.Authentication
             }
 
             // Write an audit record
-            await Auditing.SaveAuditRecord(new UserAuditRecord(newUser, AuditedUserAction.Register));
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(newUser, AuditedUserAction.Register));
 
             Entities.Users.Add(newUser);
             await Entities.SaveChangesAsync();
@@ -399,7 +399,7 @@ namespace NuGetGallery.Authentication
             user.PasswordResetToken = CryptographyService.GenerateToken();
             user.PasswordResetTokenExpirationDate = _dateTimeProvider.UtcNow.AddMinutes(expirationInMinutes);
 
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.RequestPasswordReset));
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.RequestPasswordReset));
 
             await Entities.SaveChangesAsync();
         }
@@ -449,7 +449,7 @@ namespace NuGetGallery.Authentication
 
         public virtual async Task AddCredential(User user, Credential credential)
         {
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.AddCredential, credential));
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.AddCredential, credential));
             user.Credentials.Add(credential);
             await Entities.SaveChangesAsync();
         }
@@ -494,7 +494,7 @@ namespace NuGetGallery.Authentication
 
         public virtual async Task RemoveCredential(User user, Credential cred)
         {
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.RemoveCredential, cred));
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.RemoveCredential, cred));
             user.Credentials.Remove(cred);
             Entities.Credentials.Remove(cred);
             await Entities.SaveChangesAsync();
@@ -511,7 +511,7 @@ namespace NuGetGallery.Authentication
 
             await Entities.SaveChangesAsync();
 
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.EditCredential, cred));
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.EditCredential, cred));
         }
 
         public virtual async Task<AuthenticateExternalLoginResult> ReadExternalLoginCredential(IOwinContext context)
@@ -616,13 +616,13 @@ namespace NuGetGallery.Authentication
 
             if (toRemove.Any())
             {
-                await Auditing.SaveAuditRecord(new UserAuditRecord(
+                await Auditing.SaveAuditRecordAsync(new UserAuditRecord(
                     user, AuditedUserAction.RemoveCredential, toRemove));
             }
 
             user.Credentials.Add(credential);
 
-            await Auditing.SaveAuditRecord(new UserAuditRecord(
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(
                 user, AuditedUserAction.AddCredential, credential));
         }
 
@@ -808,13 +808,13 @@ namespace NuGetGallery.Authentication
                 user.Credentials.Remove(cred);
                 Entities.DeleteOnCommit(cred);
             }
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.RemoveCredential, toRemove));
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.RemoveCredential, toRemove));
 
             // Now add one if there are no credentials left
             if (creds.Count == 0)
             {
                 var newCred = _credentialBuilder.CreatePasswordCredential(password);
-                await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.AddCredential, newCred));
+                await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.AddCredential, newCred));
                 user.Credentials.Add(newCred);
             }
 

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -312,7 +312,7 @@ namespace NuGetGallery
                             if (!packageRegistration.IsOwner(user))
                             {
                                 // Audit that a non-owner tried to push the package
-                                await AuditingService.SaveAuditRecord(
+                                await AuditingService.SaveAuditRecordAsync(
                                     new FailedAuthenticatedOperationAuditRecord(
                                         user.Username, 
                                         AuditedAuthenticatedOperationAction.PackagePushAttemptByNonOwner, 
@@ -396,7 +396,7 @@ namespace NuGetGallery
                         IndexingService.UpdatePackage(package);
                         
                         // Write an audit record
-                        await AuditingService.SaveAuditRecord(
+                        await AuditingService.SaveAuditRecordAsync(
                             new PackageAuditRecord(package, AuditedPackageAction.Create, PackageCreatedVia.Api));
 
                         // Notify user of push

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -146,7 +146,7 @@ namespace NuGetGallery
             }
             else if (numOK > 0)
             {
-                await _auditingService.SaveAuditRecord(new PackageAuditRecord(package, AuditedPackageAction.UndoEdit));
+                await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(package, AuditedPackageAction.UndoEdit));
 
                 TempData["Message"] = "Your pending edits for this package were successfully canceled.";
             }
@@ -916,7 +916,7 @@ namespace NuGetGallery
 
                     var packageWithEditsApplied = formData.Edit.ApplyTo(package);
 
-                    await _auditingService.SaveAuditRecord(new PackageAuditRecord(packageWithEditsApplied, AuditedPackageAction.Edit));
+                    await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(packageWithEditsApplied, AuditedPackageAction.Edit));
                 }
                 catch (EntityException ex)
                 {
@@ -1196,7 +1196,7 @@ namespace NuGetGallery
                 _indexingService.UpdateIndex();
 
                 // write an audit record
-                await _auditingService.SaveAuditRecord(
+                await _auditingService.SaveAuditRecordAsync(
                     new PackageAuditRecord(package, AuditedPackageAction.Create, PackageCreatedVia.Web));
 
                 // notify user

--- a/src/NuGetGallery/Services/PackageDeleteService.cs
+++ b/src/NuGetGallery/Services/PackageDeleteService.cs
@@ -87,7 +87,7 @@ namespace NuGetGallery
                     package.Deleted = true;
                     packageDelete.Packages.Add(package);
 
-                    await _auditingService.SaveAuditRecord(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.SoftDelete, reason));
+                    await _auditingService.SaveAuditRecordAsync(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.SoftDelete, reason));
                 }
 
                 _packageDeletesRepository.InsertOnCommit(packageDelete);
@@ -135,7 +135,7 @@ namespace NuGetGallery
                         "DELETE pf FROM PackageFrameworks pf JOIN Packages p ON p.[Key] = pf.Package_Key WHERE p.[Key] = @key",
                         new SqlParameter("@key", package.Key));
 
-                    await _auditingService.SaveAuditRecord(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.Delete, reason));
+                    await _auditingService.SaveAuditRecordAsync(CreateAuditRecord(package, package.PackageRegistration, AuditedPackageAction.Delete, reason));
 
                     package.PackageRegistration.Packages.Remove(package);
                     _packageRepository.DeleteOnCommit(package);

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -284,7 +284,7 @@ namespace NuGetGallery
                 await _packageOwnerRequestRepository.CommitChangesAsync();
             }
             
-            await _auditingService.SaveAuditRecord(
+            await _auditingService.SaveAuditRecordAsync(
                 new PackageRegistrationAuditRecord(package, AuditedPackageRegistrationAction.AddOwner, user.Username));
         }
 
@@ -306,7 +306,7 @@ namespace NuGetGallery
             package.Owners.Remove(user);
             await _packageRepository.CommitChangesAsync();
 
-            await _auditingService.SaveAuditRecord(
+            await _auditingService.SaveAuditRecordAsync(
                 new PackageRegistrationAuditRecord(package, AuditedPackageRegistrationAction.RemoveOwner, user.Username));
         }
 
@@ -338,7 +338,7 @@ namespace NuGetGallery
 
             await UpdateIsLatestAsync(package.PackageRegistration, false);
             
-            await _auditingService.SaveAuditRecord(new PackageAuditRecord(package, AuditedPackageAction.List));
+            await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(package, AuditedPackageAction.List));
 
             if (commitChanges)
             {
@@ -367,7 +367,7 @@ namespace NuGetGallery
                 await UpdateIsLatestAsync(package.PackageRegistration, false);
             }
 
-            await _auditingService.SaveAuditRecord(new PackageAuditRecord(package, AuditedPackageAction.Unlist));
+            await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(package, AuditedPackageAction.Unlist));
 
             if (commitChanges)
             {

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -97,7 +97,7 @@ namespace NuGetGallery
                 throw new EntityException(Strings.EmailAddressBeingUsed, newEmailAddress);
             }
 
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.ChangeEmail, newEmailAddress));
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.ChangeEmail, newEmailAddress));
 
             user.UpdateEmailAddress(newEmailAddress, Crypto.GenerateToken);
             await UserRepository.CommitChangesAsync();
@@ -105,7 +105,7 @@ namespace NuGetGallery
 
         public async Task CancelChangeEmailAddress(User user)
         {
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.CancelChangeEmail, user.UnconfirmedEmailAddress));
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.CancelChangeEmail, user.UnconfirmedEmailAddress));
 
             user.CancelChangeEmailAddress();
             await UserRepository.CommitChangesAsync();
@@ -144,7 +144,7 @@ namespace NuGetGallery
                 throw new EntityException(Strings.EmailAddressBeingUsed, user.UnconfirmedEmailAddress);
             }
 
-            await Auditing.SaveAuditRecord(new UserAuditRecord(user, AuditedUserAction.ConfirmEmail, user.UnconfirmedEmailAddress));
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.ConfirmEmail, user.UnconfirmedEmailAddress));
 
             user.ConfirmEmailAddress();
 

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditActorTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditActorTests.cs
@@ -1,0 +1,351 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Security.Principal;
+using System.Threading.Tasks;
+using System.Web;
+using Moq;
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class AuditActorTests
+    {
+        [Fact]
+        public void Constructor_WithoutOnBehalfOf_AcceptsNullValues()
+        {
+            var actor = new AuditActor(
+                machineName: null,
+                machineIP: null,
+                userName: null,
+                authenticationType: null,
+                timeStampUtc: DateTime.MinValue);
+
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.MachineIP);
+            Assert.Null(actor.UserName);
+            Assert.Null(actor.AuthenticationType);
+        }
+
+        [Fact]
+        public void Constructor_WithOnBehalfOf_AcceptsNullValues()
+        {
+            var actor = new AuditActor(machineName: null,
+                machineIP: null,
+                userName: null,
+                authenticationType: null,
+                timeStampUtc: DateTime.MinValue,
+                onBehalfOf: null);
+
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.MachineIP);
+            Assert.Null(actor.UserName);
+            Assert.Null(actor.AuthenticationType);
+            Assert.Null(actor.OnBehalfOf);
+        }
+
+        [Fact]
+        public void Constructor_WithoutOnBehalfOf_AcceptsEmptyStringValues()
+        {
+            var actor = new AuditActor(
+                machineName: "",
+                machineIP: "",
+                userName: "",
+                authenticationType: "",
+                timeStampUtc: DateTime.MinValue);
+
+            Assert.Equal("", actor.MachineName);
+            Assert.Equal("", actor.MachineIP);
+            Assert.Equal("", actor.UserName);
+            Assert.Equal("", actor.AuthenticationType);
+        }
+
+        [Fact]
+        public void Constructor_WithOnBehalfOf_AcceptsEmptyStringValues()
+        {
+            var actor = new AuditActor(
+                machineName: "",
+                machineIP: "",
+                userName: "",
+                authenticationType: "",
+                timeStampUtc: DateTime.MinValue,
+                onBehalfOf: null);
+
+            Assert.Equal("", actor.MachineName);
+            Assert.Equal("", actor.MachineIP);
+            Assert.Equal("", actor.UserName);
+            Assert.Equal("", actor.AuthenticationType);
+        }
+
+        [Fact]
+        public void Constructor_WithoutOnBehalfOf_SetsProperties()
+        {
+            var actor = new AuditActor(
+                machineName: "a",
+                machineIP: "b",
+                userName: "c",
+                authenticationType: "d",
+                timeStampUtc: DateTime.MinValue);
+
+            Assert.Equal("a", actor.MachineName);
+            Assert.Equal("b", actor.MachineIP);
+            Assert.Equal("c", actor.UserName);
+            Assert.Equal("d", actor.AuthenticationType);
+            Assert.Equal(DateTime.MinValue, actor.TimestampUtc);
+        }
+
+        [Fact]
+        public void Constructor_WithOnBehalfOf_SetsProperties()
+        {
+            var onBehalfOfActor = new AuditActor(
+                machineName: null,
+                machineIP: null,
+                userName: null,
+                authenticationType: null,
+                timeStampUtc: DateTime.MinValue);
+            var actor = new AuditActor(
+                machineName: "a",
+                machineIP: "b",
+                userName: "c",
+                authenticationType: "d",
+                timeStampUtc: DateTime.MinValue,
+                onBehalfOf: onBehalfOfActor);
+
+            Assert.Equal("a", actor.MachineName);
+            Assert.Equal("b", actor.MachineIP);
+            Assert.Equal("c", actor.UserName);
+            Assert.Equal("d", actor.AuthenticationType);
+            Assert.Equal(DateTime.MinValue, actor.TimestampUtc);
+            Assert.Same(onBehalfOfActor, actor.OnBehalfOf);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithoutContext_ReturnsNullForNullHttpContext()
+        {
+            var actor = await AuditActor.GetAspNetOnBehalfOfAsync();
+
+            Assert.Null(actor);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_ReturnsActor_WithHttpXForwardedForHeader()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var identity = new Mock<IIdentity>();
+            var user = new Mock<IPrincipal>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "a" } });
+            identity.Setup(x => x.Name)
+                .Returns("b");
+            identity.Setup(x => x.AuthenticationType)
+                .Returns("c");
+            user.Setup(x => x.Identity)
+                .Returns(identity.Object);
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns(user.Object);
+
+            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Equal("c", actor.AuthenticationType);
+            Assert.Equal("a", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal("b", actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_ReturnsActor_WithRemoteAddrHeader()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var identity = new Mock<IIdentity>();
+            var user = new Mock<IPrincipal>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection() { { "REMOTE_ADDR", "a" } });
+            identity.Setup(x => x.Name)
+                .Returns("b");
+            identity.Setup(x => x.AuthenticationType)
+                .Returns("c");
+            user.Setup(x => x.Identity)
+                .Returns(identity.Object);
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns(user.Object);
+
+            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Equal("c", actor.AuthenticationType);
+            Assert.Equal("a", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal("b", actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_ReturnsActor_WithUserHostAddress()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var identity = new Mock<IIdentity>();
+            var user = new Mock<IPrincipal>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection());
+            request.SetupGet(x => x.UserHostAddress)
+                .Returns("a");
+            identity.Setup(x => x.Name)
+                .Returns("b");
+            identity.Setup(x => x.AuthenticationType)
+                .Returns("c");
+            user.Setup(x => x.Identity)
+                .Returns(identity.Object);
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns(user.Object);
+
+            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Equal("c", actor.AuthenticationType);
+            Assert.Equal("a", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal("b", actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_ObfuscatesLastIpAddressOctet()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var identity = new Mock<IIdentity>();
+            var user = new Mock<IPrincipal>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "1.2.3.4" } });
+            identity.Setup(x => x.Name)
+                .Returns("b");
+            identity.Setup(x => x.AuthenticationType)
+                .Returns("c");
+            user.Setup(x => x.Identity)
+                .Returns(identity.Object);
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns(user.Object);
+
+            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Equal("c", actor.AuthenticationType);
+            Assert.Equal("1.2.3.0", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal("b", actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_SupportsNullUser()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "1.2.3.4" } });
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns((IPrincipal)null);
+
+            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Null(actor.AuthenticationType);
+            Assert.Equal("1.2.3.0", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Null(actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetCurrentMachineActorAsync_WithoutOnBehalfOf()
+        {
+            var actor = await AuditActor.GetCurrentMachineActorAsync();
+            var expectedIpAddress = await AuditActor.GetLocalIpAddressAsync();
+
+            Assert.NotNull(actor);
+            Assert.Equal(Environment.MachineName, actor.MachineName);
+            Assert.Equal(expectedIpAddress, actor.MachineIP);
+            Assert.Equal($@"{Environment.UserDomainName}\{Environment.UserName}", actor.UserName);
+            Assert.Equal("MachineUser", actor.AuthenticationType);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Null(actor.OnBehalfOf);
+        }
+
+        [Fact]
+        public async Task GetCurrentMachineActorAsync_WithOnBehalfOf_AcceptsNull()
+        {
+            var expectedResult = await AuditActor.GetCurrentMachineActorAsync();
+            var actualResult = await AuditActor.GetCurrentMachineActorAsync(onBehalfOf: null);
+
+            Assert.NotNull(expectedResult);
+            Assert.NotNull(actualResult);
+            Assert.Equal(expectedResult.MachineName, actualResult.MachineName);
+            Assert.Equal(expectedResult.MachineIP, actualResult.MachineIP);
+            Assert.Equal(expectedResult.UserName, actualResult.UserName);
+            Assert.Equal(expectedResult.AuthenticationType, actualResult.AuthenticationType);
+            Assert.InRange(actualResult.TimestampUtc, expectedResult.TimestampUtc, expectedResult.TimestampUtc.AddMinutes(1));
+            Assert.Null(actualResult.OnBehalfOf);
+        }
+
+        [Fact]
+        public async Task GetLocalIpAddressAsync_ReturnsAppropriateValueForLocalMachine()
+        {
+            string expectedIpAddress = null;
+
+            if (NetworkInterface.GetIsNetworkAvailable())
+            {
+                var entry = await Dns.GetHostEntryAsync(Dns.GetHostName());
+
+                if (entry != null)
+                {
+                    expectedIpAddress =
+                        TryGetAddress(entry.AddressList, AddressFamily.InterNetworkV6) ??
+                        TryGetAddress(entry.AddressList, AddressFamily.InterNetwork);
+                }
+            }
+
+            var actualIpAddress = await AuditActor.GetLocalIpAddressAsync();
+
+            Assert.Equal(expectedIpAddress, actualIpAddress);
+        }
+
+        private static string TryGetAddress(IEnumerable<IPAddress> addresses, AddressFamily family)
+        {
+            return addresses.Where(address => address.AddressFamily == family)
+                            .Select(address => address.ToString())
+                            .FirstOrDefault();
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditEntryTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditEntryTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Moq;
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class AuditEntryTests
+    {
+        [Fact]
+        public void Constructor_AcceptsNulls()
+        {
+            var entry = new AuditEntry(record: null, actor: null);
+
+            Assert.Null(entry.Record);
+            Assert.Null(entry.Actor);
+        }
+
+        [Fact]
+        public void Constructor_SetsProperties()
+        {
+            var record = new Mock<AuditRecord>();
+            var actor = new AuditActor(
+                machineName: null,
+                machineIP: null,
+                userName: null,
+                authenticationType: null,
+                timeStampUtc: DateTime.MinValue);
+            var entry = new AuditEntry(record.Object, actor);
+
+            Assert.Same(record.Object, entry.Record);
+            Assert.Same(actor, entry.Actor);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditedAuthenticatedOperationActionTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditedAuthenticatedOperationActionTests.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class AuditedAuthenticatedOperationActionTests : EnumTests
+    {
+        [Fact]
+        public void Definition_HasNotChanged()
+        {
+            var expectedNames = new[]
+            {
+                "FailedLoginInvalidPassword",
+                "FailedLoginNoSuchUser",
+                "PackagePushAttemptByNonOwner"
+            };
+
+            Verify(typeof(AuditedAuthenticatedOperationAction), expectedNames);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditedPackageActionTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditedPackageActionTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class AuditedPackageActionTests : EnumTests
+    {
+        [Fact]
+        public void Definition_HasNotChanged()
+        {
+            var expectedNames = new[]
+            {
+                "Create",
+                "Delete",
+                "Edit",
+                "List",
+                "SoftDelete",
+                "UndoEdit",
+                "Unlist"
+            };
+
+            Verify(typeof(AuditedPackageAction), expectedNames);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditedPackageRegistrationActionTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditedPackageRegistrationActionTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class AuditedPackageRegistrationActionTests : EnumTests
+    {
+        [Fact]
+        public void Definition_HasNotChanged()
+        {
+            var expectedNames = new[]
+            {
+                "AddOwner",
+                "RemoveOwner"
+            };
+
+            Verify(typeof(AuditedPackageRegistrationAction), expectedNames);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditedUserActionTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditedUserActionTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class AuditedUserActionTests : EnumTests
+    {
+        [Fact]
+        public void Definition_HasNotChanged()
+        {
+            var expectedNames = new []
+            {
+                "AddCredential",
+                "CancelChangeEmail",
+                "ChangeEmail",
+                "ConfirmEmail",
+                "EditCredential",
+                "ExpireCredential",
+                "Login",
+                "Register",
+                "RemoveCredential",
+                "RequestPasswordReset"
+            };
+
+            Verify(typeof(AuditedUserAction), expectedNames);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditingServiceTests.cs
@@ -1,0 +1,325 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGetGallery.Auditing.AuditedEntities;
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class AuditingServiceTests
+    {
+        [Fact]
+        public async Task SaveAuditRecordAsync_UserAuditRecord()
+        {
+            var user = new User()
+            {
+                CreatedUtc = DateTime.Now,
+                Credentials = new List<Credential>()
+                {
+                    new Credential(
+                        CredentialTypes.Password.V3,
+                        value: "a",
+                        expiration: new TimeSpan(days: 1, hours: 2, minutes:3, seconds: 4))
+                },
+                EmailAddress = "b",
+                Roles = new List<Role>() { new Role() { Key = 5, Name = "c" } },
+                UnconfirmedEmailAddress = "d",
+                Username = "e"
+            };
+            var auditRecord = new UserAuditRecord(user, AuditedUserAction.Login, user.Credentials.First());
+            var service = new TestAuditingService(async (string auditData, string resourceType, string filePath, string action, DateTime timestamp) =>
+            {
+                Assert.Equal("User", resourceType);
+                Assert.Equal("e", filePath);
+                Assert.Equal("login", action);
+                Assert.InRange(timestamp, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+
+                var jObject = JObject.Parse(auditData);
+
+                var record = jObject["Record"];
+
+                Assert.Equal("e", record["Username"].Value<string>());
+                Assert.Equal("b", record["EmailAddress"].Value<string>());
+                Assert.Equal("d", record["UnconfirmedEmailAddress"].Value<string>());
+                Assert.Equal("c", record["Roles"].ToObject<IList<string>>().Single());
+
+                var credentials = record["Credentials"];
+                var credential = credentials.AsEnumerable().Single();
+
+                Assert.Equal(0, credential["Key"].Value<int>());
+                Assert.Equal(CredentialTypes.Password.V3, credential["Type"].Value<string>());
+                Assert.Equal(JTokenType.Null, credential["Value"].Type);
+                Assert.Equal(JTokenType.Null, credential["Description"].Type);
+                Assert.False(credential["Scopes"].ToObject<IList<object>>().Any());
+                Assert.Equal(JTokenType.Null, credential["Identity"].Type);
+                Assert.Equal(DateTime.MinValue, credential["Created"].Value<DateTime>());
+                Assert.Equal(user.Credentials.First().Expires.Value, credential["Expires"].Value<DateTime>());
+                Assert.Equal(JTokenType.Null, credential["LastUsed"].Type);
+
+                var affectedCredential = record["AffectedCredential"].AsJEnumerable().Single();
+
+                Assert.Equal(0, affectedCredential["Key"].Value<int>());
+                Assert.Equal(CredentialTypes.Password.V3, affectedCredential["Type"].Value<string>());
+                Assert.Equal(JTokenType.Null, affectedCredential["Value"].Type);
+                Assert.Equal(JTokenType.Null, affectedCredential["Description"].Type);
+                Assert.Equal(0, affectedCredential["Scopes"].AsJEnumerable().Count());
+                Assert.Equal(JTokenType.Null, affectedCredential["Identity"].Type);
+                Assert.Equal(DateTime.MinValue, affectedCredential["Created"].Value<DateTime>());
+                Assert.Equal(user.Credentials.First().Expires.Value, affectedCredential["Expires"].Value<DateTime>());
+                Assert.Equal(JTokenType.Null, affectedCredential["LastUsed"].Type);
+
+                Assert.Equal(JTokenType.Null, record["AffectedEmailAddress"].Type);
+                Assert.Equal("Login", record["Action"].Value<string>());
+
+                await VerifyActor(jObject);
+
+                return null;
+            });
+
+            await service.SaveAuditRecordAsync(auditRecord);
+        }
+
+        [Fact]
+        public async Task SaveAuditRecordAsync_PackageAuditRecord()
+        {
+            var package = new Package()
+            {
+                Copyright = "a",
+                Created = DateTime.Now,
+                Deleted = true,
+                Description = "b",
+                DownloadCount = 1,
+#pragma warning disable 612
+                ExternalPackageUrl = "c",
+#pragma warning restore 612
+                FlattenedAuthors = "d",
+                FlattenedDependencies = "e",
+                Hash = "f",
+                HashAlgorithm = "g",
+                HideLicenseReport = true,
+                IconUrl = "h",
+                IsLatest = true,
+                IsLatestStable = true,
+                IsPrerelease = true,
+                Key = 2,
+                Language = "i",
+                LastEdited = DateTime.Now.AddMinutes(1),
+                LastUpdated = DateTime.Now.AddMinutes(2),
+                LicenseNames = "j",
+                LicenseReportUrl = "k",
+                LicenseUrl = "l",
+                Listed = true,
+                MinClientVersion = "m",
+                NormalizedVersion = "n",
+                PackageFileSize = 3,
+                PackageRegistration = new PackageRegistration() { Id = "o" },
+                PackageRegistrationKey = 4,
+                ProjectUrl = "p",
+                Published = DateTime.Now.AddMinutes(3),
+                ReleaseNotes = "q",
+                RequiresLicenseAcceptance = true,
+                Summary = "r",
+                Tags = "s",
+                Title = "t",
+                UserKey = 5,
+                Version = "u"
+            };
+            var auditRecord = new PackageAuditRecord(package, AuditedPackageAction.Create, reason: "v");
+            var service = new TestAuditingService(async (string auditData, string resourceType, string filePath, string action, DateTime timestamp) =>
+            {
+                Assert.Equal("Package", resourceType);
+                Assert.Equal("o/u", filePath);
+                Assert.Equal("create", action);
+                Assert.InRange(timestamp, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+
+                var jObject = JObject.Parse(auditData);
+
+                var record = jObject["Record"];
+
+                Assert.Equal("o", record["Id"].Value<string>());
+                Assert.Equal("u", record["Version"].Value<string>());
+                Assert.Equal("f", record["Hash"].Value<string>());
+
+                var packageRecord = record["PackageRecord"];
+
+                Assert.Equal(4, packageRecord["PackageRegistrationKey"].Value<int>());
+                Assert.Equal("a", packageRecord["Copyright"].Value<string>());
+                Assert.Equal(package.Created.ToUniversalTime(), packageRecord["Created"].Value<DateTime>());
+                Assert.Equal("b", packageRecord["Description"].Value<string>());
+                Assert.Equal("q", packageRecord["ReleaseNotes"].Value<string>());
+                Assert.Equal(1, packageRecord["DownloadCount"].Value<int>());
+                Assert.Equal(JTokenType.Null, packageRecord["ExternalPackageUrl"].Type);
+                Assert.Equal("g", packageRecord["HashAlgorithm"].Value<string>());
+                Assert.Equal("f", packageRecord["Hash"].Value<string>());
+                Assert.Equal("h", packageRecord["IconUrl"].Value<string>());
+                Assert.True(packageRecord["IsLatest"].Value<bool>());
+                Assert.True(packageRecord["IsLatestStable"].Value<bool>());
+                Assert.Equal(package.LastUpdated.ToUniversalTime(), packageRecord["LastUpdated"].Value<DateTime>());
+                Assert.Equal(package.LastEdited.Value.ToUniversalTime(), packageRecord["LastEdited"].Value<DateTime>());
+                Assert.Equal("l", packageRecord["LicenseUrl"].Value<string>());
+                Assert.True(packageRecord["HideLicenseReport"].Value<bool>());
+                Assert.Equal("i", packageRecord["Language"].Value<string>());
+                Assert.Equal(package.Published.ToUniversalTime(), packageRecord["Published"].Value<DateTime>());
+                Assert.Equal(3, packageRecord["PackageFileSize"].Value<int>());
+                Assert.Equal("p", packageRecord["ProjectUrl"].Value<string>());
+                Assert.True(packageRecord["RequiresLicenseAcceptance"].Value<bool>());
+                Assert.Equal("r", packageRecord["Summary"].Value<string>());
+                Assert.Equal("s", packageRecord["Tags"].Value<string>());
+                Assert.Equal("t", packageRecord["Title"].Value<string>());
+                Assert.Equal("u", packageRecord["Version"].Value<string>());
+                Assert.Equal("n", packageRecord["NormalizedVersion"].Value<string>());
+                Assert.Equal("j", packageRecord["LicenseNames"].Value<string>());
+                Assert.Equal("k", packageRecord["LicenseReportUrl"].Value<string>());
+                Assert.True(packageRecord["Listed"].Value<bool>());
+                Assert.True(packageRecord["IsPrerelease"].Value<bool>());
+                Assert.Equal("d", packageRecord["FlattenedAuthors"].Value<string>());
+                Assert.Equal("e", packageRecord["FlattenedDependencies"].Value<string>());
+                Assert.Equal(2, packageRecord["Key"].Value<int>());
+                Assert.Equal("m", packageRecord["MinClientVersion"].Value<string>());
+                Assert.Equal(5, packageRecord["UserKey"].Value<int>());
+                Assert.True(packageRecord["Deleted"].Value<bool>());
+
+                var registrationRecord = record["RegistrationRecord"];
+
+                Assert.Equal("o", registrationRecord["Id"].Value<string>());
+                Assert.Equal(0, registrationRecord["DownloadCount"].Value<int>());
+                Assert.Equal(0, registrationRecord["Key"].Value<int>());
+
+                Assert.Equal("v", record["Reason"].Value<string>());
+                Assert.Equal("Create", record["Action"].Value<string>());
+
+                await VerifyActor(jObject);
+
+                return null;
+            });
+
+            await service.SaveAuditRecordAsync(auditRecord);
+        }
+
+        [Fact]
+        public async Task SaveAuditRecordAsync_PackageRegistrationAuditRecord()
+        {
+            var packageRegistration = new PackageRegistration()
+            {
+                DownloadCount = 1,
+                Id = "a",
+                Key = 2
+            };
+            var auditRecord = new PackageRegistrationAuditRecord(packageRegistration, AuditedPackageRegistrationAction.AddOwner, owner: "b");
+            var service = new TestAuditingService(async (string auditData, string resourceType, string filePath, string action, DateTime timestamp) =>
+            {
+                Assert.Equal("PackageRegistration", resourceType);
+                Assert.Equal("a", filePath);
+                Assert.Equal("addowner", action);
+                Assert.InRange(timestamp, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+
+                var jObject = JObject.Parse(auditData);
+
+                var record = jObject["Record"];
+
+                Assert.Equal("a", record["Id"].Value<string>());
+
+                var registrationRecord = record["RegistrationRecord"];
+
+                Assert.Equal("a", registrationRecord["Id"].Value<string>());
+                Assert.Equal(1, registrationRecord["DownloadCount"].Value<int>());
+                Assert.Equal(2, registrationRecord["Key"].Value<int>());
+
+                Assert.Equal("b", record["Owner"].Value<string>());
+                Assert.Equal("AddOwner", record["Action"].Value<string>());
+
+                await VerifyActor(jObject);
+
+                return null;
+            });
+
+            await service.SaveAuditRecordAsync(auditRecord);
+        }
+
+        [Fact]
+        public async Task SaveAuditRecordAsync_FailedAuthenticatedOperationAuditRecord()
+        {
+            var expiresIn = new TimeSpan(days: 1, hours: 2, minutes: 3, seconds: 4);
+            var auditRecord = new FailedAuthenticatedOperationAuditRecord(
+                usernameOrEmail: "a",
+                action: AuditedAuthenticatedOperationAction.PackagePushAttemptByNonOwner,
+                attemptedPackage: new AuditedPackageIdentifier("b", "c"),
+                attemptedCredential: new Credential(CredentialTypes.ApiKey.V2, value: "d", expiration: expiresIn));
+            var service = new TestAuditingService(async (string auditData, string resourceType, string filePath, string action, DateTime timestamp) =>
+            {
+                Assert.Equal("FailedAuthenticatedOperation", resourceType);
+                Assert.Equal("all", filePath);
+                Assert.Equal("packagepushattemptbynonowner", action);
+                Assert.InRange(timestamp, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+
+                var jObject = JObject.Parse(auditData);
+
+                var record = jObject["Record"];
+
+                Assert.Equal("a", record["UsernameOrEmail"].Value<string>());
+
+                var attemptedPackage = record["AttemptedPackage"];
+
+                Assert.Equal("b", attemptedPackage["Id"].Value<string>());
+                Assert.Equal("c", attemptedPackage["Version"].Value<string>());
+
+                var attemptedCredential = record["AttemptedCredential"];
+
+                Assert.Equal(0, attemptedCredential["Key"].Value<int>());
+                Assert.Equal(CredentialTypes.ApiKey.V2, attemptedCredential["Type"].Value<string>());
+
+                Assert.Equal(JTokenType.Null, attemptedCredential["Value"].Type);
+                Assert.Equal(JTokenType.Null, attemptedCredential["Description"].Type);
+                Assert.False(attemptedCredential["Scopes"].ToObject<IList<object>>().Any());
+                Assert.Equal(JTokenType.Null, attemptedCredential["Identity"].Type);
+                Assert.Equal(DateTime.MinValue, attemptedCredential["Created"].Value<DateTime>());
+
+                var expiresUtc = DateTime.UtcNow.Add(expiresIn);
+
+                Assert.InRange(attemptedCredential["Expires"].Value<DateTime>(), expiresUtc.AddMinutes(-1), expiresUtc.AddMinutes(1));
+                Assert.Equal(JTokenType.Null, attemptedCredential["LastUsed"].Type);
+
+                await VerifyActor(jObject);
+
+                return null;
+            });
+
+            await service.SaveAuditRecordAsync(auditRecord);
+        }
+
+        private static async Task VerifyActor(JObject jObject)
+        {
+            var actor = jObject["Actor"];
+
+            Assert.Equal(Environment.MachineName, actor["MachineName"].Value<string>());
+
+            var expectedIpAddress = await AuditActor.GetLocalIpAddressAsync();
+
+            Assert.Equal(expectedIpAddress, actor["MachineIP"].Value<string>());
+            Assert.Equal($@"{Environment.UserDomainName}\{Environment.UserName}", actor["UserName"].Value<string>());
+            Assert.Equal("MachineUser", actor["AuthenticationType"].Value<string>());
+            Assert.InRange(actor["TimestampUtc"].Value<DateTime>(), DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal(JTokenType.Null, actor["OnBehalfOf"].Type);
+        }
+
+        private class TestAuditingService : AuditingService
+        {
+            private readonly Func<string, string, string, string, DateTime, Task<Uri>> _saveDelegate;
+
+            internal TestAuditingService(Func<string, string, string, string, DateTime, Task<Uri>> saveDelegate)
+            {
+                _saveDelegate = saveDelegate;
+            }
+
+            protected override Task<Uri> SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
+            {
+                return _saveDelegate(auditData, resourceType, filePath, action, timestamp);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/CredentialAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/CredentialAuditRecordTests.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class CredentialAuditRecordTests
+    {
+        [Fact]
+        public void Constructor_ThrowsForNullCredential()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CredentialAuditRecord(credential: null, removed: true));
+        }
+
+        [Fact]
+        public void Constructor_ThrowsForRemovalWithNullType()
+        {
+            var credential = new Credential();
+
+            Assert.Throws<ArgumentNullException>(() => new CredentialAuditRecord(credential, removed: true));
+        }
+
+        [Fact]
+        public void Constructor_RemovalOfNonPasswordSetsValue()
+        {
+            var credential = new Credential(type: "a", value: "b");
+            var record = new CredentialAuditRecord(credential, removed: true);
+
+            Assert.Equal("b", record.Value);
+        }
+
+        [Fact]
+        public void Constructor_RemovalOfPasswordDoesNotSetValue()
+        {
+            var credential = new Credential(type: CredentialTypes.Password.V3, value: "a");
+            var record = new CredentialAuditRecord(credential, removed: true);
+
+            Assert.Null(record.Value);
+        }
+
+        [Fact]
+        public void Constructor_NonRemovalOfNonPasswordDoesNotSetsValue()
+        {
+            var credential = new Credential(type: "a", value: "b");
+            var record = new CredentialAuditRecord(credential, removed: false);
+
+            Assert.Null(record.Value);
+        }
+
+        [Fact]
+        public void Constructor_NonRemovalOfPasswordDoesNotSetValue()
+        {
+            var credential = new Credential(type: CredentialTypes.Password.V3, value: "a");
+            var record = new CredentialAuditRecord(credential, removed: false);
+
+            Assert.Null(record.Value);
+        }
+
+        [Fact]
+        public void Constructor_SetsProperties()
+        {
+            var created = DateTime.MinValue;
+            var expires = DateTime.MinValue.AddDays(1);
+            var lastUsed = DateTime.MinValue.AddDays(2);
+            var credential = new Credential()
+            {
+                Created = created,
+                Description = "a",
+                Expires = expires,
+                Identity = "b",
+                Key = 1,
+                LastUsed = lastUsed,
+                Scopes = new List<Scope>() { new Scope(subject: "c", allowedAction: "d") },
+                Type = "e",
+                Value = "f"
+            };
+            var record = new CredentialAuditRecord(credential, removed: true);
+
+            Assert.Equal(created, record.Created);
+            Assert.Equal("a", record.Description);
+            Assert.Equal(expires, record.Expires);
+            Assert.Equal("b", record.Identity);
+            Assert.Equal(1, record.Key);
+            Assert.Equal(lastUsed, record.LastUsed);
+            Assert.Equal(1, record.Scopes.Count);
+            var scope = record.Scopes[0];
+            Assert.Equal("c", scope.Subject);
+            Assert.Equal("d", scope.AllowedAction);
+            Assert.Equal("e", record.Type);
+            Assert.Equal("f", record.Value);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/EnumTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/EnumTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public abstract class EnumTests
+    {
+        protected void Verify(Type enumType, string[] expectedNames)
+        {
+            var actualNames = Enum.GetNames(enumType);
+
+            Assert.Equal(expectedNames.Length, actualNames.Length);
+
+            var actualNotInExpected = actualNames.Except(expectedNames);
+            var expectedNotInActual = expectedNames.Except(actualNames);
+
+            var commonMessage = $"The {enumType.Name} enum definition has changed.  Please evaluate this change against all {nameof(AuditingService)} implementations.";
+
+            Assert.False(actualNotInExpected.Any(), $"{commonMessage}  Unexpected members found:  {string.Join(", ", actualNotInExpected)}");
+            Assert.False(expectedNotInActual.Any(), $"{commonMessage}  Expected members not found:  {string.Join(", ", expectedNotInActual)}");
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/FailedAuthenticatedOperationAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/FailedAuthenticatedOperationAuditRecordTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetGallery.Auditing.AuditedEntities;
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class FailedAuthenticatedOperationAuditRecordTests
+    {
+        [Fact]
+        public void Constructor_AcceptsNulls()
+        {
+            var record = new FailedAuthenticatedOperationAuditRecord(
+                usernameOrEmail: null,
+                action: AuditedAuthenticatedOperationAction.FailedLoginNoSuchUser,
+                attemptedPackage: null,
+                attemptedCredential: null);
+
+            Assert.Null(record.UsernameOrEmail);
+            Assert.Equal(AuditedAuthenticatedOperationAction.FailedLoginNoSuchUser, record.Action);
+            Assert.Null(record.AttemptedPackage);
+            Assert.Null(record.AttemptedCredential);
+        }
+
+        [Fact]
+        public void Constructor_AcceptsEmptyStringUserNameOrEmail()
+        {
+            var record = new FailedAuthenticatedOperationAuditRecord(
+                usernameOrEmail: "",
+                action: AuditedAuthenticatedOperationAction.FailedLoginInvalidPassword,
+                attemptedPackage: null,
+                attemptedCredential: null);
+
+            Assert.Equal("", record.UsernameOrEmail);
+        }
+
+        [Fact]
+        public void Constructor_SetsProperties()
+        {
+            var identifier = new AuditedPackageIdentifier(id: "a", version: "1.0.0");
+            var credential = new Credential(type: CredentialTypes.Password.V3, value: "b");
+            var record = new FailedAuthenticatedOperationAuditRecord(
+                usernameOrEmail: "c",
+                action: AuditedAuthenticatedOperationAction.PackagePushAttemptByNonOwner,
+                attemptedPackage: identifier,
+                attemptedCredential: credential);
+
+            Assert.Equal("c", record.UsernameOrEmail);
+            Assert.Same(identifier, record.AttemptedPackage);
+            Assert.NotNull(record.AttemptedCredential);
+            Assert.Equal(credential.Type, record.AttemptedCredential.Type);
+            Assert.Null(record.AttemptedCredential.Value);
+            Assert.Equal(AuditedAuthenticatedOperationAction.PackagePushAttemptByNonOwner, record.Action);
+        }
+
+        [Fact]
+        public void GetPath()
+        {
+            var record = new FailedAuthenticatedOperationAuditRecord(
+                usernameOrEmail: null,
+                action: AuditedAuthenticatedOperationAction.FailedLoginNoSuchUser,
+                attemptedPackage: null,
+                attemptedCredential: null);
+            var actualResult = record.GetPath();
+
+            Assert.Equal("all", actualResult);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/FileSystemAuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/FileSystemAuditingServiceTests.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NuGetGallery.Utilities;
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class FileSystemAuditingServiceTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Constructor_ThrowsForNullOrEmptyAuditingPath(string auditingPath)
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FileSystemAuditingService(auditingPath, GetOnBehalfOf));
+        }
+
+        [Fact]
+        public void Constructor_ThrowsForNullGetOnBehalfOf()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FileSystemAuditingService(auditingPath: "a", getOnBehalfOf: null));
+        }
+
+        [Fact]
+        public async Task SaveAuditRecord_ThrowsForNull()
+        {
+            var service = new FileSystemAuditingService(
+                auditingPath: "a",
+                getOnBehalfOf: AuditActor.GetAspNetOnBehalfOfAsync);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await service.SaveAuditRecordAsync(record: null));
+        }
+
+        [Fact]
+        public async Task SaveAuditRecord_ReturnsUriForAuditFile()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var service = new FileSystemAuditingService(
+                    auditingPath: testDirectory.FullPath,
+                    getOnBehalfOf: GetOnBehalfOf);
+                var record = new PackageAuditRecord(
+                    new Package()
+                    {
+                        Hash = "a",
+                        PackageRegistration = new PackageRegistration() { Id = "b" },
+                        Version = "1.0.0"
+                    },
+                    AuditedPackageAction.Create);
+
+                var uri = await service.SaveAuditRecordAsync(record);
+
+                Assert.True(Regex.IsMatch(uri.AbsoluteUri, "^https://auditing.local/package/b/1.0.0/[0-9a-f]{32}-create.audit.v1.json$"));
+
+                var files = Directory.GetFiles(testDirectory.FullPath, "*", SearchOption.AllDirectories);
+                var actualFilePath = files.Single();
+                var expectedFilePath = Path.Combine(testDirectory.FullPath, uri.AbsolutePath.Replace('/', '\\').TrimStart('\\'));
+
+                Assert.Equal(expectedFilePath, actualFilePath);
+            }
+        }
+
+        [Fact]
+        public async Task SaveAuditRecord_CreatesAuditFile()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var service = new FileSystemAuditingService(
+                    auditingPath: testDirectory.FullPath,
+                    getOnBehalfOf: GetOnBehalfOf);
+                var record = new PackageAuditRecord(
+                    new Package()
+                    {
+                        Hash = "a",
+                        PackageRegistration = new PackageRegistration() { Id = "b" },
+                        Version = "1.0.0"
+                    },
+                    AuditedPackageAction.Create);
+
+                await service.SaveAuditRecordAsync(record);
+
+                var files = Directory.GetFiles(testDirectory.FullPath, "*", SearchOption.AllDirectories);
+                var json = JObject.Parse(File.ReadAllText(files.Single()));
+
+                Assert.NotNull(json["Record"]);
+                Assert.NotNull(json["Record"]["Id"]);
+                Assert.Equal("b", json["Record"]["Id"].Value<string>());
+                Assert.NotNull(json["Record"]["Version"]);
+                Assert.Equal("1.0.0", json["Record"]["Version"].Value<string>());
+                Assert.NotNull(json["Record"]["Hash"]);
+                Assert.Equal("a", json["Record"]["Hash"].Value<string>());
+                Assert.NotNull(json["Record"]["PackageRecord"]);
+                Assert.NotNull(json["Record"]["PackageRecord"]["Hash"]);
+                Assert.Equal("a", json["Record"]["PackageRecord"]["Hash"].Value<string>());
+                Assert.NotNull(json["Record"]["PackageRecord"]["Version"]);
+                Assert.Equal("1.0.0", json["Record"]["PackageRecord"]["Version"].Value<string>());
+                Assert.NotNull(json["Record"]["RegistrationRecord"]);
+                Assert.NotNull(json["Record"]["RegistrationRecord"]["Id"]);
+                Assert.Equal("b", json["Record"]["RegistrationRecord"]["Id"].Value<string>());
+                Assert.NotNull(json["Record"]["Action"]);
+                Assert.Equal("Create", json["Record"]["Action"].Value<string>());
+                Assert.NotNull(json["Actor"]);
+                Assert.NotNull(json["Actor"]["MachineName"]);
+                Assert.Equal(Environment.MachineName, json["Actor"]["MachineName"].Value<string>());
+                Assert.NotNull(json["Actor"]["MachineIP"]);
+                Assert.True(IsValidMachineIpValue(json["Actor"]["MachineIP"].Value<string>()));
+                Assert.NotNull(json["Actor"]["UserName"]);
+                Assert.Equal($@"{Environment.UserDomainName}\{Environment.UserName}", json["Actor"]["UserName"].Value<string>());
+                Assert.NotNull(json["Actor"]["AuthenticationType"]);
+                Assert.Equal("MachineUser", json["Actor"]["AuthenticationType"].Value<string>());
+                Assert.NotNull(json["Actor"]["TimestampUtc"]);
+                Assert.InRange(DateTime.Parse(json["Actor"]["TimestampUtc"].Value<string>()), DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+                Assert.NotNull(json["Actor"]["OnBehalfOf"]);
+                Assert.NotNull(json["Actor"]["OnBehalfOf"]["MachineName"]);
+                Assert.Equal("a", json["Actor"]["OnBehalfOf"]["MachineName"].Value<string>());
+                Assert.NotNull(json["Actor"]["OnBehalfOf"]["MachineIP"]);
+                Assert.Equal("b", json["Actor"]["OnBehalfOf"]["MachineIP"].Value<string>());
+                Assert.NotNull(json["Actor"]["OnBehalfOf"]["UserName"]);
+                Assert.Equal("c", json["Actor"]["OnBehalfOf"]["UserName"].Value<string>());
+                Assert.NotNull(json["Actor"]["OnBehalfOf"]["AuthenticationType"]);
+                Assert.Equal("d", json["Actor"]["OnBehalfOf"]["AuthenticationType"].Value<string>());
+                Assert.NotNull(json["Actor"]["OnBehalfOf"]["TimestampUtc"]);
+                Assert.Equal(DateTime.MinValue, DateTime.Parse(json["Actor"]["OnBehalfOf"]["TimestampUtc"].Value<string>()));
+                Assert.Equal(JTokenType.Null, json["Actor"]["OnBehalfOf"]["OnBehalfOf"].Type);
+            }
+        }
+
+        private static Task<AuditActor> GetOnBehalfOf()
+        {
+            var actor = new AuditActor(
+                machineName: "a",
+                machineIP: "b",
+                userName: "c",
+                authenticationType: "d",
+                timeStampUtc: DateTime.MinValue);
+
+            return Task.FromResult<AuditActor>(actor);
+        }
+
+        private static bool IsValidMachineIpValue(string ipAddress)
+        {
+            if (ipAddress == null)
+            {
+                return true;
+            }
+
+            IPAddress value;
+
+            return IPAddress.TryParse(ipAddress, out value);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/PackageAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/PackageAuditRecordTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class PackageAuditRecordTests
+    {
+        [Fact]
+        public void Constructor_SetsProperties()
+        {
+            var record = new PackageAuditRecord(
+                new Package()
+                {
+                    Hash = "a",
+                    PackageRegistration = new PackageRegistration() { Id = "b" },
+                    Version = "1.0.0"
+                },
+                AuditedPackageAction.Create,
+                reason: "c");
+
+            Assert.Equal("b", record.Id);
+            Assert.Equal("1.0.0", record.Version);
+            Assert.Equal("a", record.Hash);
+            Assert.NotNull(record.PackageRecord);
+            Assert.Equal("a", record.PackageRecord.Hash);
+            Assert.Equal("1.0.0", record.PackageRecord.Version);
+            Assert.NotNull(record.RegistrationRecord);
+            Assert.Equal("b", record.RegistrationRecord.Id);
+            Assert.Equal("c", record.Reason);
+            Assert.Equal(AuditedPackageAction.Create, record.Action);
+        }
+
+        [Fact]
+        public void GetPath_ReturnsNormalizedPackageIdAndVersion()
+        {
+            var record = new PackageAuditRecord(
+                new Package()
+                {
+                    Hash = "a",
+                    PackageRegistration = new PackageRegistration() { Id = "B" },
+                    Version = "1.0.0+c"
+                },
+                AuditedPackageAction.Create,
+                reason: "d");
+
+            var actualResult = record.GetPath();
+
+            Assert.Equal("b/1.0.0", actualResult);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/PackageRegistrationAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/PackageRegistrationAuditRecordTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class PackageRegistrationAuditRecordTests
+    {
+        [Fact]
+        public void Constructor_SetsProperties()
+        {
+            var record = new PackageRegistrationAuditRecord(
+                new PackageRegistration() { Id = "a" },
+                AuditedPackageRegistrationAction.AddOwner,
+                owner: "b");
+
+            Assert.Equal("a", record.Id);
+            Assert.NotNull(record.RegistrationRecord);
+            Assert.Equal("a", record.RegistrationRecord.Id);
+            Assert.Equal("b", record.Owner);
+            Assert.Equal(AuditedPackageRegistrationAction.AddOwner, record.Action);
+        }
+
+        [Fact]
+        public void GetPath_ReturnsLowerCasedId()
+        {
+            var record = new PackageRegistrationAuditRecord(
+                new PackageRegistration() { Id = "A" },
+                AuditedPackageRegistrationAction.AddOwner,
+                owner: "b");
+
+            var actualPath = record.GetPath();
+
+            Assert.Equal("a", actualPath);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/ScopeAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/ScopeAuditRecordTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class ScopeAuditRecordTests
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("a", "b")]
+        public void Constructor_SetsProperties(string subject, string allowedAction)
+        {
+            var entry = new ScopeAuditRecord(subject, allowedAction);
+
+            Assert.Equal(subject, entry.Subject);
+            Assert.Equal(allowedAction, entry.AllowedAction);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/UserAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/UserAuditRecordTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class UserAuditRecordTests
+    {
+        [Fact]
+        public void Constructor_WithoutAffected_ThrowsForNullUser()
+        {
+            Assert.Throws<ArgumentNullException>(() => new UserAuditRecord(user: null, action: AuditedUserAction.Login));
+        }
+
+        [Fact]
+        public void Constructor_WithAffected_SetsProperties()
+        {
+            var user = new User()
+            {
+                Username = "a",
+                EmailAddress = "b",
+                UnconfirmedEmailAddress = "c",
+                Roles = new List<Role>() { new Role() { Name = "d" } },
+                Credentials = new List<Credential>()
+                {
+                    new Credential(type: CredentialTypes.Password.V3, value: "e"),
+                    new Credential(type: "f", value: "g")
+                }
+            };
+
+            var record = new UserAuditRecord(user, AuditedUserAction.Login, new Credential(type: "h", value: "i"));
+
+            Assert.Equal("a", record.Username);
+            Assert.Equal("b", record.EmailAddress);
+            Assert.Equal("c", record.UnconfirmedEmailAddress);
+            Assert.Equal(1, record.Roles.Length);
+            Assert.Equal("d", record.Roles[0]);
+            Assert.Equal(1, record.Credentials.Length);
+            Assert.Equal(CredentialTypes.Password.V3, record.Credentials[0].Type);
+            Assert.Null(record.Credentials[0].Value);
+            Assert.Equal(1, record.AffectedCredential.Length);
+            Assert.Equal("h", record.AffectedCredential[0].Type);
+            Assert.Null(record.AffectedCredential[0].Value);
+        }
+
+        [Fact]
+        public void GetPath_ReturnsLowerCasedUserName()
+        {
+            var user = new User()
+            {
+                Username = "A",
+                Roles = new List<Role>(),
+                Credentials = new List<Credential>()
+            };
+
+            var record = new UserAuditRecord(user, AuditedUserAction.Login);
+            var actualPath = record.GetPath();
+
+            Assert.Equal("a", actualPath);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -40,6 +40,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\entityframework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
@@ -75,6 +78,12 @@
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=2.1.0.3, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\WindowsAzure.Storage.2.1.0.3\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Moq, Version=4.7.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.7.0\lib\net45\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Common, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Common.3.5.0-rc1-final\lib\net45\NuGet.Common.dll</HintPath>
@@ -139,6 +148,21 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Auditing\AuditActorTests.cs" />
+    <Compile Include="Auditing\AuditedAuthenticatedOperationActionTests.cs" />
+    <Compile Include="Auditing\AuditedPackageActionTests.cs" />
+    <Compile Include="Auditing\AuditedPackageRegistrationActionTests.cs" />
+    <Compile Include="Auditing\AuditedUserActionTests.cs" />
+    <Compile Include="Auditing\AuditEntryTests.cs" />
+    <Compile Include="Auditing\AuditingServiceTests.cs" />
+    <Compile Include="Auditing\CredentialAuditRecordTests.cs" />
+    <Compile Include="Auditing\EnumTests.cs" />
+    <Compile Include="Auditing\FailedAuthenticatedOperationAuditRecordTests.cs" />
+    <Compile Include="Auditing\FileSystemAuditingServiceTests.cs" />
+    <Compile Include="Auditing\PackageAuditRecordTests.cs" />
+    <Compile Include="Auditing\PackageRegistrationAuditRecordTests.cs" />
+    <Compile Include="Auditing\ScopeAuditRecordTests.cs" />
+    <Compile Include="Auditing\UserAuditRecordTests.cs" />
     <Compile Include="Entities\PackageFacts.cs" />
     <Compile Include="Entities\UserFacts.cs" />
     <Compile Include="Packaging\ManifestValidatorFacts.cs" />
@@ -146,6 +170,7 @@
     <Compile Include="Packaging\PackageMetadataFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Packaging\NupkgRewriterFacts.cs" />
+    <Compile Include="Utilities\TestDirectory.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NuGetGallery.Core\NuGetGallery.Core.csproj">

--- a/tests/NuGetGallery.Core.Facts/Utilities/TestDirectory.cs
+++ b/tests/NuGetGallery.Core.Facts/Utilities/TestDirectory.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace NuGetGallery.Utilities
+{
+    internal sealed class TestDirectory : IDisposable
+    {
+        public string FullPath { get; }
+
+        private TestDirectory(string fullPath)
+        {
+            FullPath = fullPath;
+        }
+
+        public void Dispose()
+        {
+            DeleteDirectory(FullPath);
+        }
+
+        internal static TestDirectory Create()
+        {
+            var baseDirectoryPath = Path.Combine(Path.GetTempPath(), "NuGetTestFolder");
+            var subdirectoryName = Guid.NewGuid().ToString();
+            var fullPath = Path.Combine(baseDirectoryPath, subdirectoryName);
+
+            Directory.CreateDirectory(fullPath);
+
+            return new TestDirectory(fullPath);
+        }
+
+        public static implicit operator string(TestDirectory directory)
+        {
+            return directory.FullPath;
+        }
+
+        public override string ToString()
+        {
+            return FullPath;
+        }
+
+        private static void DeleteDirectory(string path)
+        {
+            if (Directory.Exists(path))
+            {
+                try
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/app.config
+++ b/tests/NuGetGallery.Core.Facts/app.config
@@ -23,7 +23,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/tests/NuGetGallery.Core.Facts/packages.config
+++ b/tests/NuGetGallery.Core.Facts/packages.config
@@ -1,11 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="4.0.0" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.6.5-beta" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.6.5-beta" targetFramework="net452" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net452" />
+  <package id="Moq" version="4.7.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Common" version="3.5.0-rc1-final" targetFramework="net452" />
   <package id="NuGet.Frameworks" version="3.5.0-rc1-final" targetFramework="net452" />
   <package id="NuGet.Logging" version="3.5.0-beta-1160" targetFramework="net452" />

--- a/tests/NuGetGallery.Facts/Framework/TestAuditingService.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestAuditingService.cs
@@ -15,13 +15,13 @@ namespace NuGetGallery.Framework
 
         public IReadOnlyList<AuditRecord> Records { get { return _records.AsReadOnly(); } }
 
-        public override Task<Uri> SaveAuditRecord(AuditRecord record)
+        public override Task<Uri> SaveAuditRecordAsync(AuditRecord record)
         {
             _records.Add(record);
             return Task.FromResult(new Uri("http://nuget.local/auditing/test"));
         }
 
-        protected override Task<Uri> SaveAuditRecord(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
+        protected override Task<Uri> SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
         {
             // Not necessary since we override the only caller of this protected method
             throw new NotImplementedException();

--- a/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
@@ -227,7 +227,7 @@ namespace NuGetGallery
                 var testService = service as TestPackageDeleteService;
                 Assert.Equal(package.PackageRegistration.Id, testService.LastAuditRecord.Id);
                 Assert.Equal(package.Version, testService.LastAuditRecord.Version);
-                auditingService.Verify(x => x.SaveAuditRecord(testService.LastAuditRecord));
+                auditingService.Verify(x => x.SaveAuditRecordAsync(testService.LastAuditRecord));
             }
         }
 
@@ -405,7 +405,7 @@ namespace NuGetGallery
                 var testService = service as TestPackageDeleteService;
                 Assert.Equal(package.PackageRegistration.Id, testService.LastAuditRecord.Id);
                 Assert.Equal(package.Version, testService.LastAuditRecord.Version);
-                auditingService.Verify(x => x.SaveAuditRecord(testService.LastAuditRecord));
+                auditingService.Verify(x => x.SaveAuditRecordAsync(testService.LastAuditRecord));
             }
         }
     }


### PR DESCRIPTION
- Fix #3594
- Add a bunch of unit tests to an area that had none, partly to improve test coverage and partly to ensure that the `AuditingService` contracts do not change unexpectedly.
- Rename a few async methods with -`Async` postfix.