### PR TITLE
Depend on signed version of Elmah

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -36,8 +36,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah, Version=1.2.14706.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
+    <Reference Include="Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\elmah.corelibrary.strongname.1.2.2\lib\Elmah.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/src/NuGetGallery.Core/packages.config
+++ b/src/NuGetGallery.Core/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="elmah.corelibrary" version="1.2.2" targetFramework="net452" />
+  <package id="elmah.corelibrary.strongname" version="1.2.2" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.6.5-beta" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.6.5-beta" targetFramework="net452" />

--- a/src/NuGetGallery/Diagnostics/ElmahHandleErrorAttribute.cs
+++ b/src/NuGetGallery/Diagnostics/ElmahHandleErrorAttribute.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Web;
+using System.Web.Mvc;
+using Elmah;
+
+namespace NuGetGallery.Diagnostics
+{
+    /// <summary>
+    /// Source: http://stackoverflow.com/a/779961/52749
+    /// </summary>
+    public class ElmahHandleErrorAttribute : HandleErrorAttribute
+    {
+        public override void OnException(ExceptionContext context)
+        {
+            base.OnException(context);
+            if (!context.ExceptionHandled       // if unhandled, will be logged anyhow
+                || TryRaiseErrorSignal(context) // prefer signaling, if possible
+                || IsFiltered(context))         // filtered?
+                return;
+
+            LogException(context);
+        }
+
+        private static bool TryRaiseErrorSignal(ExceptionContext context)
+        {
+            var httpContext = GetHttpContextImpl(context.HttpContext);
+            if (httpContext == null)
+                return false;
+            var signal = ErrorSignal.FromContext(httpContext);
+            if (signal == null)
+                return false;
+            signal.Raise(context.Exception, httpContext);
+            return true;
+        }
+
+        private static bool IsFiltered(ExceptionContext context)
+        {
+            var config = context.HttpContext.GetSection("elmah/errorFilter")
+                            as ErrorFilterConfiguration;
+
+            if (config == null)
+                return false;
+
+            var testContext = new ErrorFilterModule.AssertionHelperContext(
+                                  context.Exception,
+                                  GetHttpContextImpl(context.HttpContext));
+            return config.Assertion.Test(testContext);
+        }
+
+        private static void LogException(ExceptionContext context)
+        {
+            var httpContext = GetHttpContextImpl(context.HttpContext);
+            var error = new Error(context.Exception, httpContext);
+            ErrorLog.GetDefault(httpContext).Log(error);
+        }
+
+        private static HttpContext GetHttpContextImpl(HttpContextBase context)
+        {
+            return context.ApplicationInstance.Context;
+        }
+    }
+}

--- a/src/NuGetGallery/Diagnostics/SendErrorsToTelemetryAttribute.cs
+++ b/src/NuGetGallery/Diagnostics/SendErrorsToTelemetryAttribute.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Web.Mvc;
-using Elmah.Contrib.Mvc;
 using Microsoft.ApplicationInsights;
 
 namespace NuGetGallery.Diagnostics

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -131,9 +131,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\DynamicData.EFCodeFirstProvider.0.3.0.0\lib\net40\DynamicData.EFCodeFirstProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Elmah, Version=1.2.14706.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
+    <Reference Include="Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\elmah.corelibrary.strongname.1.2.2\lib\Elmah.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -136,11 +136,6 @@
       <HintPath>..\..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Elmah.Contrib.Mvc, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Elmah.Contrib.Mvc.1.0\lib\net40\Elmah.Contrib.Mvc.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\entityframework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
@@ -709,6 +704,7 @@
     <Compile Include="Configuration\SecretReader\ISecretReaderFactory.cs" />
     <Compile Include="Configuration\SecretReader\SecretReaderFactory.cs" />
     <Compile Include="Controllers\NuGetContext.cs" />
+    <Compile Include="Diagnostics\ElmahHandleErrorAttribute.cs" />
     <Compile Include="Extensions\DateTimeExtensions.cs" />
     <Compile Include="Controllers\ODataV1FeedController.cs" />
     <Compile Include="Controllers\ODataV2CuratedFeedController.cs" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -10,10 +10,10 @@
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     <sectionGroup name="elmah">
-      <section name="security" requirePermission="false" type="Elmah.SecuritySectionHandler, Elmah" />
-      <section name="errorLog" requirePermission="false" type="Elmah.ErrorLogSectionHandler, Elmah" />
-      <section name="errorMail" requirePermission="false" type="Elmah.ErrorMailSectionHandler, Elmah" />
-      <section name="errorFilter" requirePermission="false" type="Elmah.ErrorFilterSectionHandler, Elmah" />
+      <section name="security" requirePermission="false" type="Elmah.SecuritySectionHandler, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" />
+      <section name="errorLog" requirePermission="false" type="Elmah.ErrorLogSectionHandler, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" />
+      <section name="errorMail" requirePermission="false" type="Elmah.ErrorMailSectionHandler, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" />
+      <section name="errorFilter" requirePermission="false" type="Elmah.ErrorFilterSectionHandler, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" />
     </sectionGroup>
     <section name="dataCacheClients" type="Microsoft.ApplicationServer.Caching.DataCacheClientsSection, Microsoft.ApplicationServer.Caching.Core" allowLocation="true" allowDefinition="Everywhere" />
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
@@ -152,13 +152,13 @@
         <equal binding="HttpStatusCode" value="404" type="Int32" />
       </test>
     </errorFilter>
