### PR TITLE
Fix Parsing of Empty Dependency Groups

### DIFF
--- a/src/NuGetGallery.Core/SemVerLevelKey.cs
+++ b/src/NuGetGallery.Core/SemVerLevelKey.cs
@@ -57,12 +57,14 @@ namespace NuGetGallery
                     // Check the package dependencies for SemVer-compliance.
                     // As soon as a SemVer2-compliant dependency version is found that is not SemVer1-compliant,
                     // this package in itself is to be identified as to have SemVerLevelKey.SemVer2.
-                    var dependencyVersionRange = VersionRange.Parse(dependency.VersionSpec);
-
-                    if ((dependencyVersionRange.MinVersion != null && dependencyVersionRange.MinVersion.IsSemVer2)
-                        || (dependencyVersionRange.MaxVersion != null && dependencyVersionRange.MaxVersion.IsSemVer2))
+                    VersionRange dependencyVersionRange;
+                    if (dependency.VersionSpec != null && VersionRange.TryParse(dependency.VersionSpec, out dependencyVersionRange))
                     {
-                        return SemVer2;
+                        if ((dependencyVersionRange.MinVersion != null && dependencyVersionRange.MinVersion.IsSemVer2)
+                            || (dependencyVersionRange.MaxVersion != null && dependencyVersionRange.MaxVersion.IsSemVer2))
+                        {
+                            return SemVer2;
+                        }
                     }
                 }
             }
@@ -98,7 +100,7 @@ namespace NuGetGallery
                 return Unknown;
             }
         }
-        
+
         /// <summary>
         /// Indicates whether the provided SemVer-level key is compliant with the provided SemVer-level version string.
         /// </summary>

--- a/tests/NuGetGallery.Core.Facts/SemVerLevelKeyFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/SemVerLevelKeyFacts.cs
@@ -93,6 +93,7 @@ namespace NuGetGallery
             [InlineData("1.0.0-alpha")]
             [InlineData("[1.0-alpha, 2.0.0)")]
             [InlineData("[1.0, 2.0.0-alpha)")]
+            [InlineData(null)]
             public void ReturnsUnknownForNonSemVer2CompliantDependenciesThatAreNotSemVer1Compliant(string versionSpec)
             {
                 // Arrange


### PR DESCRIPTION
There was a bug where the semVerLevelKey computation would fail if the package contained an empty dependency group (ie targetFramework specified, but no actual package dependencies).

This PR adds a null check to guard against this failure.

@xavierdecoster @joelverhagen @cristinamanum @skofman1 