### PR TITLE
Add support for semVerLevel query parameter to V2 endpoints

### DIFF
--- a/src/NuGetGallery.Core/SemVerLevelKey.cs
+++ b/src/NuGetGallery.Core/SemVerLevelKey.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using NuGet.Versioning;
 
 namespace NuGetGallery
@@ -100,19 +101,19 @@ namespace NuGetGallery
         /// <summary>
         /// Indicates whether the provided SemVer-level key is compliant with the provided SemVer-level version string.
         /// </summary>
-        /// <param name="key">The SemVer-level key to be checked for compliance.</param>
         /// <param name="semVerLevel">The SemVer-level string indicating the SemVer-level to comply with.</param>
         /// <returns><c>True</c> if compliant; otherwise <c>false</c>.</returns>
-        public static bool IsCompliantWithSemVerLevel(int? key, string semVerLevel)
+        public static Expression<Func<Package, bool>> IsPackageCompliantWithSemVerLevel(string semVerLevel)
         {
+            // Note: we must return an expression that Linq to Entities is able to translate to SQL
             var parsedSemVerLevelKey = ForSemVerLevel(semVerLevel);
 
             if (parsedSemVerLevelKey == SemVer2)
             {
-                return key == Unknown || key == parsedSemVerLevelKey;
+                return p => p.SemVerLevelKey == Unknown || p.SemVerLevelKey == parsedSemVerLevelKey;
             }
 
-            return key == Unknown;
+            return p => p.SemVerLevelKey == Unknown;
         }
     }
 }

--- a/src/NuGetGallery/App_Start/NuGetODataV2FeedConfig.cs
+++ b/src/NuGetGallery/App_Start/NuGetODataV2FeedConfig.cs
@@ -60,6 +60,7 @@ namespace NuGetGallery
             searchAction.Parameter<string>("searchTerm");
             searchAction.Parameter<string>("targetFramework");
             searchAction.Parameter<bool>("includePrerelease");
+            searchAction.Parameter<string>("semVerLevel");
             searchAction.ReturnsCollectionFromEntitySet<V2FeedPackage>("Packages");
 
             var findPackagesAction = builder.Action("FindPackagesById");
@@ -73,6 +74,7 @@ namespace NuGetGallery
             getUpdatesAction.Parameter<bool>("includeAllVersions");
             getUpdatesAction.Parameter<string>("targetFrameworks");
             getUpdatesAction.Parameter<string>("versionConstraints");
+            getUpdatesAction.Parameter<string>("semVerLevel");
             getUpdatesAction.ReturnsCollectionFromEntitySet<V2FeedPackage>("Packages");
 
             var model = builder.GetEdmModel();

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -632,24 +632,30 @@ namespace NuGetGallery
 
         [HttpGet]
         [ActionName("PackageIDs")]
-        public virtual async Task<ActionResult> GetPackageIds(string partialId, bool? includePrerelease)
+        public virtual async Task<ActionResult> GetPackageIds(
+            string partialId, 
+            bool? includePrerelease,
+            string semVerLevel = null)
         {
             var query = GetService<IAutoCompletePackageIdsQuery>();
             return new JsonResult
             {
-                Data = (await query.Execute(partialId, includePrerelease)).ToArray(),
+                Data = (await query.Execute(partialId, includePrerelease, semVerLevel)).ToArray(),
                 JsonRequestBehavior = JsonRequestBehavior.AllowGet
             };
         }
 
         [HttpGet]
         [ActionName("PackageVersions")]
-        public virtual async Task<ActionResult> GetPackageVersions(string id, bool? includePrerelease)
+        public virtual async Task<ActionResult> GetPackageVersions(
+            string id, 
+            bool? includePrerelease,
+            string semVerLevel = null)
         {
             var query = GetService<IAutoCompletePackageVersionsQuery>();
             return new JsonResult
             {
-                Data = (await query.Execute(id, includePrerelease)).ToArray(),
+                Data = (await query.Execute(id, includePrerelease, semVerLevel)).ToArray(),
                 JsonRequestBehavior = JsonRequestBehavior.AllowGet
             };
         }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -121,7 +121,7 @@ namespace NuGetGallery
             // some security paranoia about URL hacking somehow creating e.g. open redirects
             // validate user input: explicit calls to the same validators used during Package Registrations
             // Ideally shouldn't be necessary?
-            if (!PackageIdValidator.IsValidPackageId(id ?? ""))
+            if (!PackageIdValidator.IsValidPackageId(id ?? string.Empty))
             {
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, "The format of the package id is invalid");
             }

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -40,11 +40,11 @@ namespace NuGetGallery.Controllers
             _curatedFeedService = curatedFeedService;
         }
 
-        // /api/v2/curated-feed/curatedFeedName/Packages
+        // /api/v2/curated-feed/curatedFeedName/Packages?semVerLevel=
         [HttpGet]
         [HttpPost]
         [CacheOutput(NoCache = true)]
-        public IHttpActionResult Get(ODataQueryOptions<V2FeedPackage> options, string curatedFeedName)
+        public IHttpActionResult Get(ODataQueryOptions<V2FeedPackage> options, string curatedFeedName, string semVerLevel = null)
         {
             if (!_entities.CuratedFeeds.Any(cf => cf.Name == curatedFeedName))
             {
@@ -59,12 +59,12 @@ namespace NuGetGallery.Controllers
             return QueryResult(options, queryable, MaxPageSize);
         }
 
-        // /api/v2/curated-feed/curatedFeedName/Packages/$count
+        // /api/v2/curated-feed/curatedFeedName/Packages/$count?semVerLevel=
         [HttpGet]
         [CacheOutput(NoCache = true)]
-        public IHttpActionResult GetCount(ODataQueryOptions<V2FeedPackage> options, string curatedFeedName)
+        public IHttpActionResult GetCount(ODataQueryOptions<V2FeedPackage> options, string curatedFeedName, string semVerLevel = null)
         {
-            return Get(options, curatedFeedName).FormattedAsCountResult<V2FeedPackage>();
+            return Get(options, curatedFeedName, semVerLevel).FormattedAsCountResult<V2FeedPackage>();
         }
 
         // /api/v2/curated-feed/curatedFeedName/Packages(Id=,Version=)
@@ -76,11 +76,15 @@ namespace NuGetGallery.Controllers
             return result.FormattedAsSingleResult<V2FeedPackage>();
         }
 
-        // /api/v2/curated-feed/curatedFeedName/FindPackagesById()?id=
+        // /api/v2/curated-feed/curatedFeedName/FindPackagesById()?id=&semVerLevel=
         [HttpGet]
         [HttpPost]
         [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
-        public async Task<IHttpActionResult> FindPackagesById(ODataQueryOptions<V2FeedPackage> options, string curatedFeedName, [FromODataUri]string id)
+        public async Task<IHttpActionResult> FindPackagesById(
+            ODataQueryOptions<V2FeedPackage> options, 
+            string curatedFeedName, 
+            [FromODataUri]string id,
+            string semVerLevel = null)
         {
             if (string.IsNullOrEmpty(curatedFeedName) || string.IsNullOrEmpty(id))
             {
@@ -167,7 +171,7 @@ namespace NuGetGallery.Controllers
             return BadRequest("Querying property " + propertyName + " is not supported.");
         }
 
-        // /api/v2/curated-feed/curatedFeedName/Search()?searchTerm=&targetFramework=&includePrerelease=
+        // /api/v2/curated-feed/curatedFeedName/Search()?searchTerm=&targetFramework=&includePrerelease=&semVerLevel=
         [HttpGet]
         [HttpPost]
         [CacheOutput(ServerTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds, ClientTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds)]
@@ -176,7 +180,8 @@ namespace NuGetGallery.Controllers
             string curatedFeedName,
             [FromODataUri]string searchTerm = "",
             [FromODataUri]string targetFramework = "",
-            [FromODataUri]bool includePrerelease = false)
+            [FromODataUri]bool includePrerelease = false,
+            [FromODataUri]string semVerLevel = null)
         {
             if (!_entities.CuratedFeeds.Any(cf => cf.Name == curatedFeedName))
             {
@@ -247,9 +252,10 @@ namespace NuGetGallery.Controllers
             string curatedFeedName,
             [FromODataUri]string searchTerm = "",
             [FromODataUri]string targetFramework = "",
-            [FromODataUri]bool includePrerelease = false)
+            [FromODataUri]bool includePrerelease = false,
+            [FromODataUri]string semVerLevel = null)
         {
-            var searchResults = await Search(options, curatedFeedName, searchTerm, targetFramework, includePrerelease);
+            var searchResults = await Search(options, curatedFeedName, searchTerm, targetFramework, includePrerelease, semVerLevel);
             return searchResults.FormattedAsCountResult<V2FeedPackage>();
         }
     }

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -55,7 +55,7 @@ namespace NuGetGallery.Controllers
             }
 
             var queryable = _curatedFeedService.GetPackages(curatedFeedName)
