### PR TITLE
Remove VSTest from functional tests

### DIFF
--- a/tests/Scripts/RunEverything.cmd
+++ b/tests/Scripts/RunEverything.cmd
@@ -14,7 +14,6 @@ set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
-set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist functionaltests.*.xml (

--- a/tests/Scripts/RunEverything.cmd
+++ b/tests/Scripts/RunEverything.cmd
@@ -20,8 +20,8 @@ REM Clean previous test results
 if exist functionaltests.*.xml (
     del functionaltests.*.xml
 )
-if exist resultsfile.trx (
-    del resultsfile.trx
+if exist resultsfile.*.trx (
+    del resultsfile.*.trx
 )
 if exist TestResults (
     rd TestResults /S /Q
@@ -50,19 +50,19 @@ call %xunit% "%fluentTestDir%\NuGetGallery.FunctionalTests.Fluent.dll" -xml func
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.web1.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.web2.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.web3.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
-call %vstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
+call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /category:%testCategory% /resultsfile:resultsfile.load.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 goto end

--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -14,7 +14,6 @@ set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
-set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist functionaltests.*.xml (

--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -20,8 +20,8 @@ REM Clean previous test results
 if exist functionaltests.*.xml (
     del functionaltests.*.xml
 )
-if exist resultsfile.trx (
-    del resultsfile.trx
+if exist resultsfile.*.trx (
+    del resultsfile.*.trx
 )
 if exist TestResults (
     rd TestResults /S /Q
@@ -45,11 +45,11 @@ call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%test
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P0\bin\%config%\NuGetGallery.WebUITests.P0.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.web.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
-call %vstest% "NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
+call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /category:%testCategory% /resultsfile:resultsfile.load.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 exit /B %exitCode%

--- a/tests/Scripts/RunP1Tests.bat
+++ b/tests/Scripts/RunP1Tests.bat
@@ -14,7 +14,6 @@ set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
-set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist functionaltests.*.xml (

--- a/tests/Scripts/RunP1Tests.bat
+++ b/tests/Scripts/RunP1Tests.bat
@@ -20,14 +20,11 @@ REM Clean previous test results
 if exist functionaltests.*.xml (
     del functionaltests.*.xml
 )
-if exist resultsfile.trx (
-    del resultsfile.trx
+if exist resultsfile.*.trx (
+    del resultsfile.*.trx
 )
 if exist TestResults (
     rd TestResults /S /Q
-)
-if exist loadtests-resultsfile.trx (
-	del loadtests-resultsfile.trx
 )
 
 REM Restore packages
@@ -48,11 +45,11 @@ call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%test
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P1\bin\%config%\NuGetGallery.WebUITests.P1.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.web.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
-call %vstest% "NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
+call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /category:%testCategory% /resultsfile:resultsfile.load.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 exit /B %exitCode%

--- a/tests/Scripts/RunP2Tests.bat
+++ b/tests/Scripts/RunP2Tests.bat
@@ -14,7 +14,6 @@ set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
-set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist functionaltests.*.xml (

--- a/tests/Scripts/RunP2Tests.bat
+++ b/tests/Scripts/RunP2Tests.bat
@@ -20,14 +20,11 @@ REM Clean previous test results
 if exist functionaltests.*.xml (
     del functionaltests.*.xml
 )
-if exist resultsfile.trx (
-    del resultsfile.trx
+if exist resultsfile.*.trx (
+    del resultsfile.*.trx
 )
 if exist TestResults (
     rd TestResults /S /Q
-)
-if exist loadtests-resultsfile.trx (
-	del loadtests-resultsfile.trx
 )
 
 REM Restore packages
@@ -48,11 +45,11 @@ call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%test
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI and load tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.P2\bin\%config%\NuGetGallery.WebUITests.P2.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.web.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
-call %vstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
+call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /category:%testCategory% /resultsfile:resultsfile.load.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 exit /B %exitCode%

--- a/tests/Scripts/RunReadonlyModeTests.bat
+++ b/tests/Scripts/RunReadonlyModeTests.bat
@@ -49,7 +49,7 @@ call %mstest% /TestContainer:"NuGetGallery.WebUITests.ReadOnlyMode\bin\%config%\
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
-call %vstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
+call %vstest% "NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
 if not "%errorlevel%"=="0" set exitCode=-1
 
 exit /B %exitCode%

--- a/tests/Scripts/RunReadonlyModeTests.bat
+++ b/tests/Scripts/RunReadonlyModeTests.bat
@@ -14,14 +14,13 @@ set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
-set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
 if exist functionaltests.*.xml (
     del functionaltests.*.xml
 )
-if exist resultsfile.trx (
-    del resultsfile.trx
+if exist resultsfile.*.trx (
+    del resultsfile.*.trx
 )
 if exist TestResults (
     rd TestResults /S /Q
@@ -45,11 +44,11 @@ call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%test
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI and load tests
-call %mstest% /TestContainer:"NuGetGallery.WebUITests.ReadOnlyMode\bin\%config%\NuGetGallery.WebUITests.ReadOnlyMode.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.ReadOnlyMode\bin\%config%\NuGetGallery.WebUITests.ReadOnlyMode.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.web.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
-call %vstest% "NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
+call %mstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /TestSettings:Local.testsettings /detail:stdout /category:%testCategory% /resultsfile:resultsfile.load.trx
 if not "%errorlevel%"=="0" set exitCode=-1
 
 exit /B %exitCode%

--- a/tests/Scripts/RunReadonlyModeTests.bat
+++ b/tests/Scripts/RunReadonlyModeTests.bat
@@ -7,14 +7,19 @@ REM Configuration
 set config=Release
 set testCategory="ReadonlyModeTests"
 set solutionPath="NuGetGallery.FunctionalTests.sln"
+set exitCode=0
 
 REM Required Tools
 set msbuild="%PROGRAMFILES(X86)%\MsBuild\14.0\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
+set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 set vstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 
 REM Clean previous test results
+if exist functionaltests.*.xml (
+    del functionaltests.*.xml
+)
 if exist resultsfile.trx (
     del resultsfile.trx
 )
@@ -37,17 +42,17 @@ REM Run functional tests
 set testDir="NuGetGallery.FunctionalTests\bin\%config%"
 copy %nuget% %testDir%
 call %xunit% "%testDir%\NuGetGallery.FunctionalTests.dll" -trait "Category=%testCategory%" -xml functionaltests.readonly.xml
+if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run web UI and load tests
-call %vstest% /TestContainer:"NuGetGallery.WebUITests.ReadOnlyMode\bin\%config%\NuGetGallery.WebUITests.ReadOnlyMode.dll" /logger:trx
-if not "%errorlevel%"=="0" goto failure
+call %mstest% /TestContainer:"NuGetGallery.WebUITests.ReadOnlyMode\bin\%config%\NuGetGallery.WebUITests.ReadOnlyMode.dll" /TestSettings:Local.testsettings /detail:stdout /resultsfile:resultsfile.trx
+if not "%errorlevel%"=="0" set exitCode=-1
 
 REM Run Load tests
 call %vstest% /TestContainer:"NuGetGallery.LoadTests\bin\%config%\NuGetGallery.LoadTests.dll" /logger:trx /TestCaseFilter:"TestCategory=%testCategory%"
-if not "%errorlevel%"=="0" goto failure
+if not "%errorlevel%"=="0" set exitCode=-1
 
-:success
-exit 0
+exit /B %exitCode%
 
 :failure
 exit -1


### PR DESCRIPTION
One of our functional test scripts was attempting to run VSTest with MSTest parameters and failing. As VSTS supports both MSTest and VSTest, and VSTest cannot run all of our functional tests, rather than splitting our functional tests between both, for clarity's sake we should use only one.