### PR TITLE
IsVerificationKeyUsed telemetry fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,11 +160,7 @@ $RECYCLE.BIN/
 .DS_Store
 
 # NuGetGallery Specific Ignores
-src/NuGetGallery/App_Data/Files/Packages
-src/NuGetGallery/App_Data/Files/Downloads
-src/NuGetGallery/App_Data/Files/Uploads
-src/NuGetGallery/App_Data/Mail
-src/NuGetGallery/App_Data/Lucene
+src/NuGetGallery/App_Data/**
 !src/NuGetGallery/Views/Packages/
 !src/NuGetGallery/Branding/Views/Packages/
 

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -303,6 +303,19 @@ namespace NuGetGallery
                 .As<IAutomaticallyCuratePackageCommand>()
                 .InstancePerLifetimeScope();
 
+            if (configuration.Current.Environment == Constants.DevelopmentEnvironment)
+            {
+                builder.RegisterType<AllowLocalHttpRedirectPolicy>()
+                    .As<ISourceDestinationRedirectPolicy>()
+                    .InstancePerLifetimeScope();
+            }
+            else
+            {
+                builder.RegisterType<NoLessSecureDestinationRedirectPolicy>()
+                    .As<ISourceDestinationRedirectPolicy>()
+                    .InstancePerLifetimeScope();
+            }
+
             ConfigureAutocomplete(builder, configuration);
         }
 

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -10,7 +10,7 @@ namespace NuGetGallery.Configuration
 {
     public class AppConfiguration : IAppConfiguration
     {
-        [DefaultValue("Development")]
+        [DefaultValue(Constants.DevelopmentEnvironment)]
         public string Environment { get; set; }
 
         [DefaultValue("")]

--- a/src/NuGetGallery/Constants.cs
+++ b/src/NuGetGallery/Constants.cs
@@ -60,6 +60,8 @@ namespace NuGetGallery
         public static readonly string ReturnUrlParameterName = "ReturnUrl";
         public static readonly string CurrentUserOwinEnvironmentKey = "nuget.user";
 
+        public const string DevelopmentEnvironment = "Development";
+
         public static class ContentNames
         {
             public static readonly string Home = "Home";

--- a/src/NuGetGallery/ExtensionMethods.cs
+++ b/src/NuGetGallery/ExtensionMethods.cs
@@ -402,12 +402,16 @@ namespace NuGetGallery
 
             return !ScopeEvaluator.IsEmptyScopeClaim(scopeClaim);
         }
-
-        public static bool HasVerifyScope(this IIdentity self)
+        
+        /// <summary>
+        /// Determines if authentication is scoped and uses package verify claim.
+        /// </summary>
+        public static bool HasPackageVerifyScopeClaim(this IIdentity self)
         {
             var scopeClaim = self.GetScopeClaim();
-
-            return ScopeEvaluator.ScopeClaimsAllowsActionForSubject(scopeClaim, subject: null,
+            
+            return !ScopeEvaluator.IsEmptyScopeClaim(scopeClaim) &&
+                ScopeEvaluator.ScopeClaimsAllowsActionForSubject(scopeClaim, subject: null,
                 requestedActions: new [] { NuGetScopes.PackageVerify });
         }
 

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1420,7 +1420,10 @@
     <Compile Include="Infrastructure\Authentication\LegacyHasher.cs" />
     <Compile Include="Infrastructure\Authentication\V3Hasher.cs" />
     <Compile Include="Authentication\ScopeEvaluator.cs" />
+    <Compile Include="Services\AllowLocalHttpRedirectPolicy.cs" />
+    <Compile Include="Services\ISourceDestinationRedirectPolicy.cs" />
     <Compile Include="Services\ITelemetryService.cs" />
+    <Compile Include="Services\NoLessSecureDestinationRedirectPolicy.cs" />
     <Compile Include="Services\ReflowPackageService.cs" />
     <Compile Include="Services\TelemetryService.cs" />
     <Compile Include="ViewModels\ScopeViewModel.cs" />

--- a/src/NuGetGallery/Services/AllowLocalHttpRedirectPolicy.cs
+++ b/src/NuGetGallery/Services/AllowLocalHttpRedirectPolicy.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Redirect policy that allows potentially unsafe redirects to localhost URLs
+    /// (for debugging purposes only, not to be used in production).
+    /// </summary>
+    public class AllowLocalHttpRedirectPolicy : ISourceDestinationRedirectPolicy
+    {
+        public bool IsAllowed(Uri sourceUrl, Uri destinationUrl)
+        {
+            return sourceUrl.Scheme == Uri.UriSchemeHttp
+                || (sourceUrl.Scheme == Uri.UriSchemeHttps
+                    && (destinationUrl.Scheme == Uri.UriSchemeHttps || IsLocalhost(destinationUrl))
+                   );
+        }
+
+        private static bool IsLocalhost(Uri url)
+        {
+            // technically, any address in 127.0.0.1/8 subnet is "localhost",
+            // but it's not widely used and complicates the check, so not checking
+            // it here.
+            return url.Host == "127.0.0.1" || url.Host == "localhost" || url.Host == "[::1]";
+        }
+    }
+}

--- a/src/NuGetGallery/Services/ISourceDestinationRedirectPolicy.cs
+++ b/src/NuGetGallery/Services/ISourceDestinationRedirectPolicy.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Represents the policy services might use to allow or not allow redirects 
+    /// from and to certain URLs.
+    /// </summary>
+    public interface ISourceDestinationRedirectPolicy
+    {
+        /// <summary>
+        /// Checks if redirect is allowed 
+        /// </summary>
+        /// <param name="sourceUrl">The URL being redirected.</param>
+        /// <param name="destinationUrl">The destination URL.</param>
+        /// <returns>true if redirection is allowed, false otherwise</returns>
+        bool IsAllowed(Uri sourceUrl, Uri destinationUrl);
+    }
+}

--- a/src/NuGetGallery/Services/NoLessSecureDestinationRedirectPolicy.cs
+++ b/src/NuGetGallery/Services/NoLessSecureDestinationRedirectPolicy.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Redirect policy that only allows same or higher security level for destination URL 
+    /// compared to source URL (i.e. HTTPS to HTTP redirects are not allowed).
+    /// </summary>
+    public class NoLessSecureDestinationRedirectPolicy : ISourceDestinationRedirectPolicy
+    {
+        public bool IsAllowed(Uri sourceUrl, Uri destinationUrl)
+        {
+            return sourceUrl.Scheme == Uri.UriSchemeHttp 
+                || (sourceUrl.Scheme == Uri.UriSchemeHttps && destinationUrl.Scheme == Uri.UriSchemeHttps);
+        }
+    }
+}

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -649,7 +649,11 @@ namespace NuGetGallery
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Copyright", "4000");
             }
-            if (packageMetadata.Description != null && packageMetadata.Description.Length > 4000)
+            if (packageMetadata.Description == null)
+            {
+                throw new EntityException(Strings.NuGetPackagePropertyMissing, "Description");
+            }
+            else if (packageMetadata.Description != null && packageMetadata.Description.Length > 4000)
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Description", "4000");
             }

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -110,7 +110,7 @@ namespace NuGetGallery
             {
                 properties.Add(PackageId, packageId);
                 properties.Add(PackageVersion, packageVersion);
-                properties.Add(IsVerificationKeyUsed, identity.HasVerifyScope().ToString());
+                properties.Add(IsVerificationKeyUsed, identity.HasPackageVerifyScopeClaim().ToString());
                 properties.Add(VerifyPackageKeyStatusCode, statusCode.ToString());
             });
         }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -582,6 +582,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A nuget package&apos;s {0} property is required..
+        /// </summary>
+        public static string NuGetPackagePropertyMissing {
+            get {
+                return ResourceManager.GetString("NuGetPackagePropertyMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A nuget package&apos;s {0} property may not be more than {1} characters long..
         /// </summary>
         public static string NuGetPackagePropertyTooLong {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -440,4 +440,7 @@ The {1} Team</value>
   <data name="WarningApiDeprecated" xml:space="preserve">
     <value>API '{0}' is deprecated and may be removed in a future version.</value>
   </data>
+  <data name="NuGetPackagePropertyMissing" xml:space="preserve">
+    <value>A nuget package's {0} property is required.</value>
+  </data>
 </root>

--- a/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
+++ b/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
@@ -1,20 +1,62 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Versioning;
-using System.Text;
-using System.Threading.Tasks;
-using NuGet;
+using System.Security.Claims;
 using NuGet.Frameworks;
+using NuGetGallery.Authentication;
 using Xunit;
-using Xunit.Extensions;
 
 namespace NuGetGallery
 {
     public class ExtensionMethodsFacts
     {
+        public class TheHasPackageVerifyScopeClaimMethod
+        {
+            [Fact]
+            public void ReturnsTrueIfPackageVerifyScopeClaimExists()
+            {
+                // Arrange
+                var scope = "[{\"a\":\"package:verify\", \"s\":\"foo\"}]";
+                var identity = AuthenticationService.CreateIdentity(
+                    new User("testuser"),
+                    AuthenticationTypes.ApiKey,
+                    new Claim(NuGetClaims.ApiKey, string.Empty),
+                    new Claim(NuGetClaims.Scope, scope));
+
+                // Act & Assert
+                Assert.True(identity.HasPackageVerifyScopeClaim());
+            }
+
+            [Theory]
+            [InlineData("[{\"a\":\"package:push\", \"s\":\"foo\"}]")]
+            [InlineData("[{\"a\":\"package:pushversion\", \"s\":\"foo\"}]")]
+            [InlineData("[{\"a\":\"package:unlist\", \"s\":\"foo\"}]")]
+            public void ReturnsFalseIfPackageVerifyScopeClaimDoesNotExist(string scope)
+            {
+                // Arrange
+                var identity = AuthenticationService.CreateIdentity(
+                    new User("testuser"),
+                    AuthenticationTypes.ApiKey,
+                    new Claim(NuGetClaims.ApiKey, string.Empty),
+                    new Claim(NuGetClaims.Scope, scope));
+
+                // Act & Assert
+                Assert.False(identity.HasPackageVerifyScopeClaim());
+            }
+
+            [Fact]
+            public void ReturnsFalseIfScopeClaimDoesNotExist()
+            {
+                // Arrange
+                var identity = AuthenticationService.CreateIdentity(
+                    new User("testuser"),
+                    AuthenticationTypes.ApiKey,
+                    new Claim(NuGetClaims.ApiKey, string.Empty));
+
+                // Act & Assert
+                Assert.False(identity.HasPackageVerifyScopeClaim());
+            }
+        }
+
         public class TheToFriendlyNameMethod
         {
             [Theory]

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -408,6 +408,8 @@
     <Compile Include="SearchClient\CorrelatingHttpClientHandlerFacts.cs" />
     <Compile Include="SearchClient\RequestInspectingHandler.cs" />
     <Compile Include="SearchClient\WebApiCorrelationHandlerFacts.cs" />
+    <Compile Include="Services\AllowLocalHttpRedirectPolicyFacts.cs" />
+    <Compile Include="Services\NoLessSecureDestinationRedirectPolicyFacts.cs" />
     <Compile Include="Services\PagerDutyClientFacts.cs" />
     <Compile Include="Services\ReflowPackageServiceFacts.cs" />
     <Compile Include="Services\ScopeEvaluatorFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/AllowLocalHttpRedirectPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/AllowLocalHttpRedirectPolicyFacts.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGetGallery.Services
+{
+    public class AllowLocalHttpRedirectPolicyFacts
+    {
+        private const string HttpSourceUrl = "http://sourceUrl";
+        private const string HttpsSourceUrl = "https://sourceUrl";
+        private const string HttpDestinationUrl = "http://destinationUrl";
+        private const string HttpsDestinationUrl = "https://destinationUrl";
+        private const string HttpNumericLocalhostDestinationUrl = "http://127.0.0.1";
+        private const string HttpLocalhostDestinationUrl = "http://localhost";
+        // RFC2732 style numeric IPv6 URL
+        private const string HttpIpv6LocalhostDestinationUrl = "http://[::1]";
+
+        [Theory]
+        [InlineData(HttpSourceUrl, HttpDestinationUrl, true)]
+        [InlineData(HttpSourceUrl, HttpsDestinationUrl, true)]
+        [InlineData(HttpsSourceUrl, HttpDestinationUrl, false)]
+        [InlineData(HttpsSourceUrl, HttpsDestinationUrl, true)]
+        public void WillOnlyAllowSafeRedirects(string sourceUrl, string destinationUrl, bool expectedResult)
+        {
+            var redirectPolicy = new AllowLocalHttpRedirectPolicy();
+            Assert.Equal(expectedResult, redirectPolicy.IsAllowed(new Uri(sourceUrl), new Uri(destinationUrl)));
+        }
+
+        [Theory]
+        [InlineData(HttpsSourceUrl, HttpNumericLocalhostDestinationUrl)]
+        [InlineData(HttpsSourceUrl, HttpLocalhostDestinationUrl)]
+        [InlineData(HttpsSourceUrl, HttpIpv6LocalhostDestinationUrl)]
+        public void WillAllowLocalhostRedirects(string sourceUrl, string destinationUrl)
+        {
+            var redirectPolicy = new AllowLocalHttpRedirectPolicy();
+            Assert.True(redirectPolicy.IsAllowed(new Uri(sourceUrl), new Uri(destinationUrl)));
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Services/NoLessSecureDestinationRedirectPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/NoLessSecureDestinationRedirectPolicyFacts.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGetGallery.Services
+{
+    public class NoLessSecureDestinationRedirectPolicyFacts
+    {
+        private const string HttpSourceUrl = "http://sourceUrl";
+        private const string HttpsSourceUrl = "https://sourceUrl";
+        private const string HttpDestinationUrl = "http://destinationUrl";
+        private const string HttpsDestinationUrl = "https://destinationUrl";
+        private const string HttpNumericLocalhostDestinationUrl = "http://127.0.0.1";
+        private const string HttpLocalhostDestinationUrl = "http://localhost";
+        // RFC2732 style numeric IPv6 URL
+        private const string HttpIpv6LocalhostDestinationUrl = "http://[::1]";
+
+        [Theory]
+        [InlineData(HttpSourceUrl, HttpDestinationUrl, true)]
+        [InlineData(HttpSourceUrl, HttpsDestinationUrl, true)]
+        [InlineData(HttpsSourceUrl, HttpDestinationUrl, false)]
+        [InlineData(HttpsSourceUrl, HttpsDestinationUrl, true)]
+        public void WillOnlyAllowSafeRedirects(string sourceUrl, string destinationUrl, bool expectedResult)
+        {
+            var redirectPolicy = new NoLessSecureDestinationRedirectPolicy();
+            Assert.Equal(expectedResult, redirectPolicy.IsAllowed(new Uri(sourceUrl), new Uri(destinationUrl)));
+        }
+
+        [Theory]
+        [InlineData(HttpsSourceUrl, HttpNumericLocalhostDestinationUrl)]
+        [InlineData(HttpsSourceUrl, HttpLocalhostDestinationUrl)]
+        [InlineData(HttpsSourceUrl, HttpIpv6LocalhostDestinationUrl)]
+        public void WillNotAllowLocalhostRedirects(string sourceUrl, string destinationUrl)
+        {
+            var redirectPolicy = new NoLessSecureDestinationRedirectPolicy();
+            Assert.False(redirectPolicy.IsAllowed(new Uri(sourceUrl), new Uri(destinationUrl)));
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -830,6 +830,18 @@ namespace NuGetGallery
             }
 
             [Fact]
+            private async Task WillThrowIfTheNuGetPackageDescriptionIsNull()
+            {
+                var service = CreateService();
+                var nugetPackage = CreateNuGetPackage(description: null);
+
+                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+
+                Assert.Equal(String.Format(Strings.NuGetPackagePropertyMissing, "Description"), ex.Message);
+            }
+
+
+            [Fact]
             private async Task WillThrowIfTheNuGetPackageDescriptionIsLongerThan4000()
             {
                 var service = CreateService();

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -835,7 +835,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = CreateNuGetPackage(description: null);
 
-                var ex = await Assert.ThrowsAsync<EntityException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), null));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyMissing, "Description"), ex.Message);
             }


### PR DESCRIPTION
Reported by @skofman1, we noticed IsVerificationKeyUsed also returns true when legacy (non-scoped) API keys are used. This fixes it so only API keys with package:verify scope are reported for this property.