-                .Where(p => SemVerLevelKey.IsCompliantWithSemVerLevel(p.SemVerLevelKey, semVerLevel))
+                .Where(SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel))
                 .ToV2FeedPackageQuery(_configurationService.GetSiteRoot(UseHttps()), _configurationService.Features.FriendlyLicenses)
                 .InterceptWith(new NormalizeVersionInterceptor());
 
@@ -118,8 +118,8 @@ namespace NuGetGallery.Controllers
             }
 
             var packages = _curatedFeedService.GetPackages(curatedFeedName)
-                .Where(p => SemVerLevelKey.IsCompliantWithSemVerLevel(p.SemVerLevelKey, semVerLevel)
-                            && p.PackageRegistration.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+                .Where(SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel))
+                .Where(p => p.PackageRegistration.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
 
             if (!string.IsNullOrEmpty(version))
             {
@@ -220,7 +220,7 @@ namespace NuGetGallery.Controllers
             // Perform actual search
             var curatedFeed = _curatedFeedService.GetFeedByName(curatedFeedName, includePackages: false);
             var packages = _curatedFeedService.GetPackages(curatedFeedName)
-                .Where(p => SemVerLevelKey.IsCompliantWithSemVerLevel(p.SemVerLevelKey, semVerLevel))
+                .Where(SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel))
                 .OrderBy(p => p.PackageRegistration.Id).ThenBy(p => p.Version);
 
             // todo: search hijack should take queryOptions instead of manually parsing query options

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -44,7 +44,10 @@ namespace NuGetGallery.Controllers
         [HttpGet]
         [HttpPost]
         [CacheOutput(NoCache = true)]
-        public IHttpActionResult Get(ODataQueryOptions<V2FeedPackage> options, string curatedFeedName, string semVerLevel = null)
+        public IHttpActionResult Get(
+            ODataQueryOptions<V2FeedPackage> options,
+            string curatedFeedName,
+            [FromUri] string semVerLevel = null)
         {
             if (!_entities.CuratedFeeds.Any(cf => cf.Name == curatedFeedName))
             {
@@ -62,7 +65,10 @@ namespace NuGetGallery.Controllers
         // /api/v2/curated-feed/curatedFeedName/Packages/$count?semVerLevel=
         [HttpGet]
         [CacheOutput(NoCache = true)]
-        public IHttpActionResult GetCount(ODataQueryOptions<V2FeedPackage> options, string curatedFeedName, string semVerLevel = null)
+        public IHttpActionResult GetCount(
+            ODataQueryOptions<V2FeedPackage> options,
+            string curatedFeedName,
+            [FromUri] string semVerLevel = null)
         {
             return Get(options, curatedFeedName, semVerLevel).FormattedAsCountResult<V2FeedPackage>();
         }
@@ -81,10 +87,10 @@ namespace NuGetGallery.Controllers
         [HttpPost]
         [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
         public async Task<IHttpActionResult> FindPackagesById(
-            ODataQueryOptions<V2FeedPackage> options, 
-            string curatedFeedName, 
-            [FromODataUri]string id,
-            string semVerLevel = null)
+            ODataQueryOptions<V2FeedPackage> options,
+            string curatedFeedName,
+            [FromODataUri] string id,
+            [FromUri] string semVerLevel = null)
         {
             if (string.IsNullOrEmpty(curatedFeedName) || string.IsNullOrEmpty(id))
             {
@@ -98,10 +104,10 @@ namespace NuGetGallery.Controllers
         }
 
         private async Task<IHttpActionResult> GetCore(
-            ODataQueryOptions<V2FeedPackage> options, 
-            string curatedFeedName, 
-            string id, 
-            string version, 
+            ODataQueryOptions<V2FeedPackage> options,
+            string curatedFeedName,
+            string id,
+            string version,
             bool return404NotFoundWhenNoResults,
             string semVerLevel)
         {
@@ -187,7 +193,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]string searchTerm = "",
             [FromODataUri]string targetFramework = "",
             [FromODataUri]bool includePrerelease = false,
-            [FromODataUri]string semVerLevel = null)
+            [FromUri]string semVerLevel = null)
         {
             if (!_entities.CuratedFeeds.Any(cf => cf.Name == curatedFeedName))
             {
@@ -259,7 +265,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]string searchTerm = "",
             [FromODataUri]string targetFramework = "",
             [FromODataUri]bool includePrerelease = false,
-            [FromODataUri]string semVerLevel = null)
+            [FromUri]string semVerLevel = null)
         {
             var searchResults = await Search(options, curatedFeedName, searchTerm, targetFramework, includePrerelease, semVerLevel);
             return searchResults.FormattedAsCountResult<V2FeedPackage>();

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -57,7 +57,7 @@ namespace NuGetGallery.Controllers
                                 .Where(SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel))
                                 .WithoutSortOnColumn(Version)
                                 .WithoutSortOnColumn(Id, ShouldIgnoreOrderById<V2FeedPackage>(options))
-                                .InterceptWith(new NormalizeVersionInterceptor()) ;
+                                .InterceptWith(new NormalizeVersionInterceptor());
 
             // Try the search service
             try
@@ -122,6 +122,11 @@ namespace NuGetGallery.Controllers
             string id, 
             string version)
         {
+            // We are defaulting to semVerLevel = null ("Unknown"), 
+            // because the client is requesting a specific package version already.
+            // We'll never return a SemVer2 package version from this endpoint.
+            // This effectively means that we'll return HTTP 404 if the only available
+            // package version matching the normalized version parameter is a SemVer2 package version.
             var result = await GetCore(options, id, version, semVerLevel: null, return404NotFoundWhenNoResults: true);
             return result.FormattedAsSingleResult<V2FeedPackage>();
         }
@@ -155,7 +160,7 @@ namespace NuGetGallery.Controllers
         {
             var packages = _packagesRepository.GetAll()
                 .Include(p => p.PackageRegistration)
-                .Where(p => p.PackageRegistration.Id.Equals(id, StringComparison.OrdinalIgnoreCase) 
+                .Where(p => p.PackageRegistration.Id.Equals(id, StringComparison.OrdinalIgnoreCase)
                             && !p.Deleted)
                 .Where(SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel));
 

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -49,7 +49,7 @@ namespace NuGetGallery.Controllers
         [CacheOutput(NoCache = true)]
         public async Task<IHttpActionResult> Get(
             ODataQueryOptions<V2FeedPackage> options,
-            [FromODataUri]string semVerLevel = null)
+            [FromUri]string semVerLevel = null)
         {
             // Setup the search
             var packages = _packagesRepository.GetAll()
@@ -108,7 +108,7 @@ namespace NuGetGallery.Controllers
         [CacheOutput(NoCache = true)]
         public async Task<IHttpActionResult> GetCount(
             ODataQueryOptions<V2FeedPackage> options,
-            [FromODataUri]string semVerLevel = null)
+            [FromUri]string semVerLevel = null)
         {
             return (await Get(options, semVerLevel)).FormattedAsCountResult<V2FeedPackage>();
         }
