### PR TITLE
[Redesign] Address PM pass design issues

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -82,6 +82,10 @@ body h3 {
 .btn-search {
   height: 36px;
 }
+.icon-link .ms-Icon {
+  position: relative;
+  top: 2px;
+}
 .icon-link:hover,
 .icon-link:focus {
   text-decoration: none;
@@ -115,6 +119,7 @@ body h3 {
   color: #23527c;
 }
 .banner {
+  padding-top: 5px;
   padding-bottom: 10px;
 }
 .banner span {
@@ -123,8 +128,7 @@ body h3 {
 }
 .banner .ms-Icon {
   position: relative;
-  top: .25em;
-  font-size: 1.75em;
+  top: 2px;
 }
 .banner.banner-bright {
   background: yellow;
@@ -179,6 +183,29 @@ h3 a:active {
 img.package-icon {
   margin-right: auto;
   margin-left: auto;
+}
+.package-list {
+  padding-left: 0;
+  margin-top: 10px;
+  margin-left: -5px;
+  line-height: 20px;
+  color: #666;
+}
+.package-list li {
+  display: list-item;
+  list-style: none;
+}
+@media (min-width: 480px) {
+  .package-list li {
+    display: inline-block;
+  }
+  .package-list li + li {
+    padding-left: 10px;
+    margin-left: 10px;
+    border-color: #dbdbdb;
+    border-width: 1px;
+    border-left-style: solid;
+  }
 }
 .icon-bar {
   border: 1px solid #fff;
@@ -266,29 +293,6 @@ img.package-icon {
   .list-packages .package .package-header .package-by {
     display: block;
     margin-left: 0;
-  }
-}
-.list-packages .package .package-list {
-  padding-left: 0;
-  margin-top: 10px;
-  margin-left: -5px;
-  line-height: 20px;
-  color: #666;
-}
-.list-packages .package .package-list li {
-  display: list-item;
-  list-style: none;
-}
-@media (min-width: 480px) {
-  .list-packages .package .package-list li {
-    display: inline-block;
-  }
-  .list-packages .package .package-list li + li {
-    padding-left: 10px;
-    margin-left: 10px;
-    border-color: #dbdbdb;
-    border-width: 1px;
-    border-left-style: solid;
   }
 }
 .list-packages .package .package-details {
@@ -384,7 +388,7 @@ img.package-icon {
   margin-bottom: 10px;
 }
 .page-account-settings .form-section-title {
-  margin-top: 10px;
+  margin-top: 40px;
 }
 @media (min-width: 768px) {
   .page-account-settings .form-section-title {
@@ -393,13 +397,19 @@ img.package-icon {
   }
 }
 .page-account-settings .form-section-data {
-  margin-top: 10px;
+  margin-top: 40px;
 }
 @media (min-width: 768px) {
   .page-account-settings .form-section-data {
     float: right;
     text-align: right;
   }
+}
+.page-account-settings .panel {
+  margin-top: 5px;
+}
+.page-account-settings .form-group + .form-group .btn {
+  margin-top: 20px;
 }
 .page-api-keys .example-commands {
   padding: 8px 10px;
@@ -466,31 +476,21 @@ img.package-icon {
   margin-left: 10px;
   border-left: 1px solid #dbdbdb;
 }
-.page-api-keys .api-key-details .icon-buttons {
-  margin: 10px 0;
-  font-size: 1.2em;
-  color: #666;
-}
-.page-api-keys .api-key-details .icon-buttons li {
-  padding: 0;
-}
-.page-api-keys .api-key-details .icon-buttons li + li {
-  padding-left: 16px;
-  margin-left: 16px;
-  border-left: 1px solid #dbdbdb;
-}
 .page-package-details .no-border {
   border: 0;
-}
-.page-package-details .btn-expander:hover,
-.page-package-details .btn-expander:focus {
-  text-decoration: none;
 }
 .page-package-details .package-details-info .ms-Icon-ul li {
   margin-bottom: 15px;
 }
 .page-package-details .owner-list li {
   margin-bottom: 8px;
+}
+.page-package-details .owner-list img {
+  margin-right: 8px;
+}
+.page-package-details .share-buttons img {
+  display: inline-block;
+  margin-right: 8px;
 }
 .page-package-details .install-tabs {
   font-size: .8em;
@@ -526,7 +526,7 @@ img.package-icon {
   display: table-cell;
   width: 100%;
   max-width: 1px;
-  padding: 8px 10px;
+  padding: 0 10px 8px 10px;
   font-family: Consolas, Menlo, Monaco, "Courier New", monospace;
   line-height: 1.5;
   color: #fff;
@@ -541,7 +541,7 @@ img.package-icon {
 }
 .page-package-details .install-tabs .tab-pane .copy-button button {
   height: 100%;
-  min-height: 40px;
+  min-height: 42px;
   line-height: 1.5;
   vertical-align: baseline;
 }

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -104,12 +104,19 @@ body {
   height: 36px;
 }
 
-.icon-link:hover, .icon-link:focus {
-    text-decoration: none;
+.icon-link {
+  .ms-Icon {
+    position: relative;
+    top: 2px;
+  }
+}
 
-    span {
-        text-decoration: underline;
-    }
+.icon-link:hover, .icon-link:focus {
+  text-decoration: none;
+
+  span {
+    text-decoration: underline;
+  }
 }
 
 .dependency-groups {
@@ -155,6 +162,7 @@ body {
 
 .banner {
   padding-bottom: 10px;
+  padding-top: 5px;
 
   span {
     font-size: 1.25em;
@@ -162,9 +170,8 @@ body {
   }
 
   .ms-Icon {
-    font-size: 1.75em;
     position: relative;
-    top: 0.25em;
+    top: 2px;
   }
 
   &.banner-bright {
@@ -230,6 +237,33 @@ h2, h3 {
 img.package-icon {
   margin-left: auto;
   margin-right: auto;
+}
+
+.package-list {
+  margin-top: @padding-large-vertical;
+  margin-left: -5px;
+  padding-left: 0;
+  line-height: 20px;
+  color: @gray-light;
+
+  li {
+    list-style: none;
+    display: list-item;
+  }
+
+  @media (min-width: @screen-xs-min) {
+    li {
+      display: inline-block;
+    }
+
+    li + li {
+      margin-left: @padding-small-horizontal;
+      padding-left: @padding-small-horizontal;
+      border-left-style: solid;
+      border-width: 1px;
+      border-color: @gray-lighter;
+    }
+  }
 }
 
 // Make the hamburger button visible on high contrast.

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -24,33 +24,6 @@
       }
     }
 
-    .package-list {
-      margin-top: @padding-large-vertical;
-      margin-left: -5px;
-      padding-left: 0;
-      line-height: 20px;
-      color: @gray-light;
-
-      li {
-        list-style: none;
-        display: list-item;
-      }
-
-      @media (min-width: @screen-xs-min) {
-        li {
-          display: inline-block;
-        }
-
-        li+li {
-          margin-left: @padding-small-horizontal;
-          padding-left: @padding-small-horizontal;
-          border-left-style: solid;
-          border-width: 1px;
-          border-color: @gray-lighter;
-        }
-      }
-    }
-
     .package-details {
       margin-top: @padding-large-vertical;
       color: @text-color;

--- a/src/Bootstrap/less/theme/page-account-settings.less
+++ b/src/Bootstrap/less/theme/page-account-settings.less
@@ -1,28 +1,40 @@
 .page-account-settings {
-    h1 {
-        margin-bottom: 0;
+  @section-margin-top: 40px;
+
+  h1 {
+    margin-bottom: 0;
+  }
+
+  h2 {
+    margin-bottom: 10px;
+    margin-top: 0;
+  }
+
+  .form-section-title {
+    margin-top: @section-margin-top;
+
+    @media (min-width: @screen-sm-min) {
+      float: left;
+      text-align: right;
     }
+  }
 
-    h2 {
-        margin-bottom: 10px;
-        margin-top: 0;
+  .form-section-data {
+    margin-top: @section-margin-top;
+
+    @media (min-width: @screen-sm-min) {
+      float: right;
+      text-align: right;
     }
+  }
 
-    .form-section-title {
-        margin-top: 10px;
+  .panel {
+    margin-top: 5px;
+  }
 
-        @media (min-width: @screen-sm-min) {
-            float: left;
-            text-align: right;
-        }
+  .form-group + .form-group {
+    .btn {
+      margin-top: 20px;
     }
-
-    .form-section-data {
-        margin-top: 10px;
-
-        @media (min-width: @screen-sm-min) {
-            float: right;
-            text-align: right;
-        }
-    }
+  }
 }

--- a/src/Bootstrap/less/theme/page-api-keys.less
+++ b/src/Bootstrap/less/theme/page-api-keys.less
@@ -88,21 +88,5 @@
         border-left: 1px solid @gray-lighter;
       }
     }
-
-    .icon-buttons {
-      color: @gray-light;
-      margin: @padding-large-vertical 0;
-      font-size: 1.2em;
-
-      li {
-        padding: 0;
-      }
-
-      li + li {
-        margin-left: @padding-large-horizontal;
-        padding-left: @padding-large-horizontal;
-        border-left: 1px solid @gray-lighter;
-      }
-    }
   }
 }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -1,12 +1,6 @@
-﻿.page-package-details {
+.page-package-details {
   .no-border {
     border: 0;
-  }
-
-  .btn-expander {
-    &:hover, &:focus {
-      text-decoration: none;
-    }
   }
 
   .package-details-info {
@@ -21,6 +15,17 @@
     li {
       margin-bottom: 8px;
     }
+
+    img {
+      margin-right: 8px;
+    }
+  }
+
+  .share-buttons {
+    img {
+      margin-right: 8px;
+      display: inline-block;
+    }
   }
 
   .install-tabs {
@@ -30,7 +35,7 @@
       margin-left: 0;
     }
 
-    .nav-tabs  {
+    .nav-tabs {
       border: 0;
 
       > li {
@@ -54,7 +59,7 @@
       color: #fff;
     }
 
-    .tab-pane {    
+    .tab-pane {
       > div {
         display: table;
         height: 1px;
@@ -65,17 +70,16 @@
         background-color: @panel-footer-bg;
         font-family: @font-family-monospace;
         color: #fff;
-        padding: 8px 10px;
+        padding: 0 10px 8px 10px;
         width: 100%;
         max-width: 1px;
         word-wrap: break-word;
         line-height: 1.5;
-
         // Add a border with the same color as the background to support visual callout
         // in high contrast mode (since borders are shown).
         border-color: @panel-footer-bg;
         border-style: solid;
-        border-width: 1px 0 1px 1px;        
+        border-width: 1px 0 1px 1px;
       }
 
       .copy-button {
@@ -84,7 +88,7 @@
         button {
           height: 100%;
           vertical-align: baseline;
-          min-height: 40px;
+          min-height: 42px;
           line-height: 1.5;
         }
       }

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -5,6 +5,38 @@
 @using NuGetGallery.Helpers
 @using NuGetGallery.Configuration
 
+@helper GetColumnClasses(string screenSize, int? columns)
+{
+    const int TotalColumns = 12;
+    if (!columns.HasValue)
+    {
+        return;
+    }
+
+    var offset = (TotalColumns - columns.Value) / 2;
+    var columnsClass = "col-" + screenSize + "-" + columns.Value;
+    var offsetClass = offset == 0 ? string.Empty : " col-" + screenSize + "-offset-" + offset;
+
+    @(columnsClass + " " + offsetClass)
+}
+
+@helper GetColumnClasses(dynamic viewBag)
+{
+    int? smPageColumns = 12;
+    if (viewBag.SmPageColumns != null)
+    {
+        smPageColumns = (int)viewBag.SmPageColumns;
+    }
+
+    int? mdPageColumns = null;
+    if (viewBag.MdPageColumns != null)
+    {
+        mdPageColumns = (int)viewBag.MdPageColumns;
+    }
+
+    @(GetColumnClasses("sm", smPageColumns) + " " + GetColumnClasses("md", mdPageColumns))
+}
+
 @helper Alert(Func<MvcHtmlString, HelperResult> htmlContent, string subclass, string icon, bool isAlertRole = false)
 {
     <div class="alert alert-@subclass" @if (isAlertRole) { <text> role="alert" </text>   }>

--- a/src/NuGetGallery/Constants.cs
+++ b/src/NuGetGallery/Constants.cs
@@ -13,6 +13,10 @@ namespace NuGetGallery
         public const string DefaultPackageListSortOrder = "package-download-count";
         public const int PasswordResetTokenExpirationHours = 1;
 
+        public const int ColumnsAuthenticationSm = 6;
+        public const int ColumnsAuthenticationMd = 4;
+        public const int ColumnsFormMd = 10;
+
         /// <summary>
         /// Parameters for calculating account lockout period after 
         /// wrong password entry.

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -82,6 +82,10 @@ body h3 {
 .btn-search {
   height: 36px;
 }
+.icon-link .ms-Icon {
+  position: relative;
+  top: 2px;
+}
 .icon-link:hover,
 .icon-link:focus {
   text-decoration: none;
@@ -115,6 +119,7 @@ body h3 {
   color: #23527c;
 }
 .banner {
+  padding-top: 5px;
   padding-bottom: 10px;
 }
 .banner span {
@@ -123,8 +128,7 @@ body h3 {
 }
 .banner .ms-Icon {
   position: relative;
-  top: .25em;
-  font-size: 1.75em;
+  top: 2px;
 }
 .banner.banner-bright {
   background: yellow;
@@ -179,6 +183,29 @@ h3 a:active {
 img.package-icon {
   margin-right: auto;
   margin-left: auto;
+}
+.package-list {
+  padding-left: 0;
+  margin-top: 10px;
+  margin-left: -5px;
+  line-height: 20px;
+  color: #666;
+}
+.package-list li {
+  display: list-item;
+  list-style: none;
+}
+@media (min-width: 480px) {
+  .package-list li {
+    display: inline-block;
+  }
+  .package-list li + li {
+    padding-left: 10px;
+    margin-left: 10px;
+    border-color: #dbdbdb;
+    border-width: 1px;
+    border-left-style: solid;
+  }
 }
 .icon-bar {
   border: 1px solid #fff;
@@ -266,29 +293,6 @@ img.package-icon {
   .list-packages .package .package-header .package-by {
     display: block;
     margin-left: 0;
-  }
-}
-.list-packages .package .package-list {
-  padding-left: 0;
-  margin-top: 10px;
-  margin-left: -5px;
-  line-height: 20px;
-  color: #666;
-}
-.list-packages .package .package-list li {
-  display: list-item;
-  list-style: none;
-}
-@media (min-width: 480px) {
-  .list-packages .package .package-list li {
-    display: inline-block;
-  }
-  .list-packages .package .package-list li + li {
-    padding-left: 10px;
-    margin-left: 10px;
-    border-color: #dbdbdb;
-    border-width: 1px;
-    border-left-style: solid;
   }
 }
 .list-packages .package .package-details {
@@ -384,7 +388,7 @@ img.package-icon {
   margin-bottom: 10px;
 }
 .page-account-settings .form-section-title {
-  margin-top: 10px;
+  margin-top: 40px;
 }
 @media (min-width: 768px) {
   .page-account-settings .form-section-title {
@@ -393,13 +397,19 @@ img.package-icon {
   }
 }
 .page-account-settings .form-section-data {
-  margin-top: 10px;
+  margin-top: 40px;
 }
 @media (min-width: 768px) {
   .page-account-settings .form-section-data {
     float: right;
     text-align: right;
   }
+}
+.page-account-settings .panel {
+  margin-top: 5px;
+}
+.page-account-settings .form-group + .form-group .btn {
+  margin-top: 20px;
 }
 .page-api-keys .example-commands {
   padding: 8px 10px;
@@ -466,31 +476,21 @@ img.package-icon {
   margin-left: 10px;
   border-left: 1px solid #dbdbdb;
 }
-.page-api-keys .api-key-details .icon-buttons {
-  margin: 10px 0;
-  font-size: 1.2em;
-  color: #666;
-}
-.page-api-keys .api-key-details .icon-buttons li {
-  padding: 0;
-}
-.page-api-keys .api-key-details .icon-buttons li + li {
-  padding-left: 16px;
-  margin-left: 16px;
-  border-left: 1px solid #dbdbdb;
-}
 .page-package-details .no-border {
   border: 0;
-}
-.page-package-details .btn-expander:hover,
-.page-package-details .btn-expander:focus {
-  text-decoration: none;
 }
 .page-package-details .package-details-info .ms-Icon-ul li {
   margin-bottom: 15px;
 }
 .page-package-details .owner-list li {
   margin-bottom: 8px;
+}
+.page-package-details .owner-list img {
+  margin-right: 8px;
+}
+.page-package-details .share-buttons img {
+  display: inline-block;
+  margin-right: 8px;
 }
 .page-package-details .install-tabs {
   font-size: .8em;
@@ -526,7 +526,7 @@ img.package-icon {
   display: table-cell;
   width: 100%;
   max-width: 1px;
-  padding: 8px 10px;
+  padding: 0 10px 8px 10px;
   font-family: Consolas, Menlo, Monaco, "Courier New", monospace;
   line-height: 1.5;
   color: #fff;
@@ -541,7 +541,7 @@ img.package-icon {
 }
 .page-package-details .install-tabs .tab-pane .copy-button button {
   height: 100%;
-  min-height: 40px;
+  min-height: 42px;
   line-height: 1.5;
   vertical-align: baseline;
 }

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -26,4 +26,10 @@ $(function () {
 
     configureCopyButton('package-manager');
     configureCopyButton('dotnet-cli');
+
+    // Enable the undo edit link.
+    $("#undo-pending-edits").click(function (e) {
+        e.preventDefault();
+        $(this).closest('form').submit();
+    })
 });

--- a/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
+++ b/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
@@ -2,6 +2,8 @@
 @{
     ViewBag.Title = "Sign In";
     ViewBag.Tab = "Sign in";
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 
     // Show the sign in container if we found and existing user or if there are sign in errors.
@@ -24,7 +26,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-sm-offset-4 col-sm-4">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <p class="text-center">
                 @if (Model.External.FoundExistingUser)
                 {
@@ -54,7 +56,7 @@
         </div>
     </div>
     <div class="row @(showChoiceContainer ? string.Empty : "hidden")" aria-hidden="@(showChoiceContainer ? "false" : "true")" id="choice-container">
-        <div class="col-sm-offset-4 col-sm-4">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <div class="form-group">
                 <a class="btn btn-primary btn-block" href="#" role="button" id="show-sign-in">Connect to an existing NuGet.org account</a>
                 <b class="or-row center-block text-center">OR</b>
@@ -63,12 +65,12 @@
         </div>
     </div>
     <div class="row @(showSignInContainer ? string.Empty : "hidden")" aria-hidden="@(showSignInContainer ? "false" : "true")" id="sign-in-container">
-        <div class="col-sm-offset-4 col-sm-4">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @Html.Partial("_SignIn", Model)
         </div>
     </div>
     <div class="row @(showRegisterContainer ? string.Empty : "hidden")" aria-hidden="@(showRegisterContainer ? "false" : "true")" id="register-container">
-        <div class="col-sm-offset-4 col-sm-4">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @Html.Partial("_Register", Model)
         </div>
     </div>

--- a/src/NuGetGallery/Views/Authentication/Register.cshtml
+++ b/src/NuGetGallery/Views/Authentication/Register.cshtml
@@ -2,12 +2,14 @@
 @{
     ViewBag.Title = "Register";
     ViewBag.Tab = "Register";
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section role="main" class="container main-container page-sign-in">
     <div class="row">
-        <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
             <h1>Register</h1>
         </div>
     </div>
@@ -15,7 +17,7 @@
     @foreach (var provider in Model.Providers)
     {
         <div class="row">
-            <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
+            <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
                 <a role="button" class="btn btn-default btn-block provider-button"
                    href="@Url.Action("Authenticate", new {provider = provider.ProviderName, returnUrl = ViewData[Constants.ReturnUrlViewDataKey]})">
                     @if (!string.IsNullOrEmpty(@provider.UI.IconImagePath))
@@ -30,14 +32,14 @@
             </div>
         </div>
         <div class="row or-row">
-            <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
+            <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
                 <b>OR</b>
             </div>
         </div>
     }
 
     <div class="row">
-        <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @Html.Partial("_Register", Model)
         </div>
     </div>

--- a/src/NuGetGallery/Views/Authentication/SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/SignIn.cshtml
@@ -2,12 +2,14 @@
 @{
     ViewBag.Title = "Sign In";
     ViewBag.Tab = "Sign in";
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section role="main" class="container main-container page-sign-in">
     <div class="row">
-        <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
+        <div class="col-xs-12 text-center">
             <h1>Sign in</h1>
         </div>
     </div>
@@ -15,7 +17,7 @@
     @foreach (var provider in Model.Providers)
     {
         <div class="row">
-            <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
+            <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
                 <a role="button" class="btn btn-default btn-block provider-button"
                    href="@Url.Action("Authenticate", new {provider = provider.ProviderName, returnUrl = ViewData[Constants.ReturnUrlViewDataKey]})">
                     @if (!string.IsNullOrEmpty(@provider.UI.IconImagePath))
@@ -29,14 +31,14 @@
             </div>
         </div>
         <div class="row or-row">
-            <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
+            <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
                 <b>OR</b>
             </div>
         </div>
     }
     
     <div class="row">
-        <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @Html.Partial("_SignIn", Model)
         </div>
     </div>

--- a/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
+++ b/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
@@ -1,6 +1,7 @@
 ﻿@model CuratedFeedViewModel
 @{
     ViewBag.Title = "Curated Feed: " + Model.Name;
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
@@ -11,7 +12,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-md-10 col-md-offset-1">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <div class="row">
                 <div class="col-md-12">
                     <h2>

--- a/src/NuGetGallery/Views/CuratedPackages/CreateCuratedPackageForm.cshtml
+++ b/src/NuGetGallery/Views/CuratedPackages/CreateCuratedPackageForm.cshtml
@@ -1,5 +1,6 @@
 ﻿@model CreateCuratedPackageRequest
 @{
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 <section class="main-container container">
@@ -9,7 +10,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-md-10 col-md-offset-1">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @ViewHelpers.AlertInfo(@<text>
                 Packages might also be automatically included in your curated feed based on pre-defined rules. This form is to manually include a package in the curated feed, which will override any pre-defined rules.
             </text>)

--- a/src/NuGetGallery/Views/Packages/ConfirmOwner.cshtml
+++ b/src/NuGetGallery/Views/Packages/ConfirmOwner.cshtml
@@ -1,11 +1,13 @@
 ﻿@model PackageOwnerConfirmationModel
 @{
     ViewBag.Title = "Confirm Ownership";
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section role="main" class="container main-container page-manage-owners">
-    <div class="col-md-12">
+    <div class="col-xs-12">
         <h1 class="text-center">
             @if (Model.Result == ConfirmOwnershipResult.Success
                 || Model.Result == ConfirmOwnershipResult.AlreadyOwner)
@@ -18,7 +20,7 @@
             }
         </h1>
     </div>
-    <div class="col-md-4 col-md-offset-4">
+    <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
         @if (Model.Result == ConfirmOwnershipResult.Success)
         {
             <p class="text-center">

--- a/src/NuGetGallery/Views/Packages/ContactOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ContactOwners.cshtml
@@ -1,12 +1,13 @@
 ﻿@model ContactOwnersViewModel
 @{
     ViewBag.Tab = "Packages";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section role="main" class="container main-container page-contact-owners">
     <div class="row">
-        <div class="col-sm-offset-1 col-sm-10">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="text-center">Contact the Owners of <a href="@Url.Package(Model.PackageId)">@Model.PackageId.Abbreviate(50)</a></h1>
             @if (Model.Owners.Any())
             {

--- a/src/NuGetGallery/Views/Packages/Delete.cshtml
+++ b/src/NuGetGallery/Views/Packages/Delete.cshtml
@@ -2,12 +2,13 @@
 @{
     ViewBag.Title = "Delete Package";
     ViewBag.Tab = "Packages";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section class="container main-container page-delete-package">
     <div class="row">
-        <div class="col-md-10 col-md-offset-1">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="text-center">Manage Package Listing</h1>
             <div class="text-center ms-font-xxl">
                 <a href="@Url.Package(Model.Id, Model.Version)">@Model.Title.Abbreviate(40)</a>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -93,8 +93,7 @@
                         @<text>
                             An edit is pending for this package version. You are seeing the <em>edited</em> package description now.
                             These changes will be applied to the package file and become visible to everybody soon unless you
-                            <input type="submit" value="undo pending edits" title="undo pending edits" style="display: inline; width: 200px; font-size: 1em;" />
-                            first.
+                            <a href="#" role="button" id="undo-pending-edits">undo pending edits</a> first.
                         </text>
                     )
                 }
@@ -223,15 +222,18 @@
             }
             else
             {
+                <h2>
+                    <a href="#" role="button" data-toggle="collapse" data-target="#dependency-groups"
+                       aria-expanded="@(Model.Dependencies.DependencySets.Any() ? "false" : "true")" aria-controls="dependency-groups"
+                       id="show-dependency-groups">
+                        <i class="ms-Icon ms-Icon--@(Model.Dependencies.DependencySets.Any() ? "ChevronRight" : "ChevronDown")"
+                           aria-hidden="true"></i>
+                        <span>Dependencies</span>
+                    </a>
+                </h2>
+
                 if (Model.Dependencies.DependencySets.Any())
                 {
-                    <h2>
-                        <a href="#" role="button" data-toggle="collapse" data-target="#dependency-groups"
-                           aria-expanded="false" aria-controls="dependency-groups" id="show-dependency-groups">
-                            <i class="ms-Icon ms-Icon--ChevronRight" aria-hidden="true"></i>
-                            <span>Dependencies</span>
-                        </a>
-                    </h2>
                     <ul class="list-unstyled panel-collapse collapse dependency-groups" id="dependency-groups">
                         @foreach (var dependencySet in Model.Dependencies.DependencySets)
                         {
@@ -263,8 +265,7 @@
                 }
                 else
                 {
-                    <h2>Dependencies</h2>
-                    <p>This package has no dependencies.</p>
+                    <p class="collapse in" id="dependency-groups">This package has no dependencies.</p>
                 }
             }
 
@@ -288,16 +289,16 @@
                             }
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody class="no-border">
                         @{var rowCount = 0;}
                         @foreach (var packageVersion in Model.PackageVersions)
                         {
                             if (!packageVersion.Deleted && (packageVersion.Listed || (Model.IsOwner(User) || User.IsAdministrator())))
                             {
                                 rowCount++;
-                                if (rowCount >= 6)
+                                if (rowCount == 6)
                                 {
-                                    @:</tbody><tbody class="collapse" id="hidden-versions">
+                                    @:</tbody><tbody class="no-border collapse" id="hidden-versions">
                                 }
                                 <tr>
                                     <td>
@@ -335,9 +336,9 @@
                             else if (packageVersion.Deleted)
                             {
                                 rowCount++;
-                                if (rowCount >= 6)
+                                if (rowCount == 6)
                                 {
-                                    @:</tbody><tbody class="collapse" id="hidden-versions">
+                                    @:</tbody><tbody class="no-border collapse" id="hidden-versions">
                                 }
                                 <tr class="deleted">
                                     <td class="version">
@@ -357,11 +358,11 @@
                 </table>
                 @if (rowCount > 5)
                 {
-                    <button type="button" data-toggle="collapse" class="btn btn-link btn-expander icon-link" data-target="#hidden-versions"
+                    <a role="button" data-toggle="collapse" class="icon-link" data-target="#hidden-versions"
                             aria-expanded="false" aria-controls="hidden-versions" id="show-hidden-versions">
                         <i class="ms-Icon ms-Icon--CalculatorAddition" aria-hidden="true"></i>
                         <span>Show more</span>
-                    </button>
+                    </a>
                 }
             </div>
         </article>
@@ -528,7 +529,7 @@
 
             @if (Model.Tags.AnySafe())
             {
-                <h3>Tags</h3>
+                <h2>Tags</h2>
                 <p>
                     @foreach (var tag in Model.Tags)
                     {
@@ -537,11 +538,11 @@
                 </p>
             }
 
-            <h3>Share</h3>
+            <h2>Share</h2>
             @{
                 var encodedText = Url.Encode(string.Format("Check out {0} on #NuGet.", Model.Id));
             }
-            <p>
+            <p class="share-buttons">
                 <a href="https://www.facebook.com/sharer/sharer.php?u=@absolutePackageUrl&t=@encodedText" target="_blank"><img
                     width="24" height="24" alt="Share this package on Facebook"
                     src="@Url.Absolute("~/Content/gallery/img/facebook.svg")"

--- a/src/NuGetGallery/Views/Packages/Edit.cshtml
+++ b/src/NuGetGallery/Views/Packages/Edit.cshtml
@@ -3,12 +3,13 @@
 @{
     ViewBag.Title = "Editing: " + Model.PackageTitle + " " + Model.Version;
     ViewBag.Tab = "Packages";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <div class="container main-container page-edit-package">
     <div class="row">
-        <div class="col-xs-10 col-xs-offset-1">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="page-heading text-center">Edit Package</h1>
             <h3 class="page-subheading text-center"><a href="@Url.Package(Model.PackageId)" class="">@Model.PackageId</a></h3>
             <div id="select-package-version-container">

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -1,11 +1,12 @@
 ﻿@model ManagePackageOwnersViewModel
 @{
     ViewBag.Tab = "Packages";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section role="main" class="container main-container page-manage-owners">
-    <div class="col-md-10 col-md-offset-1">
+    <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
         <h1 class="text-center">Manage Owners for Package <a href="@Url.Package(Model.Id)">@Model.Title.Abbreviate(50)</a></h1>
 
         <div style="display: none" id="manage-owners-alert" data-bind="visible: message">

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -2,13 +2,14 @@
 @model ReportAbuseViewModel
 @{
     ViewBag.Tab = "Packages";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
     string returnUrl = ViewData.ContainsKey(Constants.ReturnUrlViewDataKey) ? (string)ViewData[Constants.ReturnUrlViewDataKey] : Request.RawUrl;
 }
 
 <section class="container main-container page-report-abuse">
     <div class="row report-form">
-        <div class="col-md-offset-1 col-md-10">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="page-heading text-center">Report Abuse by <a href="@Url.Package(@Model.PackageId, Model.PackageVersion)">@Model.PackageId @Model.PackageVersion</a></h1>
 
             @ViewHelpers.AlertWarning(isAlertRole: true, htmlContent:

--- a/src/NuGetGallery/Views/Packages/ReportMyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportMyPackage.cshtml
@@ -2,12 +2,13 @@
 @model ReportMyPackageViewModel
 @{
     ViewBag.Tab = "Packages";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <div class="container main-container page-report-abuse">
     <div class="row report-form">
-        <div class="col-md-offset-1 col-md-10">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="page-heading text-center">Contact Support about <a href="@Url.Package(@Model.PackageId, Model.PackageVersion)">@Model.PackageId @Model.PackageVersion</a></h1>
             @using (Html.BeginForm())
             {

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -2,12 +2,13 @@
 @{
     ViewBag.Title = "Upload Package";
     ViewBag.Tab = "Upload";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <div class="page-upload container main-container" role="main">
     <div class="row">
-        <div class="col-xs-10 col-xs-offset-1">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="page-heading text-center">Upload Your Package</h1>
             <div class="page-subheading text-center">
                 <p class="message">Your package file will be uploaded and hosted on the @(Config.Current.Brand) server (@(Config.Current.SiteRoot)).</p>

--- a/src/NuGetGallery/Views/Pages/Contact.cshtml
+++ b/src/NuGetGallery/Views/Pages/Contact.cshtml
@@ -2,25 +2,25 @@
 @model ContactSupportViewModel
 @{
     ViewBag.Title = "Contact";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section role="main" class="container main-container">
     <div class="row">
-        <div class="col-sm-12">
+        <div class="col-xs-12 text-center">
             <h1>Contact</h1>
             <span class="page-subheading ms-fontSize-l">Need help with NuGet? Let us know!</span>
         </div>
     </div>
     <div class="row">
-        <div class="col-sm-6">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Having problems using a specific package?</h2>
             <p>
                 If you're having trouble installing a specific package, try contacting the owner of that package first.
                 You can reach them using the "Contact Owners" link on the package details page.
             </p>
-        </div>
-        <div class="col-sm-6">
+
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Found a bug in NuGet or the website NuGet.org?</h2>
             <p>
                 If you're having trouble with the <strong>NuGet.org Website</strong>,
@@ -28,50 +28,39 @@
                 If you're having trouble with the <strong>NuGet client tools</strong> (the Visual Studio extension, NuGet.exe command line tool, .NET CLI restore etc.),
                 file a bug on the NuGet Client <a href="https://github.com/NuGet/Home/issues">Issue Tracker</a>.
             </p>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
+
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Is a package violating a license or otherwise abusive?</h2>
             <p>
                 If you feel that a package is violating the license of software you own or is violating our terms of service,
                 use the "Report Abuse" link on the package details page to report it directly to us.
             </p>
-        </div>
-        <div class="col-sm-6">
+
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Want to change your NuGet.org username?</h2>
             <p>
                 No need to contact support. Create a new user and transfer ownership of your packages to it.
             </p>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-6">
+
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Having issues working with NuGet.org?</h2>
             <p>
                 Before reaching out to NuGet support, check out the
                 <a href="https://docs.nuget.org/consume/nuget-faq#managing-packages-in-nuget.org"><abbr title="Frequently Asked Questions">FAQ</abbr></a>.
             </p>
-        </div>
-        @if (!User.Identity.IsAuthenticated)
-        {
-            <div class="col-sm-6">
+
+            @if (!User.Identity.IsAuthenticated)
+            {
                 <h2 class="ms-fontSize-xl ms-fontWeight-semibold">The above doesn't help? @Html.ActionLink("Sign in", "LogOn", new { controller = "Authentication", ReturnUrl = "/policies/Contact" }) to contact Support.</h2>
                 <p>
                     Need help with your NuGet.org account? Please feel free to <span id="emailUs"></span>.
                 </p>
-            </div>
-        }
-    </div>
-    @if(User.Identity.IsAuthenticated)
-    {
-        <div class="row">
-            <div class="col-sm-offset-2 col-sm-8">
+            }
+            else
+            {
                 <h2 class="ms-fontSize-xl ms-fontWeight-semibold">The above doesn't help? Get in touch with us using the form below</h2>
                 <p>
                     A member of our Support team will be in touch with you soon.
                 </p>
-                @using (Html.BeginForm("Contact", "Pages"))
+
+                using (Html.BeginForm("Contact", "Pages"))
                 {
                     <fieldset class="form">
                         @Html.AntiForgeryToken()
@@ -95,9 +84,9 @@
                         </div>
                     </fieldset>
                 }
-            </div>
+            }
         </div>
-    }
+    </div>
 </section>
 
 @section BottomScripts {

--- a/src/NuGetGallery/Views/Pages/Home.cshtml
+++ b/src/NuGetGallery/Views/Pages/Home.cshtml
@@ -50,28 +50,34 @@
         </div>
         <div class="row row-gap">
             <div class="col-sm-4">
-                <img width="225" height="225" alt="Cartoon image of a person lifting a package into the clouds"
-                     src="~/Content/gallery/img/orange-circle.svg"
-                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/orange-circle-225x225.png")) />
-                <h3>Learn</h3>
+                <a href="https://docs.microsoft.com/en-us/nuget/quickstart/use-a-package">
+                    <img width="225" height="225" alt="Cartoon image of a person lifting a package into the clouds"
+                         src="~/Content/gallery/img/orange-circle.svg"
+                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/orange-circle-225x225.png")) />
+                    <h3>Learn</h3>
+                </a>
                 <p>
                     New to NuGet? Start with a walkthrough showing how NuGet powers your .NET development.
                 </p>
             </div>
             <div class="col-sm-4">
-                <img width="225" height="225" alt="Cartoon image of a person looking into the clouds with a telescope"
-                     src="~/Content/gallery/img/purple-circle.svg"
-                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/purple-circle-225x225.png")) />
-                <h3>Explore</h3>
+                <a href="@Url.PackageList()">
+                    <img width="225" height="225" alt="Cartoon image of a person looking into the clouds with a telescope"
+                         src="~/Content/gallery/img/purple-circle.svg"
+                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/purple-circle-225x225.png")) />
+                    <h3>Explore</h3>
+                </a>
                 <p>
                     Browse the thousands of packages that developers like you have created and shared with the .NET community.
                 </p>
             </div>
             <div class="col-sm-4">
-                <img width="225" height="225" alt="Cartoon image of a toolbox"
-                     src="~/Content/gallery/img/blue-circle.svg"
-                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/blue-circle-225x225.png")) />
-                <h3>Create</h3>
+                <a href="https://docs.microsoft.com/en-us/nuget/quickstart/create-and-publish-a-package">
+                    <img width="225" height="225" alt="Cartoon image of a toolbox"
+                         src="~/Content/gallery/img/blue-circle.svg"
+                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/blue-circle-225x225.png")) />
+                    <h3>Create</h3>
+                </a>
                 <p>
                     Want to make your first NuGet package and share it with the community? Start with this walkthrough!
                 </p>

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -128,7 +128,9 @@
     <div class="alert-transient @(ViewBag.HasJumbotron == true ? "alert-transient-jumbotron" : string.Empty)">
         <div class="container">
             <div class="row">
-                <div class="col-sm-offset-2 col-sm-8">
+                @{ 
+                }
+                <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
                     @ViewHelpers.AlertInfo(@<text>@TempData["Message"]</text>)
                 </div>
             </div>

--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -2,6 +2,7 @@
 
 @{
     ViewBag.Title = "Account Settings";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
     ViewBag.Sections = new List<string>();
 }
@@ -52,7 +53,7 @@
 
 <section role="main" class="container main-container page-account-settings">
     <div class="row">
-        <div class="col-md-10 col-md-offset-1">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="text-center">Account Settings</h1>
             <div class="text-center ms-font-xxl">
                 <a href="@Url.User(CurrentUser)">@CurrentUser.Username</a>

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -3,6 +3,7 @@
 
 @{
     ViewBag.Title = "API Keys";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
@@ -32,7 +33,7 @@
         @Html.AntiForgeryToken()
     </form>
     <div class="row">
-        <div class="col-md-10 col-md-offset-1">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="text-center">API Keys</h1>
             <p>
                 An API key is a token that can identify you to @(Config.Current.Brand). The
@@ -188,7 +189,7 @@
                 <b>Glob pattern:</b> <span data-bind="text: GlobPattern"></span>
                 <br />
                 <!-- /ko -->
-                <ul class="list-inline icon-buttons" role="presentation">
+                <ul class="package-list" role="presentation">
                     <!-- ko if: Value -->
                     <li>
                         <a class="icon-link" href="#" role="button" data-content="Copied."

--- a/src/NuGetGallery/Views/Users/Confirm.cshtml
+++ b/src/NuGetGallery/Views/Users/Confirm.cshtml
@@ -2,6 +2,8 @@
 @{
     var titleString = Model.ConfirmingNewAccount ? "Account" : "Email";
     ViewBag.Title = "Confirm Your " + titleString;
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
@@ -19,7 +21,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-xs-4 col-xs-offset-4">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @if (Model.SuccessfulConfirmation)
             {
                 <p class="text-center">

--- a/src/NuGetGallery/Views/Users/ConfirmationRequired.cshtml
+++ b/src/NuGetGallery/Views/Users/ConfirmationRequired.cshtml
@@ -2,6 +2,8 @@
 @{
     var titleString = Model.ConfirmingNewAccount ? "Account" : "Email";
     ViewBag.Title = "Confirm Your " + titleString;
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
@@ -19,7 +21,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-md-4 col-md-offset-4 col-sm-6 col-sm-offset-3">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @if (Model.SentEmail)
             {
                 <p class="text-center">

--- a/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
+++ b/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
@@ -1,30 +1,33 @@
 ﻿@model ForgotPasswordViewModel
 @{
     ViewBag.Title = "Forgot Password";
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section role="main" class="container main-container page-forgot-password">
-    <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
-        <h1>Forgot Password</h1>
+    <div class="row">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
+            <h1>Forgot Password</h1>
 
-        <p>We are sorry to hear you forgot your NuGet.org account password. Enter your email below and we will send instructions to reset your password.</p>
+            <p>We are sorry to hear you forgot your NuGet.org account password. Enter your email below and we will send instructions to reset your password.</p>
 
-        <div class="row forgot-form text-left">
+            <div class="forgot-form text-left">
+                @using (Html.BeginForm())
+                {
+                    @Html.AntiForgeryToken()
 
-            @using (Html.BeginForm())
-            {
-                @Html.AntiForgeryToken()
-
-                <div class="form-group @Html.HasErrorFor(m => m.Email)">
-                    @Html.ShowLabelFor(m => m.Email)
-                    @Html.ShowTextBoxFor(m => m.Email)
-                    @Html.ShowValidationMessagesFor(m => m.Email)
-                </div>
-                <div class="form-group">
-                    <input type="submit" class="btn btn-primary form-control" value="Send" />
-                </div>
-            }
+                    <div class="form-group @Html.HasErrorFor(m => m.Email)">
+                        @Html.ShowLabelFor(m => m.Email)
+                        @Html.ShowTextBoxFor(m => m.Email)
+                        @Html.ShowValidationMessagesFor(m => m.Email)
+                    </div>
+                    <div class="form-group">
+                        <input type="submit" class="btn btn-primary form-control" value="Send" />
+                    </div>
+                }
+            </div>
         </div>
     </div>
 </section>

--- a/src/NuGetGallery/Views/Users/PasswordChanged.cshtml
+++ b/src/NuGetGallery/Views/Users/PasswordChanged.cshtml
@@ -1,16 +1,18 @@
 ﻿@{
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section role="main" class="container main-container">
     <div class="row">
-        <div class="col-sm-12">
+        <div class="col-xs-12">
             <h1 class="text-center">Password changed!</h1>
         </div>
     </div>
 
     <div class="row">
-        <div class="col-sm-offset-4 col-sm-4 text-center">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
             @if (Request.IsAuthenticated)
             {
                 <p>Your NuGet.org account password has been set and can now be used to sign in!</p>

--- a/src/NuGetGallery/Views/Users/PasswordSent.cshtml
+++ b/src/NuGetGallery/Views/Users/PasswordSent.cshtml
@@ -1,10 +1,12 @@
 ﻿@{
     ViewBag.Title = "Password Reset";
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
 <section role="main" class="container main-container">
-    <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 text-center">
+    <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
         <h1>Password Reset Sent</h1>
 
         <p>

--- a/src/NuGetGallery/Views/Users/ResetPassword.cshtml
+++ b/src/NuGetGallery/Views/Users/ResetPassword.cshtml
@@ -1,6 +1,8 @@
 ﻿@model PasswordResetViewModel
 @{
     ViewBag.Title = ViewBag.ForgotPassword ? "Reset Password" : "Set Password";
+    ViewBag.SmPageColumns = Constants.ColumnsAuthenticationSm;
+    ViewBag.MdPageColumns = Constants.ColumnsAuthenticationMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
@@ -12,7 +14,7 @@
     </div>
 
     <div class="row">
-        <div class="col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @if (ViewData.ModelState[""] != null && ViewData.ModelState[""].Errors.Count > 0)
             {
                 @ViewHelpers.AlertDanger(

--- a/src/NuGetGallery/Views/Users/Thanks.cshtml
+++ b/src/NuGetGallery/Views/Users/Thanks.cshtml
@@ -1,5 +1,7 @@
 ﻿@{
     ViewBag.Title = "Thanks";
+    ViewBag.SmPageColumns = 8;
+    ViewBag.MdPageColumns = 6;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
@@ -10,7 +12,7 @@
                 Thanks for registering!
             </h1>
         </div>
-        <div class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <p class="ms-fontSize-xl">Welcome @CurrentUser.Username! Now that you have a NuGet.org account, let's get you started!</p>
 
             <p>Make sure your email is verified. <a href="@Url.ConfirmationRequired()">Confirm your account</a></p>


### PR DESCRIPTION
Fixed:
- All pages: Transient messages e.g. unlisting a package should span the full 12 columns (or however many columns the page's contents take up)
  - This is fixed by telling the header Razor the page width in columns.
- Dev Environment: Warning Icon should be same height as the test for the banner
- Home Page: The 3 CTAs below the jumbotron should link to the pages
- Package Details:
   - Share and Tags Font size do not match the rest of the column
   - The show more for Version history is adding an extra bar when it is clicked
   - Copy button is not flush with commandline entry (off by about a pixel)
   - Spacing between owners name and avatar should be increased ( ~10px)
   - Icon is not centered to "Shore more/less"for expander for lists
   - Space Facebook and Twitter icons a bit more
   - Should there be an expander on the Dependencies section even if there are no dependencies? (yes)
   - Hover behavior over "Show more/less" is not consistent with other pages changes colors here, other pages, underlines (see Package Statistics). Should be consistent with other links (underline)
   - Pending edits notification has a button in the transient message, it should just be a link.
- Contact: This page should be a single column page spanning 10 columns (to make it work with the signed in version
- Account Settings:
  - Settings Entries (e.g. Email Address, Notifications, Password, etc.) should be spaced out a bit more currently it looks like ~10 px should be ~40px
  - Spacing between section header and the contents rectangle should be spaced ~5-10px more
  - More spacing between forms and buttons for each section ~20-40px
- API Keys: Buttons for each API key have font that is too big. Should match the size for Package controls (e.g. Manage my packages)


Missing:
- Home Page: Number callouts have a line between the rectangle and triangle