### PR TITLE
[Redesign] Fixed link color on package search and profile page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -164,8 +164,8 @@ img.package-icon {
   font-size: 15px;
   border-bottom: 1px solid #dbdbdb;
 }
-.list-packages .package .package-header h2 {
-  display: inline;
+.list-packages .package .package-header .package-title {
+  font-size: 34px;
   font-weight: 300;
 }
 .list-packages .package .package-header .package-by {

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -8,8 +8,8 @@
     font-size: 15px;
 
     .package-header {
-      h2 {
-        display: inline;
+      .package-title {
+        font-size: 34px;
         font-weight: 300;
       }
 

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -9,7 +9,7 @@
 
     .package-header {
       .package-title {
-        font-size: 34px;
+        font-size: @font-size-h2;
         font-weight: 300;
       }
 

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -164,8 +164,8 @@ img.package-icon {
   font-size: 15px;
   border-bottom: 1px solid #dbdbdb;
 }
-.list-packages .package .package-header h2 {
-  display: inline;
+.list-packages .package .package-header .package-title {
+  font-size: 34px;
   font-weight: 300;
 }
 .list-packages .package .package-header .package-by {

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -8,7 +8,7 @@
     </div>
     <div class="col-sm-11">
         <div class="package-header">
-            <h2><a href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)">@Model.Title.Abbreviate(60)</a></h2>
+            <a class="package-title" href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)">@Model.Title.Abbreviate(60)</a>
 
             <span class="package-by">
                 by:


### PR DESCRIPTION
The global styling changes for h2 links (intended only for collapsible sections) broke the styling for package search and profile page by turning their links black. This change fixes that by removing the h2 around the link.