### PR TITLE
[Redesign] Manage Packages Page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -157,19 +157,16 @@ img.package-icon {
   margin-left: 10px;
   color: #000;
 }
-.list-packages .package .package-statistics {
+.list-packages .package .package-list {
   margin-top: 10px;
   line-height: 20px;
   color: #666;
 }
-.list-packages .package .package-statistics .package-statistics-middle {
-  padding-right: 10px;
+.list-packages .package .package-list li + li {
   padding-left: 10px;
-  margin-right: 10px;
   margin-left: 10px;
   border-color: #dbdbdb;
   border-width: 1px;
-  border-right-style: solid;
   border-left-style: solid;
 }
 .list-packages .package .package-details {

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -19,18 +19,15 @@
       }
     }
 
-    .package-statistics {
+    .package-list {
       margin-top: @padding-large-vertical;
       line-height: 20px;
       color: @gray-light;
 
-      .package-statistics-middle {
+      li+li {
         margin-left: @padding-small-horizontal;
-        margin-right: @padding-small-horizontal;
         padding-left: @padding-small-horizontal;
-        padding-right: @padding-small-horizontal;
         border-left-style: solid;
-        border-right-style: solid;
         border-width: 1px;
         border-color: @gray-lighter;
       }

--- a/src/NuGetGallery/App_Start/AppActivator.cs
+++ b/src/NuGetGallery/App_Start/AppActivator.cs
@@ -208,6 +208,10 @@ namespace NuGetGallery
                 .Include("~/Scripts/gallery/page-display-package.js");
             BundleTable.Bundles.Add(displayPackageScriptBundle);
 
+            var managePackagesScriptBundle = new ScriptBundle("~/Scripts/gallery/page-manage-packages.min.js")
+                .Include("~/Scripts/gallery/page-manage-packages.js");
+            BundleTable.Bundles.Add(managePackagesScriptBundle);
+
             var aboutScriptBundle = new ScriptBundle("~/Scripts/gallery/page-about.min.js")
                 .Include("~/Scripts/gallery/page-about.js");
             BundleTable.Bundles.Add(aboutScriptBundle);

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -157,19 +157,16 @@ img.package-icon {
   margin-left: 10px;
   color: #000;
 }
-.list-packages .package .package-statistics {
+.list-packages .package .package-list {
   margin-top: 10px;
   line-height: 20px;
   color: #666;
 }
-.list-packages .package .package-statistics .package-statistics-middle {
-  padding-right: 10px;
+.list-packages .package .package-list li + li {
   padding-left: 10px;
-  margin-right: 10px;
   margin-left: 10px;
   border-color: #dbdbdb;
   border-width: 1px;
-  border-right-style: solid;
   border-left-style: solid;
 }
 .list-packages .package .package-details {
@@ -533,6 +530,9 @@ img.package-icon {
 }
 .page-stats-per-package .stats-table-footer tr {
   border: none;
+}
+.page-stats-per-package #hidden-rows {
+  border-top: none;
 }
 .page-stats-per-package #loading-placeholder {
   display: none;

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -164,11 +164,7 @@ namespace NuGetGallery
         {
             var user = GetCurrentUser();
             var packages = _packageService.FindPackagesByOwner(user, includeUnlisted: true)
-                .Select(p => new PackageViewModel(p)
-                {
-                    DownloadCount = p.PackageRegistration.DownloadCount,
-                    Version = null
-                }).ToList();
+                .Select(p => new ListPackageItemViewModel(p)).ToList();
 
             var model = new ManagePackagesViewModel
             {

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1481,6 +1481,7 @@
     <Compile Include="Services\NoLessSecureDestinationRedirectPolicy.cs" />
     <Compile Include="Services\ReflowPackageService.cs" />
     <Compile Include="Services\TelemetryService.cs" />
+    <Compile Include="ViewModels\ManagePackagesListViewModel.cs" />
     <Compile Include="ViewModels\ScopeViewModel.cs" />
     <Compile Include="ViewModels\PackageListSearchViewModel.cs" />
     <Compile Include="WebApi\PlainTextResult.cs" />
@@ -1803,6 +1804,7 @@
     <Content Include="Views\Pages\_PagesView.cshtml" />
     <Content Include="Views\Shared\_SearchBar.cshtml" />
     <Content Include="Views\Pages\Downloads.cshtml" />
+    <Content Include="Views\Users\_UserPackagesList.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="Properties\CodeAnalysisDictionary.xml" />

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -1,0 +1,16 @@
+﻿$(function () {
+    'use strict';
+
+    window.nuget.configureExpander(
+        "packages-Published",
+        "ChevronRight",
+        "My Published Packages",
+        "ChevronDown",
+        "My Published Packages");
+    window.nuget.configureExpander(
+        "packages-Unlisted",
+        "ChevronRight",
+        "My Unlisted Packages",
+        "ChevronDown",
+        "My Unlisted Packages");
+});

--- a/src/NuGetGallery/ViewModels/ManagePackagesListViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ManagePackagesListViewModel.cs
@@ -4,8 +4,16 @@ using System.Collections.Generic;
 
 namespace NuGetGallery
 {
-    public class ManagePackagesViewModel
+    public class ManagePackagesListViewModel
     {
         public IEnumerable<ListPackageItemViewModel> Packages { get; set; }
+
+        public string Name { get; set; }
+
+        public ManagePackagesListViewModel(IEnumerable<ListPackageItemViewModel> packages, string name)
+        {
+            Packages = packages;
+            Name = name;
+        }
     }
 }

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -19,20 +19,26 @@
             </span>
         </div>
 
-        <div class="package-statistics">
-            <span>
-                <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
-                @Model.TotalDownloadCount.ToNuGetNumberString() total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
-            </span>
-            <span class="package-statistics-middle">
-                <i class="ms-Icon ms-Icon--History" aria-hidden="true"></i>
-                last updated <span data-datetime="@Model.LastUpdated.ToJavaScriptUTC()"></span>
-            </span>
-            <span>
-                <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
-                Latest version: <span class="text-nowrap">@Model.FullVersion @(Model.Prerelease ? "(prerelease)" : "")</span>
-            </span>
-        </div>
+        <ul class="package-list list-inline">
+            <li>
+                <span>
+                    <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
+                    @Model.TotalDownloadCount.ToNuGetNumberString() total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
+                </span>
+            </li>
+            <li>
+                <span>
+                    <i class="ms-Icon ms-Icon--History" aria-hidden="true"></i>
+                    last updated <span data-datetime="@Model.LastUpdated.ToJavaScriptUTC()"></span>
+                </span>
+            </li>
+            <li>
+                <span>
+                    <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
+                    Latest version: <span class="text-nowrap">@Model.FullVersion @(Model.Prerelease ? "(prerelease)" : "")</span>
+                </span>
+            </li>
+        </ul>
 
         <div class="package-details">
             @Model.ShortDescription
@@ -50,6 +56,36 @@
                     <a href="@Url.Search("Tags:\"" + tag + "\"")" title="Search for @tag" class="tag">@tag</a>
                 }
             </div>
+        }
+
+        @if (Model.IsOwner(User))
+        {
+            <ul class="package-list list-inline">
+                <li>
+                    <a href="@Url.EditPackage(Model.Id, Model.Version)">
+                        <span>
+                            <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
+                            Edit Package
+                        </span>
+                    </a>
+                </li>
+                <li>
+                    <a href="@Url.ManagePackageOwners(Model)">
+                        <span>
+                            <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>
+                            Manage Owners
+                        </span>
+                    </a>
+                </li>
+                <li>
+                    <a href="@Url.DeletePackage(Model)">
+                        <span>
+                            <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
+                            Delete Package
+                        </span>
+                    </a>
+                </li>
+            </ul>
         }
     </div>
 </article>

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -7,24 +7,12 @@
 
 <section role="main" class="container main-container page-manage-packages page-package-details">
     <h1>Manage Packages</h1>
-    @if (Model.Packages.Any())
-            {
-                var listedPackages = Model.Packages.Where(p => p.Listed);
-                var unlistedPackages = Model.Packages.Where(p => !p.Listed);
+    @{
+        var listedPackages = Model.Packages.Where(p => p.Listed);
+        var unlistedPackages = Model.Packages.Where(p => !p.Listed);
 
-                if (listedPackages.Any())
-                {
-            @Html.Partial("_UserPackagesList", new ManagePackagesListViewModel(listedPackages, "Published"))
-        }
-        if (unlistedPackages.Any())
-        {
-            @Html.Partial("_UserPackagesList", new ManagePackagesListViewModel(unlistedPackages, "Unlisted"))
-        }
-    }
-    else
-    {
-        <h2>My Packages</h2>
-                <p>You have no packages.</p>
+        @Html.Partial("_UserPackagesList", new ManagePackagesListViewModel(listedPackages, "Published"))
+        @Html.Partial("_UserPackagesList", new ManagePackagesListViewModel(unlistedPackages, "Unlisted"))
     }
 </section>
 

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -2,131 +2,32 @@
 @{
     ViewBag.Title = "Manage My Package";
     ViewBag.Tab = "Packages";
+    Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
-<h1 class="page-heading">Manage My Packages</h1>
+<section role="main" class="container main-container page-manage-packages page-package-details">
+    <h1>Manage Packages</h1>
+    @if (Model.Packages.Any())
+            {
+                var listedPackages = Model.Packages.Where(p => p.Listed);
+                var unlistedPackages = Model.Packages.Where(p => !p.Listed);
 
-
-@if (Model.Packages.Any())
-{
-    <section id="published">
-        <h1>Packages</h1>
-        <p>These packages are currently published for the world to see.</p>
-
-        @PrintPublishedPackages(Model.Packages.Where(p => p.Listed && !p.Deleted), canEdit: true, canDelete: true)
-    </section>
-
-    var unlistedPackages = Model.Packages.Where(p => !p.Listed && !p.Deleted);
-    if (unlistedPackages.Any())
-    {
-        <section id="unlisted">
-            <h1>Unlisted Packages</h1>
-            <p>These packages are currently unlisted.</p>
-
-            @PrintPublishedPackages(unlistedPackages, canEdit: false, canDelete: true)
-        </section>
-    }
-
-    var deletedPackages = Model.Packages.Where(p => p.Deleted);
-    if (deletedPackages.Any())
-    {
-        <section id="deleted">
-            <h1>Deleted Packages</h1>
-            <p>These packages have been deleted.</p>
-
-            @PrintPublishedPackages(deletedPackages, canEdit: false, canDelete: false)
-        </section>
-    }
-}
-else
-{
-    <section id="published">
-        <h1>No Packages!</h1>
-        <p>
-            You don't have any packages. Maybe now is a good time to 
-            <a href="@Url.UploadPackage()" class="silverButtonBig">upload a package</a>.
-        </p>
-    </section>
-}
-
-@helper PrintPublishedPackages(IEnumerable<PackageViewModel> packages, bool canEdit, bool canDelete)
-{
-    var totalDownloads = 0;
-    var totalPackages = packages.Count();
-
-    if (totalPackages > 0)
-    {
-        <table class="sexy-table sexy-table-full">
-            <thead>
-                <tr>
-                    <th class="first actions">Actions</th>
-                    <th>Package</th>
-                    <th>Package ID</th>
-                    <th>Description</th>
-                    <th class="last">Downloads</th>
-                
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var package in packages)
+                if (listedPackages.Any())
                 {
-                    <tr>
-                        <td class="actions">
-                            @if (canEdit)
-                            {
-                                <a href="@Url.EditPackage(package.Id, package.Version)" title="Edit" class="table-action-link" aria-label="Edit package details">
-                                    <i class="icon-edit"></i>
-                                </a>
-                            }
-                            @if (canDelete)
-                            {
-                                <a href="@Url.DeletePackage(package)" title="Delete" class="table-action-link" aria-label="Delete package">
-                                    <i class="icon-trash"></i>
-                                </a>
-                            }
-                        </td>
-                        <td>
-                            <a href="@Url.Package(package)"  title="View package page for @package.Id">@package.Title.Abbreviate(25)</a>
-                        </td>
-                        <td>@package.Id.Abbreviate(25)</td>
-                        <td>
-                            @if (String.IsNullOrEmpty(package.Description) || package.Description.Length < 65)
-                            {
-                                @package.Description
-                            }
-                            else
-                            {
-                                @package.Description.Substring(0, 65)
-                                <a href="@Url.Package(package)" title="View package page.">...</a>
-                            }
-                        </td>
-                
-                        <td class="last">@package.DownloadCount</td>
-                    </tr>
-                    totalDownloads += package.DownloadCount;
-                }
-            </tbody>
-            <tfoot>
-                <tr>
-                    <td colspan="4">
-                        @if (totalPackages > 1)
-                        {
-                            @(string.Format("You have a total of {0} packages.", totalPackages))
-                        }
-                        else
-                        {
-                            @("You have one package.")
-                        }
-                    </td>
-                    <td class="total last">
-                        @totalDownloads
-                    </td>
-                </tr>
-            </tfoot>
-        </table>
+            @Html.Partial("_UserPackagesList", new ManagePackagesListViewModel(listedPackages, "Published"))
+        }
+        if (unlistedPackages.Any())
+        {
+            @Html.Partial("_UserPackagesList", new ManagePackagesListViewModel(unlistedPackages, "Unlisted"))
+        }
     }
     else
     {
-        <p><b>You don't have any packages here.</b></p>
+        <h2>My Packages</h2>
+                <p>You have no packages.</p>
     }
+</section>
+
+@section BottomScripts {
+    @Scripts.Render("~/Scripts/gallery/page-manage-packages.min.js")
 }

--- a/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
@@ -10,7 +10,7 @@
     <div class="col-md-12">
         <h2>
             <a href="#" role="button" data-toggle="collapse" data-target="#packages-@Model.Name"
-               aria-expanded="true" id="show-packages-@Model.Name">
+               aria-expanded="true" aria-controls="packages-@Model.Name" id="show-packages-@Model.Name">
                 <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
                 <span>My @Model.Name Packages</span>
             </a>
@@ -19,7 +19,7 @@
             <p>You have <b>@Model.Packages.Count() @Model.Name.ToLowerInvariant() @packagesString</b> with a total of <b>@numDownloads @downloadsString</b></p>
             <div class="list-packages" role="list">
                 @foreach (var package in @Model.Packages)
-            {
+                {
                     @Html.Partial("_ListPackage", package)
                 }
             </div>

--- a/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
@@ -1,0 +1,28 @@
+﻿@model ManagePackagesListViewModel
+@{
+    var packagesString = "package" + (Model.Packages.Count() != 1 ? "s" : "");
+    
+    var numDownloads = Model.Packages.Sum(p => p.DownloadCount);
+    var downloadsString = "download" + (numDownloads != 1 ? "s" : "");
+}
+
+<div class="row">
+    <div class="col-md-12">
+        <h2>
+            <a href="#" role="button" data-toggle="collapse" data-target="#packages-@Model.Name"
+               aria-expanded="true" id="show-packages-@Model.Name">
+                <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                <span>My @Model.Name Packages</span>
+            </a>
+        </h2>
+        <div class="panel-collapse collapse in" id="packages-@Model.Name" aria-expanded="true">
+            <p>You have <b>@Model.Packages.Count() @Model.Name.ToLowerInvariant() @packagesString</b> with a total of <b>@numDownloads @downloadsString</b></p>
+            <div class="list-packages" role="list">
+                @foreach (var package in @Model.Packages)
+            {
+                    @Html.Partial("_ListPackage", package)
+                }
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18014088/27361346-a23921b6-55db-11e7-859e-98aa599a050a.png)

Note that the package controls ("edit package", "manage owners', etc) now appear on all the other package lists in the site if you are the owner of those packages, e.g.:

Packages list:
![image](https://user-images.githubusercontent.com/18014088/27361370-c98848c8-55db-11e7-9c4b-101d10b893bc.png)

Profile:
![image](https://user-images.githubusercontent.com/18014088/27361382-dc7dcf20-55db-11e7-8d02-25030dc70ac2.png)

@microsoftsam