@@ -132,7 +132,7 @@ namespace NuGetGallery.Controllers
         public async Task<IHttpActionResult> FindPackagesById(
             ODataQueryOptions<V2FeedPackage> options, 
             [FromODataUri]string id,
-            [FromODataUri]string semVerLevel = null)
+            [FromUri]string semVerLevel = null)
         {
             if (string.IsNullOrEmpty(id))
             {
@@ -229,7 +229,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]string searchTerm = "",
             [FromODataUri]string targetFramework = "",
             [FromODataUri]bool includePrerelease = false,
-            [FromODataUri]string semVerLevel = null)
+            [FromUri]string semVerLevel = null)
         {
             // Handle OData-style |-separated list of frameworks.
             string[] targetFrameworkList = (targetFramework ?? "").Split(new[] { '\'', '|' }, StringSplitOptions.RemoveEmptyEntries);
@@ -303,7 +303,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]string searchTerm = "",
             [FromODataUri]string targetFramework = "",
             [FromODataUri]bool includePrerelease = false,
-            [FromODataUri]string semVerLevel = null)
+            [FromUri]string semVerLevel = null)
         {
             var searchResults = await Search(options, searchTerm, targetFramework, includePrerelease, semVerLevel);
             return searchResults.FormattedAsCountResult<V2FeedPackage>();
@@ -320,7 +320,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]bool includeAllVersions,
             [FromODataUri]string targetFrameworks = "",
             [FromODataUri]string versionConstraints = "",
-            [FromODataUri]string semVerLevel = null)
+            [FromUri]string semVerLevel = null)
         {
             if (string.IsNullOrEmpty(packageIds) || string.IsNullOrEmpty(versions))
             {
@@ -403,7 +403,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]bool includeAllVersions,
             [FromODataUri]string targetFrameworks = "",
             [FromODataUri]string versionConstraints = "",
-            [FromODataUri]string semVerLevel = null)
+            [FromUri]string semVerLevel = null)
         {
             return GetUpdates(options, packageIds, versions, includePrerelease, includeAllVersions, targetFrameworks, versionConstraints, semVerLevel)
                 .FormattedAsCountResult<V2FeedPackage>();

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -167,6 +167,8 @@ namespace NuGetGallery.Controllers
                 NuGetVersion nugetVersion;
                 if (NuGetVersion.TryParse(version, out nugetVersion))
                 {
+                    // Our APIs expect to receive normalized version strings.
+                    // We need to compare normalized versions or we can never retrieve SemVer2 package versions.
                     var normalizedString = nugetVersion.ToNormalizedString();
                     packages = packages.Where(p => p.NormalizedVersion == normalizedString);
                 }

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -164,7 +164,12 @@ namespace NuGetGallery.Controllers
 
             if (!string.IsNullOrEmpty(version))
             {
-                packages = packages.Where(p => p.Version == version);
+                NuGetVersion nugetVersion;
+                if (NuGetVersion.TryParse(version, out nugetVersion))
+                {
+                    var normalizedString = nugetVersion.ToNormalizedString();
+                    packages = packages.Where(p => p.NormalizedVersion == normalizedString);
+                }
             }
 
             // try the search service

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -122,12 +122,10 @@ namespace NuGetGallery.Controllers
             string id, 
             string version)
         {
-            // We are defaulting to semVerLevel = null ("Unknown"), 
-            // because the client is requesting a specific package version already.
-            // We'll never return a SemVer2 package version from this endpoint.
-            // This effectively means that we'll return HTTP 404 if the only available
-            // package version matching the normalized version parameter is a SemVer2 package version.
-            var result = await GetCore(options, id, version, semVerLevel: null, return404NotFoundWhenNoResults: true);
+            // We are defaulting to semVerLevel = "2.0.0" by design.
+            // The client is requesting a specific package version and should support what it requests.
+            // If not, too bad :)
+            var result = await GetCore(options, id, version, semVerLevel: "2.0.0", return404NotFoundWhenNoResults: true);
             return result.FormattedAsSingleResult<V2FeedPackage>();
         }
 

--- a/src/NuGetGallery/Queries/AutoCompleteDatabasePackageIdsQuery.cs
+++ b/src/NuGetGallery/Queries/AutoCompleteDatabasePackageIdsQuery.cs
@@ -13,15 +13,15 @@ namespace NuGetGallery
         private const string _partialIdSqlFormat = @"SELECT TOP 30 pr.ID
 FROM Packages p (NOLOCK)
     JOIN PackageRegistrations pr (NOLOCK) on pr.[Key] = p.PackageRegistrationKey
-WHERE p.[SemVerLevelKey] IS NULL AND pr.ID LIKE {{0}}
-    {0}
+WHERE {0} AND pr.ID LIKE {{0}}
+    {1}
 GROUP BY pr.ID
 ORDER BY pr.ID";
 
         private const string _noPartialIdSql = @"SELECT TOP 30 pr.ID
 FROM Packages p (NOLOCK)
     JOIN PackageRegistrations pr (NOLOCK) on pr.[Key] = p.PackageRegistrationKey
-WHERE  p.[SemVerLevelKey] IS NULL 
+WHERE  {0} 
 GROUP BY pr.ID
 ORDER BY MAX(pr.DownloadCount) DESC";
         
@@ -35,25 +35,30 @@ ORDER BY MAX(pr.DownloadCount) DESC";
             bool? includePrerelease = false,
             string semVerLevel = null)
         {
+            // Create SQL filter on SemVerLevel
+            // By default, we filter out SemVer v2.0.0 package versions.
+            var semVerLevelSqlFilter = "p.[SemVerLevelKey] IS NULL";
             if (!string.IsNullOrEmpty(semVerLevel))
             {
-                // todo: create SQL filter on SemVerLevel
+                var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
+                if (semVerLevelKey == SemVerLevelKey.SemVer2)
+                {
+                    semVerLevelSqlFilter = "p.[SemVerLevelKey] = " + SemVerLevelKey.SemVer2;
+                }
             }
 
             if (string.IsNullOrWhiteSpace(partialId))
             {
-                // todo: apply SQL filter on SemVerLevel
-                return RunSqlQuery(_noPartialIdSql);
+                return RunSqlQuery(string.Format(CultureInfo.InvariantCulture, _noPartialIdSql, semVerLevelSqlFilter));
             }
 
             var prereleaseFilter = string.Empty;
             if (!includePrerelease.HasValue || !includePrerelease.Value)
             {
-                // todo: apply SQL filter on SemVerLevel
                 prereleaseFilter = "AND p.IsPrerelease = {1}";
             }
 
-            var sql = string.Format(CultureInfo.InvariantCulture, _partialIdSqlFormat, prereleaseFilter);
+            var sql = string.Format(CultureInfo.InvariantCulture, _partialIdSqlFormat, semVerLevelSqlFilter, prereleaseFilter);
 
             return RunSqlQuery(sql, partialId + "%", includePrerelease ?? false);
         }

--- a/src/NuGetGallery/Queries/AutoCompleteDatabasePackageIdsQuery.cs
+++ b/src/NuGetGallery/Queries/AutoCompleteDatabasePackageIdsQuery.cs
@@ -32,22 +32,30 @@ ORDER BY MAX(pr.DownloadCount) DESC";
 
         public Task<IEnumerable<string>> Execute(
             string partialId,
-            bool? includePrerelease = false)
+            bool? includePrerelease = false,
+            string semVerLevel = null)
         {
+            if (!string.IsNullOrEmpty(semVerLevel))
+            {
+                // todo: create SQL filter on SemVerLevel
+            }
+
             if (string.IsNullOrWhiteSpace(partialId))
             {
-                return RunQuery(_noPartialIdSql);
+                // todo: apply SQL filter on SemVerLevel
+                return RunSqlQuery(_noPartialIdSql);
             }
 
             var prereleaseFilter = string.Empty;
             if (!includePrerelease.HasValue || !includePrerelease.Value)
             {
+                // todo: apply SQL filter on SemVerLevel
                 prereleaseFilter = "AND p.IsPrerelease = {1}";
             }
 
             var sql = string.Format(CultureInfo.InvariantCulture, _partialIdSqlFormat, prereleaseFilter);
 
-            return RunQuery(sql, partialId + "%", includePrerelease ?? false);
+            return RunSqlQuery(sql, partialId + "%", includePrerelease ?? false);
         }
     }
 }

