### PR TITLE
Revert UpdateIsLatest optimistic concurrency changes

### DIFF
--- a/src/NuGetGallery.Core/Entities/EntitiesConfiguration.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesConfiguration.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.SqlServer;
@@ -16,41 +15,19 @@ namespace NuGetGallery
         {
             // Configure Connection Resiliency / Retry Logic
             // See https://msdn.microsoft.com/en-us/data/dn456835.aspx and msdn.microsoft.com/en-us/data/dn307226
-            SetExecutionStrategy("System.Data.SqlClient", () => UseRetriableExecutionStrategy
-                ? new SqlAzureExecutionStrategy() : (IDbExecutionStrategy)new DefaultExecutionStrategy());
+            SetExecutionStrategy("System.Data.SqlClient", () => SuspendExecutionStrategy
+                ? (IDbExecutionStrategy)new DefaultExecutionStrategy() : new SqlAzureExecutionStrategy());
         }
 
-        private static bool UseRetriableExecutionStrategy
+        public static bool SuspendExecutionStrategy
         {
             get
             {
-                return (bool?)CallContext.LogicalGetData(nameof(UseRetriableExecutionStrategy)) ?? true;
+                return (bool?)CallContext.LogicalGetData("SuspendExecutionStrategy") ?? false;
             }
             set
             {
-                CallContext.LogicalSetData(nameof(UseRetriableExecutionStrategy), value);
-            }
-        }
-
-        public static IDisposable SuspendRetriableExecutionStrategy()
-        {
-            return new RetriableExecutionStrategySuspension();
-        }
-
-        private class RetriableExecutionStrategySuspension : IDisposable
-        {
-            private readonly bool _originalValue;
-
-            internal RetriableExecutionStrategySuspension()
-            {
-                _originalValue = UseRetriableExecutionStrategy;
-
-                UseRetriableExecutionStrategy = false;
-            }
-
-            public void Dispose()
-            {
-                UseRetriableExecutionStrategy = _originalValue;
+                CallContext.LogicalSetData("SuspendExecutionStrategy", value);
             }
         }
     }

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
@@ -67,11 +66,6 @@ namespace NuGetGallery
         public void SetCommandTimeout(int? seconds)
         {
             ObjectContext.CommandTimeout = seconds;
-        }
-
-        public DbChangeTracker GetChangeTracker()
-        {
-            return ChangeTracker;
         }
 
         public Database GetDatabase()

--- a/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
 {
     public interface IEntitiesContext
-        : IDisposable
     {
         IDbSet<CuratedFeed> CuratedFeeds { get; set; }
         IDbSet<CuratedPackage> CuratedPackages { get; set; }
@@ -23,8 +20,6 @@ namespace NuGetGallery
         IDbSet<T> Set<T>() where T : class;
         void DeleteOnCommit<T>(T entity) where T : class;
         void SetCommandTimeout(int? seconds);
-
-        DbChangeTracker GetChangeTracker();
         Database GetDatabase();
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -473,9 +473,6 @@ namespace NuGetGallery
                             throw;
                         }
 
-                        // Handle in separate transaction because of concurrency check with retry
-                        await PackageService.UpdateIsLatestAsync(package.PackageRegistration);
-
                         IndexingService.UpdatePackage(package);
                         
                         // Write an audit record
@@ -555,13 +552,6 @@ namespace NuGetGallery
             }
 
             await PackageService.MarkPackageUnlistedAsync(package);
-
-            // Handle in separate transaction because of concurrency check with retry. Due to using
-            // separate transactions, we must always call UpdateIsLatest on delete/unlist. This is
-            // because a concurrent thread could be marking the package as latest before this thread
-            // is able to commit the delete /unlist.
-            await PackageService.UpdateIsLatestAsync(package.PackageRegistration);
-
             IndexingService.UpdatePackage(package);
             return new EmptyResult();
         }
@@ -595,10 +585,6 @@ namespace NuGetGallery
             }
 
             await PackageService.MarkPackageListedAsync(package);
-            
-            // handle in separate transaction because of concurrency check with retry
-            await PackageService.UpdateIsLatestAsync(package.PackageRegistration);
-
             IndexingService.UpdatePackage(package);
             return new EmptyResult();
         }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -999,20 +999,11 @@ namespace NuGetGallery
             {
                 action = "unlisted";
                 await _packageService.MarkPackageUnlistedAsync(package);
-
-                // Handle in separate transaction because of concurrency check with retry. Due to using
-                // separate transactions, we must always call UpdateIsLatest on delete/unlist. This is
-                // because a concurrent thread could be marking the package as latest before this thread
-                // is able to commit the delete /unlist.
-                await _packageService.UpdateIsLatestAsync(package.PackageRegistration);
             }
             else
             {
                 action = "listed";
                 await _packageService.MarkPackageListedAsync(package);
-
-                // handle in separate transaction because of concurrency check with retry
-                await _packageService.UpdateIsLatestAsync(package.PackageRegistration);
             }
             TempData["Message"] = String.Format(
                 CultureInfo.CurrentCulture,
@@ -1203,9 +1194,6 @@ namespace NuGetGallery
                     await _packageFileService.DeletePackageFileAsync(packageMetadata.Id, packageMetadata.Version.ToNormalizedString());
                     throw;
                 }
-
-                // handle in separate transaction because of concurrency check with retry
-                await _packageService.UpdateIsLatestAsync(package.PackageRegistration);
 
                 // tell Lucene to update index for the new package
                 _indexingService.UpdateIndex();

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -16,23 +16,13 @@ namespace NuGetGallery
         IEnumerable<PackageRegistration> FindPackageRegistrationsByOwner(User user);
         IEnumerable<Package> FindDependentPackages(Package package);
 
-        /// <summary>
-        /// Updates IsLatest/IsLatestStable flags after a package create, update or delete operation.
-        /// 
-        /// Due to the manual optimistic concurrency check added to the underlying implementation,
-        /// IsLatest/IsLatestStable changes will be applied in memory and should not be committed with EF.
-        /// Callers should ensure that all other commits are complete before calling UpdateIsLatestAsync.
-        /// </summary>
-        /// <param name="packageRegistration"></param>
-        /// <returns></returns>
-        Task UpdateIsLatestAsync(PackageRegistration packageRegistration);
+        Task UpdateIsLatestAsync(PackageRegistration packageRegistration, bool commitChanges = true);
 
         /// <summary>
         /// Populate the related database tables to create the specified package for the specified user.
         /// </summary>
         /// <remarks>
         /// This method doesn't upload the package binary to the blob storage. The caller must do it after this call.
-        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
         /// </remarks>
         /// <param name="nugetPackage">The package to be created.</param>
         /// <param name="packageStreamMetadata">The package stream's metadata.</param>
@@ -43,49 +33,10 @@ namespace NuGetGallery
 
         Package EnrichPackageFromNuGetPackage(Package package, PackageArchiveReader packageArchive, PackageMetadata packageMetadata, PackageStreamMetadata packageStreamMetadata, User user);
 
-        /// <summary>
-        /// Publishes a package by listing it.
-        /// </summary>
-        /// <remarks>
-        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
-        /// </remarks>
-        /// <param name="id">ID for the package to publish</param>
-        /// <param name="version">Package version</param>
-        /// <param name="commitChanges">Whether to commit changes to the database.</param>
-        /// <returns></returns>
         Task PublishPackageAsync(string id, string version, bool commitChanges = true);
-
-        /// <summary>
-        /// Publishes a package by listing it.
-        /// </summary>
-        /// <remarks>
-        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
-        /// </remarks>
-        /// <param name="package">The package to publish</param>
-        /// <param name="commitChanges">Whether to commit changes to the database.</param>
-        /// <returns></returns>
         Task PublishPackageAsync(Package package, bool commitChanges = true);
 
