### PR TITLE
Remove validation rules that block uploading valid semver2 versions

### DIFF
--- a/src/NuGetGallery.Core/CoreStrings.Designer.cs
+++ b/src/NuGetGallery.Core/CoreStrings.Designer.cs
@@ -124,6 +124,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package manifest contains an invalid Dependency Version: &apos;{0}&apos;.
+        /// </summary>
+        public static string Manifest_InvalidDependencyVersion {
+            get {
+                return ResourceManager.GetString("Manifest_InvalidDependencyVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package manifest contains an invalid ID: &apos;{0}&apos;.
         /// </summary>
         public static string Manifest_InvalidId {
@@ -165,15 +174,6 @@ namespace NuGetGallery {
         public static string Manifest_InvalidVersion {
             get {
                 return ResourceManager.GetString("Manifest_InvalidVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The version &apos;{0}&apos; is not supported. The NuGet Gallery currently does not currently support Semantic Version 2.0 as it would break older NuGet clients..
-        /// </summary>
-        public static string Manifest_InvalidVersionSemVer200 {
-            get {
-                return ResourceManager.GetString("Manifest_InvalidVersionSemVer200", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery.Core/CoreStrings.resx
+++ b/src/NuGetGallery.Core/CoreStrings.resx
@@ -168,9 +168,6 @@
   <data name="Manifest_TargetFrameworkNotSupported" xml:space="preserve">
     <value>The target framework {0} is not supported.</value>
   </data>
-  <data name="Manifest_InvalidVersionSemVer200" xml:space="preserve">
-    <value>The version '{0}' is not supported. The NuGet Gallery currently does not currently support Semantic Version 2.0 as it would break older NuGet clients.</value>
-  </data>
   <data name="Http404NotFound" xml:space="preserve">
     <value>(404) Error - Not Found</value>
   </data>
@@ -179,5 +176,8 @@
   </data>
   <data name="NegativeIndexesAreInvalid" xml:space="preserve">
     <value>Negative indexes are invalid.</value>
+  </data>
+  <data name="Manifest_InvalidDependencyVersion" xml:space="preserve">
+    <value>The package manifest contains an invalid Dependency Version: '{0}'</value>
   </data>
 </root>

--- a/src/NuGetGallery.Core/NuGetVersionExtensions.cs
+++ b/src/NuGetGallery.Core/NuGetVersionExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text.RegularExpressions;
 using NuGet.Versioning;
 
 namespace NuGetGallery
@@ -23,19 +22,9 @@ namespace NuGetGallery
 
     public static class NuGetVersionExtensions
     {
-        private const RegexOptions Flags = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
-        private static readonly Regex SemanticVersionRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$", Flags);
-
         public static string ToNormalizedStringSafe(this NuGetVersion self)
         {
             return self != null ? self.ToNormalizedString() : String.Empty;
-        }
-
-        public static bool IsValidVersionForLegacyClients(this NuGetVersion self)
-        {
-            var match = SemanticVersionRegex.Match(self.ToString().Trim());
-
-            return match.Success;
         }
     }
 }

--- a/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
+++ b/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
@@ -28,7 +28,7 @@ namespace NuGetGallery.Packaging
             catch (Exception ex)
             {
                 nuspecReader = null;
-                return new [] { new ValidationResult(ex.Message) };
+                return new[] { new ValidationResult(ex.Message) };
             }
 
             return Enumerable.Empty<ValidationResult>();
@@ -59,7 +59,7 @@ namespace NuGetGallery.Packaging
             // Check and validate URL properties
             foreach (var result in CheckUrls(
                 packageMetadata.GetValueFromMetadata("IconUrl"),
-                packageMetadata.GetValueFromMetadata("ProjectUrl"), 
+                packageMetadata.GetValueFromMetadata("ProjectUrl"),
                 packageMetadata.GetValueFromMetadata("LicenseUrl")))
             {
                 yield return result;
@@ -74,12 +74,6 @@ namespace NuGetGallery.Packaging
                     CultureInfo.CurrentCulture,
                     CoreStrings.Manifest_InvalidVersion,
                     version));
-            }
-
-            var versionValidationResult = ValidateVersion(packageMetadata.Version);
-            if (versionValidationResult != null)
-            {
-                yield return versionValidationResult;
             }
 
             // Check framework reference groups
@@ -143,17 +137,19 @@ namespace NuGetGallery.Packaging
                         // Versions
                         if (dependency.VersionRange.MinVersion != null)
                         {
-                            var versionRangeValidationResult = ValidateVersion(dependency.VersionRange.MinVersion);
+                            var versionRangeValidationResult =
+                                ValidateDependencyVersion(dependency.VersionRange.MinVersion);
                             if (versionRangeValidationResult != null)
                             {
                                 yield return versionRangeValidationResult;
                             }
                         }
 
-                        if (dependency.VersionRange.MaxVersion != null 
+                        if (dependency.VersionRange.MaxVersion != null
                             && dependency.VersionRange.MaxVersion != dependency.VersionRange.MinVersion)
                         {
-                            var versionRangeValidationResult = ValidateVersion(dependency.VersionRange.MaxVersion);
+                            var versionRangeValidationResult =
+                                ValidateDependencyVersion(dependency.VersionRange.MaxVersion);
                             if (versionRangeValidationResult != null)
                             {
                                 yield return versionRangeValidationResult;
@@ -164,21 +160,14 @@ namespace NuGetGallery.Packaging
             }
         }
 
-        private static ValidationResult ValidateVersion(NuGetVersion version)
+        private static ValidationResult ValidateDependencyVersion(NuGetVersion version)
         {
-            if (version.IsSemVer2)
+            if (version.HasMetadata)
             {
                 return new ValidationResult(string.Format(
                     CultureInfo.CurrentCulture,
-                    CoreStrings.Manifest_InvalidVersionSemVer200,
+                    CoreStrings.Manifest_InvalidDependencyVersion,
                     version.ToFullString()));
-            }
-            else if (!version.IsValidVersionForLegacyClients())
-            {
-                return new ValidationResult(string.Format(
-                    CultureInfo.CurrentCulture,
-                    CoreStrings.Manifest_InvalidVersion,
-                    version));
             }
 
             return null;

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -626,21 +626,6 @@ namespace NuGetGallery
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Id", CoreConstants.MaxPackageIdLength);
             }
-            if (packageMetadata.Version.IsPrerelease)
-            {
-                var release = packageMetadata.Version.Release;
-
-                if (release.Contains("."))
-                {
-                    throw new EntityException(Strings.NuGetPackageReleaseVersionWithDot, "Version");
-                }
-
-                long temp;
-                if (long.TryParse(release, out temp))
-                {
-                    throw new EntityException(Strings.NuGetPackageReleaseVersionContainsOnlyNumerics, "Version");
-                }
-            }
             if (packageMetadata.Authors != null && packageMetadata.Authors.Flatten().Length > 4000)
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Authors", "4000");

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -591,24 +591,6 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package {0} invalid: the release label can not only contain numerics..
-        /// </summary>
-        public static string NuGetPackageReleaseVersionContainsOnlyNumerics {
-            get {
-                return ResourceManager.GetString("NuGetPackageReleaseVersionContainsOnlyNumerics", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Package {0} invalid: no &apos;.&apos; allowed in the release label..
-        /// </summary>
-        public static string NuGetPackageReleaseVersionWithDot {
-            get {
-                return ResourceManager.GetString("NuGetPackageReleaseVersionWithDot", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Package created from API..
         /// </summary>
         public static string PackageCreatedFromApi {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -314,12 +314,6 @@ The {1} Team</value>
   <data name="UploadPackage_InvalidNuspec" xml:space="preserve">
     <value>The NuGet package contains an invalid .nuspec file. The error encountered was: '{0}'. Correct the error and try again.</value>
   </data>
-  <data name="NuGetPackageReleaseVersionWithDot" xml:space="preserve">
-    <value>Package {0} invalid: no '.' allowed in the release label.</value>
-  </data>
-  <data name="NuGetPackageReleaseVersionContainsOnlyNumerics" xml:space="preserve">
-    <value>Package {0} invalid: the release label can not only contain numerics.</value>
-  </data>
   <data name="CopyExternalPackages_PackageFileBlobAlreadyExists" xml:space="preserve">
     <value>SKIPPED! Package file blob {0} already exists</value>
   </data>

--- a/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
@@ -424,44 +424,29 @@ namespace NuGetGallery.Packaging
         }
 
         [Fact]
-        public void ReturnsErrorIfVersionIsSemVer200()
+        public void ReturnsNoErrorIfVersionIsSemVer200()
         {
             var nuspecStream = CreateNuspecStream(NuSpecSemVer200);
 
-            Assert.Equal(new[] { String.Format(CoreStrings.Manifest_InvalidVersionSemVer200, "2.0.0+123") }, GetErrors(nuspecStream));
+            Assert.Empty(GetErrors(nuspecStream));
         }
 
-        [Theory]
-        [InlineData("1.0.0-beta.1")]
-        [InlineData("3.0.0-beta+12")]
-        public void ReturnsErrorIfDependencyVersionIsSemVer200(string version)
+        [Fact]
+        public void ReturnsNoErrorIfDependencyVersionIsSemVer200WithoutMetadataPart()
         {
+            const string version = "1.0.0-beta.1";
             var nuspecStream = CreateNuspecStream(string.Format(NuSpecDependencyVersionPlaceholder, version));
-
-            Assert.Equal(new[] { String.Format(CoreStrings.Manifest_InvalidVersionSemVer200, version) }, GetErrors(nuspecStream));
+            
+            Assert.Empty(GetErrors(nuspecStream));
         }
 
-        [Theory]
-        [InlineData("1.0.0-10")]
-        [InlineData("1.0.0--")]
-        public void ReturnsErrorIfVersionIsInvalid(string version)
+        [Fact]
+        public void ReturnsErrorIfDependencyVersionIsSemVer200WithMetadataPart()
         {
-            // https://github.com/NuGet/NuGetGallery/issues/3226
-
-            var nuspecStream = CreateNuspecStream(string.Format(NuSpecPlaceholderVersion, version));
-
-            Assert.Equal(new[] { String.Format(CoreStrings.Manifest_InvalidVersion, version) }, GetErrors(nuspecStream));
-        }
-
-
-        [Theory]
-        [InlineData("1.0.0-10")]
-        [InlineData("1.0.0--")]
-        public void ReturnsErrorIfDependencyVersionIsInvalid(string version)
-        {
+            const string version = "3.0.0-beta+12";
             var nuspecStream = CreateNuspecStream(string.Format(NuSpecDependencyVersionPlaceholder, version));
-
-            Assert.Equal(new[] { String.Format(CoreStrings.Manifest_InvalidVersion, version) }, GetErrors(nuspecStream));
+            
+            Assert.Equal(new[] { String.Format(CoreStrings.Manifest_InvalidDependencyVersion, version) }, GetErrors(nuspecStream));
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -705,25 +705,21 @@ namespace NuGetGallery
             }
 
             [Fact]
-            private async Task WillThrowIfTheNuGetPackageSpecialVersionContainsADot()
+            private async Task DoesNotThrowIfTheNuGetPackageSpecialVersionContainsADot()
             {
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(id: "theId", version: "1.2.3-alpha.0");
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
-
-                Assert.Equal(String.Format(Strings.NuGetPackageReleaseVersionWithDot, "Version"), ex.Message);
+                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null);
             }
 
             [Fact]
-            private async Task WillThrowIfTheNuGetPackageSpecialVersionContainsOnlyNumbers()
+            private async Task DoesNotThrowIfTheNuGetPackageSpecialVersionContainsOnlyNumbers()
             {
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(id: "theId", version: "1.2.3-12345");
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
-
-                Assert.Equal(String.Format(Strings.NuGetPackageReleaseVersionContainsOnlyNumerics, "Version"), ex.Message);
+                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null);
             }
 
             [Fact]


### PR DESCRIPTION
This is not to be merged into dev yet, but would like to get it reviewed and merged into semver2 feature branch earlier :)

This PR:
* Removes additional version validation for legacy clients (2.x). The fact this version is parsed as a `NuGetVersion` already is good enough as for validating the version. The default semver2 filtering on v2 endpoints will still prevent these old 2.x clients from consuming such package versions, and can be considered a replacement for this.
* Rejects dependency version ranges that have the metadata part
* No longer blocks semver2 packages