### PR TITLE
Warn package authors when uploading a semver2 package through the web site

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1223,18 +1223,24 @@ namespace NuGetGallery
                 }
             }
 
+            var dependencyGroups = packageMetadata.GetDependencyGroups();
+
             var model = new VerifyPackageRequest
             {
                 Id = packageMetadata.Id,
                 Version = packageMetadata.Version.ToFullStringSafe(),
                 OriginalVersion = packageMetadata.Version.OriginalVersion,
+                HasSemVer2Version = packageMetadata.Version.IsSemVer2,
+                HasSemVer2Dependency = dependencyGroups.Any(d => d.Packages.Any(
+                                p => (p.VersionRange.HasUpperBound && p.VersionRange.MaxVersion.IsSemVer2)
+                                    || (p.VersionRange.HasLowerBound && p.VersionRange.MinVersion.IsSemVer2))),
                 LicenseUrl = packageMetadata.LicenseUrl.ToEncodedUrlStringOrNull(),
                 Listed = true,
                 Language = packageMetadata.Language,
                 MinClientVersion = packageMetadata.MinClientVersion,
                 FrameworkReferenceGroups = packageMetadata.GetFrameworkReferenceGroups(),
                 Dependencies = new DependencySetsViewModel(
-                    packageMetadata.GetDependencyGroups().AsPackageDependencyEnumerable()),
+                    dependencyGroups.AsPackageDependencyEnumerable()),
                 DevelopmentDependency = packageMetadata.GetValueFromMetadata("developmentDependency"),
                 Edit = new EditPackageVersionRequest
                 {

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -20,6 +20,13 @@ namespace NuGetGallery
         /// </summary>
         public string OriginalVersion { get; set; }
 
+
+        public bool IsSemVer2 => HasSemVer2Version || HasSemVer2Dependency;
+
+        public bool HasSemVer2Version { get; set; }
+
+        public bool HasSemVer2Dependency { get; set; }
+
         public string LicenseUrl { get; set; }
         public bool Listed { get; set; }
         public EditPackageVersionRequest Edit { get; set; }

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -146,12 +146,12 @@
         }
 
 
