### PR TITLE
Enable runtime discovery/loading of optional AuditingService implementations

### DIFF
--- a/src/NuGetGallery.Core/Auditing/AggregateAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/AggregateAuditingService.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGetGallery.Auditing
+{
+    /// <summary>
+    /// An auditing service that aggregates multiple auditing services.
+    /// </summary>
+    public sealed class AggregateAuditingService : IAuditingService
+    {
+        private readonly IAuditingService[] _services;
+
+        /// <summary>
+        /// Instantiates a new instance.
+        /// </summary>
+        /// <param name="services">An enumerable of <see cref="IAuditingService" /> instances.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <see cref="services" /> is <c>null</c>.</exception>
+        public AggregateAuditingService(IEnumerable<IAuditingService> services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            _services = services.ToArray();
+        }
+
+        /// <summary>
+        /// Persists the audit record to storage.
+        /// </summary>
+        /// <param name="record">An audit record.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous save operation.</returns> 
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="record" /> is <c>null</c>.</exception>
+        public async Task SaveAuditRecordAsync(AuditRecord record)
+        {
+            if (record == null)
+            {
+                throw new ArgumentNullException(nameof(record));
+            }
+
+            var tasks = _services.Select(service => service.SaveAuditRecordAsync(record))
+                                 .ToArray();
+
+            await Task.WhenAll(tasks);
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Auditing/AuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditingService.cs
@@ -11,7 +11,7 @@ namespace NuGetGallery.Auditing
     /// <summary>
     /// Base class for auditing services.
     /// </summary>
-    public abstract class AuditingService
+    public abstract class AuditingService : IAuditingService
     {
         /// <summary>
         /// An auditing service instance with no backing store.
@@ -41,10 +41,9 @@ namespace NuGetGallery.Auditing
         /// Persists the audit record to storage.
         /// </summary>
         /// <param name="record">An audit record.</param>
-        /// <returns>A task that represents the asynchronous save operation.
-        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="System.Uri"/>.</returns>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous save operation.</returns> 
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="record" /> is <c>null</c>.</exception>
-        public virtual async Task<Uri> SaveAuditRecordAsync(AuditRecord record)
+        public async Task SaveAuditRecordAsync(AuditRecord record)
         {
             if (record == null)
             {
@@ -54,7 +53,7 @@ namespace NuGetGallery.Auditing
             var entry = new AuditEntry(record, await GetActorAsync());
             var rendered = RenderAuditEntry(entry);
 
-            return await SaveAuditRecordAsync(rendered, record.GetResourceType(), record.GetPath(), record.GetAction(), entry.Actor.TimestampUtc);
+            await SaveAuditRecordAsync(rendered, record.GetResourceType(), record.GetPath(), record.GetAction(), entry.Actor.TimestampUtc);
         }
 
         /// <summary>
@@ -81,8 +80,8 @@ namespace NuGetGallery.Auditing
         /// <param name="filePath">The file-system path to use to identify the audit record</param>
         /// <param name="action">The action recorded in this audit record</param>
         /// <param name="timestamp">A timestamp indicating when the record was created</param>
-        /// <returns>The URI identifying the audit record resource</returns>
-        protected abstract Task<Uri> SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp);
+        /// <returns>A <see cref="Task"/> that represents the asynchronous save operation.</returns> 
+        protected abstract Task SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp);
 
         protected virtual Task<AuditActor> GetActorAsync()
         {
@@ -91,12 +90,9 @@ namespace NuGetGallery.Auditing
 
         private class NullAuditingService : AuditingService
         {
-            protected override Task<Uri> SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
+            protected override Task SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
             {
-                var uriString = $"http://auditing.local/{resourceType}/{filePath}/{timestamp:s}-{action.ToLowerInvariant()}";
-                var uri = new Uri(uriString);
-
-                return Task.FromResult(uri);
+                return Task.FromResult(0);
             }
         }
     }

--- a/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
@@ -47,7 +47,7 @@ namespace NuGetGallery.Auditing
             return await AuditActor.GetCurrentMachineActorAsync(onBehalfOf);
         }
 
-        protected override async Task<Uri> SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
+        protected override async Task SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
         {
             string fullPath =
                 $"{resourceType.ToLowerInvariant()}/" +
@@ -82,8 +82,6 @@ namespace NuGetGallery.Auditing
                     null);
                 await WriteBlob(auditData, fullPath, blob);
             }
-
-            return blob.Uri;
         }
 
         private static CloudBlobContainer GetContainer(string storageConnectionString)

