### PR TITLE
Fix for 2483 Author and description null checks & tests

### DIFF
--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -579,7 +579,11 @@ namespace NuGetGallery
                     throw new EntityException(Strings.NuGetPackageReleaseVersionContainsOnlyNumerics, "Version");
                 }
             }
-            if (packageMetadata.Authors != null && packageMetadata.Authors.Flatten().Length > 4000)
+            if (packageMetadata.Authors == null || packageMetadata.Authors.Flatten().Length == 0)
+            {
+                throw new EntityException(Strings.NuGetPackagePropertyMissing, "Authors");
+            }
+            else if (packageMetadata.Authors != null && packageMetadata.Authors.Flatten().Length > 4000)
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Authors", "4000");
             }
@@ -587,7 +591,11 @@ namespace NuGetGallery
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Copyright", "4000");
             }
-            if (packageMetadata.Description != null && packageMetadata.Description.Length > 4000)
+            if (packageMetadata.Description == null)
+            {
+                throw new EntityException(Strings.NuGetPackagePropertyMissing, "Description");
+            }
+            else if (packageMetadata.Description != null && packageMetadata.Description.Length > 4000)
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Description", "4000");
             }

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -579,11 +579,7 @@ namespace NuGetGallery
                     throw new EntityException(Strings.NuGetPackageReleaseVersionContainsOnlyNumerics, "Version");
                 }
             }
-            if (packageMetadata.Authors == null || packageMetadata.Authors.Flatten().Length == 0)
-            {
-                throw new EntityException(Strings.NuGetPackagePropertyMissing, "Authors");
-            }
-            else if (packageMetadata.Authors != null && packageMetadata.Authors.Flatten().Length > 4000)
+            if (packageMetadata.Authors != null && packageMetadata.Authors.Flatten().Length > 4000)
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Authors", "4000");
             }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -582,6 +582,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A nuget package&apos;s {0} property is required..
+        /// </summary>
+        public static string NuGetPackagePropertyMissing {
+            get {
+                return ResourceManager.GetString("NuGetPackagePropertyMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A nuget package&apos;s {0} property may not be more than {1} characters long..
         /// </summary>
         public static string NuGetPackagePropertyTooLong {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -440,4 +440,7 @@ The {1} Team</value>
   <data name="WarningApiDeprecated" xml:space="preserve">
     <value>API '{0}' is deprecated and may be removed in a future version.</value>
   </data>
+  <data name="NuGetPackagePropertyMissing" xml:space="preserve">
+    <value>A nuget package's {0} property is required.</value>
+  </data>
 </root>

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -727,17 +727,6 @@ namespace NuGetGallery
             }
 
             [Fact]
-            private async Task WillThrowIfTheNuGetPackageAuthorsIsNullOrEmpty()
-            {
-                var service = CreateService();
-                var nugetPackage = CreateNuGetPackage(authors: null, owners: null);
-
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
-
-                Assert.Equal(String.Format(Strings.NuGetPackagePropertyMissing, "Authors"), ex.Message);
-            }
-
-            [Fact]
             private async Task WillThrowIfTheNuGetPackageAuthorsIsLongerThan4000()
             {
                 var service = CreateService();

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -727,6 +727,17 @@ namespace NuGetGallery
             }
 
             [Fact]
+            private async Task WillThrowIfTheNuGetPackageAuthorsIsNullOrEmpty()
+            {
+                var service = CreateService();
+                var nugetPackage = CreateNuGetPackage(authors: null, owners: null);
+
+                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+
+                Assert.Equal(String.Format(Strings.NuGetPackagePropertyMissing, "Authors"), ex.Message);
+            }
+
+            [Fact]
             private async Task WillThrowIfTheNuGetPackageAuthorsIsLongerThan4000()
             {
                 var service = CreateService();
@@ -828,6 +839,18 @@ namespace NuGetGallery
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Dependency.VersionSpec", 256), ex.Message);
             }
+
+            [Fact]
+            private async Task WillThrowIfTheNuGetPackageDescriptionIsNull()
+            {
+                var service = CreateService();
+                var nugetPackage = CreateNuGetPackage(description: null);
+
+                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+
+                Assert.Equal(String.Format(Strings.NuGetPackagePropertyMissing, "Description"), ex.Message);
+            }
+
 
             [Fact]
             private async Task WillThrowIfTheNuGetPackageDescriptionIsLongerThan4000()


### PR DESCRIPTION
Fix for #2483

I enhanced the PackageValidation for the "null-cases" for the description and author element. The NuGet package author itself is never (or at least currently) null, but maybe filled with an empty element. 

No <description> element set (or an empty description element will trigger the same behavior):

![image](https://cloud.githubusercontent.com/assets/756703/24631582/25803aee-18c1-11e7-9866-b0b50f09558f.png)

No <authors> or <owners> element set:

![image](https://cloud.githubusercontent.com/assets/756703/24631601/341a3500-18c1-11e7-9372-4c05a6e19518.png)

Without those checks some other processes might fail (e.g. the lucene job needs the description and might fail if it is null).

Currently you could upload something without the author tag, but when you try to update it you will get a validation error:

![image](https://cloud.githubusercontent.com/assets/756703/24631678/7f0c099e-18c1-11e7-893c-649b513d8f40.png)

This PR should fix the null handling and discard any uploads without a description or an empty author.

It seems that a empty <description></description> is also catched, because somewhere in the pipeline the description will be set to null instead of string.empty in this case, so even if you submit an empty description, the code will discard the upload.