### PR TITLE
Use 100% width for input controls on edit package page (Nr. 2)

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -951,8 +951,13 @@ fieldset.form legend {
     height: 2.25em;
 }
 
-.form-field.form-field-full input {
+.form-field.form-field-full input, 
+.form-field.form-field-full textarea {
     width: 100%;
+}
+
+.form-field.form-field-full textarea {
+    height: 96px;    
 }
 
 .form-field input[data-val-required],
@@ -1045,6 +1050,15 @@ fieldset.form legend {
     margin-top: 5px;
     width: 416px;
     z-index: 550;
+}
+
+.form-field-full > .field-validation-error,
+.form-field-full > .field-hint-message {
+    width: 98.5%;
+    padding-top: 5px;
+    padding-left: 5px;
+    padding-bottom: 5px;
+    padding-right: 0px;
 }
 
 textarea + .field-validation-error {

--- a/src/NuGetGallery/Views/Packages/Edit.cshtml
+++ b/src/NuGetGallery/Views/Packages/Edit.cshtml
@@ -216,7 +216,7 @@
 {
     var formid = ExpressionHelper.GetExpressionText(func).Replace(".", "_");
     object temp = func.Compile().Invoke(Model);
-    <div class="form-field">
+    <div class="form-field  form-field-full">
         <div style="display: block">
             @Html.LabelFor(func, new { style = "display: inline-block" })
             <button type="button" class="undo-button" id="@("Undo" + formid)" style="display: none"><span class="icon-undo" title="Undo Edit"></span></button>


### PR DESCRIPTION
This is a follow up on the original PR (https://github.com/NuGet/NuGetGallery/pull/3416)

I made a small CSS changes, so that the padding-changes are only used for the form-field-full inputs.


This css class is only used on the edit page and the signin:

![image](https://cloud.githubusercontent.com/assets/756703/24377255/0a89ccdc-133f-11e7-867a-0e212eef80e9.png)

, which looks like that in Chrome:

![image](https://cloud.githubusercontent.com/assets/756703/24377326/594a6926-133f-11e7-81b7-c4f97e959699.png)

IE 11:

![image](https://cloud.githubusercontent.com/assets/756703/24377353/6b6bc122-133f-11e7-9c65-67642126da98.png)

Edit Package in Chrome:

![image](https://cloud.githubusercontent.com/assets/756703/24377394/840ceaf8-133f-11e7-9cc4-ca50b96e536e.png)

& IE 11:

![image](https://cloud.githubusercontent.com/assets/756703/24377415/9d460126-133f-11e7-998a-6a6e2367243b.png)


Maybe you notice, that the validation error is not 100% the same width as the input field. The reason here is the padding-right, which I needed to set to 0px, otherwise the login/register would look like that:
![image](https://cloud.githubusercontent.com/assets/756703/24377516/e4a77216-133f-11e7-97e6-ab0a603a6eab.png)

Its a trade off, but I think it is still ok and enhancement to the NuGet.org UX.
]