-        /// <summary>
-        /// Mark a package as unlisted.
-        /// </summary>
-        /// <remarks>
-        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
-        /// </remarks>
-        /// <param name="package">The package to unlist</param>
-        /// <param name="commitChanges">Whether to commit changes to the database.</param>
-        /// <returns></returns>
         Task MarkPackageUnlistedAsync(Package package, bool commitChanges = true);
-
-        /// <summary>
-        /// Mark a package as listed.
-        /// </summary>
-        /// <remarks>
-        /// This method doesn't update IsLatest/IsLatestStable flags. The caller must do it after this call.
-        /// </remarks>
-        /// <param name="package">The package to list.</param>
-        /// <param name="commitChanges">Whether to commit changes to the database.</param>
-        /// <returns></returns>
         Task MarkPackageListedAsync(Package package, bool commitChanges = true);
 
         Task<PackageOwnerRequest> CreatePackageOwnerRequestAsync(PackageRegistration package, User currentOwner, User newOwner);

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -3,41 +3,30 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Data.Entity;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
-using NuGetGallery.Diagnostics;
 using NuGetGallery.Packaging;
 
 namespace NuGetGallery
 {
     public class PackageService : IPackageService
     {
-        private const int UpdateIsLatestMaxRetries = 3;
-
-        private static readonly Lazy<Random> _randomGenerator = new Lazy<Random>();
-
         private readonly IIndexingService _indexingService;
-        private readonly IEntitiesContext _entitiesContext;
         private readonly IEntityRepository<PackageOwnerRequest> _packageOwnerRequestRepository;
         private readonly IEntityRepository<PackageRegistration> _packageRegistrationRepository;
         private readonly IEntityRepository<Package> _packageRepository;
         private readonly IPackageNamingConflictValidator _packageNamingConflictValidator;
         private readonly IAuditingService _auditingService;
-        private readonly IDiagnosticsSource _trace;
 
         public PackageService(
             IEntityRepository<PackageRegistration> packageRegistrationRepository,
             IEntityRepository<Package> packageRepository,
             IEntityRepository<PackageOwnerRequest> packageOwnerRequestRepository,
-            IEntitiesContext entitiesContext,
-            IDiagnosticsService diagnostics,
             IIndexingService indexingService,
             IPackageNamingConflictValidator packageNamingConflictValidator,
             IAuditingService auditingService)
@@ -75,12 +64,9 @@ namespace NuGetGallery
             _packageRegistrationRepository = packageRegistrationRepository;
             _packageRepository = packageRepository;
             _packageOwnerRequestRepository = packageOwnerRequestRepository;
-            _entitiesContext = entitiesContext;
             _indexingService = indexingService;
             _packageNamingConflictValidator = packageNamingConflictValidator;
             _auditingService = auditingService;
-
-            _trace = diagnostics.SafeGetSource("PackageService");
         }
 
         public void EnsureValid(PackageArchiveReader packageArchiveReader)
@@ -97,7 +83,7 @@ namespace NuGetGallery
                 ValidateSupportedFrameworks(supportedFrameworks);
             }
         }
-        
+
         public async Task<Package> CreatePackageAsync(PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User user, bool commitChanges = true)
         {
             var packageMetadata = PackageMetadata.FromNuspecReader(nugetPackage.GetNuspecReader());
@@ -110,6 +96,7 @@ namespace NuGetGallery
 
             var package = CreatePackageFromNuGetPackage(packageRegistration, nugetPackage, packageMetadata, packageStreamMetadata, user);
             packageRegistration.Packages.Add(package);
+            await UpdateIsLatestAsync(packageRegistration, false);
 
             if (commitChanges)
             {
@@ -254,7 +241,7 @@ namespace NuGetGallery
 
             return dependents.Select(d => d.Package);
         }
-        
+
         public async Task PublishPackageAsync(string id, string version, bool commitChanges = true)
         {
             var package = FindPackageByIdAndVersion(id, version);
@@ -266,7 +253,7 @@ namespace NuGetGallery
 
             await PublishPackageAsync(package, commitChanges);
         }
-        
+
         public async Task PublishPackageAsync(Package package, bool commitChanges = true)
         {
             if (package == null)
@@ -276,6 +263,8 @@ namespace NuGetGallery
 
             package.Published = DateTime.UtcNow;
             package.Listed = true;
+
+            await UpdateIsLatestAsync(package.PackageRegistration, false);
 
             if (commitChanges)
             {
@@ -320,7 +309,7 @@ namespace NuGetGallery
             await _auditingService.SaveAuditRecordAsync(
                 new PackageRegistrationAuditRecord(package, AuditedPackageRegistrationAction.RemoveOwner, user.Username));
         }
-        
+
         public async Task MarkPackageListedAsync(Package package, bool commitChanges = true)
         {
             if (package == null)
@@ -346,6 +335,8 @@ namespace NuGetGallery
             package.LastUpdated = DateTime.UtcNow;
             // NOTE: LastEdited will be overwritten by a trigger defined in the migration named "AddTriggerForPackagesLastEdited".
             package.LastEdited = DateTime.UtcNow;
+
+            await UpdateIsLatestAsync(package.PackageRegistration, false);
             
             await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(package, AuditedPackageAction.List));
 
@@ -354,7 +345,7 @@ namespace NuGetGallery
                 await _packageRepository.CommitChangesAsync();
             }
         }
-        
+
         public async Task MarkPackageUnlistedAsync(Package package, bool commitChanges = true)
         {
             if (package == null)
@@ -370,6 +361,11 @@ namespace NuGetGallery
             package.LastUpdated = DateTime.UtcNow;
             // NOTE: LastEdited will be overwritten by a trigger defined in the migration named "AddTriggerForPackagesLastEdited".
             package.LastEdited = DateTime.UtcNow;
+
+            if (package.IsLatest || package.IsLatestStable)
+            {
+                await UpdateIsLatestAsync(package.PackageRegistration, false);
+            }
 
             await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(package, AuditedPackageAction.Unlist));
 
@@ -682,143 +678,51 @@ namespace NuGetGallery
             }
         }
 
