### PR TITLE
[Redesign] Updated Forgot Password Pages' Column Layouts

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -387,7 +387,7 @@ img.package-icon {
   margin-top: 20px;
 }
 .page-forgot-password .forgot-form {
-  margin-top: 80px;
+  margin-top: 20px;
 }
 .page-home .jumbotron h1 {
   margin: 32px;

--- a/src/Bootstrap/less/theme/page-forgot-password.less
+++ b/src/Bootstrap/less/theme/page-forgot-password.less
@@ -1,5 +1,5 @@
 .page-forgot-password {
   .forgot-form {
-    margin-top: 80px;
+    margin-top: (@padding-large-vertical * 2);
   }
 } 

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -387,7 +387,7 @@ img.package-icon {
   margin-top: 20px;
 }
 .page-forgot-password .forgot-form {
-  margin-top: 80px;
+  margin-top: 20px;
 }
 .page-home .jumbotron h1 {
   margin: 32px;

--- a/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
+++ b/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
@@ -5,12 +5,13 @@
 }
 
 <section role="main" class="container main-container page-forgot-password">
-    <h1>Forgot Password</h1>
+    <div class="col-sm-4 col-sm-offset-4 text-center">
+        <h1>Forgot Password</h1>
 
-    <p>We are sorry to hear you forgot your NuGet.org account password. Enter your email below and we will send instructions to reset your password.</p>
+        <p>We are sorry to hear you forgot your NuGet.org account password. Enter your email below and we will send instructions to reset your password.</p>
 
-    <div class="row forgot-form">
-        <div class="col-sm-offset-3 col-sm-6">
+        <div class="row forgot-form text-left">
+
             @using (Html.BeginForm())
             {
                 @Html.AntiForgeryToken()

--- a/src/NuGetGallery/Views/Users/PasswordSent.cshtml
+++ b/src/NuGetGallery/Views/Users/PasswordSent.cshtml
@@ -21,4 +21,6 @@
         Please check your spam folder if you don't receive the email within a
         few minutes.
     </p>
+
+    <a href="@Url.Home()" class="btn btn-primary col-xs-12">Go back</a>
 </section>

--- a/src/NuGetGallery/Views/Users/PasswordSent.cshtml
+++ b/src/NuGetGallery/Views/Users/PasswordSent.cshtml
@@ -4,23 +4,23 @@
 }
 
 <section role="main" class="container main-container">
-    <h1>Password Reset Sent</h1>
+    <div class="col-sm-4 col-sm-offset-4 text-center">
+        <h1>Password Reset Sent</h1>
 
-    <p>
-        We've sent you an email containing a temporary url that will allow you to reset your NuGet.org
-        account password for the next @if (@ViewBag.Expiration == 1)
-        {
-            <text>hour.</text>
-        }
-        else
-        {
-            <text>@ViewBag.Expiration hours.</text>
-        }
-    </p>
-    <p>
-        Please check your spam folder if you don't receive the email within a
-        few minutes.
-    </p>
-
-    <a href="@Url.Home()" class="btn btn-primary col-xs-12">Go back</a>
+        <p>
+            We've sent you an email containing a temporary url that will allow you to reset your NuGet.org
+            account password for the next @if (@ViewBag.Expiration == 1)
+            {
+                <text>hour.</text>
+            }
+            else
+            {
+                <text>@ViewBag.Expiration hours.</text>
+            }
+        </p>
+        <p>
+            Please check your spam folder if you don't receive the email within a
+            few minutes.
+        </p>
+    </div>
 </section>


### PR DESCRIPTION
This moves them to a 4-column layout with centered text to be consistent with #4252 

![forgot-password](https://user-images.githubusercontent.com/737941/27358479-b6171b08-55cb-11e7-9d1d-70ada7ff8157.png)

![password-sent](https://user-images.githubusercontent.com/737941/27358477-b2e121f4-55cb-11e7-9129-8e2bbc376ea1.png)

@microsoftsam