### PR TITLE
[Redesign] More Stats chart fixes

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -183,6 +183,11 @@ h3 a:active {
     max-height: 60px;
   }
 }
+@media screen and (max-width: 480px) {
+  .hidden-tiny {
+    display: none;
+  }
+}
 img.package-icon {
   margin-right: auto;
   margin-left: auto;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -238,6 +238,12 @@ h2, h3 {
   }
 }
 
+@media screen and (max-width: 480px) {
+    .hidden-tiny {
+        display: none;
+    }
+}
+
 img.package-icon {
   margin-left: auto;
   margin-right: auto;

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -183,6 +183,11 @@ h3 a:active {
     max-height: 60px;
   }
 }
+@media screen and (max-width: 480px) {
+  .hidden-tiny {
+    display: none;
+  }
+}
 img.package-icon {
   margin-right: auto;
   margin-left: auto;

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -94,23 +94,31 @@
                     <div class="col-xs-12 chart">
                         <svg class="chart" id="bar-chart-client-usage">
                             @{
-                                var chartFullWidthInPercent = 94.0;
+                                var limitCount = 15;
+                                var minDL = 1000;
+                                var showVersions = Model.NuGetClientVersion.Where(e => e.Downloads > minDL);
+                                if (showVersions.Count() > limitCount)
+                                {
+                                    showVersions = showVersions.Skip(Math.Max(0, showVersions.Count() - limitCount));
+                                }
+
+                                var chartFullWidthInPercent = 90.0;
                                 var chartFullHeightInPercent = 90.0;
                                 var widthOffsetPercent = 100.0 - chartFullWidthInPercent;
                                 var index = 0;
                                 var gapPercent = .1;
-                                var max = Model.NuGetClientVersion.Max(e => e.Downloads) * 1.0;
+                                var max = showVersions.Max(e => e.Downloads) * 1.0;
                                 var numYAxisLabels = 10.0;
-                                var fraction = chartFullWidthInPercent / Model.NuGetClientVersion.Count();
-                                foreach (var item in Model.NuGetClientVersion)
+                                var fraction = chartFullWidthInPercent / showVersions.Count();
+                                foreach (var item in showVersions)
                                 {
                                     <rect class="graph-bar" id="graph-bar-@(item.Version)" x="@(widthOffsetPercent + index * fraction)%" y="@(chartFullHeightInPercent-item.Downloads/max*chartFullHeightInPercent)%" width="@(fraction * (1.0 - gapPercent))%" height="@(item.Downloads/max*chartFullHeightInPercent)%">
                                         <title>@(item.Downloads) downloads</title>
                                     </rect>
 
-                                        <svg x="@(widthOffsetPercent + index * fraction + fraction/2.0 - 3)%" y="@(chartFullHeightInPercent + 1)%">
+                                        <svg x="@(widthOffsetPercent + index * fraction + fraction/2.0 - 2.5)%" y="@(chartFullHeightInPercent + 1)%">
                                             <g transform="rotate(-45)">
-                                                <text y="1.2em" x="-0.8em" class="graph-x-axis-text">@(item.Version)</text>
+                                                <text y="1.5em" x="-0.9em" class="graph-x-axis-text"> @(item.Version)</text>
                                             </g>
                                         </svg>
                                     index++;

--- a/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
+++ b/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
@@ -82,7 +82,7 @@
                 </svg>
             </div>
             <div class="col-sm-10" id="stats-data-display">
-                <div class="stats-graph col-xs-12" id="statistics-graph-id"></div>
+                <div class="stats-graph col-xs-12 hidden-tiny" id="statistics-graph-id"></div>
                 <div class="stats-table-data">
                     <table data-bind="if: Table" class="pivot-table table">
                         <thead>


### PR DESCRIPTION
 * Limits client usage chart to Most recent 15 versions to prevent overlapping of labels. The entire information is still available via table.
 * Add a new selector to hide elements at 480px threshold. Used to hide charts on package stats page when page width becomes too small.

Should address:
[Redesign] Text cut off on the chart on the statistics page in Edge #4140
[Redesign] Package Statistics / Package Version Statistics page looks odd with small window #4190

@joelverhagen @scottbommarito @loic-sharma 