-        protected internal async virtual Task<bool> TryUpdateIsLatestInDatabase(IEntitiesContext context)
+        public async Task UpdateIsLatestAsync(PackageRegistration packageRegistration, bool commitChanges = true)
         {
-            // Use the EF change tracker to identify changes made in TryUpdateIsLatestAsync which
-            // need to be applied to the database below.
-            // Note that the change tracker is not mocked which make this method hard to unit test.
-            var changeTracker = context.GetChangeTracker();
-            var modifiedPackages = changeTracker.Entries<Package>().Where(p => p.State == EntityState.Modified).ToList();
-            if (modifiedPackages.Count == 0)
+            if (!packageRegistration.Packages.Any())
             {
-                return true;
+                return;
             }
 
-            // Apply changes to the database with an optimistic concurrency check to prevent multiple
-            // threads (in the same or different gallery instance) from setting IsLatest/IsLatestStable
-            // flag to true on different package versions.
-            // To preserve existing behavior, we only want to reject concurrent updates which set the
-            // IsLatest/IsLatestStable columns. For this reason, we must avoid the EF ConcurrencyCheck
-            // attribute which could reject any package update or delete.
-            var query = new StringBuilder("DECLARE @rowCount INT = 0");
-            foreach (var packageEntry in modifiedPackages)
+            // TODO: improve setting the latest bit; this is horrible. Trigger maybe?
+            foreach (var pv in packageRegistration.Packages.Where(p => p.IsLatest || p.IsLatestStable))
             {
-                // Set LastUpdated after all IsLatest/IsLatestStable changes are complete to ensure
-                // that we don't update rows where IsLatest/IsLatestStable hasn't changed.
-                packageEntry.Entity.LastUpdated = DateTime.UtcNow;
-
-                var isLatest = packageEntry.Entity.IsLatest ? 1 : 0;
-                var isLatestStable = packageEntry.Entity.IsLatestStable ? 1 : 0;
-                var key = packageEntry.Entity.Key;
-                var originalIsLatest = Boolean.Parse(packageEntry.OriginalValues["IsLatest"].ToString()) ? 1 : 0;
-                var originalIsLatestStable = Boolean.Parse(packageEntry.OriginalValues["IsLatestStable"].ToString()) ? 1 : 0;
-
-                query.AppendLine($"UPDATE [dbo].[Packages]");
-                query.AppendLine($"SET [IsLatest] = {isLatest}, [IsLatestStable] = {isLatestStable}, [LastUpdated] = GETUTCDATE()");
-                query.AppendLine($"WHERE [Key] = {key} AND [IsLatest] = {originalIsLatest} AND [IsLatestStable] = {originalIsLatestStable}");
-                query.AppendLine($"SET @rowCount = @rowCount + @@ROWCOUNT");
+                pv.IsLatest = false;
+                pv.IsLatestStable = false;
+                pv.LastUpdated = DateTime.UtcNow;
             }
-            query.AppendLine("SELECT @rowCount");
 
-            using (var transaction = context.GetDatabase().BeginTransaction(IsolationLevel.ReadCommitted))
+            // If the last listed package was just unlisted, then we won't find another one
+            var latestPackage = FindPackage(packageRegistration.Packages, p => !p.Deleted && p.Listed);
+
+            if (latestPackage != null)
             {
-                var rowCount = await context.GetDatabase().ExecuteSqlCommandAsync(query.ToString());
-                if (rowCount == modifiedPackages.Count)
+                latestPackage.IsLatest = true;
+                latestPackage.LastUpdated = DateTime.UtcNow;
+
+                if (latestPackage.IsPrerelease)
                 {
-                    transaction.Commit();
-                    return true;
+                    // If the newest uploaded package is a prerelease package, we need to find an older package that is
+                    // a release version and set it to IsLatest.
+                    var latestReleasePackage = FindPackage(packageRegistration.Packages.Where(p => !p.IsPrerelease && !p.Deleted && p.Listed));
+                    if (latestReleasePackage != null)
+                    {
+                        // We could have no release packages
+                        latestReleasePackage.IsLatestStable = true;
+                        latestReleasePackage.LastUpdated = DateTime.UtcNow;
+                    }
                 }
                 else
                 {
-                    // RowCount will not match if one or more updates failed the concurrency check. This
-                    // likely means another thread is trying to clear the current IsLatest/IsLatestStable.
-                    transaction.Rollback();
-                    return false;
+                    // Only release versions are marked as IsLatestStable.
+                    latestPackage.IsLatestStable = true;
                 }
             }
-        }
-        
-        private Task<bool> TryUpdateIsLatestAsync(IEntitiesContext context, PackageRegistration packageRegistration)
-        {
-            if (packageRegistration.Packages.Any())
+
+            if (commitChanges)
             {
-                // Update in memory first to avoid putting request entities in a bad state should a concurrency
-                // conflict occur.
-                foreach (var pv in packageRegistration.Packages.Where(p => p.IsLatest || p.IsLatestStable))
-                {
-                    pv.IsLatest = false;
-                    pv.IsLatestStable = false;
-                }
-
-                // If the last listed package was just unlisted, then we won't find another one.
-                var latestPackage = FindPackage(packageRegistration.Packages, p => !p.Deleted && p.Listed);
-
-                if (latestPackage != null)
-                {
-                    latestPackage.IsLatest = true;
-                    latestPackage.IsLatestStable = !latestPackage.IsPrerelease;
-
-                    if (latestPackage.IsPrerelease)
-                    {
-                        // If the newest uploaded package is a prerelease package, we need to find an older package
-                        // that is a release version and set it to IsLatestStable.
-                        var latestReleasePackage = FindPackage(packageRegistration.Packages.Where(p => !p.IsPrerelease && !p.Deleted && p.Listed));
-                        if (latestReleasePackage != null)
-                        {
-                            latestReleasePackage.IsLatest = false;
-                            latestReleasePackage.IsLatestStable = true;
-                        }
-                    }
-                }
-                // Now try to apply the changes to the database. If this fails, we still keep the in-memory changes
-                // for the current executing request. More than likely the concurrent thread is just making the
-                // same changes and the in-memory changes will be correct.
-                return TryUpdateIsLatestInDatabase(context);
-            }
-            return Task.FromResult(true);
-        }
-        
-        protected internal virtual IEntitiesContext CreateNewEntitiesContext()
-        {
-            return new EntitiesContext();
-        }
-        
-        public async Task UpdateIsLatestAsync(PackageRegistration packageRegistration)
-        {
-            // Must suspend the retry execution strategy in order to use transactions.
-            using (EntitiesConfiguration.SuspendRetriableExecutionStrategy())
-            {
-                if (await TryUpdateIsLatestAsync(_entitiesContext, packageRegistration))
-                {
-                    return;
-                }
-
-                // Retry the update in case a concurrency conflict was detected on the first attempt.
-                int retryCount = 1;
-                do
-                {
-                    await Task.Delay(_randomGenerator.Value.Next(0, 1000));
-
-                    _trace.Information(String.Format("Retrying {0} for package '{1}' ({2}/{3})",
-                        nameof(UpdateIsLatestAsync), packageRegistration.Id, retryCount, UpdateIsLatestMaxRetries));
-
-                    // Since EF contexts are short-lived and do not really support refresh, we will use a
-                    // different context than the request on retry to avoid putting the request context in
-                    // a bad state. More than likely the retry will detect that the concurrent update has
-                    // already made the right updates and no changes will be necessary.
-                    using (var detachedRetryContext = CreateNewEntitiesContext())
-                    {
-                        var detachedPackageRegistration = detachedRetryContext.PackageRegistrations.SingleOrDefault(
-                            pr => pr.Id == packageRegistration.Id);
-
-                        if (await TryUpdateIsLatestAsync(detachedRetryContext, detachedPackageRegistration))
-                        {
-                            return;
-                        }
-                    }
-                    retryCount++;
-                }
-                while (retryCount <= UpdateIsLatestMaxRetries);
+                await _packageRepository.CommitChangesAsync();
             }
         }
 

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -12,7 +12,6 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
-using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
 using NuGetGallery.Packaging;
 
@@ -26,7 +25,6 @@ namespace NuGetGallery
 
         private readonly IIndexingService _indexingService;
         private readonly IEntitiesContext _entitiesContext;
-        private readonly IAppConfiguration _configuration;
         private readonly IEntityRepository<PackageOwnerRequest> _packageOwnerRequestRepository;
         private readonly IEntityRepository<PackageRegistration> _packageRegistrationRepository;
         private readonly IEntityRepository<Package> _packageRepository;
@@ -39,7 +37,6 @@ namespace NuGetGallery
             IEntityRepository<Package> packageRepository,
             IEntityRepository<PackageOwnerRequest> packageOwnerRequestRepository,
             IEntitiesContext entitiesContext,
-            IAppConfiguration configuration,
             IDiagnosticsService diagnostics,
             IIndexingService indexingService,
             IPackageNamingConflictValidator packageNamingConflictValidator,
@@ -58,16 +55,6 @@ namespace NuGetGallery
             if (packageOwnerRequestRepository == null)
             {
                 throw new ArgumentNullException(nameof(packageOwnerRequestRepository));
-            }
-
-            if (entitiesContext == null)
-            {
-                throw new ArgumentNullException(nameof(entitiesContext));
-            }
-
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
             }
 
             if (indexingService == null)
@@ -89,7 +76,6 @@ namespace NuGetGallery
             _packageRepository = packageRepository;
             _packageOwnerRequestRepository = packageOwnerRequestRepository;
             _entitiesContext = entitiesContext;
-            _configuration = configuration;
             _indexingService = indexingService;
             _packageNamingConflictValidator = packageNamingConflictValidator;
             _auditingService = auditingService;
