### PR TITLE
Adding myself to the team list static blob

### DIFF
--- a/content/PROD/Team.json
+++ b/content/PROD/Team.json
@@ -47,5 +47,6 @@
     "nkolev92",
     "rohit21agrawal",
     "rrelyea",
-    "yishaigalatzer"
+    "yishaigalatzer",
+    "agr"
 ]


### PR DESCRIPTION
Currently I am listed on the "Contributors" list on the About page on the preview site. The change should move me to the Team list.