--- a/src/NuGetGallery/Queries/AutoCompleteDatabasePackageVersionsQuery.cs
+++ b/src/NuGetGallery/Queries/AutoCompleteDatabasePackageVersionsQuery.cs
@@ -24,20 +24,27 @@ WHERE p.[SemVerLevelKey] IS NULL AND pr.ID = {{0}}
 
         public Task<IEnumerable<string>> Execute(
             string id,
-            bool? includePrerelease = false)
+            bool? includePrerelease = false,
+            string semVerLevel = null)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
                 throw new ArgumentNullException(nameof(id));
             }
-            
+
+            if (!string.IsNullOrEmpty(semVerLevel))
+            {
+                // todo: create SQL filter on SemVerLevel
+            }
+
             var prereleaseFilter = string.Empty;
             if (!includePrerelease.HasValue || !includePrerelease.Value)
             {
                 prereleaseFilter = "AND p.IsPrerelease = 0";
             }
-            
-            return RunQuery(string.Format(CultureInfo.InvariantCulture, _sqlFormat, prereleaseFilter), id);
+
+            // todo: apply SQL filter on SemVerLevel
+            return RunSqlQuery(string.Format(CultureInfo.InvariantCulture, _sqlFormat, prereleaseFilter), id);
         }
     }
 }

--- a/src/NuGetGallery/Queries/AutoCompleteDatabaseQuery.cs
+++ b/src/NuGetGallery/Queries/AutoCompleteDatabaseQuery.cs
@@ -23,7 +23,7 @@ namespace NuGetGallery
             _dbContext = (DbContext)entities;
         }
 
-        public Task<IEnumerable<string>> RunQuery(string sql, params object[] sqlParameters)
+        public Task<IEnumerable<string>> RunSqlQuery(string sql, params object[] sqlParameters)
         {
             return Task.FromResult(_dbContext.Database.SqlQuery<string>(sql, sqlParameters).AsEnumerable());
         }

--- a/src/NuGetGallery/Queries/AutoCompleteServiceQuery.cs
+++ b/src/NuGetGallery/Queries/AutoCompleteServiceQuery.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Services.Search.Client;
+using NuGet.Versioning;
 using NuGetGallery.Configuration;
 
 namespace NuGetGallery
@@ -37,7 +38,8 @@ namespace NuGetGallery
         {
             queryString += $"&prerelease={includePrerelease ?? false}";
 
-            if (!string.IsNullOrEmpty(semVerLevel))
+            NuGetVersion semVerLevelVersion;
+            if (!string.IsNullOrEmpty(semVerLevel) && NuGetVersion.TryParse(semVerLevel, out semVerLevelVersion))
             {
                 queryString += $"&semVerLevel={semVerLevel}";
             }

--- a/src/NuGetGallery/Queries/AutoCompleteServiceQuery.cs
+++ b/src/NuGetGallery/Queries/AutoCompleteServiceQuery.cs
@@ -30,9 +30,18 @@ namespace NuGetGallery
             _httpClient = new RetryingHttpClientWrapper(new HttpClient());
         }
 
-        public async Task<IEnumerable<string>> RunQuery(string queryString, bool? includePrerelease)
+        public async Task<IEnumerable<string>> RunServiceQuery(
+            string queryString, 
+            bool? includePrerelease,
+            string semVerLevel = null)
         {
             queryString += $"&prerelease={includePrerelease ?? false}";
+
+            if (!string.IsNullOrEmpty(semVerLevel))
+            {
+                queryString += $"&semVerLevel={semVerLevel}";
+            }
+
             var endpoints = await _serviceDiscoveryClient.GetEndpointsForResourceType(_autocompleteServiceResourceType);
             endpoints = endpoints.Select(e => new Uri(e + "?" + queryString)).AsEnumerable();
 

--- a/src/NuGetGallery/Queries/AutocompleteServicePackageIdsQuery.cs
+++ b/src/NuGetGallery/Queries/AutocompleteServicePackageIdsQuery.cs
@@ -18,11 +18,12 @@ namespace NuGetGallery
 
         public async Task<IEnumerable<string>> Execute(
             string partialId, 
-            bool? includePrerelease)
+            bool? includePrerelease,
+            string semVerLevel = null)
         {
             partialId = partialId ?? string.Empty;
 
-            return await RunQuery("take=30&q=" + Uri.EscapeUriString(partialId), includePrerelease);
+            return await RunServiceQuery("take=30&q=" + Uri.EscapeUriString(partialId), includePrerelease, semVerLevel);
         }
     }
 }

--- a/src/NuGetGallery/Queries/AutocompleteServicePackageVersionsQuery.cs
+++ b/src/NuGetGallery/Queries/AutocompleteServicePackageVersionsQuery.cs
@@ -18,14 +18,15 @@ namespace NuGetGallery
 
         public async Task<IEnumerable<string>> Execute(
             string id, 
-            bool? includePrerelease)
+            bool? includePrerelease,
+            string semVerLevel = null)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
                 throw new ArgumentNullException(nameof(id));
             }
 
-            return await RunQuery("id=" + Uri.EscapeUriString(id), includePrerelease);
+            return await RunServiceQuery("id=" + Uri.EscapeUriString(id), includePrerelease, semVerLevel);
         }
     }
 }

--- a/src/NuGetGallery/Queries/IAutoCompletePackageIdsQuery.cs
+++ b/src/NuGetGallery/Queries/IAutoCompletePackageIdsQuery.cs
@@ -10,6 +10,7 @@ namespace NuGetGallery
     {
         Task<IEnumerable<string>> Execute(
             string partialId,
-            bool? includePrerelease = false);
+            bool? includePrerelease = false,
+            string semVerLevel = null);
     }
 }

--- a/src/NuGetGallery/Queries/IAutoCompletePackageVersionsQuery.cs
+++ b/src/NuGetGallery/Queries/IAutoCompletePackageVersionsQuery.cs
@@ -10,6 +10,7 @@ namespace NuGetGallery
     {
         Task<IEnumerable<string>> Execute(
             string id,
-            bool? includePrerelease = false);
+            bool? includePrerelease = false,
+            string semVerLevel = null);
     }
 }

--- a/tests/NuGetGallery.Core.Facts/SemVerLevelKeyFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/SemVerLevelKeyFacts.cs
@@ -167,8 +167,12 @@ namespace NuGetGallery
             [InlineData("-2.0.1")]
             public void UnknownKey_IsCompliantWithAnySemVerLevelString(string semVerLevel)
             {
+                // Arrange
+                var package = new Package { SemVerLevelKey = SemVerLevelKey.Unknown };
+                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel).Compile();
+
                 // Act
-                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.Unknown, semVerLevel);
+                var isCompliant = compiledFunction(package);
 
                 // Assert
                 Assert.True(isCompliant);
@@ -182,8 +186,12 @@ namespace NuGetGallery
             [InlineData("2.0.1")]
             public void SemVer2Key_IsCompliantWithSemVerLevel200OrHigher(string semVerLevel)
             {
+                // Arrange
+                var package = new Package { SemVerLevelKey = SemVerLevelKey.SemVer2 };
+                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel).Compile();
+
                 // Act
-                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel);
+                var isCompliant = compiledFunction(package);
 
                 // Assert
                 Assert.True(isCompliant);
@@ -196,8 +204,12 @@ namespace NuGetGallery
             [InlineData("-2.0.1")]
             public void SemVer2Key_IsNotCompliantWithInvalidVersionStrings(string semVerLevel)
             {
+                // Arrange
+                var package = new Package { SemVerLevelKey = SemVerLevelKey.SemVer2 };
+                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel).Compile();
+
                 // Act
