### PR TITLE
Order Dependencies

### DIFF
--- a/src/NuGetGallery/ViewModels/DependencySetsViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DependencySetsViewModel.cs
@@ -32,9 +32,12 @@ namespace NuGetGallery
                     if (!DependencySets.ContainsKey(targetFramework))
                     {
                         DependencySets.Add(targetFramework,
-                            dependencySet.Select(d => d.Id == null ? null : new DependencyViewModel(d.Id, d.VersionSpec)));
+                            dependencySet.OrderBy(x => x.Id).Select(d => d.Id == null ? null : new DependencyViewModel(d.Id, d.VersionSpec)));
                     }
                 }
+
+                // Order the top level frameworks by their resulting friendly name
+                DependencySets = DependencySets.OrderBy(x => x.Key).ToDictionary(x => x.Key, x => x.Value);
             }
             catch (Exception e)
             {

--- a/src/NuGetGallery/ViewModels/DependencySetsViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DependencySetsViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,9 +17,7 @@ namespace NuGetGallery
             {
                 DependencySets = new Dictionary<string, IEnumerable<DependencyViewModel>>();
 
-                var dependencySets = packageDependencies
-                    .GroupBy(d => d.TargetFramework)
-                    .OrderBy(ds => ds.Key);
+                var dependencySets = packageDependencies.GroupBy(d => d.TargetFramework);
 
                 OnlyHasAllFrameworks = dependencySets.Count() == 1 && dependencySets.First().Key == null;
 
@@ -41,9 +39,9 @@ namespace NuGetGallery
             }
             catch (Exception e)
             {
+                // Just set Dependency Sets to null but still render the package.
                 DependencySets = null;
                 QuietLog.LogHandledException(e);
-                // Just set Dependency Sets to null but still render the package.
             }
         }
 

--- a/src/NuGetGallery/Views/Packages/_PackageDependencies.cshtml
+++ b/src/NuGetGallery/Views/Packages/_PackageDependencies.cshtml
@@ -2,7 +2,7 @@
 @if (Model.DependencySets.Any())
 {
     <ul id="dependencySets">
-        @foreach (var dependencySet in Model.DependencySets.OrderBy(x => x.Key))
+        @foreach (var dependencySet in Model.DependencySets)
         {
             var dependencySetTitle = dependencySet.Key.Replace("Windows 0.0", "Windows");
             if (dependencySetTitle == ".NETPlatform 5.0")
@@ -20,23 +20,20 @@
                     <h4>@dependencySetTitle</h4>
                 }
                 <ul class="dependencySet">
-                    @if (dependencySet.Value.First() == null)
+                    @foreach (var dependency in dependencySet.Value)
                     {
                         <li>
-                            No dependencies.
+                            @if (dependency == null)
+                            {
+                                @:No dependencies.
+                            }
+                            else
+                            {
+                                <a href="@Url.Package(dependency.Id)">@dependency.Id</a>
+                                <span>@dependency.VersionSpec</span>
+                            }
                         </li>
                     }
-                    else
-                    {
-                        foreach (var dependency in dependencySet.Value.Where(x => x != null).OrderBy(x => x.Id))
-                        {
-                            <li>
-                                    <a href="@Url.Package(dependency.Id)">@dependency.Id</a>
-                                    <span>@dependency.VersionSpec</span>
-                            </li>
-                        }
-                    }
-                    
                 </ul>
             </li>
         }

--- a/src/NuGetGallery/Views/Packages/_PackageDependencies.cshtml
+++ b/src/NuGetGallery/Views/Packages/_PackageDependencies.cshtml
@@ -2,7 +2,7 @@
 @if (Model.DependencySets.Any())
 {
     <ul id="dependencySets">
-        @foreach (var dependencySet in Model.DependencySets)
+        @foreach (var dependencySet in Model.DependencySets.OrderBy(x => x.Key))
         {
             var dependencySetTitle = dependencySet.Key.Replace("Windows 0.0", "Windows");
             if (dependencySetTitle == ".NETPlatform 5.0")
@@ -20,20 +20,23 @@
                     <h4>@dependencySetTitle</h4>
                 }
                 <ul class="dependencySet">
-                    @foreach (var dependency in dependencySet.Value)
+                    @if (dependencySet.Value.First() == null)
                     {
                         <li>
-                            @if (dependency == null)
-                            {
-                                @:No dependencies.
-                            }
-                            else
-                            {
-                                <a href="@Url.Package(dependency.Id)">@dependency.Id</a>
-                                <span>@dependency.VersionSpec</span>
-                            }
+                            No dependencies.
                         </li>
                     }
+                    else
+                    {
+                        foreach (var dependency in dependencySet.Value.Where(x => x != null).OrderBy(x => x.Id))
+                        {
+                            <li>
+                                    <a href="@Url.Package(dependency.Id)">@dependency.Id</a>
+                                    <span>@dependency.VersionSpec</span>
+                            </li>
+                        }
+                    }
+                    
                 </ul>
             </li>
         }

