### PR TITLE
Improved NuGet Gallery's Accessibility

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -1365,9 +1365,19 @@ ul.accordion {
         }
 
         ul.accordion li.accordion-item .accordion-expand-link {
-            display: inline-block;
+            background: none!important;
+            border: none;
+            padding: 0!important;
+            cursor: pointer;
             margin-top: 0.25em;
             margin-left: 3px;
+            color: #0071bc;
+            box-shadow: none;
+            font-size:0.85em;
+        }
+
+        ul.accordion li.accordion-item .accordion-expand-link:hover {
+            text-decoration: underline;
         }
 
         ul.accordion li.accordion-item.accordion-item-disabled {

--- a/src/NuGetGallery/Helpers/AccordeonHelper.cs
+++ b/src/NuGetGallery/Helpers/AccordeonHelper.cs
@@ -39,29 +39,31 @@ namespace NuGetGallery.Helpers
         public HtmlString ExpandButton(string closedTitle, string expandedTitle)
         {
             return new HtmlString(
-                "<a href=\"#\" class=\"accordion-expand-button btn btn-inline s-expand\" data-target=\"#" +
+                "<button class=\"accordion-expand-button btn btn-inline s-expand\" data-target=\"#" +
                 ContentDropDownId +
                 "\" data-toggletext=\"" +
                 (Expanded ? closedTitle : expandedTitle) +
                 "\" id=\"" +
                 CollapseButtonId +
-                "\">" +
+                "\" aria-expanded=\"" +
+                (Expanded ? "true" : "false") +"\">" +
                 (Expanded ? expandedTitle : closedTitle) +
-                "</a>");
+                "</button>");
         }
 
         public HtmlString ExpandLink(string closedTitle, string expandedTitle)
         {
             return new HtmlString(
-                "<a href=\"#\" class=\"accordion-expand-link s-expand\" data-target=\"#" +
+                "<button class=\"accordion-expand-link s-expand\" data-target=\"#" +
                 ContentDropDownId +
                 "\" data-toggletext=\"" +
                 (Expanded ? closedTitle : expandedTitle) +
                 "\" id=\"" +
                 CollapseButtonId +
-                "\">" +
+                "\" aria-expanded=\"" +
+                (Expanded ? "true" : "false") + "\">" +
                 (Expanded ? expandedTitle : closedTitle) +
-                "</a>");
+                "</button>");
         }
     }
 }

--- a/src/NuGetGallery/Scripts/nugetgallery.js
+++ b/src/NuGetGallery/Scripts/nugetgallery.js
@@ -61,12 +61,14 @@
             var data = $self.data();
             var $target = $(data.target);
             var toggletext = data.toggletext || $self.text();
+            var expanded = $self.attr('aria-expanded') == 'true';
+            var oldText = $self.text();
 