-                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel);
+                var isCompliant = compiledFunction(package);
 
                 // Assert
                 Assert.False(isCompliant);
@@ -211,8 +223,12 @@ namespace NuGetGallery
             [InlineData("1.0.1")]
             public void SemVer2Key_IsNotCompliantWithVersionStringLowerThanSemVer2(string semVerLevel)
             {
+                // Arrange
+                var package = new Package { SemVerLevelKey = SemVerLevelKey.SemVer2 };
+                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel).Compile();
+
                 // Act
-                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel);
+                var isCompliant = compiledFunction(package);
 
                 // Assert
                 Assert.False(isCompliant);
@@ -221,8 +237,12 @@ namespace NuGetGallery
             [Fact]
             public void SemVer2Key_IsNotCompliantWithUnknownSemVerLevel()
             {
+                // Arrange
+                var package = new Package { SemVerLevelKey = SemVerLevelKey.SemVer2 };
+                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(null).Compile();
+
                 // Act
-                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.SemVer2, null);
+                var isCompliant = compiledFunction(package);
 
                 // Assert
                 Assert.False(isCompliant);

--- a/tests/NuGetGallery.Core.Facts/SemVerLevelKeyFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/SemVerLevelKeyFacts.cs
@@ -167,15 +167,7 @@ namespace NuGetGallery
             [InlineData("-2.0.1")]
             public void UnknownKey_IsCompliantWithAnySemVerLevelString(string semVerLevel)
             {
-                // Arrange
-                var package = new Package { SemVerLevelKey = SemVerLevelKey.Unknown };
-                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel).Compile();
-
-                // Act
-                var isCompliant = compiledFunction(package);
-
-                // Assert
-                Assert.True(isCompliant);
+                AssertPackageIsComplianceWithSemVerLevel(SemVerLevelKey.Unknown, semVerLevel, shouldBeCompliant: true);
             }
 
             [Theory]
@@ -186,15 +178,7 @@ namespace NuGetGallery
             [InlineData("2.0.1")]
             public void SemVer2Key_IsCompliantWithSemVerLevel200OrHigher(string semVerLevel)
             {
-                // Arrange
-                var package = new Package { SemVerLevelKey = SemVerLevelKey.SemVer2 };
-                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel).Compile();
-
-                // Act
-                var isCompliant = compiledFunction(package);
-
-                // Assert
-                Assert.True(isCompliant);
+                AssertPackageIsComplianceWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel, shouldBeCompliant: true);
             }
 
             [Theory]
@@ -204,15 +188,7 @@ namespace NuGetGallery
             [InlineData("-2.0.1")]
             public void SemVer2Key_IsNotCompliantWithInvalidVersionStrings(string semVerLevel)
             {
-                // Arrange
-                var package = new Package { SemVerLevelKey = SemVerLevelKey.SemVer2 };
-                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel).Compile();
-
-                // Act
-                var isCompliant = compiledFunction(package);
-
-                // Assert
-                Assert.False(isCompliant);
+                AssertPackageIsComplianceWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel, shouldBeCompliant: false);
             }
 
 
@@ -223,29 +199,21 @@ namespace NuGetGallery
             [InlineData("1.0.1")]
             public void SemVer2Key_IsNotCompliantWithVersionStringLowerThanSemVer2(string semVerLevel)
             {
-                // Arrange
-                var package = new Package { SemVerLevelKey = SemVerLevelKey.SemVer2 };
-                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel).Compile();
-
-                // Act
-                var isCompliant = compiledFunction(package);
-
-                // Assert
-                Assert.False(isCompliant);
+                AssertPackageIsComplianceWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel, shouldBeCompliant: false);
             }
 
             [Fact]
             public void SemVer2Key_IsNotCompliantWithUnknownSemVerLevel()
             {
-                // Arrange
-                var package = new Package { SemVerLevelKey = SemVerLevelKey.SemVer2 };
-                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(null).Compile();
+                AssertPackageIsComplianceWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel: null, shouldBeCompliant: false);
+            }
 
-                // Act
-                var isCompliant = compiledFunction(package);
+            private static void AssertPackageIsComplianceWithSemVerLevel(int? packageSemVerLevelKey, string semVerLevel, bool shouldBeCompliant)
+            {
+                var package = new Package { SemVerLevelKey = packageSemVerLevelKey };
+                var compiledFunction = SemVerLevelKey.IsPackageCompliantWithSemVerLevel(semVerLevel).Compile();
 
-                // Assert
-                Assert.False(isCompliant);
+                Assert.Equal(shouldBeCompliant, compiledFunction(package));
             }
         }
     }

--- a/tests/NuGetGallery.Core.Facts/SemVerLevelKeyFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/SemVerLevelKeyFacts.cs
@@ -106,5 +106,127 @@ namespace NuGetGallery
                 Assert.Equal(SemVerLevelKey.Unknown, key);
             }
         }
+
+        public class TheForSemVerLevelMethod
+        {
+            [Theory]
+            [InlineData("")]
+            [InlineData("this.is.not.a.version.string")]
+            [InlineData("1.0.0-alpha.01")] // no leading zeros in numeric identifiers
+            [InlineData("1.0.0")]
+            [InlineData("2.0.0-alpha")]
+            public void DefaultsToUnknownKeyWhenVersionStringIsInvalidOrLowerThanVersion200(string semVerLevel)
+            {
+                // Act
+                var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
+
+                // Assert
+                Assert.Equal(SemVerLevelKey.Unknown, semVerLevelKey);
+            }
+
+            [Theory]
+            [InlineData("3.0.0")]
+            [InlineData("3.0.0-alpha")]
+            [InlineData("2.0.0")]
+            [InlineData("2.0.1")]
+            public void ReturnsSemVer2KeyWhenVersionStringAtLeastVersion200(string semVerLevel)
+            {
+                // Act
+                var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
+
+                // Assert
+                Assert.Equal(SemVerLevelKey.SemVer2, semVerLevelKey);
+            }
+
+            [Fact]
+            public void DefaultsToUnknownKeyWhenVersionStringIsNull()
+            {
+                // Act
+                var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(null);
+
+                // Assert
+                Assert.Equal(SemVerLevelKey.Unknown, semVerLevelKey);
+            }
+        }
+
+        public class TheIsCompliantWithSemVerLevelMethod
+        {
+            [Theory]
+            // Versions higher than SemVer v2.0.0
+            [InlineData("3.0.0")]
+            [InlineData("3.0.0-alpha")]
+            [InlineData("2.0.0")]
+            [InlineData("2.0.1")]
+            // Versions lower than SemVer v2.0.0
+            [InlineData("2.0.0-alpha")] // no leading zeros in numeric identifiers
+            [InlineData("1.0.1")]
+            // Invalid/undefined versions
+            [InlineData(null)]
+            [InlineData("this.is.not.a.valid.version.string")]
+            [InlineData("2.0.0-alpha.01")] // no leading zeros in numeric identifiers
+            [InlineData("-2.0.1")]
+            public void UnknownKey_IsCompliantWithAnySemVerLevelString(string semVerLevel)
+            {
+                // Act
+                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.Unknown, semVerLevel);
+
+                // Assert
+                Assert.True(isCompliant);
+            }
+
+            [Theory]
+            // Versions higher than SemVer v2.0.0
+            [InlineData("3.0.0")]
+            [InlineData("3.0.0-alpha")]
+            [InlineData("2.0.0")]
+            [InlineData("2.0.1")]
+            public void SemVer2Key_IsCompliantWithSemVerLevel200OrHigher(string semVerLevel)
+            {
+                // Act
+                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel);
+
+                // Assert
+                Assert.True(isCompliant);
+            }
+
+            [Theory]
+            // Invalid versions
+            [InlineData("this.is.not.a.valid.version.string")]
+            [InlineData("2.0.0-alpha.01")] // no leading zeros in numeric identifiers
+            [InlineData("-2.0.1")]
+            public void SemVer2Key_IsNotCompliantWithInvalidVersionStrings(string semVerLevel)
+            {
+                // Act
+                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel);
+
+                // Assert
+                Assert.False(isCompliant);
+            }
+
+
+            [Theory]
+            // Versions lower than SemVer v2.0.0
+            [InlineData(null)]
+            [InlineData("2.0.0-alpha")] // no leading zeros in numeric identifiers
+            [InlineData("1.0.1")]
+            public void SemVer2Key_IsNotCompliantWithVersionStringLowerThanSemVer2(string semVerLevel)
+            {
+                // Act
+                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.SemVer2, semVerLevel);
+
+                // Assert
+                Assert.False(isCompliant);
+            }
+
+            [Fact]
+            public void SemVer2Key_IsNotCompliantWithUnknownSemVerLevel()
+            {
+                // Act
+                var isCompliant = SemVerLevelKey.IsCompliantWithSemVerLevel(SemVerLevelKey.SemVer2, null);
+
+                // Assert
+                Assert.False(isCompliant);
+            }
+        }
     }
 }

