### PR TITLE
Block packages with illegal package dependency version ranges

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -84,23 +84,23 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Common.4.0.0\lib\net45\NuGet.Common.dll</HintPath>
+    <Reference Include="NuGet.Common, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Common.4.3.0-beta1-2441\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Frameworks.4.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-beta1-2441\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.4.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.4.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.0.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core.Types, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.0.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-beta1-2441\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -84,23 +84,20 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Common.4.3.0-beta1-2441\lib\net45\NuGet.Common.dll</HintPath>
+    <Reference Include="NuGet.Common, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Common.4.3.0-preview1-2462\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-beta1-2441\lib\net45\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-preview1-2462\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-preview1-2462\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-preview1-2462\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-beta1-2441\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2462\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery.Packaging
 
         public PackageMetadata(
             Dictionary<string, string> metadata,
-            IEnumerable<PackageDependencyGroup> dependencyGroups, 
+            IEnumerable<PackageDependencyGroup> dependencyGroups,
             IEnumerable<FrameworkSpecificGroup> frameworkGroups,
             IEnumerable<NuGet.Packaging.Core.PackageType> packageTypes,
             NuGetVersion minClientVersion)
@@ -42,26 +42,26 @@ namespace NuGetGallery.Packaging
             {
                 throw new FormatException(string.Format(CoreStrings.PackageMetadata_VersionStringInvalid, versionString));
             }
-            
+
             NuGetVersion nugetVersion;
             if (NuGetVersion.TryParse(versionString, out nugetVersion))
             {
                 Version = nugetVersion;
             }
 
-            IconUrl = GetValue(PackageMetadataStrings.IconUrl, (Uri) null);
-            ProjectUrl = GetValue(PackageMetadataStrings.ProjectUrl, (Uri) null);
-            LicenseUrl = GetValue(PackageMetadataStrings.LicenseUrl, (Uri) null);
-            Copyright = GetValue(PackageMetadataStrings.Copyright, (string) null);
-            Description = GetValue(PackageMetadataStrings.Description, (string) null);
-            ReleaseNotes = GetValue(PackageMetadataStrings.ReleaseNotes, (string) null);
+            IconUrl = GetValue(PackageMetadataStrings.IconUrl, (Uri)null);
+            ProjectUrl = GetValue(PackageMetadataStrings.ProjectUrl, (Uri)null);
+            LicenseUrl = GetValue(PackageMetadataStrings.LicenseUrl, (Uri)null);
+            Copyright = GetValue(PackageMetadataStrings.Copyright, (string)null);
+            Description = GetValue(PackageMetadataStrings.Description, (string)null);
+            ReleaseNotes = GetValue(PackageMetadataStrings.ReleaseNotes, (string)null);
             RequireLicenseAcceptance = GetValue(PackageMetadataStrings.RequireLicenseAcceptance, false);
-            Summary = GetValue(PackageMetadataStrings.Summary, (string) null);
-            Title = GetValue(PackageMetadataStrings.Title, (string) null);
-            Tags = GetValue(PackageMetadataStrings.Tags, (string) null);
-            Language = GetValue(PackageMetadataStrings.Language, (string) null);
+            Summary = GetValue(PackageMetadataStrings.Summary, (string)null);
+            Title = GetValue(PackageMetadataStrings.Title, (string)null);
+            Tags = GetValue(PackageMetadataStrings.Tags, (string)null);
+            Language = GetValue(PackageMetadataStrings.Language, (string)null);
 
-            Owners = GetValue(PackageMetadataStrings.Owners, (string) null);
+            Owners = GetValue(PackageMetadataStrings.Owners, (string)null);
 
             var authorsString = GetValue(PackageMetadataStrings.Authors, Owners ?? string.Empty);
             Authors = new List<string>(authorsString.Split(',').Select(author => author.Trim()));
@@ -87,7 +87,7 @@ namespace NuGetGallery.Packaging
 
         public string GetValueFromMetadata(string key)
         {
-            return GetValue(key, (string) null);
+            return GetValue(key, (string)null);
         }
 
         public IReadOnlyCollection<PackageDependencyGroup> GetDependencyGroups()
