### PR TITLE
Make file storage implementations atomically check for overwrite

### DIFF
--- a/src/NuGetGallery/Services/CloudBlobWrapper.cs
+++ b/src/NuGetGallery/Services/CloudBlobWrapper.cs
@@ -95,12 +95,20 @@ namespace NuGetGallery
                 state: null);
         }
 
-        public Task UploadFromStreamAsync(Stream packageFile)
+        public async Task UploadFromStreamAsync(Stream packageFile, bool overwrite)
         {
-            return Task.Factory.FromAsync(
-                (cb, state) => _blob.BeginUploadFromStream(packageFile, cb, state), 
-                ar => _blob.EndUploadFromStream(ar),
-                state: null);
+            if (overwrite)
+            {
+                await _blob.UploadFromStreamAsync(packageFile);
+            }
+            else
+            {
+                await _blob.UploadFromStreamAsync(
+                    packageFile,
+                    AccessCondition.GenerateIfNoneMatchCondition("*"),
+                    new BlobRequestOptions(),
+                    new OperationContext());
+            }
         }
 
         public Task FetchAttributesAsync()

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -156,8 +156,6 @@ namespace NuGetGallery
             }
             catch (IOException ex)
             {
-                ex.Log();
-
                 throw new InvalidOperationException(
                     String.Format(
                         CultureInfo.CurrentCulture,

--- a/src/NuGetGallery/Services/FileSystemService.cs
+++ b/src/NuGetGallery/Services/FileSystemService.cs
@@ -32,9 +32,13 @@ namespace NuGetGallery
             return File.OpenRead(path);
         }
 
-        public Stream OpenWrite(string path)
+        public Stream OpenWrite(string path, bool overwrite)
         {
-            return File.OpenWrite(path);
+            return new FileStream(
+                path,
+                overwrite ? FileMode.Create : FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None);
         }
 
         public DateTimeOffset GetCreationTimeUtc(string path)

--- a/src/NuGetGallery/Services/IFileSystemService.cs
+++ b/src/NuGetGallery/Services/IFileSystemService.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
         bool DirectoryExists(string path);
         bool FileExists(string path);
         Stream OpenRead(string path);
-        Stream OpenWrite(string path);
+        Stream OpenWrite(string path, bool overwrite);
         DateTimeOffset GetCreationTimeUtc(string path);
 
         IFileReference GetFileReference(string path);

--- a/src/NuGetGallery/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery/Services/ISimpleCloudBlob.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -22,7 +23,7 @@ namespace NuGetGallery
 
         Task<bool> ExistsAsync();
         Task SetPropertiesAsync();
-        Task UploadFromStreamAsync(Stream packageFile);
+        Task UploadFromStreamAsync(Stream packageFile, bool overwrite);
 
         Task FetchAttributesAsync();
     }

--- a/tests/NuGetGallery.Core.Facts/Utilities/TestDirectory.cs
+++ b/tests/NuGetGallery.Core.Facts/Utilities/TestDirectory.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace NuGetGallery.Utilities
 {
-    internal sealed class TestDirectory : IDisposable
+    public sealed class TestDirectory : IDisposable
     {
         public string FullPath { get; }
 
@@ -20,7 +20,7 @@ namespace NuGetGallery.Utilities
             DeleteDirectory(FullPath);
         }
 
-        internal static TestDirectory Create()
+        public static TestDirectory Create()
         {
             var baseDirectoryPath = Path.Combine(Path.GetTempPath(), "NuGetTestFolder");
             var subdirectoryName = Guid.NewGuid().ToString();

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -503,6 +503,10 @@
       <Project>{1DACF781-5CD0-4123-8BAC-CD385D864BE5}</Project>
       <Name>NuGetGallery</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGetGallery.Core.Facts\NuGetGallery.Core.Facts.csproj">
+      <Project>{8ac9e39e-366c-47e5-80ae-38e71cd31386}</Project>
+      <Name>NuGetGallery.Core.Facts</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Web;
@@ -200,7 +201,6 @@ namespace NuGetGallery
                 fakeBlobContainer.Setup(x => x.GetBlobReference(It.IsAny<string>())).Returns(fakeBlob.Object);
                 fakeBlob.Setup(x => x.Uri).Returns(new Uri("http://theUri"));
                 fakeBlob.Setup(x => x.DeleteIfExistsAsync()).Returns(Task.FromResult(0));
-                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>())).Returns(Task.FromResult(0));
                 fakeBlob.Setup(x => x.SetPropertiesAsync()).Returns(Task.FromResult(0));
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 
@@ -306,7 +306,6 @@ namespace NuGetGallery
                 var fakeBlobContainer = new Mock<ICloudBlobContainer>();
                 var fakeBlob = new Mock<ISimpleCloudBlob>();
                 fakeBlob.Setup(x => x.DeleteIfExistsAsync()).Returns(Task.FromResult(0));
-                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>())).Returns(Task.FromResult(0));
                 fakeBlob.Setup(x => x.SetPropertiesAsync()).Returns(Task.FromResult(0));
                 fakeBlobClient.Setup(x => x.GetContainerReference(It.IsAny<string>()))
                     .Returns<string>(
@@ -438,7 +437,7 @@ namespace NuGetGallery
                 fakeBlob.Setup(x => x.Properties).Returns(new BlobProperties());
                 fakeBlob.Setup(x => x.Uri).Returns(new Uri("http://theUri"));
                 fakeBlob.Setup(x => x.DeleteIfExistsAsync()).Returns(Task.FromResult(0));
-                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>(), true)).Returns(Task.FromResult(0));
                 fakeBlob.Setup(x => x.SetPropertiesAsync()).Returns(Task.FromResult(0));
 
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
@@ -454,8 +453,7 @@ namespace NuGetGallery
                 var fakeBlobClient = new Mock<ICloudBlobClient>();
                 var fakeBlobContainer = new Mock<ICloudBlobContainer>();
                 var fakeBlob = new Mock<ISimpleCloudBlob>();
