### PR TITLE
[Redesign] Improve Report Abuse form

### DIFF
--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -37,51 +37,54 @@
                 @Html.AntiForgeryToken()
                 @Html.SpamPreventionFields()
 
-                <div class="form-group @Html.HasErrorFor(m => m.Email)">
-                    @Html.ShowLabelFor(m => m.Email)
-                    @Html.ShowTextBoxFor(m => m.Email)
-                    @Html.ShowValidationMessagesFor(m => m.Email)
-                </div>
                 <div id="form-field-reason" class="form-group @Html.HasErrorFor(m => m.Reason)">
                     @Html.ShowLabelFor(m => m.Reason)
                     <p>Please select the reason for contacting support about this package.</p>
                     @Html.ShowEnumDropDownListFor(m => m.Reason, Model.ReasonChoices, "<Choose a Reason>")
                     @Html.ShowValidationMessagesFor(m => m.Reason)
                 </div>
-                <div class="form-group @Html.HasErrorFor(m => m.AlreadyContactedOwner)">
-                    @Html.ShowSliderFor(m => m.AlreadyContactedOwner)
-                    @Html.ShowValidationMessagesFor(m => m.AlreadyContactedOwner)
-                </div>
-                <div class="form-group @Html.HasErrorFor(m => m.Message)">
-                    @Html.ShowLabelFor(m => m.Message)
-                    <p>Please provide a detailed description of the problem.</p>
-                    @Html.ShowTextAreaFor(m => m.Message, 10, 50)
-                    @Html.ShowValidationMessagesFor(m => m.Message)
-                </div>
-                <div class="form-group @Html.HasErrorFor(m => m.CopySender)">
-                    @Html.ShowSliderFor(m => m.CopySender)
-                    @Html.ShowValidationMessagesFor(m => m.CopySender)
-                </div>
-                <div class="form-group infringement-claim-requirements @Html.HasErrorFor(m => m.Signature)">
-                    <h2><span style="color:red">*</span> Required Statements for infringement claims</h2>
-                    <h2>Good Faith Belief:</h2>
-                    <p>
-                        By typing my name (electronic signature), I have a good faith belief that the use of the material is not authorized by the intellectual property owner, its agent, or the law (e.g., it is not fair use).
-                    </p>
-                    <h2>Authority to Act:</h2>
-                    <p>
-                        I represent that the information in the notification is accurate, and under penalty of perjury, that I am authorized to act on behalf of the owner of an exclusive right that is allegedly infringed.
-                    </p>
-                    <h2>512(f) Acknowledgement:</h2>
-                    <p>
-                        As applicable under 17 U.S.C. 512(f), I acknowledge that I may be subject to liability for damages if I knowingly materially misrepresent that material or activity is infringing.
-                    </p>
-                    @Html.ShowLabelFor(m => m.Signature)
-                    @Html.ShowTextBoxFor(m => m.Signature)
-                    @Html.ShowValidationMessagesFor(m => m.Signature)
-                </div>
-                <div class="form-group">
-                    <input type="submit" class="btn btn-primary form-control" value="Report" />
+
+                <div id="report-abuse-form">
+                    <div class="form-group @Html.HasErrorFor(m => m.Email)">
+                        @Html.ShowLabelFor(m => m.Email)
+                        @Html.ShowTextBoxFor(m => m.Email)
+                        @Html.ShowValidationMessagesFor(m => m.Email)
+                    </div>
+                    <div class="form-group @Html.HasErrorFor(m => m.AlreadyContactedOwner)">
+                        @Html.ShowSliderFor(m => m.AlreadyContactedOwner)
+                        @Html.ShowValidationMessagesFor(m => m.AlreadyContactedOwner)
+                    </div>
+                    <div class="form-group @Html.HasErrorFor(m => m.Message)">
+                        @Html.ShowLabelFor(m => m.Message)
+                        <p>Please provide a detailed description of the problem.</p>
+                        @Html.ShowTextAreaFor(m => m.Message, 10, 50)
+                        @Html.ShowValidationMessagesFor(m => m.Message)
+                    </div>
+                    <div class="form-group @Html.HasErrorFor(m => m.CopySender)">
+                        @Html.ShowSliderFor(m => m.CopySender)
+                        @Html.ShowValidationMessagesFor(m => m.CopySender)
+                    </div>
+                    <div class="form-group infringement-claim-requirements @Html.HasErrorFor(m => m.Signature)">
+                        <h2><span style="color:red">*</span> Required Statements for infringement claims</h2>
+                        <h2>Good Faith Belief:</h2>
+                        <p>
+                            By typing my name (electronic signature), I have a good faith belief that the use of the material is not authorized by the intellectual property owner, its agent, or the law (e.g., it is not fair use).
+                        </p>
+                        <h2>Authority to Act:</h2>
+                        <p>
+                            I represent that the information in the notification is accurate, and under penalty of perjury, that I am authorized to act on behalf of the owner of an exclusive right that is allegedly infringed.
+                        </p>
+                        <h2>512(f) Acknowledgement:</h2>
+                        <p>
+                            As applicable under 17 U.S.C. 512(f), I acknowledge that I may be subject to liability for damages if I knowingly materially misrepresent that material or activity is infringing.
+                        </p>
+                        @Html.ShowLabelFor(m => m.Signature)
+                        @Html.ShowTextBoxFor(m => m.Signature)
+                        @Html.ShowValidationMessagesFor(m => m.Signature)
+                    </div>
+                    <div class="form-group">
+                        <input type="submit" class="btn btn-primary form-control" value="Report" />
+                    </div>
                 </div>
             }
         </div>
@@ -96,6 +99,13 @@
             var val = $('#Reason').val();
             if (val) {
                 $form.validate().element($('#Reason'));
+            }
+
+            if (val == 'HasABugOrFailedToInstall') {
+                $('#report-abuse-form').hide();
+            }
+            else {
+                $('#report-abuse-form').show();
             }
 
             if (val == 'ViolatesALicenseIOwn') {

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -98,12 +98,6 @@
                 $form.validate().element($('#Reason'));
             }
 
-            if (val === 'HasABugOrFailedToInstall') {
-                $form.find("input, textarea, select").not('#form-field-reason *').attr('disabled', 'disabled');
-            } else {
-                $form.find("input, textarea, select").not('#form-field-reason').removeAttr('disabled');
-            }
-
             if (val == 'ViolatesALicenseIOwn') {
                 $form.find('.infringement-claim-requirements').show();
                 $('#Signature').rules("add", {

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -101,10 +101,9 @@
                 $form.validate().element($('#Reason'));
             }
 
-            if (val == 'HasABugOrFailedToInstall') {
+            if (val === 'HasABugOrFailedToInstall') {
                 $('#report-abuse-form').hide();
-            }
-            else {
+            } else {
                 $('#report-abuse-form').show();
             }
 


### PR DESCRIPTION
Changed the report abuse form to hide the fields upon selecting the "bug/failed to install" as the reason. Fixes #4188

## Report Abuse Form (Default)

![report-abuse](https://user-images.githubusercontent.com/737941/27936487-c373e8ac-6265-11e7-9cb9-262fcd486c71.png)

## Report Abuse Form (Bug/Failed to Install)

![report-abuse-bug](https://user-images.githubusercontent.com/737941/27936495-cb7a77f0-6265-11e7-9cbb-20e87d05ddc9.png)
