### PR TITLE
Pressing Edit or Undo on the VerifyPackage page does not reset focus

### DIFF
--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -220,6 +220,7 @@
                     $("#" + name + "Field").show();
                     $("#" + name + "Button").hide();
                     $("#Undo" + name).show();
+                    $("#Undo" + name).focus();
                 });
 
                 SetDataEditedFlag = function (event) {
@@ -243,6 +244,7 @@
                     $("#" + name + "Field").hide();
                     $("#" + name + "Button").show();
                     $("#Undo" + name).hide();
+                    $("#" + name + "Button").focus();
                 });
             }
 


### PR DESCRIPTION
Previously, while tabbing through the VerifyPackage page, pressing Edit or Undo would reset the focus to the top of the page. With this change, the focus remains on the buttons.