@@ -131,7 +131,7 @@ namespace NuGetGallery.Packaging
 
         private Uri GetValue(string key, Uri alternateValue)
         {
-            var value = GetValue(key, (string) null);
+            var value = GetValue(key, (string)null);
             if (!string.IsNullOrEmpty(value))
             {
                 Uri result;

--- a/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
@@ -144,11 +144,19 @@ namespace NuGetGallery.Packaging
             return alternateValue;
         }
 
+        /// <summary>
+        /// Gets package metadata from a the provided <see cref="NuspecReader"/> instance.
+        /// </summary>
+        /// <param name="nuspecReader">The <see cref="NuspecReader"/> instance used to read the <see cref="PackageMetadata"/></param>
+        /// <exception cref="PackagingException">
+        /// We default to use a strict version-check on dependency groups. 
+        /// When an invalid dependency version range is detected, a <see cref="PackagingException"/> will be thrown.
+        /// </exception>
         public static PackageMetadata FromNuspecReader(NuspecReader nuspecReader)
         {
             return new PackageMetadata(
                 nuspecReader.GetMetadata().ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
-                nuspecReader.GetDependencyGroups(),
+                nuspecReader.GetDependencyGroups(useStrictVersionCheck: true),
                 nuspecReader.GetFrameworkReferenceGroups(),
                 nuspecReader.GetPackageTypes(),
                 nuspecReader.GetMinClientVersion()

--- a/src/NuGetGallery.Core/app.config
+++ b/src/NuGetGallery.Core/app.config
@@ -24,11 +24,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.2462" newVersion="4.3.0.2462" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.2462" newVersion="4.3.0.2462" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/NuGetGallery.Core/packages.config
+++ b/src/NuGetGallery.Core/packages.config
@@ -9,12 +9,12 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Common" version="4.0.0" targetFramework="net452" />
-  <package id="NuGet.Frameworks" version="4.0.0" targetFramework="net452" />
-  <package id="NuGet.Packaging" version="4.0.0" targetFramework="net452" />
-  <package id="NuGet.Packaging.Core" version="4.0.0" targetFramework="net452" />
-  <package id="NuGet.Packaging.Core.Types" version="4.0.0" targetFramework="net452" />
-  <package id="NuGet.Versioning" version="4.0.0" targetFramework="net452" />
+  <package id="NuGet.Common" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Frameworks" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Packaging" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Packaging.Core" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Packaging.Core.Types" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Versioning" version="4.3.0-beta1-2441" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.5-beta" targetFramework="net452" />
   <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net452" />
 </packages>

--- a/src/NuGetGallery.Core/packages.config
+++ b/src/NuGetGallery.Core/packages.config
@@ -9,12 +9,11 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Common" version="4.3.0-beta1-2441" targetFramework="net452" />
-  <package id="NuGet.Frameworks" version="4.3.0-beta1-2441" targetFramework="net452" />
-  <package id="NuGet.Packaging" version="4.3.0-beta1-2441" targetFramework="net452" />
-  <package id="NuGet.Packaging.Core" version="4.3.0-beta1-2441" targetFramework="net452" />
-  <package id="NuGet.Packaging.Core.Types" version="4.3.0-beta1-2441" targetFramework="net452" />
-  <package id="NuGet.Versioning" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Common" version="4.3.0-preview1-2462" targetFramework="net452" />
+  <package id="NuGet.Frameworks" version="4.3.0-preview1-2462" targetFramework="net452" />
+  <package id="NuGet.Packaging" version="4.3.0-preview1-2462" targetFramework="net452" />
+  <package id="NuGet.Packaging.Core" version="4.3.0-preview1-2462" targetFramework="net452" />
+  <package id="NuGet.Versioning" version="4.3.0-preview1-2462" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.5-beta" targetFramework="net452" />
   <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net452" />
 </packages>

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -17,7 +17,6 @@ using System.Web;
 using System.Web.Caching;
 using System.Web.Mvc;
 using NuGet.Packaging;
-using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuGetGallery.Areas.Admin;
 using NuGetGallery.AsyncFileUpload;
@@ -743,7 +742,7 @@ namespace NuGetGallery
 
             return View(model);
         }
-        
+
         [HttpGet]
         [Authorize]
         [RequiresAccountConfirmation("delete a package")]
@@ -773,10 +772,10 @@ namespace NuGetGallery
             {
                 return HttpNotFound();
             }
-            
+
             var reflowPackageService = new ReflowPackageService(
-                _entitiesContext, 
-                (PackageService) _packageService,
+                _entitiesContext,
+                (PackageService)_packageService,
                 _packageFileService);
 
             try
@@ -1158,8 +1157,7 @@ namespace NuGetGallery
                     package = await _packageService.CreatePackageAsync(nugetPackage, packageStreamMetadata, currentUser, commitChanges: false);
                     Debug.Assert(package.PackageRegistration != null);
                 }
-                catch(Exception ex) 
-                    when (ex is PackagingException || ex is EntityException)
+                catch (InvalidPackageException ex)
                 {
                     TempData["Message"] = ex.Message;
                     return Redirect(Url.UploadPackage());

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -17,6 +17,7 @@ using System.Web;
 using System.Web.Caching;
 using System.Web.Mvc;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuGetGallery.Areas.Admin;
 using NuGetGallery.AsyncFileUpload;
@@ -1157,7 +1158,8 @@ namespace NuGetGallery
                     package = await _packageService.CreatePackageAsync(nugetPackage, packageStreamMetadata, currentUser, commitChanges: false);
                     Debug.Assert(package.PackageRegistration != null);
                 }
-                catch (EntityException ex)
+                catch(Exception ex) 
+                    when (ex is PackagingException || ex is EntityException)
                 {
                     TempData["Message"] = ex.Message;
                     return Redirect(Url.UploadPackage());

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -423,25 +423,22 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Common.4.3.0-beta1-2441\lib\net45\NuGet.Common.dll</HintPath>
+    <Reference Include="NuGet.Common, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Common.4.3.0-preview1-2462\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-beta1-2441\lib\net45\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-preview1-2462\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Logging, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Logging.3.5.0-beta-1160\lib\net45\NuGet.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-preview1-2462\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-preview1-2462\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.KeyVault, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.0.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
@@ -452,8 +449,8 @@
       <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.29-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-beta1-2441\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2462\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="ODataNullPropagationVisitor, Version=0.5.4237.2641, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -423,25 +423,25 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Common.4.0.0\lib\net45\NuGet.Common.dll</HintPath>
+    <Reference Include="NuGet.Common, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Common.4.3.0-beta1-2441\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Frameworks.4.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-beta1-2441\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Logging, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Logging.3.5.0-beta-1160\lib\net45\NuGet.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.4.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.4.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.0.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core.Types, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.KeyVault, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.0.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
@@ -452,8 +452,8 @@
       <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.29-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.0.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-beta1-2441\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="ODataNullPropagationVisitor, Version=0.5.4237.2641, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/NuGetGallery/Scripts/nugetgallery.js
+++ b/src/NuGetGallery/Scripts/nugetgallery.js
@@ -1,5 +1,5 @@
 ﻿// Global utility script for NuGetGallery
-/// <reference path="jquery-1.6.4.js" />
+/// <reference path="jquery-1.11.0.js" />
 (function (window, $, undefined) {
     $(function () {
         // Export an object with global config data

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
 using NuGetGallery.Packaging;
@@ -69,6 +70,18 @@ namespace NuGetGallery
             _auditingService = auditingService;
         }
 
+        /// <summary>
+        /// When no exceptions thrown, this method ensures the package metadata is valid.
+        /// </summary>
+        /// <param name="packageArchiveReader">
+        /// The <see cref="PackageArchiveReader"/> instance providing the package metadata.
+        /// </param>
+        /// <exception cref="PackagingException">
+        /// This exception will be thrown if an invalid package dependency version range is detected.
+        /// </exception>
+        /// <exception cref="EntityException">
+        /// This exception will be thrown when a package metadata property violates a data validation constraint.
+        /// </exception>
         public void EnsureValid(PackageArchiveReader packageArchiveReader)
         {
             var packageMetadata = PackageMetadata.FromNuspecReader(packageArchiveReader.GetNuspecReader());
@@ -84,6 +97,20 @@ namespace NuGetGallery
             }
         }
 
+        /// <summary>
+        /// Validates and creates a <see cref="Package"/> entity from a NuGet package archive.
+        /// </summary>
+        /// <param name="nugetPackage">A <see cref="PackageArchiveReader"/> instance from which package metadata can be read.</param>
+        /// <param name="packageStreamMetadata">The <see cref="PackageStreamMetadata"/> instance providing metadata about the package stream.</param>
+        /// <param name="user">The <see cref="User"/> creating the package.</param>
+        /// <param name="commitChanges"><c>True</c> to commit the changes to the data store and notify the indexing service; otherwise <c>false</c>.</param>
+        /// <returns>Returns the created <see cref="Package"/> entity.</returns>
+        /// <exception cref="PackagingException">
+        /// This exception will be thrown if an invalid package dependency version range is detected.
+        /// </exception>
+        /// <exception cref="EntityException">
+        /// This exception will be thrown when a package metadata property violates a data validation constraint.
+        /// </exception>
         public async Task<Package> CreatePackageAsync(PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User user, bool commitChanges = true)
         {
             var packageMetadata = PackageMetadata.FromNuspecReader(nugetPackage.GetNuspecReader());

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -76,24 +76,29 @@ namespace NuGetGallery
         /// <param name="packageArchiveReader">
         /// The <see cref="PackageArchiveReader"/> instance providing the package metadata.
         /// </param>
-        /// <exception cref="PackagingException">
-        /// This exception will be thrown if an invalid package dependency version range is detected.
-        /// </exception>
-        /// <exception cref="EntityException">
+        /// <exception cref="InvalidPackageException">
         /// This exception will be thrown when a package metadata property violates a data validation constraint.
         /// </exception>
         public void EnsureValid(PackageArchiveReader packageArchiveReader)
         {
-            var packageMetadata = PackageMetadata.FromNuspecReader(packageArchiveReader.GetNuspecReader());
-
-            ValidateNuGetPackageMetadata(packageMetadata);
-
-            ValidatePackageTitle(packageMetadata);
-
-            var supportedFrameworks = GetSupportedFrameworks(packageArchiveReader).Select(fn => fn.ToShortNameOrNull()).ToArray();
-            if (!supportedFrameworks.AnySafe(sf => sf == null))
+            try
             {
-                ValidateSupportedFrameworks(supportedFrameworks);
+                var packageMetadata = PackageMetadata.FromNuspecReader(packageArchiveReader.GetNuspecReader());
+
+                ValidateNuGetPackageMetadata(packageMetadata);
+
+                ValidatePackageTitle(packageMetadata);
+
+                var supportedFrameworks = GetSupportedFrameworks(packageArchiveReader).Select(fn => fn.ToShortNameOrNull()).ToArray();
+                if (!supportedFrameworks.AnySafe(sf => sf == null))
+                {
+                    ValidateSupportedFrameworks(supportedFrameworks);
+                }
+            }
+            catch (Exception exception) when (exception is EntityException || exception is PackagingException)
+            {
+                // Wrap the exception for consistency of this API.
+                throw new InvalidPackageException(exception.Message, exception);
             }
         }
 
@@ -105,19 +110,26 @@ namespace NuGetGallery
         /// <param name="user">The <see cref="User"/> creating the package.</param>
         /// <param name="commitChanges"><c>True</c> to commit the changes to the data store and notify the indexing service; otherwise <c>false</c>.</param>
         /// <returns>Returns the created <see cref="Package"/> entity.</returns>
-        /// <exception cref="PackagingException">
-        /// This exception will be thrown if an invalid package dependency version range is detected.
-        /// </exception>
-        /// <exception cref="EntityException">
+        /// <exception cref="InvalidPackageException">
         /// This exception will be thrown when a package metadata property violates a data validation constraint.
         /// </exception>
         public async Task<Package> CreatePackageAsync(PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User user, bool commitChanges = true)
         {
-            var packageMetadata = PackageMetadata.FromNuspecReader(nugetPackage.GetNuspecReader());
+            PackageMetadata packageMetadata;
 
-            ValidateNuGetPackageMetadata(packageMetadata);
+            try
+            {
+                packageMetadata = PackageMetadata.FromNuspecReader(nugetPackage.GetNuspecReader());
 
-            ValidatePackageTitle(packageMetadata);
+                ValidateNuGetPackageMetadata(packageMetadata);
+
+                ValidatePackageTitle(packageMetadata);
+            }
+            catch (Exception exception) when (exception is EntityException || exception is PackagingException)
+            {
+                // Wrap the exception for consistency of this API.
+                throw new InvalidPackageException(exception.Message, exception);
+            }
 
             var packageRegistration = CreateOrGetPackageRegistration(user, packageMetadata);
 

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -494,11 +494,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.2462" newVersion="4.3.0.2462" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.2462" newVersion="4.3.0.2462" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -77,15 +77,15 @@
   <package id="Moment.js" version="2.11.2" targetFramework="net46" />
   <package id="MvcTreeView" version="1.4" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="NuGet.Common" version="4.0.0" targetFramework="net46" />
-  <package id="NuGet.Frameworks" version="4.0.0" targetFramework="net46" />
+  <package id="NuGet.Common" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Frameworks" version="4.3.0-beta1-2441" targetFramework="net46" />
   <package id="NuGet.Logging" version="3.5.0-beta-1160" targetFramework="net46" />
-  <package id="NuGet.Packaging" version="4.0.0" targetFramework="net46" />
-  <package id="NuGet.Packaging.Core" version="4.0.0" targetFramework="net46" />
-  <package id="NuGet.Packaging.Core.Types" version="4.0.0" targetFramework="net46" />
+  <package id="NuGet.Packaging" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Packaging.Core" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Packaging.Core.Types" version="4.3.0-beta1-2441" targetFramework="net46" />
   <package id="NuGet.Services.KeyVault" version="1.0.0.0" targetFramework="net46" />
   <package id="NuGet.Services.Platform.Client" version="3.0.29-r-master" targetFramework="net46" />
-  <package id="NuGet.Versioning" version="4.0.0" targetFramework="net46" />
+  <package id="NuGet.Versioning" version="4.3.0-beta1-2441" targetFramework="net46" />
   <package id="ODataNullPropagationVisitor" version="0.5.4237.2641" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net46" />
   <package id="PoliteCaptcha" version="0.4.0.1" targetFramework="net46" />

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -77,15 +77,14 @@
   <package id="Moment.js" version="2.11.2" targetFramework="net46" />
   <package id="MvcTreeView" version="1.4" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="NuGet.Common" version="4.3.0-beta1-2441" targetFramework="net46" />
-  <package id="NuGet.Frameworks" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Common" version="4.3.0-preview1-2462" targetFramework="net46" />
+  <package id="NuGet.Frameworks" version="4.3.0-preview1-2462" targetFramework="net46" />
   <package id="NuGet.Logging" version="3.5.0-beta-1160" targetFramework="net46" />
-  <package id="NuGet.Packaging" version="4.3.0-beta1-2441" targetFramework="net46" />
-  <package id="NuGet.Packaging.Core" version="4.3.0-beta1-2441" targetFramework="net46" />
-  <package id="NuGet.Packaging.Core.Types" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Packaging" version="4.3.0-preview1-2462" targetFramework="net46" />
+  <package id="NuGet.Packaging.Core" version="4.3.0-preview1-2462" targetFramework="net46" />
   <package id="NuGet.Services.KeyVault" version="1.0.0.0" targetFramework="net46" />
   <package id="NuGet.Services.Platform.Client" version="3.0.29-r-master" targetFramework="net46" />
-  <package id="NuGet.Versioning" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Versioning" version="4.3.0-preview1-2462" targetFramework="net46" />
   <package id="ODataNullPropagationVisitor" version="0.5.4237.2641" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net46" />
   <package id="PoliteCaptcha" version="0.4.0.1" targetFramework="net46" />

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -70,26 +70,26 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Common.4.0.0\lib\net45\NuGet.Common.dll</HintPath>
+    <Reference Include="NuGet.Common, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Common.4.3.0-beta1-2441\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Frameworks.4.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-beta1-2441\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Logging, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Logging.3.5.0-beta-1160\lib\net45\NuGet.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.4.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.4.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.0.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core.Types, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.0.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-beta1-2441\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -70,26 +70,23 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Common.4.3.0-beta1-2441\lib\net45\NuGet.Common.dll</HintPath>
+    <Reference Include="NuGet.Common, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Common.4.3.0-preview1-2462\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-beta1-2441\lib\net45\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-preview1-2462\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Logging, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Logging.3.5.0-beta-1160\lib\net45\NuGet.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-preview1-2462\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-preview1-2462\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-beta1-2441\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2462\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
@@ -476,8 +476,8 @@ namespace NuGetGallery.Packaging
         public void ReturnsErrorIfDependencySetContainsInvalidId()
         {
             var nuspecStream = CreateNuspecStream(NuSpecDependencySetContainsInvalidId);
-
-            Assert.Equal(new[] { String.Format(CoreStrings.Manifest_InvalidDependency, "a b c", "1.0") }, GetErrors(nuspecStream));
+            
+            Assert.Equal(new[] { String.Format(Strings.ErrorInvalidPackageVersionForDependency, "jQuery", "packageA.1.0.1-alpha", string.Empty) }, GetErrors(nuspecStream));
         }
         
         [Fact]

--- a/tests/NuGetGallery.Core.Facts/app.config
+++ b/tests/NuGetGallery.Core.Facts/app.config
@@ -31,11 +31,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.2462" newVersion="4.3.0.2462" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.2462" newVersion="4.3.0.2462" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/tests/NuGetGallery.Core.Facts/packages.config
+++ b/tests/NuGetGallery.Core.Facts/packages.config
@@ -9,13 +9,13 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net452" />
   <package id="Moq" version="4.7.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Common" version="4.0.0" targetFramework="net452" />
-  <package id="NuGet.Frameworks" version="4.0.0" targetFramework="net452" />
+  <package id="NuGet.Common" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Frameworks" version="4.3.0-beta1-2441" targetFramework="net452" />
   <package id="NuGet.Logging" version="3.5.0-beta-1160" targetFramework="net452" />
-  <package id="NuGet.Packaging" version="4.0.0" targetFramework="net452" />
-  <package id="NuGet.Packaging.Core" version="4.0.0" targetFramework="net452" />
-  <package id="NuGet.Packaging.Core.Types" version="4.0.0" targetFramework="net452" />
-  <package id="NuGet.Versioning" version="4.0.0" targetFramework="net452" />
+  <package id="NuGet.Packaging" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Packaging.Core" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Packaging.Core.Types" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Versioning" version="4.3.0-beta1-2441" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.5-beta" targetFramework="net452" />
   <package id="xunit" version="2.0.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/tests/NuGetGallery.Core.Facts/packages.config
+++ b/tests/NuGetGallery.Core.Facts/packages.config
@@ -9,13 +9,12 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net452" />
   <package id="Moq" version="4.7.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Common" version="4.3.0-beta1-2441" targetFramework="net452" />
-  <package id="NuGet.Frameworks" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Common" version="4.3.0-preview1-2462" targetFramework="net452" />
+  <package id="NuGet.Frameworks" version="4.3.0-preview1-2462" targetFramework="net452" />
   <package id="NuGet.Logging" version="3.5.0-beta-1160" targetFramework="net452" />
-  <package id="NuGet.Packaging" version="4.3.0-beta1-2441" targetFramework="net452" />
-  <package id="NuGet.Packaging.Core" version="4.3.0-beta1-2441" targetFramework="net452" />
-  <package id="NuGet.Packaging.Core.Types" version="4.3.0-beta1-2441" targetFramework="net452" />
-  <package id="NuGet.Versioning" version="4.3.0-beta1-2441" targetFramework="net452" />
+  <package id="NuGet.Packaging" version="4.3.0-preview1-2462" targetFramework="net452" />
+  <package id="NuGet.Packaging.Core" version="4.3.0-preview1-2462" targetFramework="net452" />
+  <package id="NuGet.Versioning" version="4.3.0-preview1-2462" targetFramework="net452" />
   <package id="System.Spatial" version="5.6.5-beta" targetFramework="net452" />
   <package id="xunit" version="2.0.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/tests/NuGetGallery.Facts/App.config
+++ b/tests/NuGetGallery.Facts/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
@@ -70,11 +70,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.2462" newVersion="4.3.0.2462" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.2462" newVersion="4.3.0.2462" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -193,32 +193,32 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Common.4.0.0\lib\net45\NuGet.Common.dll</HintPath>
+    <Reference Include="NuGet.Common, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Common.4.3.0-beta1-2441\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Frameworks.4.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-beta1-2441\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Logging, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Logging.3.5.0-beta-1160\lib\net45\NuGet.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.4.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.4.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.0.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core.Types, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.KeyVault, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.0.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.0.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-beta1-2441\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -193,32 +193,29 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Common.4.3.0-beta1-2441\lib\net45\NuGet.Common.dll</HintPath>
+    <Reference Include="NuGet.Common, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Common.4.3.0-preview1-2462\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-beta1-2441\lib\net45\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.4.3.0-preview1-2462\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Logging, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Logging.3.5.0-beta-1160\lib\net45\NuGet.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.4.3.0-preview1-2462\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.4.3.0-beta1-2441\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.4.3.0-preview1-2462\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.KeyVault, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.0.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-beta1-2441\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=4.3.0.2462, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2462\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -660,7 +660,7 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns(packageRegistration); });
                 var nugetPackage = CreateNuGetPackage();
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, true));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, true));
 
                 Assert.Equal(String.Format(Strings.PackageIdNotAvailable, "theId"), ex.Message);
             }
@@ -688,7 +688,7 @@ namespace NuGetGallery
                 var nugetPackage = CreateNuGetPackage(title: newPackageTitle);
 
                 // Assert
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, true));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, true));
 
                 Assert.Equal(String.Format(Strings.TitleMatchesExistingRegistration, newPackageTitle), ex.Message);
             }