--- a/src/NuGetGallery.Core/Auditing/FileSystemAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/FileSystemAuditingService.cs
@@ -45,7 +45,7 @@ namespace NuGetGallery.Auditing
             return await AuditActor.GetCurrentMachineActorAsync(onBehalfOf);
         }
 
-        protected override Task<Uri> SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
+        protected override Task SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
         {
             // Build relative file path
             var relativeFilePath =
@@ -66,10 +66,7 @@ namespace NuGetGallery.Auditing
             // Write the data
             File.WriteAllText(fullFilePath, auditData);
 
-            // Generate a local URL
-            var uri = new Uri($"https://auditing.local/{relativeFilePath.Replace(Path.DirectorySeparatorChar, '/')}");
-
-            return Task.FromResult(uri);
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/NuGetGallery.Core/Auditing/IAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/IAuditingService.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGetGallery.Auditing
+{
+    /// <summary>
+    /// Base interface for an auditing service.
+    /// </summary>
+    public interface IAuditingService
+    {
+        /// <summary>
+        /// Persists the audit record to storage.
+        /// </summary>
+        /// <param name="record">An audit record.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous save operation.</returns> 
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="record" /> is <c>null</c>.</exception>
+        Task SaveAuditRecordAsync(AuditRecord record);
+    }
+}

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -123,6 +123,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Auditing\AggregateAuditingService.cs" />
     <Compile Include="Auditing\AuditedEntities\AuditedPackage.cs" />
     <Compile Include="Auditing\AuditedEntities\AuditedPackageIdentifier.cs" />
     <Compile Include="Auditing\AuditedAuthenticatedOperationAction.cs" />
@@ -135,6 +136,7 @@
     <Compile Include="Auditing\CloudAuditingService.cs" />
     <Compile Include="Auditing\CredentialAuditRecord.cs" />
     <Compile Include="Auditing\AuditedPackageAction.cs" />
+    <Compile Include="Auditing\IAuditingService.cs" />
     <Compile Include="Auditing\PackageCreatedVia.cs" />
     <Compile Include="Auditing\AuditedPackageRegistrationAction.cs" />
     <Compile Include="Auditing\AuditedEntities\AuditedPackageRegistration.cs" />

--- a/src/NuGetGallery/App_Start/RuntimeServiceProvider.cs
+++ b/src/NuGetGallery/App_Start/RuntimeServiceProvider.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition.Hosting;
+using System.IO;
+using System.Linq;
+
+namespace NuGetGallery
+{
+    internal sealed class RuntimeServiceProvider : IDisposable
+    {
+        private readonly CompositionContainer _compositionContainer;
+        private bool _isDisposed;
+
+        private RuntimeServiceProvider(CompositionContainer compositionContainer)
+        {
+            _compositionContainer = compositionContainer;
+        }
+
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+                _compositionContainer.Dispose();
+
+                _isDisposed = true;
+            }
+        }
+
+        internal static RuntimeServiceProvider Create(string baseDirectoryPath)
+        {
+            if (string.IsNullOrEmpty(baseDirectoryPath))
+            {
+                throw new ArgumentException(Strings.ParameterCannotBeNullOrEmpty, nameof(baseDirectoryPath));
+            }
+
+            var compositionContainer = CreateCompositionContainer(baseDirectoryPath);
+
+            return new RuntimeServiceProvider(compositionContainer);
+        }
+
+        internal IEnumerable<T> GetExportedValues<T>()
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(RuntimeServiceProvider));
+            }
+
+            return _compositionContainer.GetExportedValues<T>();
+        }
+
+        // Runtime loadable services are only allowed from subdirectories of the base directory path.
+        private static CompositionContainer CreateCompositionContainer(string baseDirectoryPath)
+        {
+            if (!Directory.Exists(baseDirectoryPath))
+            {
+                return new CompositionContainer();
+            }
+
+            var subdirectoryPaths = Directory.GetDirectories(baseDirectoryPath);
+
+            if (!subdirectoryPaths.Any())
+            {
+                return new CompositionContainer();
+            }
+
+            var catalog = new AggregateCatalog();
+
+            foreach (var subdirectoryPath in subdirectoryPaths)
+            {
+                catalog.Catalogs.Add(new DirectoryCatalog(subdirectoryPath));
+            }
+
+            return new CompositionContainer(catalog);
+        }
+    }
+}

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -41,7 +41,7 @@ namespace NuGetGallery.Authentication
 
         public AuthenticationService(
             IEntitiesContext entities, IAppConfiguration config, IDiagnosticsService diagnostics,
-            AuditingService auditing, IEnumerable<Authenticator> providers, ICredentialBuilder credentialBuilder,
+            IAuditingService auditing, IEnumerable<Authenticator> providers, ICredentialBuilder credentialBuilder,
             ICredentialValidator credentialValidator, IDateTimeProvider dateTimeProvider)
         {
             if (entities == null)
@@ -98,7 +98,7 @@ namespace NuGetGallery.Authentication
 
         public IEntitiesContext Entities { get; private set; }
         public IDictionary<string, Authenticator> Authenticators { get; private set; }
-        public AuditingService Auditing { get; private set; }
+        public IAuditingService Auditing { get; private set; }
 
         private void InitCredentialFormatters()
         {

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -41,12 +41,12 @@ namespace NuGetGallery
         public IAutomaticallyCuratePackageCommand AutoCuratePackage { get; set; }
         public IStatusService StatusService { get; set; }
         public IMessageService MessageService { get; set; }
-        public AuditingService AuditingService { get; set; }
+        public IAuditingService AuditingService { get; set; }
         public IGalleryConfigurationService ConfigurationService { get; set; }
 
         protected ApiController()
         {
-            AuditingService = AuditingService.None;
+            AuditingService = NuGetGallery.Auditing.AuditingService.None;
         }
 
         public ApiController(
@@ -61,7 +61,7 @@ namespace NuGetGallery
             IAutomaticallyCuratePackageCommand autoCuratePackage,
             IStatusService statusService,
             IMessageService messageService,
-            AuditingService auditingService,
+            IAuditingService auditingService,
             IGalleryConfigurationService configurationService)
         {
             EntitiesContext = entitiesContext;
@@ -93,7 +93,7 @@ namespace NuGetGallery
             IStatusService statusService,
             IStatisticsService statisticsService,
             IMessageService messageService,
-            AuditingService auditingService,
+            IAuditingService auditingService,
             IGalleryConfigurationService configurationService)
             : this(entitiesContext, packageService, packageFileService, userService, nugetExeDownloaderService, contentService, indexingService, searchService, autoCuratePackage, statusService, messageService, auditingService, configurationService)
         {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -51,7 +51,7 @@ namespace NuGetGallery
         private readonly EditPackageService _editPackageService;
         private readonly IPackageDeleteService _packageDeleteService;
         private readonly ISupportRequestService _supportRequestService;
-        private readonly AuditingService _auditingService;
+        private readonly IAuditingService _auditingService;
 
         public PackagesController(
             IPackageService packageService,
@@ -67,7 +67,7 @@ namespace NuGetGallery
             EditPackageService editPackageService,
             IPackageDeleteService packageDeleteService,
             ISupportRequestService supportRequestService,
-            AuditingService auditingService)
+            IAuditingService auditingService)
         {
             _packageService = packageService;
             _uploadFileService = uploadFileService;

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -497,6 +497,7 @@
       <HintPath>..\..\packages\RouteMagic.1.1.3\lib\net40\RouteMagic.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.IdentityModel" />
@@ -651,6 +652,7 @@
     <Compile Include="App_Start\NuGetODataV2FeedConfig.cs" />
     <Compile Include="App_Start\NuGetODataV1FeedConfig.cs" />
     <Compile Include="App_Start\NuGetODataConfig.cs" />
+    <Compile Include="App_Start\RuntimeServiceProvider.cs" />
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="App_Start\AutofacConfig.cs" />
     <Compile Include="Areas\Admin\Controllers\DeleteController.cs" />

--- a/src/NuGetGallery/Properties/AssemblyInfo.cs
+++ b/src/NuGetGallery/Properties/AssemblyInfo.cs
@@ -16,6 +16,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
+[assembly: InternalsVisibleTo("NuGetGallery.Facts")]
+
 #if !PORTABLE
 [assembly: ComVisible(false)]
 #endif

--- a/src/NuGetGallery/Services/PackageDeleteService.cs
+++ b/src/NuGetGallery/Services/PackageDeleteService.cs
@@ -34,7 +34,7 @@ namespace NuGetGallery
         private readonly IPackageService _packageService;
         private readonly IIndexingService _indexingService;
         private readonly IPackageFileService _packageFileService;
-        private readonly AuditingService _auditingService;
+        private readonly IAuditingService _auditingService;
 
         public PackageDeleteService(
             IEntityRepository<Package> packageRepository,
@@ -43,7 +43,7 @@ namespace NuGetGallery
             IPackageService packageService,
             IIndexingService indexingService,
             IPackageFileService packageFileService,
-            AuditingService auditingService)
+            IAuditingService auditingService)
         {
             _packageRepository = packageRepository;
             _packageDeletesRepository = packageDeletesRepository;

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -29,7 +29,7 @@ namespace NuGetGallery
         private readonly IEntityRepository<PackageRegistration> _packageRegistrationRepository;
         private readonly IEntityRepository<Package> _packageRepository;
         private readonly IPackageNamingConflictValidator _packageNamingConflictValidator;
-        private readonly AuditingService _auditingService;
+        private readonly IAuditingService _auditingService;
         private readonly IDiagnosticsSource _trace;
 
         public PackageService(
@@ -40,7 +40,7 @@ namespace NuGetGallery
             IDiagnosticsService diagnostics,
             IIndexingService indexingService,
             IPackageNamingConflictValidator packageNamingConflictValidator,
-            AuditingService auditingService)
+            IAuditingService auditingService)
         {
             if (packageRegistrationRepository == null)
             {

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -18,7 +18,7 @@ namespace NuGetGallery
         public IAppConfiguration Config { get; protected set; }
         public IEntityRepository<User> UserRepository { get; protected set; }
         public IEntityRepository<Credential> CredentialRepository { get; protected set; }
-        public AuditingService Auditing { get; protected set; }
+        public IAuditingService Auditing { get; protected set; }
 
         protected UserService() { }
 
@@ -26,7 +26,7 @@ namespace NuGetGallery
             IAppConfiguration config,
             IEntityRepository<User> userRepository,
             IEntityRepository<Credential> credentialRepository,
-            AuditingService auditing)
+            IAuditingService auditing)
             : this()
         {
             Config = config;

--- a/tests/NuGetGallery.Core.Facts/Auditing/AggregateAuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AggregateAuditingServiceTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGetGallery.Auditing
+{
+    public class AggregateAuditingServiceTests
+    {
+        [Fact]
+        public void Constructor_ThrowsForNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AggregateAuditingService(services: null));
+        }
+
+        [Fact]
+        public async Task SaveAuditRecordAsync_ThrowsForNull()
+        {
+            var services = Enumerable.Empty<IAuditingService>();
+            var aggregatedService = new AggregateAuditingService(services);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => aggregatedService.SaveAuditRecordAsync(record: null));
+        }
+
+        [Fact]
+        public async Task SaveAuditRecordAsync_AwaitsAllServices()
+        {
+            var services = CreateTestAuditingServices();
+            var auditRecord = CreateAuditRecord();
+            var aggregatedService = new AggregateAuditingService(services);
+
+            await aggregatedService.SaveAuditRecordAsync(auditRecord);
+
+            foreach (var service in services)
+            {
+                Assert.True(service.Awaited);
+            }
+        }
+
+        private static AuditRecord CreateAuditRecord()
+        {
+            var packageRegistration = new PackageRegistration()
+            {
+                DownloadCount = 1,
+                Id = "a",
+                Key = 2
+            };
+
+            return new PackageRegistrationAuditRecord(packageRegistration, AuditedPackageRegistrationAction.AddOwner, owner: "b");
+        }
+
+        private static IEnumerable<TestAuditingService> CreateTestAuditingServices()
+        {
+            var services = new List<TestAuditingService>();
+
+            for (var i = 0; i < 10; ++i)
+            {
+                services.Add(new TestAuditingService());
+            }
+
+            return services;
+        }
+
+        private class TestAuditingService : AuditingService
+        {
+            internal bool Awaited { get; private set; }
+
+            protected override Task SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
+            {
+                Awaited = true;
+
+                return Task.FromResult(0);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditingServiceTests.cs
@@ -316,7 +316,7 @@ namespace NuGetGallery.Auditing
                 _saveDelegate = saveDelegate;
             }
 
-            protected override Task<Uri> SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
+            protected override Task SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
             {
                 return _saveDelegate(auditData, resourceType, filePath, action, timestamp);
             }

--- a/tests/NuGetGallery.Core.Facts/Auditing/FileSystemAuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/FileSystemAuditingServiceTests.cs
@@ -59,15 +59,13 @@ namespace NuGetGallery.Auditing
                     },
                     AuditedPackageAction.Create);
 
-                var uri = await service.SaveAuditRecordAsync(record);
-
-                Assert.True(Regex.IsMatch(uri.AbsoluteUri, "^https://auditing.local/package/b/1.0.0/[0-9a-f]{32}-create.audit.v1.json$"));
+                await service.SaveAuditRecordAsync(record);
 
                 var files = Directory.GetFiles(testDirectory.FullPath, "*", SearchOption.AllDirectories);
                 var actualFilePath = files.Single();
-                var expectedFilePath = Path.Combine(testDirectory.FullPath, uri.AbsolutePath.Replace('/', '\\').TrimStart('\\'));
+                var expectedFilePathPattern = new Regex(@"package\\b\\1.0.0\\[0-9a-f]{32}-create.audit.v1.json$");
 
-                Assert.Equal(expectedFilePath, actualFilePath);
+                Assert.True(expectedFilePathPattern.IsMatch(actualFilePath));
             }
         }
 

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -148,6 +148,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Auditing\AggregateAuditingServiceTests.cs" />
     <Compile Include="Auditing\AuditActorTests.cs" />
     <Compile Include="Auditing\AuditedAuthenticatedOperationActionTests.cs" />
     <Compile Include="Auditing\AuditedPackageActionTests.cs" />

