### PR TITLE
[Redesign] Email Confirmation

### DIFF
--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -82,12 +82,7 @@ namespace NuGetGallery
         [Authorize]
         public virtual ActionResult ConfirmationRequired()
         {
-            User user = GetCurrentUser();
-            var model = new ConfirmationViewModel
-            {
-                ConfirmingNewAccount = !(user.Confirmed),
-                UnconfirmedEmailAddress = user.UnconfirmedEmailAddress,
-            };
+            var model = new ConfirmationViewModel(GetCurrentUser());
             return View(model);
         }
 
@@ -108,16 +103,14 @@ namespace NuGetGallery
             {
                 _messageService.SendNewAccountEmail(new MailAddress(user.UnconfirmedEmailAddress, user.Username), confirmationUrl);
 
-                model = new ConfirmationViewModel
+                model = new ConfirmationViewModel(user)
                 {
-                    ConfirmingNewAccount = !(user.Confirmed),
-                    UnconfirmedEmailAddress = user.UnconfirmedEmailAddress,
-                    SentEmail = true,
+                    SentEmail = true
                 };
             }
             else
             {
-                model = new ConfirmationViewModel {AlreadyConfirmed = true};
+                model = new ConfirmationViewModel(user);
             }
             return View(model);
         }
@@ -277,40 +270,29 @@ namespace NuGetGallery
         [Authorize]
         public virtual async Task<ActionResult> Confirm(string username, string token)
         {
-            // We don't want Login to have us as a return URL
+            // We don't want Login to go to this page as a return URL
             // By having this value present in the dictionary BUT null, we don't put "returnUrl" on the Login link at all
             ViewData[Constants.ReturnUrlViewDataKey] = null;
 
-            if (!String.Equals(username, User.Identity.Name, StringComparison.OrdinalIgnoreCase))
-            {
-                return View(new ConfirmationViewModel
-                    {
-                        WrongUsername = true,
-                        SuccessfulConfirmation = false,
-                    });
-            }
-
             var user = GetCurrentUser();
 
-            var alreadyConfirmed = user.UnconfirmedEmailAddress == null;
+            if (!String.Equals(username, User.Identity.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return View(new ConfirmationViewModel(user)
+                {
+                    WrongUsername = true,
+                    SuccessfulConfirmation = false,
+                });
+            }
 
             string existingEmail = user.EmailAddress;
-            var model = new ConfirmationViewModel
-            {
-                ConfirmingNewAccount = String.IsNullOrEmpty(existingEmail),
-                SuccessfulConfirmation = !alreadyConfirmed,
-                AlreadyConfirmed = alreadyConfirmed
-            };
+            var model = new ConfirmationViewModel(user);
 
-            if (!alreadyConfirmed)
+            if (!model.AlreadyConfirmed)
             {
-
                 try
                 {
-                    if (!(await _userService.ConfirmEmailAddress(user, token)))
-                    {
-                        model.SuccessfulConfirmation = false;
-                    }
+                    model.SuccessfulConfirmation = await _userService.ConfirmEmailAddress(user, token);
                 }
                 catch (EntityException)
                 {

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1805,6 +1805,7 @@
     <Content Include="Views\Shared\_SearchBar.cshtml" />
     <Content Include="Views\Pages\Downloads.cshtml" />
     <Content Include="Views\Users\_UserPackagesList.cshtml" />
+    <Content Include="Views\Users\_ConfirmationResendForm.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="Properties\CodeAnalysisDictionary.xml" />

--- a/src/NuGetGallery/ViewModels/ConfirmationViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ConfirmationViewModel.cs
@@ -4,10 +4,6 @@ namespace NuGetGallery
 {
     public class ConfirmationViewModel
     {
-        public string UnconfirmedEmailAddress { get; set; }
-
-        public bool ConfirmingNewAccount { get; set; }
-
         public bool SuccessfulConfirmation { get; set; }
 
         public bool SentEmail { get; set; }
@@ -16,9 +12,20 @@ namespace NuGetGallery
 
         public bool DuplicateEmailAddress { get; set; }
 
-        /// <summary>
-        /// Email is already confirmed
-        /// </summary>
-        public bool AlreadyConfirmed { get; set; }
+        public bool AlreadyConfirmed { get; }
+
+        public bool ConfirmingNewAccount { get; }
+
+        public string ConfirmedEmailAddress { get; }
+
+        public string UnconfirmedEmailAddress { get; }
+
+        public ConfirmationViewModel(User user)
+        {
+            AlreadyConfirmed = user.UnconfirmedEmailAddress == null;
+            ConfirmingNewAccount = !user.Confirmed;
+            ConfirmedEmailAddress = user.EmailAddress;
+            UnconfirmedEmailAddress = user.UnconfirmedEmailAddress;
+        }
     }
 }

--- a/src/NuGetGallery/Views/Users/Confirm.cshtml
+++ b/src/NuGetGallery/Views/Users/Confirm.cshtml
@@ -1,61 +1,78 @@
 ﻿@model ConfirmationViewModel
-
-<h1 class="page-heading">Confirm Registration</h1>
-
-@if (Model.SuccessfulConfirmation)
-{
-    <p>
-        Account confirmed! Your email address has been verified.
-    </p>
-    <p>
-        You may now upload packages and make your mark in
-        the community.
-    </p>
+@{
+    ViewBag.Title = "Confirm Your Account";
+    Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
-else
-{
-    if (Model.WrongUsername)
-    {
-        <p class="message error">
-            You cannot confirm a different user's email address.
-        </p>
-        <p>
-            Please check that you used the link from the right confirmation email, and are logged in as the right user.
-        </p>
-        <p>
-            <a href="@Url.ConfirmationRequired()" >Resend confirmation email.</a>
-        </p>
-    }
-    else if (Model.DuplicateEmailAddress)
-    {
-        <p class="message error">
-            Your email address is confirmed as belonging to another user account (or your 'old' account).
-        </p>
-        <p>
-            You can change your email address to something else, or perhaps reuse the old account registered with this email address.
-        </p>
-    }
-    else if(Model.AlreadyConfirmed)
-    {
-        <p class="message">
-            Your email address has already been confirmed.
-        </p>
 
-    }
-    else
-    {
-        <p class="message error">
-            We could not confirm your email address. The token was invalid or expired.
-        </p>
-        <p>
-             Please check that you used the link from the confirmation email we sent.
-        </p>
-    }
+<div class="container main-container">
+    <div class="row">
+        <div class="col-xs-12">
+            @if (Model.SuccessfulConfirmation)
+            {
+                <h1 class="text-center">@(Model.ConfirmingNewAccount ? "Account" : "Email") Confirmed</h1>
+            }
+            else
+            {
+                <h1 class="text-center">Email Confirmation Failed</h1>
+            }
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-xs-4 col-xs-offset-4">
+            @if (Model.SuccessfulConfirmation)
+            {
+                <p class="text-center">
+                    Your email address has been verified@(Model.ConfirmingNewAccount ? " and your account is confirmed" : "").
+                </p>
+            }
+            else
+            {
+                @ViewHelpers.AlertDanger(isAlertRole: true, htmlContent:
+                    @<text>
+                        @if (Model.WrongUsername)
+                        {
+                            <p>
+                                You cannot confirm a different user's email address!
+                            </p>
+                            <p>
+                                Please check that you used the link from the right confirmation email, and are logged in as the right user.
+                            </p>
+                        }
+                        else if (Model.DuplicateEmailAddress)
+                        {
+                            <p>
+                                Your email address is confirmed as belonging to another user account (likely another account you own).
+                            </p>
+                            <p>
+                                You can <span class="ms-noWrap">@Html.ActionLink("change your email address", "Account", "Users")</span>, reuse the account registered with this email address, or change the email address of the account registered with this email address.
+                            </p>
+                        }
+                        else if (Model.AlreadyConfirmed)
+                        {
+                            <p>
+                                Your email address has already been confirmed.
+                            </p>
+                            <p>
+                                Is @Model.ConfirmedEmailAddress incorrect? <span class="ms-noWrap">@Html.ActionLink("Change your email", "Account", "Users")</span>
+                            </p>
+                        }
+                        else
+                        {
+                            <p>
+                                We could not confirm your email address. This probably means the confirmation token was invalid or expired.
+                            </p>
+                            <p>
+                                Please check that you used the link from the confirmation email we sent. If you did, try resending your confirmation email.
+                            </p>
+                        }
+                    </text>
+                )
 
-    if (!Model.AlreadyConfirmed)
-     {
-         <p>
-             <a href="@Url.ConfirmationRequired()">Resend confirmation email.</a>
-         </p>
-     }
-}
+                if (!Model.AlreadyConfirmed)
+                {
+                    @Html.Partial("_ConfirmationResendForm");
+                }
+            }
+        </div>
+    </div>
+</div>

--- a/src/NuGetGallery/Views/Users/Confirm.cshtml
+++ b/src/NuGetGallery/Views/Users/Confirm.cshtml
@@ -5,7 +5,7 @@
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
-<div class="container main-container">
+<section class="container main-container" role="main">
     <div class="row">
         <div class="col-xs-12">
             @if (Model.SuccessfulConfirmation)
@@ -76,4 +76,4 @@
             }
         </div>
     </div>
-</div>
+</section>

--- a/src/NuGetGallery/Views/Users/Confirm.cshtml
+++ b/src/NuGetGallery/Views/Users/Confirm.cshtml
@@ -1,6 +1,7 @@
 ﻿@model ConfirmationViewModel
 @{
-    ViewBag.Title = "Confirm Your Account";
+    var titleString = Model.ConfirmingNewAccount ? "Account" : "Email";
+    ViewBag.Title = "Confirm Your " + titleString;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 

--- a/src/NuGetGallery/Views/Users/Confirm.cshtml
+++ b/src/NuGetGallery/Views/Users/Confirm.cshtml
@@ -42,7 +42,7 @@
                         else if (Model.DuplicateEmailAddress)
                         {
                             <p>
-                                Your email address is confirmed as belonging to another user account (likely another account you own).
+                                Your email address has already been confirmed by another account (likely another account you own).
                             </p>
                             <p>
                                 You can <span class="ms-noWrap">@Html.ActionLink("change your email address", "Account", "Users")</span>, reuse the account registered with this email address, or change the email address of the account registered with this email address.

--- a/src/NuGetGallery/Views/Users/ConfirmationRequired.cshtml
+++ b/src/NuGetGallery/Views/Users/ConfirmationRequired.cshtml
@@ -1,55 +1,59 @@
 ﻿@model ConfirmationViewModel
 @{
-    ViewBag.Title = "Confirm Your Account";
-    var alreadyConfirmed = Model.UnconfirmedEmailAddress == null || Model.AlreadyConfirmed;
+    var titleString = Model.ConfirmingNewAccount ? "Account" : "Email";
+    ViewBag.Title = "Confirm Your " + titleString;
+    Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
-@if (Model.SentEmail)
-{
-    <h2>Confirmation Email Sent!</h2>
-}
-else
-{
-    if (TempData.ContainsKey("ConfirmationRequiredMessage"))
-    {
-        <p class="message">@((string)TempData["ConfirmationRequiredMessage"])</p>
-    }
-
-    if (alreadyConfirmed)
-    {
-
-        <p class="message">
-            Your email address has already been confirmed.
-        </p>
-
-    }
-    else
-    {
-
-        <h2>Confirm Your Account</h2>
-
-
-        using (Html.BeginForm())
-        {
-            <fieldset class="form">
-                <legend>Verify Email Address</legend>
-                @Html.AntiForgeryToken()
-
-                <p>
-                    Click the button to send confirmation email.
+<div class="container main-container">
+    <div class="row">
+        <div class="col-sm-12">
+            @if (Model.SentEmail)
+            {
+                <h1 class="text-center">Confirmation Email Sent</h1>
+            }
+            else
+            {
+                <h1 class="text-center">Confirm Your @(Model.ConfirmingNewAccount ? "Account" : "Email")</h1>
+            }
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-4 col-md-offset-4 col-sm-6 col-sm-offset-3">
+            @if (Model.SentEmail)
+            {
+                <p class="text-center">
+                    Please make sure to check your spam folder if you did not receive the confirmation email.
                 </p>
-                <p>
-                    <input type="submit" value="Send Confirmation Email" title="Send Confirmation Email" style="width: auto; margin: 5px;"/>
-                    to @(Model.UnconfirmedEmailAddress) @Html.ActionLink("(change)", "Account", "Users")
-                </p>
+            }
+            else
+            {
+                if (TempData.ContainsKey("ConfirmationRequiredMessage"))
+                {
+                    @ViewHelpers.AlertInfo(@<text>@((string)TempData["ConfirmationRequiredMessage"])</text>)
+                }
 
-            </fieldset>
-        }
-    }
-}
+                if (Model.AlreadyConfirmed)
+                {
+                    <p class="text-center">
+                        Your email address has already been confirmed.
+                    </p>
+                }
+                else
+                {
+                    <p class="text-center">
+                        A confirmation link was sent to you (@Model.UnconfirmedEmailAddress) when you @(Model.ConfirmingNewAccount ? "created your account" : "changed your email"). Please click on that link to verify your email address.
+                    </p>
+                    <p class="text-center">
+                        If you cannot find this email (be sure to check your spam folder), you can resend the confirmation email.
+                    </p>
+                    <p class="text-center">
+                        If you're still having trouble, you can <a class="ms-noWrap" href="mailto:@Config.Current.GalleryOwner.Address">contact support.</a>
+                    </p>
 
-<h3>Problems with your confirmation email?</h3>
-
-<p>
-    Please check your spam folder if you did not receive the confirmation email.
-</p>
+                    @Html.Partial("_ConfirmationResendForm");
+                }
+            }
+        </div>
+    </div>
+</div>

--- a/src/NuGetGallery/Views/Users/ConfirmationRequired.cshtml
+++ b/src/NuGetGallery/Views/Users/ConfirmationRequired.cshtml
@@ -5,7 +5,7 @@
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
-<div class="container main-container">
+<section class="container main-container" role="main">
     <div class="row">
         <div class="col-sm-12">
             @if (Model.SentEmail)
@@ -56,4 +56,4 @@
             }
         </div>
     </div>
-</div>
+</section>

--- a/src/NuGetGallery/Views/Users/_ConfirmationResendForm.cshtml
+++ b/src/NuGetGallery/Views/Users/_ConfirmationResendForm.cshtml
@@ -1,0 +1,11 @@
+﻿@model ConfirmationViewModel
+
+@using (Html.BeginForm("ConfirmationRequired", "Users"))
+{
+    @Html.AntiForgeryToken()
+
+    <div class="form-group">
+        <input type="submit" class="btn btn-primary form-control" value="Resend Confirmation Email" />
+    </div>
+}
+<p class="text-center">Is @Model.UnconfirmedEmailAddress incorrect? <span class="ms-noWrap">@Html.ActionLink("Change your email", "Account", "Users")</span></p>


### PR DESCRIPTION
Did some minor refactoring to the controller code because it expected the user to specify all of the `ConfirmationViewModel`'s fields manually instead of automatically populating them from a `User` ([this line, case in point](https://github.com/NuGet/NuGetGallery/blob/master/src/NuGetGallery/Views/Users/ConfirmationRequired.cshtml#L4)).

The following pictures aren't all possible states, but they should be a good sampler of the possibilities.

![image](https://user-images.githubusercontent.com/18014088/27615977-156d3142-5b61-11e7-8b5b-fec2a6390cf7.png)

![image](https://user-images.githubusercontent.com/18014088/27615982-19f91514-5b61-11e7-99c0-74b84d4b4d8d.png)

![image](https://user-images.githubusercontent.com/18014088/27615999-3baceb7c-5b61-11e7-9438-ec11b0897b8e.png)

@microsoftsam