### PR TITLE
[Redesign]Make svg render culture invariant.

### DIFF
--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@model StatisticsPackagesViewModel
+@using System.Globalization
 @{
     ViewBag.Title = "Statistics";
     ViewBag.Tab = "Statistics";
@@ -112,11 +113,11 @@
                                 var fraction = chartFullWidthInPercent / showVersions.Count();
                                 foreach (var item in showVersions)
                                 {
-                                    <rect class="graph-bar" id="graph-bar-@(item.Version)" x="@(widthOffsetPercent + index * fraction)%" y="@(chartFullHeightInPercent-item.Downloads/max*chartFullHeightInPercent)%" width="@(fraction * (1.0 - gapPercent))%" height="@(item.Downloads/max*chartFullHeightInPercent)%">
+                                    <rect class="graph-bar" id="graph-bar-@(item.Version)" x="@((widthOffsetPercent + index * fraction).ToString(CultureInfo.InvariantCulture))%" y="@((chartFullHeightInPercent-item.Downloads/max*chartFullHeightInPercent).ToString(CultureInfo.InvariantCulture))%" width="@((fraction * (1.0 - gapPercent)).ToString(CultureInfo.InvariantCulture))%" height="@((item.Downloads/max*chartFullHeightInPercent).ToString(CultureInfo.InvariantCulture))%">
                                         <title>@(item.Downloads) downloads</title>
                                     </rect>
 
-                                        <svg x="@(widthOffsetPercent + index * fraction + fraction/2.0 - 2.5)%" y="@(chartFullHeightInPercent + 1)%">
+                                        <svg x="@((widthOffsetPercent + index * fraction + fraction/2.0 - 2.5).ToString(CultureInfo.InvariantCulture))%" y="@((chartFullHeightInPercent + 1).ToString(CultureInfo.InvariantCulture))%">
                                             <g transform="rotate(-45)">
                                                 <text y="1.5em" x="-0.9em" class="graph-x-axis-text"> @(item.Version)</text>
                                             </g>
@@ -126,7 +127,7 @@
 
                                 for (var i = 0; i < numYAxisLabels; i++)
                                 {
-                                    @:<text class="graph-y-axis-text" x="0" y="@(i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
+                                    @:<text class="graph-y-axis-text" x="0" y="@((i / numYAxisLabels * chartFullHeightInPercent).ToString(CultureInfo.InvariantCulture))%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
                                 }
                         }
                         </svg>
@@ -180,22 +181,22 @@
                                     centerY = topOffset + chartFullHeightInPercent - item.Downloads / max * chartFullHeightInPercent;
                                     if (prevCenterY >= 0 && prevCenterX >= 0 && prevItem != null)
                                     {
-                                        <line class="graph-line" x1="@prevCenterX%" y1="@prevCenterY%" x2="@centerX%" y2="@centerY%" />
-                                            <circle class="graph-dot" id="graph-dot-@(prevItem.Year)-@(prevItem.WeekOfYear)" cx="@prevCenterX%" cy="@prevCenterY%" r="5px">
+                                        <line class="graph-line" x1="@((prevCenterX).ToString(CultureInfo.InvariantCulture))%" y1="@((prevCenterY).ToString(CultureInfo.InvariantCulture))%" x2="@((centerX).ToString(CultureInfo.InvariantCulture))%" y2="@((centerY).ToString(CultureInfo.InvariantCulture))%" />
+                                            <circle class="graph-dot" id="graph-dot-@(prevItem.Year)-@(prevItem.WeekOfYear)" cx="@((prevCenterX).ToString(CultureInfo.InvariantCulture))%" cy="@((prevCenterY).ToString(CultureInfo.InvariantCulture))%" r="5px">
                                                 <title>@(prevItem.Downloads) downloads</title>
                                             </circle>
                                     }
 
-                                    <circle class="graph-dot" id="graph-dot-@(item.Year)-@(item.WeekOfYear)" cx="@centerX%" cy="@centerY%" r="5px">
+                                    <circle class="graph-dot" id="graph-dot-@(item.Year)-@(item.WeekOfYear)" cx="@((centerX).ToString(CultureInfo.InvariantCulture))%" cy="@((centerY).ToString(CultureInfo.InvariantCulture))%" r="5px">
                                         <title>@(item.Downloads) downloads</title>
                                     </circle>
 
-                                        <svg x="@(widthOffsetPercent + index * fraction + fraction/2.0 - 5)%" y="@(topOffset + chartFullHeightInPercent + 2)%">
-                                            <g transform="rotate(-45)">
-                                                <text y="2.6em" x="-2.0em" class="graph-x-axis-date">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.StartOnly)-</text>
-                                                <text y="2.6em" x="-2.0em" class="graph-x-axis-date" dy="1em">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.EndOnly)</text>
-                                            </g>
-                                        </svg>
+                                    <svg x="@((widthOffsetPercent + index * fraction + fraction/2.0 - 5).ToString(CultureInfo.InvariantCulture))%" y="@((topOffset + chartFullHeightInPercent + 2).ToString(CultureInfo.InvariantCulture))%">
+                                        <g transform="rotate(-45)">
+                                            <text y="2.6em" x="-2.0em" class="graph-x-axis-date">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.StartOnly)-</text>
+                                            <text y="2.6em" x="-2.0em" class="graph-x-axis-date" dy="1em">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.EndOnly)</text>
+                                        </g>
+                                    </svg>
 
                                     prevCenterX = widthOffsetPercent + index * fraction + fraction / 3;
                                     prevCenterY = topOffset + chartFullHeightInPercent - item.Downloads / max * chartFullHeightInPercent;
