### PR TITLE
Detect if package only differ by metadata and show optimal user-facing error message

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -282,13 +282,35 @@ namespace NuGetGallery
                     return View();
                 }
 
-                var package = _packageService.FindPackageByIdAndVersionStrict(nuspec.GetId(), nuspec.GetVersion().ToStringSafe());
-                if (package != null)
+                var nuspecVersion = nuspec.GetVersion();
+                var existingPackage = _packageService.FindPackageByIdAndVersionStrict(nuspec.GetId(), nuspecVersion.ToStringSafe());
+                if (existingPackage != null)
                 {
-                    ModelState.AddModelError(
-                        string.Empty,
-                        string.Format(
-                            CultureInfo.CurrentCulture, Strings.PackageExistsAndCannotBeModified, package.PackageRegistration.Id, package.Version));
+                    // Determine if the package versions only differ by metadata, 
+                    // and provide the most optimal the user-facing error message.
+                    var existingPackageVersion = new NuGetVersion(existingPackage.Version);
+                    if ((existingPackageVersion.HasMetadata || nuspecVersion.HasMetadata) 
+                        && !string.Equals(existingPackageVersion.Metadata, nuspecVersion.Metadata))
+                    {
+                        ModelState.AddModelError(
+                            string.Empty,
+                            string.Format(
+                                CultureInfo.CurrentCulture, 
+                                Strings.PackageVersionDiffersOnlyByMetadataAndCannotBeModified, 
+                                existingPackage.PackageRegistration.Id, 
+                                existingPackage.Version));
+                    }
+                    else
+                    {
+                        ModelState.AddModelError(
+                            string.Empty,
+                            string.Format(
+                                CultureInfo.CurrentCulture, 
+                                Strings.PackageExistsAndCannotBeModified, 
+                                existingPackage.PackageRegistration.Id, 
+                                existingPackage.Version));
+                    }
+
                     return View();
                 }
 

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -650,6 +650,15 @@ namespace NuGetGallery {
         public static string PackageIsMissingRequiredData {
             get {
                 return ResourceManager.GetString("PackageIsMissingRequiredData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package versions that differ only by metadata cannot be uploaded. A package with ID &apos;{0}&apos; and version &apos;{1}&apos; already exists and cannot be modified..
+        /// </summary>
+        public static string PackageVersionDiffersOnlyByMetadataAndCannotBeModified {
+            get {
+                return ResourceManager.GetString("PackageVersionDiffersOnlyByMetadataAndCannotBeModified", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -443,4 +443,7 @@ The {1} Team</value>
   <data name="SecurityPolicy_RequireMinClientVersionForPush" xml:space="preserve">
     <value>Your account requires client version '{0}' or higher to be able to push packages. Please contact support@nuget.org to get more details.</value>
   </data>
+  <data name="PackageVersionDiffersOnlyByMetadataAndCannotBeModified" xml:space="preserve">
+    <value>Package versions that differ only by metadata cannot be uploaded. A package with ID '{0}' and version '{1}' already exists and cannot be modified.</value>
+  </data>
 </root>

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1094,7 +1094,7 @@ namespace NuGetGallery
                 fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
                 var fakePackageService = new Mock<IPackageService>();
                 fakePackageService.Setup(x => x.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>())).Returns(
-                    new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" });
+                    new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "1.0.0" });
                 var controller = CreateController(
                     packageService: fakePackageService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
@@ -1104,7 +1104,30 @@ namespace NuGetGallery
                 Assert.NotNull(result);
                 Assert.False(controller.ModelState.IsValid);
                 Assert.Equal(
-                    String.Format(Strings.PackageExistsAndCannotBeModified, "theId", "theVersion"),
+                    String.Format(Strings.PackageExistsAndCannotBeModified, "theId", "1.0.0"),
+                    controller.ModelState[String.Empty].Errors[0].ErrorMessage);
+            }
+
+            [Fact]
+            public async Task WillShowTheViewWithErrorsWhenThePackageAlreadyExistsAndOnlyDiffersByMetadata()
+            {
+                var fakeUploadedFile = new Mock<HttpPostedFileBase>();
+                fakeUploadedFile.Setup(x => x.FileName).Returns("theFile.nupkg");
+                var fakeFileStream = TestPackage.CreateTestPackageStream("theId", "1.0.0+metadata2");
+                fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
+                var fakePackageService = new Mock<IPackageService>();
+                fakePackageService.Setup(x => x.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>())).Returns(
+                    new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "1.0.0+metadata" });
+                var controller = CreateController(
+                    packageService: fakePackageService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var result = await controller.UploadPackage(fakeUploadedFile.Object) as ViewResult;
+
+                Assert.NotNull(result);
+                Assert.False(controller.ModelState.IsValid);
+                Assert.Equal(
+                    String.Format(Strings.PackageVersionDiffersOnlyByMetadataAndCannotBeModified, "theId", "1.0.0+metadata"),
                     controller.ModelState[String.Empty].Errors[0].ErrorMessage);
             }
 


### PR DESCRIPTION
When an exact package id and version (including metadata) match is detected during package upload, we still show the current error message.

However, when we detect that the newly uploaded package version only differs by metadata with an existing package version, we'll enhance the message and clarify.

![image](https://cloud.githubusercontent.com/assets/880728/26106199/6c4ce67a-3a45-11e7-8c9d-5565b9700373.png)

Fixes #3910