### PR TITLE
Preserve original 409/conflict exception for transient auditing issue

### DIFF
--- a/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
@@ -116,7 +116,7 @@ namespace NuGetGallery.Auditing
                     throw new InvalidOperationException(String.Format(
                         CultureInfo.CurrentCulture,
                         CoreStrings.CloudAuditingService_DuplicateAuditRecord,
-                        fullPath));
+                        fullPath), ex);
                 }
                 throw;
             }


### PR DESCRIPTION
see: https://github.com/NuGet/Engineering/issues/495

Attaching original exception for access to the ExtendedErrorInformation.ErrorCode which may provide more insight into what the conflict was. I think it's unlikely to be BlobAlreadyExists, since that would imply the retry path due to ContainerNotFound.