### PR TITLE
Adding support for EU cookie compliance

### DIFF
--- a/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
+++ b/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using System.Web;
+using NuGetGallery.Diagnostics;
+
+namespace NuGetGallery.Cookies
+{
+    /// <summary>
+    /// Base cookie compliance service with access to some Gallery resources.
+    /// </summary>
+    public abstract class CookieComplianceServiceBase : ICookieComplianceService
+    {
+        private string _siteName;
+        private IDiagnosticsSource _diagnostics;
+
+        protected string SiteName
+        {
+            get
+            {
+                return _siteName ?? throw new InvalidOperationException("Cookie compliance service has not been initialized");
+            }
+        }
+
+        protected IDiagnosticsSource Diagnostics
+        {
+            get
+            {
+                return _diagnostics ?? throw new InvalidOperationException("Cookie compliance service has not been initialized");
+            }
+        }
+
+        protected string Locale
+        {
+            get
+            {
+                return CultureInfo.CurrentCulture.Name;
+            }
+        }
+
+        public virtual Task InitializeAsync(string siteName, IDiagnosticsService diagnostics)
+        {
+            _siteName = siteName;
+            _diagnostics = diagnostics.GetSource("CookieComplianceService");
+            return Task.Delay(0);
+        }
+        
+        public abstract bool CanWriteNonEssentialCookies(HttpRequestBase request);
+
+        public abstract bool NeedsConsentForNonEssentialCookies(HttpRequestBase request);
+
+        public abstract string GetConsentMarkup();
+
+        public abstract string[] GetConsentScripts();
+
+        public abstract string[] GetConsentStylesheets();
+    }
+}

--- a/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
+++ b/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
@@ -17,7 +17,7 @@ namespace NuGetGallery.Cookies
         private string _siteName;
         private IDiagnosticsSource _diagnostics;
 
-        protected string SiteName
+        protected internal string SiteName
         {
             get
             {
@@ -25,7 +25,7 @@ namespace NuGetGallery.Cookies
             }
         }
 
-        protected IDiagnosticsSource Diagnostics
+        protected internal IDiagnosticsSource Diagnostics
         {
             get
             {
@@ -33,7 +33,7 @@ namespace NuGetGallery.Cookies
             }
         }
 
-        protected string Locale
+        protected internal string Locale
         {
             get
             {

--- a/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
+++ b/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
@@ -14,6 +14,8 @@ namespace NuGetGallery.Cookies
     /// </summary>
     public abstract class CookieComplianceServiceBase : ICookieComplianceService
     {
+        private const string DiagnosticsSourceName = "CookieComplianceService";
+
         private string _siteName;
         private IDiagnosticsSource _diagnostics;
 
@@ -21,7 +23,7 @@ namespace NuGetGallery.Cookies
         {
             get
             {
-                return _siteName ?? throw new InvalidOperationException("Cookie compliance service has not been initialized");
+                return _siteName ?? throw new InvalidOperationException(CoreStrings.CookieComplianceServiceNotInitialized);
             }
         }
 
@@ -29,7 +31,7 @@ namespace NuGetGallery.Cookies
         {
             get
             {
-                return _diagnostics ?? throw new InvalidOperationException("Cookie compliance service has not been initialized");
+                return _diagnostics ?? throw new InvalidOperationException(CoreStrings.CookieComplianceServiceNotInitialized);
             }
         }
 
@@ -44,7 +46,7 @@ namespace NuGetGallery.Cookies
         public virtual Task InitializeAsync(string siteName, IDiagnosticsService diagnostics)
         {
             _siteName = siteName;
-            _diagnostics = diagnostics.GetSource("CookieComplianceService");
+            _diagnostics = diagnostics.GetSource(DiagnosticsSourceName);
             return Task.Delay(0);
         }
         

--- a/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
+++ b/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
@@ -40,6 +40,8 @@ namespace NuGetGallery.Cookies
 
         public abstract bool NeedsConsentForNonEssentialCookies(HttpRequestBase request);
 
+        public abstract CookieConsentMessage GetConsentMessage(HttpRequestBase request, string locale = null);
+
         public abstract string GetConsentMarkup(HttpRequestBase request, string locale = null);
 
         public abstract IEnumerable<string> GetConsentScripts(HttpRequestBase request, string locale = null);

--- a/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
+++ b/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
@@ -18,9 +18,9 @@ namespace NuGetGallery.Cookies
         private string _domain;
         private IDiagnosticsSource _diagnostics;
 
-        protected internal string Domain => _domain ?? throw new InvalidOperationException(CoreStrings.CookieComplianceServiceNotInitialized);
+        protected string Domain => _domain ?? throw new InvalidOperationException(CoreStrings.CookieComplianceServiceNotInitialized);
 
-        protected internal IDiagnosticsSource Diagnostics => _diagnostics ?? throw new InvalidOperationException(CoreStrings.CookieComplianceServiceNotInitialized);
+        protected IDiagnosticsSource Diagnostics => _diagnostics ?? throw new InvalidOperationException(CoreStrings.CookieComplianceServiceNotInitialized);
 
         public virtual Task InitializeAsync(string domain, IDiagnosticsService diagnostics, CancellationToken cancellationToken)
         {

--- a/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
+++ b/src/NuGetGallery.Core/Cookies/CookieComplianceServiceBase.cs
@@ -36,14 +36,14 @@ namespace NuGetGallery.Cookies
             return Task.Delay(0);
         }
         
-        public abstract bool CanWriteNonEssentialCookies(HttpContextBase httpContext);
+        public abstract bool CanWriteNonEssentialCookies(HttpRequestBase request);
 
-        public abstract bool NeedsConsentForNonEssentialCookies(HttpContextBase httpContext);
+        public abstract bool NeedsConsentForNonEssentialCookies(HttpRequestBase request);
 
-        public abstract string GetConsentMarkup(HttpContextBase httpContext, string locale = null);
+        public abstract string GetConsentMarkup(HttpRequestBase request, string locale = null);
 
-        public abstract IEnumerable<string> GetConsentScripts(HttpContextBase httpContext, string locale = null);
+        public abstract IEnumerable<string> GetConsentScripts(HttpRequestBase request, string locale = null);
 
-        public abstract IEnumerable<string> GetConsentStylesheets(HttpContextBase httpContext, string locale = null);
+        public abstract IEnumerable<string> GetConsentStylesheets(HttpRequestBase request, string locale = null);
     }
 }

--- a/src/NuGetGallery.Core/Cookies/CookieConsentMessage.cs
+++ b/src/NuGetGallery.Core/Cookies/CookieConsentMessage.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Cookies
+{
+    public class CookieConsentMessage
+    {
+        public string Message { get; set; }
+
+        public string MoreInfoUrl { get; set; }
+
+        public string MoreInfoText { get; set; }
+
+        public string MoreInfoAriaLabel { get; set; }
+
+        public string[] Javascripts { get; set; }
+    }
+}

--- a/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using System.Web;
+using NuGetGallery.Diagnostics;
+
+namespace NuGetGallery.Cookies
+{
+    /// <summary>
+    /// Cookie compliance service, used to comply with EU privacy laws.
+    /// </summary>
+    public interface ICookieComplianceService
+    {
+        /// <summary>
+        /// Run service startup initialization, on App_Start.
+        /// </summary>
+        Task InitializeAsync(string siteName, IDiagnosticsService diagnostics);
+
+        /// <summary>
+        /// Determine if consent is still needed for writing non-essential cookies.
+        /// </summary>
+        /// <returns>True if consent is needed, false if consent is already provided or not required.</returns>
+        bool NeedsConsentForNonEssentialCookies(HttpRequestBase request);
+
+        /// <summary>
+        /// Determine if non-essential cookies can be written.
+        /// </summary>
+        /// <returns>True if non-essential cookies can be written, false otherwise.</returns>
+        bool CanWriteNonEssentialCookies(HttpRequestBase request);
+
+        /// <summary>
+        /// Get HTML markup for the cookie consent banner.
+        /// </summary>
+        string GetConsentMarkup();
+
+        /// <summary>
+        /// Get CSS links for the cookie consent banner.
+        /// </summary>
+        string[] GetConsentStylesheets();
+
+        /// <summary>
+        /// Get Javascript links for the cookie consent banner.
+        /// </summary>
+        string[] GetConsentScripts();
+    }
+}

--- a/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Web;
-using NuGetGallery.Diagnostics;
 
 namespace NuGetGallery.Cookies
 {
@@ -14,11 +11,6 @@ namespace NuGetGallery.Cookies
     /// </summary>
     public interface ICookieComplianceService
     {
-        /// <summary>
-        /// Run service startup initialization, on App_Start.
-        /// </summary>
-        Task InitializeAsync(string domain, IDiagnosticsService diagnostics, CancellationToken cancellationToken);
-
         /// <summary>
         /// Determine if consent is still needed for writing non-essential cookies.
         /// </summary>

--- a/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using NuGetGallery.Diagnostics;
@@ -15,33 +17,33 @@ namespace NuGetGallery.Cookies
         /// <summary>
         /// Run service startup initialization, on App_Start.
         /// </summary>
-        Task InitializeAsync(string siteName, IDiagnosticsService diagnostics);
+        Task InitializeAsync(string domain, IDiagnosticsService diagnostics, CancellationToken cancellationToken);
 
         /// <summary>
         /// Determine if consent is still needed for writing non-essential cookies.
         /// </summary>
         /// <returns>True if consent is needed, false if consent is already provided or not required.</returns>
-        bool NeedsConsentForNonEssentialCookies(HttpRequestBase request);
+        bool NeedsConsentForNonEssentialCookies(HttpContextBase httpContext);
 
         /// <summary>
         /// Determine if non-essential cookies can be written.
         /// </summary>
         /// <returns>True if non-essential cookies can be written, false otherwise.</returns>
-        bool CanWriteNonEssentialCookies(HttpRequestBase request);
+        bool CanWriteNonEssentialCookies(HttpContextBase httpContext);
 
         /// <summary>
         /// Get HTML markup for the cookie consent banner.
         /// </summary>
-        string GetConsentMarkup();
+        string GetConsentMarkup(HttpContextBase httpContext, string locale = null);
 
         /// <summary>
         /// Get CSS links for the cookie consent banner.
         /// </summary>
-        string[] GetConsentStylesheets();
+        IEnumerable<string> GetConsentStylesheets(HttpContextBase httpContext, string locale = null);
 
         /// <summary>
         /// Get Javascript links for the cookie consent banner.
         /// </summary>
-        string[] GetConsentScripts();
+        IEnumerable<string> GetConsentScripts(HttpContextBase httpContext, string locale = null);
     }
 }

--- a/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
@@ -23,27 +23,27 @@ namespace NuGetGallery.Cookies
         /// Determine if consent is still needed for writing non-essential cookies.
         /// </summary>
         /// <returns>True if consent is needed, false if consent is already provided or not required.</returns>
-        bool NeedsConsentForNonEssentialCookies(HttpContextBase httpContext);
+        bool NeedsConsentForNonEssentialCookies(HttpRequestBase request);
 
         /// <summary>
         /// Determine if non-essential cookies can be written.
         /// </summary>
         /// <returns>True if non-essential cookies can be written, false otherwise.</returns>
-        bool CanWriteNonEssentialCookies(HttpContextBase httpContext);
+        bool CanWriteNonEssentialCookies(HttpRequestBase request);
 
         /// <summary>
         /// Get HTML markup for the cookie consent banner.
         /// </summary>
-        string GetConsentMarkup(HttpContextBase httpContext, string locale = null);
+        string GetConsentMarkup(HttpRequestBase request, string locale = null);
 
         /// <summary>
         /// Get CSS links for the cookie consent banner.
         /// </summary>
-        IEnumerable<string> GetConsentStylesheets(HttpContextBase httpContext, string locale = null);
+        IEnumerable<string> GetConsentStylesheets(HttpRequestBase request, string locale = null);
 
         /// <summary>
         /// Get Javascript links for the cookie consent banner.
         /// </summary>
-        IEnumerable<string> GetConsentScripts(HttpContextBase httpContext, string locale = null);
+        IEnumerable<string> GetConsentScripts(HttpRequestBase request, string locale = null);
     }
 }