@@ -794,7 +780,7 @@ namespace NuGetGallery
         
         protected internal virtual IEntitiesContext CreateNewEntitiesContext()
         {
-            return new EntitiesContext(_configuration.SqlConnectionString, readOnly: false);
+            return new EntitiesContext();
         }
         
         public async Task UpdateIsLatestAsync(PackageRegistration packageRegistration)

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -729,14 +729,7 @@ namespace NuGetGallery
 
                 query.AppendLine($"UPDATE [dbo].[Packages]");
                 query.AppendLine($"SET [IsLatest] = {isLatest}, [IsLatestStable] = {isLatestStable}, [LastUpdated] = GETUTCDATE()");
-                query.AppendLine($"WHERE [Key] = {key}");
-                // optimistic concurrency check to prevent concurrent sets of latest/latestStable
-                query.AppendLine($" AND [IsLatest] = {originalIsLatest} AND [IsLatestStable] = {originalIsLatestStable}");
-                // ensure new latest/latestStable was not concurrently unlisted/deleted
-                if (packageEntry.Entity.IsLatest || packageEntry.Entity.IsLatestStable)
-                {
-                    query.AppendLine($" AND [Listed] = 1 AND [Deleted] = 0");
-                }
+                query.AppendLine($"WHERE [Key] = {key} AND [IsLatest] = {originalIsLatest} AND [IsLatestStable] = {originalIsLatestStable}");
                 query.AppendLine($"SET @rowCount = @rowCount + @@ROWCOUNT");
             }
             query.AppendLine("SELECT @rowCount");

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -10,18 +10,18 @@ using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
-using Xunit;
 using Moq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
-using NuGetGallery.Areas.Admin;
 using NuGetGallery.AsyncFileUpload;
-using NuGetGallery.Auditing;
 using NuGetGallery.Configuration;
 using NuGetGallery.Framework;
 using NuGetGallery.Helpers;
 using NuGetGallery.Packaging;
+using NuGetGallery.Areas.Admin;
+using NuGetGallery.Auditing;
+using Xunit;
 
 namespace NuGetGallery
 {
@@ -51,9 +51,9 @@ namespace NuGetGallery
             if (uploadFileService == null)
             {
                 uploadFileService = new Mock<IUploadFileService>();
-                uploadFileService.Setup(x => x.DeleteUploadFileAsync(It.IsAny<int>())).Returns(Task.CompletedTask);
+                uploadFileService.Setup(x => x.DeleteUploadFileAsync(It.IsAny<int>())).Returns(Task.FromResult(0));
                 uploadFileService.Setup(x => x.GetUploadFileAsync(42)).Returns(Task.FromResult<Stream>(null));
-                uploadFileService.Setup(x => x.SaveUploadFileAsync(42, It.IsAny<Stream>())).Returns(Task.CompletedTask);
+                uploadFileService.Setup(x => x.SaveUploadFileAsync(42, It.IsAny<Stream>())).Returns(Task.FromResult(0));
             }
             messageService = messageService ?? new Mock<IMessageService>();
             searchService = searchService ?? CreateSearchService();
@@ -63,7 +63,7 @@ namespace NuGetGallery
             if (packageFileService == null)
             {
                 packageFileService = new Mock<IPackageFileService>();
-                packageFileService.Setup(p => p.SavePackageFileAsync(It.IsAny<Package>(), It.IsAny<Stream>())).Returns(Task.CompletedTask);
+                packageFileService.Setup(p => p.SavePackageFileAsync(It.IsAny<Package>(), It.IsAny<Stream>())).Returns(Task.FromResult(0));
             }
 
             entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
@@ -137,7 +137,7 @@ namespace NuGetGallery
             public async Task DeletesTheInProgressPackageUpload()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(42)).Returns(Task.CompletedTask);
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(42)).Returns(Task.FromResult(0));
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
@@ -151,7 +151,7 @@ namespace NuGetGallery
             public async Task RedirectsToUploadPageAfterDelete()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(42)).Returns(Task.CompletedTask);
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(42)).Returns(Task.FromResult(0));
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
@@ -545,11 +545,9 @@ namespace NuGetGallery
                 packageService.Setup(svc => svc.MarkPackageListedAsync(It.IsAny<Package>(), It.IsAny<bool>()))
                     .Throws(new Exception("Shouldn't be called"));
                 packageService.Setup(svc => svc.MarkPackageUnlistedAsync(It.IsAny<Package>(), It.IsAny<bool>()))
-                    .Returns(Task.CompletedTask).Verifiable();
+                    .Returns(Task.FromResult(0)).Verifiable();
                 packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0", true))
                     .Returns(package).Verifiable();
-                packageService.Setup(svc => svc.UpdateIsLatestAsync(It.IsAny<PackageRegistration>()))
-                    .Returns(Task.CompletedTask).Verifiable();
 
                 var indexingService = new Mock<IIndexingService>();
 
@@ -581,13 +579,11 @@ namespace NuGetGallery
 
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
                 packageService.Setup(svc => svc.MarkPackageListedAsync(It.IsAny<Package>(), It.IsAny<bool>()))
-                    .Returns(Task.CompletedTask).Verifiable();
+                    .Returns(Task.FromResult(0)).Verifiable();
                 packageService.Setup(svc => svc.MarkPackageUnlistedAsync(It.IsAny<Package>(), It.IsAny<bool>()))
                     .Throws(new Exception("Shouldn't be called"));
                 packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0", true))
                     .Returns(package).Verifiable();
-                packageService.Setup(svc => svc.UpdateIsLatestAsync(It.IsAny<PackageRegistration>()))
-                    .Returns(Task.CompletedTask).Verifiable();
 
                 var indexingService = new Mock<IIndexingService>();
 
@@ -1047,9 +1043,9 @@ namespace NuGetGallery
                 fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
 
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                 fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(null));
-                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.CompletedTask);
+                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService,
                     fakeNuGetPackage: fakeFileStream);
@@ -1069,9 +1065,9 @@ namespace NuGetGallery
                 var fakeFileStream = TestPackage.CreateTestPackageStream("thePackageId", "1.0.0");
                 fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                 fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(null));
-                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.CompletedTask);
+                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
@@ -1090,7 +1086,7 @@ namespace NuGetGallery
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
                 fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns<Stream>(null);
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                 fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(null));
                 var controller = CreateController(
                     uploadFileService: fakeUploadFileService);
@@ -1391,7 +1387,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>())).Returns(
                         Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
@@ -1417,7 +1413,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1425,7 +1421,7 @@ namespace NuGetGallery
                     var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
                     var fakePackageFileService = new Mock<IPackageFileService>();
-                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.CompletedTask).Verifiable();
+                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.FromResult(0)).Verifiable();
 
                     var controller = CreateController(
                         packageService: fakePackageService,
@@ -1453,7 +1449,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = packageId }, Version = packageVersion };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1492,7 +1488,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1531,14 +1527,14 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
                         .Returns(Task.FromResult(fakePackage));
                     var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
                     var fakePackageFileService = new Mock<IPackageFileService>();
-                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.CompletedTask).Verifiable();
+                    fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.FromResult(0)).Verifiable();
 
                     var fakeIndexingService = new Mock<IIndexingService>(MockBehavior.Strict);
                     fakeIndexingService.Setup(f => f.UpdateIndex()).Verifiable();
@@ -1614,8 +1610,6 @@ namespace NuGetGallery
                         .Returns(Task.CompletedTask);
                     fakePackageService.Setup(x => x.MarkPackageUnlistedAsync(fakePackage, false))
                         .Returns(Task.CompletedTask);
-                    fakePackageService.Setup(x => x.UpdateIsLatestAsync(It.IsAny<PackageRegistration>()))
-                        .Returns(Task.CompletedTask);
                     var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
 
                     var controller = CreateController(
@@ -1639,7 +1633,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1664,7 +1658,7 @@ namespace NuGetGallery
                 var fakeUploadFileService = new Mock<IUploadFileService>();
                 using (var fakeFileStream = new MemoryStream())
                 {
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1693,7 +1687,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
                         .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
@@ -1715,7 +1709,7 @@ namespace NuGetGallery
             public async Task WillDeleteTheUploadFile()
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask).Verifiable();
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0)).Verifiable();
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
@@ -1743,8 +1737,8 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.CompletedTask);
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
                         .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
