### PR TITLE
Expose api/status with HTTP + fix functional tests

### DIFF
--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -106,7 +106,8 @@ namespace NuGetGallery
                 }
                 else
                 {
-                    app.UseForceSsl(config.Current.SSLPort, new[] { config.Current.ForceSslExclusion });
+                    var paths = config.Current.ForceSslExclusion.Split(';');
+                    app.UseForceSsl(config.Current.SSLPort, paths);
                 }
             }
 

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -21,7 +21,6 @@ using NuGetGallery.Authentication;
 using NuGetGallery.Authentication.Providers;
 using NuGetGallery.Authentication.Providers.Cookie;
 using NuGetGallery.Configuration;
-using NuGetGallery.Helpers;
 using NuGetGallery.Infrastructure;
 using Owin;
 
@@ -100,14 +99,13 @@ namespace NuGetGallery
             if (config.Current.RequireSSL)
             {
                 // Put a middleware at the top of the stack to force the user over to SSL
-                if (string.IsNullOrWhiteSpace(config.Current.ForceSslExclusion))
+                if (config.Current.ForceSslExclusion == null)
                 {
                     app.UseForceSsl(config.Current.SSLPort);
                 }
                 else
                 {
-                    var paths = config.Current.ForceSslExclusion.Split(';');
-                    app.UseForceSsl(config.Current.SSLPort, paths);
+                    app.UseForceSsl(config.Current.SSLPort, config.Current.ForceSslExclusion);
                 }
             }
 

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -29,8 +29,8 @@ namespace NuGetGallery.Configuration
         public int SSLPort { get; set; }
 
         /// <summary>
-        /// A string containing a path exluded from
-        /// forcing the HTTP to HTTPS redirection.
+        /// A string containing a path exluded from forcing the HTTP to HTTPS redirection. 
+        /// To provide multiple paths separate them with ;
         /// </summary>
         [DefaultValue("")]
         public string ForceSslExclusion { get; set; }

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -32,8 +32,9 @@ namespace NuGetGallery.Configuration
         /// A string containing a path exluded from forcing the HTTP to HTTPS redirection. 
         /// To provide multiple paths separate them with ;
         /// </summary>
-        [DefaultValue("")]
-        public string ForceSslExclusion { get; set; }
+        [DefaultValue(null)]
+        [TypeConverter(typeof(StringArrayConverter))]
+        public string[] ForceSslExclusion { get; set; }
 
         /// <summary>
         /// Gets the connection string to use when connecting to azure storage

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -34,8 +34,8 @@ namespace NuGetGallery.Configuration
         int SSLPort { get; set; }
 
         /// <summary>
-        /// A string containing a path exluded from
-        /// forcing the HTTP to HTTPS redirection.
+        /// A string containing a path exluded from forcing the HTTP to HTTPS redirection.
+        /// To provide multiple paths separate them with ;
         /// </summary>
         /// <example>/api/health-probe</example>
         string ForceSslExclusion { get; set; }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -38,7 +38,7 @@ namespace NuGetGallery.Configuration
         /// To provide multiple paths separate them with ;
         /// </summary>
         /// <example>/api/health-probe</example>
-        string ForceSslExclusion { get; set; }
+        string[] ForceSslExclusion { get; set; }
 
         /// <summary>
         /// Gets the connection string to use when connecting to azure storage

