### PR TITLE
[Redesign] Made authentication pages' layout consistent

### DIFF
--- a/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
+++ b/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
@@ -5,7 +5,7 @@
 }
 
 <section role="main" class="container main-container page-forgot-password">
-    <div class="col-sm-4 col-sm-offset-4 text-center">
+    <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
         <h1>Forgot Password</h1>
 
         <p>We are sorry to hear you forgot your NuGet.org account password. Enter your email below and we will send instructions to reset your password.</p>

--- a/src/NuGetGallery/Views/Users/PasswordSent.cshtml
+++ b/src/NuGetGallery/Views/Users/PasswordSent.cshtml
@@ -4,7 +4,7 @@
 }
 
 <section role="main" class="container main-container">
-    <div class="col-sm-4 col-sm-offset-4 text-center">
+    <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
         <h1>Password Reset Sent</h1>
 
         <p>

--- a/src/NuGetGallery/Views/Users/ResetPassword.cshtml
+++ b/src/NuGetGallery/Views/Users/ResetPassword.cshtml
@@ -12,7 +12,7 @@
     </div>
 
     <div class="row">
-        <div class="col-sm-offset-4 col-sm-4">
+        <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4">
             @if (ViewData.ModelState[""] != null && ViewData.ModelState[""].Errors.Count > 0)
             {
                 @ViewHelpers.AlertDanger(


### PR DESCRIPTION
Made the forgot password and reset password pages be 6 columns when on small screen layouts.

Fixes #4252 