@@ -1769,7 +1763,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
                         .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
@@ -1795,7 +1789,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
@@ -1824,7 +1818,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
                     var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
                     fakePackageService.Setup(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))

--- a/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
@@ -173,7 +173,7 @@ namespace NuGetGallery
 
                 await service.SoftDeletePackagesAsync(new[] { package }, user, string.Empty, string.Empty);
 
-                packageService.Verify(x => x.UpdateIsLatestAsync(packageRegistration));
+                packageService.Verify(x => x.UpdateIsLatestAsync(packageRegistration, false));
             }
 
             [Fact]
@@ -351,7 +351,7 @@ namespace NuGetGallery
 
                 await service.HardDeletePackagesAsync(new[] { package }, user, string.Empty, string.Empty, false);
 
-                packageService.Verify(x => x.UpdateIsLatestAsync(packageRegistration));
+                packageService.Verify(x => x.UpdateIsLatestAsync(packageRegistration, false));
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -3,15 +3,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
-using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
 using Xunit;
@@ -99,31 +98,6 @@ namespace NuGetGallery
             Mock<IEntityRepository<PackageRegistration>> packageRegistrationRepository = null,
             Mock<IEntityRepository<Package>> packageRepository = null,
             Mock<IEntityRepository<PackageOwnerRequest>> packageOwnerRequestRepo = null,
-            Mock<IEntitiesContext> entitiesContext = null,
-            Mock<IDiagnosticsService> diagnosticsService = null,
-            Mock<IIndexingService> indexingService = null,
-            IPackageNamingConflictValidator packageNamingConflictValidator = null,
-            IAuditingService auditingService = null,
-            Action<Mock<PackageService>> setup = null)
-        {
-            return CreateServiceMock(
-                packageRegistrationRepository,
-                packageRepository,
-                packageOwnerRequestRepo,
-                entitiesContext,
-                diagnosticsService,
-                indexingService,
-                packageNamingConflictValidator,
-                auditingService,
-                setup).Object;
-        }
-
-        private static Mock<PackageService> CreateServiceMock(
-            Mock<IEntityRepository<PackageRegistration>> packageRegistrationRepository = null,
-            Mock<IEntityRepository<Package>> packageRepository = null,
-            Mock<IEntityRepository<PackageOwnerRequest>> packageOwnerRequestRepo = null,
-            Mock<IEntitiesContext> entitiesContext = null,
-            Mock<IDiagnosticsService> diagnosticsService = null,
             Mock<IIndexingService> indexingService = null,
             IPackageNamingConflictValidator packageNamingConflictValidator = null,
             IAuditingService auditingService = null,
@@ -132,13 +106,6 @@ namespace NuGetGallery
             packageRegistrationRepository = packageRegistrationRepository ?? new Mock<IEntityRepository<PackageRegistration>>();
             packageRepository = packageRepository ?? new Mock<IEntityRepository<Package>>();
             packageOwnerRequestRepo = packageOwnerRequestRepo ?? new Mock<IEntityRepository<PackageOwnerRequest>>();
-            
-            var dbContext = new Mock<DbContext>();
-            entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
-            entitiesContext.Setup(m => m.GetDatabase()).Returns(dbContext.Object.Database);
-            entitiesContext.Setup(m => m.GetChangeTracker()).Returns(dbContext.Object.ChangeTracker);
-
-            diagnosticsService = diagnosticsService ?? new Mock<IDiagnosticsService>();
             indexingService = indexingService ?? new Mock<IIndexingService>();
             auditingService = auditingService ?? new TestAuditingService();
 
@@ -153,15 +120,9 @@ namespace NuGetGallery
                 packageRegistrationRepository.Object,
                 packageRepository.Object,
                 packageOwnerRequestRepo.Object,
-                entitiesContext.Object,
-                diagnosticsService.Object,
                 indexingService.Object,
                 packageNamingConflictValidator,
                 auditingService);
-
-            packageService.Setup(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()))
-                .Returns(Task.FromResult(true));
-            packageService.Setup(s => s.CreateNewEntitiesContext()).Returns(entitiesContext.Object);
 
             packageService.CallBase = true;
 
@@ -170,7 +131,7 @@ namespace NuGetGallery
                 setup(packageService);
             }
 
-            return packageService;
+            return packageService.Object;
         }
 
         public class TheAddPackageOwnerMethod
@@ -617,6 +578,19 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public async Task WillSetTheNewPackagesLastUpdatedTimes()
+            {
+                var service = CreateService(setup:
+                        mockPackageService => { mockPackageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null); });
+                var nugetPackage = CreateNuGetPackage();
+                var currentUser = new User();
+
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser);
+
+                Assert.NotEqual(DateTime.MinValue, package.LastUpdated);
+            }
+
+            [Fact]
             public async Task WillSaveThePackageFileAndSetThePackageFileSize()
             {
                 var service = CreateService(setup:
@@ -1039,26 +1013,45 @@ namespace NuGetGallery
         public class TheUpdateIsLatestMethod
         {
             [Fact]
-            public async Task AlwaysCommitChanges()
+            public async Task DoNotCommitIfCommitChangesIsFalse()
             {
                 // Arrange
                 var packageRegistration = new PackageRegistration();
                 var package = new Package { PackageRegistration = packageRegistration, Version = "1.0.0" };
                 packageRegistration.Packages.Add(package);
                 var packageRepository = new Mock<IEntityRepository<Package>>();
-                
-                var service = CreateServiceMock(packageRepository: packageRepository, setup:
+
+                var service = CreateService(packageRepository: packageRepository, setup:
                         mockService => { mockService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package); });
 
                 // Act
-                await service.Object.UpdateIsLatestAsync(packageRegistration);
+                await service.UpdateIsLatestAsync(packageRegistration, commitChanges: false);
 
                 // Assert
-                service.Verify(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()), Times.Once);
+                packageRepository.Verify(r => r.CommitChangesAsync(), Times.Never());
             }
 
             [Fact]
-            public async Task UpdateIsLatestAsync_DifferentLatestAndLatestStableVersions()
+            public async Task CommitIfCommitChangesIsTrue()
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration();
+                var package = new Package { PackageRegistration = packageRegistration, Version = "1.0.0" };
+                packageRegistration.Packages.Add(package);
+                var packageRepository = new Mock<IEntityRepository<Package>>();
+
+                var service = CreateService(packageRepository: packageRepository, setup:
+                        mockService => { mockService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package); });
+
+                // Act
+                await service.UpdateIsLatestAsync(packageRegistration, true);
+
+                // Assert
+                packageRepository.Verify(r => r.CommitChangesAsync(), Times.Once());
+            }
+
+            [Fact]
+            public async Task WillUpdateIsLatest1()
             {
                 // Arrange
                 var packages = new HashSet<Package>();
@@ -1068,23 +1061,24 @@ namespace NuGetGallery
                 var package09 = new Package { PackageRegistration = packageRegistration, Version = "0.9.0" };
                 packages.Add(package09);
                 var packageRepository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var service = CreateServiceMock(packageRepository: packageRepository, setup:
+                packageRepository.Setup(r => r.CommitChangesAsync())
+                    .Returns(Task.CompletedTask).Verifiable();
+                var service = CreateService(packageRepository: packageRepository, setup:
                         mockService => { mockService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package10A); });
 
                 // Act
-                await service.Object.UpdateIsLatestAsync(packageRegistration);
+                await service.UpdateIsLatestAsync(packageRegistration, true);
 
                 // Assert
                 Assert.True(package10A.IsLatest);
                 Assert.False(package10A.IsLatestStable);
                 Assert.False(package09.IsLatest);
                 Assert.True(package09.IsLatestStable);
-
-                service.Verify(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()), Times.Once);
+                packageRepository.Verify();
             }
 
             [Fact]
