### PR TITLE
[Redesign]Fix structure of alerts for screen-readers

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -40,13 +40,9 @@
 
 @helper Alert(Func<MvcHtmlString, HelperResult> htmlContent, string subclass, string icon, bool isAlertRole = false)
 {
-    <div class="alert alert-@subclass" @if (isAlertRole) { <text> role="alert" aria-live="assertive" </text>   }>
-        <ul class="list-unstyled ms-Icon-ul">
-            <li>
-                <i class="ms-Icon ms-Icon--@icon" aria-hidden="true"></i>
-                @htmlContent(MvcHtmlString.Empty)
-            </li>
-        </ul>
+    <div class="icon-link alert alert-@subclass" @if (isAlertRole) { <text> role="alert" aria-live="assertive" </text>   }>
+        <i class="ms-Icon ms-Icon--@icon" aria-hidden="true"></i>
+        @htmlContent(MvcHtmlString.Empty)
     </div>
 }
 

--- a/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
@@ -1,12 +1,8 @@
 ﻿<script type="text/html" id="validation-errors">
     <div data-bind="foreach:$data" class="validation-error-message-list">
-        <div class="alert alert-danger" role="alert" aria-live="assertive">
-            <ul class="list-unstyled ms-Icon-ul">
-                <li>
-                    <i class="ms-Icon ms-Icon--ErrorBadge" aria-hidden="true"></i>
-                    <span data-bind="text:$data"></span>
-                </li>
-            </ul>
+        <div class="icon-link alert alert-danger" role="alert" aria-live="assertive">
+            <i class="ms-Icon ms-Icon--ErrorBadge" aria-hidden="true"></i>
+            <span data-bind="text:$data"></span>
         </div>
     </div>
 </script>

--- a/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
@@ -1,9 +1,6 @@
 ﻿<script type="text/html" id="validation-errors">
     <div data-bind="foreach:$data" class="validation-error-message-list">
-        <div class="icon-link alert alert-danger" role="alert" aria-live="assertive">
-            <i class="ms-Icon ms-Icon--ErrorBadge" aria-hidden="true"></i>
-            <span data-bind="text:$data"></span>
-        </div>
+        @ViewHelpers.AlertDanger(@<text><span data-bind="text:$data"></span></text>)
     </div>
 </script>
 


### PR DESCRIPTION
Fixes a small issue with the alert dialogs that was causing them to not be able to have their content read out by screen readers.

@joelverhagen @microsoftsam