### PR TITLE
[Redesign] Hide charts if data to display isn't there.

### DIFF
--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -6,101 +6,106 @@
 }
 
 <section class="container main-container page-statistics-overview">
-        <h1>Statistics</h1>
-        <span class="page-subheading ms-fontSize-l">
-            @Html.Partial("_LastUpdated", Model)
-        </span>
+    <h1>Statistics</h1>
+    <span class="page-subheading ms-fontSize-l">
+        @Html.Partial("_LastUpdated", Model)
+    </span>
 
-        <div class="row">
-            @if (Model.IsDownloadPackageAvailable)
-            {
-                <div class="col-md-6 col-xs-12">
-                    <h2 class="stats-title-text">Package Downloads</h2>
-                    <table class="table col-xs-12 borderless">
-                        <thead>
-                            <tr>
-                                <th class="text-left">Name</th>
-                                <th class="text-right">Downloads</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @{
-                                var index = 0;
-                                foreach (var item in Model.DownloadPackagesSummary)
-                                {
-                                    index++;
+    <div class="row">
+        @if (Model.IsDownloadPackageAvailable)
+        {
+            <div class="col-md-6 col-xs-12">
+                <h2 class="stats-title-text">Package Downloads</h2>
+                <table class="table col-xs-12 borderless">
+                    <thead>
+                        <tr>
+                            <th class="text-left">Name</th>
+                            <th class="text-right">Downloads</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @{
+                            var index = 0;
+                            foreach (var item in Model.DownloadPackagesSummary)
+                            {
+                                index++;
 
-                                    <tr>
-                                        <td class="text-left"><a href="@Url.Package(item.PackageId)" title="@item.PackageId">@item.PackageId</a></td>
-                                        <td class="text-right"><a href="@Url.StatisticsPackageDownloadByVersion(item.PackageId)">@Model.DisplayDownloads(item.Downloads)</a></td>
-                                    </tr>
-                                }
+                                <tr>
+                                    <td class="text-left"><a href="@Url.Package(item.PackageId)" title="@item.PackageId">@item.PackageId</a></td>
+                                    <td class="text-right"><a href="@Url.StatisticsPackageDownloadByVersion(item.PackageId)">@Model.DisplayDownloads(item.Downloads)</a></td>
+                                </tr>
                             }
-                        </tbody>
-                        <tfoot>
-                            <tr>
-                                <td colspan="2">
-                                    <a href="@Url.StatisticsAllPackageDownloads()">More...<span class="sr-only">View more package download statistics</span></a>
-                                </td>
-                            </tr>
-                        </tfoot>
-                    </table>
-                </div>
-            }
-            @if (Model.IsDownloadPackageDetailAvailable)
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td colspan="2">
+                                <a href="@Url.StatisticsAllPackageDownloads()">More...<span class="sr-only">View more package download statistics</span></a>
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        }
+        @if (Model.IsDownloadPackageDetailAvailable)
             {
-                <div class="col-md-6 col-xs-12">
-                    <h2 class="stats-title-text">Version Downloads</h2>
-                    <table class="table col-xs-12 borderless">
-                        <thead>
-                            <tr>
-                                <th class="text-left">Name</th>
-                                <th class="text-center">Version</th>
-                                <th class="text-right">Downloads</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @{
-                                var index = 0;
-                                foreach (var item in Model.DownloadPackageVersionsSummary)
-                                {
-                                    index++;
+            <div class="col-md-6 col-xs-12">
+                <h2 class="stats-title-text">Version Downloads</h2>
+                <table class="table col-xs-12 borderless">
+                    <thead>
+                        <tr>
+                            <th class="text-left">Name</th>
+                            <th class="text-center">Version</th>
+                            <th class="text-right">Downloads</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @{
+                            var index = 0;
+                            foreach (var item in Model.DownloadPackageVersionsSummary)
+                            {
+                                index++;
 
-                                    <tr>
-                                        <td class="text-left"><a href="@Url.Package(item.PackageId)" title="@item.PackageId">@item.PackageId</a></td>
-                                        <td class="text-center"><a href="@Url.Package(item.PackageId, item.PackageVersion)">@item.PackageVersion</a></td>
-                                        <td class="text-right"><a href="@Url.StatisticsPackageDownloadsDetail(item.PackageId, item.PackageVersion)">@Model.DisplayDownloads(item.Downloads)</a></td>
-                                    </tr>
-                                }
+                                <tr>
+                                    <td class="text-left"><a href="@Url.Package(item.PackageId)" title="@item.PackageId">@item.PackageId</a></td>
+                                    <td class="text-center"><a href="@Url.Package(item.PackageId, item.PackageVersion)">@item.PackageVersion</a></td>
+                                    <td class="text-right"><a href="@Url.StatisticsPackageDownloadsDetail(item.PackageId, item.PackageVersion)">@Model.DisplayDownloads(item.Downloads)</a></td>
+                                </tr>
                             }
-                        </tbody>
-                        <tfoot>
-                            <tr>
-                                <td colspan="3">
-                                    <a href="@Url.StatisticsAllPackageVersionDownloads()">More...<span class="sr-only">View more package version download statistics</span></a>
-                                </td>
-                            </tr>
-                        </tfoot>
-                    </table>
-                </div>
-            }
-        </div>
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td colspan="3">
+                                <a href="@Url.StatisticsAllPackageVersionDownloads()">More...<span class="sr-only">View more package version download statistics</span></a>
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+          }
+    </div>
 
-        <div class="row">
-            @if (Model.IsNuGetClientVersionAvailable)
+    <div class="row">
+        @if (Model.IsNuGetClientVersionAvailable)
             {
-                <div class="col-md-6 col-xs-12">
-                    <h2 class="stats-title-text">NuGet Client Usage (Last 6 Weeks)</h2>
-                    <div class="col-xs-12 chart">
+            <div class="col-md-6 col-xs-12">
+                <h2 class="stats-title-text">NuGet Client Usage (Last 6 Weeks)</h2>
+                <div class="col-xs-12 chart">
+                    @{ 
+
+                        var limitCount = 15;
+                        var minDL = 1000;
+                        var showVersions = Model.NuGetClientVersion.Where(e => e.Downloads > minDL);
+                        if (showVersions.Count() > limitCount)
+                        {
+                            showVersions = showVersions.Skip(Math.Max(0, showVersions.Count() - limitCount));
+                        }
+                    }
+                    @if (showVersions != null && showVersions.Count() > 0)
+                    {
                         <svg class="chart" id="bar-chart-client-usage">
                             @{
-                                var limitCount = 15;
-                                var minDL = 1000;
-                                var showVersions = Model.NuGetClientVersion.Where(e => e.Downloads > minDL);
-                                if (showVersions.Count() > limitCount)
-                                {
-                                    showVersions = showVersions.Skip(Math.Max(0, showVersions.Count() - limitCount));
-                                }
 
                                 var chartFullWidthInPercent = 90.0;
                                 var chartFullHeightInPercent = 90.0;
@@ -112,11 +117,11 @@
                                 var fraction = chartFullWidthInPercent / showVersions.Count();
                                 foreach (var item in showVersions)
                                 {
-                                    <rect class="graph-bar" id="graph-bar-@(item.Version)" x="@(widthOffsetPercent + index * fraction)%" y="@(chartFullHeightInPercent-item.Downloads/max*chartFullHeightInPercent)%" width="@(fraction * (1.0 - gapPercent))%" height="@(item.Downloads/max*chartFullHeightInPercent)%">
+                                    <rect class="graph-bar" id="graph-bar-@(item.Version)" x="@(widthOffsetPercent + index * fraction)%" y="@(chartFullHeightInPercent - item.Downloads / max * chartFullHeightInPercent)%" width="@(fraction * (1.0 - gapPercent))%" height="@(item.Downloads / max * chartFullHeightInPercent)%">
                                         <title>@(item.Downloads) downloads</title>
                                     </rect>
 
-                                        <svg x="@(widthOffsetPercent + index * fraction + fraction/2.0 - 2.5)%" y="@(chartFullHeightInPercent + 1)%">
+                                        <svg x="@(widthOffsetPercent + index * fraction + fraction / 2.0 - 2.5)%" y="@(chartFullHeightInPercent + 1)%">
                                             <g transform="rotate(-45)">
                                                 <text y="1.5em" x="-0.9em" class="graph-x-axis-text"> @(item.Version)</text>
                                             </g>
@@ -128,37 +133,38 @@
                                 {
                                     @:<text class="graph-y-axis-text" x="0" y="@(i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
                                 }
-                        }
-                        </svg>
-                    </div>
-                    <table class="table col-xs-12 borderless">
-                        <thead>
-                            <tr>
-                                <th class="text-left">NuGet Client Version</th>
-                                <th class="text-right">Downloads</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @{
-                                foreach (var item in Model.NuGetClientVersion.Reverse())
-                                {
-                                    index++;
-
-                                    <tr tabindex="0" aria-label="Version @(item.Version) with @(item.Downloads) Downloads">
-                                        <td class="text-left">@item.Version</td>
-                                        <td class="text-right">@Model.DisplayDownloads(item.Downloads)</td>
-                                    </tr>
-                                }
                             }
-                        </tbody>
-                    </table>
+                        </svg>
+                    }
                 </div>
-            }
-            @if (Model.IsLast6WeeksAvailable)
+                <table class="table col-xs-12 borderless">
+                    <thead>
+                        <tr>
+                            <th class="text-left">NuGet Client Version</th>
+                            <th class="text-right">Downloads</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @{
+                            foreach (var item in Model.NuGetClientVersion.Reverse())
+                            {
+                                <tr tabindex="0" aria-label="Version @(item.Version) with @(item.Downloads) Downloads">
+                                    <td class="text-left">@item.Version</td>
+                                    <td class="text-right">@Model.DisplayDownloads(item.Downloads)</td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+                            }
+        @if (Model.IsLast6WeeksAvailable)
             {
-                <div class="col-md-6 col-xs-12">
-                    <h2 class="stats-title-text">Downloaded Packages Per Week (Last 6 Weeks)</h2>
-                    <div class="col-xs-12 chart">
+            <div class="col-md-6 col-xs-12">
+                <h2 class="stats-title-text">Downloaded Packages Per Week (Last 6 Weeks)</h2>
+                <div class="col-xs-12 chart">
+                    @if (Model.Last6Weeks != null)
+                    {
                         <svg class="chart" id="line-chart-sixweeks-downloads">
                             @{
                                 var chartFullWidthInPercent = 90.0;
@@ -181,21 +187,21 @@
                                     if (prevCenterY >= 0 && prevCenterX >= 0 && prevItem != null)
                                     {
                                         <line class="graph-line" x1="@prevCenterX%" y1="@prevCenterY%" x2="@centerX%" y2="@centerY%" />
-                                            <circle class="graph-dot" id="graph-dot-@(prevItem.Year)-@(prevItem.WeekOfYear)" cx="@prevCenterX%" cy="@prevCenterY%" r="5px">
-                                                <title>@(prevItem.Downloads) downloads</title>
-                                            </circle>
+                                        <circle class="graph-dot" id="graph-dot-@(prevItem.Year)-@(prevItem.WeekOfYear)" cx="@prevCenterX%" cy="@prevCenterY%" r="5px">
+                                            <title>@(prevItem.Downloads) downloads</title>
+                                        </circle>
                                     }
 
                                     <circle class="graph-dot" id="graph-dot-@(item.Year)-@(item.WeekOfYear)" cx="@centerX%" cy="@centerY%" r="5px">
                                         <title>@(item.Downloads) downloads</title>
                                     </circle>
 
-                                        <svg x="@(widthOffsetPercent + index * fraction + fraction/2.0 - 5)%" y="@(topOffset + chartFullHeightInPercent + 2)%">
-                                            <g transform="rotate(-45)">
-                                                <text y="2.6em" x="-2.0em" class="graph-x-axis-date">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.StartOnly)-</text>
-                                                <text y="2.6em" x="-2.0em" class="graph-x-axis-date" dy="1em">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.EndOnly)</text>
-                                            </g>
-                                        </svg>
+                                    <svg x="@(widthOffsetPercent + index * fraction + fraction / 2.0 - 5)%" y="@(topOffset + chartFullHeightInPercent + 2)%">
+                                        <g transform="rotate(-45)">
+                                            <text y="2.6em" x="-2.0em" class="graph-x-axis-date">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.StartOnly)-</text>
+                                            <text y="2.6em" x="-2.0em" class="graph-x-axis-date" dy="1em">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.EndOnly)</text>
+                                        </g>
+                                    </svg>
 
                                     prevCenterX = widthOffsetPercent + index * fraction + fraction / 3;
                                     prevCenterY = topOffset + chartFullHeightInPercent - item.Downloads / max * chartFullHeightInPercent;
@@ -208,31 +214,30 @@
                                     @:<text class="graph-y-axis-text" x="0" y="@(topOffset + i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
                                 }
 
-                        }
-                        </svg>
-                    </div>
-                    <table class="table col-xs-12 borderless">
-                        <thead>
-                            <tr>
-                                <th class="text-left">Week</th>
-                                <th class="text-right">Downloads</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @{
-                                foreach (var item in Model.Last6Weeks)
-                                {
-                                    index++;
-
-                                    <tr tabindex="0" aria-label="Week of @Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.StartOnly), @(item.Downloads) Downloads">
-                                        <td class="text-left" title="@Model.DisplayWeek(item.Year, item.WeekOfYear)">@Model.DisplayWeek(item.Year, item.WeekOfYear)</td>
-                                        <td class="text-right">@Model.DisplayDownloads(item.Downloads)</td>
-                                    </tr>
-                                }
                             }
-                        </tbody>
-                    </table>
+                        </svg>
+                      }
                 </div>
-            }
+                <table class="table col-xs-12 borderless">
+                    <thead>
+                        <tr>
+                            <th class="text-left">Week</th>
+                            <th class="text-right">Downloads</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @{
+                            foreach (var item in Model.Last6Weeks)
+                            {
+                                <tr tabindex="0" aria-label="Week of @Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.StartOnly), @(item.Downloads) Downloads">
+                                    <td class="text-left" title="@Model.DisplayWeek(item.Year, item.WeekOfYear)">@Model.DisplayWeek(item.Year, item.WeekOfYear)</td>
+                                    <td class="text-right">@Model.DisplayDownloads(item.Downloads)</td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
+         }
     </div>
 </section>


### PR DESCRIPTION
Addresses the following issue:
[Redesign] Stats page crashes when there are no client versions #4464

Skips rendering of components that break if we don't have data.

@joelverhagen 