### PR TITLE
[Redesign] Address PM pass redesign issues (loshar)

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -295,6 +295,9 @@ img.package-icon {
     margin-left: 0;
   }
 }
+.list-packages .package .manage-package {
+  margin-bottom: 0;
+}
 .list-packages .package .package-details {
   margin-top: 10px;
   line-height: 20px;

--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -2742,7 +2742,7 @@ tbody.collapse.in {
 }
 .dropdown-menu > li > a {
   display: block;
-  padding: 3px 20px;
+  padding: 5px 20px;
   clear: both;
   font-weight: normal;
   line-height: 1.42857143;

--- a/src/Bootstrap/less/dropdowns.less
+++ b/src/Bootstrap/less/dropdowns.less
@@ -59,7 +59,7 @@
   // Links within the dropdown menu
   > li > a {
     display: block;
-    padding: 3px 20px;
+    padding: 5px 20px;
     clear: both;
     font-weight: normal;
     line-height: @line-height-base;

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -24,6 +24,10 @@
       }
     }
 
+    .manage-package {
+      margin-bottom: 0px;
+    }
+
     .package-details {
       margin-top: @padding-large-vertical;
       color: @text-color;

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -189,7 +189,14 @@
 
 @helper GravatarImage(string email, string username, int size)
 {
-    @GravatarHelper.Image(email, size, attributes: new { width = size, height = size, title = username, @class = "owner-image" });
+    @GravatarImage(email, username, size, responsive: false);
+}
+
+@helper GravatarImage(string email, string username, int size, bool responsive)
+{
+    var classAttribute = responsive ? "owner-image img-responsive" : "owner-image";
+
+    @GravatarHelper.Image(email, size, attributes: new { width = size, height = size, title = username, @class = classAttribute });
 }
 
 @helper WriteMeta(string name, string val) {

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -295,6 +295,9 @@ img.package-icon {
     margin-left: 0;
   }
 }
+.list-packages .package .manage-package {
+  margin-bottom: 0;
+}
 .list-packages .package .package-details {
   margin-top: 10px;
   line-height: 20px;

--- a/src/NuGetGallery/Content/gallery/css/bootstrap.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap.css
@@ -2742,7 +2742,7 @@ tbody.collapse.in {
 }
 .dropdown-menu > li > a {
   display: block;
-  padding: 3px 20px;
+  padding: 5px 20px;
   clear: both;
   font-weight: normal;
   line-height: 1.42857143;

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -1,7 +1,6 @@
 ﻿@model ManagePackageOwnersViewModel
 @{
     ViewBag.Tab = "Packages";
-    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -52,7 +52,8 @@
                         @Html.ShowValidationMessagesFor(m => m.Email)
                     </div>
                     <div class="form-group @Html.HasErrorFor(m => m.AlreadyContactedOwner)">
-                        @Html.ShowSliderFor(m => m.AlreadyContactedOwner)
+                        @Html.ShowCheckboxFor(m => m.AlreadyContactedOwner)
+                        @Html.ShowLabelFor(m => m.AlreadyContactedOwner)
                         @Html.ShowValidationMessagesFor(m => m.AlreadyContactedOwner)
                     </div>
                     <div class="form-group @Html.HasErrorFor(m => m.Message)">
@@ -62,7 +63,8 @@
                         @Html.ShowValidationMessagesFor(m => m.Message)
                     </div>
                     <div class="form-group @Html.HasErrorFor(m => m.CopySender)">
-                        @Html.ShowSliderFor(m => m.CopySender)
+                        @Html.ShowCheckboxFor(m => m.CopySender)
+                        @Html.ShowLabelFor(m => m.CopySender)
                         @Html.ShowValidationMessagesFor(m => m.CopySender)
                     </div>
                     <div class="form-group infringement-claim-requirements @Html.HasErrorFor(m => m.Signature)">

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -56,56 +56,54 @@
                             @DisplayNavigationItem("Admin", Url.Action("Index", "Home", new { area = "Admin" }))
                         }
                         @DisplayNavigationItem("Documentation", "https://docs.microsoft.com/en-us/nuget/")
-                        @DisplayNavigationItem("Downloads", Url.Downloads())
+                        @DisplayNavigationItem("Downloads", Url.RouteUrl(RouteName.Downloads))
                         @DisplayNavigationItem("Blog", "http://blog.nuget.org/")
                     </ul>
-                    @if (ViewBag.ShowUserInNavBar != false)
-                    {
-                        <ul class="nav navbar-nav navbar-right navbar-seperated" role="menu">
-                            @if (!User.Identity.IsAuthenticated)
-                            {
-                                var returnUrl = ViewData.ContainsKey(Constants.ReturnUrlViewDataKey) ? (string)ViewData[Constants.ReturnUrlViewDataKey] : Request.RawUrl;
-                                @DisplayNavigationItem("Sign in", Url.LogOn(returnUrl), title: "Sign in to an existing NuGet.org account")
-                                <li class="hidden-xs seperator" role="presentation"><span></span></li>
-                                @DisplayNavigationItem("Register", Url.SignUp(returnUrl), title: "Register for a new NuGet.org account")
-                            }
-                            else
-                            {
-                                <li class="@(ViewBag.Tab == User.Identity.Name ? "active" : string.Empty) dropdown"
-                                    aria-selected="@(ViewBag.Tab == User.Identity.Name ? "true" : "false")" role="presentation">
-                                    <a href="#" role="menuitem" id="account-dropdown" class="dropdown-toggle" title="Open profile dropdown" data-toggle="dropdown">
-                                        <b><span>@User.Identity.Name</span></b>
-                                        <span class="caret"></span>
-                                    </a>
-                                    <ul class="dropdown-menu" role="menu" aria-labelledby="account-dropdown">
-                                        <li class="dropdown-header row">
-                                            <div class="col-sm-3">
-                                                @ViewHelpers.GravatarImage(CurrentUser.EmailAddress ?? CurrentUser.UnconfirmedEmailAddress, CurrentUser.Username, 50)
-                                            </div>
-                                            <div class="col-sm-9 dropdown-profile">
-                                                <span class="dropdown-username">@User.Identity.Name.Abbreviate(20)</span>
-                                                <br />
-                                                <span class="dropdown-email">@CurrentUser.EmailAddress.Abbreviate(35)</span>
-                                            </div>
-                                        </li>
-                                        @if (Request.IsAuthenticated && User.IsInRole(Constants.AdminRoleName))
-                                        {
-                                            <li class="divider"></li>
-                                            <li role="presentation"><a href="@Url.Action("Index", "Home", new { area = "Admin" })" role="menuitem">Admin</a></li>
-                                        }
+                    <ul class="nav navbar-nav navbar-right navbar-seperated" role="menu">
+                        @if (!User.Identity.IsAuthenticated)
+                        {
+                            var returnUrl = ViewData.ContainsKey(Constants.ReturnUrlViewDataKey) ? (string)ViewData[Constants.ReturnUrlViewDataKey] : Request.RawUrl;
+                            @DisplayNavigationItem("Sign in", Url.LogOn(returnUrl), title: "Sign in to an existing NuGet.org account")
+                            <li class="hidden-xs seperator" role="presentation"><span></span></li>
+                            @DisplayNavigationItem("Register", Url.SignUp(returnUrl), title: "Register for a new NuGet.org account")
+                        }
+                        else
+                        {
+                            <li class="@(ViewBag.Tab == User.Identity.Name ? "active" : string.Empty) dropdown"
+                                aria-selected="@(ViewBag.Tab == User.Identity.Name ? "true" : "false")" role="presentation">
+                                <a href="#" role="menuitem" id="account-dropdown" class="dropdown-toggle" title="Open profile dropdown" data-toggle="dropdown">
+                                    <b><span>@User.Identity.Name</span></b>
+                                    <span class="caret"></span>
+                                </a>
+                                <ul class="dropdown-menu" role="menu" aria-labelledby="account-dropdown">
+                                    <li class="dropdown-header row">
+                                        <div class="col-sm-3">
+                                            @ViewHelpers.GravatarImage(CurrentUser.EmailAddress ?? CurrentUser.UnconfirmedEmailAddress, CurrentUser.Username, 50)
+                                        </div>
+                                        <div class="col-sm-9 dropdown-profile">
+                                            <span class="dropdown-username">@User.Identity.Name.Abbreviate(20)</span>
+                                            <br />
+                                            <span class="dropdown-email">@CurrentUser.EmailAddress.Abbreviate(35)</span>
+                                        </div>
+                                    </li>
+                                    @if (Request.IsAuthenticated && User.IsInRole(Constants.AdminRoleName))
+                                    {
                                         <li class="divider"></li>
-                                        <li role="presentation"><a href="@Url.User(CurrentUser.Username)" role="menuitem">View Profile</a></li>
-                                        <li role="presentation"><a href="@Url.AccountSettings()" role="menuitem">Account Settings</a></li>
-                                        <li role="presentation"><a href="@Url.ManageMyApiKeys()" role="menuitem">API Keys</a></li>
-                                        <li role="presentation"><a href="@Url.ManageMyPackages()" role="menuitem">Manage Packages</a></li>
-                                        <li role="presentation"><a href="@Url.UploadPackage()" role="menuitem">Upload Package</a></li>
-                                        <li class="divider"></li>
-                                        <li role="presentation"><a href="@Url.LogOff()" role="menuitem">Sign Out</a></li>
-                                    </ul>
-                                </li>
-                            }
-                        </ul>
-                    }
+                                        <li role="presentation"><a href="@Url.Action("Index", "Home", new { area = "Admin" })" role="menuitem">Admin</a></li>
+                                    }
+                                    <li class="divider"></li>
+                                    <li role="presentation"><a href="@Url.User(CurrentUser.Username)" role="menuitem">View Profile</a></li>
+                                    <li role="presentation"><a href="@Url.AccountSettings()" role="menuitem">Account Settings</a></li>
+                                    <li role="presentation"><a href="@Url.ManageMyApiKeys()" role="menuitem">API Keys</a></li>
+                                    <li class="divider"></li>
+                                    <li role="presentation"><a href="@Url.ManageMyPackages()" role="menuitem">Manage Packages</a></li>
+                                    <li role="presentation"><a href="@Url.UploadPackage()" role="menuitem">Upload Package</a></li>
+                                    <li class="divider"></li>
+                                    <li role="presentation"><a href="@Url.LogOff()" role="menuitem">Sign Out</a></li>
+                                </ul>
+                            </li>
+                        }
+                    </ul>
                 </div>
             </div>
         </div>

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -60,7 +60,7 @@
 
         @if (Model.IsOwner(User))
         {
-            <ul class="package-list">
+            <ul class="package-list manage-package">
                 <li>
                     <a href="@Url.EditPackage(Model.Id, Model.Version)" class="icon-link">
                         <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -7,8 +7,8 @@
 
 <div class="container main-container page-profile">
     <section role="main" class="row">
-        <aside class="col-md-4 col-md-push-8 profile-details">
-            @ViewHelpers.GravatarImage(Model.EmailAddress ?? Model.UnconfirmedEmailAddress, Model.Username, 332)
+        <aside class="col-md-3 col-md-push-9 profile-details">
+            @ViewHelpers.GravatarImage(Model.EmailAddress ?? Model.UnconfirmedEmailAddress, Model.Username, 332, responsive: true)
 
             <div class="statistics">
                 <div class="statistic">
@@ -21,7 +21,7 @@
                 </div>
             </div>
         </aside>
-        <article class="col-md-8 col-md-pull-4">
+        <article class="col-md-9 col-md-pull-3">
             <div class="profile-title">
                 <h1>@Model.Username</h1>
 


### PR DESCRIPTION
Fixes the following issues:

* Increases space between account dropdown menu entries from 6px to 10px
* Added separator between API Keys and Manage Packges on account dropdown menu
* Fixed spacing issue where the manage package links increased a package's bottom margin on search/profile page.
* Fixed column layout of profile page (packages are now 9 columns, profile aside is 3 columns)
* Fixed link styling to remove a package owner
* Removed toggles on Report Abuse page