--- a/tests/NuGetGallery.Facts/Controllers/ODataV1FeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV1FeedControllerFacts.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery.Controllers
                 "/api/v1/Packages");
 
             // Assert
-            AssertResultCorrect(resultSet);
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
             Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
         }
 
@@ -47,7 +47,7 @@ namespace NuGetGallery.Controllers
                 $"/api/v1/FindPackagesById?id='{TestPackageId}'");
 
             // Assert
-            AssertResultCorrect(resultSet);
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
             Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
         }
 
@@ -60,7 +60,7 @@ namespace NuGetGallery.Controllers
                 $"/api/v1/Search?searchTerm='{TestPackageId}'");
 
             // Assert
-            AssertResultCorrect(resultSet);
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
             Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
         }
 
@@ -82,7 +82,7 @@ namespace NuGetGallery.Controllers
             return new ODataV1FeedController(packagesRepository, configurationService, searchService);
         }
 
-        private void AssertResultCorrect(IEnumerable<V1FeedPackage> resultSet)
+        private void AssertSemVer2PackagesFilteredFromResult(IEnumerable<V1FeedPackage> resultSet)
         {
             foreach (var feedPackage in resultSet)
             {

--- a/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
@@ -26,8 +26,25 @@ namespace NuGetGallery.Controllers
                 $"/api/v2/curated-feed/{_curatedFeedName}/Packages");
 
             // Assert
-            AssertResultCorrect(resultSet);
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
             Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
+        }
+        
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task Get_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var resultSet = await GetCollection<V2FeedPackage>(
+                (controller, options) => controller.Get(options, _curatedFeedName, semVerLevel),
+                $"/api/v2/curated-feed/{_curatedFeedName}/Packages?semVerLevel={semVerLevel}");
+
+            // Assert
+            AssertSemVer2PackagesIncludedInResult(resultSet);
+            Assert.Equal(AllPackages.Count(), resultSet.Count);
         }
 
         [Fact]
@@ -41,6 +58,22 @@ namespace NuGetGallery.Controllers
             // Assert
             Assert.Equal(NonSemVer2Packages.Count, count);
         }
+        
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task GetCount_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var count = await GetInt<V2FeedPackage>(
+                (controller, options) => controller.GetCount(options, _curatedFeedName, semVerLevel),
+                $"/api/v2/curated-feed/{_curatedFeedName}/Packages/$count?semVerLevel={semVerLevel}");
+
+            // Assert
+            Assert.Equal(AllPackages.Count(), count);
+        }
 
         [Fact]
         public async Task FindPackagesById_FiltersSemVerV2PackageVersions()
@@ -51,8 +84,25 @@ namespace NuGetGallery.Controllers
                 $"/api/v2/curated-feed/{_curatedFeedName}/FindPackagesById?id='{TestPackageId}'");
 
             // Assert
-            AssertResultCorrect(resultSet);
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
             Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
+        }
+
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task FindPackagesById_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var resultSet = await GetCollection<V2FeedPackage>(
+                async (controller, options) => await controller.FindPackagesById(options, _curatedFeedName, id: TestPackageId, semVerLevel: semVerLevel),
+                $"/api/v2/curated-feed/{_curatedFeedName}/FindPackagesById?id='{TestPackageId}'?semVerLevel={semVerLevel}");
+
+            // Assert
+            AssertSemVer2PackagesIncludedInResult(resultSet);
+            Assert.Equal(AllPackages.Count(), resultSet.Count);
         }
 
         [Fact]
@@ -60,12 +110,29 @@ namespace NuGetGallery.Controllers
         {
             // Act
             var resultSet = await GetCollection<V2FeedPackage>(
-                async (controller, options) => await controller.Search(options, _curatedFeedName, TestPackageId),
+                async (controller, options) => await controller.Search(options, _curatedFeedName, searchTerm: TestPackageId),
                 $"/api/v2/curated-feed/{_curatedFeedName}/Search?searchTerm='{TestPackageId}'");
 
             // Assert
-            AssertResultCorrect(resultSet);
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
             Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
+        }
+        
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task Search_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var resultSet = await GetCollection<V2FeedPackage>(
+                async (controller, options) => await controller.Search(options, _curatedFeedName, searchTerm: TestPackageId, semVerLevel: semVerLevel),
+                $"/api/v2/curated-feed/{_curatedFeedName}/Search?searchTerm='{TestPackageId}'?semVerLevel={semVerLevel}");
+
+            // Assert
+            AssertSemVer2PackagesIncludedInResult(resultSet);
+            Assert.Equal(AllPackages.Count(), resultSet.Count);
         }
 
         [Fact]
@@ -73,11 +140,27 @@ namespace NuGetGallery.Controllers
         {
             // Act
             var searchCount = await GetInt<V2FeedPackage>(
-                async (controller, options) => await controller.SearchCount(options, _curatedFeedName, TestPackageId),
+                async (controller, options) => await controller.SearchCount(options, _curatedFeedName, searchTerm: TestPackageId),
                 $"/api/v2/curated-feed/{_curatedFeedName}/Search/$count?searchTerm='{TestPackageId}'");
 
             // Assert
             Assert.Equal(NonSemVer2Packages.Count, searchCount);
+        }
+
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task SearchCount_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var searchCount = await GetInt<V2FeedPackage>(
+                async (controller, options) => await controller.SearchCount(options, _curatedFeedName, searchTerm: TestPackageId, semVerLevel: semVerLevel),
+                $"/api/v2/curated-feed/{_curatedFeedName}/Search/$count?searchTerm='{TestPackageId}'&semVerLevel={semVerLevel}");
+
+            // Assert
+            Assert.Equal(AllPackages.Count(), searchCount);
         }
 
         protected override ODataV2CuratedFeedController CreateController(
@@ -115,7 +198,7 @@ namespace NuGetGallery.Controllers
             return dbSet.Object;
         }
 