-                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>())).Returns(Task.FromResult(0));
-                fakeBlob.Setup(x => x.DeleteIfExistsAsync()).Returns(Task.FromResult(0)).Verifiable();
+                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>(), true)).Returns(Task.FromResult(0));
                 fakeBlob.Setup(x => x.SetPropertiesAsync()).Returns(Task.FromResult(0)).Verifiable();
                 fakeBlobClient.Setup(x => x.GetContainerReference(It.IsAny<string>())).Returns(fakeBlobContainer.Object);
                 fakeBlobContainer.Setup(x => x.GetBlobReference(It.IsAny<string>())).Returns(fakeBlob.Object);
@@ -476,8 +474,12 @@ namespace NuGetGallery
                 var fakeBlobClient = new Mock<ICloudBlobClient>();
                 var fakeBlobContainer = new Mock<ICloudBlobContainer>();
                 var fakeBlob = new Mock<ISimpleCloudBlob>();
-                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>())).Returns(Task.FromResult(0));
-                fakeBlob.Setup(x => x.ExistsAsync()).Returns(Task.FromResult(true)).Verifiable();
+                fakeBlob
+                    .Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>(), false))
+                    .Throws(new StorageException(
+                        new RequestResult { HttpStatusCode = (int)HttpStatusCode.Conflict },
+                        "Conflict!",
+                        new Exception("inner")));
                 fakeBlobClient.Setup(x => x.GetContainerReference(It.IsAny<string>())).Returns(fakeBlobContainer.Object);
                 fakeBlobContainer.Setup(x => x.GetBlobReference(It.IsAny<string>())).Returns(fakeBlob.Object);
                 fakeBlobContainer.Setup(x => x.SetPermissionsAsync(It.IsAny<BlobContainerPermissions>())).Returns(Task.FromResult(0));
@@ -507,7 +509,7 @@ namespace NuGetGallery
                 fakeBlob.Setup(x => x.SetPropertiesAsync()).Returns(Task.FromResult(0));
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
                 var fakePackageFile = new MemoryStream();
-                fakeBlob.Setup(x => x.UploadFromStreamAsync(fakePackageFile)).Returns(Task.FromResult(0)).Verifiable();
+                fakeBlob.Setup(x => x.UploadFromStreamAsync(fakePackageFile, true)).Returns(Task.FromResult(0)).Verifiable();
 
                 await service.SaveFileAsync(Constants.PackagesFolderName, "theFileName", fakePackageFile);
 
@@ -542,7 +544,7 @@ namespace NuGetGallery
                 fakeBlob.Setup(x => x.Properties).Returns(new BlobProperties());
                 fakeBlob.Setup(x => x.Uri).Returns(new Uri("http://theUri"));
                 fakeBlob.Setup(x => x.DeleteIfExistsAsync()).Returns(Task.FromResult(0));
-                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                fakeBlob.Setup(x => x.UploadFromStreamAsync(It.IsAny<Stream>(), true)).Returns(Task.FromResult(0));
                 fakeBlob.Setup(x => x.SetPropertiesAsync()).Returns(Task.FromResult(0));
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
@@ -67,6 +68,7 @@
     <Compile Include="ODataFeeds\FeedType.cs" />
     <Compile Include="ODataFeeds\SearchTest.cs" />
     <Compile Include="ODataFeeds\V2FeedExtendedTests.cs" />
