### PR TITLE
[Redesign] Make package ID more prominent than package title (but still keep title visible)

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -313,6 +313,9 @@ img.package-icon {
     margin-left: 0;
   }
 }
+.list-packages .package .package-title {
+  margin-top: 2px;
+}
 .list-packages .package .manage-package {
   margin-top: 20px;
   margin-bottom: 0;
@@ -518,6 +521,15 @@ img.package-icon {
 }
 .page-package-details .no-border {
   border: 0;
+}
+.page-package-details h1 {
+  margin-bottom: 0;
+}
+.page-package-details .package-title {
+  margin-bottom: 24px;
+}
+.page-package-details .package-title div {
+  margin-top: 2px;
 }
 .page-package-details .package-details-info .ms-Icon-ul li {
   margin-bottom: 15px;

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -24,6 +24,10 @@
       }
     }
 
+    .package-title {
+      margin-top: 2px;
+    }
+
     .manage-package {
       margin-top: 20px;
       margin-bottom: 0px;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -3,6 +3,18 @@
     border: 0;
   }
 
+  h1 {
+    margin-bottom: 0;
+  }
+
+  .package-title {
+    margin-bottom: 24px;
+
+    div {
+      margin-top: 2px;
+    }
+  }
+
   .package-details-info {
     .ms-Icon-ul {
       li {

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -313,6 +313,9 @@ img.package-icon {
     margin-left: 0;
   }
 }
+.list-packages .package .package-title {
+  margin-top: 2px;
+}
 .list-packages .package .manage-package {
   margin-top: 20px;
   margin-bottom: 0;
@@ -518,6 +521,15 @@ img.package-icon {
 }
 .page-package-details .no-border {
   border: 0;
+}
+.page-package-details h1 {
+  margin-bottom: 0;
+}
+.page-package-details .package-title {
+  margin-bottom: 24px;
+}
+.page-package-details .package-title div {
+  margin-top: 2px;
 }
 .page-package-details .package-details-info .ms-Icon-ul li {
   margin-bottom: 15px;

--- a/src/NuGetGallery/Views/Packages/Delete.cshtml
+++ b/src/NuGetGallery/Views/Packages/Delete.cshtml
@@ -11,7 +11,7 @@
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="text-center">Manage Package Listing</h1>
             <div class="text-center ms-font-xxl">
-                <a href="@Url.Package(Model.Id, Model.Version)">@Model.Title.Abbreviate(40)</a>
+                <a href="@Url.Package(Model.Id, Model.Version)">@Model.Id</a>
             </div>
 
             <h2>
@@ -84,7 +84,7 @@
                     @Html.Hidden("version", @Model.Version)
                     <div class="form-group @Html.HasErrorFor(package => package.Listed)">
                         @Html.ShowCheckboxFor(package => package.Listed)
-                        @Html.ShowLabelFor(package => package.Listed, "List " + Model.Title + " " + Model.Version + " in search results.")
+                        @Html.ShowLabelFor(package => package.Listed, "List " + Model.Id + " " + Model.Version + " in search results.")
                         @Html.ShowValidationMessagesFor(package => package.Listed)
 
                         <p>Unlisted packages cannot be installed directly and do not show up in search results.</p>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1,7 +1,7 @@
 @model DisplayPackageViewModel
 
 @{
-    ViewBag.Title = Model.Title + " " + Model.Version;
+    ViewBag.Title = Model.Id + " " + Model.Version;
     ViewBag.Tab = "Packages";
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
     var absolutePackageUrl = Url.Absolute(Url.Package(Model.Id));
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@("@nuget")">
 
-    <meta property="og:title" content="@Model.Title" />
+    <meta property="og:title" content="@Model.Id @Model.Version" />
     <meta property="og:type" content="nugetgallery:package" />
     <meta property="og:url" content="@absolutePackageUrl" />
     <meta property="og:description" content="@Model.Description" />
@@ -68,10 +68,19 @@
             </h3>
         </aside>
         <article class="col-sm-8">
-            <h1 title="@Model.Title">
-                @Model.Title.Abbreviate(40)
-                <small class="text-nowrap">@Model.FullVersion</small>
-            </h1>
+            <div class="package-title">
+                <h1>
+                    @Model.Id
+                    <small class="text-nowrap">@Model.FullVersion</small>
+                </h1>
+
+                @if (!StringComparer.OrdinalIgnoreCase.Equals(Model.Id, Model.Title))
+                {
+                    <div class="ms-fontSize-xl">
+                        @Model.Title
+                    </div>
+                }
+            </div>
 
             @if (!String.IsNullOrWhiteSpace(Model.Description))
             {
@@ -114,7 +123,7 @@
             {
                 @ViewHelpers.AlertInfo(
                     @<text>
-                        This is a prerelease version of @(Model.Title.Abbreviate(65)).
+                        This is a prerelease version of @(Model.Id).
                     </text>
                 )
             }

--- a/src/NuGetGallery/Views/Packages/Edit.cshtml
+++ b/src/NuGetGallery/Views/Packages/Edit.cshtml
@@ -1,7 +1,7 @@
 ﻿@using System.Linq.Expressions
 @model EditPackageRequest
 @{
-    ViewBag.Title = "Editing: " + Model.PackageTitle + " " + Model.Version;
+    ViewBag.Title = "Editing: " + Model.PackageId + " " + Model.Version;
     ViewBag.Tab = "Packages";
     ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -6,7 +6,7 @@
 
 <section role="main" class="container main-container page-manage-owners">
     <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
-        <h1 class="text-center">Manage Owners for Package <a href="@Url.Package(Model.Id)">@Model.Title.Abbreviate(50)</a></h1>
+        <h1 class="text-center">Manage Owners for Package <a href="@Url.Package(Model.Id)">@Model.Id</a></h1>
 
         <div style="display: none" id="manage-owners-alert" data-bind="visible: message">
             @ViewHelpers.AlertDanger(
@@ -41,7 +41,7 @@
                         </span>
                     </div>
                     <div class="col-md-3 remove-owner">
-                        <a class="icon-link" href="#" title="Remove as owner of @Model.Title" data-bind="visible: !current  || $parent.hasMoreThanOneOwner, click: $root.removeOwner">
+                        <a class="icon-link" href="#" title="Remove as owner of @Model.Id" data-bind="visible: !current  || $parent.hasMoreThanOneOwner, click: $root.removeOwner">
                             <i class="ms-Icon ms-Icon--Cancel" aria-hidden="true"></i>
                             <span>Remove</span>
                         </a>
@@ -83,7 +83,7 @@
                     </div>
 
                     <div class="form-group">
-                        <input type="submit" class="btn btn-primary form-control" value="Add" title="Add the user as an owner to @Model.Title" data-bind="click: confirmAddOwner" />
+                        <input type="submit" class="btn btn-primary form-control" value="Add" title="Add the user as an owner to @Model.Id" data-bind="click: confirmAddOwner" />
                     </div>
                 </div>
 
@@ -101,7 +101,7 @@
 
                     <div class="row">
                         <div class="col-md-6">
-                            <input type="submit" class="btn btn-primary form-control" value="Confirm" title="Confirm adding the user as an owner to @Model.Title" data-bind="click: addOwner" />
+                            <input type="submit" class="btn btn-primary form-control" value="Confirm" title="Confirm adding the user as an owner to @Model.Id" data-bind="click: addOwner" />
                         </div>
                         <div class="col-md-6 text-right">
                             <a href="#" class="btn btn-default form-control text-right" title="Cancel changes and reload the page." role="button" data-bind="click: cancelAddOwnerConfirmation">Cancel</a>

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -10,7 +10,7 @@
         </div>
         <div class="col-sm-11">
             <div class="package-header">
-                <a class="package-title" href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)">@Model.Title.Abbreviate(60)</a>
+                <a class="package-title" href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)">@Model.Id</a>
 
                 <span class="package-by">
                     by:
@@ -21,7 +21,14 @@
                 </span>
             </div>
 
-            <ul class="package-list">
+            @if (!StringComparer.OrdinalIgnoreCase.Equals(Model.Id, Model.Title))
+            {
+                <div class="package-title ms-fontSize-l">
+                    @Model.Title
+                </div>
+            }
+
+            <ul class="package-list ms-fontWeight-semibold">
                 <li>
                     <span>
                         <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
@@ -45,7 +52,7 @@
             <div class="package-details">
                 @Model.ShortDescription
                 @if (Model.IsDescriptionTruncated)
-            {
+                {
                     @Html.RouteLink("More information", RouteName.DisplayPackage, new { Model.Id, Model.Version })
                 }
             </div>


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/4413.

Top of package details page:
![image](https://user-images.githubusercontent.com/94054/28395572-e4bb421e-6ca9-11e7-8f93-2d9e8f786d86.png)

Search result:
![image](https://user-images.githubusercontent.com/94054/28395582-f1ff425e-6ca9-11e7-9c81-7f364e500c51.png)
