### PR TITLE
Update ServicePointManager to use TLS1.2

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ServicePointManagerInitializer.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ServicePointManagerInitializer.cs
@@ -12,6 +12,8 @@ namespace NuGetGallery.FunctionalTests
     {
         public static void InitializeServerCertificateValidationCallback()
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             // suppress SSL validation for *.cloudapp.net
             ServicePointManager.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
         }


### PR DESCRIPTION
Functional tests were failing to create secure connections over https due to using wrong security protocol. This change updates them to use TLS 1.2

@scottbommarito @chenriksson @skofman1 