-            public async Task UpdateIsLatestAsync_SameLatestAndLatestStableVersions()
+            public async Task WillUpdateIsLatest2()
             {
                 // Arrange
                 var packages = new HashSet<Package>();
@@ -1096,11 +1090,13 @@ namespace NuGetGallery
                 var package09 = new Package { PackageRegistration = packageRegistration, Version = "0.9.0" };
                 packages.Add(package09);
                 var packageRepository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var service = CreateServiceMock(packageRepository: packageRepository, setup:
+                packageRepository.Setup(r => r.CommitChangesAsync())
+                    .Returns(Task.CompletedTask).Verifiable();
+                var service = CreateService(packageRepository: packageRepository, setup:
                         mockService => { mockService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package100); });
 
                 // Act
-                await service.Object.UpdateIsLatestAsync(packageRegistration);
+                await service.UpdateIsLatestAsync(packageRegistration, true);
 
                 // Assert
                 Assert.True(package100.IsLatest);
@@ -1109,42 +1105,7 @@ namespace NuGetGallery
                 Assert.False(package10A.IsLatestStable);
                 Assert.False(package09.IsLatest);
                 Assert.False(package09.IsLatestStable);
-
-                service.Verify(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()), Times.Once);
-            }
-
-            [Fact]
-            public async Task UpdateIsLatestAsync_SameNewLatestAndLatestStableVersions()
-            {
-                // Arrange
-                var packages = new HashSet<Package>();
-                var packageRegistration = new PackageRegistration { Packages = packages };
-                var package10A = new Package { PackageRegistration = packageRegistration, Version = "1.0.0-a", IsPrerelease = true, IsLatest = true };
-                packages.Add(package10A);
-                var package10 = new Package { PackageRegistration = packageRegistration, Version = "1.0.0" };
-                packages.Add(package10);
-                var package09 = new Package { PackageRegistration = packageRegistration, Version = "0.9.0", IsLatestStable = true };
-                packages.Add(package09);
-                var package20 = new Package { PackageRegistration = packageRegistration, Version = "2.0.0" };
-                packages.Add(package20);
-                var packageRepository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var service = CreateServiceMock(packageRepository: packageRepository, setup:
-                        mockService => { mockService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package10A); });
-
-                // Act
-                await service.Object.UpdateIsLatestAsync(packageRegistration);
-
-                // Assert
-                Assert.True(package20.IsLatest);
-                Assert.True(package20.IsLatestStable);
-                Assert.False(package10A.IsLatest);
-                Assert.False(package10A.IsLatestStable);
-                Assert.False(package10.IsLatest);
-                Assert.False(package10.IsLatestStable);
-                Assert.False(package09.IsLatest);
-                Assert.False(package09.IsLatestStable);
-
-                service.Verify(s => s.TryUpdateIsLatestInDatabase(It.IsAny<IEntitiesContext>()), Times.Once);
+                packageRepository.Verify();
             }
         }
 
@@ -1443,7 +1404,6 @@ namespace NuGetGallery
                 var service = CreateService(packageRepository: packageRepository);
 
                 await service.MarkPackageListedAsync(packages[0]);
-                await service.UpdateIsLatestAsync(packageRegistration);
 
                 Assert.True(packageRegistration.Packages.ElementAt(0).IsLatest);
                 Assert.True(packageRegistration.Packages.ElementAt(0).IsLatestStable);
@@ -1549,7 +1509,6 @@ namespace NuGetGallery
                 var service = CreateService(packageRepository: packageRepository);
 
                 await service.MarkPackageUnlistedAsync(packages[0]);
-                await service.UpdateIsLatestAsync(packages[0].PackageRegistration);
 
                 Assert.False(packageRegistration.Packages.ElementAt(0).IsLatest);
                 Assert.False(packageRegistration.Packages.ElementAt(0).IsLatestStable);
@@ -1567,7 +1526,6 @@ namespace NuGetGallery
                 var service = CreateService(packageRepository: packageRepository);
 
                 await service.MarkPackageUnlistedAsync(package);
-                await service.UpdateIsLatestAsync(package.PackageRegistration);
 
                 Assert.False(package.IsLatest, "IsLatest");
                 Assert.False(package.IsLatestStable, "IsLatestStable");
@@ -1663,7 +1621,6 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package); });
 
                 await service.PublishPackageAsync(package);
-                await service.UpdateIsLatestAsync(package.PackageRegistration);
 
                 Assert.True(package.IsLatestStable);
             }
@@ -1687,7 +1644,6 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package); });
 
                 await service.PublishPackageAsync("theId", "1.0.42");
-                await service.UpdateIsLatestAsync(package.PackageRegistration);
 
                 Assert.True(package.IsLatestStable);
             }
@@ -1717,7 +1673,6 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package); });
 
                 await service.PublishPackageAsync(package);
-                await service.UpdateIsLatestAsync(package.PackageRegistration);
 
                 Assert.False(package.IsLatestStable);
             }
@@ -1749,8 +1704,6 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package); });
 
                 await service.PublishPackageAsync("theId", "1.0.42-alpha");
-                await service.UpdateIsLatestAsync(package.PackageRegistration);
-
                 Assert.True(package39.IsLatestStable);
                 Assert.False(package39.IsLatest);
                 Assert.False(package.IsLatestStable);
@@ -1784,7 +1737,6 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package); });
 
                 await service.PublishPackageAsync(package);
-                await service.UpdateIsLatestAsync(package.PackageRegistration);
 
                 Assert.True(package39.IsLatestStable);
                 Assert.False(package39.IsLatest);
@@ -1820,8 +1772,6 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package); });
 
                 await service.PublishPackageAsync("theId", "1.0.42-alpha");
-                await service.UpdateIsLatestAsync(package.PackageRegistration);
-
                 Assert.False(package39.IsLatestStable);
                 Assert.False(package39.IsLatest);
                 Assert.False(package.IsLatestStable);
@@ -1856,8 +1806,6 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), true)).Returns(package); });
 
                 await service.PublishPackageAsync(package);
-                await service.UpdateIsLatestAsync(package.PackageRegistration);
-
                 Assert.False(package39.IsLatestStable);
                 Assert.False(package39.IsLatest);
                 Assert.False(package.IsLatestStable);

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -11,7 +11,6 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
-using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
@@ -101,7 +100,6 @@ namespace NuGetGallery
             Mock<IEntityRepository<Package>> packageRepository = null,
             Mock<IEntityRepository<PackageOwnerRequest>> packageOwnerRequestRepo = null,
             Mock<IEntitiesContext> entitiesContext = null,
-            Mock<IAppConfiguration> configuration = null,
             Mock<IDiagnosticsService> diagnosticsService = null,
             Mock<IIndexingService> indexingService = null,
             IPackageNamingConflictValidator packageNamingConflictValidator = null,
@@ -113,7 +111,6 @@ namespace NuGetGallery
                 packageRepository,
                 packageOwnerRequestRepo,
                 entitiesContext,
-                configuration,
                 diagnosticsService,
                 indexingService,
                 packageNamingConflictValidator,
@@ -126,7 +123,6 @@ namespace NuGetGallery
             Mock<IEntityRepository<Package>> packageRepository = null,
             Mock<IEntityRepository<PackageOwnerRequest>> packageOwnerRequestRepo = null,
             Mock<IEntitiesContext> entitiesContext = null,
-            Mock<IAppConfiguration> configuration = null,
             Mock<IDiagnosticsService> diagnosticsService = null,
             Mock<IIndexingService> indexingService = null,
             IPackageNamingConflictValidator packageNamingConflictValidator = null,