--- a/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/ICookieComplianceService.cs
@@ -32,18 +32,28 @@ namespace NuGetGallery.Cookies
         bool CanWriteNonEssentialCookies(HttpRequestBase request);
 
         /// <summary>
-        /// Get HTML markup for the cookie consent banner.
+        /// Get the cookie consent banner message and resources. This API is an alternative to the default
+        /// rendering APIs below and can be used to customize the UI. Note that the messaging must remain intact.
+        /// </summary>
+        CookieConsentMessage GetConsentMessage(HttpRequestBase request, string locale = null);
+
+        #region Default CookieConsent rendering
+
+        /// <summary>
+        /// Get the default HTML markup for the cookie consent banner.
         /// </summary>
         string GetConsentMarkup(HttpRequestBase request, string locale = null);
 
         /// <summary>
-        /// Get CSS links for the cookie consent banner.
+        /// Get the default CSS links for the cookie consent banner.
         /// </summary>
         IEnumerable<string> GetConsentStylesheets(HttpRequestBase request, string locale = null);
 
         /// <summary>
-        /// Get Javascript links for the cookie consent banner.
+        /// Get the default Javascript links for the cookie consent banner.
         /// </summary>
         IEnumerable<string> GetConsentScripts(HttpRequestBase request, string locale = null);
+
+        #endregion
     }
 }