--- a/tests/NuGetGallery.Facts/App_Start/RuntimeServiceProviderTests.cs
+++ b/tests/NuGetGallery.Facts/App_Start/RuntimeServiceProviderTests.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace NuGetGallery.App_Start
+{
+    public class RuntimeServiceProviderTests
+    {
+        private readonly string _baseDirectoryPath;
+
+        public RuntimeServiceProviderTests()
+        {
+            var thisAssemblyDirectoryPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            _baseDirectoryPath = Path.GetDirectoryName(thisAssemblyDirectoryPath);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Create_ThrowsForNullOrEmptyString(string baseDirectoryPath)
+        {
+            Assert.Throws<ArgumentException>(() => RuntimeServiceProvider.Create(baseDirectoryPath));
+        }
+
+        [Fact]
+        public void Create_HandlesNonexistentDirectoryPath()
+        {
+            var baseDirectoryPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            var serviceProvider = RuntimeServiceProvider.Create(baseDirectoryPath);
+
+            Assert.NotNull(serviceProvider);
+        }
+
+        [Fact]
+        public void Dispose_IsIdempotent()
+        {
+            var serviceProvider = RuntimeServiceProvider.Create(_baseDirectoryPath);
+
+            serviceProvider.Dispose();
+            serviceProvider.Dispose();
+        }
+
+        [Fact]
+        public void GetExportedValues_ThrowsIfDisposed()
+        {
+            var serviceProvider = RuntimeServiceProvider.Create(_baseDirectoryPath);
+
+            serviceProvider.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => serviceProvider.GetExportedValues<ExportedType>());
+        }
+
+        [Fact]
+        public void GetExportedValues_ReturnsInstanceForExportedType()
+        {
+            using (var serviceProvider = RuntimeServiceProvider.Create(_baseDirectoryPath))
+            {
+                var services = serviceProvider.GetExportedValues<ExportedType>();
+
+                Assert.NotNull(services);
+                Assert.Single(services);
+            }
+        }
+
+        [Fact]
+        public void GetExportedValues_ReturnsEmptyEnumerableForNonExportedType()
+        {
+            using (var serviceProvider = RuntimeServiceProvider.Create(_baseDirectoryPath))
+            {
+                var services = serviceProvider.GetExportedValues<NonExportedType>();
+
+                Assert.NotNull(services);
+                Assert.Empty(services);
+            }
+        }
+
+        [Export]
+        [PartCreationPolicy(CreationPolicy.NonShared)]
+        private class ExportedType
+        {
+        }
+
+        private class NonExportedType
+        {
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -44,7 +44,7 @@ namespace NuGetGallery
             Mock<ICacheService> cacheService = null,
             Mock<IPackageDeleteService> packageDeleteService = null,
             Mock<ISupportRequestService> supportRequestService = null,
-            AuditingService auditingService = null)
+            IAuditingService auditingService = null)
         {
             packageService = packageService ?? new Mock<IPackageService>();
             if (uploadFileService == null)

--- a/tests/NuGetGallery.Facts/Framework/TestAuditingService.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestAuditingService.cs
@@ -9,28 +9,22 @@ using NuGetGallery.Auditing;
 
 namespace NuGetGallery.Framework
 {
-    public class TestAuditingService : AuditingService
+    public class TestAuditingService : IAuditingService
     {
         private List<AuditRecord> _records = new List<AuditRecord>();
 
         public IReadOnlyList<AuditRecord> Records { get { return _records.AsReadOnly(); } }
 
-        public override Task<Uri> SaveAuditRecordAsync(AuditRecord record)
+        public Task SaveAuditRecordAsync(AuditRecord record)
         {
             _records.Add(record);
-            return Task.FromResult(new Uri("http://nuget.local/auditing/test"));
-        }
-
-        protected override Task<Uri> SaveAuditRecordAsync(string auditData, string resourceType, string filePath, string action, DateTime timestamp)
-        {
-            // Not necessary since we override the only caller of this protected method
-            throw new NotImplementedException();
+            return Task.FromResult(0);
         }
     }
 
     public static class AuditingServiceTestExtensions
     {
-        public static bool WroteRecord<T>(this AuditingService self, Func<T, bool> predicate) where T : AuditRecord
+        public static bool WroteRecord<T>(this IAuditingService self, Func<T, bool> predicate) where T : AuditRecord
         {
             TestAuditingService testService = self as TestAuditingService;
             if (testService != null)
@@ -40,7 +34,7 @@ namespace NuGetGallery.Framework
             return false;
         }
 
-        public static bool WroteRecordOfType<T>(this AuditingService self) where T : AuditRecord
+        public static bool WroteRecordOfType<T>(this IAuditingService self) where T : AuditRecord
         {
             return WroteRecord<T>(self, _ => true);
         }

--- a/tests/NuGetGallery.Facts/Framework/UnitTestBindings.cs
+++ b/tests/NuGetGallery.Facts/Framework/UnitTestBindings.cs
@@ -43,7 +43,7 @@ namespace NuGetGallery.Framework
                 .SingleInstance();
 
             builder.RegisterType<TestAuditingService>()
-                .As<AuditingService>();
+                .As<IAuditingService>();
 
             builder.Register(_ =>
             {

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -383,6 +383,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppConfigIsCorrectlyApplied.cs" />
+    <Compile Include="App_Start\RuntimeServiceProviderTests.cs" />
     <Compile Include="Authentication\AuthenticatorFacts.cs" />
     <Compile Include="Authentication\Providers\ApiKey\ApiKeyAuthenticationHandlerFacts.cs" />
     <Compile Include="Authentication\AuthenticationServiceFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
@@ -23,7 +23,7 @@ namespace NuGetGallery
             Mock<IPackageService> packageService = null,
             Mock<IIndexingService> indexingService = null,
             Mock<IPackageFileService> packageFileService = null,
-            Mock<AuditingService> auditingService = null,
+            Mock<IAuditingService> auditingService = null,
             Action<Mock<TestPackageDeleteService>> setup = null)
         {
             packageRepository = packageRepository ?? new Mock<IEntityRepository<Package>>();
@@ -37,7 +37,7 @@ namespace NuGetGallery
             indexingService = indexingService ?? new Mock<IIndexingService>();
             packageFileService = packageFileService ?? new Mock<IPackageFileService>();
 
-            auditingService = auditingService ?? new Mock<AuditingService>();
+            auditingService = auditingService ?? new Mock<IAuditingService>();
 
             var packageDeleteService = new Mock<TestPackageDeleteService>(
                 packageRepository.Object,
@@ -63,7 +63,7 @@ namespace NuGetGallery
         {
             public PackageAuditRecord LastAuditRecord { get; set; }
 
-            public TestPackageDeleteService(IEntityRepository<Package> packageRepository, IEntityRepository<PackageDelete> packageDeletesRepository, IEntitiesContext entitiesContext, IPackageService packageService, IIndexingService indexingService, IPackageFileService packageFileService, AuditingService auditingService)
+            public TestPackageDeleteService(IEntityRepository<Package> packageRepository, IEntityRepository<PackageDelete> packageDeletesRepository, IEntitiesContext entitiesContext, IPackageService packageService, IIndexingService indexingService, IPackageFileService packageFileService, IAuditingService auditingService)
                 : base(packageRepository, packageDeletesRepository, entitiesContext, packageService, indexingService, packageFileService, auditingService)
             {
             }
@@ -213,7 +213,7 @@ namespace NuGetGallery
             [Fact]
             public async Task WillCreateAuditRecordUsingAuditService()
             {
-                var auditingService = new Mock<AuditingService>();
+                var auditingService = new Mock<IAuditingService>();
                 var service = CreateService(auditingService: auditingService);
                 var packageRegistration = new PackageRegistration();
                 var package = new Package { PackageRegistration = packageRegistration, Version = "1.0.0", Hash = _packageHashForTests };
@@ -391,7 +391,7 @@ namespace NuGetGallery
             [Fact]
             public async Task WillCreateAuditRecordUsingAuditService()
             {
-                var auditingService = new Mock<AuditingService>();
+                var auditingService = new Mock<IAuditingService>();
                 var service = CreateService(auditingService: auditingService);
                 var packageRegistration = new PackageRegistration();
                 var package = new Package { Key = 123, PackageRegistration = packageRegistration, Version = "1.0.0", Hash = _packageHashForTests };

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -103,7 +103,7 @@ namespace NuGetGallery
             Mock<IDiagnosticsService> diagnosticsService = null,
             Mock<IIndexingService> indexingService = null,
             IPackageNamingConflictValidator packageNamingConflictValidator = null,
-            AuditingService auditingService = null,
+            IAuditingService auditingService = null,
             Action<Mock<PackageService>> setup = null)
         {
             return CreateServiceMock(
@@ -126,7 +126,7 @@ namespace NuGetGallery
             Mock<IDiagnosticsService> diagnosticsService = null,
             Mock<IIndexingService> indexingService = null,
             IPackageNamingConflictValidator packageNamingConflictValidator = null,
-            AuditingService auditingService = null,
+            IAuditingService auditingService = null,
             Action<Mock<PackageService>> setup = null)
         {
             packageRegistrationRepository = packageRegistrationRepository ?? new Mock<IEntityRepository<PackageRegistration>>();


### PR DESCRIPTION
Internally we (nuget.org) have to log audit data to an additional service.  Without polluting NuGetGallery code with implementation details of this internal auditing service, this change enables the NuGetGallery to discover new `AuditingService` implementations and add them to an `AggregateAuditingService` instance.