@@ -141,8 +137,6 @@ namespace NuGetGallery
             entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
             entitiesContext.Setup(m => m.GetDatabase()).Returns(dbContext.Object.Database);
             entitiesContext.Setup(m => m.GetChangeTracker()).Returns(dbContext.Object.ChangeTracker);
-
-            configuration = configuration ?? new Mock<IAppConfiguration>();
 
             diagnosticsService = diagnosticsService ?? new Mock<IDiagnosticsService>();
             indexingService = indexingService ?? new Mock<IIndexingService>();
@@ -160,7 +154,6 @@ namespace NuGetGallery
                 packageRepository.Object,
                 packageOwnerRequestRepo.Object,
                 entitiesContext.Object,
-                configuration.Object,
                 diagnosticsService.Object,
                 indexingService.Object,
                 packageNamingConflictValidator,

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Packaging;
-using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
 using Xunit;
@@ -283,8 +282,6 @@ namespace NuGetGallery
             var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
             var packageRepository = new Mock<IEntityRepository<Package>>();
             var packageOwnerRequestRepo = new Mock<IEntityRepository<PackageOwnerRequest>>();
-            var diagnosticsService = new Mock<IDiagnosticsService>();
-            var entitiesContext = new Mock<IEntitiesContext>();
             var indexingService = new Mock<IIndexingService>();
             var packageNamingConflictValidator = new PackageNamingConflictValidator(
                     packageRegistrationRepository.Object,
@@ -295,8 +292,6 @@ namespace NuGetGallery
                 packageRegistrationRepository.Object,
                 packageRepository.Object,
                 packageOwnerRequestRepo.Object,
-                entitiesContext.Object,
-                diagnosticsService.Object,
                 indexingService.Object,
                 packageNamingConflictValidator,
                 auditingService);

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Packaging;
-using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
@@ -286,7 +285,6 @@ namespace NuGetGallery
             var packageOwnerRequestRepo = new Mock<IEntityRepository<PackageOwnerRequest>>();
             var diagnosticsService = new Mock<IDiagnosticsService>();
             var entitiesContext = new Mock<IEntitiesContext>();
-            var configuration = new Mock<IAppConfiguration>();
             var indexingService = new Mock<IIndexingService>();
             var packageNamingConflictValidator = new PackageNamingConflictValidator(
                     packageRegistrationRepository.Object,
@@ -298,7 +296,6 @@ namespace NuGetGallery
                 packageRepository.Object,
                 packageOwnerRequestRepo.Object,
                 entitiesContext.Object,
-                configuration.Object,
                 diagnosticsService.Object,
                 indexingService.Object,
                 packageNamingConflictValidator,

--- a/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Data.Entity.Infrastructure;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -131,18 +130,9 @@ namespace NuGetGallery
             throw new NotSupportedException();
         }
 
-        public DbChangeTracker GetChangeTracker()
-        {
-            throw new NotSupportedException();
-        }
-
         public Database GetDatabase()
         {
             throw new NotSupportedException();
-        }
-
-        public void Dispose()
-        {
         }
     }
 }

--- a/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
+++ b/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
@@ -48,8 +48,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.XML" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -211,7 +211,6 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
             foreach (var version in versions)
             {
                 var feedUrl = $"{UrlHelper.V2FeedRootUrl}/Packages?$filter=Id eq '{packageId}' and Version eq '{version}'" +
-                    "and 1 eq 1" + // Disable search hijacking to get immediate results.
                     "&$select=Id,Version,IsLatestVersion,IsAbsoluteLatestVersion";
                 var packageDetails = await _odataHelper.GetPackagePropertiesFromResponse(feedUrl, packageId, version);
                 Assert.NotNull(packageDetails);

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -91,60 +91,6 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
             await CheckPackageTimestampsInOrder(packageIds, "LastEdited", unlistStartTimestamp);
         }
 
