### PR TITLE
[Redesign]Update Manage Packages to be more compact.

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -347,6 +347,15 @@ img.package-icon {
   margin-top: 75px;
   margin-bottom: 0;
 }
+.user-package-list .manage-package-listing .package-icon {
+  max-height: 2em;
+}
+.user-package-list .manage-package-listing .align-middle {
+  vertical-align: middle;
+}
+.user-package-list .table {
+  border-bottom: 1px solid #ddd;
+}
 .page-about .contributors .contributor {
   padding: 5px;
 }

--- a/src/Bootstrap/less/theme/all.less
+++ b/src/Bootstrap/less/theme/all.less
@@ -2,6 +2,7 @@
 @import "common-edit-metadata.less";
 @import "common-high-contrast.less";
 @import "common-list-packages.less";
+@import "common-user-package-list.less";
 @import "page-about.less";
 @import "page-account-settings.less";
 @import "page-api-keys.less";

--- a/src/Bootstrap/less/theme/common-user-package-list.less
+++ b/src/Bootstrap/less/theme/common-user-package-list.less
@@ -1,0 +1,15 @@
+.user-package-list {
+    .manage-package-listing {
+        .package-icon {
+            max-height: 2em;
+        }
+
+        .align-middle {
+            vertical-align: middle;
+        }
+    }
+
+    .table {
+        border-bottom: 1px solid @table-border-color;
+    }
+}

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -347,6 +347,15 @@ img.package-icon {
   margin-top: 75px;
   margin-bottom: 0;
 }
+.user-package-list .manage-package-listing .package-icon {
+  max-height: 2em;
+}
+.user-package-list .manage-package-listing .align-middle {
+  vertical-align: middle;
+}
+.user-package-list .table {
+  border-bottom: 1px solid #ddd;
+}
 .page-about .contributors .contributor {
   padding: 5px;
 }

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -153,7 +153,7 @@ namespace NuGetGallery
         {
             var user = GetCurrentUser();
             var packages = _packageService.FindPackagesByOwner(user, includeUnlisted: true)
-                .Select(p => new ListPackageItemViewModel(p)).ToList();
+                .Select(p => new ListPackageItemViewModel(p)).OrderBy(p => p.Id).ToList();
 
             var model = new ManagePackagesViewModel
             {

--- a/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
@@ -6,7 +6,7 @@
     var downloadsString = "download" + (numDownloads != 1 ? "s" : "");
 }
 
-<div class="row">
+<div class="row user-package-list">
     <div class="col-md-12">
         <h2>
             <a href="#" role="button" data-toggle="collapse" data-target="#packages-@Model.Name"
@@ -21,10 +21,53 @@
                 with a total of <b>@numDownloads.ToNuGetNumberString() @downloadsString</b>
             </p>
             <div class="list-packages" role="list">
-                @foreach (var package in @Model.Packages)
-                {
-                    @Html.Partial("_ListPackage", package)
-                }
+                <table class="table">
+                    <thead>
+                        <tr class="manage-package-headings">
+                            <th class="col-sm-1"></th>
+                            <th class="col-sm-3">Package Id</th>
+                            <th class="col-sm-2">Authors</th>
+                            <th class="col-sm-2">Downloads</th>
+                            <th class="col-sm-2">Latest Version</th>
+                            <th class="col-sm-2"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @foreach (var package in @Model.Packages)
+                    {
+                        //@Html.Partial("_ListPackage", package)
+                        <tr class="manage-package-listing">
+                            <td class="col-sm-1 align-middle">
+                                <img class="package-icon img-responsive" aria-hidden="true" alt="" 
+                                     src="@(PackageHelper.ShouldRenderUrl(package.IconUrl) ? package.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))" 
+                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
+                            </td>
+                            <td class="col-sm-3 align-middle"><a href="@Url.Package(package.Id)">@package.Id</a></td>
+                            <td class="col-sm-2 align-middle">
+                            @foreach (var owner in package.Owners)
+                            {
+                                <a href="@Url.User(owner.Username)">@owner.Username  </a>
+                            }
+                            </td>
+                            <td class="col-sm-2 align-middle">@package.DownloadCount</td>
+                            <td class="col-sm-2 align-middle">@package.Version</td>
+                            <td class="col-sm-2 text-right align-middle">
+                                <div class="btn-group">
+                                    <a href="@Url.EditPackage(package.Id, package.Version)" class="btn" title="Edit Package">
+                                        <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
+                                    </a>
+                                    <a href="@Url.ManagePackageOwners(package)" class="btn" title="Manage Owners">
+                                        <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>
+                                    </a>
+                                    <a href="@Url.DeletePackage(package)" class="btn" title="Delete Package">
+                                        <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
+                                    </a>
+                                </div>
+                            </td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>

--- a/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
@@ -53,13 +53,13 @@
                             <td class="col-sm-2 align-middle">@package.Version</td>
                             <td class="col-sm-2 text-right align-middle">
                                 <div class="btn-group">
-                                    <a href="@Url.EditPackage(package.Id, package.Version)" class="btn" title="Edit Package">
+                                    <a href="@Url.EditPackage(package.Id, package.Version)" class="btn" title="Edit Package" aria-label="Edit Package @package.Id  Version @package.Version">
                                         <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
                                     </a>
-                                    <a href="@Url.ManagePackageOwners(package)" class="btn" title="Manage Owners">
+                                    <a href="@Url.ManagePackageOwners(package)" class="btn" title="Manage Owners" aria-label="Manage Owners for Package @package.Id">
                                         <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>
                                     </a>
-                                    <a href="@Url.DeletePackage(package)" class="btn" title="Delete Package">
+                                    <a href="@Url.DeletePackage(package)" class="btn" title="Delete Package" aria-lable="Delete Package @package.Id  Version @package.Version">
                                         <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
                                     </a>
                                 </div>

--- a/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
@@ -49,7 +49,7 @@
                                 <a href="@Url.User(owner.Username)">@owner.Username  </a>
                             }
                             </td>
-                            <td class="col-sm-2 align-middle">@package.DownloadCount</td>
+                            <td class="col-sm-2 align-middle">@package.TotalDownloadCount</td>
                             <td class="col-sm-2 align-middle">@package.Version</td>
                             <td class="col-sm-2 text-right align-middle">
                                 <div class="btn-group">


### PR DESCRIPTION
Make manage package page more compact through horizontal layout.

First part of addressing https://github.com/NuGet/NuGetGallery/issues/4431

@joelverhagen @jonwchu 

Preview:
![image](https://user-images.githubusercontent.com/11051729/28638864-13399e78-71fb-11e7-95f1-c9879052bd3c.png)