-            $target.slideToggle('fast', function () {
-                var oldText = $self.text();
-                $self.text(toggletext);
-                data.toggletext = oldText;
-            });
+            $self.attr('aria-expanded', expanded ? 'false' : 'true');
+            $self.text(toggletext);
+            data.toggletext = oldText;
+
+            $target.slideToggle('fast');
         });
         $('.s-confirm[data-confirm]').delegate('', 'click', function (evt) {
             if (!confirm($(this).data().confirm)) {

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -19,8 +19,8 @@
         @Html.ValidationSummary(true)
 
         <div class="form-field">
-            <label for="PackageFile">Choose a package...</label>
-            <input type="file" name="UploadFile" accept=".nupkg" />
+            <label for="PackageFile" id="PackageFileLabel">Choose a package...</label>
+            <input type="file" name="UploadFile" accept=".nupkg" aria-labelledby="PackageFileLabel" />
         </div>
 
         <input type="submit" value="Upload" title="Upload the package." />

--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -50,12 +50,12 @@
 <section>
     <ul class="actionlist">
         <li class="actionlist-item">
-            <a class="actionlist-item-link" href="@Url.UploadPackage()">
+            <a class="actionlist-item-link" href="@Url.UploadPackage()" aria-labelledby="upload-package-label" aria-describedby="upload-package-description">
                 <div class="actionlist-item-header">
                     <i class="icon-cloud-upload actionlist-item-header-icon"></i>
-                    <span class="actionlist-item-header-text">Upload a Package</span>
+                    <span class="actionlist-item-header-text" id="upload-package-label">Upload a Package</span>
                 </div>
-                <p class="actionlist-item-content">
+                <p class="actionlist-item-content" id="upload-package-description">
                     Upload and publish your package for other NuGet users to download and enjoy.
                     You can upload multiple revisions of the same package, as long as the version
                     is different.
@@ -64,12 +64,12 @@
         </li>
 
         <li class="actionlist-item">
-            <a class="actionlist-item-link" href="@Url.Action(actionName: "Packages", controllerName: "Users")">
+            <a class="actionlist-item-link" href="@Url.Action(actionName: "Packages", controllerName: "Users")" aria-labelledby="manage-my-packages-label" aria-describedby="manage-my-packages-description">
                 <div class="actionlist-item-header">
                     <i class="icon-gears actionlist-item-header-icon"></i>
-                    <span class="actionlist-item-header-text">Manage my Packages</span>
+                    <span class="actionlist-item-header-text" id="manage-my-packages-label">Manage my Packages</span>
                 </div>
-                <p class="actionlist-item-content">
+                <p class="actionlist-item-content" id="manage-my-packages-description">
                     Edit package details or Remove packages that you have previously uploaded.
                 </p>
             </a>

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -339,7 +339,7 @@
                              <h5>Select packages</h5><hr />
                              To select which packages to associate with a key use a glob pattern, select individual packages, or both. 
                              
-                             <a class="globHelpLink">Example glob patterns</a>.
+                             <a href="#" class="globHelpLink">Example glob patterns</a>.
                              <div class="popup">
                                  <div class="popupbox" id="addapikeypopup">
                                      <a class="boxclose"><i class="icon-remove"></i></a>
@@ -405,7 +405,7 @@
                             </div>
                          </div>
 
-                        <button class="btn" type="button" id="generateKey">Add key</button>
+                        <button class="btn" type="button" id="generateKey" aria-disabled="true">Add key</button>
                     </fieldset>
                     <br />
                     }
@@ -535,14 +535,13 @@
         var globValid = $('#addkeyglobPattern').valid();
         var globEmpty = $('#addkeyglobPattern').val() == null || $.trim($('#addkeyglobPattern').val()) == '';
 
-        if (!globValid) {
-            $('#generateKey').addClass('disabled-div');
-        }
-        else if (packagesWereSelected || !globEmpty) {
+        if (globValid && (packagesWereSelected || !globEmpty)) {
             $('#generateKey').removeClass('disabled-div');
+            $('#generateKey').removeAttr('aria-disabled');
         }
         else {
             $('#generateKey').addClass('disabled-div');
+            $('#generateKey').attr('aria-disabled', 'true');
         }
     }
 

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -344,7 +344,7 @@
                                  <div class="popupbox" id="addapikeypopup">
                                      <a class="boxclose"><i class="icon-remove"></i></a>
                                      <div class="innertext">
-                                         A glob pattern allows you to replace any sequence of charecters with '*'.
+                                         A glob pattern allows you to replace any sequence of characters with '*'.
                                          <h5>Example glob patterns</h5>
                                          <table>
                                              <tr>
@@ -1136,6 +1136,7 @@
         selectPackagesDiv.appendChild(document
             .createTextNode("To select which packages to associate with a key use a glob pattern, select individual packages, or both. "));
         var helpLink = document.createElement("a");
+        helpLink.href = "#";
         helpLink.className = "globHelpLink";
         helpLink.appendChild(document.createTextNode("Example glob patterns"));
         selectPackagesDiv.appendChild(helpLink);
@@ -1153,7 +1154,7 @@
         var innerTextDiv = document.createElement("div");
         innerTextDiv.className = "innertext";
         innerTextDiv.appendChild(document
-            .createTextNode("A glob pattern allows you to replace any sequence of charecters with '*'."));
+            .createTextNode("A glob pattern allows you to replace any sequence of characters with '*'."));
         var popupheader = document.createElement("h5");
         popupheader.appendChild(document.createTextNode("Example glob patterns"));
         innerTextDiv.appendChild(popupheader);

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -74,13 +74,13 @@ else
                         <td class="actions">
                             @if (canEdit)
                             {
-                                <a href="@Url.EditPackage(package.Id, package.Version)" title="Edit" class="table-action-link">
+                                <a href="@Url.EditPackage(package.Id, package.Version)" title="Edit" class="table-action-link" aria-label="Edit package details">
                                     <i class="icon-edit"></i>
                                 </a>
                             }
                             @if (canDelete)
                             {
-                                <a href="@Url.DeletePackage(package)" title="Delete" class="table-action-link">
+                                <a href="@Url.DeletePackage(package)" title="Delete" class="table-action-link" aria-label="Delete package">
                                     <i class="icon-trash"></i>
                                 </a>
                             }


### PR DESCRIPTION
Improved accessibility for the following pages:

* Account Page
  * Improved the upload and manage package links by separating the label
  and describe sections. Resolves [VSTS #395337](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=395337&_a=edit)
  * Improved accessibility of "Change" button toggles. The screen reader
  will now describe their state as "expanded" or "collapsed".
  Fixes [VSTS #395336](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=395336&_a=edit)
  * Improved accessibility of "Add Key" button for API Key management.
  The screen reader will now describe the button as disabled or not.
  Fixes [VSTS #395343](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=395343&_a=edit).
  * Improved accessibility of "Example glob patterns" link on the API
  Key management by making it selectable with the "Tab" key.
* Manage my Packages Page
  * Improved the `Edit` and `Delete` accessibility labels. Fixes
  [VSTS #395342](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=395342&_a=edit).
* Upload Package Page
  * Added label to the file upload input. Fixes [VSTS #395339](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=395339&_a=edit)