### PR TITLE
Update Report Abuse Page

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -555,7 +555,13 @@ namespace NuGetGallery
             // Html Encode the message
             reportForm.Message = System.Web.HttpUtility.HtmlEncode(reportForm.Message);
 
-            if (!ModelState.IsValid)
+            var modelIsValid = ModelState.IsValid;
+            if (reportForm.Reason == ReportPackageReason.ViolatesALicenseIOwn)
+            {
+                modelIsValid = modelIsValid && !string.IsNullOrEmpty(reportForm.Signature);
+            }
+
+            if (!modelIsValid)
             {
                 return ReportAbuse(id, version);
             }

--- a/src/NuGetGallery/ViewModels/ReportAbuseViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ReportAbuseViewModel.cs
@@ -40,7 +40,6 @@ namespace NuGetGallery
             ErrorMessage = "This doesn't appear to be a valid email address.")]
         public string Email { get; set; }
 
-        [Required(ErrorMessage = "Please sign using your name.")]
         [StringLength(1000)]
         [Display(Name = "Signature")]
         public string Signature { get; set; }

--- a/src/NuGetGallery/ViewModels/ReportPackageReason.cs
+++ b/src/NuGetGallery/ViewModels/ReportPackageReason.cs
@@ -16,7 +16,7 @@ namespace NuGetGallery
         [Description("The package contains malicious code")]
         ContainsMaliciousCode,
 
-        [Description("The package violates a license I own")]
+        [Description("The package violates a copyright I own")]
         ViolatesALicenseIOwn,
 
         [Description("The package owner is fraudulently claiming authorship")]

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -88,7 +88,7 @@
             <span class="field-hint-message">Sign with your real name.</span>
             @Html.ValidationMessageFor(m => m.Signature)
         </div>
-        <div class="infringement-claim-requirements">You can also send us an email at <a href="mailto:admn@nuget.org">admin@nuget.org</a></div>
+        <div class="infringement-claim-requirements">You can also send us an email at <a href="mailto:admin@nuget.org">admin@nuget.org</a></div>
         <img src="@Url.Content("~/Content/images/required.png")" alt="Blue border on left means required." />
         @Html.SpamPreventionFields()
         <input id="form-submit" type="submit" value="Report" title="Report '@Model.PackageId' for abuse" />

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -69,7 +69,7 @@
             @Html.CheckBoxFor(m => m.CopySender)
             @Html.LabelFor(m => m.CopySender, new { @class = "checkbox" })
         </div>
-        <div class="form-field">
+        <div id="infringement-claim-requirements" class="form-field">
             <br /><span style="color: red">*</span> Required Statements for infringement claims<br /><br />
             <strong>Good Faith Belief:</strong><br />
             <p>
@@ -108,6 +108,12 @@
                 $form.find("input, textarea, select").not('#form-field-reason *').attr('disabled', 'disabled');
             } else {
                 $form.find("input, textarea, select").not('#form-field-reason').removeAttr('disabled');
+            }
+
+            if (val == 'ViolatesALicenseIOwn') {
+                $form.find('#infringement-claim-requirements').show();
+            } else {
+                $form.find('#infringement-claim-requirements').hide();
             }
         }
 

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -69,7 +69,7 @@
             @Html.CheckBoxFor(m => m.CopySender)
             @Html.LabelFor(m => m.CopySender, new { @class = "checkbox" })
         </div>
-        <div id="infringement-claim-requirements" class="form-field">
+        <div class="form-field infringement-claim-requirements">
             <br /><span style="color: red">*</span> Required Statements for infringement claims<br /><br />
             <strong>Good Faith Belief:</strong><br />
             <p>
@@ -88,6 +88,7 @@
             <span class="field-hint-message">Sign with your real name.</span>
             @Html.ValidationMessageFor(m => m.Signature)
         </div>
+        <div class="infringement-claim-requirements">You can also send us an email at <a href="mailto:admn@nuget.org">admin@nuget.org</a></div>
         <img src="@Url.Content("~/Content/images/required.png")" alt="Blue border on left means required." />
         @Html.SpamPreventionFields()
         <input id="form-submit" type="submit" value="Report" title="Report '@Model.PackageId' for abuse" />
@@ -111,7 +112,7 @@
             }
 
             if (val == 'ViolatesALicenseIOwn') {
-                $form.find('#infringement-claim-requirements').show();
+                $form.find('.infringement-claim-requirements').show();
                 $('#Signature').rules("add", {
                     required: true,
                     maxlength: 1000,
@@ -119,9 +120,10 @@
                         required: "Please sign using your name."
                     }
                 });
+                $('#Signature').attr('data-val-required', 'Please sign using your name.');
             } else {
-                $form.find('#infringement-claim-requirements').hide();
-                $('#Signature').rules("remove", "required");
+                $form.find('.infringement-claim-requirements').hide();
+                $('#Signature').rules('remove', 'required');
             }
         }
 

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -112,8 +112,16 @@
 
             if (val == 'ViolatesALicenseIOwn') {
                 $form.find('#infringement-claim-requirements').show();
+                $('#Signature').rules("add", {
+                    required: true,
+                    maxlength: 1000,
+                    messages: {
+                        required: "Please sign using your name."
+                    }
+                });
             } else {
                 $form.find('#infringement-claim-requirements').hide();
+                $('#Signature').rules("remove", "required");
             }
         }
 


### PR DESCRIPTION
This PR updates the report abuse page with the following:
1. Hides the block that only pertains to copyright claims when the report reason is not copyrighting.
2. Moves validation of Signature to controller from model.
3. Updates option to read "copyright" instead of "license"
4. Adds a small blurb about contact via an email address.

See https://github.com/NuGet/NuGetGallery/issues/3792 for more information.

@karann-msft @xavierdecoster @skofman1 