### PR TITLE
100% Table width for Manage My Package overview

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -633,6 +633,14 @@ ul.pager {
     font-size: 1.1em;
 }
 
+.sexy-table-full {
+    width: 100%;
+}
+
+.sexy-table-full .last {
+    text-align: right;
+    padding: 5px 15px 5px 0;
+}
 
 /* header */
 

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -56,7 +56,7 @@ else
 
     if (totalPackages > 0)
     {
-        <table class="sexy-table">
+        <table class="sexy-table sexy-table-full">
             <thead>
                 <tr>
                     <th class="first actions">Actions</th>
@@ -101,7 +101,7 @@ else
                             }
                         </td>
                 
-                        <td>@package.DownloadCount</td>
+                        <td class="last">@package.DownloadCount</td>
                     </tr>
                     totalDownloads += package.DownloadCount;
                 }
@@ -118,7 +118,7 @@ else
                             @("You have one package.")
                         }
                     </td>
-                    <td class="total">
+                    <td class="total last">
                         @totalDownloads
                     </td>
                 </tr>


### PR DESCRIPTION
Fix for https://github.com/NuGet/NuGetGallery/issues/3783

With the changes applied it looks like this:

![image](https://cloud.githubusercontent.com/assets/756703/25457837/f39e0898-2ad7-11e7-9adb-5a99cfad07d8.png)

* Table is stretched to the full content 
* last column is right aligned, so it has a straight line

Currently both tables can still look "different", because the width of the columns are not fix, but at least the downloads count will be aligned.

The simplest fix was to use a new css class, because the "sexy-table" is used on other sites as well. The "last" css class on all last tds was needed to ensure everything is aligned the right way and is compatible with all IE versions.

What do you think?