### PR TITLE
[Redesign]Small Fixes for StatisticsPages

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -23,6 +23,12 @@
         return false;
     }
 
+    nuget.parseNumber = function (unparsedValue) {
+        unparsedValue = ('' + unparsedValue).replace(/,/g, '');
+        var parsedValue = parseInt(unparsedValue);
+        return parsedValue;
+    }
+
     // source: http://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
     // enhancement with special case for IEs, otherwise the temp textarea will be visible
     nuget.copyTextToClipboard = function (text) {

--- a/src/NuGetGallery/Scripts/gallery/page-home.js
+++ b/src/NuGetGallery/Scripts/gallery/page-home.js
@@ -1,12 +1,6 @@
 $(function () {
     'use strict';
 
-    function parseNumber(unparsedValue) {
-        unparsedValue = ('' + unparsedValue).replace(/,/g, '');
-        var parsedValue = parseInt(unparsedValue);
-        return parsedValue;
-    }
-
     function commaThousands(value) {
         var output = value.toString();
         for (var i = output.length - 3; i > 0; i -= 3)
@@ -18,7 +12,7 @@ $(function () {
     }
 
     function updateStat(observable, unparsedValue) {
-        var parsedValue = parseNumber(unparsedValue);
+        var parsedValue = window.nuget.parseNumber(unparsedValue);
         if (!isNaN(parsedValue)) {
             observable(parsedValue);
         }
@@ -55,7 +49,7 @@ $(function () {
             $(element).text(value);
         },
         update: function (element, valueAccessor) {
-            var oldValue = parseNumber($(element).text());
+            var oldValue = window.nuget.parseNumber($(element).text());
             var newValue = ko.unwrap(valueAccessor());
 
             $({ value: oldValue }).animate({ value: newValue }, {

--- a/src/NuGetGallery/Scripts/gallery/stats-dimensions.js
+++ b/src/NuGetGallery/Scripts/gallery/stats-dimensions.js
@@ -4,7 +4,7 @@
 
         $("#loading-placeholder").hide();
         // Populate the data table
-        data['reportSize'] = data.Table != null? data.Table.length : 0;
+        data['reportSize'] = data.Table != null ? data.Table.length : 0;
 
         $("#report").remove();
 

--- a/src/NuGetGallery/Scripts/gallery/stats-dimensions.js
+++ b/src/NuGetGallery/Scripts/gallery/stats-dimensions.js
@@ -4,7 +4,7 @@
 
         $("#loading-placeholder").hide();
         // Populate the data table
-        data['reportSize'] = data.Table.length;
+        data['reportSize'] = data.Table != null? data.Table.length : 0;
 
         $("#report").remove();
 

--- a/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
+++ b/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
@@ -232,7 +232,7 @@ var GetChartData = function (rawData, filter) {
         rawData.Table.forEach(function (dataPoint) {
             var item = {
                 label: dataPoint[0].Data,
-                downloads: parseInt(dataPoint[1].Data.replace(",", ""))
+                downloads: window.nuget.parseNumber(dataPoint[1].Data)
             };
 
             if (!filter(item)) {

--- a/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
+++ b/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
@@ -36,6 +36,10 @@ var drawDownloadsByVersionBarChart = function (rawData) {
     // we get descending order from server. Reverse so we can cut the right versions.
     data.reverse();
 
+    if (data.length < 1) {
+        return;
+    }
+
     //  limit the bar graph to the most recent 15 versions
     if (data.length > 15) {
         data = data.slice(data.length - 15, data.length);
@@ -151,6 +155,10 @@ var drawDownloadsByClientNameBarChart = function (rawData) {
     }
 
     data.reverse();
+
+    if (data.length < 1) {
+        return;
+    }
 
     //  draw graph
 

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -38,7 +38,7 @@
                         <tfoot>
                             <tr>
                                 <td colspan="2">
-                                    <a href="@Url.StatisticsAllPackageVersionDownloads()">More...<span class="sr-only">View more package download statistics</span></a>
+                                    <a href="@Url.StatisticsAllPackageDownloads()">More...<span class="sr-only">View more package download statistics</span></a>
                                 </td>
                             </tr>
                         </tfoot>

--- a/src/NuGetGallery/Views/Statistics/PackageDownloadsByVersion.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageDownloadsByVersion.cshtml
@@ -15,7 +15,7 @@
 
 @section BottomScripts
 {
-    @Scripts.Render("~/Scripts/gallery/stats.min.js");
+    @Scripts.Render("~/Scripts/gallery/stats.min.js")
     <script>
         $(document)
             .ready(function () {

--- a/src/NuGetGallery/Views/Statistics/PackageDownloadsDetail.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageDownloadsDetail.cshtml
@@ -15,7 +15,7 @@
 
 @section BottomScripts
 {
-    @Scripts.Render("~/Scripts/gallery/stats.min.js");
+    @Scripts.Render("~/Scripts/gallery/stats.min.js")
     <script>
         $(document)
             .ready(function () {

--- a/src/NuGetGallery/Views/Statistics/_LastUpdated.cshtml
+++ b/src/NuGetGallery/Views/Statistics/_LastUpdated.cshtml
@@ -1,9 +1,7 @@
 ﻿@model StatisticsPackagesViewModel
 @if (Model.LastUpdatedUtc != null)
 {
-    <div class="row">
-        <div class="last-updated col-xs-12">
-            Statistics last updated at @Model.LastUpdatedUtc.Value.ToNuGetShortDateTimeString() UTC.
-        </div>
+    <div class="last-updated col-xs-12">
+        Statistics last updated at @Model.LastUpdatedUtc.Value.ToNuGetShortDateTimeString() UTC.
     </div>
 }


### PR DESCRIPTION
Addresses the following issues:
 - [Stray semicolon on the package statistics page #4189](https://github.com/NuGet/NuGetGallery/issues/4189)
   - Removed Semicolon
 - [[Redesign] Statistics Overview page Last Updated timestamp has no gutter #4180](https://github.com/NuGet/NuGetGallery/issues/4180)
   - Removed encapsulating row
 - [[Redesign] JavaScript Error on Statistic Page #4174](https://github.com/NuGet/NuGetGallery/issues/4174)
   - Added a null check to js.
 - [[Redesign][PackageStats]High download versions are losing digits on the chart. #4163](https://github.com/NuGet/NuGetGallery/issues/4163)
   - Generalized and switched to better number parsing
 - [[Redesign] package statistics - when all downloads are from unknown client - graph is empty #4164](https://github.com/NuGet/NuGetGallery/issues/4164)
   - Removed chart when there is nothing to show on it.
 - [[Redesign] Statistics overview page does links to Most Downloaded Versions instead of Most Downloaded Packages #4134](https://github.com/NuGet/NuGetGallery/issues/4134)
   - Fixed link

@joelverhagen @scottbommarito @agr @skofman1 @loic-sharma 