### PR TITLE
[Redesign] Fix Several Package Listing Issues

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -157,17 +157,34 @@ img.package-icon {
   margin-left: 10px;
   color: #000;
 }
+@media (max-width: 480px) {
+  .list-packages .package .package-header .package-by {
+    display: block;
+    margin-left: 0;
+  }
+}
 .list-packages .package .package-list {
+  padding-left: 0;
   margin-top: 10px;
+  margin-left: -5px;
   line-height: 20px;
   color: #666;
 }
-.list-packages .package .package-list li + li {
-  padding-left: 10px;
-  margin-left: 10px;
-  border-color: #dbdbdb;
-  border-width: 1px;
-  border-left-style: solid;
+.list-packages .package .package-list li {
+  display: list-item;
+  list-style: none;
+}
+@media (min-width: 480px) {
+  .list-packages .package .package-list li {
+    display: inline-block;
+  }
+  .list-packages .package .package-list li + li {
+    padding-left: 10px;
+    margin-left: 10px;
+    border-color: #dbdbdb;
+    border-width: 1px;
+    border-left-style: solid;
+  }
 }
 .list-packages .package .package-details {
   margin-top: 10px;

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -16,20 +16,38 @@
       .package-by {
         margin-left: @padding-small-horizontal;
         color: @gray-base;
+
+        @media (max-width: @screen-xs-min) {
+          margin-left: 0;
+          display: block;
+        }
       }
     }
 
     .package-list {
       margin-top: @padding-large-vertical;
+      margin-left: -5px;
+      padding-left: 0;
       line-height: 20px;
       color: @gray-light;
 
-      li+li {
-        margin-left: @padding-small-horizontal;
-        padding-left: @padding-small-horizontal;
-        border-left-style: solid;
-        border-width: 1px;
-        border-color: @gray-lighter;
+      li {
+        list-style: none;
+        display: list-item;
+      }
+
+      @media (min-width: @screen-xs-min) {
+        li {
+          display: inline-block;
+        }
+
+        li+li {
+          margin-left: @padding-small-horizontal;
+          padding-left: @padding-small-horizontal;
+          border-left-style: solid;
+          border-width: 1px;
+          border-color: @gray-lighter;
+        }
       }
     }
 

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -157,17 +157,34 @@ img.package-icon {
   margin-left: 10px;
   color: #000;
 }
+@media (max-width: 480px) {
+  .list-packages .package .package-header .package-by {
+    display: block;
+    margin-left: 0;
+  }
+}
 .list-packages .package .package-list {
+  padding-left: 0;
   margin-top: 10px;
+  margin-left: -5px;
   line-height: 20px;
   color: #666;
 }
-.list-packages .package .package-list li + li {
-  padding-left: 10px;
-  margin-left: 10px;
-  border-color: #dbdbdb;
-  border-width: 1px;
-  border-left-style: solid;
+.list-packages .package .package-list li {
+  display: list-item;
+  list-style: none;
+}
+@media (min-width: 480px) {
+  .list-packages .package .package-list li {
+    display: inline-block;
+  }
+  .list-packages .package .package-list li + li {
+    padding-left: 10px;
+    margin-left: 10px;
+    border-color: #dbdbdb;
+    border-width: 1px;
+    border-left-style: solid;
+  }
 }
 .list-packages .package .package-details {
   margin-top: 10px;

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -15,7 +15,11 @@ namespace NuGetGallery
         public ListPackageItemViewModel(Package package)
             : base(package)
         {
-            Tags = package.Tags?.Trim().Split(' ');
+            Tags = package.Tags?
+                .Split(' ')
+                .Where(t => !string.IsNullOrEmpty(t))
+                .Select(t => t.Trim())
+                .ToArray();
 
             Authors = package.FlattenedAuthors;
             MinClientVersion = package.MinClientVersion;

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -1,7 +1,7 @@
 ﻿@model ListPackageItemViewModel
 
 <article class="row package" role="listitem">
-    <div class="col-sm-1">
+    <div class="col-sm-1 hidden-xs hidden-sm">
         <img class="package-icon img-responsive" aria-hidden="true" alt=""
              src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
              @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
@@ -19,7 +19,7 @@
             </span>
         </div>
 
-        <ul class="package-list list-inline">
+        <ul class="package-list">
             <li>
                 <span>
                     <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
@@ -60,7 +60,7 @@
 
         @if (Model.IsOwner(User))
         {
-            <ul class="package-list list-inline">
+            <ul class="package-list">
                 <li>
                     <a href="@Url.EditPackage(Model.Id, Model.Version)">
                         <span>

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -7,7 +7,21 @@
 
 <div class="container main-container page-profile">
     <section role="main" class="row">
-        <article class="col-md-8">
+        <aside class="col-md-4 col-md-push-8 profile-details">
+            @ViewHelpers.GravatarImage(Model.EmailAddress, Model.Username, 332)
+
+            <div class="statistics">
+                <div class="statistic">
+                    <div class="value">@Model.AllPackages.Count.ToNuGetNumberString()</div>
+                    <div class="description">@(Model.AllPackages.Count == 1 ? "Package" : "Packages")</div>
+                </div>
+                <div class="statistic">
+                    <div class="value">@Model.TotalPackageDownloadCount.ToNuGetNumberString()</div>
+                    <div class="description">Total @(Model.TotalPackageDownloadCount == 1 ? "download" : "downloads") of packages</div>
+                </div>
+            </div>
+        </aside>
+        <article class="col-md-8 col-md-pull-4">
             <div class="profile-title">
                 <h1>@Model.Username</h1>
 
@@ -29,19 +43,5 @@
 
             @ViewHelpers.PreviousNextPager(Model.Pager)
         </article>
-        <aside class="col-md-4 profile-details">
-            @ViewHelpers.GravatarImage(Model.EmailAddress, Model.Username, 332)
-
-            <div class="statistics">
-                <div class="statistic">
-                    <div class="value">@Model.AllPackages.Count.ToNuGetNumberString()</div>
-                    <div class="description">@(Model.AllPackages.Count == 1 ? "Package" : "Packages")</div>
-                </div>
-                <div class="statistic">
-                    <div class="value">@Model.TotalPackageDownloadCount.ToNuGetNumberString()</div>
-                    <div class="description">Total @(Model.TotalPackageDownloadCount == 1 ? "download" : "downloads") of packages</div>
-                </div>
-            </div>
-        </aside>
     </section>
 </div>


### PR DESCRIPTION
* Made Profile Picture appear before packages on mobile profile page
* Made package lists' statistics and management links flat on mobile
* Hid package icons on very narrow screens
* Fixed empty tag issue

## Wide Package Listing View

![list-wide](https://user-images.githubusercontent.com/737941/27709847-79827698-5cd2-11e7-83d6-8f21afaf7afe.png)

## Narrow Package Listing View

![list-narrow](https://user-images.githubusercontent.com/737941/27709860-838e2254-5cd2-11e7-974f-482a2c0d3852.png)

## Profile Page

![narrow-profile](https://user-images.githubusercontent.com/737941/27709953-dab4f5ee-5cd2-11e7-8c22-0350d1bfbca9.png)

Fixed #4173, #4185, and #4184 
