### PR TITLE
Avoid separate context from policy service

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -203,8 +203,9 @@ namespace NuGetGallery
                 .InstancePerLifetimeScope();
 
             builder.RegisterType<SecurityPolicyService>()
+                .AsSelf()
                 .As<ISecurityPolicyService>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
 
             builder.RegisterType<SecurePushSubscription>()
                 .SingleInstance();


### PR DESCRIPTION
Issue found in DEV: SecurityPolicyService.SubscribeAsync adds user policies but EF wasn't saving the changes to the DB. The issue is that the controller and service have different EF contexts, resulting in a user from the controller being in a detached state when it reaches the policy service.

Changing back to InstancePerLifetimeScope results in the same EF context instance.