### PR TITLE
Update WindowsAzure.Storage to 7.0.0

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -50,6 +50,9 @@
       <HintPath>..\..\packages\entityframework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.5-beta\lib\net40\Microsoft.Data.Edm.dll</HintPath>
@@ -75,10 +78,8 @@
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.7.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/NuGetGallery.Core/packages.config
+++ b/src/NuGetGallery.Core/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="elmah.corelibrary.strongname" version="1.2.2" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Data.Edm" version="5.6.5-beta" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.6.5-beta" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.6.5-beta" targetFramework="net452" />
@@ -15,5 +16,5 @@
   <package id="NuGet.Packaging.Core.Types" version="3.5.0-rc1-final" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.5.0-rc1-final" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.5-beta" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net452" />
 </packages>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -295,6 +295,9 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.1.0.0\lib\net45\Microsoft.Azure.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.Data.Edm, Version=5.6.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -403,10 +406,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\Program Files\Microsoft SDKs\Azure\.NET SDK\v2.7\ref\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.7.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsFabric.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -51,6 +51,7 @@
   <package id="Microsoft.Azure.Common" version="2.0.4" targetFramework="net452" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net452" />
@@ -101,5 +102,5 @@
   <package id="WebBackgrounder.EntityFramework" version="0.1" targetFramework="net452" />
   <package id="WebGrease" version="1.1.0" targetFramework="net452" />
   <package id="WindowsAzure.Caching" version="1.7.0.0" targetFramework="net452" />
-  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net452" />
+  <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net452" />
 </packages>

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -82,8 +82,9 @@
     <Reference Include="Moq, Version=4.7.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.7.0\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Common, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Common.3.5.0-rc1-final\lib\net45\NuGet.Common.dll</HintPath>

--- a/tests/NuGetGallery.Core.Facts/app.config
+++ b/tests/NuGetGallery.Core.Facts/app.config
@@ -23,7 +23,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/tests/NuGetGallery.Core.Facts/packages.config
+++ b/tests/NuGetGallery.Core.Facts/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net452" />
   <package id="Moq" version="4.7.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="NuGet.Common" version="3.5.0-rc1-final" targetFramework="net452" />
   <package id="NuGet.Frameworks" version="3.5.0-rc1-final" targetFramework="net452" />
   <package id="NuGet.Logging" version="3.5.0-beta-1160" targetFramework="net452" />

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -92,6 +92,9 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.1.0.0\lib\net45\Microsoft.Azure.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.5-beta\lib\net40\Microsoft.Data.Edm.dll</HintPath>
@@ -173,10 +176,8 @@
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\WindowsAzure.Storage.4.3.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.7.0.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/tests/NuGetGallery.Facts/packages.config
+++ b/tests/NuGetGallery.Facts/packages.config
@@ -15,6 +15,7 @@
   <package id="Microsoft.Azure.Common" version="2.0.4" targetFramework="net461" />
   <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net461" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />
@@ -79,7 +80,7 @@
   <package id="WebActivatorEx" version="2.0.6" targetFramework="net461" />
   <package id="WebBackgrounder" version="0.2.0" targetFramework="net461" />
   <package id="WebBackgrounder.EntityFramework" version="0.1" targetFramework="net461" />
-  <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net461" />
+  <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net461" />
   <package id="xunit" version="2.0.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net461" />


### PR DESCRIPTION
This is to align with NuGet.Services.Metadata.Catalog ([source](https://github.com/NuGet/NuGet.Services.Metadata/blob/d1a39464c5ef4cf54c6afa60e3ce7d8ddccb6686/src/Catalog/packages.config#L15)).

The alignment is necessary because the dashboard jobs depend on both NuGetGallery.Core and NuGet.Services.Metadata.Catalog. There was a breaking API change from 4.3.0 to 7.0.0 resulting in the following error in the dashboard jobs at runtime:
```
error: MissingMethodException: Method not found: 'Microsoft.WindowsAzure.Storage.Table.TableOperation Microsoft.WindowsAzure.Storage.Table.TableOperation.Retrieve(System.String, System.String)'.
error:  Stack Trace:    at NuGetGallery.Infrastructure.AzureEntityList`1..ctor(String connStr, String tableName)
error:    at NuGetGallery.Infrastructure.TableErrorLog..ctor(String connectionString)
error: at NuGetGallery.Operations.CreateElmahErrorOverviewReportTask.ExecuteCommand() in
error: C:\src\git\github.com\NuGet\NuGet.Services.Dashboard\NuGet.Services.Dashboard.Operations\Tasks\DashBoardTasks\V2GalleryFrontendTasks\CreateElmahErrorOverviewReportTask.cs:line 19
error:    at NuGetGallery.Operations.OpsTask.Execute() in C:\src\git\github.com\NuGet\NuGet.Services.Dashboard\NuGet.Services.Dashboard.Operations\Tasks\OpsTask.cs:line 101
error:    at NuGetGallery.Operations.Tools.Program.Invoke(String[] args) in C:\src\git\github.com\NuGet\NuGet.Services.Dashboard\NuGet.Services.Dashboard.Operations.Tools\Program.cs:line 79
```

This is another example of how optional parameters can lead to sneaky breaking API changes.