### PR TITLE
[Redesign] Make the package list more compact

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -294,14 +294,15 @@ img.package-icon {
   border-top: 1px solid #dbdbdb;
 }
 .list-packages .package {
-  padding-top: 20px;
-  padding-bottom: 20px;
+  padding-top: 15px;
+  padding-bottom: 15px;
   font-size: 15px;
   border-bottom: 1px solid #dbdbdb;
 }
 .list-packages .package .package-header .package-title {
   font-size: 34px;
   font-weight: 300;
+  line-height: .9;
 }
 .list-packages .package .package-header .package-by {
   margin-left: 10px;
@@ -317,7 +318,7 @@ img.package-icon {
   margin-top: 2px;
 }
 .list-packages .package .manage-package {
-  margin-top: 20px;
+  margin-top: 10px;
   margin-bottom: 0;
 }
 .list-packages .package .package-details {

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -2,8 +2,8 @@
   border-top: 1px solid @gray-lighter;
 
   .package {
-    padding-top: (@padding-large-vertical * 2);
-    padding-bottom: (@padding-large-vertical * 2);
+    padding-top: (@padding-large-vertical * 1.5);
+    padding-bottom: (@padding-large-vertical * 1.5);
     border-bottom: 1px solid @gray-lighter;
     font-size: 15px;
 
@@ -11,6 +11,7 @@
       .package-title {
         font-size: @font-size-h2;
         font-weight: 300;
+        line-height: 0.9;
       }
 
       .package-by {
@@ -29,8 +30,8 @@
     }
 
     .manage-package {
-      margin-top: 20px;
-      margin-bottom: 0px;
+      margin-top: @padding-large-vertical;
+      margin-bottom: 0;
     }
 
     .package-details {

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -294,14 +294,15 @@ img.package-icon {
   border-top: 1px solid #dbdbdb;
 }
 .list-packages .package {
-  padding-top: 20px;
-  padding-bottom: 20px;
+  padding-top: 15px;
+  padding-bottom: 15px;
   font-size: 15px;
   border-bottom: 1px solid #dbdbdb;
 }
 .list-packages .package .package-header .package-title {
   font-size: 34px;
   font-weight: 300;
+  line-height: .9;
 }
 .list-packages .package .package-header .package-by {
   margin-left: 10px;
@@ -317,7 +318,7 @@ img.package-icon {
   margin-top: 2px;
 }
 .list-packages .package .manage-package {
-  margin-top: 20px;
+  margin-top: 10px;
   margin-bottom: 0;
 }
 .list-packages .package .package-details {


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/4421.

Before:
![screencapture-localhost-packages-1500512614941 1](https://user-images.githubusercontent.com/94054/28395924-b662d906-6cac-11e7-8732-c072f556df02.png)

After:
![screencapture-localhost-packages-1500512599472](https://user-images.githubusercontent.com/94054/28395925-b7250eb8-6cac-11e7-89fb-5e5faccffa92.png)
