### PR TITLE
[Redesign]Fix loading Spinner in Edge/IE

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -888,6 +888,51 @@ img.package-icon {
 .page-stats-per-package #hidden-rows {
   border-top: none;
 }
+.page-stats-per-package .loader {
+  width: 120px;
+  height: 120px;
+  margin: 0 auto;
+  border: 16px solid #f3f3f3;
+  /* Light grey */
+  border-top: 16px solid #3498db;
+  /* Blue */
+  border-radius: 50%;
+  -webkit-animation: spin 2s linear infinite;
+       -o-animation: spin 2s linear infinite;
+          animation: spin 2s linear infinite;
+}
+@-webkit-keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+@-o-keyframes spin {
+  0% {
+    -o-transform: rotate(0deg);
+       transform: rotate(0deg);
+  }
+  100% {
+    -o-transform: rotate(360deg);
+       transform: rotate(360deg);
+  }
+}
+@keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+         -o-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+         -o-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
 .page-stats-per-package #loading-placeholder {
   display: none;
 }

--- a/src/Bootstrap/less/theme/page-statistics-per-package.less
+++ b/src/Bootstrap/less/theme/page-statistics-per-package.less
@@ -20,6 +20,21 @@
         border-top: none;
     }
 
+    .loader {
+        margin: 0 auto;
+        border: 16px solid #f3f3f3; /* Light grey */
+        border-top: 16px solid #3498db; /* Blue */
+        border-radius: 50%;
+        width: 120px;
+        height: 120px;
+        animation: spin 2s linear infinite;
+    }
+
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+
     #loading-placeholder {
         display: none;
     }

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -888,6 +888,51 @@ img.package-icon {
 .page-stats-per-package #hidden-rows {
   border-top: none;
 }
+.page-stats-per-package .loader {
+  width: 120px;
+  height: 120px;
+  margin: 0 auto;
+  border: 16px solid #f3f3f3;
+  /* Light grey */
+  border-top: 16px solid #3498db;
+  /* Blue */
+  border-radius: 50%;
+  -webkit-animation: spin 2s linear infinite;
+       -o-animation: spin 2s linear infinite;
+          animation: spin 2s linear infinite;
+}
+@-webkit-keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
+@-o-keyframes spin {
+  0% {
+    -o-transform: rotate(0deg);
+       transform: rotate(0deg);
+  }
+  100% {
+    -o-transform: rotate(360deg);
+       transform: rotate(360deg);
+  }
+}
+@keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+         -o-transform: rotate(0deg);
+            transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+         -o-transform: rotate(360deg);
+            transform: rotate(360deg);
+  }
+}
 .page-stats-per-package #loading-placeholder {
   display: none;
 }

--- a/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
+++ b/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
@@ -40,46 +40,7 @@
                 </form>
             </div>
             <div class="col-sm-10 text-center" id="loading-placeholder">
-                <svg width='200px' height='200px' xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" class="uil-default">
-                    <rect x="0" y="0" width="100" height="100" fill="none" class="bk">
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(0 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-1s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(30 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.9166666666666666s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(60 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.8333333333333334s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(90 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.75s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(120 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.6666666666666666s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(150 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.5833333333333334s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(180 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.5s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(210 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.4166666666666667s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(240 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.3333333333333333s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(270 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.25s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(300 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.16666666666666666s' repeatCount='indefinite' />
-                    </rect>
-                    <rect x='45' y='45' width='10' height='10' rx='10' ry='10' fill='#004880' transform='rotate(330 50 50) translate(0 -30)'>
-                        <animate attributeName='opacity' from='1' to='0' dur='1s' begin='-0.08333333333333333s' repeatCount='indefinite' />
-                    </rect>
-                </svg>
+                <div class="loader"></div>
             </div>
             <div class="col-sm-10" id="stats-data-display">
                 <div class="stats-graph col-xs-12 hidden-tiny" id="statistics-graph-id"></div>


### PR DESCRIPTION
Switch loading spinner from an svg to a div with border.
This is due to an issue where svg's cannot be animated through css in Edge/IE.
See https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8487752/

Addresses:
[Redesign] Spinning loading indicator does not spin in Edge #4150

@joelverhagen @agr 