-        private void AssertResultCorrect(IEnumerable<V2FeedPackage> resultSet)
+        private void AssertSemVer2PackagesFilteredFromResult(IEnumerable<V2FeedPackage> resultSet)
         {
             foreach (var feedPackage in resultSet)
             {
@@ -126,6 +209,29 @@ namespace NuGetGallery.Controllers
                 Assert.Single(NonSemVer2Packages.Where(p =>
                     string.Equals(p.Version, feedPackage.Version) &&
                     string.Equals(p.PackageRegistration.Id, feedPackage.Id)));
+            }
+        }
+
+        private void AssertSemVer2PackagesIncludedInResult(IReadOnlyCollection<V2FeedPackage> resultSet)
+        {
+            foreach (var package in SemVer2Packages)
+            {
+                // Assert all of the SemVer2 packages are included in the result.
+                // Whilst at it, also check the NormalizedVersion on the OData feed.
+                Assert.Single(resultSet.Where(feedPackage =>
+                    string.Equals(feedPackage.Version, package.Version)
+                    && string.Equals(feedPackage.NormalizedVersion, package.NormalizedVersion)
+                    && string.Equals(feedPackage.Id, package.PackageRegistration.Id)));
+            }
+
+            foreach (var package in NonSemVer2Packages)
+            {
+                // Assert all of the non-SemVer2 packages are included in the result.
+                // Whilst at it, also check the NormalizedVersion on the OData feed.
+                Assert.Single(resultSet.Where(feedPackage =>
+                    string.Equals(feedPackage.Version, package.Version)
+                    && string.Equals(feedPackage.NormalizedVersion, package.NormalizedVersion)
+                    && string.Equals(feedPackage.Id, package.PackageRegistration.Id)));
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Controllers/ODataV2FeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV2FeedControllerFacts.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery.Controllers
         : ODataFeedControllerFactsBase<ODataV2FeedController>
     {
         [Fact]
-        public async Task Get_FiltersSemVerV2PackageVersions()
+        public async Task Get_FiltersSemVerV2PackageVersionsByDefault()
         {
             // Act
             var resultSet = await GetCollection<V2FeedPackage>(
@@ -23,12 +23,29 @@ namespace NuGetGallery.Controllers
                 "/api/v2/Packages");
 
             // Assert
-            AssertResultCorrect(resultSet);
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
             Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
         }
 
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task Get_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var resultSet = await GetCollection<V2FeedPackage>(
+                (controller, options) => controller.Get(options, semVerLevel),
+                $"/api/v2/Packages?semVerLevel={semVerLevel}");
+
+            // Assert
+            AssertSemVer2PackagesIncludedInResult(resultSet);
+            Assert.Equal(AllPackages.Count(), resultSet.Count);
+        }
+
         [Fact]
-        public async Task GetCount_FiltersSemVerV2PackageVersions()
+        public async Task GetCount_FiltersSemVerV2PackageVersionsByDefault()
         {
             // Act
             var count =  await GetInt<V2FeedPackage>(
@@ -38,9 +55,25 @@ namespace NuGetGallery.Controllers
             // Assert
             Assert.Equal(NonSemVer2Packages.Count, count);
         }
+        
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task GetCount_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var count = await GetInt<V2FeedPackage>(
+                (controller, options) => controller.GetCount(options, semVerLevel),
+                $"/api/v2/Packages/$count?semVerLevel={semVerLevel}");
+
+            // Assert
+            Assert.Equal(AllPackages.Count(), count);
+        }
 
         [Fact]
-        public async Task FindPackagesById_FiltersSemVerV2PackageVersions()
+        public async Task FindPackagesById_FiltersSemVerV2PackageVersionsByDefault()
         {
             // Act
             var resultSet = await GetCollection<V2FeedPackage>(
@@ -48,37 +81,87 @@ namespace NuGetGallery.Controllers
                 $"/api/v2/FindPackagesById?id='{TestPackageId}'");
 
             // Assert
-            AssertResultCorrect(resultSet);
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
             Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
         }
 
-        [Fact]
-        public async Task Search_FiltersSemVerV2PackageVersions()
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task FindPackagesById_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
         {
             // Act
             var resultSet = await GetCollection<V2FeedPackage>(
-                async (controller, options) => await controller.Search(options, TestPackageId),
-                $"/api/v2/Search?searchTerm='{TestPackageId}'");
+                (controller, options) => controller.FindPackagesById(options, id: TestPackageId, semVerLevel: semVerLevel),
+                $"/api/v2/FindPackagesById?id='{TestPackageId}'?semVerLevel={semVerLevel}");
 
             // Assert
-            AssertResultCorrect(resultSet);
-            Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
+            AssertSemVer2PackagesIncludedInResult(resultSet);
+            Assert.Equal(AllPackages.Count(), resultSet.Count);
         }
 
         [Fact]
-        public async Task SearchCount_FiltersSemVerV2PackageVersions()
+        public async Task Search_FiltersSemVerV2PackageVersionsByDefault()
+        {
+            // Act
+            var resultSet = await GetCollection<V2FeedPackage>(
+                async (controller, options) => await controller.Search(options, searchTerm: TestPackageId),
+                $"/api/v2/Search?searchTerm='{TestPackageId}'");
+
+            // Assert
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
+            Assert.Equal(NonSemVer2Packages.Count, resultSet.Count);
+        }
+        
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task Search_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var resultSet = await GetCollection<V2FeedPackage>(
+                (controller, options) => controller.Search(options, searchTerm: TestPackageId, semVerLevel: semVerLevel),
+                $"/api/v2/Search?searchTerm='{TestPackageId}'?semVerLevel={semVerLevel}");
+
+            // Assert
+            AssertSemVer2PackagesIncludedInResult(resultSet);
+            Assert.Equal(AllPackages.Count(), resultSet.Count);
+        }
+
+        [Fact]
+        public async Task SearchCount_FiltersSemVerV2PackageVersionsByDefault()
         {
             // Act
             var searchCount = await GetInt<V2FeedPackage>(
-                async (controller, options) => await controller.SearchCount(options, TestPackageId),
+                async (controller, options) => await controller.SearchCount(options, searchTerm: TestPackageId),
                 $"/api/v2/Search/$count?searchTerm='{TestPackageId}'");
 
             // Assert
             Assert.Equal(NonSemVer2Packages.Count, searchCount);
         }
-        
+
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task SearchCount_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var searchCount = await GetInt<V2FeedPackage>(
+                async (controller, options) => await controller.SearchCount(options, searchTerm: TestPackageId, semVerLevel: semVerLevel),
+                $"/api/v2/Search/$count?searchTerm='{TestPackageId}'&semVerLevel={semVerLevel}");
+
+            // Assert
+            Assert.Equal(AllPackages.Count(), searchCount);
+        }
+
         [Fact]
-        public async Task GetUpdates_FiltersSemVerV2PackageVersions()
+        public async Task GetUpdates_FiltersSemVerV2PackageVersionsByDefault()
         {
             // Arrange
             const string currentVersionString = "1.0.0";
@@ -91,12 +174,53 @@ namespace NuGetGallery.Controllers
                 $"/api/v2/GetUpdates()?packageIds='{TestPackageId}'&versions='{currentVersionString}'&includePrerelease=true&includeAllVersions=true");
 
             // Assert
-            AssertResultCorrect(resultSet);
+            AssertSemVer2PackagesFilteredFromResult(resultSet);
+            Assert.Equal(expected.Count(), resultSet.Count);
+        }
+
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task GetUpdates_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Arrange
+            const string currentVersionString = "1.0.0";
+            var currentVersion = NuGetVersion.Parse(currentVersionString);
+            var expected = AllPackages.Where(p => NuGetVersion.Parse(p.Version) > currentVersion);
+
+            // Act
+            var resultSet = await GetCollection<V2FeedPackage>(
+                (controller, options) => controller.GetUpdates(options, TestPackageId, currentVersionString, includePrerelease: true, includeAllVersions: true, semVerLevel: semVerLevel),
+                $"/api/v2/GetUpdates()?packageIds='{TestPackageId}'&versions='{currentVersionString}'&includePrerelease=true&includeAllVersions=true&semVerLevel={semVerLevel}");
+
+            // Assert
+            foreach (var package in SemVer2Packages.Where(p => NuGetVersion.Parse(p.Version) > currentVersion))
+            {
+                // Assert all of the SemVer2 packages are included in the result.
+                // Whilst at it, also check the NormalizedVersion on the OData feed.
+                Assert.Single(resultSet.Where(feedPackage =>
+                            string.Equals(feedPackage.Version, package.Version)
+                            && string.Equals(feedPackage.NormalizedVersion, package.NormalizedVersion)
+                            && string.Equals(feedPackage.Id, package.PackageRegistration.Id)));
+            }
+
+            foreach (var package in NonSemVer2Packages.Where(p => NuGetVersion.Parse(p.Version) > currentVersion))
+            {
+                // Assert all of the non-SemVer2 packages are included in the result.
+                // Whilst at it, also check the NormalizedVersion on the OData feed.
+                Assert.Single(resultSet.Where(feedPackage =>
+                            string.Equals(feedPackage.Version, package.Version)
+                            && string.Equals(feedPackage.NormalizedVersion, package.NormalizedVersion)
+                            && string.Equals(feedPackage.Id, package.PackageRegistration.Id)));
+            }
+
             Assert.Equal(expected.Count(), resultSet.Count);
         }
 
         [Fact]
