### PR TITLE
[Redesign] Use a darker border for input fields so that high contrast on macOS is more usable

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -1750,7 +1750,7 @@ output {
   color: #555;
   background-color: #fff;
   background-image: none;
-  border: 1px solid #ccc;
+  border: 1px solid #7f7f7f;
   border-radius: 0;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
           box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
@@ -3090,7 +3090,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   color: #555;
   text-align: center;
   background-color: #dbdbdb;
-  border: 1px solid #ccc;
+  border: 1px solid #7f7f7f;
   border-radius: 0;
 }
 .input-group-addon.input-sm {

--- a/src/Bootstrap/less/variables.less
+++ b/src/Bootstrap/less/variables.less
@@ -191,7 +191,7 @@
 //** Text color for `<input>`s
 @input-color:                    @gray;
 //** `<input>` border color
-@input-border:                   #ccc;
+@input-border:                   #7f7f7f;
 
 // TODO: Rename `@input-border-radius` to `@input-border-radius-base` in v4
 //** Default `.form-control` border radius

--- a/src/NuGetGallery/Content/gallery/css/bootstrap.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap.css
@@ -1750,7 +1750,7 @@ output {
   color: #555;
   background-color: #fff;
   background-image: none;
-  border: 1px solid #ccc;
+  border: 1px solid #7f7f7f;
   border-radius: 0;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
           box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
@@ -3090,7 +3090,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   color: #555;
   text-align: center;
   background-color: #dbdbdb;
-  border: 1px solid #ccc;
+  border: 1px solid #7f7f7f;
   border-radius: 0;
 }
 .input-group-addon.input-sm {


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/4196

I chose to leave the gray buttons as-is.

Windows, normal constrast

![image](https://user-images.githubusercontent.com/94054/28040274-26a3bc88-657a-11e7-8f13-4a1c7ccce9d5.png)

High contrast

![img_20170710_141904](https://user-images.githubusercontent.com/94054/28040538-f8d75fd4-657a-11e7-9fbc-49021deed9dc.jpg)
