### PR TITLE
Fixing Package Description truncation

### DIFF
--- a/src/NuGetGallery/Helpers/StringExtensions.cs
+++ b/src/NuGetGallery/Helpers/StringExtensions.cs
@@ -43,7 +43,7 @@ namespace NuGetGallery.Helpers
             return text.Substring(0, length - 3) + "...";
         }
 
-        public static string TruncateAtWordBoundary(this string input, int length, string ommission, string moreText, out bool wasTruncated)
+        public static string TruncateAtWordBoundary(this string input, int length, string omission, out bool wasTruncated)
         {
             wasTruncated = false;
             if (string.IsNullOrEmpty(input) || input.Length < length)
@@ -52,10 +52,9 @@ namespace NuGetGallery.Helpers
             int nextSpace = input.LastIndexOf(" ", length, StringComparison.Ordinal);
 
             wasTruncated = true;
-            return string.Format(CultureInfo.CurrentCulture, "{0}{1}{2}",
+            return string.Format(CultureInfo.CurrentCulture, "{0}{1}",
                                 input.Substring(0, (nextSpace > 0) ? nextSpace : length).Trim(),
-                                ommission,
-                                moreText);
+                                omission);
         }
     }
 }

--- a/src/NuGetGallery/Helpers/StringExtensions.cs
+++ b/src/NuGetGallery/Helpers/StringExtensions.cs
@@ -43,13 +43,15 @@ namespace NuGetGallery.Helpers
             return text.Substring(0, length - 3) + "...";
         }
 
-        public static string TruncateAtWordBoundary(this string input, int length = 300, string ommission = "...", string moreText = "")
+        public static string TruncateAtWordBoundary(this string input, int length, string ommission, string moreText, out bool wasTruncated)
         {
+            wasTruncated = false;
             if (string.IsNullOrEmpty(input) || input.Length < length)
                 return input;
 
             int nextSpace = input.LastIndexOf(" ", length, StringComparison.Ordinal);
 
+            wasTruncated = true;
             return string.Format(CultureInfo.CurrentCulture, "{2}{1}{0}",
                                 moreText,
                                 ommission,

--- a/src/NuGetGallery/Helpers/StringExtensions.cs
+++ b/src/NuGetGallery/Helpers/StringExtensions.cs
@@ -47,7 +47,9 @@ namespace NuGetGallery.Helpers
         {
             wasTruncated = false;
             if (string.IsNullOrEmpty(input) || input.Length < length)
+            {
                 return input;
+            }
 
             int nextSpace = input.LastIndexOf(" ", length, StringComparison.Ordinal);
 

--- a/src/NuGetGallery/Helpers/StringExtensions.cs
+++ b/src/NuGetGallery/Helpers/StringExtensions.cs
@@ -52,10 +52,10 @@ namespace NuGetGallery.Helpers
             int nextSpace = input.LastIndexOf(" ", length, StringComparison.Ordinal);
 
             wasTruncated = true;
-            return string.Format(CultureInfo.CurrentCulture, "{2}{1}{0}",
-                                moreText,
+            return string.Format(CultureInfo.CurrentCulture, "{0}{1}{2}",
+                                input.Substring(0, (nextSpace > 0) ? nextSpace : length).Trim(),
                                 ommission,
-                                input.Substring(0, (nextSpace > 0) ? nextSpace : length).Trim());
+                                moreText);
         }
     }
 }

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery
 
             Authors = package.FlattenedAuthors;
             MinClientVersion = package.MinClientVersion;
-            Owners = package.PackageRegistration.Owners;
+            Owners = package.PackageRegistration?.Owners;
 
             bool wasTruncated;
             ShortDescription = Description.TruncateAtWordBoundary(_descriptionLengthLimit, _omissionString, string.Empty, out wasTruncated);

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery
             Owners = package.PackageRegistration?.Owners;
 
             bool wasTruncated;
