### PR TITLE
Version validation should happen on the full string

### DIFF
--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -760,7 +760,7 @@ namespace NuGetGallery
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Title", "256");
             }
 
-            if (packageMetadata.Version != null && packageMetadata.Version.ToString().Length > 64)
+            if (packageMetadata.Version != null && packageMetadata.Version.ToFullString().Length > 64)
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Version", "64");
             }


### PR DESCRIPTION
Fixes #3916

The code was relying on `NuGetVersion.ToString` implementation instead of `NuGetVersion.ToFullString`.