### PR TITLE
[Redesign]Few Stats Chart fixes

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -214,6 +214,14 @@ img.package-icon {
   max-width: 300px;
   max-height: 300px;
 }
+@media (-ms-high-contrast: active) {
+  svg {
+    color: WindowText;
+  }
+  svg text {
+    fill: WindowText;
+  }
+}
 .list-packages {
   border-top: 1px solid #dbdbdb;
 }

--- a/src/Bootstrap/less/theme/all.less
+++ b/src/Bootstrap/less/theme/all.less
@@ -1,5 +1,6 @@
 ﻿@import "base.less";
 @import "common-edit-metadata.less";
+@import "common-high-contrast.less";
 @import "common-list-packages.less";
 @import "common-slider.less";
 @import "page-about.less";

--- a/src/Bootstrap/less/theme/common-high-contrast.less
+++ b/src/Bootstrap/less/theme/common-high-contrast.less
@@ -1,7 +1,7 @@
 @media (-ms-high-contrast:active) {
     svg {
         text {
-            fill:WindowText;
+            fill: WindowText;
         }
 
         color: WindowText;

--- a/src/Bootstrap/less/theme/common-high-contrast.less
+++ b/src/Bootstrap/less/theme/common-high-contrast.less
@@ -1,0 +1,9 @@
+@media (-ms-high-contrast:active) {
+    svg {
+        text {
+            fill:WindowText;
+        }
+
+        color: WindowText;
+    }
+}

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -214,6 +214,14 @@ img.package-icon {
   max-width: 300px;
   max-height: 300px;
 }
+@media (-ms-high-contrast: active) {
+  svg {
+    color: WindowText;
+  }
+  svg text {
+    fill: WindowText;
+  }
+}
 .list-packages {
   border-top: 1px solid #dbdbdb;
 }

--- a/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
+++ b/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
@@ -55,7 +55,7 @@ var drawDownloadsByVersionBarChart = function (rawData) {
         height = 450 - margin.top - margin.bottom;
 
     var xScale = d3.scale.ordinal()
-        .rangeRoundBands([0, width], .1);
+        .rangeRoundBands([10, width], .1);
 
     var yScale = d3.scale.linear()
         .range([height, 0]);


### PR DESCRIPTION
Addresses the following:
 * Text was invisible on high-contrast mode.
 * [[Redesign] The word "downloads" hidden on package stats page #4154 ](https://github.com/NuGet/NuGetGallery/issues/4154)

@joelverhagen @skofman1 @microsoftsam @loic-sharma @scottbommarito 