### PR TITLE
IsVerificationKeyUsed telemetry fix

### DIFF
--- a/src/NuGetGallery/ExtensionMethods.cs
+++ b/src/NuGetGallery/ExtensionMethods.cs
@@ -402,12 +402,16 @@ namespace NuGetGallery
 
             return !ScopeEvaluator.IsEmptyScopeClaim(scopeClaim);
         }
-
-        public static bool HasVerifyScope(this IIdentity self)
+        
+        /// <summary>
+        /// Determines if authentication is scoped and uses package verify claim.
+        /// </summary>
+        public static bool HasPackageVerifyScopeClaim(this IIdentity self)
         {
             var scopeClaim = self.GetScopeClaim();
-
-            return ScopeEvaluator.ScopeClaimsAllowsActionForSubject(scopeClaim, subject: null,
+            
+            return !ScopeEvaluator.IsEmptyScopeClaim(scopeClaim) &&
+                ScopeEvaluator.ScopeClaimsAllowsActionForSubject(scopeClaim, subject: null,
                 requestedActions: new [] { NuGetScopes.PackageVerify });
         }
 

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -110,7 +110,7 @@ namespace NuGetGallery
             {
                 properties.Add(PackageId, packageId);
                 properties.Add(PackageVersion, packageVersion);
-                properties.Add(IsVerificationKeyUsed, identity.HasVerifyScope().ToString());
+                properties.Add(IsVerificationKeyUsed, identity.HasPackageVerifyScopeClaim().ToString());
                 properties.Add(VerifyPackageKeyStatusCode, statusCode.ToString());
             });
         }

--- a/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
+++ b/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
@@ -1,20 +1,62 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Versioning;
-using System.Text;
-using System.Threading.Tasks;
-using NuGet;
+using System.Security.Claims;
 using NuGet.Frameworks;
+using NuGetGallery.Authentication;
 using Xunit;
-using Xunit.Extensions;
 
 namespace NuGetGallery
 {
     public class ExtensionMethodsFacts
     {
+        public class TheHasPackageVerifyScopeClaimMethod
+        {
+            [Fact]
+            public void ReturnsTrueIfPackageVerifyScopeClaimExists()
+            {
+                // Arrange
+                var scope = "[{\"a\":\"package:verify\", \"s\":\"foo\"}]";
+                var identity = AuthenticationService.CreateIdentity(
+                    new User("testuser"),
+                    AuthenticationTypes.ApiKey,
+                    new Claim(NuGetClaims.ApiKey, string.Empty),
+                    new Claim(NuGetClaims.Scope, scope));
+
+                // Act & Assert
+                Assert.True(identity.HasPackageVerifyScopeClaim());
+            }
+
+            [Theory]
+            [InlineData("[{\"a\":\"package:push\", \"s\":\"foo\"}]")]
+            [InlineData("[{\"a\":\"package:pushversion\", \"s\":\"foo\"}]")]
+            [InlineData("[{\"a\":\"package:unlist\", \"s\":\"foo\"}]")]
+            public void ReturnsFalseIfPackageVerifyScopeClaimDoesNotExist(string scope)
+            {
+                // Arrange
+                var identity = AuthenticationService.CreateIdentity(
+                    new User("testuser"),
+                    AuthenticationTypes.ApiKey,
+                    new Claim(NuGetClaims.ApiKey, string.Empty),
+                    new Claim(NuGetClaims.Scope, scope));
+
+                // Act & Assert
+                Assert.False(identity.HasPackageVerifyScopeClaim());
+            }
+
+            [Fact]
+            public void ReturnsFalseIfScopeClaimDoesNotExist()
+            {
+                // Arrange
+                var identity = AuthenticationService.CreateIdentity(
+                    new User("testuser"),
+                    AuthenticationTypes.ApiKey,
+                    new Claim(NuGetClaims.ApiKey, string.Empty));
+
+                // Act & Assert
+                Assert.False(identity.HasPackageVerifyScopeClaim());
+            }
+        }
+
         public class TheToFriendlyNameMethod
         {
             [Theory]


### PR DESCRIPTION
Reported by @skofman1, we noticed IsVerificationKeyUsed also returns true when legacy (non-scoped) API keys are used. This fixes it so only API keys with package:verify scope are reported for this property.