### PR TITLE
Make PackageDownloadsDetail and PackageDownloadsByVersion graphs update without refreshing the page

### DIFF
--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -70,9 +70,19 @@ namespace NuGetGallery
                 new { controller = "Statistics", action = "PackageDownloadsDetail" });
 
             routes.MapRoute(
+                RouteName.StatisticsPackageDownloadsDetailReport,
+                "stats/reports/packages/{id}/{version}",
+                new { controller = "Statistics", action = "PackageDownloadsDetailReport" });
+
+            routes.MapRoute(
                 RouteName.StatisticsPackageDownloadsByVersion,
                 "stats/packages/{id}",
                 new { controller = "Statistics", action = "PackageDownloadsByVersion" });
+
+            routes.MapRoute(
+                RouteName.StatisticsPackageDownloadsByVersionReport,
+                "stats/reports/packages/{id}",
+                new { controller = "Statistics", action = "PackageDownloadsByVersionReport" });
 
             routes.MapRoute(
                 RouteName.JsonApi,

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -160,7 +160,7 @@ namespace NuGetGallery
 
             var report = await GetPackageDownloadsByVersionReport(id, groupby);
 
-            StatisticsPackagesViewModel model = new StatisticsPackagesViewModel();
+            var model = new StatisticsPackagesViewModel();
 
             model.SetPackageDownloadsByVersion(id);
 
@@ -172,8 +172,13 @@ namespace NuGetGallery
         //
         // GET: /stats/reports/packages/{id}
 
-        public virtual async Task<JsonResult> PackageDownloadsByVersionReport(string id, string[] groupby)
+        public virtual async Task<ActionResult> PackageDownloadsByVersionReport(string id, string[] groupby)
         {
+            if (_statisticsService == NullStatisticsService.Instance)
+            {
+                return new HttpStatusCodeResult(HttpStatusCode.NotFound);
+            }
+
             return Json(await GetPackageDownloadsByVersionReport(id, groupby), JsonRequestBehavior.AllowGet);
         }
 
@@ -201,8 +206,13 @@ namespace NuGetGallery
         //
         // GET: /stats/reports/packages/{id}/{version}
 
-        public virtual async Task<JsonResult> PackageDownloadsDetailReport(string id, string version, string[] groupby)
+        public virtual async Task<ActionResult> PackageDownloadsDetailReport(string id, string version, string[] groupby)
         {
+            if (_statisticsService == NullStatisticsService.Instance)
+            {
+                return new HttpStatusCodeResult(HttpStatusCode.NotFound);
+            }
+
             var report = await GetPackageDownloadsDetailReport(id, version, groupby);
 
             if (report != null)

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -162,7 +162,7 @@ namespace NuGetGallery
 
             StatisticsPackagesViewModel model = new StatisticsPackagesViewModel();
 
-            model.SetPackageDownloadsByVersion(id, report);
+            model.SetPackageDownloadsByVersion(id);
 
             model.UseD3 = UseD3();
 
@@ -191,7 +191,7 @@ namespace NuGetGallery
 
             var model = new StatisticsPackagesViewModel();
 
-            model.SetPackageVersionDownloadsByClient(id, version, report);
+            model.SetPackageVersionDownloadsByClient(id, version);
 
             model.UseD3 = UseD3();
 

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -174,7 +174,7 @@ namespace NuGetGallery
 
         public virtual async Task<JsonResult> PackageDownloadsByVersionReport(string id, string[] groupby)
         {
-            return Json(await GetPackageDownloadsByVersionReport(id, groupby));
+            return Json(await GetPackageDownloadsByVersionReport(id, groupby), JsonRequestBehavior.AllowGet);
         }
 
         //
@@ -210,7 +210,7 @@ namespace NuGetGallery
                 report.Id = MakeReportId(groupby);
             }
 
-            return Json(report);
+            return Json(report, JsonRequestBehavior.AllowGet);
         }
 
         private async Task<StatisticsPackagesReport> GetPackageDownloadsByVersionReport(string id, string[] groupby)