+    <Compile Include="PackageCreation\ApiPushTests.cs" />
     <Compile Include="Statistics\PackageStatisticsTests.cs" />
     <Compile Include="ODataFeeds\V2FeedTests.cs" />
     <Compile Include="WebPages\FluentLinkChecker.cs" />

--- a/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
@@ -62,7 +62,7 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
                         TestOutputHelper.WriteLine($"Task {taskIndex:D2} push:     HTTP {(int)statusCodes[taskIndex - 1]}");
                     }
 
-                    var downloadUrl = $"http://nuget.localtest.me/api/v2/package/{packageId}/{packageVersion}";
+                    var downloadUrl = $"{UrlHelper.V2FeedRootUrl}package/{packageId}/{packageVersion}";
                     using (var response = await client.GetAsync(downloadUrl))
                     {
                         TestOutputHelper.WriteLine($"Package download: HTTP {(int)response.StatusCode}");
@@ -88,12 +88,10 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
             Barrier barrier)
         {
             using (var package = File.OpenRead(packagePath))
-            using (var request = new HttpRequestMessage(HttpMethod.Put, "http://nuget.localtest.me/api/v2/package"))
-            // using (var request = new HttpRequestMessage(HttpMethod.Put, UrlHelper.V2FeedPushSourceUrl))
+            using (var request = new HttpRequestMessage(HttpMethod.Put, UrlHelper.V2FeedPushSourceUrl))
             {
                 request.Content = new StreamContent(new BarrierStream(package, barrier));
-                // request.Headers.Add("X-NuGet-ApiKey", EnvironmentSettings.TestAccountApiKey_Push);
-                request.Headers.Add("X-NuGet-ApiKey", "25cbd955-0b03-4c36-8c44-f0a86004ec42");
+                request.Headers.Add("X-NuGet-ApiKey", EnvironmentSettings.TestAccountApiKey_Push);
 
                 using (var response = await client.SendAsync(request))
                 {

--- a/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetGallery.FunctionalTests.PackageCreation
+{
+    public class ApiPushTests : GalleryTestBase
+    {
+        private const int TaskCount = 16;
+
+        public ApiPushTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        public async Task DuplicatePushesAreRejectedAndNotDeleted()
+        {
+            // Arrange
+            using (var client = new HttpClient())
+            {
+                var packageCreationHelper = new PackageCreationHelper(TestOutputHelper);
+                var packageId = $"{nameof(DuplicatePushesAreRejectedAndNotDeleted)}.{DateTime.UtcNow.Ticks}";
+
+                for (var i = 0; i < 10; i++)
+                {
+                    if (i > 0)
+                    {
+                        TestOutputHelper.WriteLine(string.Empty);
+                        TestOutputHelper.WriteLine(new string('=', 80));
+                        TestOutputHelper.WriteLine(string.Empty);
+                    }
+
+                    var packageVersion = $"1.0.{i}";
+                    TestOutputHelper.WriteLine($"Starting package {packageId} {packageVersion}...");
+
+                    var packagePath = await packageCreationHelper.CreatePackage(packageId, packageVersion);
+
+                    var tasks = new List<Task<HttpStatusCode>>();
+                    var barrier = new Barrier(TaskCount);
+
+                    // Act
+                    for (var taskIndex = 0; taskIndex < TaskCount; taskIndex++)
+                    {
+                        tasks.Add(PushAsync(client, packagePath, barrier));
+                    }
+
+                    var statusCodes = await Task.WhenAll(tasks);
+
+                    // Assert
+                    for (var taskIndex = 1; taskIndex <= statusCodes.Length; taskIndex++)
+                    {
+                        TestOutputHelper.WriteLine($"Task {taskIndex:D2} push:     HTTP {(int)statusCodes[taskIndex - 1]}");
+                    }
+
+                    var downloadUrl = $"http://nuget.localtest.me/api/v2/package/{packageId}/{packageVersion}";
+                    using (var response = await client.GetAsync(downloadUrl))
+                    {
+                        TestOutputHelper.WriteLine($"Package download: HTTP {(int)response.StatusCode}");
+
+                        Assert.Equal(response.StatusCode, HttpStatusCode.OK);
+                        var expectedBytes = File.ReadAllBytes(packagePath);
+                        var actualPackageBytes = await response.Content.ReadAsByteArrayAsync();
+
+                        // The file length assertion is easier to read in the log.
+                        Assert.Equal(expectedBytes.Length, actualPackageBytes.Length);
+                        Assert.Equal(expectedBytes, actualPackageBytes);
+                    }
+
+                    Assert.Equal(1, statusCodes.Count(x => x == HttpStatusCode.Created));
+                    Assert.Equal(TaskCount - 1, statusCodes.Count(x => x == HttpStatusCode.Conflict));
+                }
+            }
+        }
+
+        private async Task<HttpStatusCode> PushAsync(
+            HttpClient client,
+            string packagePath,
+            Barrier barrier)
+        {
+            using (var package = File.OpenRead(packagePath))
+            using (var request = new HttpRequestMessage(HttpMethod.Put, "http://nuget.localtest.me/api/v2/package"))
+            // using (var request = new HttpRequestMessage(HttpMethod.Put, UrlHelper.V2FeedPushSourceUrl))
+            {
+                request.Content = new StreamContent(new BarrierStream(package, barrier));
+                // request.Headers.Add("X-NuGet-ApiKey", EnvironmentSettings.TestAccountApiKey_Push);
+                request.Headers.Add("X-NuGet-ApiKey", "25cbd955-0b03-4c36-8c44-f0a86004ec42");
+
+                using (var response = await client.SendAsync(request))
+                {
+                    if (response.StatusCode != HttpStatusCode.Created &&
+                        response.StatusCode != HttpStatusCode.Conflict)
+                    {
+                        var content = await response.Content.ReadAsStringAsync();
+                        TestOutputHelper.WriteLine($"HTTP {(int)response.StatusCode} {response.ReasonPhrase}{Environment.NewLine}{content}");
+                    }
+
+                    return response.StatusCode;
+                }
+            }
+        }
+
+        private class BarrierStream : Stream
+        {
+            private readonly Stream _innerStream;
+            private readonly Barrier _barrier;
+
+            public BarrierStream(Stream innerStream, Barrier barrier)
+            {
+                _innerStream = innerStream;
+                _barrier = barrier;
+            }
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => false;
+
+            public override long Length => _innerStream.Length;
+
+            public override long Position
+            {
+                get => _innerStream.Position;
+                set => _innerStream.Position = value;
+            }
+
+            public override void Flush()
+            {
+                throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var read = _innerStream.Read(buffer, offset, count);
+                return GetReadAndWait(read);
+            }
+
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                var read = await _innerStream.ReadAsync(buffer, offset, count);
+                return GetReadAndWait(read);
+            }
+
+            private int GetReadAndWait(int read)
+            {
+                // Wait for the event once the entire inner stream has been consumed.
+                if (read == 0)
+                {
+                    _barrier.SignalAndWait();
+                }
+
+                return read;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -23,6 +24,9 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
         }
 
         [Fact]
+        [Description("Pushes many packages of the same ID and version. Verifies exactly one push succeeds and the rest fail with a conflict.")]
+        [Priority(2)]
+        [Category("P2Tests")]
         public async Task DuplicatePushesAreRejectedAndNotDeleted()
         {
             // Arrange
@@ -128,8 +132,14 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
 
             public override long Position
             {
-                get => _innerStream.Position;
-                set => _innerStream.Position = value;
+                get
+                {
+                    return _innerStream.Position;
+                }
+                set
+                {
+                    _innerStream.Position = value;
+                }
             }
 
             public override void Flush()

--- a/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -95,7 +96,7 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
             using (var request = new HttpRequestMessage(HttpMethod.Put, UrlHelper.V2FeedPushSourceUrl))
             {
                 request.Content = new StreamContent(new BarrierStream(package, barrier));
-                request.Headers.Add("X-NuGet-ApiKey", EnvironmentSettings.TestAccountApiKey_Push);
+                request.Headers.Add("X-NuGet-ApiKey", EnvironmentSettings.TestAccountApiKey);
 
                 using (var response = await client.SendAsync(request))
                 {


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/3661.

The problem here is that the `overwrite` parameter on `IFileStorageService.SaveFileAsync` is not implemented in a thread-safe way. In both file system and Azure blob storage cases, the logic is:

1. Check if the file exists.
1. If we are allowed to overwrite, delete the file if it exists.
1. If we are not allowed to overwrite, throw.
1. Persist the provided stream.
1. Commit the package to the database.
1. If the commit fails, delete the package file.

Between step number 1 and 4, two threads can enter and persist the stream successfully when one thread should have failed on step 3. The two threads continue on to the next step in the push flow, which is persisting the package to the database. The first thread succeeds but the second fails with a `UNIQUE` constraint failure. In our code, we react to database exceptions by deleting the package. When the second thread fails the database commit, it ends up deleting the package persisted even though the first thread successfully committed to the database.

This leads to a package that is in the database but is not in file storage, meaning we lost the .nupkg.

The fix for the file system storage is to open the file with `FileMode.CreateNew` when `overwrite` is `false`. This tells .NET to throw an exception if the file already exists. We catch this and fall into the already existing code path.

The fix for the Azure storage is to upload the file stream with `If-None-Match: *`. Blob storage will reject the upload if the blob already exists with a `409 Conflict`. We handle this HTTP exception and fall into the already existing code path.