--- a/tests/NuGetGallery.Facts/ViewModels/DependencySetsViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DependencySetsViewModelFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -14,14 +14,14 @@ namespace NuGetGallery.ViewModels
             public void GivenAListOfDependenciesItShouldGroupByTargetFrameworkName()
             {
                 // Arrange
-                var deps = new[] {
-                    new PackageDependency() { TargetFramework = null },
-                    new PackageDependency() { TargetFramework = "portable-net45+win8" },
-                    new PackageDependency() { TargetFramework = "portable-net40+sl40+win8+wp71", Id = "Microsoft.Net.Http", VersionSpec = "[2.1,3.0)" },
+                var dependencies = new[] {
+                    new PackageDependency { TargetFramework = null },
+                    new PackageDependency { TargetFramework = "portable-net45+win8" },
+                    new PackageDependency { TargetFramework = "portable-net40+sl40+win8+wp71", Id = "Microsoft.Net.Http", VersionSpec = "[2.1,3.0)" },
                 };
 
                 // Act
-                var vm = new DependencySetsViewModel(deps);
+                var vm = new DependencySetsViewModel(dependencies);
 
                 // Assert
                 Assert.Equal(3, vm.DependencySets.Count);
@@ -32,6 +32,63 @@ namespace NuGetGallery.ViewModels
                 Assert.Equal(1, actual.Length);
                 Assert.Equal("Microsoft.Net.Http", actual[0].Id);
                 Assert.Equal("(>= 2.1.0 && < 3.0.0)", actual[0].VersionSpec);
+            }
+
+            [Fact]
+            public void GivenAListOfDependenciesTargetFrameworksWillBeOrdered()
+            {
+                // Arrange
+                var dependencies = new[] {
+                    new PackageDependency { TargetFramework = "sl50" },
+                    new PackageDependency { TargetFramework = "monoandroid23" },
+                    new PackageDependency { TargetFramework = "net45" },
+                    new PackageDependency { TargetFramework = "sl40" },
+                    new PackageDependency { TargetFramework = "net462"},
+                    new PackageDependency { TargetFramework = "netstandard1.5" },
+                    new PackageDependency { TargetFramework = "netstandard1.3" }
+                };
+
+                // Act
+                var viewModel = new DependencySetsViewModel(dependencies);
+
+                // Assert
+                Assert.Equal(7, viewModel.DependencySets.Count);
+
+                var dependencySetsList = viewModel.DependencySets.Keys.ToList();
+
+                Assert.Equal(".NETFramework 4.5", dependencySetsList[0]);
+                Assert.Equal(".NETFramework 4.6.2", dependencySetsList[1]);
+                Assert.Equal(".NETStandard 1.3", dependencySetsList[2]);
+                Assert.Equal(".NETStandard 1.5", dependencySetsList[3]);
+                Assert.Equal("MonoAndroid 2.3", dependencySetsList[4]);
+                Assert.Equal("Silverlight 4.0", dependencySetsList[5]);
+                Assert.Equal("Silverlight 5.0", dependencySetsList[6]);
+            }
+
+            [Fact]
+            public void GivenAListOfDependenciesPackageIdsWillBeOrdered()
+            {
+                // Arrange
+                var dependencies = new[] {
+                    new PackageDependency { TargetFramework = null, Id = "cde" },
+                    new PackageDependency { TargetFramework = null, Id = "abc" },
+                    new PackageDependency { TargetFramework = null, Id = "bcd" },
+                    new PackageDependency { TargetFramework = null, Id = "def" }
+                };
+
+                // Act
+                var viewModel = new DependencySetsViewModel(dependencies);
+
+                // Assert
+                Assert.Equal(1, viewModel.DependencySets.Count);
+                Assert.Equal(4, viewModel.DependencySets.First().Value.Count());
+
+                var dependencyViewModels = viewModel.DependencySets.First().Value.ToList();
+
+                Assert.Equal("abc", dependencyViewModels[0].Id);
+                Assert.Equal("bcd", dependencyViewModels[1].Id);
+                Assert.Equal("cde", dependencyViewModels[2].Id);
+                Assert.Equal("def", dependencyViewModels[3].Id);
             }
         }
     }


### PR DESCRIPTION
This PR should fix this issue https://github.com/NuGet/NuGetGallery/issues/3550

The change is only added in the view-logic and this partial-view is used on the upload-verify page and the display package page. These are the only two sites that are able to list dependencies, so with this PR everything should be ordered the same way on the website.

Some dependencySets (e.g. .NET 4.5 Framework) only have on "null" empty in it, so I needed to split those with dependencies and those with the null dependency - thats why I inserted the if/else stuff.

The result of this PR. Lets take a example from this package: https://www.nuget.org/packages/NLog/5.0.0-beta06

The order is pretty random on all levels:

![image](https://cloud.githubusercontent.com/assets/756703/24378724/468eb8d2-1344-11e7-94ce-258b36c30399.png)


With this PR:
![image](https://cloud.githubusercontent.com/assets/756703/24378741/566c698e-1344-11e7-9292-bf03760eb2ca.png)

The verify upload page is ordered the same way:

![image](https://cloud.githubusercontent.com/assets/756703/24378768/747bb740-1344-11e7-8637-a1093bdfd4a9.png)


Another example (the AutoMapper package) with the PR:

![image](https://cloud.githubusercontent.com/assets/756703/24378791/8be3f53c-1344-11e7-82a8-bcf5f95ce373.png)




