### PR TITLE
Removing the "WITH(ONLINE=ON)" from the index creation as per #3952

### DIFF
--- a/src/NuGetGallery/Migrations/201705031714183_AddIndexSemVerLevelKey.cs
+++ b/src/NuGetGallery/Migrations/201705031714183_AddIndexSemVerLevelKey.cs
@@ -7,7 +7,7 @@ namespace NuGetGallery.Migrations
     {
         public override void Up()
         {
-            Sql("IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'nci_wi_Packages_SemVerLevelKey' AND object_id = OBJECT_ID('Packages')) CREATE NONCLUSTERED INDEX [nci_wi_Packages_SemVerLevelKey] ON [dbo].[Packages] ([SemVerLevelKey], [IsLatest], [Deleted]) INCLUDE ([PackageRegistrationKey]) WITH (ONLINE = ON)");
+            Sql("IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'nci_wi_Packages_SemVerLevelKey' AND object_id = OBJECT_ID('Packages')) CREATE NONCLUSTERED INDEX [nci_wi_Packages_SemVerLevelKey] ON [dbo].[Packages] ([SemVerLevelKey], [IsLatest], [Deleted]) INCLUDE ([PackageRegistrationKey])");
         }
         
         public override void Down()


### PR DESCRIPTION
Now, the change is deployed, removing the non-SQL express friendly bits. 