@@ -699,7 +699,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(id: "theId".PadRight(131, '_'));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Id", CoreConstants.MaxPackageIdLength), ex.Message);
             }
@@ -710,7 +710,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(id: "theId", version: "1.2.3-alpha.0");
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackageReleaseVersionWithDot, "Version"), ex.Message);
             }
@@ -721,7 +721,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(id: "theId", version: "1.2.3-12345");
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackageReleaseVersionContainsOnlyNumerics, "Version"), ex.Message);
             }
@@ -732,7 +732,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(authors: "theFirstAuthor".PadRight(2001, '_') + ", " + "theSecondAuthor".PadRight(2001, '_'));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Authors", "4000"), ex.Message);
             }
@@ -743,7 +743,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(copyright:  "theCopyright".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Copyright", "4000"), ex.Message);
             }
@@ -755,7 +755,7 @@ namespace NuGetGallery
                 var versionString = "1.0.0-".PadRight(65, 'a');
                 var nugetPackage = CreateNuGetPackage(version: versionString);
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Version", "64"), ex.Message);
             }
@@ -780,7 +780,7 @@ namespace NuGetGallery
                         packageDependencies),
                 });
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Dependencies", Int16.MaxValue), ex.Message);
             }
@@ -802,7 +802,7 @@ namespace NuGetGallery
                                 })
                     });
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Dependency.Id", CoreConstants.MaxPackageIdLength), ex.Message);
             }
