### PR TITLE
Improved the Gallery's Screen Reader Accessibility

### DIFF
--- a/src/NuGetGallery/Views/Authentication/_Register.cshtml
+++ b/src/NuGetGallery/Views/Authentication/_Register.cshtml
@@ -18,27 +18,27 @@
             @Html.ValidationSummaryFor("Register")
 
             <div class="form-field form-field-full">
-                @Html.LabelFor(m => m.Register.Username)
-                @Html.EditorFor(m => m.Register.Username)
+                @Html.LabelFor(m => m.Register.Username, new { id = "Register_Username_Label" })
+                @Html.EditorFor(m => m.Register.Username, new { htmlAttributes = new { aria_labelledby = "Register_Username_Label Register_Username_Help" } })
                 @Html.ValidationMessageFor(m => m.Register.Username)
-                <span class="field-hint-message">@RegisterViewModel.UserNameHint</span>
+                <span class="field-hint-message" id="Register_Username_Help">@RegisterViewModel.UserNameHint</span>
             </div>
 
             @if (Model.External == null)
             {
                 <div class="form-field form-field-full">
-                    @Html.LabelFor(m => m.Register.Password)
-                    @Html.EditorFor(m => m.Register.Password)
+                    @Html.LabelFor(m => m.Register.Password, new { id = "Register_Password_Label" })
+                    @Html.EditorFor(m => m.Register.Password, new { htmlAttributes = new { aria_labelledby = "Register_Password_Label Register_Password_Help" } })
                     @Html.ValidationMessageFor(m => m.Register.Password)
-                    <span class="field-hint-message">@PasswordHint()</span>
+                    <span class="field-hint-message" id="Register_Password_Help">@PasswordHint()</span>
                 </div>
             }
 
             <div class="form-field form-field-full">
-                <label for="EmailAddress">Email (<a href="http://www.gravatar.com">Gravatar</a>, notifications, and password recovery)</label>
-                @Html.EditorFor(m => m.Register.EmailAddress)
+                <label for="Register_EmailAddress" id="Register_EmailAddress_Label">Email (<a href="http://www.gravatar.com">Gravatar</a>, notifications, and password recovery)</label>
+                @Html.EditorFor(m => m.Register.EmailAddress, new { htmlAttributes = new { aria_labelledby = "Register_EmailAddress_Label Register_EmailAddress_Help" } })
                 @Html.ValidationMessageFor(m => m.Register.EmailAddress)
-                <span class="field-hint-message">@RegisterViewModel.EmailHint</span>
+                <span class="field-hint-message" id="Register_EmailAddress_Help">@RegisterViewModel.EmailHint</span>
             </div>
 
             <img src="@Url.Content("~/Content/images/required.png")" alt="Blue border on left means required." />

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -44,7 +44,7 @@
     <div class="form-field">
         <div style="display: block" >
             @Html.Label(formid, name, new { style = "display: inline-block" })
-            <button type="button" class="edit-button" id="@(formid + "Button")"><span class="icon-edit" title="Edit"></span></button>
+            <button type="button" class="edit-button" id="@(formid + "Button")"><span class="icon-edit" title="Edit @(name)"></span></button>
             <button type="button" class="undo-button" id="@("Undo" + formid)" style="display: none"><span class="icon-undo" title="Undo Edit"></span></button>
         </div>
         <div id="@(formid + "Text")">
@@ -147,7 +147,7 @@
                 <h4>Requires License Acceptance
                     @{
                                             var formid2 = "Edit_RequiresLicenseAcceptance";
-                        <button type="button" class="edit-button" id="@(formid2 + "Button")"><span class="icon-edit"></span></button>
+                        <button type="button" class="edit-button" id="@(formid2 + "Button")"><span class="icon-edit" title="Edit Requires License Acceptance"></span></button>
                         <button type="button" class="undo-button" id="@("Undo" + formid2)" style="display: none"><span class="icon-undo"></span></button>
                     }
                 </h4>
@@ -162,6 +162,10 @@
                                 {
                                     new SelectListItem { Text = Strings.Yes, Value = "true" },
                                     new SelectListItem { Text = Strings.No, Value = "false" },
+                                },
+                                new Dictionary<string, object>
+                                {
+                                    { "aria-label", "Requires License Acceptance" }
                                 })
                             @Html.ValidationMessageFor(model => model.Edit.RequiresLicenseAcceptance)
                         </div>
@@ -178,6 +182,10 @@
                         {
                             new SelectListItem { Text = Strings.Yes, Value = "true", Selected = true },
                             new SelectListItem { Text = Strings.No, Value = "false" },
+                        },
+                        new Dictionary<string, object>
+                        {
+                            { "aria-label", "Listed in Search Results" }
                         })
                     @Html.ValidationMessageFor(model => model.Listed)
                     @*<label for="Listed" class="checkbox">


### PR DESCRIPTION
This pull request does the following accessibility improvements:

* Improved the titles of the buttons and select drop-down box on the Upload Verification page
* Improved the registration form
  * Fixed issue where the email input wasn't properly labelled
  * Made all help texts part of the fields' labels.

All of these changes are on the UI, thus, I didn't do any changes to unit tests.

Fixes VSTS bugs [#395317](https://devdiv.visualstudio.com/DevDiv/_workitems?id=395317&_a=edit&triage=true), [#395879](https://devdiv.visualstudio.com/DevDiv/_workitems?id=395879&_a=edit&triage=true), and [#395340](https://devdiv.visualstudio.com/DevDiv/_workitems?id=395340&_a=edit&triage=true).