-                                    @if (!String.IsNullOrEmpty(Model.LicenseUrl))
+        @if (!String.IsNullOrEmpty(Model.LicenseUrl))
         {
             <li>
                 <h4>Requires License Acceptance
                     @{
-                                            var formid2 = "Edit_RequiresLicenseAcceptance";
+                        var formid2 = "Edit_RequiresLicenseAcceptance";
                         <button type="button" class="edit-button" id="@(formid2 + "Button")"><span class="icon-edit" title="Edit Requires License Acceptance"></span></button>
                         <button type="button" class="undo-button" id="@("Undo" + formid2)" style="display: none"><span class="icon-undo"></span></button>
                     }
@@ -201,8 +201,44 @@
     </ul>
 
     @Html.AntiForgeryToken()
-    <input id="verifyUploadSubmit" type="submit" value="Submit" title="Verify Details &amp; Submit" /> 
-    <a class="cancel" href="@Url.CancelUpload()" title="Cancel the upload in progress.">Cancel</a>
+    @if (Model.IsSemVer2)
+    {
+        <p class="message warning fancy">
+            <span class="icon-stack warningsign">
+                <i class="icon-circle icon-stack-base"></i>
+                <i class="icon-exclamation"></i>
+            </span>
+            @if (Model.HasSemVer2Version)
+            {
+                <text>
+                    Warning: This package has a SemVer2 package version. <br />
+                    <span style="font-weight: normal; font-style:italic;">
+                        This package will only be available for download with SemVer2-compatible NuGet clients, such as Visual Studio 2017 (version 15.3) and above or NuGet client 4.3.0 and above.<br />
+                        Reach out to support if you have more questions.
+                    </span>
+                </text>
+            }
+            else if (Model.HasSemVer2Dependency)
+            {
+                <text>
+                    Warning: This package is considered a SemVer2 package as it has a package dependency declaring a SemVer2 version range.<br />
+                    <span style="font-weight: normal; font-style:italic;">
+                        This package will only be available for download with SemVer2-compatible NuGet clients, such as Visual Studio 2017 (version 15.3) and above or NuGet client 4.3.0 and above.<br />
+                        Reach out to support if you have more questions.
+                    </span>
+                </text>
+            }
+            <br />
+            <br />
+            <input id="verifyUploadSubmit" type="submit" value="Submit" title="Verify Details &amp; Submit" />
+            <a class="cancel" href="@Url.CancelUpload()" title="Cancel the upload in progress.">Cancel</a>
+</p>
+    }
+    else
+    {
+        <input id="verifyUploadSubmit" type="submit" value="Submit" title="Verify Details &amp; Submit" />
+        <a class="cancel" href="@Url.CancelUpload()" title="Cancel the upload in progress.">Cancel</a>
+    }
 </fieldset>
 }
 

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -211,23 +211,19 @@
             @if (Model.HasSemVer2Version)
             {
                 <text>
-                    Warning: This package has a SemVer2 package version. <br />
-                    <span style="font-weight: normal; font-style:italic;">
-                        This package will only be available for download with SemVer2-compatible NuGet clients, such as Visual Studio 2017 (version 15.3) and above or NuGet client 4.3.0 and above.<br />
-                        Reach out to support if you have more questions.
-                    </span>
+                    Warning: This package has a SemVer 2.0.0 package version. <br />
                 </text>
             }
             else if (Model.HasSemVer2Dependency)
             {
                 <text>
-                    Warning: This package is considered a SemVer2 package as it has a package dependency declaring a SemVer2 version range.<br />
-                    <span style="font-weight: normal; font-style:italic;">
-                        This package will only be available for download with SemVer2-compatible NuGet clients, such as Visual Studio 2017 (version 15.3) and above or NuGet client 4.3.0 and above.<br />
-                        Reach out to support if you have more questions.
-                    </span>
+                    Warning: This package is considered a SemVer 2.0.0 package as it has a package dependency declaring a SemVer2 version range.<br />
                 </text>
             }
+            <span style="font-weight: normal; font-style:italic;">
+                This package will only be available for download with SemVer 2.0.0 compatible NuGet clients, such as Visual Studio 2017 (version 15.3) and above or NuGet client 4.3.0 and above.<br />
+                Reach out to support if you have more questions.
+            </span>
             <br />
             <br />
             <input id="verifyUploadSubmit" type="submit" value="Submit" title="Verify Details &amp; Submit" />

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -217,7 +217,7 @@
             else if (Model.HasSemVer2Dependency)
             {
                 <text>
-                    Warning: This package is considered a SemVer 2.0.0 package as it has a package dependency declaring a SemVer2 version range.<br />
+                    Warning: This package is considered a SemVer 2.0.0 package as it has a package dependency declaring a SemVer 2.0.0 version range.<br />
                 </text>
             }
             <span style="font-weight: normal; font-style:italic;">

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -224,17 +224,12 @@
                 This package will only be available for download with SemVer 2.0.0 compatible NuGet clients, such as Visual Studio 2017 (version 15.3) and above or NuGet client 4.3.0 and above.<br />
                 Reach out to support if you have more questions.
             </span>
-            <br />
-            <br />
-            <input id="verifyUploadSubmit" type="submit" value="Submit" title="Verify Details &amp; Submit" />
-            <a class="cancel" href="@Url.CancelUpload()" title="Cancel the upload in progress.">Cancel</a>
-</p>
+        </p>
     }
-    else
-    {
+
         <input id="verifyUploadSubmit" type="submit" value="Submit" title="Verify Details &amp; Submit" />
         <a class="cancel" href="@Url.CancelUpload()" title="Cancel the upload in progress.">Cancel</a>
-    }
+        
 </fieldset>
 }
 