-    <errorLog type="Elmah.SqlErrorLog, Elmah" connectionStringName="NuGetGallery" />
+    <errorLog type="Elmah.SqlErrorLog, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" connectionStringName="NuGetGallery" />
   </elmah>
   <!-- Ensure only Admins may access elmah -->
   <location path="Admin" inheritInChildApplications="false">
     <system.web>
       <httpHandlers>
-        <add name="Elmah" verb="POST,GET,HEAD" path="Errors.axd" type="Elmah.ErrorLogPageFactory, Elmah" />
+        <add name="Elmah" verb="POST,GET,HEAD" path="Errors.axd" type="Elmah.ErrorLogPageFactory, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" />
       </httpHandlers>
       <authorization>
         <allow roles="Admins" />
@@ -169,7 +169,7 @@
     <system.webServer>
       <handlers>
         <remove name="Elmah" />
-        <add name="Elmah" path="Errors.axd" verb="POST,GET,HEAD" type="Elmah.ErrorLogPageFactory, Elmah" preCondition="integratedMode" />
+        <add name="Elmah" path="Errors.axd" verb="POST,GET,HEAD" type="Elmah.ErrorLogPageFactory, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" preCondition="integratedMode" />
       </handlers>
       <httpErrors>
         <clear />
@@ -263,9 +263,9 @@
     <httpRuntime targetFramework="4.5" maxQueryStringLength="12000" maxRequestLength="2000000000" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" relaxedUrlToFileSystemMapping="true" enableVersionHeader="false" />
 
     <httpModules>
-      <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah" />
-      <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" />
-      <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" />
+      <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" />
+      <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" />
+      <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" />
       <add name="AsyncFileUpload" type="NuGetGallery.AsyncFileUpload.AsyncFileUploadModule, NuGetGallery" />
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
     </httpModules>
@@ -308,9 +308,9 @@
       <remove name="StaticFile" />
     </handlers>
     <modules runAllManagedModulesForAllRequests="true">
-      <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" preCondition="managedHandler" />
-      <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" preCondition="managedHandler" />
-      <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah" preCondition="managedHandler" />
+      <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" preCondition="managedHandler" />
+      <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" preCondition="managedHandler" />
+      <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" preCondition="managedHandler" />
       <add name="AsyncFileUpload" type="NuGetGallery.AsyncFileUpload.AsyncFileUploadModule, NuGetGallery" preCondition="managedHandler" />
       <remove name="RoleManager" />
       <remove name="ApplicationInsightsWebTracking" />

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -9,9 +9,9 @@
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net452" />
   <package id="d3" version="3.0.2" targetFramework="net452" />
   <package id="DynamicData.EFCodeFirstProvider" version="0.3.0.0" targetFramework="net45" />
-  <package id="elmah" version="1.2.2" targetFramework="net452" />
-  <package id="elmah.corelibrary" version="1.2.2" targetFramework="net452" />
-  <package id="elmah.sqlserver" version="1.2" targetFramework="net452" />
+  <package id="elmah.corelibrary.strongname" version="1.2.2" targetFramework="net452" />
+  <package id="elmah.sqlserver.strongname" version="1.2.2" targetFramework="net452" />
+  <package id="elmah.strongname" version="1.2.2" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="FontAwesome" version="3.0.2.3" targetFramework="net452" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net452" />

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -10,7 +10,6 @@
   <package id="d3" version="3.0.2" targetFramework="net452" />
   <package id="DynamicData.EFCodeFirstProvider" version="0.3.0.0" targetFramework="net45" />
   <package id="elmah" version="1.2.2" targetFramework="net452" />
-  <package id="Elmah.Contrib.Mvc" version="1.0" targetFramework="net452" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net452" />
   <package id="elmah.sqlserver" version="1.2" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />


### PR DESCRIPTION
1. Change from `elmah.sqlserver` to `elmah.sqlserver.strongname`
1. Change from `elmah` to `elmah.strongname`
1. Change from `elmah.corelibrary` to `elmah.corelibrary.strongname`
1. Remove `Elmah.Contrib.Mvc` and copy the source (it's a single class from a StackOverflow answer).

This means that dashboard can remove its NuGetGallery dependency and just depend on NuGetGallery.Core (which can not be strong name signed).

Verification steps:

1. Generate exception with SQL Server error sink.
1. Generate exception with Azure Table Storage error sink.
1. Make sure the admin error page works.
1. Make sure non-admins cannot access the error page.
