### PR TITLE
[Redesign]Add Column content overflow

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -840,6 +840,12 @@ img.package-icon {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.page-statistics-overview td {
+  max-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .page-statistics-overview .stats-title-text {
   margin-bottom: 10px;
   font-size: 1.6em;

--- a/src/Bootstrap/less/theme/page-statistics-overview.less
+++ b/src/Bootstrap/less/theme/page-statistics-overview.less
@@ -1,4 +1,11 @@
 .page-statistics-overview {
+    td {
+        max-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
     .stats-title-text {
         font-size: 1.6em;
         margin-bottom: 10px;

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -840,6 +840,12 @@ img.package-icon {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.page-statistics-overview td {
+  max-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .page-statistics-overview .stats-title-text {
   margin-bottom: 10px;
   font-size: 1.6em;

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -225,7 +225,7 @@
                                     index++;
 
                                     <tr tabindex="0" aria-label="Week of @Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.StartOnly), @(item.Downloads) Downloads">
-                                        <td class="text-left">@Model.DisplayWeek(item.Year, item.WeekOfYear)</td>
+                                        <td class="text-left" title="@Model.DisplayWeek(item.Year, item.WeekOfYear)">@Model.DisplayWeek(item.Year, item.WeekOfYear)</td>
                                         <td class="text-right">@Model.DisplayDownloads(item.Downloads)</td>
                                     </tr>
                                 }


### PR DESCRIPTION
Add ability for columns to hide content with ellipsis when narrow screen.
Addresses:
[Redesign] Statistics overview page Version Downloads graph with small window cuts off data #4176

@joelverhagen @scottbommarito 