### PR TITLE
[Redesign]Addressing some more Accessibility issues

### DIFF
--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -31,9 +31,9 @@
                         @Html.ValidationSummary(true)
 
                         <div class="input-group">
-                            <input type="text" class="form-control" id="file-select-feedback" value="Browse to select a package file..." readonly />
+                            <input type="text" class="form-control" id="file-select-feedback" value="Browse or Drop files to select a package..." aria-label="Upload Your Package" readonly />
                             <label for="input-select-file" id="PackageFileLabel" class="input-group-btn">
-                                <span id="browse-for-package-button" class="btn btn-primary form-control" tabindex="0">
+                                <span id="browse-for-package-button" class="btn btn-primary form-control" tabindex="0" aria-label="Browse for package" role="button">
                                     Browse&hellip;<input type="file" name="UploadFile" accept=".nupkg" aria-labelledby="PackageFileLabel" id="input-select-file" style="display:none;" />
                                 </span>
                             </label>

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -33,7 +33,7 @@
                         <div class="input-group">
                             <input type="text" class="form-control" id="file-select-feedback" value="Browse to select a package file..." readonly />
                             <label for="input-select-file" id="PackageFileLabel" class="input-group-btn">
-                                <span id="browse-for-package-button" class="btn btn-primary form-control">
+                                <span id="browse-for-package-button" class="btn btn-primary form-control" tabindex="0">
                                     Browse&hellip;<input type="file" name="UploadFile" accept=".nupkg" aria-labelledby="PackageFileLabel" id="input-select-file" style="display:none;" />
                                 </span>
                             </label>
@@ -83,6 +83,14 @@
         var InProgressPackage = @Html.Raw(Json.Encode(Model.InProgressUpload));
         window.nuget.configureExpanderHeading("upload-package-form");
         $(function () {
+            $("#browse-for-package-button").on("keypress", function (e) {
+                var keyCode = (e.keyCode || e.which);
+                var isInteract = (code == 13 /*enter*/ || code == 32 /*space*/) && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+                if (isInteract) {
+                    $(this).click();
+                }
+            });
+
             AsyncFileUploadManager.init(
                 '@Url.Action(actionName: "UploadPackageProgress", controllerName: "Packages")',
                 'uploadForm',

--- a/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
@@ -102,33 +102,33 @@
 
                 <!--BEGIN EDITABLE FIELDS-->
                 <div class="verify-package-field form-group editable">
-                    <div class="verify-package-field-heading">Title</div>
+                    <label for="title-field" class="verify-package-field-heading">Title</label>
                     <input data-bind="value: Edit.VersionTitle" type="text" class="form-control" name="Edit.VersionTitle" id="title-field" />
                 </div>
 
                 <div class="verify-package-field form-group editable">
-                    <div class="verify-package-field-heading">Description</div>
+                    <label for="description-field" class="verify-package-field-heading">Description</label>
                     <textarea data-bind="value: Edit.Description" class="form-control tall-text-input" name="Edit.Description" id="description-field" />
                 </div>
 
                 <div class="verify-package-field form-group editable">
-                    <div class="verify-package-field-heading">Summary (shown on package search page)</div>
+                    <div class="verify-package-field-heading"><label for="summary-field">Summary</label> (shown on package search page)</div>
                     <textarea data-bind="value: Edit.Summary" class="form-control tall-text-input" name="Edit.Summary" id="summary-field" />
                 </div>
 
                 <div class="verify-package-field form-group editable">
-                    <div class="verify-package-field-heading">Release Notes (for this version)</div>
+                    <div class="verify-package-field-heading"><label for="releasenotes-field">Release Notes</label> (for this version)</div>
                     <textarea data-bind="value: Edit.ReleaseNotes" class="form-control tall-text-input" name="Edit.ReleaseNotes" id="releasenotes-field" />
                 </div>
 
                 <div class="verify-package-field form-group editable">
-                    <div class="verify-package-field-heading">Project URL</div>
+                    <label for="projecturl-field" class="verify-package-field-heading">Project URL</label>
                     <input data-bind="value: Edit.ProjectUrl" type="text" class="form-control" name="Edit.ProjectUrl" id="projecturl-field" />
                 </div>
 
                 <div class="verify-package-field form-group editable">
                     <!-- Bind an on change event here to update the preview below-->
-                    <div class="verify-package-field-heading">Icon URL</div>
+                    <label for="iconurl-field" class="verify-package-field-heading">Icon URL</label>
                     <input data-bind="value: Edit.IconUrl" type="text" class="form-control" name="Edit.IconUrl" id="iconurl-field" />
                 </div>
 
@@ -145,18 +145,18 @@
                 </div>
 
                 <div class="verify-package-field form-group editable">
-                    <div class="verify-package-field-heading">Authors (comma separated - e.g. 'Anna, Bob, Carl')</div>
-                    <input data-bind="value: Edit.Authors" type="text" class="form-control" name="Edit.Authors" />
+                    <div class="verify-package-field-heading"><label for="authors-field">Authors</label> (comma separated - e.g. 'Anna, Bob, Carl')</div>
+                    <input data-bind="value: Edit.Authors" type="text" class="form-control" name="Edit.Authors" id="authors-field" />
                 </div>
 
                 <div class="verify-package-field form-group editable">
-                    <div class="verify-package-field-heading">Copyright</div>
-                    <input data-bind="value: Edit.Copyright" type="text" class="form-control" name="Edit.Copyright" />
+                    <label for="copyright-field" class="verify-package-field-heading">Copyright</label>
+                    <input data-bind="value: Edit.Copyright" type="text" class="form-control" name="Edit.Copyright" id="copyright-field" />
                 </div>
 
                 <div class="verify-package-field form-group editable">
-                    <div class="verify-package-field-heading">Tags (space separated - e.g. 'ASP.NET Template MVC')</div>
-                    <input data-bind="value: Edit.Tags" type="text" class="form-control" name="Edit.Tags" />
+                    <div class="verify-package-field-heading"><label for="tags-field">Tags</label> (space separated - e.g. 'ASP.NET Template MVC')</div>
+                    <input data-bind="value: Edit.Tags" type="text" class="form-control" name="Edit.Tags" id="tags-field" />
                 </div>
 
                 <!-- ko if: $data.LicenseUrl -->

--- a/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
+++ b/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
@@ -60,11 +60,13 @@
                         <tbody data-bind="foreach: HiddenRows" class="collapse" id="hidden-rows"></tbody>
 
                     </table>
+                    <!-- ko if: $data.reportSize > 6 -->
                     <button data-bind="if: $data.reportSize > 6, click: $data.SetupHiddenRows" type="button" data-toggle="collapse" class="btn btn-link btn-expander icon-link" data-target="#hidden-rows"
                             aria-expanded="false" aria-controls="hidden-rows" id="show-hidden-rows">
                         <i class="ms-Icon ms-Icon--CalculatorAddition" aria-hidden="true"></i>
                         <span>Show more</span>
                     </button>
+                    <!-- /ko -->
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Addresses the Following:
 - 467730: "Browse" Button is not accessible using keyboard in "Upload your package" page. 
   - Made Browse button have a tab stop. Added a hook to enter and space keys to trigger the file dialog.
 - 469489: Name property value is null for all the edit field  present in "Upload your package" page.
   - Added an aria-label. Hooked up the labels to the proper input boxes.
 - 470353: Keyboard focus is going to invisible elements in View full status package page. 
   - Removed the offending element. It wasn't supposed to be there.

@joelverhagen @microsoftsam @jonwchu 