### PR TITLE
Make sure the footer release information does not wrap when the content is too long

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -30,13 +30,13 @@ body h3 {
 .footer a {
   color: #e3ebf1;
 }
-.footer .footer-dotnet-foundation {
-  float: left;
-  width: 48px;
-  margin-right: 15px;
-}
-.footer .footer-release-info {
-  float: left;
+@media (min-width: 992px) {
+  .footer .footer-dotnet-foundation-logo {
+    text-align: right;
+  }
+  .footer .footer-release-info {
+    padding-left: 0;
+  }
 }
 .row-gap {
   margin-top: 50px;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -35,14 +35,14 @@ body {
     color: @panel-footer-color;
   }
 
-  .footer-dotnet-foundation {
-    width: 48px;
-    float: left;
-    margin-right: 15px;
-  }
+  @media (min-width: @screen-md-min) {
+    .footer-dotnet-foundation-logo {
+      text-align: right;
+    }
 
-  .footer-release-info {
-    float: left;
+    .footer-release-info {
+      padding-left: 0;
+    }
   }
 }
 

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -30,13 +30,13 @@ body h3 {
 .footer a {
   color: #e3ebf1;
 }
-.footer .footer-dotnet-foundation {
-  float: left;
-  width: 48px;
-  margin-right: 15px;
-}
-.footer .footer-release-info {
-  float: left;
+@media (min-width: 992px) {
+  .footer .footer-dotnet-foundation-logo {
+    text-align: right;
+  }
+  .footer .footer-release-info {
+    padding-left: 0;
+  }
 }
 .row-gap {
   margin-top: 50px;

--- a/src/NuGetGallery/Views/Shared/Gallery/Footer.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Footer.cshtml
@@ -31,22 +31,25 @@
                      @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/logo-184x55.png")) />
             </div>
             <div class="col-md-9 row-gap">
-                <div class="text-right footer-dotnet-foundation">
-                    <a href="https://www.dotnetfoundation.org"><img 
-                        width="36" height="34" alt=".NET Foundation website"
-                        src="~/Content/gallery/img/dotnet-foundation.svg"
-                        @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/dotnet-foundation-36x34.png")) /></a>
-                </div>
-                <div class="footer-release-info">
-                    <p>
-                        &copy; @DateTime.UtcNow.Year .NET Foundation -
-                        <a href="@Url.Action("Terms", "Pages")">Terms of Use</a> -
-                        <a href="@Url.Action("Privacy", "Pages")">Privacy Policy</a> -
-                        <a href="@Url.Action("About", "Pages")">About the Gallery</a>
-                        <br />
-                        Deployed using <a href="https://octopus.com/" target="referral">Octopus Deploy</a>
-                    </p>
-                    @ViewHelpers.ReleaseTag()
+                <div class="row">
+                    <div class="col-md-1 footer-dotnet-foundation-logo">
+                        <a href="https://www.dotnetfoundation.org">
+                            <img width="36" height="34" alt=".NET Foundation website"
+                                 src="~/Content/gallery/img/dotnet-foundation.svg"
+                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/dotnet-foundation-36x34.png")) />
+                        </a>
+                    </div>
+                    <div class="col-md-11 footer-release-info">
+                        <p>
+                            &copy; @DateTime.UtcNow.Year .NET Foundation -
+                            <a href="@Url.Action("Terms", "Pages")">Terms of Use</a> -
+                            <a href="@Url.Action("Privacy", "Pages")">Privacy Policy</a> -
+                            <a href="@Url.Action("About", "Pages")">About the Gallery</a>
+                            <br />
+                            Deployed using <a href="https://octopus.com/" target="referral">Octopus Deploy</a>
+                        </p>
+                        @ViewHelpers.ReleaseTag()
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Observe the problem in INT:
![image](https://user-images.githubusercontent.com/94054/27302033-3813508c-54ea-11e7-8d52-5513ad27a2e4.png)