@@ -205,7 +206,7 @@
 
                                 for (var i = 0; i < numYAxisLabels; i++)
                                 {
-                                    @:<text class="graph-y-axis-text" x="0" y="@(topOffset + i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
+                                    @:<text class="graph-y-axis-text" x="0" y="@((topOffset + i / numYAxisLabels * chartFullHeightInPercent).ToString(CultureInfo.InvariantCulture))%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
                                 }
 
                         }

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -6,6 +6,14 @@
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
+@functions
+{
+    private static string Format(double input)
+    {
+        return input.ToString(CultureInfo.InvariantCulture);
+    }
+}
+
 <section class="container main-container page-statistics-overview">
     <h1>Statistics</h1>
     <span class="page-subheading ms-fontSize-l">
@@ -118,11 +126,11 @@
                                 var fraction = chartFullWidthInPercent / showVersions.Count();
                                 foreach (var item in showVersions)
                                 {
-                                    <rect class="graph-bar" id="graph-bar-@(item.Version)" x="@((widthOffsetPercent + index * fraction).ToString(CultureInfo.InvariantCulture))%" y="@((chartFullHeightInPercent-item.Downloads/max*chartFullHeightInPercent).ToString(CultureInfo.InvariantCulture))%" width="@((fraction * (1.0 - gapPercent)).ToString(CultureInfo.InvariantCulture))%" height="@((item.Downloads/max*chartFullHeightInPercent).ToString(CultureInfo.InvariantCulture))%">
+                                    <rect class="graph-bar" id="graph-bar-@(item.Version)" x="@Format(widthOffsetPercent + index * fraction)%" y="@Format(chartFullHeightInPercent-item.Downloads/max*chartFullHeightInPercent)%" width="@Format(fraction * (1.0 - gapPercent))%" height="@Format(item.Downloads/max*chartFullHeightInPercent)%">
                                         <title>@(item.Downloads) downloads</title>
                                     </rect>
 
-                                        <svg x="@((widthOffsetPercent + index * fraction + fraction/2.0 - 2.5).ToString(CultureInfo.InvariantCulture))%" y="@((chartFullHeightInPercent + 1).ToString(CultureInfo.InvariantCulture))%">
+                                        <svg x="@Format(widthOffsetPercent + index * fraction + fraction/2.0 - 2.5)%" y="@Format(chartFullHeightInPercent + 1)%">
                                             <g transform="rotate(-45)">
                                                 <text y="1.5em" x="-0.9em" class="graph-x-axis-text"> @(item.Version)</text>
                                             </g>
@@ -132,7 +140,7 @@
 
                                 for (var i = 0; i < numYAxisLabels; i++)
                                 {
-                                    @:<text class="graph-y-axis-text" x="0" y="@((i / numYAxisLabels * chartFullHeightInPercent).ToString(CultureInfo.InvariantCulture))%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
+                                    @:<text class="graph-y-axis-text" x="0" y="@Format(i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
                                 }
                             }
                         </svg>