--- a/src/NuGetGallery/RouteNames.cs
+++ b/src/NuGetGallery/RouteNames.cs
@@ -47,7 +47,9 @@ namespace NuGetGallery
         public const string StatisticsPackages = "StatisticsPackages";
         public const string StatisticsPackageVersions = "StatisticsPackageVersions";
         public const string StatisticsPackageDownloadsByVersion = "StatisticsPackageDownloadsByVersion";
+        public const string StatisticsPackageDownloadsByVersionReport = "StatisticsPackageDownloadsByVersionReport";
         public const string StatisticsPackageDownloadsDetail = "StatisticsPackageDownloadsDetail";
+        public const string StatisticsPackageDownloadsDetailReport = "StatisticsPackageDownloadsDetailReport";
         public const string StatisticsDownloadsApi = "StatisticsDownloadsApi";
         public const string LegacyRegister = "LegacyRegister";
         public const string LegacyRegister2 = "LegacyRegister2";

--- a/src/NuGetGallery/Scripts/statsdimensions.js
+++ b/src/NuGetGallery/Scripts/statsdimensions.js
@@ -1,6 +1,5 @@
 ﻿var renderGraph = function (baseUrl, query, clickedId) {
     var renderGraphHandler = function (data) {
-        console.log(data);
         // Populate the data table
         ko.applyBindings({ report: data });
         // Render the graph using the data table

--- a/src/NuGetGallery/Scripts/statsdimensions.js
+++ b/src/NuGetGallery/Scripts/statsdimensions.js
@@ -1,5 +1,50 @@
-﻿var groupbyNavigation = function () {
-    $('.dimension-checkbox').click(function () {
-        $('#dimension-form').submit();
+﻿var renderGraph = function (baseUrl, query, clickedId) {
+    var renderGraphHandler = function (data) {
+        console.log(data);
+        // Populate the data table
+        ko.applyBindings({ report: data });
+        // Render the graph using the data table
+        packageDisplayGraphs();
+
+        // Add the click handler to the checkboxes
+        groupbyNavigation(baseUrl);
+        // Set the focus to the checkbox that initiated this request
+        if (clickedId) {
+            $('#' + clickedId).focus();
+        }
+    }
+
+    $.ajax({
+        url: baseUrl + query,
+        type: 'GET',
+        dataType: 'json',
+        success: renderGraphHandler,
+        error: function () {
+            renderGraphHandler(null);
+
+            $('#statistics-retry').click(function () {
+                renderGraph(baseUrl, query);
+            });
+        }
+    });
+}
+
+var groupbyNavigation = function (baseUrl) {
+    $('.dimension-checkbox').click(function (event) {
+        var clickedId = event.target.id;
+
+        var query = '';
+        $('.dimension-checkbox').each(function (index, element) {
+            if (element.checked) {
+                if (query) {
+                    query += '&';
+                } else {
+                    query = '?';
+                }
+                query += 'groupby=' + element.value;
+            }
+        });
+
+        renderGraph(baseUrl, query, clickedId);
     });
 }

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -40,8 +40,6 @@ namespace NuGetGallery
 
         public int NuGetClientVersionTotalDownloads { get; private set; }
 
-        public bool IsReportAvailable { get { return (Report != null); } }
-
         public string PackageId { get; private set; }
 
         public string PackageVersion { get; private set; }
@@ -50,7 +48,7 @@ namespace NuGetGallery
 
         public DateTime? LastUpdatedUtc
         {
-            get { return Report == null ? _lastUpdatedUtc : Report.LastUpdatedUtc; }
+            get { return _lastUpdatedUtc; }
             set { _lastUpdatedUtc = value; }
         }
 

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -28,8 +28,6 @@ namespace NuGetGallery
 
         public IEnumerable<StatisticsWeeklyUsageItem> Last6Weeks { get; set; }
 
-        public StatisticsPackagesReport Report { get; private set; }
-
         public bool IsDownloadPackageAvailable { get; set; }
 
         public bool IsDownloadPackageDetailAvailable { get; set; }
@@ -52,17 +50,15 @@ namespace NuGetGallery
             set { _lastUpdatedUtc = value; }
         }
 
-        public void SetPackageDownloadsByVersion(string packageId, StatisticsPackagesReport report)
+        public void SetPackageDownloadsByVersion(string packageId)
         {
             PackageId = packageId;
-            Report = report;
         }
 
-        public void SetPackageVersionDownloadsByClient(string packageId, string packageVersion, StatisticsPackagesReport report)
+        public void SetPackageVersionDownloadsByClient(string packageId, string packageVersion)
         {
             PackageId = packageId;
             PackageVersion = packageVersion;
-            Report = report;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "We want to be able to use this easily in the related view.")]

--- a/src/NuGetGallery/Views/Statistics/PackageDownloadsByVersion.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageDownloadsByVersion.cshtml
@@ -19,7 +19,7 @@
     <script>
         $(document)
             .ready(function () {
-                renderGraph('@Url.Action("PackageDownloadsByVersionReport", "Statistics")', location.search.toLowerCase());
+                renderGraph('@Url.Action("PackageDownloadsByVersionReport", "Statistics")', location.search);
             });
     </script>
 }

--- a/src/NuGetGallery/Views/Statistics/PackageDownloadsByVersion.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageDownloadsByVersion.cshtml
@@ -4,22 +4,12 @@
     ViewBag.Tab = "Statistics";
 }
 
-@if (Model.IsReportAvailable && Model.Report != null)
-{
-    <h1 class="statistics-report-title">Package Downloads for <a href="@Url.Package(Model.PackageId)">@Model.PackageId</a> (@Model.Report.Total over the Last 6 Weeks)</h1>
-    @Html.Partial("_LastUpdated", Model)
-    @Html.Partial("_PivotTable", Model.Report)
-}
-else
-{
-    <h1 class="statistics-report-title">Package Downloads for <a href="@Url.Package(Model.PackageId)">@Model.PackageId</a></h1>
-    <p>
-        Download statistics are not currently available for this package, please check back later. 
-    </p>
-}
+@Html.Partial("_PivotTable")
 
 @section BottomScripts
 {
+    <script src="@Url.Content("~/Scripts/knockout-2.2.1.js")"></script>
+    <script src="@Url.Content("~/Scripts/moment.js")"></script>
     @if (Model.UseD3)
     {
         @Scripts.Render("~/Scripts/d3.v3.min.js")
@@ -29,22 +19,7 @@ else
     <script>
         $(document)
             .ready(function () {
-                groupbyNavigation();
-                packageDisplayGraphs();
-
-                @if (Model.IsReportAvailable)
-                {
-                    <text>
-                if ($('.dimension-checkbox:checked').length == 0) {
-                    var search = location.search.toLowerCase();
-                    if (search.indexOf('groupby=@Constants.StatisticsDimensions.ClientName.ToLowerInvariant()') >= 0 ||
-                        search.indexOf('groupby=@Constants.StatisticsDimensions.ClientVersion.ToLowerInvariant()') >= 0 ||
-                        search.indexOf('groupby=@Constants.StatisticsDimensions.Operation.ToLowerInvariant()') >= 0) {
-                        location.reload();
-                    }
-                }
-                </text>
-                }
+                renderGraph('@Url.Action("PackageDownloadsByVersionReport", "Statistics")', location.search.toLowerCase());
             });
     </script>
 }

--- a/src/NuGetGallery/Views/Statistics/PackageDownloadsDetail.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageDownloadsDetail.cshtml
@@ -4,22 +4,12 @@
     ViewBag.Tab = "Statistics";
 }
 
-@if (Model.IsReportAvailable)
-{
-    <h1 class="statistics-report-title">Package Downloads for <a href="@Url.Package(Model.PackageId, Model.PackageVersion)">@Model.PackageId @Model.PackageVersion</a> (@Model.Report.Total over the Last 6 Weeks)</h1>
-    @Html.Partial("_LastUpdated", Model)
-    @Html.Partial("_PivotTable", Model.Report)
-}
-else
-{
-    <h1 class="statistics-report-title">Package Downloads for <a href="@Url.Package(Model.PackageId, Model.PackageVersion)">@Model.PackageId @Model.PackageVersion</a></h1>
-    <p>
-        Download statistics are not currently available for this package, please check back later.
-    </p>
-}
+@Html.Partial("_PivotTable")
 
 @section BottomScripts
 {
+    <script src="@Url.Content("~/Scripts/knockout-2.2.1.js")"></script>
+    <script src="@Url.Content("~/Scripts/moment.js")"></script>
     @if (Model.UseD3)
     {
         @Scripts.Render("~/Scripts/d3.v3.min.js")
@@ -28,24 +18,8 @@ else
     @Scripts.Render("~/Scripts/perpackagestatsgraphs.js")
     <script>
         $(document)
-            .ready(function() {
-                groupbyNavigation();
-                packageDisplayGraphs();
-
-                @if (Model.IsReportAvailable)
-                {
-                    <text>
-                        if ($('.dimension-checkbox:checked').length == 0) {
-                            var search = location.search.toLowerCase();
-                            if (search.indexOf('groupby=@Constants.StatisticsDimensions.Version.ToLowerInvariant()') >= 0 ||
-                                search.indexOf('groupby=@Constants.StatisticsDimensions.ClientName.ToLowerInvariant()') >= 0 ||
-                                search.indexOf('groupby=@Constants.StatisticsDimensions.ClientVersion.ToLowerInvariant()') >= 0 ||
-                                search.indexOf('groupby=@Constants.StatisticsDimensions.Operation.ToLowerInvariant()') >= 0) {
-                                location.reload();
-                            }
-                        }
-                    </text>
-                }
+            .ready(function () {
+                renderGraph('@Url.Action("PackageDownloadsDetailReport", "Statistics")', location.search.toLowerCase());
             });
     </script>
 }

--- a/src/NuGetGallery/Views/Statistics/PackageDownloadsDetail.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageDownloadsDetail.cshtml
@@ -19,7 +19,7 @@
     <script>
         $(document)
             .ready(function () {
-                renderGraph('@Url.Action("PackageDownloadsDetailReport", "Statistics")', location.search.toLowerCase());
+                renderGraph('@Url.Action("PackageDownloadsDetailReport", "Statistics")', location.search);
             });
     </script>
 }

--- a/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
+++ b/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
@@ -1,93 +1,81 @@
-﻿<div class="statistics-pivot" id="@Model.Id">
+﻿@model StatisticsPackagesViewModel
 
-    <div class="statistics-graph" id="statistics-graph-id"></div>
-    <div style="clear: both;"></div>
+<div data-bind="template: { name: 'report-template', data: report }"></div>
 
-    <div class="statistics-sidebar">
+<script type="text/html" id="report-template">
+    <h1 class="statistics-report-title">
+        Package Downloads for <a href="@Url.Package(Model.PackageId)">@Model.PackageId</a>
+        <!-- ko if: $data && Total -->
+            <span data-bind="text: '(' + Total + ' over the Last 6 Weeks)'"></span>
+        <!-- /ko -->
+    </h1>
 
-        <form id="dimension-form">
-            <table class="statistics-dimensions-table">
-                @foreach (var item in Model.Dimensions)
-                {
-                    <tr>
-                        <td>
-                            <label for="checkbox-@item.Value">@item.DisplayName</label>
-                        </td>
-                        <td>
-                            <input id="checkbox-@item.Value" class="dimension-checkbox" name="groupby" value="@item.Value" type="checkbox" checked="@item.IsChecked">
-                        </td>
-                    </tr>
-                }
-            </table>
-        </form>
-
+    <div data-bind="if: $data && LastUpdatedUtc" class="last-updated">
+        <span data-bind="text: 'Statistics last updated at ' + moment(LastUpdatedUtc).format('YYYY-MM-dd HH:mm:ss') + ' UTC.'"></span>
     </div>
 
-    <div class="statistics-data">
+    <div data-bind="if: $data">
+        <div data-bind="attr: { id: Id }" class="statistics-pivot">
 
-        @if (Model.Table != null)
-        {
-            <table class="pivot-table">
-                <thead>
-                    <tr>
-                        @foreach (var column in Model.Columns)
-                        {
-                            var id = column + "-column";
+            <div class="statistics-graph" id="statistics-graph-id"></div>
+            <div style="clear: both;"></div>
 
-                            <th scope="col" class="dimension-column">@column</th>
-                        }
-                        <th scope="col">Downloads</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @{
-                        foreach (var row in Model.Table)
-                        {
-                            <tr>
+            <div class="statistics-sidebar">
 
-                                @foreach (var entry in row)
-                                {
-                                    if (entry != null)
-                                    {
-                                        var entryClass = entry.IsNumeric ? "statistics-number" : "";
+                <form id="dimension-form">
+                    <table data-bind="foreach: Dimensions" class="statistics-dimensions-table">
+                        <tr>
+                            <td>
+                                <label data-bind="attr: { for: 'checkbox-' + Value }, text: DisplayName" />
+                            </td>
+                            <td>
+                                <input data-bind="attr: { id: 'checkbox-' + Value, value: Value, checked: IsChecked }" class="dimension-checkbox" name="groupby" type="checkbox">
+                            </td>
+                        </tr>
+                    </table>
+                </form>
 
-                                        if (entry.Rowspan > 1)
-                                        {
-                                            <td class="@entryClass" rowspan="@entry.Rowspan" style="vertical-align:top">
-                                                @if (entry.Uri == null)
-                                                {
-                                                    @entry.Data
-                                                }
-                                                else
-                                                {
-                                                    <a href="@entry.Uri">@entry.Data</a>
-                                                }
-                                            </td>
-                                        }
-                                        else
-                                        {
-                                            <td class="@entryClass">
-                                                @if (entry.Uri == null)
-                                                {
-                                                    @entry.Data
-                                                }
-                                                else
-                                                {
-                                                    <a href="@entry.Uri">@entry.Data</a>
-                                                }
-                                            </td>
-                                        }
-                                    }
-                                }
+            </div>
 
-                            </tr>
-                        }
-                    }
-                </tbody>
-            </table>
-                        }
+            <div class="statistics-data">
 
+                <table data-bind="if: Table" class="pivot-table">
+                    <thead>
+                        <tr>
+                            <!-- ko foreach: Columns -->
+                                <th data-bind="attr: { id: $data + '-column' }, text: $data" scope="col" class="dimension-column"></th>
+                            <!-- /ko -->
+                            <th scope="col">Downloads</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: Table">
+                        <tr>
+
+                            <!-- ko foreach: $data -->
+                                <!-- ko if: $data -->
+                                    <td data-bind="attr: { class: IsNumeric ? 'statistics-number' : '', rowspan: Rowspan > 1 ? Rowspan : null }" style="vertical-align:top">
+                                        <!-- ko if: Uri -->
+                                            <a data-bind="attr: { href: Uri }, text: Data"></a>
+                                        <!-- /ko -->
+                                        <!-- ko ifnot: Uri -->
+                                            <span data-bind="text: Data"></span>
+                                        <!-- /ko -->
+                                    </td>
+                                <!-- /ko -->
+                            <!-- /ko -->
+
+                        </tr>
+
+                    </tbody>
+                </table>
+
+            </div>
+            <div style="clear: both;"></div>
+
+        </div>
     </div>
-    <div style="clear: both;"></div>
 
-</div>
+    <p data-bind="ifnot: $data">
+        Download statistics are not currently available for this package. Please <a href="#" id="statistics-retry">retry</a> or check back later.
+    </p>
+</script>

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -342,6 +342,22 @@ namespace NuGetGallery
         }
 
         [Fact]
+        public async void StatisticsHomePage_Per_Package_ValidateModel()
+        {
+            string PackageId = "A";
+
+            var fakeReportService = new Mock<IReportService>();
+
+            var controller = new StatisticsController(new JsonStatisticsService(fakeReportService.Object));
+
+            TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
+
+            var model = (StatisticsPackagesViewModel)((ViewResult)await controller.PackageDownloadsByVersion(PackageId, new[] { Constants.StatisticsDimensions.Version })).Model;
+
+            Assert.Equal(PackageId, model.PackageId);
+        }
+
+        [Fact]
         public async void StatisticsHomePage_Per_Package_ValidateReportStructureAndAvailability()
         {
             string PackageId = "A";
@@ -408,7 +424,7 @@ namespace NuGetGallery
 
             TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
 
-            var actualReport = (StatisticsPackagesReport)(await controller.PackageDownloadsByVersionReport(PackageId, new[] { Constants.StatisticsDimensions.Version })).Data;
+            var actualReport = (StatisticsPackagesReport)((JsonResult)await controller.PackageDownloadsByVersionReport(PackageId, new[] { Constants.StatisticsDimensions.Version })).Data;
 
             int sum = 0;
 
@@ -492,7 +508,7 @@ namespace NuGetGallery
 
             var invalidDimension = "this_dimension_does_not_exist";
             
-            var actualReport = (StatisticsPackagesReport)(await controller.PackageDownloadsByVersionReport(PackageId, new[] { Constants.StatisticsDimensions.Version, invalidDimension })).Data;
+            var actualReport = (StatisticsPackagesReport)((JsonResult)await controller.PackageDownloadsByVersionReport(PackageId, new[] { Constants.StatisticsDimensions.Version, invalidDimension })).Data;
 
             int sum = 0;
 
@@ -506,6 +522,24 @@ namespace NuGetGallery
             Assert.True(actualReport.LastUpdatedUtc.HasValue);
             Assert.Equal(updatedUtc, actualReport.LastUpdatedUtc.Value);
             Assert.DoesNotContain(invalidDimension, actualReport.Columns);
+        }
+
+        [Fact]
+        public async void Statistics_By_Client_Operation_ValidateModel()
+        {
+            string PackageId = "A";
+            string PackageVersion = "2.0";
+
+            var fakeReportService = new Mock<IReportService>();
+
+            var controller = new StatisticsController(new JsonStatisticsService(fakeReportService.Object));
+
+            TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
+            
+            var model = (StatisticsPackagesViewModel)((ViewResult)await controller.PackageDownloadsDetail(PackageId, PackageVersion, new string[] { "ClientName" })).Model;
+
+            Assert.Equal(PackageId, model.PackageId);
+            Assert.Equal(PackageVersion, model.PackageVersion);
         }
 
         [Fact]
@@ -576,7 +610,7 @@ namespace NuGetGallery
 
             TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
             
-            var actualReport = (StatisticsPackagesReport)(await controller.PackageDownloadsDetailReport(PackageId, PackageVersion, new string[] { "ClientName" })).Data;
+            var actualReport = (StatisticsPackagesReport)((JsonResult)await controller.PackageDownloadsDetailReport(PackageId, PackageVersion, new string[] { "ClientName" })).Data;
 
             int sum = 0;
 

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -12,6 +12,7 @@ using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 using Moq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -407,19 +408,19 @@ namespace NuGetGallery
 
             TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
 
-            var model = (StatisticsPackagesViewModel)((ViewResult)await controller.PackageDownloadsByVersion(PackageId, new[] { Constants.StatisticsDimensions.Version })).Model;
+            var actualReport = (StatisticsPackagesReport)(await controller.PackageDownloadsByVersionReport(PackageId, new[] { Constants.StatisticsDimensions.Version })).Data;
 
             int sum = 0;
 
-            foreach (var row in model.Report.Table)
+            foreach (var row in actualReport.Table)
             {
                 sum += int.Parse(row[row.GetLength(0) - 1].Data);
             }
 
             Assert.Equal(603, sum);
-            Assert.Equal("603", model.Report.Total);
-            Assert.True(model.LastUpdatedUtc.HasValue);
-            Assert.Equal(updatedUtc, model.LastUpdatedUtc.Value);
+            Assert.Equal("603", actualReport.Total);
+            Assert.True(actualReport.LastUpdatedUtc.HasValue);
+            Assert.Equal(updatedUtc, actualReport.LastUpdatedUtc.Value);
         }
 
         [Fact]
@@ -490,21 +491,21 @@ namespace NuGetGallery
             TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
 
             var invalidDimension = "this_dimension_does_not_exist";
-
-            var model = (StatisticsPackagesViewModel)((ViewResult)await controller.PackageDownloadsByVersion(PackageId, new[] { Constants.StatisticsDimensions.Version, invalidDimension })).Model;
+            
+            var actualReport = (StatisticsPackagesReport)(await controller.PackageDownloadsByVersionReport(PackageId, new[] { Constants.StatisticsDimensions.Version, invalidDimension })).Data;
 
             int sum = 0;
 
-            foreach (var row in model.Report.Table)
+            foreach (var row in actualReport.Table)
             {
                 sum += int.Parse(row[row.GetLength(0) - 1].Data);
             }
 
             Assert.Equal(603, sum);
-            Assert.Equal("603", model.Report.Total);
-            Assert.True(model.LastUpdatedUtc.HasValue);
-            Assert.Equal(updatedUtc, model.LastUpdatedUtc.Value);
-            Assert.DoesNotContain(invalidDimension, model.Report.Columns);
+            Assert.Equal("603", actualReport.Total);
+            Assert.True(actualReport.LastUpdatedUtc.HasValue);
+            Assert.Equal(updatedUtc, actualReport.LastUpdatedUtc.Value);
+            Assert.DoesNotContain(invalidDimension, actualReport.Columns);
         }
 
         [Fact]