@@ -824,7 +824,7 @@ namespace NuGetGallery
                                 })
                     });
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Dependency.VersionSpec", 256), ex.Message);
             }
@@ -835,7 +835,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(description:  "theDescription".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Description", "4000"), ex.Message);
             }
@@ -846,7 +846,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(iconUrl: new Uri("http://theIconUrl/".PadRight(4001, '-'), UriKind.Absolute));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "IconUrl", "4000"), ex.Message);
             }
@@ -857,7 +857,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(licenseUrl: new Uri("http://theLicenseUrl/".PadRight(4001, '-'), UriKind.Absolute));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "LicenseUrl", "4000"), ex.Message);
             }
@@ -868,7 +868,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(projectUrl: new Uri("http://theProjectUrl/".PadRight(4001, '-'), UriKind.Absolute));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "ProjectUrl", "4000"), ex.Message);
             }
@@ -879,7 +879,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(summary: "theSummary".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Summary", "4000"), ex.Message);
             }
@@ -890,7 +890,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(tags:  "theTags".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Tags", "4000"), ex.Message);
             }
@@ -901,7 +901,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(title: "theTitle".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Title", "256"), ex.Message);
             }
@@ -914,7 +914,7 @@ namespace NuGetGallery
                 var nugetPackage = CreateNuGetPackage(language: new string('a', 21));
 
                 // Act
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 // Assert
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Language", "20"), ex.Message);

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -171,7 +171,7 @@ namespace NuGetGallery
                 Assert.Equal("package A description.", result.Description);
                 Assert.Equal("en-US", result.Language);
 