@@ -187,17 +195,17 @@
                                     centerY = topOffset + chartFullHeightInPercent - item.Downloads / max * chartFullHeightInPercent;
                                     if (prevCenterY >= 0 && prevCenterX >= 0 && prevItem != null)
                                     {
-                                        <line class="graph-line" x1="@((prevCenterX).ToString(CultureInfo.InvariantCulture))%" y1="@((prevCenterY).ToString(CultureInfo.InvariantCulture))%" x2="@((centerX).ToString(CultureInfo.InvariantCulture))%" y2="@((centerY).ToString(CultureInfo.InvariantCulture))%" />
-                                            <circle class="graph-dot" id="graph-dot-@(prevItem.Year)-@(prevItem.WeekOfYear)" cx="@((prevCenterX).ToString(CultureInfo.InvariantCulture))%" cy="@((prevCenterY).ToString(CultureInfo.InvariantCulture))%" r="5px">
+                                        <line class="graph-line" x1="@Format(prevCenterX)%" y1="@Format(prevCenterY)%" x2="@Format(centerX)%" y2="@Format(centerY)%" />
+                                            <circle class="graph-dot" id="graph-dot-@(prevItem.Year)-@(prevItem.WeekOfYear)" cx="@Format(prevCenterX)%" cy="@Format(prevCenterY)%" r="5px">
                                                 <title>@(prevItem.Downloads) downloads</title>
                                             </circle>
                                     }
 
-                                    <circle class="graph-dot" id="graph-dot-@(item.Year)-@(item.WeekOfYear)" cx="@((centerX).ToString(CultureInfo.InvariantCulture))%" cy="@((centerY).ToString(CultureInfo.InvariantCulture))%" r="5px">
+                                    <circle class="graph-dot" id="graph-dot-@(item.Year)-@(item.WeekOfYear)" cx="@Format(centerX)%" cy="@Format(centerY)%" r="5px">
                                         <title>@(item.Downloads) downloads</title>
                                     </circle>
 
-                                    <svg x="@((widthOffsetPercent + index * fraction + fraction/2.0 - 5).ToString(CultureInfo.InvariantCulture))%" y="@((topOffset + chartFullHeightInPercent + 2).ToString(CultureInfo.InvariantCulture))%">
+                                    <svg x="@Format(widthOffsetPercent + index * fraction + fraction/2.0 - 5)%" y="@Format(topOffset + chartFullHeightInPercent + 2)%">
                                         <g transform="rotate(-45)">
                                             <text y="2.6em" x="-2.0em" class="graph-x-axis-date">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.StartOnly)-</text>
                                             <text y="2.6em" x="-2.0em" class="graph-x-axis-date" dy="1em">@Model.DisplayWeek(item.Year, item.WeekOfYear, StatisticsPackagesViewModel.WeekFormats.EndOnly)</text>
@@ -212,7 +220,7 @@
 
                                 for (var i = 0; i < numYAxisLabels; i++)
                                 {
-                                    @:<text class="graph-y-axis-text" x="0" y="@((topOffset + i / numYAxisLabels * chartFullHeightInPercent).ToString(CultureInfo.InvariantCulture))%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
+                                    @:<text class="graph-y-axis-text" x="0" y="@Format(topOffset + i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
                                 }
 
                             }


### PR DESCRIPTION
Addresses issue https://github.com/NuGet/NuGetGallery/issues/4450
The problem was that when the svg was being generated, the floating point numbers were being rendered with commas as decimal separators, which SVG render didn't understand.

Fix was to make this part of rendering culture invariant.

@joelverhagen 