--- a/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using System.Web;
+using NuGetGallery.Diagnostics;
+
+namespace NuGetGallery.Cookies
+{
+    /// <summary>
+    /// Default instance of the cookie compliance service, used when no shim is registered.
+    /// </summary>
+    public class NullCookieComplianceService: ICookieComplianceService
+    {
+        public virtual Task InitializeAsync(string siteName, IDiagnosticsService diagnostics)
+        {
+            return Task.Delay(0);
+        }
+        
+        public bool NeedsConsentForNonEssentialCookies(HttpRequestBase request)
+        {
+            return false;
+        }
+
+        public bool CanWriteNonEssentialCookies(HttpRequestBase request)
+        {
+            return true;
+        }
+
+        public string GetConsentMarkup()
+        {
+            return string.Empty;
+        }
+
+        public string[] GetConsentScripts()
+        {
+            return new string[0];
+        }
+
+        public string[] GetConsentStylesheets()
+        {
+            return new string[0];
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
@@ -22,16 +22,16 @@ namespace NuGetGallery.Cookies
 
         // Consent is not necessary and cookies can be written.
 
-        public bool NeedsConsentForNonEssentialCookies(HttpContextBase httpContext) => false;
+        public bool NeedsConsentForNonEssentialCookies(HttpRequestBase request) => false;
 
-        public bool CanWriteNonEssentialCookies(HttpContextBase httpContext) => true;
+        public bool CanWriteNonEssentialCookies(HttpRequestBase request) => true;
 
         // No markdown or scripts will be included.
 
-        public string GetConsentMarkup(HttpContextBase httpContext, string locale = null) => string.Empty;
+        public string GetConsentMarkup(HttpRequestBase request, string locale = null) => string.Empty;
 
-        public IEnumerable<string> GetConsentScripts(HttpContextBase httpContext, string locale = null) => EmptyStringArray;
+        public IEnumerable<string> GetConsentScripts(HttpRequestBase request, string locale = null) => EmptyStringArray;
 
-        public IEnumerable<string> GetConsentStylesheets(HttpContextBase httpContext, string locale = null) => EmptyStringArray;
+        public IEnumerable<string> GetConsentStylesheets(HttpRequestBase request, string locale = null) => EmptyStringArray;
     }
 }

--- a/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Web;
-using NuGetGallery.Diagnostics;
 
 namespace NuGetGallery.Cookies
 {
@@ -23,6 +20,8 @@ namespace NuGetGallery.Cookies
         public override bool CanWriteNonEssentialCookies(HttpRequestBase request) => true;
 
         // No markdown or scripts will be included.
+
+        public override CookieConsentMessage GetConsentMessage(HttpRequestBase request, string locale = null) => null;
 
         public override string GetConsentMarkup(HttpRequestBase request, string locale = null) => string.Empty;
 

--- a/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
@@ -12,26 +12,22 @@ namespace NuGetGallery.Cookies
     /// <summary>
     /// Default, no-op instance of the cookie compliance service, used when no shim is registered.
     /// </summary>
-    public class NullCookieComplianceService: ICookieComplianceService
+    public class NullCookieComplianceService: CookieComplianceServiceBase
     {
         private static readonly string[] EmptyStringArray = new string[0];
 
-        // No initialization.
-
-        public virtual Task InitializeAsync(string domain, IDiagnosticsService diagnostics, CancellationToken cancellationToken) => Task.Delay(0);
-
         // Consent is not necessary and cookies can be written.
 
-        public bool NeedsConsentForNonEssentialCookies(HttpRequestBase request) => false;
+        public override bool NeedsConsentForNonEssentialCookies(HttpRequestBase request) => false;
 
-        public bool CanWriteNonEssentialCookies(HttpRequestBase request) => true;
+        public override bool CanWriteNonEssentialCookies(HttpRequestBase request) => true;
 
         // No markdown or scripts will be included.
 
-        public string GetConsentMarkup(HttpRequestBase request, string locale = null) => string.Empty;
+        public override string GetConsentMarkup(HttpRequestBase request, string locale = null) => string.Empty;
 
-        public IEnumerable<string> GetConsentScripts(HttpRequestBase request, string locale = null) => EmptyStringArray;
+        public override IEnumerable<string> GetConsentScripts(HttpRequestBase request, string locale = null) => EmptyStringArray;
 
-        public IEnumerable<string> GetConsentStylesheets(HttpRequestBase request, string locale = null) => EmptyStringArray;
+        public override IEnumerable<string> GetConsentStylesheets(HttpRequestBase request, string locale = null) => EmptyStringArray;
     }
 }

--- a/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
+++ b/src/NuGetGallery.Core/Cookies/NullCookieComplianceService.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using NuGetGallery.Diagnostics;
@@ -8,38 +10,28 @@ using NuGetGallery.Diagnostics;
 namespace NuGetGallery.Cookies
 {
     /// <summary>
-    /// Default instance of the cookie compliance service, used when no shim is registered.
+    /// Default, no-op instance of the cookie compliance service, used when no shim is registered.
     /// </summary>
     public class NullCookieComplianceService: ICookieComplianceService
     {
-        public virtual Task InitializeAsync(string siteName, IDiagnosticsService diagnostics)
-        {
-            return Task.Delay(0);
-        }
-        
-        public bool NeedsConsentForNonEssentialCookies(HttpRequestBase request)
-        {
-            return false;
-        }
+        private static readonly string[] EmptyStringArray = new string[0];
 
-        public bool CanWriteNonEssentialCookies(HttpRequestBase request)
-        {
-            return true;
-        }
+        // No initialization.
 
-        public string GetConsentMarkup()
-        {
-            return string.Empty;
-        }
+        public virtual Task InitializeAsync(string domain, IDiagnosticsService diagnostics, CancellationToken cancellationToken) => Task.Delay(0);
 
-        public string[] GetConsentScripts()
-        {
-            return new string[0];
-        }
+        // Consent is not necessary and cookies can be written.
 
-        public string[] GetConsentStylesheets()
-        {
-            return new string[0];
-        }
+        public bool NeedsConsentForNonEssentialCookies(HttpContextBase httpContext) => false;
+
+        public bool CanWriteNonEssentialCookies(HttpContextBase httpContext) => true;
+
+        // No markdown or scripts will be included.
+
+        public string GetConsentMarkup(HttpContextBase httpContext, string locale = null) => string.Empty;
+
+        public IEnumerable<string> GetConsentScripts(HttpContextBase httpContext, string locale = null) => EmptyStringArray;
+
+        public IEnumerable<string> GetConsentStylesheets(HttpContextBase httpContext, string locale = null) => EmptyStringArray;
     }
 }

--- a/src/NuGetGallery.Core/CoreStrings.Designer.cs
+++ b/src/NuGetGallery.Core/CoreStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class CoreStrings {
@@ -75,6 +75,15 @@ namespace NuGetGallery {
         public static string CommandExecutor_UnhandledCommand {
             get {
                 return ResourceManager.GetString("CommandExecutor_UnhandledCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The cookie compliance service is not initialized..
+        /// </summary>
+        public static string CookieComplianceServiceNotInitialized {
+            get {
+                return ResourceManager.GetString("CookieComplianceServiceNotInitialized", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery.Core/CoreStrings.Designer.cs
+++ b/src/NuGetGallery.Core/CoreStrings.Designer.cs
@@ -79,6 +79,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The cookie compliance service is already initialized..
+        /// </summary>
+        public static string CookieComplianceServiceAlreadyInitialized {
+            get {
+                return ResourceManager.GetString("CookieComplianceServiceAlreadyInitialized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The cookie compliance service is not initialized..
         /// </summary>
         public static string CookieComplianceServiceNotInitialized {

--- a/src/NuGetGallery.Core/CoreStrings.resx
+++ b/src/NuGetGallery.Core/CoreStrings.resx
@@ -180,4 +180,7 @@
   <data name="Manifest_InvalidDependencyVersion" xml:space="preserve">
     <value>The package manifest contains an invalid Dependency Version: '{0}'</value>
   </data>
+  <data name="CookieComplianceServiceNotInitialized" xml:space="preserve">
+    <value>The cookie compliance service is not initialized.</value>
+  </data>
 </root>

--- a/src/NuGetGallery.Core/CoreStrings.resx
+++ b/src/NuGetGallery.Core/CoreStrings.resx
@@ -183,4 +183,7 @@
   <data name="CookieComplianceServiceNotInitialized" xml:space="preserve">
     <value>The cookie compliance service is not initialized.</value>
   </data>
+  <data name="CookieComplianceServiceAlreadyInitialized" xml:space="preserve">
+    <value>The cookie compliance service is already initialized.</value>
+  </data>
 </root>

--- a/src/NuGetGallery.Core/Diagnostics/IDiagnosticsService.cs
+++ b/src/NuGetGallery.Core/Diagnostics/IDiagnosticsService.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Diagnostics
+{
+    public interface IDiagnosticsService
+    {
+        /// <summary>
+        /// Gets an <see cref="IDiagnosticsSource"/> by the specified name.
+        /// </summary>
+        /// <param name="name">The name of the source, it's recommended you use the unqualified type name (i.e. 'UserService')</param>
+        /// <returns></returns>
+        IDiagnosticsSource GetSource(string name);
+    }
+}

--- a/src/NuGetGallery.Core/Diagnostics/IDiagnosticsService.cs
+++ b/src/NuGetGallery.Core/Diagnostics/IDiagnosticsService.cs
@@ -9,7 +9,6 @@ namespace NuGetGallery.Diagnostics
         /// Gets an <see cref="IDiagnosticsSource"/> by the specified name.
         /// </summary>
         /// <param name="name">The name of the source, it's recommended you use the unqualified type name (i.e. 'UserService')</param>
-        /// <returns></returns>
         IDiagnosticsSource GetSource(string name);
     }
 }

--- a/src/NuGetGallery.Core/Diagnostics/IDiagnosticsService.cs
+++ b/src/NuGetGallery.Core/Diagnostics/IDiagnosticsService.cs
@@ -8,7 +8,7 @@ namespace NuGetGallery.Diagnostics
         /// <summary>
         /// Gets an <see cref="IDiagnosticsSource"/> by the specified name.
         /// </summary>
-        /// <param name="name">The name of the source, it's recommended you use the unqualified type name (i.e. 'UserService')</param>
+        /// <param name="name">The name of the source. It's recommended that you use the unqualified type name (i.e. 'UserService').</param>
         IDiagnosticsSource GetSource(string name);
     }
 }

--- a/src/NuGetGallery.Core/Diagnostics/IDiagnosticsSource.cs
+++ b/src/NuGetGallery.Core/Diagnostics/IDiagnosticsSource.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace NuGetGallery.Diagnostics
+{
+    public interface IDiagnosticsSource
+    {
+        void TraceEvent(TraceEventType type, int id, string message,
+            [CallerMemberName] string member = null, [CallerFilePath] string file = null, [CallerLineNumber] int line = 0);
+
+        void PerfEvent(string name, TimeSpan time, IEnumerable<KeyValuePair<string, object>> payload);
+    }
+}

--- a/src/NuGetGallery.Core/Diagnostics/IDiagnosticsSource.cs
+++ b/src/NuGetGallery.Core/Diagnostics/IDiagnosticsSource.cs
@@ -10,9 +10,11 @@ namespace NuGetGallery.Diagnostics
 {
     public interface IDiagnosticsSource
     {
+        void ExceptionEvent(Exception exception);
+        
         void TraceEvent(TraceEventType type, int id, string message,
             [CallerMemberName] string member = null, [CallerFilePath] string file = null, [CallerLineNumber] int line = 0);
-
+        
         void PerfEvent(string name, TimeSpan time, IEnumerable<KeyValuePair<string, object>> payload);
     }
 }

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -143,9 +143,14 @@
     <Compile Include="Auditing\PackageAuditRecord.cs" />
     <Compile Include="Auditing\ScopeAuditRecord.cs" />
     <Compile Include="Auditing\UserAuditRecord.cs" />
+    <Compile Include="Cookies\CookieComplianceServiceBase.cs" />
+    <Compile Include="Cookies\ICookieComplianceService.cs" />
+    <Compile Include="Cookies\NullCookieComplianceService.cs" />
     <Compile Include="CoreConstants.cs" />
     <Compile Include="CredentialTypes.cs" />
     <Compile Include="Completion.cs" />
+    <Compile Include="Diagnostics\IDiagnosticsService.cs" />
+    <Compile Include="Diagnostics\IDiagnosticsSource.cs" />
     <Compile Include="DisposableAction.cs" />
     <Compile Include="Entities\Credential.cs" />
     <Compile Include="Entities\CuratedFeed.cs" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Auditing\ScopeAuditRecord.cs" />
     <Compile Include="Auditing\UserAuditRecord.cs" />
     <Compile Include="Cookies\CookieComplianceServiceBase.cs" />
+    <Compile Include="Cookies\CookieConsentMessage.cs" />
     <Compile Include="Cookies\ICookieComplianceService.cs" />
     <Compile Include="Cookies\NullCookieComplianceService.cs" />
     <Compile Include="CoreConstants.cs" />

--- a/src/NuGetGallery.Core/Properties/AssemblyInfo.cs
+++ b/src/NuGetGallery.Core/Properties/AssemblyInfo.cs
@@ -8,6 +8,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("NuGetGallery.Core")]
+[assembly: InternalsVisibleTo("NuGetGallery.Core.Facts")]
+
 [assembly: AssemblyCompany(".NET Foundation")]
 [assembly: AssemblyProduct("NuGet Services")]
 [assembly: AssemblyCopyright("\x00a9 .NET Foundation. All rights reserved.")]

--- a/src/NuGetGallery.Core/Properties/AssemblyInfo.cs
+++ b/src/NuGetGallery.Core/Properties/AssemblyInfo.cs
@@ -14,8 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: InternalsVisibleTo("NuGetGallery.Core.Facts")]
-
 #if !PORTABLE
 [assembly: ComVisible(false)]
 #endif

--- a/src/NuGetGallery.Core/Properties/AssemblyInfo.cs
+++ b/src/NuGetGallery.Core/Properties/AssemblyInfo.cs
@@ -8,13 +8,13 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("NuGetGallery.Core")]
-[assembly: InternalsVisibleTo("NuGetGallery.Core.Facts")]
-
 [assembly: AssemblyCompany(".NET Foundation")]
 [assembly: AssemblyProduct("NuGet Services")]
 [assembly: AssemblyCopyright("\x00a9 .NET Foundation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+
+[assembly: InternalsVisibleTo("NuGetGallery.Core.Facts")]
 
 #if !PORTABLE
 [assembly: ComVisible(false)]
@@ -35,4 +35,3 @@ using System.Runtime.InteropServices;
 // AssemblyVersion, AssemblyFileVersion, AssemblyInformationalVersion, AssemblyMetadata (for Branch, CommitId, and BuildDateUtc)
 
 [assembly: AssemblyMetadata("RepositoryUrl", "https://www.github.com/NuGet/NuGetGallery")]
-

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -3,6 +3,7 @@
 @using NuGetGallery
 @using NuGetGallery.Helpers
 @using NuGetGallery.Configuration
+@using NuGetGallery.Cookies
 
 @helper PreviousNextPager(IPreviousNextPager pager)
 {
@@ -128,30 +129,34 @@
 
     if (!string.IsNullOrEmpty(iKey))
     {
-        <!-- Telemetry -->
-        <script type="text/javascript">
-            var appInsights = window.appInsights || function (config) {
-                function s(config) {
-                    t[config] = function () {
-                        var i = arguments;
-                        t.queue.push(function () { t[config].apply(t, i) })
+        var cookies = DependencyResolver.Current.GetService<ICookieComplianceService>();
+        if (cookies.CanWriteNonEssentialCookies(Request))
+        {
+            <!-- Telemetry -->
+            <script type="text/javascript">
+                var appInsights = window.appInsights || function (config) {
+                    function s(config) {
+                        t[config] = function () {
+                            var i = arguments;
+                            t.queue.push(function () { t[config].apply(t, i) })
+                        }
                     }
-                }
 
-                var t = { config: config }, r = document, f = window, e = "script", o = r.createElement(e), i, u;
-                for (o.src = config.url || "//az416426.vo.msecnd.net/scripts/a/ai.0.js", r.getElementsByTagName(e)[0].parentNode.appendChild(o), t.cookie = r.cookie, t.queue = [], i = ["Event", "Exception", "Metric", "PageView", "Trace"]; i.length;) s("track" + i.pop());
-                return config.disableExceptionTracking || (i = "onerror", s("_" + i), u = f[i], f[i] = function (config, r, f, e, o) {
-                    var s = u && u(config, r, f, e, o);
-                    return s !== !0 && t["_" + i](config, r, f, e, o), s
-                }), t
-            }({
-                instrumentationKey: '@(iKey)',
-                samplingPercentage: @(samplingPct)
-            });
+                    var t = { config: config }, r = document, f = window, e = "script", o = r.createElement(e), i, u;
+                    for (o.src = config.url || "//az416426.vo.msecnd.net/scripts/a/ai.0.js", r.getElementsByTagName(e)[0].parentNode.appendChild(o), t.cookie = r.cookie, t.queue = [], i = ["Event", "Exception", "Metric", "PageView", "Trace"]; i.length;) s("track" + i.pop());
+                    return config.disableExceptionTracking || (i = "onerror", s("_" + i), u = f[i], f[i] = function (config, r, f, e, o) {
+                        var s = u && u(config, r, f, e, o);
+                        return s !== !0 && t["_" + i](config, r, f, e, o), s
+                    }), t
+                }({
+                    instrumentationKey: '@(iKey)',
+                    samplingPercentage: @(samplingPct)
+                });
 
-            window.appInsights = appInsights;
-            appInsights.trackPageView();
-        </script>
+                window.appInsights = appInsights;
+                appInsights.trackPageView();
+            </script>
+        }
     }
 }
 
@@ -209,15 +214,35 @@
         var propertyId = config.Current.GoogleAnalyticsPropertyId;
         if (!string.IsNullOrEmpty(propertyId))
         {
-            <script>
-                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+            var cookies = DependencyResolver.Current.GetService<ICookieComplianceService>();
+            if (cookies.CanWriteNonEssentialCookies(Request))
+            {
+                <script>
+                    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-                ga('create', '@propertyId', 'auto');
-                ga('send', 'pageview');
-            </script>
+                    ga('create', '@propertyId', 'auto');
+                    ga('send', 'pageview');
+                </script>
+            }
+        }
+    }
+}
+
+@helper CookieComplianceScripts()
+{
+    var cookies = DependencyResolver.Current.GetService<ICookieComplianceService>();
+    if (cookies.NeedsConsentForNonEssentialCookies(Request))
+    {
+        foreach (var cookieScript in cookies.GetConsentScripts())
+        {
+            <script src="@cookieScript"></script>
+        }
+        foreach (var cookieStyle in cookies.GetConsentStylesheets())
+        {
+            <link rel="stylesheet" type="text/css" href="@cookieStyle" />
         }
     }
 }

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -231,22 +231,6 @@
     }
 }
 
-@helper CookieComplianceScripts()
-{
-    var cookieService = DependencyResolver.Current.GetService<ICookieComplianceService>();
-    if (cookieService.NeedsConsentForNonEssentialCookies(Request))
-    {
-        foreach (var cookieScript in cookieService.GetConsentScripts(Request))
-        {
-            <script src="@cookieScript"></script>
-        }
-        foreach (var cookieStyle in cookieService.GetConsentStylesheets(Request))
-        {
-            <link rel="stylesheet" type="text/css" href="@cookieStyle" />
-        }
-    }
-}
-
 @helper AccordionBar(
     string groupName,
     WebViewPage page,

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -129,8 +129,8 @@
 
     if (!string.IsNullOrEmpty(iKey))
     {
-        var cookies = DependencyResolver.Current.GetService<ICookieComplianceService>();
-        if (cookies.CanWriteNonEssentialCookies(Request))
+        var cookieService = DependencyResolver.Current.GetService<ICookieComplianceService>();
+        if (cookieService.CanWriteNonEssentialCookies(Request))
         {
             <!-- Telemetry -->
             <script type="text/javascript">
@@ -214,8 +214,8 @@
         var propertyId = config.Current.GoogleAnalyticsPropertyId;
         if (!string.IsNullOrEmpty(propertyId))
         {
-            var cookies = DependencyResolver.Current.GetService<ICookieComplianceService>();
-            if (cookies.CanWriteNonEssentialCookies(Request))
+            var cookieService = DependencyResolver.Current.GetService<ICookieComplianceService>();
+            if (cookieService.CanWriteNonEssentialCookies(Request))
             {
                 <script>
                     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -233,14 +233,14 @@
 
 @helper CookieComplianceScripts()
 {
-    var cookies = DependencyResolver.Current.GetService<ICookieComplianceService>();
-    if (cookies.NeedsConsentForNonEssentialCookies(Request))
+    var cookieService = DependencyResolver.Current.GetService<ICookieComplianceService>();
+    if (cookieService.NeedsConsentForNonEssentialCookies(Request))
     {
-        foreach (var cookieScript in cookies.GetConsentScripts())
+        foreach (var cookieScript in cookieService.GetConsentScripts(Request))
         {
             <script src="@cookieScript"></script>
         }
-        foreach (var cookieStyle in cookies.GetConsentStylesheets())
+        foreach (var cookieStyle in cookieService.GetConsentStylesheets(Request))
         {
             <link rel="stylesheet" type="text/css" href="@cookieStyle" />
         }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -520,10 +520,10 @@ namespace NuGetGallery
 
         private static void RegisterCookieComplianceService(ContainerBuilder builder, ConfigurationService configuration, DiagnosticsService diagnostics)
         {
-            ICookieComplianceService service = null;
+            CookieComplianceServiceBase service = null;
             if (configuration.Current.CookieComplianceEnabled)
             {
-                service = GetAddInServices<ICookieComplianceService>(builder).FirstOrDefault();
+                service = GetAddInServices<CookieComplianceServiceBase>(builder).FirstOrDefault();
             }
             
             builder.RegisterInstance(service ?? new NullCookieComplianceService())

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -523,7 +523,7 @@ namespace NuGetGallery
             CookieComplianceServiceBase service = null;
             if (configuration.Current.CookieComplianceEnabled)
             {
-                service = GetAddInServices<CookieComplianceServiceBase>(builder).FirstOrDefault();
+                service = GetAddInServices<ICookieComplianceService>(builder).FirstOrDefault() as CookieComplianceServiceBase;
             }
             
             builder.RegisterInstance(service ?? new NullCookieComplianceService())

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Mail;
 using System.Security.Principal;
+using System.Threading;
 using System.Web;
 using System.Web.Hosting;
 using System.Web.Mvc;
@@ -528,7 +529,7 @@ namespace NuGetGallery
             
             // Initialize the service on App_Start to avoid any performance degradation during initial requests.
             var siteName = configuration.GetSiteRoot(true);
-            HostingEnvironment.QueueBackgroundWorkItem(async cancellationToken => await service.InitializeAsync(siteName, diagnostics));
+            HostingEnvironment.QueueBackgroundWorkItem(async cancellationToken => await service.InitializeAsync(siteName, diagnostics, CancellationToken.None));
         }
     }
 }

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -19,6 +19,9 @@ namespace NuGetGallery.Configuration
         [DefaultValue("")]
         public string RedesignBanner { get; set; }
 
+        [DefaultValue(false)]
+        public bool CookieComplianceEnabled { get; set; }
+
         /// <summary>
         /// Gets a setting indicating if SSL is required for all operations once logged in.
         /// </summary>

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -27,6 +27,11 @@ namespace NuGetGallery.Configuration
         /// Gets the warning banner text
         /// </summary>
         string RedesignBanner { get; set; }
+        
+        /// <summary>
+        /// Gets a setting if cookie compliance shim should be enabled.
+        /// </summary>
+        bool CookieComplianceEnabled { get; set; }
 
         /// <summary>
         /// Gets a setting indicating if SSL is required for all operations once logged in.

--- a/src/NuGetGallery/Content/Layout.css
+++ b/src/NuGetGallery/Content/Layout.css
@@ -51,7 +51,7 @@ ul.share-buttons i {
         text-decoration: underline;
     }
 
-.banner-redesign {
+.banner-redesign, .banner-cookies {
     padding: 0.25em;
     text-align: center;
     color: #FFFFFF;
@@ -62,13 +62,13 @@ ul.share-buttons i {
     line-height: 40px;
 }
 
-    .banner-redesign .ms-Icon {
+    .banner-redesign .ms-Icon, .banner-cookies .ms-Icon {
         position: relative;
         top: .1em;
         font-size: 0.8em;
     }
 
-    .banner-redesign a {
+    .banner-redesign a, .banner-cookies a {
         color: white;
         text-decoration: underline;
     }

--- a/src/NuGetGallery/Controllers/NuGetContext.cs
+++ b/src/NuGetGallery/Controllers/NuGetContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Web.Mvc;
 using NuGetGallery.Configuration;
+using NuGetGallery.Cookies;
 
 namespace NuGetGallery
 {
@@ -14,11 +15,15 @@ namespace NuGetGallery
         public NuGetContext(AppController ctrl)
         {
             Config = DependencyResolver.Current.GetService<IGalleryConfigurationService>();
+            Cookies = DependencyResolver.Current.GetService<ICookieComplianceService>();
 
             _currentUser = new Lazy<User>(() => ctrl.OwinContext.GetCurrentUser());
         }
 
         public IGalleryConfigurationService Config { get; internal set; }
+
+        public ICookieComplianceService Cookies { get; }
+
         public User CurrentUser { get { return _currentUser.Value; } }
     }
 }

--- a/src/NuGetGallery/Controllers/NuGetContext.cs
+++ b/src/NuGetGallery/Controllers/NuGetContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Web;
 using System.Web.Mvc;
 using NuGetGallery.Configuration;
 using NuGetGallery.Cookies;
@@ -22,8 +23,17 @@ namespace NuGetGallery
 
         public IGalleryConfigurationService Config { get; internal set; }
 
-        public ICookieComplianceService CookieComplianceService { get; }
-
         public User CurrentUser { get { return _currentUser.Value; } }
+
+        private ICookieComplianceService CookieComplianceService { get; }
+
+        public CookieConsentMessage GetCookieConsentMessage(HttpRequestBase request)
+        {
+            if (CookieComplianceService.NeedsConsentForNonEssentialCookies(request))
+            {
+                return CookieComplianceService.GetConsentMessage(request);
+            }
+            return null;
+        }
     }
 }

--- a/src/NuGetGallery/Controllers/NuGetContext.cs
+++ b/src/NuGetGallery/Controllers/NuGetContext.cs
@@ -15,14 +15,14 @@ namespace NuGetGallery
         public NuGetContext(AppController ctrl)
         {
             Config = DependencyResolver.Current.GetService<IGalleryConfigurationService>();
-            Cookies = DependencyResolver.Current.GetService<ICookieComplianceService>();
+            CookieComplianceService = DependencyResolver.Current.GetService<ICookieComplianceService>();
 
             _currentUser = new Lazy<User>(() => ctrl.OwinContext.GetCurrentUser());
         }
 
         public IGalleryConfigurationService Config { get; internal set; }
 
-        public ICookieComplianceService Cookies { get; }
+        public ICookieComplianceService CookieComplianceService { get; }
 
         public User CurrentUser { get { return _currentUser.Value; } }
     }

--- a/src/NuGetGallery/Diagnostics/DiagnosticsServiceExtensions.cs
+++ b/src/NuGetGallery/Diagnostics/DiagnosticsServiceExtensions.cs
@@ -3,16 +3,6 @@
 using System;
 namespace NuGetGallery.Diagnostics
 {
-    public interface IDiagnosticsService
-    {
-        /// <summary>
-        /// Gets an <see cref="IDiagnosticsSource"/> by the specified name.
-        /// </summary>
-        /// <param name="name">The name of the source, it's recommended you use the unqualified type name (i.e. 'UserService')</param>
-        /// <returns></returns>
-        IDiagnosticsSource GetSource(string name);
-    }
-
     public static class DiagnosticsServiceExtensions
     {
         public static IDiagnosticsSource SafeGetSource(this IDiagnosticsService self, string name)

--- a/src/NuGetGallery/Diagnostics/DiagnosticsServiceExtensions.cs
+++ b/src/NuGetGallery/Diagnostics/DiagnosticsServiceExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
+
 namespace NuGetGallery.Diagnostics
 {
     public static class DiagnosticsServiceExtensions

--- a/src/NuGetGallery/Diagnostics/DiagnosticsSourceExtensions.cs
+++ b/src/NuGetGallery/Diagnostics/DiagnosticsSourceExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -10,13 +9,6 @@ using System.Threading;
 
 namespace NuGetGallery.Diagnostics
 {
-    public interface IDiagnosticsSource
-    {
-        void TraceEvent(TraceEventType type, int id, string message, [CallerMemberName] string member = null, [CallerFilePath] string file = null, [CallerLineNumber] int line = 0);
-
-        void PerfEvent(string name, TimeSpan time, IEnumerable<KeyValuePair<string, object>> payload);
-    }
-
     public static class DiagnosticsSourceExtensions
     {
         private static int _activityId = 0;

--- a/src/NuGetGallery/Diagnostics/NullDiagnosticsSource.cs
+++ b/src/NuGetGallery/Diagnostics/NullDiagnosticsSource.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
 
 namespace NuGetGallery.Diagnostics
 {
@@ -14,6 +13,11 @@ namespace NuGetGallery.Diagnostics
         public static readonly NullDiagnosticsSource Instance = new NullDiagnosticsSource();
 
         private NullDiagnosticsSource() { }
+
+        public void ExceptionEvent(Exception exception)
+        {
+            // No-op!
+        }
 
         public void TraceEvent(System.Diagnostics.TraceEventType type, int id, string message, string member = null, string file = null, int line = 0)
         {

--- a/src/NuGetGallery/Diagnostics/TraceDiagnosticsSource.cs
+++ b/src/NuGetGallery/Diagnostics/TraceDiagnosticsSource.cs
@@ -9,6 +9,11 @@ using System.Runtime.CompilerServices;
 
 namespace NuGetGallery.Diagnostics
 {
+    /// <summary>
+    /// Gallery diagnostics source. Trace events (including LogError extension) use System.Diagnostics traces, whereas
+    /// Exception events are tracked as exceptions in ApplicationInsights. Eventually this class should be updated to
+    /// use ApplicationInsights for trace events for consistency across the Gallery.
+    /// </summary>
     public class TraceDiagnosticsSource : IDiagnosticsSource, IDisposable
     {
         private const string ObjectName = "TraceDiagnosticsSource";
@@ -26,6 +31,24 @@ namespace NuGetGallery.Diagnostics
             _source.Listeners.AddRange(Trace.Listeners);
         }
 
+        /// <summary>
+        /// Write exception to ApplicationInsights.
+        /// 
+        /// Note that Source.Error (DiagnosticsSourceExtensions) currently uses TraceEvent instead.
+        /// </summary>
+        public virtual void ExceptionEvent(Exception exception)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
+            Telemetry.TrackException(exception);
+        }
+
+        /// <summary>
+        /// Write a System.Diagnostics trace event.
+        /// </summary>
         public virtual void TraceEvent(TraceEventType type, int id, string message, [CallerMemberName] string member = null, [CallerFilePath] string file = null, [CallerLineNumber] int line = 0)
         {
             if (_source == null)

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2148,7 +2148,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>False</UseIIS>
+          <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>80</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -915,8 +915,8 @@
     <Compile Include="Infrastructure\MessageQueue.cs" />
     <Compile Include="Diagnostics\NullDiagnosticsSource.cs" />
     <Compile Include="Diagnostics\TraceDiagnosticsSource.cs" />
-    <Compile Include="Diagnostics\IDiagnosticsService.cs" />
-    <Compile Include="Diagnostics\IDiagnosticsSource.cs" />
+    <Compile Include="Diagnostics\DiagnosticsServiceExtensions.cs" />
+    <Compile Include="Diagnostics\DiagnosticsSourceExtensions.cs" />
     <Compile Include="Configuration\StorageType.cs" />
     <Content Include="bin\NuGetGallery.dll.config">
       <SubType>Designer</SubType>
@@ -2148,7 +2148,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>True</UseIIS>
+          <UseIIS>False</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>80</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>

--- a/src/NuGetGallery/Properties/AssemblyInfo.cs
+++ b/src/NuGetGallery/Properties/AssemblyInfo.cs
@@ -16,8 +16,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: InternalsVisibleTo("NuGetGallery.Facts")]
-
 #if !PORTABLE
 [assembly: ComVisible(false)]
 #endif

--- a/src/NuGetGallery/Properties/AssemblyInfo.cs
+++ b/src/NuGetGallery/Properties/AssemblyInfo.cs
@@ -8,13 +8,13 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("NuGetGallery")]
-[assembly: InternalsVisibleTo("NuGetGallery.Facts")]
-
 [assembly: AssemblyCompany(".NET Foundation")]
 [assembly: AssemblyProduct("NuGet Services")]
 [assembly: AssemblyCopyright("\x00a9 .NET Foundation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+
+[assembly: InternalsVisibleTo("NuGetGallery.Facts")]
 
 #if !PORTABLE
 [assembly: ComVisible(false)]

--- a/src/NuGetGallery/Views/NuGetViewBase.cs
+++ b/src/NuGetGallery/Views/NuGetViewBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Web.Mvc;
 using NuGetGallery.Configuration;
+using NuGetGallery.Cookies;
 
 namespace NuGetGallery.Views
 {
@@ -24,6 +25,11 @@ namespace NuGetGallery.Views
         public User CurrentUser
         {
             get { return NuGetContext.CurrentUser; }
+        }
+        
+        public ICookieComplianceService Cookies
+        {
+            get { return NuGetContext.Cookies; }
         }
 
         protected NuGetViewBase()
@@ -62,6 +68,11 @@ namespace NuGetGallery.Views
         public User CurrentUser
         {
             get { return NuGetContext.CurrentUser; }
+        }
+
+        public ICookieComplianceService Cookies
+        {
+            get { return NuGetContext.Cookies; }
         }
 
         protected NuGetViewBase()

--- a/src/NuGetGallery/Views/NuGetViewBase.cs
+++ b/src/NuGetGallery/Views/NuGetViewBase.cs
@@ -11,6 +11,7 @@ namespace NuGetGallery.Views
     public abstract class NuGetViewBase : WebViewPage
     {
         private readonly Lazy<NuGetContext> _nugetContext;
+        private readonly Lazy<CookieConsentMessage> _cookieConsentMessage;
 
         public NuGetContext NuGetContext
         {
@@ -26,15 +27,16 @@ namespace NuGetGallery.Views
         {
             get { return NuGetContext.CurrentUser; }
         }
-        
-        public ICookieComplianceService CookieComplianceService
+
+        public CookieConsentMessage CookieConsentMessage
         {
-            get { return NuGetContext.CookieComplianceService; }
+            get { return _cookieConsentMessage.Value; }
         }
 
         protected NuGetViewBase()
         {
             _nugetContext = new Lazy<NuGetContext>(GetNuGetContextThunk(this));
+            _cookieConsentMessage = new Lazy<CookieConsentMessage>(() => NuGetContext.GetCookieConsentMessage(Request));
         }
 
         internal static Func<NuGetContext> GetNuGetContextThunk(WebViewPage self)
@@ -54,6 +56,7 @@ namespace NuGetGallery.Views
     public abstract class NuGetViewBase<T> : WebViewPage<T>
     {
         private readonly Lazy<NuGetContext> _nugetContext;
+        private readonly Lazy<CookieConsentMessage> _cookieConsentMessage;
 
         public NuGetContext NuGetContext
         {
@@ -70,14 +73,15 @@ namespace NuGetGallery.Views
             get { return NuGetContext.CurrentUser; }
         }
 
-        public ICookieComplianceService CookieComplianceService
+        public CookieConsentMessage CookieConsentMessage
         {
-            get { return NuGetContext.CookieComplianceService; }
+            get { return _cookieConsentMessage.Value; }
         }
 
         protected NuGetViewBase()
         {
             _nugetContext = new Lazy<NuGetContext>(NuGetViewBase.GetNuGetContextThunk(this));
+            _cookieConsentMessage = new Lazy<CookieConsentMessage>(() => NuGetContext.GetCookieConsentMessage(Request));
         }
     }
 }

--- a/src/NuGetGallery/Views/NuGetViewBase.cs
+++ b/src/NuGetGallery/Views/NuGetViewBase.cs
@@ -70,7 +70,7 @@ namespace NuGetGallery.Views
             get { return NuGetContext.CurrentUser; }
         }
 
-        public ICookieComplianceService Cookies
+        public ICookieComplianceService CookieComplianceService
         {
             get { return NuGetContext.CookieComplianceService; }
         }

--- a/src/NuGetGallery/Views/NuGetViewBase.cs
+++ b/src/NuGetGallery/Views/NuGetViewBase.cs
@@ -27,9 +27,9 @@ namespace NuGetGallery.Views
             get { return NuGetContext.CurrentUser; }
         }
         
-        public ICookieComplianceService Cookies
+        public ICookieComplianceService CookieComplianceService
         {
-            get { return NuGetContext.Cookies; }
+            get { return NuGetContext.CookieComplianceService; }
         }
 
         protected NuGetViewBase()
@@ -72,7 +72,7 @@ namespace NuGetGallery.Views
 
         public ICookieComplianceService Cookies
         {
-            get { return NuGetContext.Cookies; }
+            get { return NuGetContext.CookieComplianceService; }
         }
 
         protected NuGetViewBase()

--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -26,8 +26,14 @@
         @RenderSection("TopScripts", required: false)
         @ViewHelpers.ReleaseMeta()
         @ViewHelpers.InstrumentationScript()
+
+        @ViewHelpers.CookieComplianceScripts()
     </head>
     <body class="s-noclickonce">
+        @if (Cookies.NeedsConsentForNonEssentialCookies(Request))
+        {
+            @Html.Raw(Cookies.GetConsentMarkup());
+        }
         @if (!string.IsNullOrWhiteSpace(Config.Current.WarningBanner))
         {
             <div id="service-alert">

--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -30,9 +30,9 @@
         @ViewHelpers.CookieComplianceScripts()
     </head>
     <body class="s-noclickonce">
-        @if (Cookies.NeedsConsentForNonEssentialCookies(Request))
+        @if (CookieComplianceService.NeedsConsentForNonEssentialCookies(Request))
         {
-            @Html.Raw(Cookies.GetConsentMarkup());
+            @Html.Raw(CookieComplianceService.GetConsentMarkup(Request));
         }
         @if (!string.IsNullOrWhiteSpace(Config.Current.WarningBanner))
         {

--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -31,7 +31,7 @@
         @if (CookieConsentMessage != null)
         {
             <div id="service-alert">
-                <div class="banner-cookies">
+                <div class="banner-cookies" role="alert">
                     <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
                     @CookieConsentMessage.Message
                     <a href="@CookieConsentMessage.MoreInfoUrl" aria-label="@CookieConsentMessage.MoreInfoAriaLabel">@CookieConsentMessage.MoreInfoText</a>

--- a/src/NuGetGallery/Views/Shared/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Layout.cshtml
@@ -26,13 +26,17 @@
         @RenderSection("TopScripts", required: false)
         @ViewHelpers.ReleaseMeta()
         @ViewHelpers.InstrumentationScript()
-
-        @ViewHelpers.CookieComplianceScripts()
     </head>
     <body class="s-noclickonce">
-        @if (CookieComplianceService.NeedsConsentForNonEssentialCookies(Request))
+        @if (CookieConsentMessage != null)
         {
-            @Html.Raw(CookieComplianceService.GetConsentMarkup(Request));
+            <div id="service-alert">
+                <div class="banner-cookies">
+                    <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
+                    @CookieConsentMessage.Message
+                    <a href="@CookieConsentMessage.MoreInfoUrl" aria-label="@CookieConsentMessage.MoreInfoAriaLabel">@CookieConsentMessage.MoreInfoText</a>
+                </div>
+            </div>
         }
         @if (!string.IsNullOrWhiteSpace(Config.Current.WarningBanner))
         {
@@ -83,5 +87,13 @@
         </div>
         @Scripts.Render("~/Scripts/all")
         @RenderSection("BottomScripts", required: false)
+
+        @if (CookieConsentMessage != null)
+        {
+            foreach (var cookieScript in CookieConsentMessage.Javascripts)
+            {
+                <script src="@cookieScript" type="text/javascript"></script>
+            }
+        }
     </body>
 </html>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -42,6 +42,9 @@
     <add key="Gallery.WarningBanner" value="" />
     <!-- redesign banner on the top - leave blank to remove the banner from the site. -->
     <add key="Gallery.RedesignBanner" value="" />
+    
+    <!-- EU cookie banner integration settings -->
+    <add key="Gallery.CookieComplianceEnabled" value="false" />
 
     <add key="Gallery.FacebookAppId" value="" />
     <!-- Set this if you have a Application Insights instrumentation key to use for your gallery deployment -->

--- a/tests/NuGetGallery.Core.Facts/Cookies/CookieComplianceServiceBaseFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Cookies/CookieComplianceServiceBaseFacts.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGetGallery.Diagnostics;
+using Xunit;
+
+namespace NuGetGallery.Cookies
+{
+    public class CookieComplianceServiceBaseFacts
+    {
+        [Fact]
+        public void SiteName_ThrowsInvalidOperationExceptionIfNotInitialized()
+        {
+            var service = new Mock<CookieComplianceServiceBase>().Object;
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var result = service.SiteName;
+            });
+        }
+
+        [Fact]
+        public void Diagnostics_ThrowsInvalidOperationExceptionIfNotInitialized()
+        {
+            var service = new Mock<CookieComplianceServiceBase>().Object;
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var result = service.Diagnostics;
+            });
+        }
+
+        [Fact]
+        public async Task SiteName_ReturnsValueIfInitialized()
+        {
+            // Arrange
+            var service = new Mock<CookieComplianceServiceBase>() { CallBase = true }.Object;
+            var diagnostics = new Mock<IDiagnosticsService>().Object;
+            await service.InitializeAsync("nuget.org", diagnostics);
+
+            // Act & Assert
+            Assert.Equal("nuget.org", service.SiteName);
+        }
+
+        [Fact]
+        public async Task Diagnostics_ReturnsValueIfInitialized()
+        {
+            // Arrange
+            var service = new Mock<CookieComplianceServiceBase>() { CallBase = true}.Object;
+
+            var diagnostics = new Mock<IDiagnosticsService>();
+            diagnostics.Setup(d => d.GetSource(It.IsAny<string>()))
+                .Returns(new Mock<IDiagnosticsSource>().Object);
+
+            await service.InitializeAsync("nuget.org", diagnostics.Object);
+
+            // Act & Assert
+            Assert.NotNull(service.Diagnostics);
+        }
+
+        [Theory]
+        [InlineData("en-GB")]
+        [InlineData("fr-FR")]
+        public void Locale_ReturnsCurrentCulture(string currentCulture)
+        {
+            var culture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                // Arrange
+                var service = new Mock<CookieComplianceServiceBase>().Object;
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(currentCulture);
+
+                // Act & Assert
+                Assert.Equal(currentCulture, service.Locale);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = culture;
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Cookies/CookieComplianceServiceBaseFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Cookies/CookieComplianceServiceBaseFacts.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery.Cookies
         [Fact]
         public void Domain_ThrowsInvalidOperationExceptionIfNotInitialized()
         {
-            var service = new Mock<CookieComplianceServiceBase>().Object;
+            var service = new Mock<InternalCookieComplianceService>().Object;
 
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -26,7 +26,7 @@ namespace NuGetGallery.Cookies
         [Fact]
         public void Diagnostics_ThrowsInvalidOperationExceptionIfNotInitialized()
         {
-            var service = new Mock<CookieComplianceServiceBase>().Object;
+            var service = new Mock<InternalCookieComplianceService>().Object;
 
             Assert.Throws<InvalidOperationException>(() =>
             {
@@ -38,7 +38,7 @@ namespace NuGetGallery.Cookies
         public async Task Domain_ReturnsValueIfInitialized()
         {
             // Arrange
-            var service = new Mock<CookieComplianceServiceBase>() { CallBase = true }.Object;
+            var service = new Mock<InternalCookieComplianceService>() { CallBase = true }.Object;
             var diagnostics = new Mock<IDiagnosticsService>().Object;
             await service.InitializeAsync("nuget.org", diagnostics, CancellationToken.None);
 
@@ -50,7 +50,7 @@ namespace NuGetGallery.Cookies
         public async Task Diagnostics_ReturnsValueIfInitialized()
         {
             // Arrange
-            var service = new Mock<CookieComplianceServiceBase>() { CallBase = true}.Object;
+            var service = new Mock<InternalCookieComplianceService>() { CallBase = true}.Object;
 
             var diagnostics = new Mock<IDiagnosticsService>();
             diagnostics.Setup(d => d.GetSource(It.IsAny<string>()))
@@ -60,6 +60,13 @@ namespace NuGetGallery.Cookies
 
             // Act & Assert
             Assert.NotNull(service.Diagnostics);
+        }
+
+        // Added to avoid InternalsVisibleTo in Gallery.Core which can be delay signed.
+        public class InternalCookieComplianceService : NullCookieComplianceService
+        {
+            public new IDiagnosticsSource Diagnostics => base.Diagnostics;
+            public new string Domain => base.Domain;
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Cookies/CookieComplianceServiceBaseFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Cookies/CookieComplianceServiceBaseFacts.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -14,13 +13,13 @@ namespace NuGetGallery.Cookies
     public class CookieComplianceServiceBaseFacts
     {
         [Fact]
-        public void SiteName_ThrowsInvalidOperationExceptionIfNotInitialized()
+        public void Domain_ThrowsInvalidOperationExceptionIfNotInitialized()
         {
             var service = new Mock<CookieComplianceServiceBase>().Object;
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                var result = service.SiteName;
+                var result = service.Domain;
             });
         }
 
@@ -36,15 +35,15 @@ namespace NuGetGallery.Cookies
         }
 
         [Fact]
-        public async Task SiteName_ReturnsValueIfInitialized()
+        public async Task Domain_ReturnsValueIfInitialized()
         {
             // Arrange
             var service = new Mock<CookieComplianceServiceBase>() { CallBase = true }.Object;
             var diagnostics = new Mock<IDiagnosticsService>().Object;
-            await service.InitializeAsync("nuget.org", diagnostics);
+            await service.InitializeAsync("nuget.org", diagnostics, CancellationToken.None);
 
             // Act & Assert
-            Assert.Equal("nuget.org", service.SiteName);
+            Assert.Equal("nuget.org", service.Domain);
         }
 
         [Fact]
@@ -57,31 +56,10 @@ namespace NuGetGallery.Cookies
             diagnostics.Setup(d => d.GetSource(It.IsAny<string>()))
                 .Returns(new Mock<IDiagnosticsSource>().Object);
 
-            await service.InitializeAsync("nuget.org", diagnostics.Object);
+            await service.InitializeAsync("nuget.org", diagnostics.Object, CancellationToken.None);
 
             // Act & Assert
             Assert.NotNull(service.Diagnostics);
-        }
-
-        [Theory]
-        [InlineData("en-GB")]
-        [InlineData("fr-FR")]
-        public void Locale_ReturnsCurrentCulture(string currentCulture)
-        {
-            var culture = Thread.CurrentThread.CurrentCulture;
-            try
-            {
-                // Arrange
-                var service = new Mock<CookieComplianceServiceBase>().Object;
-                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(currentCulture);
-
-                // Act & Assert
-                Assert.Equal(currentCulture, service.Locale);
-            }
-            finally
-            {
-                Thread.CurrentThread.CurrentCulture = culture;
-            }
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Auditing\PackageRegistrationAuditRecordTests.cs" />
     <Compile Include="Auditing\ScopeAuditRecordTests.cs" />
     <Compile Include="Auditing\UserAuditRecordTests.cs" />
+    <Compile Include="Cookies\CookieComplianceServiceBaseFacts.cs" />
     <Compile Include="Entities\PackageFacts.cs" />
     <Compile Include="Entities\UserFacts.cs" />
     <Compile Include="Entities\UserSecurityPolicyFacts.cs" />


### PR DESCRIPTION
There will be 3 PRs altogether: Gallery, Shims, Deployment

When shim is deployed, banner will display if client IP is from region which requires it. Message indicates that user gives consent if they continue to navigate, and does not include any buttons. Provided JS detects and sets consent cookie if user clicks on any non-external links, which automatically closes the banner.

I've verified the banner locally, by spoofing the consent status. I've verified AI logs in DEV, but am not able to test the banner there yet since domain isn't enabled. Will see if there's a way to enable this.

Note:
- Onus is on us to monitor logs and report if service isn't working.
- API includes 'fire and forget' background refresh; with initial refresh done when service is created (see DefaultDependenciesModule.RegisterCookieComplianceService)