--- a/src/NuGetGallery/Configuration/StringArrayConverter.cs
+++ b/src/NuGetGallery/Configuration/StringArrayConverter.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace NuGetGallery.Configuration
+{
+    public class StringArrayConverter : ArrayConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            string s = value as string;
+
+            if (!string.IsNullOrEmpty(s))
+            {
+                return ((string)value).Split(';');
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -702,6 +702,7 @@
     <Compile Include="Configuration\SecretReader\EmptySecretReaderFactory.cs" />
     <Compile Include="Configuration\SecretReader\ISecretReaderFactory.cs" />
     <Compile Include="Configuration\SecretReader\SecretReaderFactory.cs" />
+    <Compile Include="Configuration\StringArrayConverter.cs" />
     <Compile Include="Controllers\NuGetContext.cs" />
     <Compile Include="Diagnostics\ElmahHandleErrorAttribute.cs" />
     <Compile Include="Extensions\DateTimeExtensions.cs" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -100,7 +100,7 @@
     <add key="Gallery.LuceneIndexLocation" value="AppData" />
     <add key="Gallery.RequireSSL" value="true" />
 
-    <!-- The path to exclude from the HTTP to HTTPS force redirects. -->
+    <!-- The paths to exclude from the HTTP to HTTPS force redirects. Use ; to separate between paths.-->
     <add key="Gallery.ForceSslExclusion" value="/api/health-probe;/api/status" />
     
     <!-- Set this value to use a remote search service. This overrides ALL other Lucene-related settings and disables indexing jobs. -->

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -98,10 +98,10 @@
             Temp -> [Path.GetTempPath()]/NuGetGallery/Lucene,
     -->
     <add key="Gallery.LuceneIndexLocation" value="AppData" />
-    <add key="Gallery.RequireSSL" value="false" />
+    <add key="Gallery.RequireSSL" value="true" />
 
     <!-- The path to exclude from the HTTP to HTTPS force redirects. -->
-    <add key="Gallery.ForceSslExclusion" value="/api/health-probe" />
+    <add key="Gallery.ForceSslExclusion" value="/api/health-probe;/api/status" />
     
     <!-- Set this value to use a remote search service. This overrides ALL other Lucene-related settings and disables indexing jobs. -->
     <!-- Example:

--- a/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
@@ -92,7 +92,7 @@ namespace NuGetGallery.FunctionalTests
                         string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SearchServiceUrl",
                             EnvironmentVariableTarget.Machine)))
                     {
-                        _searchServiceBaseurl = "http://nuget-int-0-v2v3search.cloudapp.net/";
+                        _searchServiceBaseurl = "https://nuget-int-0-v2v3search.cloudapp.net/";
                     }
                     else
                     {
@@ -119,7 +119,7 @@ namespace NuGetGallery.FunctionalTests
 
                 if (string.IsNullOrEmpty(_searchServiceBaseurl))
                 {
-                    _searchServiceBaseurl = "http://nuget-int-0-v2v3search.cloudapp.net/";
+                    _searchServiceBaseurl = "https://nuget-int-0-v2v3search.cloudapp.net/";
                 }
 
                 return _searchServiceBaseurl;

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/UrlHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/UrlHelper.cs
@@ -32,7 +32,7 @@ namespace NuGetGallery.FunctionalTests
         private const string _manageMyPackagesUrlSuffix = "/account/Packages";
         private const string _aboutPageUrlSuffix = "policies/About";
         private const string _apiStatusUrlSuffix = "api/status";
-        private const string _apiGalleryHealthProbeUrlSuffix = "api/gallery-status";
+        private const string _apiGalleryHealthProbeUrlSuffix = "api/health-probe";
 
         public static string BaseUrl
         {

--- a/tests/NuGetGallery.FunctionalTests/Security/HttpToHttpsRedirectTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/Security/HttpToHttpsRedirectTests.cs
@@ -29,6 +29,7 @@ namespace NuGetGallery.FunctionalTests.Security
         public static IEnumerable<object[]> UrlsExcludedFromRedirect => new[]
         {
             new object[] { UrlHelper.ApiGalleryHealthProbeUrl },
+            new object[] { UrlHelper.ApiStatusPageUrl }
         };
 
         public static IEnumerable<object[]> GetForAllUrls()
@@ -43,6 +44,8 @@ namespace NuGetGallery.FunctionalTests.Security
 
         [Theory]
         [MemberData(nameof(GetForAllUrls))]
+        [Priority(0)]
+        [Category("P0Tests")]
         public async Task HttpToHttpsRedirectHappensForSupportedMethods(HttpMethod method, string url)
         {
             // Ideally, we should test both GET and HEAD methods for all the URLs, 
@@ -58,6 +61,8 @@ namespace NuGetGallery.FunctionalTests.Security
 
         [Theory]
         [MemberData(nameof(NonHeadAndGetForAllUrls))]
+        [Priority(0)]
+        [Category("P0Tests")]
         public async Task HttpRequestsFailureResponseForUnsupportedMethods(HttpMethod method, string url)
         {
             Uri uri = ForceHttp(url);
@@ -68,6 +73,8 @@ namespace NuGetGallery.FunctionalTests.Security
 
         [Theory]
         [MemberData(nameof(UrlsToTest))]
+        [Priority(0)]
+        [Category("P0Tests")]
         public void ForceHttpMethodCorreclyRemovesHttps(string url)
         {
             Uri uri = ForceHttp(url);
@@ -76,6 +83,8 @@ namespace NuGetGallery.FunctionalTests.Security
 
         [Theory]
         [MemberData(nameof(UrlsExcludedFromRedirect))]
+        [Priority(0)]
+        [Category("P0Tests")]
         public async Task ExcludedUrlsDontRedirect(string url)
         {
             Uri uri = ForceHttp(url);


### PR DESCRIPTION
Fixes: https://github.com/NuGet/NuGetGallery/issues/4336

Noticed HttpToHttps functional tests don't run during deployment, so fixed it.