### PR TITLE
fix for issue 3828: Link to "master" in the footer points to a 410 page on GitHub

### DIFF
--- a/src/NuGetGallery/Infrastructure/ApplicationVersionHelper.cs
+++ b/src/NuGetGallery/Infrastructure/ApplicationVersionHelper.cs
@@ -48,7 +48,7 @@ namespace NuGetGallery
 
             if (repositoryBase != null)
             {
-                BranchUri = CombineUri(repositoryBase, "branches/" + branch);
+                BranchUri = CombineUri(repositoryBase, "tree/" + branch);
                 CommitUri = CombineUri(repositoryBase, "commit/" + ShortCommit);
             }
         }


### PR DESCRIPTION
Link to "master" in the footer points to a 410 page on GitHub: https://github.com/NuGet/NuGetGallery/issues/3828