-        [Fact]
-        [Description("Verifies that the IsLatest/IsLatestStable flags are set correctly when different package versions are pushed concurrently")]
-        [Priority(1)]
-        [Category("P0Tests")]
-        public async Task PackageLatestSetCorrectlyOnConcurrentPushes()
-        {
-            var latestAll = "7.0.2-abc";
-            var latestStableAll = "7.0.1";
-            var latestFirstHalf = "3.0.2-abc";
-            var latestStableFirstHalf = "3.0.1";
-
-            var packageId = $"TestV2FeedPackageLatestSetCorrectlyOnConcurrentPushes.{DateTime.UtcNow.Ticks}";
-            var packageVersions = new List<string>()
-            {
-                 "1.0.0-a",  "1.0.0-b",  "1.0.0",  "1.0.1",  "1.0.2-abc",
-                 "2.0.0-a",  "2.0.0-b",  "2.0.0",  "2.0.1",  "2.0.2-abc",
-                 "3.0.0-a",  "3.0.0-b",  "3.0.0",  "3.0.1",  "3.0.2-abc",
-                 "4.0.0-a",  "4.0.0-b",  "4.0.0",  "4.0.1",  "4.0.2-abc",
-                 "6.0.0-a",  "6.0.0-b",  "6.0.0",  "6.0.1",  "6.0.2-abc",
-                 "7.0.0-a",  "7.0.0-b",  "7.0.0",  "7.0.1",  "7.0.2-abc"
-            };
-
-            // push all and verify; ~15-20 concurrency conflicts seen in testing
-            var concurrentTasks = new Task[packageVersions.Count];
-            for (int i = 0; i < concurrentTasks.Length; i++)
-            {
-                var packageVersion = packageVersions[i];
-                concurrentTasks[i] = Task.Run(() => _clientSdkHelper.UploadNewPackage(packageId, version: packageVersion));
-            }
-            Task.WaitAll(concurrentTasks);
-            
-            await CheckPackageLatestVersions(packageId, packageVersions, latestAll, latestStableAll);
-
-            // unlist last half and verify; ~1-2 concurrency conflicts seen in testing
-            for (int i = concurrentTasks.Length - 1; i >= 15; i--)
-            {
-                var packageVersion = packageVersions[i];
-                concurrentTasks[i] = Task.Run(() => _clientSdkHelper.UnlistPackage(packageId, version: packageVersion));
-            }
-            Task.WaitAll(concurrentTasks);
-
-            await CheckPackageLatestVersions(packageId, packageVersions, latestFirstHalf, latestStableFirstHalf);
-
-            // unlist remaining and verify; ~1-2 concurrency conflicts seen in testing
-            for (int i = 14; i >= 0; i--)
-            {
-                var packageVersion = packageVersions[i];
-                concurrentTasks[i] = Task.Run(() => _clientSdkHelper.UnlistPackage(packageId, version: packageVersion));
-            }
-            Task.WaitAll(concurrentTasks);
-
-            await CheckPackageLatestVersions(packageId, packageVersions, string.Empty, string.Empty);
-        }
-
         private static string GetPackagesAppearInFeedInOrderPackageId(DateTime startingTime, int i)
         {
             return $"TestV2FeedPackagesAppearInFeedInOrderTest.{startingTime.Ticks}.{i}";
@@ -152,7 +98,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
 
         private static string GetPackagesAppearInFeedInOrderUrl(DateTime time, string timestamp)
         {
-            return $"{UrlHelper.V2FeedRootUrl}/Packages?$filter={timestamp} gt DateTime'{time:o}'&$orderby={timestamp} desc&$select={timestamp},IsLatestVersion,IsAbsoluteLatestVersion,Published";
+            return $"{UrlHelper.V2FeedRootUrl}/Packages?$filter={timestamp} gt DateTime'{time:o}'&$orderby={timestamp} desc&$select={timestamp}";
         }
 
         /// <summary>
@@ -161,7 +107,6 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         /// <param name="packageIds">An ordered list of package ids. Each package id in the list must have a timestamp in the feed earlier than all package ids after it.</param>
         /// <param name="timestampPropertyName">The timestamp property to test the ordering of. For example, "Created" or "LastEdited".</param>
         /// <param name="operationStartTimestamp">A timestamp that is before all of the timestamps expected to be found in the feed. This is used in a request to the feed.</param>
-        /// <param name="packagesListed">Whether packages are listed, used to verify if latest flags are set properly.</param>
         private async Task CheckPackageTimestampsInOrder(List<string> packageIds, string timestampPropertyName,
             DateTime operationStartTimestamp)
         {
@@ -171,54 +116,17 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 var packageId = packageIds[i];
                 TestOutputHelper.WriteLine($"Attempting to check order of package #{i} {timestampPropertyName} timestamp in feed.");
 
-                var feedUrl = GetPackagesAppearInFeedInOrderUrl(operationStartTimestamp, timestampPropertyName);
-                var packageDetails = await _odataHelper.GetPackagePropertiesFromResponse(feedUrl, packageId);
-                Assert.NotNull(packageDetails);
-                
-                var newTimestamp = (DateTime?)(packageDetails.ContainsKey(timestampPropertyName)
-                    ? packageDetails[timestampPropertyName]
-                    : null);
+                var newTimestamp =
+                    await
+                        _odataHelper.GetTimestampOfPackageFromResponse(
+                            GetPackagesAppearInFeedInOrderUrl(operationStartTimestamp, timestampPropertyName),
+                            timestampPropertyName,
+                            packageId);
 
                 Assert.True(newTimestamp.HasValue);
                 Assert.True(newTimestamp.Value > lastTimestamp,
                     $"Package #{i} was last modified after package #{i - 1} but has an earlier {timestampPropertyName} timestamp ({newTimestamp} should be greater than {lastTimestamp}).");
                 lastTimestamp = newTimestamp.Value;
-
-                var published= packageDetails["Published"] as DateTime?;
-                var isListed = !published?.Year.Equals(1900);
-                var isLatest = packageDetails["IsAbsoluteLatestVersion"] as bool?;
-                var isLatestStable = packageDetails["IsLatestVersion"] as bool?;
-
-                Assert.NotNull(isLatest);
-                Assert.Equal(isLatest, isListed);
-
-                Assert.NotNull(isLatestStable);
-                Assert.Equal(isLatestStable, isListed);
-            }
-        }
-        
-        private async Task CheckPackageLatestVersions(string packageId, List<string> versions, string expectedLatest, string expectedLatestStable)
-        {
-            foreach (var version in versions)
-            {
-                var feedUrl = $"{UrlHelper.V2FeedRootUrl}/Packages?$filter=Id eq '{packageId}' and Version eq '{version}'" +
-                    "&$select=Id,Version,IsLatestVersion,IsAbsoluteLatestVersion";
-                var packageDetails = await _odataHelper.GetPackagePropertiesFromResponse(feedUrl, packageId, version);
-                Assert.NotNull(packageDetails);
-
-                var actualId = packageDetails["Id"] as string;
-                Assert.True(packageId.Equals(actualId, StringComparison.InvariantCultureIgnoreCase));
-
-                var actualVersion = packageDetails["Version"] as string;
-                Assert.True(version.Equals(actualVersion, StringComparison.InvariantCultureIgnoreCase));
-
-                var isLatest = packageDetails["IsAbsoluteLatestVersion"] as bool?;
-                Assert.NotNull(isLatest);
-                Assert.Equal(isLatest, expectedLatest.Equals(version, StringComparison.InvariantCultureIgnoreCase));
-
-                var isLatestStable = packageDetails["IsLatestVersion"] as bool?;
-                Assert.NotNull(isLatestStable);
-                Assert.Equal(isLatestStable, expectedLatestStable.Equals(version, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -97,6 +97,11 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         [Category("P0Tests")]
         public async Task PackageLatestSetCorrectlyOnConcurrentPushes()
         {
+            var latestAll = "7.0.2-abc";
+            var latestStableAll = "7.0.1";
+            var latestFirstHalf = "3.0.2-abc";
+            var latestStableFirstHalf = "3.0.1";
+
             var packageId = $"TestV2FeedPackageLatestSetCorrectlyOnConcurrentPushes.{DateTime.UtcNow.Ticks}";
             var packageVersions = new List<string>()
             {
@@ -104,8 +109,8 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                  "2.0.0-a",  "2.0.0-b",  "2.0.0",  "2.0.1",  "2.0.2-abc",
                  "3.0.0-a",  "3.0.0-b",  "3.0.0",  "3.0.1",  "3.0.2-abc",
                  "4.0.0-a",  "4.0.0-b",  "4.0.0",  "4.0.1",  "4.0.2-abc",
-                 "5.0.0-a",  "5.0.0-b",  "5.0.0",  "5.0.1",  "5.0.2-abc",
-                 "6.0.0-a",  "6.0.0-b",  "6.0.0",  "6.0.1",  "6.0.2-abc"
+                 "6.0.0-a",  "6.0.0-b",  "6.0.0",  "6.0.1",  "6.0.2-abc",
+                 "7.0.0-a",  "7.0.0-b",  "7.0.0",  "7.0.1",  "7.0.2-abc"
             };
 
             // first push should not be concurrent to avoid conflict on creation of package registration.
@@ -114,7 +119,6 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
             concurrentTasks[0].Wait();
 
             // push remaining packages over period of 5 seconds
-            // goal is insert of multiple packages that would be marked as new latest/latestStable
             var random = new Random();
             for (int i = 1; i < concurrentTasks.Length; i++)
             {
@@ -126,30 +130,27 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 });
             }
             Task.WaitAll(concurrentTasks);
+            
+            await CheckPackageLatestVersions(packageId, packageVersions, latestAll, latestStableAll);
 
-            // unlist packages a row at a time
-            // goal is unlist of package that would be marked latest/latestStable by concurrent UpdateIsLatest            
-            var rowCount = 6;
-            var columnCount = 5;
-            var concurrentUnlists = new Task[columnCount];
-            for (int r = rowCount; r > 0; r--)
+            // unlist last half and verify; ~1-2 concurrency conflicts seen in testing
+            for (int i = concurrentTasks.Length - 1; i >= 15; i--)
             {
-                // verify current latest/latestStable before unlisting next row
-                var latestIndex = (r * columnCount) - 1;
-                var latestStableIndex = (r * columnCount) - 2;
-                await CheckPackageLatestVersions(packageId, packageVersions, packageVersions[latestIndex], packageVersions[latestStableIndex]);
-
-                // unlist each package in the current row
-                for (int c = 1; c <= columnCount; c++)
-                {
-                    var index = (r * columnCount) - c;
-                    var versionToUnlist = packageVersions[index];
-                    concurrentUnlists[c - 1] = Task.Run(() => _clientSdkHelper.UnlistPackage(packageId, version: versionToUnlist));
-                }
-                Task.WaitAll(concurrentUnlists);
+                var packageVersion = packageVersions[i];
+                concurrentTasks[i] = Task.Run(() => _clientSdkHelper.UnlistPackage(packageId, version: packageVersion));
             }
+            Task.WaitAll(concurrentTasks);
 
-            // no latest/latestStable, as all packages have been unlisted
+            await CheckPackageLatestVersions(packageId, packageVersions, latestFirstHalf, latestStableFirstHalf);
+
+            // unlist remaining and verify; ~1-2 concurrency conflicts seen in testing
+            for (int i = 14; i >= 0; i--)
+            {
+                var packageVersion = packageVersions[i];
+                concurrentTasks[i] = Task.Run(() => _clientSdkHelper.UnlistPackage(packageId, version: packageVersion));
+            }
+            Task.WaitAll(concurrentTasks);
+
             await CheckPackageLatestVersions(packageId, packageVersions, string.Empty, string.Empty);
         }
 


### PR DESCRIPTION
Revert of attempted fix to UpdateIsLatest, which still had concurrency issue for unlist. Deployed to dev0, with all tests passing except the concurrency functional test which will be removed as part of this revert.