-            ShortDescription = Description.TruncateAtWordBoundary(_descriptionLengthLimit, _omissionString, string.Empty, out wasTruncated);
+            ShortDescription = Description.TruncateAtWordBoundary(_descriptionLengthLimit, _omissionString, out wasTruncated);
             IsDescriptionTruncated = wasTruncated;
         }
 

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using NuGetGallery.Helpers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Principal;
@@ -8,7 +9,8 @@ namespace NuGetGallery
 {
     public class ListPackageItemViewModel : PackageViewModel
     {
-        private int _descriptionLengthLimit = 350;
+        private const int _descriptionLengthLimit = 300;
+        private const string _omissionString = "...";
 
         public ListPackageItemViewModel(Package package)
             : base(package)
@@ -19,32 +21,17 @@ namespace NuGetGallery
             MinClientVersion = package.MinClientVersion;
             Owners = package.PackageRegistration.Owners;
 
+            bool wasTruncated;
+            ShortDescription = Description.TruncateAtWordBoundary(_descriptionLengthLimit, _omissionString, string.Empty, out wasTruncated);
+            IsDescriptionTruncated = wasTruncated;
         }
 
         public string Authors { get; set; }
         public ICollection<User> Owners { get; set; }
         public IEnumerable<string> Tags { get; set; }
         public string MinClientVersion { get; set; }
-        public string ShortDescription
-        {
-            get
-            {
-                if (this.Description.Length > _descriptionLengthLimit)
-                {
-                    return this.Description.Substring(1, _descriptionLengthLimit) + "...";
-                }
-
-                return this.Description;
-            }
-        }
-
-        public int DescriptionLengthLimit
-        {
-            get
-            {
-                return _descriptionLengthLimit;
-            }
-        }
+        public string ShortDescription { get; set; }
+        public bool IsDescriptionTruncated { get; set; }
 
         public bool UseVersion
         {

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -8,6 +8,8 @@ namespace NuGetGallery
 {
     public class ListPackageItemViewModel : PackageViewModel
     {
+        private int _descriptionLengthLimit = 350;
+
         public ListPackageItemViewModel(Package package)
             : base(package)
         {
@@ -16,12 +18,33 @@ namespace NuGetGallery
             Authors = package.FlattenedAuthors;
             MinClientVersion = package.MinClientVersion;
             Owners = package.PackageRegistration.Owners;
+
         }
 
         public string Authors { get; set; }
         public ICollection<User> Owners { get; set; }
         public IEnumerable<string> Tags { get; set; }
         public string MinClientVersion { get; set; }
+        public string ShortDescription
+        {
+            get
+            {
+                if (this.Description.Length > _descriptionLengthLimit)
+                {
+                    return this.Description.Substring(1, _descriptionLengthLimit) + "...";
+                }
+
+                return this.Description;
+            }
+        }
+
+        public int DescriptionLengthLimit
+        {
+            get
+            {
+                return _descriptionLengthLimit;
+            }
+        }
 
         public bool UseVersion
         {

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -46,14 +46,14 @@
             </p>
 
             @if (@Model.Tags.AnySafe())
-                    {
+            {
                 <div class="tags">
                     <h2>Tags</h2>
                     <ul class="tags">
-                        @foreach (var tag in Model.Tags)
+                    @foreach (var tag in Model.Tags)
                     {
-                            <li><a href="@Url.Search("Tags:\"" + tag + "\"")" title="Search for @tag">@tag</a></li>
-                        }
+                        <li><a href="@Url.Search("Tags:\"" + tag + "\"")" title="Search for @tag">@tag</a></li>
+                    }
                     </ul>
                 </div>
             }

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -25,10 +25,10 @@
                 </span>
             </p>
             <p>
-                @Model.ShortDescription;
-                @if (Model.Description.Length > Model.DescriptionLengthLimit)
+                @Model.ShortDescription
+                @if (Model.IsDescriptionTruncated)
                 {
-                    @Html.Raw(string.Format(System.Globalization.CultureInfo.CurrentCulture, " <a href=\"{0}\">More information</a>", @Url.Package(Model)))
+                    @Html.RouteLink("More information", RouteName.DisplayPackage, new { Model.Id, Model.Version })
                 }
             </p>
 
@@ -46,12 +46,12 @@
             </p>
 
             @if (@Model.Tags.AnySafe())
-            {
+                    {
                 <div class="tags">
                     <h2>Tags</h2>
                     <ul class="tags">
                         @foreach (var tag in Model.Tags)
-                        {
+                    {
                             <li><a href="@Url.Search("Tags:\"" + tag + "\"")" title="Search for @tag">@tag</a></li>
                         }
                     </ul>

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -25,7 +25,11 @@
                 </span>
             </p>
             <p>
-                @Model.Description.TruncateAtWordBoundary(350, "...", string.Format(System.Globalization.CultureInfo.CurrentCulture, " <a href=\"{0}\">More information</a>", @Url.Package(Model)))
+                @Model.ShortDescription;
+                @if (Model.Description.Length > Model.DescriptionLengthLimit)
+                {
+                    @Html.Raw(string.Format(System.Globalization.CultureInfo.CurrentCulture, " <a href=\"{0}\">More information</a>", @Url.Package(Model)))
+                }
             </p>
 
             @if (!String.IsNullOrEmpty(Model.MinClientVersion))

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -484,6 +484,7 @@
     <Compile Include="UrlExtensionsFacts.cs" />
     <Compile Include="ViewModels\DependencySetsViewModelFacts.cs" />
     <Compile Include="ViewModels\DisplayPackageViewModelFacts.cs" />
+    <Compile Include="ViewModels\ListPackageItemViewModelFacts.cs" />
     <Compile Include="ViewModels\PackageViewModelFacts.cs" />
     <Compile Include="ViewModels\PreviousNextPagerViewModelFacts.cs" />
   </ItemGroup>

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
@@ -115,6 +115,7 @@ namespace NuGetGallery.ViewModels
         [Fact]
         public void LongDescriptionsTruncated()
         {
+            var omission = "...";
             var description = @"A Longer description full of nonsense that will get truncated. Lorem ipsum dolor sit amet, ad nemore gubergren eam. Ea quaeque labores deseruisse his, eos munere convenire at, in eos audire persius corpora. Te his volumus detracto offendit, has ne illud choro. No illum quaestio mel, novum democritum te sea, et nam nisl officiis salutandi. Vis ut harum docendi incorrupte, nam affert putent sententiae id, mei cibo omnium id. Ea est falli graeci voluptatibus, est mollis denique ne.
 An nec tempor cetero vituperata.Ius cu dicunt regione interpretaris, posse veniam facilisis ad vim, sit ei sale integre. Mel cu aliquid impedit scribentur.Nostro recusabo sea ei, nec habeo instructior no, saepe altera adversarium vel cu.Nonumes molestiae sit at, per enim necessitatibus cu.
 At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex.Vim dolorem fuisset an. At sit veri illum oratio, et per dicat contentiones. In eam tale tation, mei dicta labitur corpora ei, homero equidem suscipit ut eam.";
@@ -128,7 +129,27 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
 
             Assert.NotEqual(description, listPackageItemViewModel.ShortDescription);
             Assert.Equal(true, listPackageItemViewModel.IsDescriptionTruncated);
-            Assert.True(listPackageItemViewModel.ShortDescription.EndsWith("..."));
+            Assert.True(listPackageItemViewModel.ShortDescription.EndsWith(omission));
+            Assert.True(description.Contains(listPackageItemViewModel.ShortDescription.Substring(0, listPackageItemViewModel.ShortDescription.Length - 1 - omission.Length)));
+        }
+
+        [Fact]
+        public void LongDescriptionsSingleWordTruncatedToLimit()
+        {
+            var charLimit = 300;
+            var omission = "...";
+            var description = @"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
+
+            var package = new Package()
+            {
+                Description = description
+            };
+
+            var listPackageItemViewModel = new ListPackageItemViewModel(package);
+
+            Assert.Equal(charLimit + omission.Length, listPackageItemViewModel.ShortDescription.Length);
+            Assert.Equal(true, listPackageItemViewModel.IsDescriptionTruncated);
+            Assert.True(listPackageItemViewModel.ShortDescription.EndsWith(omission));
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
@@ -198,16 +198,16 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
             var listPackageItemViewModel = new ListPackageItemViewModel(package);
             Assert.True(listPackageItemViewModel.UseVersion);
 
-            package.IsLatest = false;
-            package.IsLatestStable = true;
+            listPackageItemViewModel.LatestVersion = false;
+            listPackageItemViewModel.LatestStableVersion = true;
             Assert.True(listPackageItemViewModel.UseVersion);
 
-            package.IsLatest = false;
-            package.IsLatestStable = false;
+            listPackageItemViewModel.LatestVersion = false;
+            listPackageItemViewModel.LatestStableVersion = false;
             Assert.True(listPackageItemViewModel.UseVersion);
 
-            package.IsLatest = true;
-            package.IsLatestStable = true;
+            listPackageItemViewModel.LatestVersion = true;
+            listPackageItemViewModel.LatestStableVersion = true;
             Assert.False(listPackageItemViewModel.UseVersion);
         }
     }

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGetGallery.ViewModels
+{
+    public class ListPackageItemViewModelFacts
+    {
+        // start with replicating the PackageViewModelFacts here since we shouldn't be breaking these
+        // ListPackageItemViewModel extends PackageViewModel
+        #region CopiedFromPackageViewModelFacts
+        [Fact]
+        public void UsesNormalizedVersionForDisplay()
+        {
+            var package = new Package()
+            {
+                Version = "01.02.00.00",
+                NormalizedVersion = "1.3.0" // Different just to prove the View Model is using the DB column.
+            };
+            var packageViewModel = new ListPackageItemViewModel(package);
+            Assert.Equal("1.3.0", packageViewModel.Version);
+        }
+
+        [Fact]
+        public void UsesNormalizedPackageVersionIfNormalizedVersionMissing()
+        {
+            var package = new Package()
+            {
+                Version = "01.02.00.00"
+            };
+            var packageViewModel = new ListPackageItemViewModel(package);
+            Assert.Equal("1.2.0", packageViewModel.Version);
+        }
+
+        [Fact]
+        public void LicenseNamesAreParsedByCommas()
+        {
+            var package = new Package
+            {
+                LicenseNames = "l1,l2, l3 ,l4  ,  l5 ",
+            };
+            var packageViewModel = new ListPackageItemViewModel(package);
+            Assert.Equal(new string[] { "l1", "l2", "l3", "l4", "l5" }, packageViewModel.LicenseNames);
+        }
+
+        [Fact]
+        public void LicenseReportFieldsKeptWhenLicenseReportDisabled()
+        {
+            var package = new Package
+            {
+                HideLicenseReport = true,
+                LicenseNames = "l1",
+                LicenseReportUrl = "url"
+            };
+            var packageViewModel = new ListPackageItemViewModel(package);
+            Assert.NotNull(packageViewModel.LicenseNames);
+            Assert.NotNull(packageViewModel.LicenseReportUrl);
+        }
+
+        [Fact]
+        public void LicenseReportUrlKeptWhenLicenseReportEnabled()
+        {
+            var package = new Package
+            {
+                HideLicenseReport = false,
+                LicenseReportUrl = "url"
+            };
+            var packageViewModel = new ListPackageItemViewModel(package);
+            Assert.NotNull(packageViewModel.LicenseReportUrl);
+        }
+
+        [Fact]
+        public void LicenseNamesKeptWhenLicenseReportEnabled()
+        {
+            var package = new Package
+            {
+                HideLicenseReport = false,
+                LicenseNames = "l1"
+            };
+            var packageViewModel = new ListPackageItemViewModel(package);
+            Assert.NotNull(packageViewModel.LicenseNames);
+        }
+
+        [Fact]
+        public void LicenseUrlKeptWhenLicenseReportDisabled()
+        {
+            var package = new Package
+            {
+                HideLicenseReport = true,
+                LicenseUrl = "url"
+            };
+            var packageViewModel = new ListPackageItemViewModel(package);
+            Assert.NotNull(packageViewModel.LicenseUrl);
+        }
+        #endregion
+
+        [Fact]
+        public void ShortDescriptionsNotTruncated()
+        {
+            var description = "A Short Description";
+            var package = new Package()
+            {
+                Description = description
+            };
+
+            var listPackageItemViewModel = new ListPackageItemViewModel(package);
+
+            Assert.Equal(description, listPackageItemViewModel.ShortDescription);
+            Assert.Equal(false, listPackageItemViewModel.IsDescriptionTruncated);
+        }
+
+        [Fact]
+        public void LongDescriptionsTruncated()
+        {
+            var description = @"A Longer description full of nonsense that will get truncated. Lorem ipsum dolor sit amet, ad nemore gubergren eam. Ea quaeque labores deseruisse his, eos munere convenire at, in eos audire persius corpora. Te his volumus detracto offendit, has ne illud choro. No illum quaestio mel, novum democritum te sea, et nam nisl officiis salutandi. Vis ut harum docendi incorrupte, nam affert putent sententiae id, mei cibo omnium id. Ea est falli graeci voluptatibus, est mollis denique ne.
+An nec tempor cetero vituperata.Ius cu dicunt regione interpretaris, posse veniam facilisis ad vim, sit ei sale integre. Mel cu aliquid impedit scribentur.Nostro recusabo sea ei, nec habeo instructior no, saepe altera adversarium vel cu.Nonumes molestiae sit at, per enim necessitatibus cu.
+At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex.Vim dolorem fuisset an. At sit veri illum oratio, et per dicat contentiones. In eam tale tation, mei dicta labitur corpora ei, homero equidem suscipit ut eam.";
+
+            var package = new Package()
+            {
+                Description = description
+            };
+
+            var listPackageItemViewModel = new ListPackageItemViewModel(package);
+
+            Assert.NotEqual(description, listPackageItemViewModel.ShortDescription);
+            Assert.Equal(true, listPackageItemViewModel.IsDescriptionTruncated);
+            Assert.True(listPackageItemViewModel.ShortDescription.EndsWith("..."));
+        }
+
+        [Fact]
+        public void EmptyTagsAreParsedEmpty()
+        {
+            var package = new Package() { };
+
+            var listPackageItemViewModel = new ListPackageItemViewModel(package);
+
+            Assert.Equal(null, listPackageItemViewModel.Tags);
+        }
+
+        [Fact]
+        public void TagsAreParsed()
+        {
+            var package = new Package()
+            {
+                Tags = "tag1 tag2 tag3"
+            };
+
+            var listPackageItemViewModel = new ListPackageItemViewModel(package);
+
+            Assert.Equal(3, listPackageItemViewModel.Tags.Count());
+            Assert.True(listPackageItemViewModel.Tags.Contains("tag1"));
+            Assert.True(listPackageItemViewModel.Tags.Contains("tag2"));
+            Assert.True(listPackageItemViewModel.Tags.Contains("tag3"));
+        }
+
+        [Fact]
+        public void AuthorsIsFlattenedAuthors()
+        {
+            var authors = new HashSet<PackageAuthor>();
+            var author1 = new PackageAuthor
+            {
+                Name = "author1"
+            };
+            var author2 = new PackageAuthor
+            {
+                Name = "author2"
+            };
+
+            authors.Add(author1);
+            authors.Add(author2);
+
+            var flattenedAuthors = "something Completely different";
+
+            var package = new Package()
+            {
+                Authors = authors,
+                FlattenedAuthors = flattenedAuthors
+            };
+
+            var listPackageItemViewModel = new ListPackageItemViewModel(package);
+
+            Assert.Equal(flattenedAuthors, listPackageItemViewModel.Authors);
+        }
+
+        [Fact]
+        public void UseVersionIfLatestAndStableNotSame()
+        {
+            var package = new Package()
+            {
+                IsLatest = true,
+                IsLatestStable = false
+            };
+
+            var listPackageItemViewModel = new ListPackageItemViewModel(package);
+            Assert.True(listPackageItemViewModel.UseVersion);
+
+            package.IsLatest = false;
+            package.IsLatestStable = true;
+            Assert.True(listPackageItemViewModel.UseVersion);
+
+            package.IsLatest = false;
+            package.IsLatestStable = false;
+            Assert.True(listPackageItemViewModel.UseVersion);
+
+            package.IsLatest = true;
+            package.IsLatestStable = true;
+            Assert.False(listPackageItemViewModel.UseVersion);
+        }
+    }
+}


### PR DESCRIPTION
Split description truncation from extra information so we can parse html in extra info.
Fix for https://github.com/NuGet/NuGetGallery/issues/3604

@skofman1 @shishirx34 @joelverhagen 