-        public async Task GetUpdatesCount_FiltersSemVerV2PackageVersions()
+        public async Task GetUpdatesCount_FiltersSemVerV2PackageVersionsByDefault()
         {
             // Arrange
             const string currentVersionString = "1.0.0";
@@ -112,6 +236,33 @@ namespace NuGetGallery.Controllers
             Assert.Equal(expected.Count(), updatesCount);
         }
 
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task GetUpdatesCount_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Arrange
+            const string currentVersionString = "1.0.0";
+            var currentVersion = NuGetVersion.Parse(currentVersionString);
+            var expected = AllPackages.Where(p => NuGetVersion.Parse(p.Version) > currentVersion);
+
+            // Act
+            var searchCount = await GetInt<V2FeedPackage>(
+                (controller, options) => controller.GetUpdatesCount(
+                    options,
+                    packageIds: TestPackageId,
+                    versions: currentVersionString,
+                    includePrerelease: true,
+                    includeAllVersions: true,
+                    semVerLevel: semVerLevel),
+                $"/api/v2/GetUpdates()?packageIds='{TestPackageId}'&versions='{currentVersionString}'&includePrerelease=true&includeAllVersions=true&semVerLevel={semVerLevel}");
+
+            // Assert
+            Assert.Equal(expected.Count(), searchCount);
+        }
+
         protected override ODataV2FeedController CreateController(
             IEntityRepository<Package> packagesRepository,
             IGalleryConfigurationService configurationService,
@@ -120,7 +271,7 @@ namespace NuGetGallery.Controllers
             return new ODataV2FeedController(packagesRepository, configurationService, searchService);
         }
 
-        private void AssertResultCorrect(IEnumerable<V2FeedPackage> resultSet)
+        private void AssertSemVer2PackagesFilteredFromResult(IEnumerable<V2FeedPackage> resultSet)
         {
             foreach (var feedPackage in resultSet)
             {
@@ -131,6 +282,29 @@ namespace NuGetGallery.Controllers
                 Assert.Single(NonSemVer2Packages.Where(p =>
                     string.Equals(p.Version, feedPackage.Version) &&
                     string.Equals(p.PackageRegistration.Id, feedPackage.Id)));
+            }
+        }
+
+        private void AssertSemVer2PackagesIncludedInResult(IReadOnlyCollection<V2FeedPackage> resultSet)
+        {
+            foreach (var package in SemVer2Packages)
+            {
+                // Assert all of the SemVer2 packages are included in the result.
+                // Whilst at it, also check the NormalizedVersion on the OData feed.
+                Assert.Single(resultSet.Where(feedPackage =>
+                    string.Equals(feedPackage.Version, package.Version)
+                    && string.Equals(feedPackage.NormalizedVersion, package.NormalizedVersion)
+                    && string.Equals(feedPackage.Id, package.PackageRegistration.Id)));
+            }
+
+            foreach (var package in NonSemVer2Packages)
+            {
+                // Assert all of the non-SemVer2 packages are included in the result.
+                // Whilst at it, also check the NormalizedVersion on the OData feed.
+                Assert.Single(resultSet.Where(feedPackage =>
+                    string.Equals(feedPackage.Version, package.Version)
+                    && string.Equals(feedPackage.NormalizedVersion, package.NormalizedVersion)
+                    && string.Equals(feedPackage.Id, package.PackageRegistration.Id)));
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
@@ -635,7 +635,9 @@ namespace NuGetGallery
                     searchService.Setup(s => s.ContainsAllVersions).Returns(false);
 
                     var v2Service = new TestableV2Feed(repo.Object, configuration.Object, searchService.Object);
-                    v2Service.Request = new HttpRequestMessage(HttpMethod.Get, "https://localhost:8081/api/v2/Packages(Id='" + expectedId + "', Version='" + expectedVersion + "')");
+                    v2Service.Request = new HttpRequestMessage(
+                        HttpMethod.Get,
+                        $"https://localhost:8081/api/v2/Packages(Id=\'{expectedId}\', Version=\'{expectedVersion}\')");
 
                     // Act
                     var result = (await v2Service.Get(new ODataQueryOptions<V2FeedPackage>(new ODataQueryContext(NuGetODataV2FeedConfig.GetEdmModel(), typeof(V2FeedPackage)), v2Service.Request), expectedId, expectedVersion))

--- a/tests/NuGetGallery.Facts/TestUtils/Infrastructure/FeedServiceHelpers.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/Infrastructure/FeedServiceHelpers.cs
@@ -45,6 +45,7 @@ namespace NuGetGallery.TestUtils.Infrastructure
                 {
                     PackageRegistration = fooPackage,
                     Version = "1.0.0",
+                    NormalizedVersion = "1.0.0",
                     IsPrerelease = false,
                     Listed = true,
                     Authors = new [] { new PackageAuthor { Name = "Test "} },
@@ -57,6 +58,7 @@ namespace NuGetGallery.TestUtils.Infrastructure
                 {
                     PackageRegistration = fooPackage,
                     Version = "1.0.1-a",
+                    NormalizedVersion = "1.0.1-a",
                     IsPrerelease = true,
                     Listed = true,
                     Authors = new [] { new PackageAuthor { Name = "Test "} },
@@ -69,6 +71,7 @@ namespace NuGetGallery.TestUtils.Infrastructure
                 {
                     PackageRegistration = barPackage,
                     Version = "1.0.0",
+                    NormalizedVersion = "1.0.0",
                     IsPrerelease = false,
                     Listed = true,
                     Authors = new [] { new PackageAuthor { Name = "Test "} },
@@ -81,6 +84,7 @@ namespace NuGetGallery.TestUtils.Infrastructure
                 {
                     PackageRegistration = barPackage,
                     Version = "2.0.0",
+                    NormalizedVersion = "2.0.0",
                     IsPrerelease = false,
                     Listed = true,
                     Authors = new [] { new PackageAuthor { Name = "Test "} },
@@ -93,6 +97,7 @@ namespace NuGetGallery.TestUtils.Infrastructure
                 {
                     PackageRegistration = barPackage,
                     Version = "2.0.1-a",
+                    NormalizedVersion = "2.0.1-a",
                     IsPrerelease = true,
                     Listed = true,
                     Authors = new [] { new PackageAuthor { Name = "Test "} },
@@ -105,6 +110,7 @@ namespace NuGetGallery.TestUtils.Infrastructure
                 {
                     PackageRegistration = barPackage,
                     Version = "2.0.1-b",
+                    NormalizedVersion = "2.0.1-b",
                     IsPrerelease = true,
                     Listed = false,
                     Authors = new [] { new PackageAuthor { Name = "Test "} },
@@ -117,6 +123,7 @@ namespace NuGetGallery.TestUtils.Infrastructure
                 {
                     PackageRegistration = bazPackage,
                     Version = "1.0.0",
+                    NormalizedVersion = "1.0.0",
                     IsPrerelease = false,
                     Listed = false,
                     Deleted = true, // plot twist: this package is a soft-deleted one


### PR DESCRIPTION
This PR is about adding support for the new `semVerLevel` query parameter on the V2, V2-curatedfeed and V2 AutoComplete endpoints, as per the [design](https://github.com/NuGet/Home/wiki/SemVer2-support-for-nuget.org-(server-side)).

This PR changes V2 OData feed projections to always use normalized versions in navigation links.

It is a follow-up on https://github.com/NuGet/NuGetGallery/issues/3686 (filter SemVer2 package versions by default).