### PR TITLE
[ReleasePrep][2017.06.13] RI of dev into master

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -210,6 +210,9 @@ namespace NuGetGallery
             builder.RegisterType<SecurePushSubscription>()
                 .SingleInstance();
 
+            builder.RegisterType<RequireSecurePushForCoOwnersPolicy>()
+                .SingleInstance();
+
             var mailSenderThunk = new Lazy<IMailSender>(
                 () =>
                 {

--- a/src/NuGetGallery/Areas/Admin/Controllers/SecurityPolicyController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/SecurityPolicyController.cs
@@ -48,7 +48,9 @@ namespace NuGetGallery.Areas.Admin.Controllers
         {
             // Parse query and look for users in the DB.
             var usernames = GetUsernamesFromQuery(query ?? "");
-            var users = FindUsers(usernames);
+            var users = EntitiesContext.Users
+                .Where(u => usernames.Any(name => u.Username == name))
+                .ToList();
             var usersNotFound = usernames.Except(users.Select(u => u.Username));
 
             var results = new UserSecurityPolicySearchResult()
@@ -69,40 +71,49 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpPost]
-        [ValidateAntiForgeryToken]
-        public async Task<ActionResult> Update(SecurityPolicyViewModel viewModel)
+        public async Task<JsonResult> Update(List<string> subscriptionsJson)
         {
-            // Policy subscription requests by user.
-            var subscriptions = viewModel.UserSubscriptions?
-                .Select(json => JsonConvert.DeserializeObject<JObject>(json))
+            var subscribeRequests =  subscriptionsJson?.Select(JsonConvert.DeserializeObject<JObject>)
+                .Where(obj => obj["v"].ToObject<bool>())
                 .GroupBy(obj => obj["u"].ToString())
                 .ToDictionary(
-                    g => g.Key,
-                    g => g.Select(obj => obj["g"].ToString())
+                    g => g.Key, // username
+                    g => g.Select(obj => obj["g"].ToString()) // subscriptions
+                );
+            
+            var unsubscribeRequests = subscriptionsJson?.Select(JsonConvert.DeserializeObject<JObject>)
+                .Where(obj => !obj["v"].ToObject<bool>())
+                .GroupBy(obj => obj["u"].ToString())
+                .ToDictionary(
+                    g => g.Key, // username
+                    g => g.Select(obj => obj["g"].ToString()) // subscriptions
                 );
 
-            // Iterate all users and groups to handle both subscribe and unsubscribe.
-            var usernames = GetUsernamesFromQuery(viewModel.UsersQuery);
-            var users = FindUsers(usernames);
-            foreach (var user in users)
+            foreach (var r in subscribeRequests)
             {
-                foreach (var subscription in PolicyService.UserSubscriptions)
+                var user = EntitiesContext.Users.FirstOrDefault(u => u.Username == r.Key);
+                if (user != null)
                 {
-                    var userKeyExists = subscriptions?.ContainsKey(user.Username) ?? false;
-                    if (userKeyExists && subscriptions[user.Username].Contains(subscription.SubscriptionName))
+                    foreach (var subscription in r.Value)
                     {
                         await PolicyService.SubscribeAsync(user, subscription);
                     }
-                    else
+                }
+            }
+
+            foreach (var r in unsubscribeRequests)
+            {
+                var user = EntitiesContext.Users.FirstOrDefault(u => u.Username == r.Key);
+                if (user != null)
+                {
+                    foreach (var subscription in r.Value)
                     {
                         await PolicyService.UnsubscribeAsync(user, subscription);
                     }
                 }
             }
 
-            TempData["Message"] = $"Updated policies for {users.Count()} users.";
-
-            return RedirectToAction("Index");
+            return Json(new { success = true });
         }
 
         private static string[] GetUsernamesFromQuery(string query)
@@ -110,13 +121,6 @@ namespace NuGetGallery.Areas.Admin.Controllers
             return query.Split(',', '\r', '\n')
                 .Select(username => username.Trim())
                 .Where(username => !string.IsNullOrEmpty(username)).ToArray();
-        }
-
-        private IEnumerable<User> FindUsers(string[] usernames)
-        {
-            return EntitiesContext.Users
-                .Where(u => usernames.Any(name => u.Username.Equals(name, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
         }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/Views/SecurityPolicy/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SecurityPolicy/Index.cshtml
@@ -6,62 +6,62 @@
 
 <section>
     <article id="stage">
+
+        <div class="message" style="display: none" data-bind="text: message, visible: message"></div>
+
         <h2>User Security Policies</h2>
 
         <form>
             <textarea placeholder="Search for usernames (comma-separated)" autocomplete="off" autofocus style="width: 100%;" rows="5" data-bind="value: searchQuery"></textarea><br />
-            <input type="button" value="Search" data-bind="click: search" />
+            <input type="button" value="Search" title="Search" data-bind="click: search" />
         </form><br />
 
-        @using (Html.BeginForm("Update", "SecurityPolicy", new { area = "Admin" }, FormMethod.Post, new { id = "delete-form" }))
-        {
             <div data-bind="visible: searchResults().length > 0">
-                <input type="hidden" name="UsersQuery" data-bind="value: searchQuery" />
-
+                
                 <div class="message warning" style="display: none;" data-bind="visible: searchNotFoundResults().length > 0">
                     <strong>The following users were not found:</strong><br />
                     <span data-bind="text: searchNotFoundResults().join(',')"></span>
                 </div>
+                
+                @using (Html.BeginForm())
+                {
+                    <div>
+                        <table id="searchResults" class="sexy-table">
+                            <thead>
+                                <tr>
+                                    <th>Username</th>
+                                    @foreach (var subscription in Model.SubscriptionNames)
+                                    {
+                                        <th><input type="checkbox" data-bind="click: toggleSelectAll, checked: selectAllState.@subscription" />@subscription</th>
+                                    }
+                                </tr>
+                            </thead>
+                            <tbody id="policies" data-bind="foreach: searchResults">
+                                <tr>
+                                    <td><a href="#" data-bind="text: Username, attr: { href: $parent.generateUserUrl($data) }"></a></td>
+                                    @foreach (var subscription in Model.SubscriptionNames)
+                                    {
+                                        <td><input type="checkbox" data-bind="checked: $data.Selected.@subscription, value: $parent.generateValue($data, '@subscription')" /></td>
+                                    }
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
 
-                <div>
-                    <table id="searchResults" class="sexy-table">
-                        <thead>
-                            <tr>
-                                <th>Username</th>
-                                @foreach (var subscription in Model.SubscriptionNames)
-                                {
-                                    <th><input type="checkbox" data-bind="click: toggleSelectAll, checked: selectAllState.@subscription" />@subscription</th>
-                                }
-                            </tr>
-                        </thead>
-                        <tbody data-bind="foreach: searchResults">
-                            <tr>
-                                <td><a href="#" data-bind="text: Username, attr: { href: $parent.generateUserUrl($data) }"></a></td>
-                                @foreach (var subscription in Model.SubscriptionNames)
-                                {
-                                    <td><input type="checkbox" name="UserSubscriptions[]" data-bind="checked: $data.Selected.@subscription, value: $parent.generateValue($data, '@subscription')" /></td>
-                                }
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-
-                <div class="danger-zone" style="display: none;" data-bind="visible: changeTracker">
+                    <div class="danger-zone" style="display: none;" data-bind="visible: changeTracker">
                     
-                <fieldset id="unlist-form" class="form">
-                    @Html.AntiForgeryToken()
+                    <fieldset id="update-form" class="form">
+                        <p>
+                            Onboarding users to security policy subscriptions could result in changes which <strong>CANNOT</strong> be undone.
+                        </p>
 
-                    <p>
-                        Onboarding users to security policy subscriptions could result in changes which <strong>CANNOT</strong> be undone.
-                    </p>
-
-                    <input type="submit" value="I understand, update security policies." title="I understand, update security policies." />
-                    <a class="cancel" href="@Url.Action("Index", "Home")" title="Cancel changes">Cancel</a>
-                    </fieldset>
-                </div>
+                        <input type="submit" value="I understand, update policies." title="I understand, update policies." data-bind="click: update"  />
+                        <a class="cancel" href="@Url.Action("Index", "Home")" title="Cancel changes">Cancel</a>
+                        </fieldset>
+                    </div>
+                }
 
             </div>
-        }
 </article>
 </section>
 
@@ -72,63 +72,88 @@
             var viewModel = function () {
                 var $self = this;
 
-                this.subscriptions = @Html.Raw(Json.Encode(@Model.SubscriptionNames));
+                this.message = ko.observable('');
+
+                this.currentSubscription;
+                this.subscriptionNames = @Html.Raw(Json.Encode(@Model.SubscriptionNames));
                 this.searchQuery = ko.observable('');
 
+                this.update = function () {
+                    var subscriptions = [];
+                    $('#policies input:checkbox').each(function (i, checkbox) {
+                        subscriptions.push(checkbox.value);
+                    });
+                    
+                    $.ajax({
+                        url: '@Url.Action("Update", "SecurityPolicy", new { area = "Admin" })',
+                        cache: false,
+                        dataType: 'json',
+                        type: 'POST',
+                        data: JSON.stringify(subscriptions),
+                        contentType: 'application/json; charset=utf-8',
+                        success: function (data) {
+                            $self.changeTracker(false);
+                            $self.message("Security policies updated!");
+                        }
+                    })
+                    .error(function(jqXhr, textStatus, errorThrown) {
+                        alert("Error: " + errorThrown);
+                    });
+                },
+
                 this.search = function () {
+                    $self.message("");
                     $.ajax({
                         url: '@Url.Action("Search", "SecurityPolicy", new {area = "Admin"})?query=' + encodeURIComponent($self.searchQuery()),
-                            cache: false,
-                            dataType: 'json',
-                            success: function (data) {
-                                $self.changeTracker(false);
-                                $self.resetSelectAllState();
-                                $self.searchResults.removeAll();
-                                $self.searchNotFoundResults.removeAll();
+                        cache: false,
+                        dataType: 'json',
+                        success: function (data) {
+                            $self.changeTracker(false);
+                            $self.resetSelectAllState();
+                            $self.searchResults.removeAll();
+                            $self.searchNotFoundResults.removeAll();
 
-                                for (var i = 0; i < data.Users.length; i++) {
-                                    var user = data.Users[i];
-                                    user.Selected = {};
-                                    for (var key in user.Subscriptions) {
-                                        user.Selected[key] = ko.observable(user.Subscriptions[key]);
-                                        user.Selected[key].subscribe($self.markDirty);
-                                    }
+                            for (var i = 0; i < data.Users.length; i++) {
+                                var user = data.Users[i];
+                                user.Selected = {};
+                                for (var key in user.Subscriptions) {
+                                    user.Selected[key] = ko.observable(user.Subscriptions[key]);
+                                    user.Selected[key].subscribe($self.markDirty);
                                 }
-
-                                $self.searchResults(data.Users);
-                                $self.searchNotFoundResults(data.UsersNotFound);
-                            },
-                            error: function (data) {
-                                alert("Error: " + errorThrown);
                             }
-                        })
-                        .error(function(jqXhr, textStatus, errorThrown) {
-                            alert("Error: " + errorThrown);
-                        });
+
+                            $self.searchResults(data.Users);
+                            $self.searchNotFoundResults(data.UsersNotFound);
+                        }
+                    })
+                    .error(function(jqXhr, textStatus, errorThrown) {
+                        alert("Error: " + errorThrown);
+                    });
                 };
-                
+
                 this.selectAllState = {};
-                for (var i = 0; i < this.subscriptions.length; i++)
+                for (var i = 0; i < this.subscriptionNames.length; i++)
                 {
-                    var subscription = this.subscriptions[i];
+                    var subscription = this.subscriptionNames[i];
                     this.selectAllState[subscription] = ko.observable(false);
                 }
 
                 this.resetSelectAllState = function () {
-                    for (var i = 0; i < $self.subscriptions.length; i++)
+                    for (var i = 0; i < $self.subscriptionNames.length; i++)
                     {
-                        $self.selectAllState[$self.subscriptions[i]](false);
+                        var subscription = $self.subscriptionNames[i];
+                        $self.selectAllState[subscription](false);
                     }
                 }
-                
+
                 this.toggleSelectAll = function (data, e) {
-                    var subscription = e.currentTarget.nextSibling.data;
-                    $self.selectAllState[subscription](!$self.selectAllState[subscription]());
+                    $self.currentSubscription = e.currentTarget.nextSibling.data;
+                    $self.selectAllState[$self.currentSubscription](!$self.selectAllState[$self.currentSubscription]());
                     return true;
                 };
 
                 this.generateValue = function (user, subscription) {
-                    return JSON.stringify({ "u": user.Username, "g": subscription })
+                    return JSON.stringify({ "u": user.Username, "g": subscription, "v": user.Selected[subscription]() })
                 };
 
                 this.generateUserUrl = function (user) {
@@ -145,24 +170,19 @@
                     $self.changeTracker(true);
                 };
 
-                for (var i = 0; i < this.subscriptions.length; i++) {
+                for (var i = 0; i < this.subscriptionNames.length; i++) {
+                    var subscription = this.subscriptionNames[i];
                     this.selectAllState[subscription].subscribe(function () {
-                        var state = $self.selectAllState[subscription]();
+                        var state = $self.selectAllState[$self.currentSubscription]();
 
                         ko.utils.arrayForEach($self.searchResults(), function (result) {
-                            result.Selected[subscription](state);
+                            result.Selected[$self.currentSubscription](state);
                         });
                     });
                 }
             };
 
             ko.applyBindings(new viewModel(), $('#stage').get(0));
-
-            $('#delete-form').submit(function (e) {
-                if (!confirm('Are you sure you want to continue?')) {
-                    e.preventDefault();
-                }
-            });
         });
     </script>
 }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -773,6 +773,7 @@
     <Compile Include="Migrations\201706080930506_AddIndexSemVerLevelKeyPackageRegistrationKey.Designer.cs">
       <DependentUpon>201706080930506_AddIndexSemVerLevelKeyPackageRegistrationKey.cs</DependentUpon>
     </Compile>
+    <Compile Include="Security\RequireSecurePushForCoOwnersPolicy.cs" />
     <Compile Include="Security\SecurePushSubscription.cs" />
     <Compile Include="Security\IUserSecurityPolicySubscription.cs" />
     <Compile Include="OData\Serializers\FeedPackageAnnotationStrategy.cs" />

--- a/src/NuGetGallery/Security/ISecurityPolicyService.cs
+++ b/src/NuGetGallery/Security/ISecurityPolicyService.cs
@@ -21,12 +21,27 @@ namespace NuGetGallery.Security
         /// <summary>
         /// Check if a user is subscribed to one or more security policies.
         /// </summary>
+        bool IsSubscribed(User user, string subscriptionName);
+
+        /// <summary>
+        /// Check if a user is subscribed to one or more security policies.
+        /// </summary>
         bool IsSubscribed(User user, IUserSecurityPolicySubscription subscription);
 
         /// <summary>
         /// Subscribe a user to one or more security policies.
         /// </summary>
-        Task SubscribeAsync(User user, IUserSecurityPolicySubscription subscription);
+        Task<bool> SubscribeAsync(User user, string subscriptionName);
+
+        /// <summary>
+        /// Subscribe a user to one or more security policies.
+        /// </summary>
+        Task<bool> SubscribeAsync(User user, IUserSecurityPolicySubscription subscription);
+
+        /// <summary>
+        /// Unsubscribe a user from one or more security policies.
+        /// </summary>
+        Task UnsubscribeAsync(User user, string subscriptionName);
 
         /// <summary>
         /// Unsubscribe a user from one or more security policies.

--- a/src/NuGetGallery/Security/RequireMinClientVersionForPushPolicy.cs
+++ b/src/NuGetGallery/Security/RequireMinClientVersionForPushPolicy.cs
@@ -16,7 +16,7 @@ namespace NuGetGallery.Security
     /// </summary>
     public class RequireMinClientVersionForPushPolicy : UserSecurityPolicyHandler
     {
-        public const string PolicyName = "RequireMinClientVersionForPushPolicy";
+        public const string PolicyName = nameof(RequireMinClientVersionForPushPolicy);
 
         public class State
         {

--- a/src/NuGetGallery/Security/RequirePackageVerifyScopePolicy.cs
+++ b/src/NuGetGallery/Security/RequirePackageVerifyScopePolicy.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using NuGetGallery.Filters;
 
 namespace NuGetGallery.Security
 {
@@ -11,7 +10,7 @@ namespace NuGetGallery.Security
     /// </summary>
     public class RequirePackageVerifyScopePolicy : UserSecurityPolicyHandler
     {
-        public const string PolicyName = "RequirePackageVerifyScopePolicy";
+        public const string PolicyName = nameof(RequirePackageVerifyScopePolicy);
 
         public RequirePackageVerifyScopePolicy()
             : base(PolicyName, SecurityPolicyAction.PackageVerify)

--- a/src/NuGetGallery/Security/RequireSecurePushForCoOwnersPolicy.cs
+++ b/src/NuGetGallery/Security/RequireSecurePushForCoOwnersPolicy.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGetGallery.Security
+{
+    /// <summary>
+    /// Subscribable policy that propagates secure push policies to new package co-owners.
+    /// </summary>
+    public class RequireSecurePushForCoOwnersPolicy : UserSecurityPolicyHandler, IUserSecurityPolicySubscription
+    {
+        public const string _SubscriptionName = "SecurePushForCoOwners";
+        public const string PolicyName = nameof(RequireSecurePushForCoOwnersPolicy);
+
+        public string SubscriptionName => _SubscriptionName;
+
+        public IEnumerable<UserSecurityPolicy> Policies
+        {
+            get
+            {
+                yield return new UserSecurityPolicy(PolicyName, SubscriptionName);
+            }
+        }
+
+        public RequireSecurePushForCoOwnersPolicy()
+            : base(PolicyName, SecurityPolicyAction.ManagePackageOwners)
+        {
+        }
+
+        public Task OnSubscribeAsync(UserSecurityPolicySubscriptionContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OnUnsubscribeAsync(UserSecurityPolicySubscriptionContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override SecurityPolicyResult Evaluate(UserSecurityPolicyEvaluationContext context)
+        {
+            return SecurityPolicyResult.SuccessResult;
+        }
+
+        public static bool IsSubscribed(User user)
+        {
+            return user.SecurityPolicies.Any(p => p.Name.Equals(RequireSecurePushForCoOwnersPolicy.PolicyName, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/NuGetGallery/Security/SecurePushSubscription.cs
+++ b/src/NuGetGallery/Security/SecurePushSubscription.cs
@@ -18,8 +18,8 @@ namespace NuGetGallery.Security
     public class SecurePushSubscription : IUserSecurityPolicySubscription
     {
         public const string Name = "SecurePush";
-        private const string MinClientVersion = "4.1.0";
-        private const int PushKeysExpirationInDays = 30;
+        internal const string MinClientVersion = "4.1.0";
+        internal const int PushKeysExpirationInDays = 30;
 
         private IAuditingService _auditing;
         private IDiagnosticsSource _diagnostics;

--- a/src/NuGetGallery/Security/SecurityPolicyAction.cs
+++ b/src/NuGetGallery/Security/SecurityPolicyAction.cs
@@ -6,6 +6,7 @@ namespace NuGetGallery.Security
     public enum SecurityPolicyAction
     {
         PackagePush,
-        PackageVerify
+        PackageVerify,
+        ManagePackageOwners
     }
 }

--- a/src/NuGetGallery/Services/ConfirmOwnershipResult.cs
+++ b/src/NuGetGallery/Services/ConfirmOwnershipResult.cs
@@ -1,9 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace NuGetGallery
 {

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -15,7 +15,8 @@ namespace NuGetGallery
         void SendEmailChangeConfirmationNotice(MailAddress newEmailAddress, string confirmationUrl);
         void SendPasswordResetInstructions(User user, string resetPasswordUrl, bool forgotPassword);
         void SendEmailChangeNoticeToPreviousEmailAddress(User user, string oldEmailAddress);
-        void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string confirmationUrl, string message);
+        void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string packageUrl, string confirmationUrl, string message, string policyMessage);
+        void SendPackageOwnerAddedNotice(User toUser, User newOwner, PackageRegistration package, string packageUrl, string policyMessage);
         void SendPackageOwnerRemovedNotice(User fromUser, User toUser, PackageRegistration package);
         void SendCredentialRemovedNotice(User user, Credential removed);
         void SendCredentialAddedNotice(User user, Credential added);

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -59,8 +59,24 @@ namespace NuGetGallery
         Task MarkPackageListedAsync(Package package, bool commitChanges = true);
 
         Task<PackageOwnerRequest> CreatePackageOwnerRequestAsync(PackageRegistration package, User currentOwner, User newOwner);
-        Task<ConfirmOwnershipResult> ConfirmPackageOwnerAsync(PackageRegistration package, User user, string token);
-        Task AddPackageOwnerAsync(PackageRegistration package, User user);
+        
+        /// <summary>
+        /// Checks if the pending owner has a request for this package which matches the specified token.
+        /// </summary>
+        /// <param name="package">Package associated with the request.</param>
+        /// <param name="pendingOwner">Pending owner for the request.</param>
+        /// <param name="token">Token generated for the owner request.</param>
+        /// <returns>True if valid, false otherwise.</returns>
+        bool IsValidPackageOwnerRequest(PackageRegistration package, User pendingOwner, string token);
+
+        /// <summary>
+        /// Performs database changes to add a new package owner while removing the corresponding package owner request.
+        /// </summary>
+        /// <param name="package">Package to which owner is added.</param>
+        /// <param name="newOwner">New owner to add.</param>
+        /// <returns>Awaitable task.</returns>
+        Task AddPackageOwnerAsync(PackageRegistration package, User newOwner);
+
         Task RemovePackageOwnerAsync(PackageRegistration package, User user);
 
         Task SetLicenseReportVisibilityAsync(Package package, bool visible, bool commitChanges = true);

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -285,22 +285,28 @@ The {0} Team";
             }
         }
 
-        public void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string confirmationUrl, string message)
+        public void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string packageUrl, string confirmationUrl, string message, string policyMessage)
         {
             if (!toUser.EmailAllowed)
             {
                 return;
             }
 
-            const string subject = "[{0}] The user '{1}' wants to add you as an owner of the package '{2}'.";
+            if (!string.IsNullOrEmpty(policyMessage))
+            {
+                policyMessage = Environment.NewLine + policyMessage + Environment.NewLine;
+            }
+
+            const string subject = "[{0}] The user '{1}' would like to add you as an owner of the package '{2}'.";
 
             string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{fromUser.Username}' wants to add you as an owner of the package '{package.Id}'.
 If you do not want to be listed as an owner of this package, simply delete this email.
 
+Package URL on NuGet.org: [{packageUrl}]({packageUrl})
+{policyMessage}
 To accept this request and become a listed owner of the package, click the following URL:
 
 [{confirmationUrl}]({confirmationUrl})");
-
 
             if (!string.IsNullOrWhiteSpace(message))
             {
@@ -318,6 +324,40 @@ The {Config.GalleryOwner.DisplayName} Team";
                 mailMessage.Body = body;
                 mailMessage.From = Config.GalleryNoReplyAddress;
                 mailMessage.ReplyToList.Add(fromUser.ToMailAddress());
+
+                mailMessage.To.Add(toUser.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendPackageOwnerAddedNotice(User toUser, User newOwner, PackageRegistration package, string packageUrl, string policyMessage)
+        {
+            if (!toUser.EmailAllowed)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(policyMessage))
+            {
+                policyMessage = Environment.NewLine + policyMessage + Environment.NewLine;
+            }
+
+            const string subject = "[{0}] The user '{1}' is now an owner of the package '{2}'.";
+
+            string body = @"This is to inform you that '{0}' is now an owner of the package
+
+{1}
+{2}
+Thanks,
+The {3} Team";
+            body = String.Format(CultureInfo.CurrentCulture, body, newOwner.Username, packageUrl, policyMessage, Config.GalleryOwner.DisplayName);
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = String.Format(CultureInfo.CurrentCulture, subject, Config.GalleryOwner.DisplayName, newOwner.Username, package.Id);
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(Config.GalleryNoReplyAddress);
 
                 mailMessage.To.Add(toUser.ToMailAddress());
                 SendMessage(mailMessage);

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -61,6 +61,152 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Current user not found..
+        /// </summary>
+        public static string AddOwner_CurrentUserNotFound {
+            get {
+                return ResourceManager.GetString("AddOwner_CurrentUserNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are not the package owner..
+        /// </summary>
+        public static string AddOwner_NotPackageOwner {
+            get {
+                return ResourceManager.GetString("AddOwner_NotPackageOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sorry, &apos;{0}&apos; hasn&apos;t verified their email account yet and we cannot proceed with the request..
+        /// </summary>
+        public static string AddOwner_OwnerNotConfirmed {
+            get {
+                return ResourceManager.GetString("AddOwner_OwnerNotConfirmed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Owner not found..
+        /// </summary>
+        public static string AddOwner_OwnerNotFound {
+            get {
+                return ResourceManager.GetString("AddOwner_OwnerNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package not found..
+        /// </summary>
+        public static string AddOwner_PackageNotFound {
+            get {
+                return ResourceManager.GetString("AddOwner_PackageNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please confirm if you would like to proceed adding &apos;{0}&apos; as a co-owner of this package..
+        /// </summary>
+        public static string AddOwnerConfirmation {
+            get {
+                return ResourceManager.GetString("AddOwnerConfirmation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to User &apos;{0}&apos; has the following requirements that will be enforced for all co-owners once the user accepts ownership of this package:
+        ///{1}
+        ///Note this step cannot be easily undone. If you are unsure and/or need more information, please contact &apos;{2}&apos;..
+        /// </summary>
+        public static string AddOwnerConfirmation_SecurePushRequiredByNewOwner {
+            get {
+                return ResourceManager.GetString("AddOwnerConfirmation_SecurePushRequiredByNewOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Owner(s) &apos;{0}&apos; has (have) the following requirements that will be enforced for user &apos;{1}&apos; once the user accepts ownership of this package:
+        ///{2}
+        ///Note this step cannot be easily undone. If you are unsure and/or need more information, please contact &apos;{3}&apos;..
+        /// </summary>
+        public static string AddOwnerConfirmation_SecurePushRequiredByOwner {
+            get {
+                return ResourceManager.GetString("AddOwnerConfirmation_SecurePushRequiredByOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pending owner(s) &apos;{0}&apos; has (have) the following requirements that will be enforced for all co-owners, including &apos;{1}&apos;, once ownership requests are accepted:
+        ///{2}
+        ///Note this step cannot be easily undone. If you are unsure and/or need more information, please contact &apos;{3}&apos;..
+        /// </summary>
+        public static string AddOwnerConfirmation_SecurePushRequiredByPendingOwner {
+            get {
+                return ResourceManager.GetString("AddOwnerConfirmation_SecurePushRequiredByPendingOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Owner(s) &apos;{0}&apos; has (have) the following requirements that are now enforced for co-owner(s) &apos;{1}&apos;:
+        ///
+        ///{2}
+        ///
+        ///For more information, please contact &apos;{3}&apos;..
+        /// </summary>
+        public static string AddOwnerNotification_SecurePushRequired_Propagators {
+            get {
+                return ResourceManager.GetString("AddOwnerNotification_SecurePushRequired_Propagators", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Owner(s) &apos;{0}&apos; has (have) the following requirements that are now enforced for your account:
+        ///
+        ///{1}
+        ///
+        ///For more information, please contact &apos;{2}&apos;..
+        /// </summary>
+        public static string AddOwnerNotification_SecurePushRequired_Subscribed {
+            get {
+                return ResourceManager.GetString("AddOwnerNotification_SecurePushRequired_Subscribed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Note: The following policies will be enforced on package co-owners once you accept this request. If you are unsure and/or need more information, please contact &apos;{0}&apos;.
+        ///
+        ///{1}.
+        /// </summary>
+        public static string AddOwnerRequest_SecurePushRequiredByNewOwner {
+            get {
+                return ResourceManager.GetString("AddOwnerRequest_SecurePushRequiredByNewOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Note: Owner(s) &apos;{0}&apos; has (have) the following policies that will be enforced on your account once you accept this request. If you are unsure and/or need more information, please contact &apos;{1}&apos;.
+        ///
+        ///{2}.
+        /// </summary>
+        public static string AddOwnerRequest_SecurePushRequiredByOwner {
+            get {
+                return ResourceManager.GetString("AddOwnerRequest_SecurePushRequiredByOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Note: Pending owner(s) &apos;{0}&apos; has (have) the following policies that will be enforced on your account once ownership requests are accepted. If you are unsure and/or need more information, please contact &apos;{1}&apos;.
+        ///
+        ///{2}.
+        /// </summary>
+        public static string AddOwnerRequest_SecurePushRequiredByPendingOwner {
+            get {
+                return ResourceManager.GetString("AddOwnerRequest_SecurePushRequiredByPendingOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You are already logged in!.
         /// </summary>
         public static string AlreadyLoggedIn {
@@ -283,6 +429,16 @@ namespace NuGetGallery {
         public static string DefaultUserSafeExceptionMessage {
             get {
                 return ResourceManager.GetString("DefaultUserSafeExceptionMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Owner(s) &apos;{0}&apos; require(s) that all co-owners use client version {1} or higher to push all of their packages. For more information, contact {2}.
+        ///.
+        /// </summary>
+        public static string DisplayPackage_SecurePushRequired {
+            get {
+                return ResourceManager.GetString("DisplayPackage_SecurePushRequired", resourceCulture);
             }
         }
         
@@ -776,6 +932,28 @@ namespace NuGetGallery {
         public static string ScopeDescription_VerifyPackage {
             get {
                 return ResourceManager.GetString("ScopeDescription_VerifyPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 1. All co-owners must use client version {0} or higher to push all of their packages.
+        ///2. All existing push API keys for co-owners new to this policy will expire in {1} days..
+        /// </summary>
+        public static string SecurePushPolicyDescriptions {
+            get {
+                return ResourceManager.GetString("SecurePushPolicyDescriptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;ol&gt;
+        ///&lt;li&gt;All co-owners must use client version {0} or higher to push all of their packages.&lt;/li&gt;
+        ///&lt;li&gt;All existing push API keys for co-owners new to this policy will expire in {1} days.&lt;/li&gt;
+        ///&lt;/ol&gt;.
+        /// </summary>
+        public static string SecurePushPolicyDescriptionsHtml {
+            get {
+                return ResourceManager.GetString("SecurePushPolicyDescriptionsHtml", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -446,4 +446,80 @@ The {1} Team</value>
   <data name="PackageVersionDiffersOnlyByMetadataAndCannotBeModified" xml:space="preserve">
     <value>Package versions that differ only by metadata cannot be uploaded. A package with ID '{0}' and version '{1}' already exists and cannot be modified.</value>
   </data>
+  <data name="AddOwnerConfirmation" xml:space="preserve">
+    <value>Please confirm if you would like to proceed adding '{0}' as a co-owner of this package.</value>
+  </data>
+  <data name="AddOwner_CurrentUserNotFound" xml:space="preserve">
+    <value>Current user not found.</value>
+  </data>
+  <data name="AddOwner_NotPackageOwner" xml:space="preserve">
+    <value>You are not the package owner.</value>
+  </data>
+  <data name="AddOwner_OwnerNotConfirmed" xml:space="preserve">
+    <value>Sorry, '{0}' hasn't verified their email account yet and we cannot proceed with the request.</value>
+  </data>
+  <data name="AddOwner_OwnerNotFound" xml:space="preserve">
+    <value>Owner not found.</value>
+  </data>
+  <data name="AddOwner_PackageNotFound" xml:space="preserve">
+    <value>Package not found.</value>
+  </data>
+  <data name="SecurePushPolicyDescriptions" xml:space="preserve">
+    <value>1. All co-owners must use client version {0} or higher to push all of their packages.
+2. All existing push API keys for co-owners new to this policy will expire in {1} days.</value>
+  </data>
+  <data name="AddOwnerConfirmation_SecurePushRequiredByNewOwner" xml:space="preserve">
+    <value>User '{0}' has the following requirements that will be enforced for all co-owners once the user accepts ownership of this package:
+{1}
+Note this step cannot be easily undone. If you are unsure and/or need more information, please contact '{2}'.</value>
+  </data>
+  <data name="AddOwnerConfirmation_SecurePushRequiredByOwner" xml:space="preserve">
+    <value>Owner(s) '{0}' has (have) the following requirements that will be enforced for user '{1}' once the user accepts ownership of this package:
+{2}
+Note this step cannot be easily undone. If you are unsure and/or need more information, please contact '{3}'.</value>
+  </data>
+  <data name="AddOwnerConfirmation_SecurePushRequiredByPendingOwner" xml:space="preserve">
+    <value>Pending owner(s) '{0}' has (have) the following requirements that will be enforced for all co-owners, including '{1}', once ownership requests are accepted:
+{2}
+Note this step cannot be easily undone. If you are unsure and/or need more information, please contact '{3}'.</value>
+  </data>
+  <data name="AddOwnerNotification_SecurePushRequired_Propagators" xml:space="preserve">
+    <value>Owner(s) '{0}' has (have) the following requirements that are now enforced for co-owner(s) '{1}':
+
+{2}
+
+For more information, please contact '{3}'.</value>
+  </data>
+  <data name="AddOwnerRequest_SecurePushRequiredByNewOwner" xml:space="preserve">
+    <value>Note: The following policies will be enforced on package co-owners once you accept this request. If you are unsure and/or need more information, please contact '{0}'.
+
+{1}</value>
+  </data>
+  <data name="AddOwnerRequest_SecurePushRequiredByOwner" xml:space="preserve">
+    <value>Note: Owner(s) '{0}' has (have) the following policies that will be enforced on your account once you accept this request. If you are unsure and/or need more information, please contact '{1}'.
+
+{2}</value>
+  </data>
+  <data name="AddOwnerRequest_SecurePushRequiredByPendingOwner" xml:space="preserve">
+    <value>Note: Pending owner(s) '{0}' has (have) the following policies that will be enforced on your account once ownership requests are accepted. If you are unsure and/or need more information, please contact '{1}'.
+
+{2}</value>
+  </data>
+  <data name="AddOwnerNotification_SecurePushRequired_Subscribed" xml:space="preserve">
+    <value>Owner(s) '{0}' has (have) the following requirements that are now enforced for your account:
+
+{1}
+
+For more information, please contact '{2}'.</value>
+  </data>
+  <data name="DisplayPackage_SecurePushRequired" xml:space="preserve">
+    <value>Owner(s) '{0}' require(s) that all co-owners use client version {1} or higher to push all of their packages. For more information, contact {2}.
+</value>
+  </data>
+  <data name="SecurePushPolicyDescriptionsHtml" xml:space="preserve">
+    <value>&lt;ol&gt;
+&lt;li&gt;All co-owners must use client version {0} or higher to push all of their packages.&lt;/li&gt;
+&lt;li&gt;All existing push API keys for co-owners new to this policy will expire in {1} days.&lt;/li&gt;
+&lt;/ol&gt;</value>
+  </data>
 </root>

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -32,6 +32,7 @@ namespace NuGetGallery
         public string MinClientVersion { get; set; }
         public string ShortDescription { get; set; }
         public bool IsDescriptionTruncated { get; set; }
+        public string PolicyMessage { get; set; }
 
         public bool UseVersion
         {

--- a/src/NuGetGallery/ViewModels/ManagePackageOwnersViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ManagePackageOwnersViewModel.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using System.Collections.Generic;
-using System.Linq;
+
 using System.Security.Principal;
 
 namespace NuGetGallery
@@ -11,16 +10,6 @@ namespace NuGetGallery
         public ManagePackageOwnersViewModel(Package package, IPrincipal currentUser)
             : base(package)
         {
-            CurrentOwnerUsername = currentUser.Identity.Name;
-            OtherOwners = Owners.Where(o => o.Username != CurrentOwnerUsername);
         }
-
-        public bool HasOtherOwners
-        {
-            get { return OtherOwners.Any(); }
-        }
-
-        public string CurrentOwnerUsername { get; private set; }
-        public IEnumerable<User> OtherOwners { get; private set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/PackageOwnerConfirmationModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageOwnerConfirmationModel.cs
@@ -4,8 +4,17 @@ namespace NuGetGallery
 {
     public class PackageOwnerConfirmationModel
     {
-        public ConfirmOwnershipResult Result { get; set; }
-        public string PackageId { get; set; }
-        public string Username { get; set; }
+        public PackageOwnerConfirmationModel(string packageId, string username, ConfirmOwnershipResult result)
+        {
+            Result = result;
+            PackageId = packageId;
+            Username = username;
+        }
+
+        public ConfirmOwnershipResult Result { get; }
+
+        public string PackageId { get; }
+
+        public string Username { get; }
     }
 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -167,6 +167,10 @@
 
 }
 <div class="package-page">
+    @if (!string.IsNullOrEmpty(Model.PolicyMessage))
+    {
+        <p class="message warning">@Model.PolicyMessage</p>
+    }
     @if (Model.HasPendingMetadata)
     {
         using (Html.BeginForm(actionName: "UndoPendingEdits", controllerName: "Packages"))

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -5,6 +5,7 @@
 
 
 <h1 class="page-heading">Manage Owners for Package "@Model.Title.Abbreviate(50)"</h1>
+
 <div class="error message" style="display: none" data-bind="text: message, visible: message"></div>
 
 <h2>Current Owners</h2>
@@ -29,15 +30,28 @@
     @Html.AntiForgeryToken()
     <fieldset class="form">
         <legend>Add Owner</legend>
-        <div class="form-field">
-            <label for="newOwnerUserName">Username</label>
-            <input type="text" id="newOwnerUserName" name="newOwnerUserName" data-bind="value: newOwnerUsername"/>
+        <div id="input-form">
+            <div class="form-field">
+                <label for="newOwnerUserName">Username</label>
+                <input type="text" id="newOwnerUserName" name="newOwnerUserName" data-bind="value: newOwnerUsername" />
+            </div>
+            <div class="form-field">
+                <label for="newOwnerUserName">Message</label>
+                <textarea id="newOwnerMessage" name="newOwnerUserName" data-bind="value: newOwnerMessage"></textarea>
+            </div>
+            <input type="submit" value="Add" title="Add the user as an owner to @Model.Title" data-bind="click: confirmAddOwner" />
         </div>
-        <div class="form-field">
-            <label for="newOwnerUserName">Message</label>
-            <textarea id="newOwnerMessage" name="newOwnerUserName" data-bind="value: newOwnerMessage"></textarea>
+        <div style="display: none" data-bind="visible: confirmation">
+            <h2>Confirm</h2>
+
+            <div data-bind="text: confirmation"></div>
+            <br />
+
+            <div class="warning message" data-bind="visible: policyMessage, html: policyMessage"></div>
+            <br />
+            <input type="submit" value="Confirm" title="Confirm adding the user as an owner to @Model.Title" data-bind="click: addOwner" />
+            <a class="cancel" title="Cancel changes and reload the page." data-bind="click: resetAddOwnerConfirmation">Cancel</a>
         </div>
-        <input type="submit" value="Add" title="Add the user as an owner to @Model.Title" data-bind="click: addOwner" />
     </fieldset>
 }
 
@@ -55,6 +69,8 @@
                 owners: ko.observableArray([]),
                 newOwnerUsername: ko.observable(''),
                 newOwnerMessage: ko.observable(''),
+                confirmation: ko.observable(''),
+                policyMessage: ko.observable(''),
 
                 message: ko.observable(''),
 
@@ -62,10 +78,18 @@
                     return true;
                 },
 
-                addOwner: function () {
-                    var newUsername = viewModel.newOwnerUsername();
-                    var message = viewModel.newOwnerMessage();
+                headers: function () {
+                    return { '__RequestVerificationToken': $('input[name=""__RequestVerificationToken""]').val() };
+                },
 
+                resetAddOwnerConfirmation: function () {
+                    viewModel.confirmation('');
+                    viewModel.policyMessage('');
+                    $("#input-form :input").attr("disabled", false);
+                },
+
+                confirmAddOwner: function () {
+                    var newUsername = viewModel.newOwnerUsername();
                     if (!newUsername) {
                         viewModel.message("Please enter a valid user name.");
                         return;
@@ -80,6 +104,31 @@
                         return;
                     }
 
+                    $.ajax({
+                        url: '@Url.Action("GetAddPackageOwnerConfirmation", "JsonApi")?id=' + viewModel.package.id + '&username=' + newUsername,
+                        cache: false,
+                        dataType: 'json',
+                        type: 'GET',
+                        headers: viewModel.headers(),
+                        contentType: 'application/json; charset=utf-8',
+                        success: function (data) {
+                            if (data.success) {
+                                viewModel.confirmation(data.confirmation);
+                                viewModel.policyMessage(data.policyMessage);
+                                $("#input-form :input").attr("disabled", true);
+                            }
+                            else {
+                                viewModel.message(data.message);
+                            }
+                        }
+                    })
+                    .error(failHandler);
+                },
+
+                addOwner: function () {
+                    var newUsername = viewModel.newOwnerUsername();
+                    var message = viewModel.newOwnerMessage();
+
                     var ownerInputModel =
                     {
                         username: newUsername,
@@ -87,14 +136,12 @@
                         message: message
                     };
 
-                    var headers = { '__RequestVerificationToken': $('input[name=""__RequestVerificationToken""]').val() };
-
                     $.ajax({
                         url: '@Url.Action("AddPackageOwner", "JsonApi")',
                         cache: false,
                         dataType: 'json',
                         type: 'POST',
-                        headers: headers,
+                        headers: viewModel.headers(),
                         data: window.JSON.stringify(ownerInputModel),
                         contentType: 'application/json; charset=utf-8',
                         success: function (data) {
@@ -108,6 +155,7 @@
 
                                 // when an operation succeeds, always clear the error message
                                 viewModel.message('');
+                                viewModel.resetAddOwnerConfirmation();
                             }
                             else {
                                 viewModel.message(data.message);
@@ -119,23 +167,19 @@
 
                 removeOwner: function (item) {
                     var package = viewModel.package;
-                    var headers = { '__RequestVerificationToken': $('input[name=""__RequestVerificationToken""]').val() };
-
-                    var proceedToRemoveFunction = true;
 
                     if (item.current) {
-                        proceedToRemoveFunction = confirm("Are you sure you want to remove yourself from the owners?");
+                        if (!confirm("Are you sure you want to remove yourself from the owners?")) {
+                            return;
+                        }
                     }
-
-                    if (proceedToRemoveFunction === false)
-                        return;
 
                     $.ajax({
                         url: '@Url.Action("RemovePackageOwner", "JsonApi")?id=' + package.id + '&username=' + item.name(),
                         cache: false,
                         dataType: 'json',
                         type: 'POST',
-                        headers: headers,
+                        headers: viewModel.headers(),
                         contentType: 'application/json; charset=utf-8',
                         success: function (data) {
                             if (data.success) {

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -1,18 +1,323 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Net.Mail;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
+using Moq;
+using NuGetGallery.Configuration;
 using NuGetGallery.Framework;
+using NuGetGallery.Security;
 using Xunit;
 
 namespace NuGetGallery.Controllers
 {
     public class JsonApiControllerFacts
     {
+        public class TheGetAddPackageOwnerConfirmationMethod : TestContainer
+        {
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public void ThrowsArgumentNullIfPackageIdMissing(string id)
+            {
+                // Arrange
+                var controller = GetController<JsonApiController>();
+
+                // Act & Assert
+                Assert.Throws<ArgumentException>(() => controller.GetAddPackageOwnerConfirmation(id, "user"));
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public void ThrowsArgumentNullIfUsernameMissing(string username)
+            {
+                // Arrange
+                var controller = GetController<JsonApiController>();
+
+                // Act & Assert
+                Assert.Throws<ArgumentException>(() => controller.GetAddPackageOwnerConfirmation("package", username));
+            }
+
+            [Fact]
+            public void ReturnsFailureIfPackageNotFound()
+            {
+                // Arrange
+                var controller = GetController<JsonApiController>();
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation("package", "user");
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.False(data.success);
+                Assert.Equal("Package not found.", data.message);
+            }
+
+            [Fact]
+            public void ReturnsFailureIfUserIsNotPackageOwner()
+            {
+                // Arrange
+                var controller = GetController<JsonApiController>();
+                GetMock<IPackageService>()
+                    .Setup(svc => svc.FindPackageRegistrationById("package"))
+                    .Returns(new PackageRegistration());
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation("package", "nonOwner");
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.False(data.success);
+                Assert.Equal("You are not the package owner.", data.message);
+            }
+
+            [Fact]
+            public void ReturnsFailureIfOwnerIsNotRealUser()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, "nonUser");
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.False(data.success);
+                Assert.Equal("Owner not found.", data.message);
+            }
+
+            [Fact]
+            public void ReturnsFailureIfNewOwnerIsNotConfirmed()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                fakes.User.UnconfirmedEmailAddress = fakes.Owner.EmailAddress;
+                fakes.User.EmailAddress = null;
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.False(data.success);
+                Assert.Equal("Sorry, 'testUser' hasn't verified their email account yet and we cannot proceed with the request.", data.message);
+            }
+
+            [Fact]
+            public void ReturnsFailureIfCurrentUserNotFound()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                GetMock<IUserService>()
+                    .Setup(s => s.FindByUsername(fakes.Owner.Username))
+                    .ReturnsNull();
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.False(data.success);
+                Assert.Equal("Current user not found.", data.message);
+            }
+
+            [Fact]
+            public void ReturnsDefaultConfirmationIfNoPolicyPropagation()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.True(data.success);
+                Assert.Equal("Please confirm if you would like to proceed adding 'testUser' as a co-owner of this package.", data.confirmation);
+            }
+
+            [Fact]
+            public void ReturnsDetailedConfirmationIfNewOwnerPropagatesPolicy()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                fakes.User.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.True(data.success);
+                Assert.StartsWith(
+                    "User 'testUser' has the following requirements that will be enforced for all co-owners once the user accepts ownership of this package:",
+                    data.policyMessage);
+            }
+
+            [Fact]
+            public void ReturnsDetailedConfirmationIfCurrentOwnerPropagatesPolicy()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                fakes.Owner.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.True(data.success);
+                Assert.StartsWith(
+                    "Owner(s) 'testPackageOwner' has (have) the following requirements that will be enforced for user 'testUser' once the user accepts ownership of this package:",
+                    data.policyMessage);
+            }
+
+            [Fact]
+            public void DoesNotReturnConfirmationIfCurrentOwnerPropagatesButNewOwnerIsSubscribed()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                GetMock<ISecurityPolicyService>().Setup(s => s.IsSubscribed(fakes.User, SecurePushSubscription.Name)).Returns(true);
+                fakes.Owner.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.True(data.success);
+                Assert.StartsWith("Please confirm if you would like to proceed adding 'testUser' as a co-owner of this package.",
+                    data.confirmation);
+            }
+
+            [Fact]
+            public void ReturnsDetailedConfirmationIfPendingOwnerPropagatesPolicy()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+
+                fakes.ShaUser.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+                var pendingOwner = new PackageOwnerRequest()
+                {
+                    PackageRegistrationKey = fakes.Package.Key,
+                    NewOwner = fakes.ShaUser
+                };
+                GetMock<IEntityRepository<PackageOwnerRequest>>()
+                    .Setup(r => r.GetAll())
+                    .Returns((new [] { pendingOwner }).AsQueryable());
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.True(data.success);
+                Assert.StartsWith(
+                    "Pending owner(s) 'testShaUser' has (have) the following requirements that will be enforced for all co-owners, including 'testUser', once ownership requests are accepted:",
+                    data.policyMessage);
+            }
+            
+            [Fact]
+            public void DoesNotReturnConfirmationIfPendingOwnerPropagatesButNewOwnerIsSubscribed()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                GetMock<ISecurityPolicyService>().Setup(s => s.IsSubscribed(fakes.User, SecurePushSubscription.Name)).Returns(true);
+
+                fakes.ShaUser.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+                var pendingOwner = new PackageOwnerRequest()
+                {
+                    PackageRegistrationKey = fakes.Package.Key,
+                    NewOwner = fakes.ShaUser
+                };
+                GetMock<IEntityRepository<PackageOwnerRequest>>()
+                    .Setup(r => r.GetAll())
+                    .Returns((new[] { pendingOwner }).AsQueryable());
+
+                // Act
+                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
+                dynamic data = ((JsonResult)result).Data;
+
+                // Assert
+                Assert.True(data.success);
+                Assert.StartsWith("Please confirm if you would like to proceed adding 'testUser' as a co-owner of this package.",
+                    data.confirmation);
+            }
+
+        }
+
         public class TheAddPackageOwnerMethod : TestContainer
         {
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public async Task ThrowsArgumentNullIfPackageIdMissing(string id)
+            {
+                // Arrange
+                var controller = GetController<JsonApiController>();
+
+                // Act & Assert
+                await Assert.ThrowsAsync<ArgumentException>(() => controller.AddPackageOwner(id, "user", string.Empty));
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public async Task ThrowsArgumentNullIfUsernameMissing(string username)
+            {
+                // Arrange
+                var controller = GetController<JsonApiController>();
+
+                // Act & Assert
+                await Assert.ThrowsAsync<ArgumentException>(() => controller.AddPackageOwner("package", username, string.Empty));
+            }
+
             [Fact]
             public async Task ReturnsFailureWhenPackageNotFound()
             {
@@ -57,6 +362,49 @@ namespace NuGetGallery.Controllers
             }
 
             [Fact]
+            public async Task ReturnsFailureIfNewOwnerIsNotConfirmed()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                fakes.User.UnconfirmedEmailAddress = fakes.Owner.EmailAddress;
+                fakes.User.EmailAddress = null;
+
+                // Act
+                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, "message");
+                dynamic data = result.Data;
+
+                // Assert
+                Assert.False(data.success);
+                Assert.Equal("Sorry, 'testUser' hasn't verified their email account yet and we cannot proceed with the request.", data.message);
+            }
+
+            [Fact]
+            public async Task ReturnsFailureIfCurrentUserNotFound()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var controller = GetController<JsonApiController>();
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                GetMock<IUserService>()
+                    .Setup(s => s.FindByUsername(fakes.Owner.Username))
+                    .ReturnsNull();
+
+                // Act
+                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, "message");
+                dynamic data = result.Data;
+
+                // Assert
+                Assert.False(data.success);
+                Assert.Equal("Current user not found.", data.message);
+            }
+
+            [Fact]
             public async Task CreatesPackageOwnerRequestSendsEmailAndReturnsPendingState()
             {
                 var fakes = Get<Fakes>();
@@ -81,8 +429,10 @@ namespace NuGetGallery.Controllers
                         fakes.Owner,
                         fakes.User,
                         fakes.Package,
+                        "http://nuget.local/packages/FakePackage/",
                         "https://nuget.local/packages/FakePackage/owners/testUser/confirm/confirmation-code",
-                        "Hello World! Html Encoded &lt;3"))
+                        "Hello World! Html Encoded &lt;3",
+                        ""))
                     .Verifiable();
 
                 JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, "Hello World! Html Encoded <3");
@@ -95,6 +445,121 @@ namespace NuGetGallery.Controllers
                 httpContextMock.Verify();
                 packageServiceMock.Verify();
                 messageServiceMock.Verify();
+            }
+
+            [Fact]
+            public async Task SendsPackageOwnerRequestEmailWhereNewOwnerPropagatesPolicy()
+            {
+                // Arrange & Act
+                var fakes = Get<Fakes>();
+                var policyMessage = await GetSendPackageOwnerRequestPolicyMessage(fakes, fakes.User);
+
+                // Assert
+                Assert.StartsWith(
+                    "Note: The following policies will be enforced on package co-owners once you accept this request.",
+                    policyMessage);
+            }
+
+            [Fact]
+            public async Task SendsPackageOwnerRequestEmailWhereCurrentOwnerPropagatesPolicy()
+            {
+                // Arrange & Act
+                var fakes = Get<Fakes>();
+                var policyMessage = await GetSendPackageOwnerRequestPolicyMessage(fakes, fakes.Owner);
+
+                // Assert
+                Assert.StartsWith(
+                    "Note: Owner(s) 'testPackageOwner' has (have) the following policies that will be enforced on your account once you accept this request.",
+                    policyMessage);
+            }
+
+            [Fact]
+            public async Task SendsPackageOwnerRequestEmailWherePendingOwnerPropagatesPolicy()
+            {
+                // Arrange & Act
+                var fakes = Get<Fakes>();
+
+                var pendingOwner = new PackageOwnerRequest()
+                {
+                    PackageRegistrationKey = fakes.Package.Key,
+                    NewOwner = fakes.ShaUser
+                };
+                GetMock<IEntityRepository<PackageOwnerRequest>>()
+                    .Setup(r => r.GetAll())
+                    .Returns((new[] { pendingOwner }).AsQueryable());
+
+                var policyMessage = await GetSendPackageOwnerRequestPolicyMessage(fakes, fakes.ShaUser);
+
+                // Assert
+                Assert.StartsWith(
+                    "Note: Pending owner(s) 'testShaUser' has (have) the following policies that will be enforced on your account once ownership requests are accepted.",
+                    policyMessage);
+            }
+
+            private async Task<string> GetSendPackageOwnerRequestPolicyMessage(Fakes fakes, User userToSubscribe)
+            {
+                // Arrange
+                var controller = GetController<JsonApiController>();
+                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
+                GetMock<HttpContextBase>()
+                    .Setup(c => c.User)
+                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                userToSubscribe.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+
+                var packageServiceMock = GetMock<IPackageService>();
+                packageServiceMock
+                    .Setup(p => p.CreatePackageOwnerRequestAsync(fakes.Package, fakes.Owner, fakes.User))
+                    .Returns(Task.FromResult(new PackageOwnerRequest { ConfirmationCode = "confirmation-code" }))
+                    .Verifiable();
+
+                string actualMessage = string.Empty;
+                GetMock<IMessageService>()
+                    .Setup(m => m.SendPackageOwnerRequest(
+                        fakes.Owner,
+                        fakes.User,
+                        fakes.Package,
+                        "http://nuget.local/packages/FakePackage/",
+                        "https://nuget.local/packages/FakePackage/owners/testUser/confirm/confirmation-code",
+                        string.Empty,
+                        It.IsAny<string>()))
+                    .Callback<User, User, PackageRegistration, string, string, string, string>(
+                        (from, to, pkg, pkgUrl, cnfUrl, msg, policyMsg) => actualMessage = policyMsg);
+
+                // Act
+                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, string.Empty);
+                dynamic data = result.Data;
+
+                // Assert
+                Assert.True(data.success);
+                Assert.False(String.IsNullOrEmpty(actualMessage));
+                return actualMessage;
+            }
+        }
+
+        public class TheRemovePackageOwnerMethod : TestContainer
+        {
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public async Task ThrowsArgumentNullIfPackageIdMissing(string id)
+            {
+                // Arrange
+                var controller = GetController<JsonApiController>();
+
+                // Act & Assert
+                await Assert.ThrowsAsync<ArgumentException>(() => controller.RemovePackageOwner(id, "user"));
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public async Task ThrowsArgumentNullIfUsernameMissing(string username)
+            {
+                // Arrange
+                var controller = GetController<JsonApiController>();
+
+                // Act & Assert
+                await Assert.ThrowsAsync<ArgumentException>(() => controller.RemovePackageOwner("package", username));
             }
         }
     }

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -413,6 +413,7 @@
     <Compile Include="SearchClient\WebApiCorrelationHandlerFacts.cs" />
     <Compile Include="Security\RequirePackageVerifyScopePolicyFacts.cs" />
     <Compile Include="Security\RequireMinClientVersionForPushPolicyFacts.cs" />
+    <Compile Include="Security\RequireSecurePushForCoOwnersPolicyFacts.cs" />
     <Compile Include="Security\SecurityPolicyServiceFacts.cs" />
     <Compile Include="Security\SecurePushSubscriptionFacts.cs" />
     <Compile Include="Security\TestSecurityPolicyService.cs" />

--- a/tests/NuGetGallery.Facts/Security/RequireSecurePushForCoOwnersPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/RequireSecurePushForCoOwnersPolicyFacts.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using NuGetGallery.Framework;
+using Xunit;
+
+namespace NuGetGallery.Security
+{
+    public class RequireSecurePushForCoOwnersPolicyFacts : TestContainer
+    {
+        private RequireSecurePushForCoOwnersPolicy _policy;
+
+        public RequireSecurePushForCoOwnersPolicyFacts()
+        {
+            _policy = new RequireSecurePushForCoOwnersPolicy();
+        }
+
+        [Fact]
+        public void PolicyHandlerName_ReturnsExpected()
+        {
+            Assert.Equal("RequireSecurePushForCoOwnersPolicy", _policy.Name);
+        }
+
+        [Fact]
+        public void SubscriptionName_ReturnsExpected()
+        {
+            Assert.Equal("SecurePushForCoOwners", _policy.SubscriptionName);
+        }
+
+        [Fact]
+        public void PolicyHandlerPolicies_ReturnsExpected()
+        {
+            Assert.Equal(1, _policy.Policies.Count());
+
+            var policyModel = _policy.Policies.FirstOrDefault();
+            Assert.NotNull(policyModel);
+
+            Assert.Equal("RequireSecurePushForCoOwnersPolicy", policyModel.Name);
+            Assert.Equal("SecurePushForCoOwners", policyModel.Subscription);
+        }
+
+        [Fact]
+        public void IsSubscribed_ReturnsFalseIfNotSubscribed()
+        {
+            var fakes = Get<Fakes>();
+
+            Assert.False(RequireSecurePushForCoOwnersPolicy.IsSubscribed(fakes.User));
+        }
+
+        [Fact]
+        public void IsSubscribed_ReturnsTrueIfSubscribed()
+        {
+            var fakes = Get<Fakes>();
+            fakes.User.SecurityPolicies = _policy.Policies.ToList();
+
+            Assert.True(RequireSecurePushForCoOwnersPolicy.IsSubscribed(fakes.User));
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Security/SecurityPolicyServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/SecurityPolicyServiceFacts.cs
@@ -139,6 +139,14 @@ namespace NuGetGallery.Security
             service.MockAuditingService.Verify(s => s.SaveAuditRecordAsync(It.IsAny<AuditRecord>()), Times.Exactly(times));
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void IsSubscribed_ThrowsArgumentIfUsernameMissing(string username)
+        {
+            Assert.Throws<ArgumentException>(() => new TestSecurityPolicyService().IsSubscribed(new User(), username));
+        }
+
         [Fact]
         public void IsSubscribed_ThrowsArgumentNullIfUserIsNull()
         {
@@ -150,7 +158,7 @@ namespace NuGetGallery.Security
         public void IsSubscribed_ThrowsArgumentNullIfSubscriptionIsNull()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new TestSecurityPolicyService().IsSubscribed(new User(), null));
+                new TestSecurityPolicyService().IsSubscribed(new User(), (IUserSecurityPolicySubscription)null));
         }
 
         [Fact]
@@ -207,7 +215,16 @@ namespace NuGetGallery.Security
         public void SubscribeAsync_ThrowsArgumentNullIfSubscriptionIsNull()
         {
             Assert.ThrowsAsync<ArgumentNullException>(() =>
-                new TestSecurityPolicyService().SubscribeAsync(new User(), null));
+                new TestSecurityPolicyService().SubscribeAsync(new User(), (IUserSecurityPolicySubscription)null));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void SubscribeAsync_ThrowsArgumentNullIfSubscriptionNameIsMissing(string subscriptionName)
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(() =>
+                new TestSecurityPolicyService().SubscribeAsync(new User(), subscriptionName));
         }
 
         [Fact]
@@ -218,9 +235,10 @@ namespace NuGetGallery.Security
             var user = new User("testUser");
 
             // Act.
-            await service.SubscribeAsync(user, service.UserSubscriptions.First());
+            var subscribed = await service.SubscribeAsync(user, service.UserSubscriptions.First());
 
             // Act & Assert.
+            Assert.True(subscribed);
             Assert.Equal(2, user.SecurityPolicies.Count);
             service.Mocks.VerifySubscriptionPolicies(user.SecurityPolicies);
 
@@ -242,9 +260,11 @@ namespace NuGetGallery.Security
             }
 
             // Act.
-            await service.SubscribeAsync(user, service.UserSubscriptions.First());
+            var subscribed = await service.SubscribeAsync(user, service.UserSubscriptions.First());
 
             // Act & Assert.
+            Assert.True(subscribed);
+
             var policies = user.SecurityPolicies.ToList();
             Assert.Equal(4, policies.Count);
             Assert.Equal(subscriptionName2, policies[0].Subscription);
@@ -269,9 +289,10 @@ namespace NuGetGallery.Security
             Assert.Equal(2, user.SecurityPolicies.Count);
 
             // Act.
-            await service.SubscribeAsync(user, service.UserSubscriptions.First());
+            var subscribed = await service.SubscribeAsync(user, service.UserSubscriptions.First());
 
             // Act & Assert.
+            Assert.False(subscribed);
             Assert.Equal(2, user.SecurityPolicies.Count);
             service.Mocks.VerifySubscriptionPolicies(user.SecurityPolicies);
 
@@ -322,7 +343,16 @@ namespace NuGetGallery.Security
         public void UnsubscribeAsync_ThrowsArgumentNullIfSubscriptionIsNull()
         {
             Assert.ThrowsAsync<ArgumentNullException>(() =>
-                new TestSecurityPolicyService().UnsubscribeAsync(new User(), null));
+                new TestSecurityPolicyService().UnsubscribeAsync(new User(), (IUserSecurityPolicySubscription)null));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void UnsubscribeAsync_ThrowsArgumentNullIfSubscriptionNameIsMissing(string subscriptionName)
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(() =>
+                new TestSecurityPolicyService().UnsubscribeAsync(new User(), subscriptionName));
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -333,16 +333,17 @@ namespace NuGetGallery
                 var to = new User { Username = "Noob", EmailAddress = "new-owner@example.com", EmailAllowed = true };
                 var from = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
                 var package = new PackageRegistration { Id = "CoolStuff" };
+                const string packageUrl = "http://nuget.local/packages/CoolStuff";
                 const string confirmationUrl = "http://example.com/confirmation-token-url";
                 const string userMessage = "Hello World!";
                 var messageService = new TestableMessageService();
-                messageService.SendPackageOwnerRequest(from, to, package, confirmationUrl, userMessage);
+                messageService.SendPackageOwnerRequest(from, to, package, packageUrl, confirmationUrl, userMessage, string.Empty);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal("new-owner@example.com", message.To[0].Address);
                 Assert.Equal(TestGalleryNoReplyAddress.Address, message.From.Address);
                 Assert.Equal("existing-owner@example.com", message.ReplyToList.Single().Address);
-                Assert.Equal("[Joe Shmoe] The user 'Existing' wants to add you as an owner of the package 'CoolStuff'.", message.Subject);
+                Assert.Equal("[Joe Shmoe] The user 'Existing' would like to add you as an owner of the package 'CoolStuff'.", message.Subject);
                 Assert.Contains("The user 'Existing' added the following message for you", message.Body);
                 Assert.Contains(userMessage, message.Body);
                 Assert.Contains(confirmationUrl, message.Body);
@@ -356,9 +357,10 @@ namespace NuGetGallery
                 var to = new User { Username = "Noob", EmailAddress = "new-owner@example.com", EmailAllowed = true };
                 var from = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
                 var package = new PackageRegistration { Id = "CoolStuff" };
+                const string packageUrl = "http://nuget.local/packages/CoolStuff";
                 const string confirmationUrl = "http://example.com/confirmation-token-url";
                 var messageService = new TestableMessageService();
-                messageService.SendPackageOwnerRequest(from, to, package, confirmationUrl, string.Empty);
+                messageService.SendPackageOwnerRequest(from, to, package, packageUrl, confirmationUrl, string.Empty, string.Empty);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.DoesNotContain("The user 'Existing' added the following message for you", message.Body);
@@ -370,11 +372,52 @@ namespace NuGetGallery
                 var to = new User { Username = "Noob", EmailAddress = "new-owner@example.com", EmailAllowed = false };
                 var from = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
                 var package = new PackageRegistration { Id = "CoolStuff" };
+                const string packageUrl = "http://nuget.local/packages/CoolStuff";
                 const string confirmationUrl = "http://example.com/confirmation-token-url";
 
                 var messageService = new TestableMessageService();
-                messageService.SendPackageOwnerRequest(from, to, package, confirmationUrl, string.Empty);
+                messageService.SendPackageOwnerRequest(from, to, package, packageUrl, confirmationUrl, string.Empty, string.Empty);
 
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendPackageOwnerAddedNoticeMethod
+        {
+            [Fact]
+            public void SendsPackageOwnerAddedNotice()
+            {
+                // Arrange
+                var toUser = new User { Username = "Existing", EmailAddress = "existing-owner@example.com", EmailAllowed = true };
+                var newUser = new User { Username = "Noob", EmailAddress = "new-owner@example.com" };
+                var package = new PackageRegistration { Id = "CoolStuff" };
+
+                // Act
+                var messageService = new TestableMessageService();
+                messageService.SendPackageOwnerAddedNotice(toUser, newUser, package, "packageUrl", "policyMessage");
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+                Assert.Equal("existing-owner@example.com", message.To[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress.Address, "noreply@example.com");
+                Assert.Contains("The user 'Noob' is now an owner of the package 'CoolStuff'.", message.Subject);
+                Assert.Contains("This is to inform you that 'Noob' is now an owner of the package", message.Body);
+                Assert.Contains("policyMessage", message.Body);
+            }
+
+            [Fact]
+            public void DoesNotSendPackageOwnerAddedNoticeIfUserDoesNotAllowEmails()
+            {
+                // Arrange
+                var toUser = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
+                var newUser = new User { Username = "Noob", EmailAddress = "new-owner@example.com", EmailAllowed = false };
+                var package = new PackageRegistration { Id = "CoolStuff" };
+
+                // Act
+                var messageService = new TestableMessageService();
+                messageService.SendPackageOwnerAddedNotice(toUser, newUser, package, "packageUrl", "policyMessage");
+
+                // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
             }
         }

--- a/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
@@ -37,6 +37,7 @@ namespace NuGetGallery
             controller.ControllerContext = controllerContext;
             var routeCollection = new RouteCollection();
             routeCollection.MapRoute("catch-all", "{*catchall}");
+            routeCollection.MapRoute(RouteName.DisplayPackage, "");
             controller.Url = new UrlHelper(requestContext, routeCollection);
             return httpContext;
         }


### PR DESCRIPTION
- Added inline confirmation when adding new package owner
- Added package URL link to package owner request emails
- Added new notification to co-owners when package owner request is confirmed
- Added secure push policy messaging to communication above (confirmation, request, and notification)
- Added secure push policy messaging to package view for owners and admins
- Fixed bug on security policy admin view where toggle all broken if multiple subscriptions
- Updated security policy admin view to not reload page on update postback