### PR TITLE
Fix for UpdateIsLatestAsync retry connection string

### DIFF
--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -12,6 +12,7 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
+using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
 using NuGetGallery.Packaging;
 
@@ -25,6 +26,7 @@ namespace NuGetGallery
 
         private readonly IIndexingService _indexingService;
         private readonly IEntitiesContext _entitiesContext;
+        private readonly IAppConfiguration _configuration;
         private readonly IEntityRepository<PackageOwnerRequest> _packageOwnerRequestRepository;
         private readonly IEntityRepository<PackageRegistration> _packageRegistrationRepository;
         private readonly IEntityRepository<Package> _packageRepository;
@@ -37,6 +39,7 @@ namespace NuGetGallery
             IEntityRepository<Package> packageRepository,
             IEntityRepository<PackageOwnerRequest> packageOwnerRequestRepository,
             IEntitiesContext entitiesContext,
+            IAppConfiguration configuration,
             IDiagnosticsService diagnostics,
             IIndexingService indexingService,
             IPackageNamingConflictValidator packageNamingConflictValidator,
@@ -55,6 +58,16 @@ namespace NuGetGallery
             if (packageOwnerRequestRepository == null)
             {
                 throw new ArgumentNullException(nameof(packageOwnerRequestRepository));
+            }
+
+            if (entitiesContext == null)
+            {
+                throw new ArgumentNullException(nameof(entitiesContext));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
             }
 
             if (indexingService == null)
@@ -76,6 +89,7 @@ namespace NuGetGallery
             _packageRepository = packageRepository;
             _packageOwnerRequestRepository = packageOwnerRequestRepository;
             _entitiesContext = entitiesContext;
+            _configuration = configuration;
             _indexingService = indexingService;
             _packageNamingConflictValidator = packageNamingConflictValidator;
             _auditingService = auditingService;
@@ -780,7 +794,7 @@ namespace NuGetGallery
         
         protected internal virtual IEntitiesContext CreateNewEntitiesContext()
         {
-            return new EntitiesContext();
+            return new EntitiesContext(_configuration.SqlConnectionString, readOnly: false);
         }
         
         public async Task UpdateIsLatestAsync(PackageRegistration packageRegistration)

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -11,6 +11,7 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
+using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
@@ -100,6 +101,7 @@ namespace NuGetGallery
             Mock<IEntityRepository<Package>> packageRepository = null,
             Mock<IEntityRepository<PackageOwnerRequest>> packageOwnerRequestRepo = null,
             Mock<IEntitiesContext> entitiesContext = null,
+            Mock<IAppConfiguration> configuration = null,
             Mock<IDiagnosticsService> diagnosticsService = null,
             Mock<IIndexingService> indexingService = null,
             IPackageNamingConflictValidator packageNamingConflictValidator = null,
@@ -111,6 +113,7 @@ namespace NuGetGallery
                 packageRepository,
                 packageOwnerRequestRepo,
                 entitiesContext,
+                configuration,
                 diagnosticsService,
                 indexingService,
                 packageNamingConflictValidator,
@@ -123,6 +126,7 @@ namespace NuGetGallery
             Mock<IEntityRepository<Package>> packageRepository = null,
             Mock<IEntityRepository<PackageOwnerRequest>> packageOwnerRequestRepo = null,
             Mock<IEntitiesContext> entitiesContext = null,
+            Mock<IAppConfiguration> configuration = null,
             Mock<IDiagnosticsService> diagnosticsService = null,
             Mock<IIndexingService> indexingService = null,
             IPackageNamingConflictValidator packageNamingConflictValidator = null,
@@ -137,6 +141,8 @@ namespace NuGetGallery
             entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
             entitiesContext.Setup(m => m.GetDatabase()).Returns(dbContext.Object.Database);
             entitiesContext.Setup(m => m.GetChangeTracker()).Returns(dbContext.Object.ChangeTracker);
+
+            configuration = configuration ?? new Mock<IAppConfiguration>();
 
             diagnosticsService = diagnosticsService ?? new Mock<IDiagnosticsService>();
             indexingService = indexingService ?? new Mock<IIndexingService>();
@@ -154,6 +160,7 @@ namespace NuGetGallery
                 packageRepository.Object,
                 packageOwnerRequestRepo.Object,
                 entitiesContext.Object,
+                configuration.Object,
                 diagnosticsService.Object,
                 indexingService.Object,
                 packageNamingConflictValidator,

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Packaging;
+using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
@@ -285,6 +286,7 @@ namespace NuGetGallery
             var packageOwnerRequestRepo = new Mock<IEntityRepository<PackageOwnerRequest>>();
             var diagnosticsService = new Mock<IDiagnosticsService>();
             var entitiesContext = new Mock<IEntitiesContext>();
+            var configuration = new Mock<IAppConfiguration>();
             var indexingService = new Mock<IIndexingService>();
             var packageNamingConflictValidator = new PackageNamingConflictValidator(
                     packageRegistrationRepository.Object,
@@ -296,6 +298,7 @@ namespace NuGetGallery
                 packageRepository.Object,
                 packageOwnerRequestRepo.Object,
                 entitiesContext.Object,
+                configuration.Object,
                 diagnosticsService.Object,
                 indexingService.Object,
                 packageNamingConflictValidator,

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -113,12 +113,21 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                  "7.0.0-a",  "7.0.0-b",  "7.0.0",  "7.0.1",  "7.0.2-abc"
             };
 
-            // push all and verify; ~15-20 concurrency conflicts seen in testing
+            // first push should not be concurrent to avoid conflict on creation of package registration.
             var concurrentTasks = new Task[packageVersions.Count];
-            for (int i = 0; i < concurrentTasks.Length; i++)
+            concurrentTasks[0] = Task.Run(() => _clientSdkHelper.UploadNewPackage(packageId, version: packageVersions[0]));
+            concurrentTasks[0].Wait();
+
+            // push remaining packages over period of 5 seconds
+            var random = new Random();
+            for (int i = 1; i < concurrentTasks.Length; i++)
             {
                 var packageVersion = packageVersions[i];
-                concurrentTasks[i] = Task.Run(() => _clientSdkHelper.UploadNewPackage(packageId, version: packageVersion));
+                concurrentTasks[i] = Task.Run(async () =>
+                {
+                    await Task.Delay(random.Next(0, 5000));
+                    await _clientSdkHelper.UploadNewPackage(packageId, version: packageVersion);
+                });
             }
             Task.WaitAll(concurrentTasks);
             


### PR DESCRIPTION
Regression from PR #3548, found during dev deployment

EntitiesContext default ctor pulls connection string from web.config (localdb), but we needed cloud configuration.

Updated functional test to push first package non-concurrently to avoid conflict on registration creation, and to spread remaining pushes over 5s period (~6 pkg/second) which is more realistic.