@@ -574,20 +575,20 @@ namespace NuGetGallery
             var controller = new StatisticsController(new JsonStatisticsService(fakeReportService.Object));
 
             TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
-
-            var model = (StatisticsPackagesViewModel)((ViewResult)await controller.PackageDownloadsDetail(PackageId, PackageVersion, new string[] { "ClientName" })).Model;
+            
+            var actualReport = (StatisticsPackagesReport)(await controller.PackageDownloadsDetailReport(PackageId, PackageVersion, new string[] { "ClientName" })).Data;
 
             int sum = 0;
 
-            foreach (var row in model.Report.Table)
+            foreach (var row in actualReport.Table)
             {
                 sum += int.Parse(row[row.GetLength(0) - 1].Data);
             }
 
             Assert.Equal(502, sum);
-            Assert.Equal("502", model.Report.Total);
-            Assert.True(model.LastUpdatedUtc.HasValue);
-            Assert.Equal(updatedUtc, model.LastUpdatedUtc.Value);
+            Assert.Equal("502", actualReport.Total);
+            Assert.True(actualReport.LastUpdatedUtc.HasValue);
+            Assert.Equal(updatedUtc, actualReport.LastUpdatedUtc.Value);
         }
 
         public class TheTotalsAllAction


### PR DESCRIPTION
This is an accessibility fix that has developed into a user experience improvement in general.

Previously, the [PackageDownloadsDetail](https://www.nuget.org/stats/packages/newtonsoft.json/10.0.1) and [PackageDownloadsByVersion](https://www.nuget.org/stats/packages/newtonsoft.json) pages would refresh every time the selected dimensions were changed. This was obviously bad for accessibility, as the focus would be lost every time the page refreshed, which disorients users.

I have fixed this.

- Previously, the logic to inflate the table of information used by the browser was done in CSHTML, which is created server side. This logic is now done in JS using knockout (see `_PivotTable.cshtml`). We already had knockout in our project so I used the existing version.

- Added a route that returns the statistics report in JSON.

- Clicking upon a checkbox now makes an AJAX call that, on success, reinflates the information table using the statistics report in JSON. On error, it shows a message that asks the user if they would like to try again, which can be clicked to retry the AJAX call.

Tested on all the major browsers (`Firefox`, `Chrome`, `Edge`).