### PR TITLE
Fix the date format on stats page

### DIFF
--- a/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
+++ b/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
@@ -11,7 +11,7 @@
     </h1>
 
     <div data-bind="if: $data && LastUpdatedUtc" class="last-updated">
-        <span data-bind="text: 'Statistics last updated at ' + moment(LastUpdatedUtc).format('YYYY-MM-dd HH:mm:ss') + ' UTC.'"></span>
+        <span data-bind="text: 'Statistics last updated at ' + moment(LastUpdatedUtc).format('YYYY-MM-DD HH:mm:ss') + ' UTC.'"></span>
     </div>
 
     <div data-bind="if: $data">


### PR DESCRIPTION
A quick fix for the date format on stats page. Fixes https://github.com/NuGet/NuGetGallery/issues/4053

![image](https://cloud.githubusercontent.com/assets/1646506/26803544/7a193c36-49f9-11e7-9678-45c0c37f7d53.png)
