### PR TITLE
added AllowHtml attribute to avoid errors in contact form submissions…

### DIFF
--- a/src/NuGetGallery/Controllers/PagesController.cs
+++ b/src/NuGetGallery/Controllers/PagesController.cs
@@ -71,6 +71,10 @@ namespace NuGetGallery
                 return View();
             }
 
+            // since HTML is allowed in these fields, encode it to avoid malicious HTML
+            contactForm.Message = HttpUtility.HtmlEncode(contactForm.Message);
+            contactForm.SubjectLine = HttpUtility.HtmlEncode(contactForm.SubjectLine);
+
             var user = GetCurrentUser();
             var request = new ContactSupportRequest
             {

--- a/src/NuGetGallery/ViewModels/ContactSupportViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ContactSupportViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
+using System.Web.Mvc;
 
 namespace NuGetGallery.ViewModels
 {
@@ -10,11 +11,13 @@ namespace NuGetGallery.ViewModels
         [Required(ErrorMessage ="Please enter a subject line.")]
         [StringLength(100)]
         [Display(Name ="Subject Line")]
+        [AllowHtml]
         public string SubjectLine { get; set; }
 
         [Required(ErrorMessage ="Please enter a message.")]
         [StringLength(4000)]
         [Display(Name ="Message for support")]
+        [AllowHtml]
         public string Message { get; set; }
 
         [Display(Name = "Send me a copy")]

--- a/tests/NuGetGallery.Facts/Controllers/PagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PagesControllerFacts.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using System.Web;
+using Moq;
+using NuGetGallery.Areas.Admin;
+using NuGetGallery.Framework;
+using NuGetGallery.Services;
+using NuGetGallery.ViewModels;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class PagesControllerFacts
+    {
+        public class TheContactAction : TestContainer
+        {
+            [Fact]
+            public async Task HtmlEncodesTheSupportContactEmail()
+            {
+                // arrage: the contact form, the expected encoding, and setup a user
+                var contactForm = new ContactSupportViewModel
+                {
+                    Message = "<strong>Something with HTML in it</strong>",
+                    SubjectLine = "<script>alert('malicious javascript perhaps')</script>"
+                };
+
+                var expectedMessage = HttpUtility.HtmlEncode(contactForm.Message);
+                var expectedSubjectLine = HttpUtility.HtmlEncode(contactForm.SubjectLine);
+
+                var controller = GetController<PagesController>();
+                // Have to set this up first because it needs current user
+                controller.SetCurrentUser(new User
+                {
+                    Username = "aUsername",
+                    UnconfirmedEmailAddress = "old@example.com",
+                    EmailConfirmationToken = "aToken",
+                });
+
+                // act: run the controller action
+                await controller.Contact(contactForm);
+
+                // assert: the HTML encoded message was passed to the service
+                GetMock<IMessageService>()
+                    .Verify(m => m.SendContactSupportEmail(
+                        It.Is<ContactSupportRequest>(c =>
+                            c.Message == expectedMessage
+                            && c.SubjectLine == expectedSubjectLine)));
+            }
+
+            [Fact]
+            public async Task HtmlEncodesTheSupportRequest()
+            {
+                // arrage: the contact form, the expected encoding, and setup a user
+                var contactForm = new ContactSupportViewModel
+                {
+                    Message = "<b>some html</b>",
+                    SubjectLine = "maybe some malicious javascript: <script>alert('teh XSS hax')</script>"
+                };
+
+                var expectedMessage = HttpUtility.HtmlEncode(contactForm.Message);
+
+                var controller = GetController<PagesController>();
+                // Have to set this up first because it needs current user
+                controller.SetCurrentUser(new User
+                {
+                    Username = "aUsername",
+                    UnconfirmedEmailAddress = "old@example.com",
+                    EmailConfirmationToken = "aToken",
+                });
+
+                // act: run the controller action
+                await controller.Contact(contactForm);
+
+                // assert: the HTML encoded message was passed to the service
+                GetMock<ISupportRequestService>()
+                    .Verify(m => m.AddNewSupportRequestAsync(
+                        It.IsAny<string>(),
+                        expectedMessage,
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<User>(),
+                        It.IsAny<Package>()));
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -401,6 +401,7 @@
     <Compile Include="Controllers\CuratedPackagesControllerFacts.cs" />
     <Compile Include="Controllers\JsonApiControllerFacts.cs" />
     <Compile Include="Controllers\PackagesControllerFacts.cs" />
+    <Compile Include="Controllers\PagesControllerFacts.cs" />
     <Compile Include="Controllers\StatisticsControllerFacts.cs" />
     <Compile Include="Controllers\UsersControllerFacts.cs" />
     <Compile Include="Framework\TestGalleryConfigurationService.cs" />


### PR DESCRIPTION
This is the exact fix suggested for issue #3448: I added the AllowHtml attribute to the SubjectLine and Message fields on the view model.