### PR TITLE
Move AzureEntityList and TableErrorLog to NuGetGallery.Core

### DIFF
--- a/src/NuGetGallery.Core/CoreStrings.Designer.cs
+++ b/src/NuGetGallery.Core/CoreStrings.Designer.cs
@@ -79,6 +79,24 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (404) Error - Not Found.
+        /// </summary>
+        public static string Http404NotFound {
+            get {
+                return ResourceManager.GetString("Http404NotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Index does not exist.
+        /// </summary>
+        public static string IndexDoesNotExist {
+            get {
+                return ResourceManager.GetString("IndexDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package manifest contains a duplicate dependency: {0} {1}.
         /// </summary>
         public static string Manifest_DuplicateDependency {
@@ -174,6 +192,15 @@ namespace NuGetGallery {
         public static string Manifest_TargetFrameworkNotSupported {
             get {
                 return ResourceManager.GetString("Manifest_TargetFrameworkNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Negative indexes are invalid..
+        /// </summary>
+        public static string NegativeIndexesAreInvalid {
+            get {
+                return ResourceManager.GetString("NegativeIndexesAreInvalid", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery.Core/CoreStrings.resx
+++ b/src/NuGetGallery.Core/CoreStrings.resx
@@ -171,4 +171,13 @@
   <data name="Manifest_InvalidVersionSemVer200" xml:space="preserve">
     <value>The version '{0}' is not supported. The NuGet Gallery currently does not currently support Semantic Version 2.0 as it would break older NuGet clients.</value>
   </data>
+  <data name="Http404NotFound" xml:space="preserve">
+    <value>(404) Error - Not Found</value>
+  </data>
+  <data name="IndexDoesNotExist" xml:space="preserve">
+    <value>Index does not exist</value>
+  </data>
+  <data name="NegativeIndexesAreInvalid" xml:space="preserve">
+    <value>Negative indexes are invalid.</value>
+  </data>
 </root>

--- a/src/NuGetGallery.Core/Infrastructure/AzureEntityList.cs
+++ b/src/NuGetGallery.Core/Infrastructure/AzureEntityList.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -83,12 +84,12 @@ namespace NuGetGallery.Infrastructure
             {
                 if (index < 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, Strings.NegativeIndexesAreInvalid);
+                    throw new ArgumentOutOfRangeException(nameof(index), index, CoreStrings.NegativeIndexesAreInvalid);
                 }
 
                 if (index >= LongCount)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, Strings.IndexDoesNotExist);
+                    throw new ArgumentOutOfRangeException(nameof(index), index, CoreStrings.IndexDoesNotExist);
                 }
 
                 long page = index / 1000;
@@ -99,7 +100,7 @@ namespace NuGetGallery.Infrastructure
                 var response = _tableRef.Execute(TableOperation.Retrieve<T>(partitionKey, rowKey));
                 if (response.HttpStatusCode == 404)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, Strings.Http404NotFound);
+                    throw new ArgumentOutOfRangeException(nameof(index), index, CoreStrings.Http404NotFound);
                 }
 
                 ThrowIfErrorStatus(response);
@@ -110,12 +111,12 @@ namespace NuGetGallery.Infrastructure
             {
                 if (index < 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, Strings.NegativeIndexesAreInvalid);
+                    throw new ArgumentOutOfRangeException(nameof(index), index, CoreStrings.NegativeIndexesAreInvalid);
                 }
 
                 if (index >= LongCount)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, Strings.IndexDoesNotExist);
+                    throw new ArgumentOutOfRangeException(nameof(index), index, CoreStrings.IndexDoesNotExist);
                 }
 
                 long page = index / 1000;

--- a/src/NuGetGallery.Core/Infrastructure/TableErrorLog.cs
+++ b/src/NuGetGallery.Core/Infrastructure/TableErrorLog.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -7,7 +8,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using Elmah;
-using Microsoft.WindowsAzure.ServiceRuntime;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 
@@ -143,21 +143,10 @@ namespace NuGetGallery.Infrastructure
             private readonly string _connectionString;
             private readonly AzureEntityList<ErrorEntity> _entityList;
 
-            public TableErrorLog(IDictionary config)
-            {
-                _connectionString = (string)config["connectionString"] ?? RoleEnvironment.GetConfigurationSettingValue((string)config["connectionStringName"]);
-                _entityList = new AzureEntityList<ErrorEntity>(_connectionString, TableName);
-            }
-
             public TableErrorLog(string connectionString)
             {
                 _connectionString = connectionString;
                 _entityList = new AzureEntityList<ErrorEntity>(connectionString, TableName);
-            }
-
-            public TableErrorLog()
-            {
-                _entityList = new AzureEntityList<ErrorEntity>(_connectionString, TableName);
             }
 
             public override ErrorLogEntry GetError(string id)

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -36,6 +36,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Elmah, Version=1.2.14706.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\entityframework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
@@ -179,6 +183,8 @@
     <Compile Include="Entities\Role.cs" />
     <Compile Include="Entities\Scope.cs" />
     <Compile Include="Entities\User.cs" />
+    <Compile Include="Infrastructure\AzureEntityList.cs" />
+    <Compile Include="Infrastructure\TableErrorLog.cs" />
     <Compile Include="PackageReaderCoreExtensions.cs" />
     <Compile Include="Packaging\InvalidPackageException.cs" />
     <Compile Include="Packaging\ManifestEdit.cs" />

--- a/src/NuGetGallery.Core/packages.config
+++ b/src/NuGetGallery.Core/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="elmah.corelibrary" version="1.2.2" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.6.5-beta" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.6.5-beta" targetFramework="net452" />

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1134,7 +1134,6 @@
     <Compile Include="ImageResult.cs" />
     <Compile Include="Infrastructure\AntiForgeryErrorFilter.cs" />
     <Compile Include="Infrastructure\ApplicationVersionHelper.cs" />
-    <Compile Include="Infrastructure\AzureEntityList.cs" />
     <Compile Include="Infrastructure\ChallengeResult.cs" />
     <Compile Include="Infrastructure\Lucene\ExternalSearchService.cs" />
     <Compile Include="Infrastructure\MandatoryAttribute.cs" />
@@ -1145,7 +1144,6 @@
     <Compile Include="Infrastructure\SafeRedirectResult.cs" />
     <Compile Include="Infrastructure\StatisticsReport.cs" />
     <Compile Include="Infrastructure\SubtextAttribute.cs" />
-    <Compile Include="Infrastructure\TableErrorLog.cs" />
     <Compile Include="Authentication\AsyncFileUpload\AsyncFileUploadExtensions.cs" />
     <Compile Include="Authentication\AsyncFileUpload\AsyncFileUploadModule.cs" />
     <Compile Include="Authentication\AsyncFileUpload\AsyncFileUploadProgress.cs" />

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -456,24 +456,6 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (404) Error - Not Found.
-        /// </summary>
-        public static string Http404NotFound {
-            get {
-                return ResourceManager.GetString("Http404NotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Index does not exist.
-        /// </summary>
-        public static string IndexDoesNotExist {
-            get {
-                return ResourceManager.GetString("IndexDoesNotExist", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The API key &apos;{0}&apos; is invalid..
         /// </summary>
         public static string InvalidApiKey {
@@ -569,15 +551,6 @@ namespace NuGetGallery {
         public static string MultipleMatchingCredentials {
             get {
                 return ResourceManager.GetString("MultipleMatchingCredentials", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Negative indexes are invalid..
-        /// </summary>
-        public static string NegativeIndexesAreInvalid {
-            get {
-                return ResourceManager.GetString("NegativeIndexesAreInvalid", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -329,17 +329,8 @@ The {1} Team</value>
   <data name="JobLogBlobNameInvalid" xml:space="preserve">
     <value>Job Log Blob name is invalid Bob! Expected [jobname].[yyyy-MM-dd].json or [jobname].json. Got: {0}</value>
   </data>
-  <data name="NegativeIndexesAreInvalid" xml:space="preserve">
-    <value>Negative indexes are invalid.</value>
-  </data>
-  <data name="IndexDoesNotExist" xml:space="preserve">
-    <value>Index does not exist</value>
-  </data>
   <data name="PackageIsMissingRequiredData" xml:space="preserve">
     <value>The package is missing required data.</value>
-  </data>
-  <data name="Http404NotFound" xml:space="preserve">
-    <value>(404) Error - Not Found</value>
   </data>
   <data name="ErrorInSendingMail" xml:space="preserve">
     <value>Error in sending mail : {0}</value>


### PR DESCRIPTION
These are used by dashboard. Right now, dashboard depends on a checked in version of NuGetGallery.Core and NuGetGallery (!!!). This needs to be fixed up for signing. Moving these types to NuGetGallery.Core means we don't have start signing NuGetGallery quite yet. And it simplifies dashboard dependencies.