### PR TITLE
Upload README html sanitization and E2E fixes

### DIFF
--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -135,6 +135,11 @@ namespace NuGetGallery
                 new { controller = "Packages", action = "VerifyPackage" });
 
             routes.MapRoute(
+                            "PreviewReadMe",
+                            "packages/manage/preview-readme",
+                            new { controller = "Packages", action = "PreviewReadMe" });
+
+            routes.MapRoute(
                 RouteName.CancelUpload,
                 "packages/manage/cancel-upload",
                 new { controller = "Packages", action = "CancelUpload" });

--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -135,9 +135,9 @@ namespace NuGetGallery
                 new { controller = "Packages", action = "VerifyPackage" });
 
             routes.MapRoute(
-                            "PreviewReadMe",
-                            "packages/manage/preview-readme",
-                            new { controller = "Packages", action = "PreviewReadMe" });
+                RouteName.PreviewReadMe,
+                "packages/manage/preview-readme",
+                new { controller = "Packages", action = "PreviewReadMe" });
 
             routes.MapRoute(
                 RouteName.CancelUpload,

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1049,7 +1049,6 @@ namespace NuGetGallery
         [RequiresAccountConfirmation("edit a package")]
         public virtual async Task<JsonResult> Edit(string id, string version, VerifyPackageRequest formData, string returnUrl)
         {
-
             var package = _packageService.FindPackageByIdAndVersion(id, version);
             if (package == null)
             {
@@ -1073,7 +1072,35 @@ namespace NuGetGallery
             {
                 try
                 {
-                    formData.Edit.ReadMeState = PackageEditReadMeState.Unchanged;
+                    // Checks to see if a ReadMe file has been added and uploads ReadMe
+                    // Add the edit request to a queue where it will be processed in the background.
+                    var readMeChanged = PackageEditReadMeState.Unchanged;
+
+                    if (ReadMeHelper.HasReadMe(formData.ReadMe))
+                    {
+                        readMeChanged = PackageEditReadMeState.Changed;
+                        try
+                        {
+                            using (var readMeInputStream = ReadMeHelper.GetReadMeMarkdownStream(formData.ReadMe).AsSeekableStream())
+                            {
+                                await _packageFileService.SaveReadMeFileAsync(package, readMeInputStream);
+                            }
+                        }
+                        catch (Exception ex) when (
+                            ex is InvalidOperationException
+                            || ex is ArgumentException
+                            || ex is ArgumentNullException
+                        )
+                        {
+                            TempData["Message"] = ex.Message;
+
+                            Response.StatusCode = 400;
+                            return Json(new string[] { ex.GetUserSafeMessage() });
+                        }
+                    }
+
+                    formData.ReadMe.ReadMeState = readMeChanged;
+
                     _editPackageService.StartEditPackageRequest(package, formData.Edit, user);
                     await _entitiesContext.SaveChangesAsync();
 

--- a/src/NuGetGallery/Helpers/ReadMeHelper.cs
+++ b/src/NuGetGallery/Helpers/ReadMeHelper.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery.Helpers
         private const string TypeUrl = "Url";
         private const string TypeFile = "File";
         private const string TypeWritten = "Written";
-        private const string UriHostRequirement = "https://raw.githubusercontent.com";
+        private const string UriHostRequirement = "raw.githubusercontent.com";
         private const int UrlTimeout = 10000;
         private const int MaxFileSize = 40000;
 
@@ -44,7 +44,7 @@ namespace NuGetGallery.Helpers
         /// <returns>A string containing the HTML version of the markdown</returns>
         private static string ConvertMarkDownToHtml(string readMe)
         {
-            return CommonMark.CommonMarkConverter.Convert(readMe);
+            return CommonMark.CommonMarkConverter.Convert(readMe).Trim();
         }
 
         /// <summary>

--- a/src/NuGetGallery/Helpers/ReadMeHelper.cs
+++ b/src/NuGetGallery/Helpers/ReadMeHelper.cs
@@ -4,18 +4,21 @@
 using System;
 using System.IO;
 using System.Net;
+using CommonMark;
+using Ganss.XSS;
 
 namespace NuGetGallery.Helpers
 {
     internal static class ReadMeHelper
     {
-
         private const string TypeUrl = "Url";
         private const string TypeFile = "File";
         private const string TypeWritten = "Written";
         private const string UriHostRequirement = "raw.githubusercontent.com";
         private const int UrlTimeout = 10000;
         private const int MaxFileSize = 40000;
+
+        private static Lazy<HtmlSanitizer> Sanitizer = new Lazy<HtmlSanitizer>(() => new HtmlSanitizer());
 
         /// <summary>
         /// Returns if posted package form contains a ReadMe.
@@ -44,7 +47,8 @@ namespace NuGetGallery.Helpers
         /// <returns>A string containing the HTML version of the markdown</returns>
         private static string ConvertMarkDownToHtml(string readMe)
         {
-            return CommonMark.CommonMarkConverter.Convert(readMe).Trim();
+            var html = CommonMarkConverter.Convert(readMe).Trim();
+            return Sanitizer.Value.Sanitize(html);
         }
 
         /// <summary>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -93,6 +93,9 @@
     <CodeAnalysisRuleSet>..\Frontend.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
+    </Reference>
     <Reference Include="AnglicanGeek.MarkdownMailer, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\AnglicanGeek.MarkdownMailer.1.2\lib\net40\AnglicanGeek.MarkdownMailer.dll</HintPath>
@@ -148,6 +151,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\entityframework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="HtmlSanitizer, Version=3.0.0.0, Culture=neutral, PublicKeyToken=61c49a1a9e79cc28, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\HtmlSanitizer.3.4.156\lib\net45\HtmlSanitizer.dll</HintPath>
     </Reference>
     <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>

--- a/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
-using System.Web;
 using NuGetGallery.Packaging;
 
 namespace NuGetGallery
@@ -39,6 +38,8 @@ namespace NuGetGallery
             Summary = packageMetadata.Summary;
             Tags = PackageHelper.ParseTags(packageMetadata.Tags);
             VersionTitle = packageMetadata.Title;
+
+            ReadMe = new ReadMeRequest();
         }
 
         public EditPackageVersionRequest(Package package, PackageEdit pendingMetadata)
@@ -71,6 +72,8 @@ namespace NuGetGallery
             Tags = metadata.Tags;
             VersionTitle = metadata.Title;
             ReadMeState = metadata.ReadMeState;
+
+            ReadMe = new ReadMeRequest();
         }
 
         // We won't show this in the UI, and we won't actually honor edits to it at the moment, by our current policy.
@@ -134,6 +137,8 @@ namespace NuGetGallery
         public bool RequiresLicenseAcceptance { get; set; }
 
         public PackageEditReadMeState ReadMeState { get; set; }
+
+        public ReadMeRequest ReadMe { get; set; }
 
         /// <summary>
         /// Applied the edit to a package

--- a/src/NuGetGallery/RequestModels/ReadMeRequest.cs
+++ b/src/NuGetGallery/RequestModels/ReadMeRequest.cs
@@ -1,19 +1,22 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Web;
+using System.Web.Mvc;
 
 namespace NuGetGallery
 {
     public class ReadMeRequest
     {
         public virtual HttpPostedFileBase ReadMeFile { get; set; }
+
+        [AllowHtml]
         public virtual string ReadMeWritten { get; set; }
+
         public virtual string ReadMeUrl { get; set; }
+
         public virtual string ReadMeType { get; set; }
+
         public PackageEditReadMeState ReadMeState { get; set; }
     }
 }

--- a/src/NuGetGallery/RouteNames.cs
+++ b/src/NuGetGallery/RouteNames.cs
@@ -36,6 +36,7 @@ namespace NuGetGallery
         public const string PasswordSet = "PasswordSet";
         public const string NewSubmission = "NewSubmission";
         public const string VerifyPackage = "VerifyPackage";
+        public const string PreviewReadMe = "PreviewReadMe";
         public const string CreatePackageVerificationKey = "CreatePackageVerificationKey";
         public const string VerifyPackageKey = "VerifyPackageKey";
         public const string CancelUpload = "CancelUpload";

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -265,7 +265,7 @@ var AsyncFileUploadManager = new function () {
         $(reportContainerElement).attr("id", "verify-package-block");
         $(reportContainerElement).attr("class", "collapse in");
         $(reportContainerElement).attr("aria-expanded", "true");
-        $(reportContainerElement).attr("data-bind", "template: { name: 'verify-metadata-template', data: data }");
+        $(reportContainerElement).attr("data-bind", "template: { name: 'edit-metadata-template', data: data }");
         $("#verify-package-container").append(reportContainerElement);
         ko.applyBindings({ data: model }, reportContainerElement);
 

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -310,7 +310,7 @@ var AsyncFileUploadManager = new function () {
         $("#verify-collapser-container").removeClass("hidden");
         $("#readme-collapser-container").removeClass("hidden");
         $("#submit-collapser-container").removeClass("hidden");
-        
+
         window.nuget.configureExpander(
             "verify-package-form",
             "ChevronRight",

--- a/src/NuGetGallery/Scripts/gallery/page-edit.js
+++ b/src/NuGetGallery/Scripts/gallery/page-edit.js
@@ -28,7 +28,7 @@ var EditViewManager = new function () {
             document.location = $(this).val();
         });
 
-        $('input[type="text"], input[type="checkbox"], textarea').on('change keydown', function () {
+        $('input[type="text"], input[type="checkbox"], input[type="url"], textarea').on('change keydown', function () {
             $(this).addClass("edited");
             _changedState[$(this).attr('id')] = true;
             $('#verify-submit-button').removeAttr('disabled');
@@ -83,7 +83,7 @@ var EditViewManager = new function () {
         formData.append("ReadMeWritten", $("#readme-written").val());
 
         $.ajax({
-            url: "preview-readme",
+            url: "/packages/manage/preview-readme",
             type: 'POST',
             contentType: false,
             processData: false,
@@ -206,7 +206,7 @@ var EditViewManager = new function () {
         $(readMeContainerElement).attr("aria-expanded", "true");
         $(readMeContainerElement).attr("data-bind", "template: { name: 'import-readme-template', data: data }");
         $("#import-readme-container").append(readMeContainerElement);
-        ko.applyBindings({ data: model }, readMeContainerElement);
+        ko.applyBindings({ data: model.Edit }, readMeContainerElement);
 
         var submitContainerElement = document.createElement("div");
         $(submitContainerElement).attr("id", "submit-block");

--- a/src/NuGetGallery/Scripts/gallery/page-edit.js
+++ b/src/NuGetGallery/Scripts/gallery/page-edit.js
@@ -196,7 +196,7 @@ var EditViewManager = new function () {
         $(reportContainerElement).attr("id", "verify-package-block");
         $(reportContainerElement).attr("class", "collapse in");
         $(reportContainerElement).attr("aria-expanded", "true");
-        $(reportContainerElement).attr("data-bind", "template: { name: 'verify-metadata-template', data: data }");
+        $(reportContainerElement).attr("data-bind", "template: { name: 'edit-metadata-template', data: data }");
         $("#verify-package-container").append(reportContainerElement);
         ko.applyBindings({ data: model }, reportContainerElement);
 

--- a/src/NuGetGallery/Services/IPackageFileService.cs
+++ b/src/NuGetGallery/Services/IPackageFileService.cs
@@ -34,7 +34,7 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="package">The package that this file belongs to</param>
         /// <param name="readMe">The stream representing the ReadMe file</param>
-        Task SaveReadMeFileAsync(Package package, Stream readMe, string fileExtension);
+        Task SaveReadMeFileAsync(Package package, Stream readMe);
 
         /// <summary>
         ///     Copies the contents of the package represented by the stream into the file storage backup location.
@@ -49,6 +49,6 @@ namespace NuGetGallery
         /// <summary>
         ///     Downloads the README from the file storage and reads it into a Stream asynchronously.
         /// </summary>
-        Task<Stream> DownloadReadmeFileAsync(Package package, string extension);
+        Task<Stream> DownloadReadmeFileAsync(Package package);
     }
 }

--- a/src/NuGetGallery/Services/PackageFileService.cs
+++ b/src/NuGetGallery/Services/PackageFileService.cs
@@ -65,17 +65,14 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="package">The package to which this readme belongs.</param>
         /// <param name="readMe">The stream representing the readme's data.</param>
-        public Task SaveReadMeFileAsync(Package package, Stream readMe, string fileExtension)
+        public Task SaveReadMeFileAsync(Package package, Stream readMe)
         {
             if (readMe == null)
             {
                 throw new ArgumentNullException(nameof(readMe));
             }
-            if (string.IsNullOrEmpty(fileExtension))
-            {
-                throw new ArgumentException(nameof(fileExtension));
-            }
-            var fileName = BuildFileName(package, Constants.ReadMeFileSavePathTemplatePending, fileExtension);
+
+            var fileName = BuildFileName(package, Constants.ReadMeFileSavePathTemplatePending, Constants.MarkdownFileExtension);
             return _fileStorageService.SaveFileAsync(Constants.PackagesReadMeFolderName, fileName, readMe, overwrite:false);
         }
 
@@ -109,15 +106,16 @@ namespace NuGetGallery
             return (await _fileStorageService.GetFileAsync(Constants.PackagesFolderName, fileName));
         }
         
-        public Task<Stream> DownloadReadmeFileAsync(Package package, string extension)
+        public Task<Stream> DownloadReadmeFileAsync(Package package)
         {
             if (package == null)
             {
                 throw new ArgumentNullException("Package cannot be null!");
             }
-            var fileName = BuildFileName(package, Constants.ReadMeFileSavePathTemplateActive, extension);
+            var fileName = BuildFileName(package, Constants.ReadMeFileSavePathTemplateActive, Constants.MarkdownFileExtension);
             return  _fileStorageService.GetFileAsync(Constants.PackagesReadMeFolderName, fileName);
         }
+
         private static string BuildFileName(string id, string version, string pathTemplate, string extension)
         {
             if (id == null)

--- a/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
@@ -48,7 +48,7 @@
     </div>
 </script>
 
-<script type="text/html" id="verify-metadata-template">
+<script type="text/html" id="edit-metadata-template">
     <div class="collapse in">
         <div data-bind="if: $data">
 

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AngleSharp" version="0.9.9" targetFramework="net46" />
   <package id="AnglicanGeek.MarkdownMailer" version="1.2" targetFramework="net46" />
   <package id="AnglicanGeek.WindowsAzure.ServiceRuntime" version="1.6" targetFramework="net46" />
   <package id="Antlr" version="3.4.1.9004" targetFramework="net46" />
@@ -16,6 +17,7 @@
   <package id="elmah.strongname" version="1.2.2" targetFramework="net46" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net46" />
   <package id="FontAwesome" version="3.0.2.3" targetFramework="net46" />
+  <package id="HtmlSanitizer" version="3.4.156" targetFramework="net46" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net46" />
   <package id="jQuery" version="1.11.0" targetFramework="net46" />
   <package id="jQuery.UI.Combined" version="1.10.3" targetFramework="net46" />
@@ -90,8 +92,8 @@
   <package id="NuGet.Packaging.Core" version="4.3.0-preview1-2524" targetFramework="net46" />
   <package id="NuGet.Protocol" version="4.3.0-preview1-2524" targetFramework="net46" />
   <package id="NuGet.Services.KeyVault" version="1.0.0.0" targetFramework="net46" />
-  <package id="NuGet.Services.Owin" version="2.2.3" targetFramework="net46" />
   <package id="NuGet.Services.Logging" version="2.2.3.0" targetFramework="net46" />
+  <package id="NuGet.Services.Owin" version="2.2.3" targetFramework="net46" />
   <package id="NuGet.Services.Platform.Client" version="3.0.29-r-master" targetFramework="net46" />
   <package id="NuGet.Versioning" version="4.3.0-preview1-2524" targetFramework="net46" />
   <package id="ODataNullPropagationVisitor" version="0.5.4237.2641" targetFramework="net46" />

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -459,10 +459,10 @@ namespace NuGetGallery
             [Fact]
             public async Task GivenAValidPackageWithReadMeItDisplaysReadMe()
             {
-                //Arrange
+                // Arrange
                 var readMeStream = new MemoryStream(Encoding.UTF8.GetBytes("<p>Hello World!</p>"));
                 
-                //Act
+                // Act
                 var result = await GetDisplayPackageResultWithReadMeStream(readMeStream, true);
 
                 // Assert
@@ -473,10 +473,10 @@ namespace NuGetGallery
             [Fact]
             public async Task GivenAPackageWithReadMeHandlesFailedDownload()
             {
-                //Arrange and Act
+                // Arrange & Act
                 var result = await GetDisplayPackageResultWithReadMeStream((Stream)null, true);
 
-                //Assert
+                // Assert
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Null(model.ReadMeHtml);
             }
@@ -487,7 +487,7 @@ namespace NuGetGallery
                 // Arrange and Act
                 var result = await GetDisplayPackageResultWithReadMeStream((Stream)null, false);
 
-                //Assert
+                // Assert
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Null(model.ReadMeHtml);
             }
@@ -1899,7 +1899,7 @@ namespace NuGetGallery
                     var fakeEditPackageService = new Mock<EditPackageService>();
 
                     var fakePackageFileService = new Mock<IPackageFileService>();
-                    fakePackageFileService.Setup(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>(), It.IsAny<String>())).Returns(Task.CompletedTask);
+                    fakePackageFileService.Setup(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.CompletedTask);
 
                     var controller = CreateController(packageService: packageService, editPackageService: fakeEditPackageService, uploadFileService: fakeUploadFileService, packageFileService: fakePackageFileService);
                     controller.SetCurrentUser(TestUtility.FakeUser);
@@ -1909,7 +1909,7 @@ namespace NuGetGallery
 
                     // Assert 
                     fakeEditPackageService.Verify(x => x.StartEditPackageRequest(fakePackage, edit, TestUtility.FakeUser), Times.Once);
-                    fakePackageFileService.Verify(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>(), It.IsAny<String>()), Times.Never);
+                    fakePackageFileService.Verify(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>()), Times.Never);
                 }
             }
         }
@@ -1952,7 +1952,7 @@ namespace NuGetGallery
                 var fakeEditPackageService = new Mock<EditPackageService>();
 
                 var fakePackageFileService = new Mock<IPackageFileService>();
-                fakePackageFileService.Setup(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>(), It.IsAny<String>())).Returns(Task.CompletedTask);
+                fakePackageFileService.Setup(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.CompletedTask);
                 
                 var controller = CreateController(packageService: packageService, editPackageService: fakeEditPackageService, uploadFileService: fakeUploadFileService, packageFileService: fakePackageFileService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
@@ -1968,9 +1968,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.Equal(PackageEditReadMeState.Changed, fakeVerifyPackageRequest.ReadMe.ReadMeState);
-                fakePackageFileService.Verify(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>(), It.IsAny<String>()), Times.Exactly(2));
-                fakePackageFileService.Verify(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>(), Constants.HtmlFileExtension), Times.Once);
-                fakePackageFileService.Verify(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>(), Constants.MarkdownFileExtension), Times.Once);
+                fakePackageFileService.Verify(x => x.SaveReadMeFileAsync(fakePackage, It.IsAny<Stream>()), Times.Once);
                 fakeEditPackageService.Verify(x => x.StartEditPackageRequest(fakePackage, edit, TestUtility.FakeUser), Times.Once);
             }
         }
@@ -2092,7 +2090,7 @@ namespace NuGetGallery
 
             if (hasReadMe)
             {
-                fileService.Setup(f => f.DownloadReadmeFileAsync(It.IsAny<Package>(), It.IsAny<string>())).Returns(Task.FromResult(readMeHtmlStream));
+                fileService.Setup(f => f.DownloadReadmeFileAsync(It.IsAny<Package>())).Returns(Task.FromResult(readMeHtmlStream));
             }
 
             return await controller.DisplayPackage("Foo", /*version*/null);

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
@@ -455,12 +455,12 @@ namespace NuGetGallery
                     fileStorageSvc.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult((Stream)stream)).Verifiable();
 
                     //Act
-                    var result = await service.DownloadReadmeFileAsync(package, Constants.HtmlFileExtension);
+                    var result = await service.DownloadReadmeFileAsync(package);
                     using (var reader = new StreamReader(result))
                     {
                         //Assert
                         Assert.Equal("<p>Hello World!</p>", await reader.ReadToEndAsync());
-                        fileStorageSvc.Verify(f => f.GetFileAsync(Constants.PackagesReadMeFolderName, "active/foo/1.1.1.html"), Times.Once);
+                        fileStorageSvc.Verify(f => f.GetFileAsync(Constants.PackagesReadMeFolderName, "active/foo/1.1.1.md"), Times.Once);
                     }
                 }
             }
@@ -483,11 +483,11 @@ namespace NuGetGallery
                 fileStorageSvc.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult((Stream)null)).Verifiable();
 
                 //Act
-                var result = await service.DownloadReadmeFileAsync(package, Constants.HtmlFileExtension);
+                var result = await service.DownloadReadmeFileAsync(package);
 
                 //Assert
                 Assert.Null(result);
-                fileStorageSvc.Verify(f => f.GetFileAsync(Constants.PackagesReadMeFolderName, "active/foo/1.1.1.html"), Times.Once);
+                fileStorageSvc.Verify(f => f.GetFileAsync(Constants.PackagesReadMeFolderName, "active/foo/1.1.1.md"), Times.Once);
             }
         }
 


### PR DESCRIPTION
@fayrose @laurenshen @JarahSi 

Changes include:
- Post-rebase fixes for upload E2E (cherry-picked from feature-nuggets)
- Allow HTML input for written README
- Use HtmlSanitizer after MD conversion to protect against XSS
- Edit E2E fixes