--- a/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/VerifyPackage.cshtml
@@ -211,18 +211,18 @@
             @if (Model.HasSemVer2Version)
             {
                 <text>
-                    Warning: This package has a SemVer 2.0.0 package version. <br />
+                    Warning: This package has a SemVer 2.0.0 package version.<br />
                 </text>
             }
             else if (Model.HasSemVer2Dependency)
             {
                 <text>
-                    Warning: This package is considered a SemVer 2.0.0 package as it has a package dependency declaring a SemVer 2.0.0 version range.<br />
+                    Warning: This package is considered a SemVer 2.0.0 package as it has a package dependency on SemVer 2.0.0 package(s).<br />
                 </text>
             }
             <span style="font-weight: normal; font-style:italic;">
-                This package will only be available for download with SemVer 2.0.0 compatible NuGet clients, such as Visual Studio 2017 (version 15.3) and above or NuGet client 4.3.0 and above.<br />
-                Reach out to support if you have more questions.
+                This package will only be available to download with SemVer 2.0.0 compatible NuGet clients, such as Visual Studio 2017 (version 15.3) and above or NuGet client 4.3.0 and above.
+                <a href="https://go.microsoft.com/fwlink/?linkid=852248" alt="Read more">Read more</a><br />
             </span>
         </p>
     }

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1346,6 +1346,42 @@ namespace NuGetGallery
                 }
             }
 
+            [Theory]
+            [InlineData("1.0.42+metadata", true)]
+            [InlineData("1.0.42-alpha.1", true)]
+            [InlineData("1.0.42", false)]
+            public async Task WillPassHasSemVer2VersionToTheView(string originalVersion, bool isSemVer2)
+            {
+                using (var fakeUploadFileStream = TestPackage.CreateTestPackageStream("theId", originalVersion))
+                {
+                    var model = await CreateVerifyPackageRequestForPackage(fakeUploadFileStream);
+                    Assert.Equal(isSemVer2, model.IsSemVer2);
+                }
+            }
+
+            [Theory]
+            [InlineData("1.0.42-alpha.1", true)]
+            [InlineData("1.0.42", false)]
+            public async Task WillPassHasSemVer2DependencyToTheView(string minVersion, bool isSemVer2)
+            {
+                var versionRange = new VersionRange(new NuGetVersion(minVersion));
+
+                var packageDependency = new NuGet.Packaging.Core.PackageDependency("theId", versionRange);
+                var packageDependencies = new List<NuGet.Packaging.Core.PackageDependency>
+                {
+                    packageDependency
+                };
+                var packageDependencyGroup = new PackageDependencyGroup(NuGetFramework.AnyFramework, packageDependencies);
+                var packageDependencyGroups = new List<PackageDependencyGroup>();
+                packageDependencyGroups.Add(packageDependencyGroup);
+
+                using (var fakeUploadFileStream = TestPackage.CreateTestPackageStream("theId", "1.0.42", packageDependencyGroups: packageDependencyGroups))
+                {
+                    var model = await CreateVerifyPackageRequestForPackage(fakeUploadFileStream);
+                    Assert.Equal(isSemVer2, model.IsSemVer2);
+                }
+            }
+
             [Fact]
             public async Task WillPassThePackageTitleToTheView()
             {


### PR DESCRIPTION
This PR is a proposal we can start working from. Awaiting final wording from @anangaur. 

I'd suggest to have the warning as close as possible to the submit button to ensure maximum visibility (people don't always read messages at the top of the page).

When a package has a semver2 version itself:

![image](https://user-images.githubusercontent.com/880728/27371658-f4342674-5661-11e7-97d3-14ae0f370208.png)

When a package has a non-semver2 version, but is considered semver2 due to a dependency declaration:

![image](https://user-images.githubusercontent.com/880728/27371602-c23246b0-5661-11e7-972b-51014e7c104d.png)
