### PR TITLE
Remove flaky assert dependent on system clocks

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -302,9 +302,6 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
             }
 
             var json = JObject.Parse(responseText);
-            var expiration = json.Value<DateTime>("Expires");
-            Assert.True(expiration - DateTime.UtcNow < TimeSpan.FromDays(1), "Verification keys should expire after 1 day.");
-
             return json.Value<string>("Key");
         }
 

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -302,6 +302,11 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
             }
 
             var json = JObject.Parse(responseText);
+            var expiration = json.Value<DateTime>("Expires");
+
+            // Verification key should expire in 1 day. Ensure expiration is within 2 days in case client/server clocks differ.
+            Assert.True(expiration - DateTime.UtcNow < TimeSpan.FromDays(2), "Verification keys should expire after 1 day.");
+
             return json.Value<string>("Key");
         }
 


### PR DESCRIPTION
Remove flaky assert which depends on client/server clocks being in sync. Instead will just continue verifying that key is expired after first use.