### PR TITLE
Fix: Choosing package list view trash icon leads to failure path

### DIFF
--- a/src/NuGetGallery/Views/Packages/Delete.cshtml
+++ b/src/NuGetGallery/Views/Packages/Delete.cshtml
@@ -26,6 +26,7 @@ else
     <fieldset id="unlist-form" class="form">
         <legend>Edit @Model.Title Package</legend>
         @Html.AntiForgeryToken()
+        @Html.Hidden("version", @Model.Version)
         <div class="form-field">
             @Html.EditorFor(package => package.Listed)
             <label for="Listed" class="checkbox">


### PR DESCRIPTION
Fixes: https://github.com/NuGet/NuGetGallery/issues/4323