### PR TITLE
[Redesign]Upload page contrast fix

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -26,12 +26,12 @@
             var fileName = $('#input-select-file').val().split("\\").pop();
 
             if (fileName.length > 0) {
-                $('#file-select-feedback').attr('placeholder', fileName);
+                $('#file-select-feedback').attr('value', fileName);
                 // Cancel any ongoing upload, and then start the new upload.
                 // If the cancel fails, still try to upload the new one.
                 cancelUploadAsync(startUploadAsync, startUploadAsync);
             } else {
-                $('#file-select-feedback').attr('placeholder', 'Browse to select a package file...');
+                $('#file-select-feedback').attr('value', 'Browse to select a package file...');
             }
         })
 
@@ -180,7 +180,7 @@
             $('#verify-cancel-button').addClass('.loading');
             $('#verify-submit-button').attr('disabled', 'disabled');
             $('#input-select-file').val("");
-            $('#file-select-feedback').attr('placeholder', 'Browse to select a package file...');
+            $('#file-select-feedback').attr('value', 'Browse to select a package file...');
             cancelUploadAsync();
         });
 

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -30,7 +30,7 @@
                         @Html.ValidationSummary(true)
 
                         <div class="input-group">
-                            <input type="text" class="form-control" id="file-select-feedback" placeholder="Browse to select a package file..." readonly />
+                            <input type="text" class="form-control" id="file-select-feedback" value="Browse to select a package file..." readonly />
                             <label for="input-select-file" id="PackageFileLabel" class="input-group-btn">
                                 <span class="btn btn-primary form-control">
                                     Browse&hellip;<input type="file" name="UploadFile" accept=".nupkg" aria-labelledby="PackageFileLabel" id="input-select-file" style="display:none;" />


### PR DESCRIPTION
Change from using placeholder attribute to value attribute.
This is ok since the input box is readonly and for feedback on the selected file.
Changing to value also picks up styles that make the contrast compliant.

@joelverhagen @scottbommarito @loic-sharma @microsoftsam