-                Assert.Equal("WebActivator:[1.1.0, ):net40|PackageC:[1.1.0, 2.0.1):net40|jQuery:(, ):net451", result.FlattenedDependencies);
+                Assert.Equal("WebActivator:[1.1.0, ):net40|PackageC:[1.1.0, 2.0.1):net40|jQuery:[1.0.0, ):net451", result.FlattenedDependencies);
                 Assert.Equal(3, result.Dependencies.Count);
 
                 Assert.True(result.Dependencies.Any(d =>
@@ -186,7 +186,7 @@ namespace NuGetGallery
 
                 Assert.True(result.Dependencies.Any(d =>
                     d.Id == "jQuery"
-                    && d.VersionSpec == "(, )"
+                    && d.VersionSpec == "[1.0.0, )"
                     && d.TargetFramework == "net451"));
 
                 Assert.Equal(0, result.SupportedFrameworks.Count);
@@ -248,7 +248,7 @@ namespace NuGetGallery
 
             var framework = new PackageFramework();
             var author = new PackageAuthor { Name = "maarten" };
-            var dependency = new PackageDependency { Id = "other" };
+            var dependency = new PackageDependency { Id = "other", VersionSpec = "1.0.0" };
 
             var package = new Package
             {
@@ -375,7 +375,7 @@ namespace NuGetGallery
                               <dependency id=""PackageC"" version=""[1.1.0, 2.0.1)"" />
                             </group>
                             <group targetFramework=""net451"">
-                              <dependency id=""jQuery"" />
+                              <dependency id=""jQuery"" version=""1.0.0""/>
                             </group>
                         </dependencies>
                       </metadata>

--- a/tests/NuGetGallery.Facts/packages.config
+++ b/tests/NuGetGallery.Facts/packages.config
@@ -37,14 +37,14 @@
   <package id="Moq" version="4.7.0" targetFramework="net46" />
   <package id="MvcHaack.Ajax.MVC4" version="2.0.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="NuGet.Common" version="4.0.0" targetFramework="net46" />
-  <package id="NuGet.Frameworks" version="4.0.0" targetFramework="net46" />
+  <package id="NuGet.Common" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Frameworks" version="4.3.0-beta1-2441" targetFramework="net46" />
   <package id="NuGet.Logging" version="3.5.0-beta-1160" targetFramework="net46" />
-  <package id="NuGet.Packaging" version="4.0.0" targetFramework="net46" />
-  <package id="NuGet.Packaging.Core" version="4.0.0" targetFramework="net46" />
-  <package id="NuGet.Packaging.Core.Types" version="4.0.0" targetFramework="net46" />
+  <package id="NuGet.Packaging" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Packaging.Core" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Packaging.Core.Types" version="4.3.0-beta1-2441" targetFramework="net46" />
   <package id="NuGet.Services.KeyVault" version="1.0.0.0" targetFramework="net46" />
-  <package id="NuGet.Versioning" version="4.0.0" targetFramework="net46" />
+  <package id="NuGet.Versioning" version="4.3.0-beta1-2441" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net46" />
   <package id="PoliteCaptcha" version="0.4.0.1" targetFramework="net46" />
   <package id="recaptcha" version="1.0.5.0" targetFramework="net46" />

--- a/tests/NuGetGallery.Facts/packages.config
+++ b/tests/NuGetGallery.Facts/packages.config
@@ -37,14 +37,13 @@
   <package id="Moq" version="4.7.0" targetFramework="net46" />
   <package id="MvcHaack.Ajax.MVC4" version="2.0.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="NuGet.Common" version="4.3.0-beta1-2441" targetFramework="net46" />
-  <package id="NuGet.Frameworks" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Common" version="4.3.0-preview1-2462" targetFramework="net46" />
+  <package id="NuGet.Frameworks" version="4.3.0-preview1-2462" targetFramework="net46" />
   <package id="NuGet.Logging" version="3.5.0-beta-1160" targetFramework="net46" />
-  <package id="NuGet.Packaging" version="4.3.0-beta1-2441" targetFramework="net46" />
-  <package id="NuGet.Packaging.Core" version="4.3.0-beta1-2441" targetFramework="net46" />
-  <package id="NuGet.Packaging.Core.Types" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Packaging" version="4.3.0-preview1-2462" targetFramework="net46" />
+  <package id="NuGet.Packaging.Core" version="4.3.0-preview1-2462" targetFramework="net46" />
   <package id="NuGet.Services.KeyVault" version="1.0.0.0" targetFramework="net46" />
-  <package id="NuGet.Versioning" version="4.3.0-beta1-2441" targetFramework="net46" />
+  <package id="NuGet.Versioning" version="4.3.0-preview1-2462" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net46" />
   <package id="PoliteCaptcha" version="0.4.0.1" targetFramework="net46" />
   <package id="recaptcha" version="1.0.5.0" targetFramework="net46" />


### PR DESCRIPTION
Fixes #3482 

Using `strictVersionCheck=true` by default, to block packages from being uploaded to nuget.org if they contain package dependencies with an invalid version range.