### PR TITLE
[Redesign]Few Small fixes

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -967,6 +967,9 @@ img.package-icon {
 .page-stats-per-package #stats-graph-svg .bartext {
   font-size: 1em;
 }
+.page-stats-per-package #stats-graph-svg p {
+  margin-bottom: none;
+}
 .page-status .status-general {
   padding: 13px;
   margin-bottom: 24px;

--- a/src/Bootstrap/less/theme/page-statistics-per-package.less
+++ b/src/Bootstrap/less/theme/page-statistics-per-package.less
@@ -64,5 +64,9 @@
         .bartext {
             font-size: 1em;
         }
+
+        p {
+            margin-bottom: none;
+        }
     }
 }

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -967,6 +967,9 @@ img.package-icon {
 .page-stats-per-package #stats-graph-svg .bartext {
   font-size: 1em;
 }
+.page-stats-per-package #stats-graph-svg p {
+  margin-bottom: none;
+}
 .page-status .status-general {
   padding: 13px;
   margin-bottom: 24px;

--- a/src/NuGetGallery/Scripts/gallery/page-edit.js
+++ b/src/NuGetGallery/Scripts/gallery/page-edit.js
@@ -28,7 +28,7 @@ var EditViewManager = new function () {
             document.location = $(this).val();
         });
 
-        $('input[type="text"], input[type="checkbox"], textarea').on('change', function () {
+        $('input[type="text"], input[type="checkbox"], textarea').on('change keydown', function () {
             $(this).addClass("edited");
             _changedState[$(this).attr('id')] = true;
             $('#verify-submit-button').removeAttr('disabled');

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -358,7 +358,7 @@
                 </table>
                 @if (rowCount > 5)
                 {
-                    <a role="button" data-toggle="collapse" class="icon-link" data-target="#hidden-versions"
+                    <a href="#" role="button" data-toggle="collapse" class="icon-link" data-target="#hidden-versions"
                             aria-expanded="false" aria-controls="hidden-versions" id="show-hidden-versions">
                         <i class="ms-Icon ms-Icon--CalculatorAddition" aria-hidden="true"></i>
                         <span>Show more</span>

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -1,85 +1,88 @@
 ﻿@model ListPackageItemViewModel
 
-<article class="row package" role="listitem">
-    <div class="col-sm-1 hidden-xs hidden-sm">
-        <img class="package-icon img-responsive" aria-hidden="true" alt=""
-             src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
-             @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
-    </div>
-    <div class="col-sm-11">
-        <div class="package-header">
-            <a class="package-title" href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)">@Model.Title.Abbreviate(60)</a>
+<article class="package" role="listitem">
 
-            <span class="package-by">
-                by:
-                @foreach (var owner in Model.Owners)
-                {
-                    <a href="@Url.User(owner)" title="View @owner.Username's profile">@owner.Username</a>
-                }
-            </span>
+    <div class="row">
+        <div class="col-sm-1 hidden-xs hidden-sm">
+            <img class="package-icon img-responsive" aria-hidden="true" alt=""
+                 src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
+                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
         </div>
+        <div class="col-sm-11">
+            <div class="package-header">
+                <a class="package-title" href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)">@Model.Title.Abbreviate(60)</a>
 
-        <ul class="package-list">
-            <li>
-                <span>
-                    <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
-                    @Model.TotalDownloadCount.ToNuGetNumberString() total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
+                <span class="package-by">
+                    by:
+                    @foreach (var owner in Model.Owners)
+                    {
+                        <a href="@Url.User(owner)" title="View @owner.Username's profile">@owner.Username</a>
+                    }
                 </span>
-            </li>
-            <li>
-                <span>
-                    <i class="ms-Icon ms-Icon--History" aria-hidden="true"></i>
-                    last updated <span data-datetime="@Model.LastUpdated.ToJavaScriptUTC()"></span>
-                </span>
-            </li>
-            <li>
-                <span>
-                    <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
-                    Latest version: <span class="text-nowrap">@Model.FullVersion @(Model.Prerelease ? "(prerelease)" : "")</span>
-                </span>
-            </li>
-        </ul>
-
-        <div class="package-details">
-            @Model.ShortDescription
-            @if (Model.IsDescriptionTruncated)
-            {
-                @Html.RouteLink("More information", RouteName.DisplayPackage, new { Model.Id, Model.Version })
-            }
-        </div>
-
-        @if (@Model.Tags.AnySafe())
-        {
-            <div class="package-tags">
-                @foreach (var tag in Model.Tags)
-                {
-                    <a href="@Url.Search("Tags:\"" + tag + "\"")" title="Search for @tag" class="tag">@tag</a>
-                }
             </div>
-        }
 
-        @if (Model.IsOwner(User))
-        {
-            <ul class="package-list manage-package">
+            <ul class="package-list">
                 <li>
-                    <a href="@Url.EditPackage(Model.Id, Model.Version)" class="icon-link">
-                        <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
-                        <span>Edit Package</span>
-                    </a>
+                    <span>
+                        <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
+                        @Model.TotalDownloadCount.ToNuGetNumberString() total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
+                    </span>
                 </li>
                 <li>
-                    <a href="@Url.ManagePackageOwners(Model)" class="icon-link">
-                        <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>
-                        <span>Manage Owners</span>
-                    </a>
+                    <span>
+                        <i class="ms-Icon ms-Icon--History" aria-hidden="true"></i>
+                        last updated <span data-datetime="@Model.LastUpdated.ToJavaScriptUTC()"></span>
+                    </span>
                 </li>
                 <li>
-                    <a href="@Url.DeletePackage(Model)" class="icon-link">
-                        <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
-                        <span>Delete Package</span>
-                    </a>
+                    <span>
+                        <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
+                        Latest version: <span class="text-nowrap">@Model.FullVersion @(Model.Prerelease ? "(prerelease)" : "")</span>
+                    </span>
                 </li>
             </ul>
-        }
+
+            <div class="package-details">
+                @Model.ShortDescription
+                @if (Model.IsDescriptionTruncated)
+            {
+                    @Html.RouteLink("More information", RouteName.DisplayPackage, new { Model.Id, Model.Version })
+                }
+            </div>
+
+            @if (@Model.Tags.AnySafe())
+            {
+                <div class="package-tags">
+                    @foreach (var tag in Model.Tags)
+                {
+                        <a href="@Url.Search("Tags:\"" + tag + "\"")" title="Search for @tag" class="tag">@tag</a>
+                    }
+                </div>
+            }
+
+            @if (Model.IsOwner(User))
+            {
+                <ul class="package-list manage-package">
+                    <li>
+                        <a href="@Url.EditPackage(Model.Id, Model.Version)" class="icon-link">
+                            <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
+                            <span>Edit Package</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="@Url.ManagePackageOwners(Model)" class="icon-link">
+                            <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>
+                            <span>Manage Owners</span>
+                        </a>
+                    </li>
+                    <li>
+                        <a href="@Url.DeletePackage(Model)" class="icon-link">
+                            <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
+                            <span>Delete Package</span>
+                        </a>
+                    </li>
+                </ul>
+            }
+        </div>
     </div>
 </article>


### PR DESCRIPTION
Addresses the following issues:
[Redesign] Statistics page - top client name appears cut-off #4416
[Redesign] Package page - versions list "show less" doesn't have a tab stop #4417
[Redesign] Horizontal rule at the top of the packages page is narrower than the others #4425
[Redesign] Package edit - submit-button enabled only by focus change #4418

@joelverhagen