### PR TITLE
Add AntiForgery tokens to some actions that were missing them

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -311,3 +311,10 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
         }
     </li>
 }
+
+@helper AjaxAntiForgeryToken(System.Web.Mvc.HtmlHelper html)
+{
+    <form id="AntiForgeryForm">
+        @html.AntiForgeryToken()
+    </form>
+}

--- a/src/NuGetGallery/Areas/Admin/Controllers/LuceneController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/LuceneController.cs
@@ -55,6 +55,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public virtual Task<ActionResult> Rebuild()
         {
             IndexingService.UpdateIndex(forceRefresh: true);

--- a/src/NuGetGallery/Areas/Admin/Controllers/SecurityPolicyController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/SecurityPolicyController.cs
@@ -71,6 +71,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<JsonResult> Update(List<string> subscriptionsJson)
         {
             var subscribeRequests =  subscriptionsJson?.Select(JsonConvert.DeserializeObject<JObject>)

--- a/src/NuGetGallery/Areas/Admin/Controllers/SupportRequestController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/SupportRequestController.cs
@@ -54,6 +54,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<ActionResult> DisableAdmin(int key)
         {
             try
@@ -69,6 +70,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<ActionResult> EnableAdmin(int key)
         {
             try
@@ -84,6 +86,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<ActionResult> AddAdmin(string galleryUsername, string pagerDutyUsername)
         {
             try
@@ -99,6 +102,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<ActionResult> UpdateAdmin(int key, string galleryUsername, string pagerDutyUsername)
         {
             try
@@ -114,6 +118,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public async Task<ActionResult> Save(int issueKey, int? assignedToId, int issueStatusId, string comment)
         {
             try

--- a/src/NuGetGallery/Areas/Admin/Views/Lucene/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Lucene/Index.cshtml
@@ -31,10 +31,11 @@ else
     </p>
 }
 
-@if(Model.IsLocal) 
+@if (Model.IsLocal)
 {
     using (Html.BeginForm("Rebuild", "Lucene"))
     {
+        @Html.AntiForgeryToken()
         <fieldset class="form">
             <input type="submit" value="Rebuild Now" />
             <p>NOTE: This will only affect the current instance!</p>

--- a/src/NuGetGallery/Areas/Admin/Views/SecurityPolicy/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SecurityPolicy/Index.cshtml
@@ -4,9 +4,7 @@
     ViewBag.Title = "Security Policies";
 }
 
-<form id="AntiForgeryForm">
-    @Html.AntiForgeryToken()
-</form>
+@ViewHelpers.AjaxAntiForgeryToken(Html)
 
 <section>
     <article id="stage">
@@ -73,12 +71,6 @@
     <script src="@Url.Content("~/Scripts/knockout-2.2.1.js")"></script>
     <script>
         $(document).ready(function () {
-            var addAntiForgeryToken = function (data) {
-                var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
-                data["__RequestVerificationToken"] = $field.val();
-                return data;
-            }
-
             var viewModel = function () {
                 var $self = this;
 
@@ -99,7 +91,7 @@
                         cache: false,
                         dataType: 'json',
                         type: 'POST',
-                        data: addAntiForgeryToken({ subscriptionsJson: subscriptions }),
+                        data: addAjaxAntiForgeryToken({ subscriptionsJson: subscriptions }),
                         success: function (data) {
                             $self.changeTracker(false);
                             $self.message("Security policies updated!");

--- a/src/NuGetGallery/Areas/Admin/Views/SecurityPolicy/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SecurityPolicy/Index.cshtml
@@ -4,6 +4,10 @@
     ViewBag.Title = "Security Policies";
 }
 
+<form id="AntiForgeryForm">
+    @Html.AntiForgeryToken()
+</form>
+
 <section>
     <article id="stage">
 
@@ -68,7 +72,13 @@
 @section BottomScripts {
     <script src="@Url.Content("~/Scripts/knockout-2.2.1.js")"></script>
     <script>
-        $(document).ready(function() {
+        $(document).ready(function () {
+            var addAntiForgeryToken = function (data) {
+                var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
+                data["__RequestVerificationToken"] = $field.val();
+                return data;
+            }
+
             var viewModel = function () {
                 var $self = this;
 
@@ -89,8 +99,7 @@
                         cache: false,
                         dataType: 'json',
                         type: 'POST',
-                        data: JSON.stringify(subscriptions),
-                        contentType: 'application/json; charset=utf-8',
+                        data: addAntiForgeryToken({ subscriptionsJson: subscriptions }),
                         success: function (data) {
                             $self.changeTracker(false);
                             $self.message("Security policies updated!");

--- a/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Admins.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Admins.cshtml
@@ -10,11 +10,14 @@
     @Styles.Render("~/Content/supportrequests")
 }
 
+<form id="AntiForgeryForm">
+    @Html.AntiForgeryToken()
+</form>
+
 <section>
     <article id="supportrequests">
         <div style="display: none;" id="addAdmin-dialog">
             <form id="addAdmin-form">
-                @Html.AntiForgeryToken()
                 <fieldset class="form">
                     <legend>Add</legend>
 
@@ -39,7 +42,6 @@
 
         <div style="display: none;" id="editAdmin-dialog">
             <form id="editAdmin-form">
-                @Html.AntiForgeryToken()
                 <fieldset class="form">
                     <legend>Edit</legend>
 
@@ -115,6 +117,12 @@
 
     <script type="text/javascript">
         $(function () {
+            var addAntiForgeryToken = function (data) {
+                var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
+                data["__RequestVerificationToken"] = $field.val();
+                return data;
+            }
+
             function AddAdminViewModel() {
                 var $self = this;
                 this.newGalleryUsername = ko.observable();
@@ -122,18 +130,17 @@
 
                 this.createAdmin = function (success, error) {
                     var url = '@Url.Action("AddAdmin")';
-                    var model = JSON.stringify({
+                    var model = {
                         galleryUsername: $self.newGalleryUsername(),
                         pagerDutyUsername: $self.newPagerDutyUsername()
-                    });
+                    };
 
                     $.ajax({
                         url: url,
                         type: 'POST',
                         cache: false,
                         dataType: 'json',
-                        contentType: 'application/json; charset=utf-8',
-                        data: model,
+                        data: addAntiForgeryToken(model),
                         success: success
                     })
                     .error(error);
@@ -148,19 +155,18 @@
 
                 this.updateAdmin = function (success, error) {
                     var url = '@Url.Action("UpdateAdmin")';
-                    var model = JSON.stringify({
+                    var model = {
                         key: $self.admin.Key,
                         galleryUsername: $self.editGalleryUsername,
                         pagerDutyUsername: $self.editPagerDutyUsername
-                    });
+                    };
 
                     $.ajax({
                         url: url,
                         type: 'POST',
                         cache: false,
                         dataType: 'json',
-                        contentType: 'application/json; charset=utf-8',
-                        data: model,
+                        data: addAntiForgeryToken(model),
                         success: success
                     })
                     .error(error);
@@ -204,9 +210,9 @@
 
                 this.toggleAdminAccess = function (data) {
                     var confirmationText, url;
-                    var model = JSON.stringify({
+                    var model = {
                         key: data.Key
-                    });
+                    };
 
                     if (data.AccessDisabled !== false) {
                         confirmationText = 'Are you sure you want to enable access for ' + data.GalleryUsername + '?';
@@ -222,8 +228,7 @@
                             type: 'POST',
                             cache: false,
                             dataType: 'json',
-                            contentType: 'application/json; charset=utf-8',
-                            data: model,
+                            data: addAntiForgeryToken(model),
                             success: function () {
                                 $self.refresh();
                             }

--- a/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Admins.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Admins.cshtml
@@ -10,9 +10,7 @@
     @Styles.Render("~/Content/supportrequests")
 }
 
-<form id="AntiForgeryForm">
-    @Html.AntiForgeryToken()
-</form>
+@ViewHelpers.AjaxAntiForgeryToken(Html)
 
 <section>
     <article id="supportrequests">
@@ -117,12 +115,6 @@
 
     <script type="text/javascript">
         $(function () {
-            var addAntiForgeryToken = function (data) {
-                var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
-                data["__RequestVerificationToken"] = $field.val();
-                return data;
-            }
-
             function AddAdminViewModel() {
                 var $self = this;
                 this.newGalleryUsername = ko.observable();
@@ -140,7 +132,7 @@
                         type: 'POST',
                         cache: false,
                         dataType: 'json',
-                        data: addAntiForgeryToken(model),
+                        data: addAjaxAntiForgeryToken(model),
                         success: success
                     })
                     .error(error);
@@ -166,7 +158,7 @@
                         type: 'POST',
                         cache: false,
                         dataType: 'json',
-                        data: addAntiForgeryToken(model),
+                        data: addAjaxAntiForgeryToken(model),
                         success: success
                     })
                     .error(error);
@@ -228,7 +220,7 @@
                             type: 'POST',
                             cache: false,
                             dataType: 'json',
-                            data: addAntiForgeryToken(model),
+                            data: addAjaxAntiForgeryToken(model),
                             success: function () {
                                 $self.refresh();
                             }

--- a/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Index.cshtml
@@ -10,6 +10,10 @@
     @Styles.Render("~/Content/supportrequests")
 }
 
+<form id="AntiForgeryForm">
+    @Html.AntiForgeryToken()
+</form>
+
 <section>
     <article id="supportrequests">
         <div id="sr-nav-menu">
@@ -50,7 +54,6 @@
 
             <div style="display: none;" id="editSupportRequest-dialog">
                 <form id="editSupportRequest-form">
-                    @Html.AntiForgeryToken()
                     <fieldset class="form">
                         <legend>Edit</legend>
 

--- a/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Index.cshtml
@@ -10,9 +10,7 @@
     @Styles.Render("~/Content/supportrequests")
 }
 
-<form id="AntiForgeryForm">
-    @Html.AntiForgeryToken()
-</form>
+@ViewHelpers.AjaxAntiForgeryToken(Html)
 
 <section>
     <article id="supportrequests">

--- a/src/NuGetGallery/Controllers/CuratedPackagesController.cs
+++ b/src/NuGetGallery/Controllers/CuratedPackagesController.cs
@@ -46,6 +46,7 @@ namespace NuGetGallery
 
         [ActionName("CuratedPackage")]
         [HttpDelete]
+        [ValidateAntiForgeryToken]
         public virtual async Task<ActionResult> DeleteCuratedPackage(
             string curatedFeedName,
             string curatedPackageId)
@@ -76,6 +77,7 @@ namespace NuGetGallery
 
         [ActionName("CuratedPackage")]
         [AcceptVerbs("patch")]
+        [ValidateAntiForgeryToken]
         public virtual async Task<ActionResult> PatchCuratedPackage(
             string curatedFeedName,
             string curatedPackageId,
@@ -113,6 +115,7 @@ namespace NuGetGallery
 
         [ActionName("CuratedPackages")]
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public virtual async Task<ActionResult> PostCuratedPackages(
             string curatedFeedName,
             CreateCuratedPackageRequest request)

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -364,6 +364,7 @@ namespace NuGetGallery
 
         [HttpPost]
         [Authorize]
+        [ValidateAntiForgeryToken]
         public virtual async Task<ActionResult> ChangeEmail(AccountViewModel model)
         {
             if (!ModelState.IsValidField("ChangeEmail.NewEmail"))
@@ -424,6 +425,7 @@ namespace NuGetGallery
 
         [HttpPost]
         [Authorize]
+        [ValidateAntiForgeryToken]
         public virtual async Task<ActionResult> CancelChangeEmail(AccountViewModel model)
         {
             var user = GetCurrentUser();

--- a/src/NuGetGallery/Scripts/nugetgallery.js
+++ b/src/NuGetGallery/Scripts/nugetgallery.js
@@ -1,5 +1,13 @@
 ﻿// Global utility script for NuGetGallery
 /// <reference path="jquery-1.11.0.js" />
+
+// Shared function for adding an anti-forgery token defined by ViewHelpers.AjaxAntiForgeryToken to an ajax request
+function addAjaxAntiForgeryToken(data) {
+    var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
+    data["__RequestVerificationToken"] = $field.val();
+    return data;
+}
+
 (function (window, $, undefined) {
     $(function () {
         // Export an object with global config data

--- a/src/NuGetGallery/Scripts/supportrequests.js
+++ b/src/NuGetGallery/Scripts/supportrequests.js
@@ -1,10 +1,4 @@
-﻿var addAntiForgeryToken = function (data) {
-    var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
-    data["__RequestVerificationToken"] = $field.val();
-    return data;
-}
-
-function HistoryViewModel() {
+﻿function HistoryViewModel() {
     var $self = this;
 
     this.issue = ko.observable();
@@ -34,7 +28,7 @@ function EditViewModel(editUrl) {
             type: 'POST',
             cache: false,
             dataType: 'json',
-            data: addAntiForgeryToken(model),
+            data: addAjaxAntiForgeryToken(model),
             success: success
         })
         .error(error);

--- a/src/NuGetGallery/Scripts/supportrequests.js
+++ b/src/NuGetGallery/Scripts/supportrequests.js
@@ -1,4 +1,10 @@
-﻿function HistoryViewModel() {
+﻿var addAntiForgeryToken = function (data) {
+    var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
+    data["__RequestVerificationToken"] = $field.val();
+    return data;
+}
+
+function HistoryViewModel() {
     var $self = this;
 
     this.issue = ko.observable();
@@ -16,20 +22,19 @@ function EditViewModel(editUrl) {
     this.issueStatusChoices = ko.observableArray();
 
     this.updateSupportRequest = function (success, error) {
-        var model = JSON.stringify({
+        var model = {
             issueKey: $self.issue.Key,
             assignedToId: $self.editAssignedToId,
             issueStatusId: $self.editIssueStatusId,
             comment: $self.editIssueComment()
-        });
+        };
 
         $.ajax({
             url: editUrl,
             type: 'POST',
             cache: false,
             dataType: 'json',
-            contentType: 'application/json; charset=utf-8',
-            data: model,
+            data: addAntiForgeryToken(model),
             success: success
         })
         .error(error);

--- a/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
+++ b/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
@@ -2,14 +2,27 @@
 @{
     ViewBag.Title = "Curated Feed: " + Model.Name;
 }
+
+<form id="AntiForgeryForm">
+    @Html.AntiForgeryToken()
+</form>
+
 @section BottomScripts {
     <script>
         var urlFormat = "@Url.RouteUrl(RouteName.CuratedPackage, new { curatedFeedName = Model.Name, curatedPackageId = "PACKAGE_ID" })";
 
+        var addAntiForgeryToken = function (data) {
+            var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
+            data["__RequestVerificationToken"] = $field.val();
+            return data;
+        }
+
         function deleteCuratedPackage(packageId) {
             $.ajax({
                 type: 'delete',
-                url: urlFormat.replace("PACKAGE_ID", packageId)
+                url: urlFormat.replace("PACKAGE_ID", packageId),
+                dataType: 'json',
+                data: addAntiForgeryToken({})
             })
                 .error(function(jqXhr, textStatus, errorThrown) {
                     alert("Error: " + errorThrown);
@@ -23,7 +36,7 @@
             $.ajax({
                 type: 'patch',
                 url: urlFormat.replace("PACKAGE_ID", packageId),
-                data: { included: included },
+                data: addAntiForgeryToken({ included: included }),
                 dataType: 'json'
             })
                 .error(function(jqXhr, textStatus, errorThrown) {

--- a/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
+++ b/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
@@ -3,26 +3,18 @@
     ViewBag.Title = "Curated Feed: " + Model.Name;
 }
 
-<form id="AntiForgeryForm">
-    @Html.AntiForgeryToken()
-</form>
+@ViewHelpers.AjaxAntiForgeryToken(Html)
 
 @section BottomScripts {
     <script>
         var urlFormat = "@Url.RouteUrl(RouteName.CuratedPackage, new { curatedFeedName = Model.Name, curatedPackageId = "PACKAGE_ID" })";
-
-        var addAntiForgeryToken = function (data) {
-            var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
-            data["__RequestVerificationToken"] = $field.val();
-            return data;
-        }
-
+        
         function deleteCuratedPackage(packageId) {
             $.ajax({
                 type: 'delete',
                 url: urlFormat.replace("PACKAGE_ID", packageId),
                 dataType: 'json',
-                data: addAntiForgeryToken({})
+                data: addAjaxAntiForgeryToken({})
             })
                 .error(function(jqXhr, textStatus, errorThrown) {
                     alert("Error: " + errorThrown);
@@ -36,7 +28,7 @@
             $.ajax({
                 type: 'patch',
                 url: urlFormat.replace("PACKAGE_ID", packageId),
-                data: addAntiForgeryToken({ included: included }),
+                data: addAjaxAntiForgeryToken({ included: included }),
                 dataType: 'json'
             })
                 .error(function(jqXhr, textStatus, errorThrown) {

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -3,9 +3,7 @@
     ViewBag.Tab = "Packages";
 }
 
-<form id="AntiForgeryForm">
-    @Html.AntiForgeryToken()
-</form>
+@ViewHelpers.AjaxAntiForgeryToken(Html)
 
 <h1 class="page-heading">Manage Owners for Package "@Model.Title.Abbreviate(50)"</h1>
 
@@ -65,12 +63,6 @@
             var failHandler = function (jqXHR, textStatus, errorThrown) {
                 alert('An unexpected error occurred! "' + errorThrown + '"');
             };
-
-            var addAntiForgeryToken = function (data) {
-                var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
-                data["__RequestVerificationToken"] = $field.val();
-                return data;
-            }
 
             var viewModel = {
                 package: { id: '@Model.Id' },
@@ -145,7 +137,7 @@
                         dataType: 'json',
                         type: 'POST',
                         dataType: 'json',
-                        data: addAntiForgeryToken(ownerInputModel),
+                        data: addAjaxAntiForgeryToken(ownerInputModel),
                         success: function (data) {
                             if (data.success) {
                                 var newOwner = new Owner(data.name, /* pending */ true, data.current);
@@ -182,7 +174,7 @@
                         dataType: 'json',
                         type: 'POST',
                         dataType: 'json',
-                        data: addAntiForgeryToken({}),
+                        data: addAjaxAntiForgeryToken({}),
                         success: function (data) {
                             if (data.success) {
                                 if (item.current) {

--- a/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Web.Mvc;
+using Xunit;
+
+namespace NuGetGallery.Controllers
+{
+    public class ControllerTests
+    {
+        private class AntiForgeryTokenException : IEquatable<AntiForgeryTokenException>
+        {
+            public Type Controller { get; private set; }
+
+            public string Name { get; private set; }
+
+            public AntiForgeryTokenException(Type controller, string name)
+            {
+                Controller = controller;
+                Name = name;
+            }
+
+            public AntiForgeryTokenException(MethodInfo method)
+            {
+                Controller = method.DeclaringType;
+                Name = method.Name;
+            }
+            
+            public bool Equals(AntiForgeryTokenException other)
+            {
+                return other != null && other.Controller == Controller && other.Name == Name;
+            }
+
+            public override int GetHashCode()
+            {
+                return Controller.GetHashCode() ^ Name.GetHashCode();
+            }
+        }
+
+        [Fact]
+        public void AllActionsHaveAntiForgeryTokenIfNotGet()
+        {
+            // Arrange
+
+            // If an action only supports these verbs, it doesn't need the anti-forgery token attribute.
+            var verbExceptions = new HttpVerbs[]
+            {
+                HttpVerbs.Get,
+                HttpVerbs.Head
+            };
+
+            // These actions cannot have the AntiForgery token attribute.
+            // For example: API methods intended to be called by clients.
+            var actionExceptions = new AntiForgeryTokenException[]
+            {
+                new AntiForgeryTokenException(typeof(ApiController), nameof(ApiController.CreatePackagePut)),
+                new AntiForgeryTokenException(typeof(ApiController), nameof(ApiController.CreatePackagePost)),
+                new AntiForgeryTokenException(typeof(ApiController), nameof(ApiController.CreatePackageVerificationKeyAsync)),
+                new AntiForgeryTokenException(typeof(ApiController), nameof(ApiController.DeletePackage)),
+                new AntiForgeryTokenException(typeof(ApiController), nameof(ApiController.PublishPackage)),
+                new AntiForgeryTokenException(typeof(AuthenticationController), nameof(AuthenticationController.ChallengeAuthentication))
+            };
+
+            // Act
+            var assembly = Assembly.GetAssembly(typeof(AppController));
+
+            var actions = assembly.GetTypes()
+                // Get all types that are controllers.
+                .Where(t => typeof(Controller).IsAssignableFrom(t))
+                // Get all public methods of those types.
+                .SelectMany(t => t.GetMethods(BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.Public))
+                // Filter out compiler generated methods.
+                .Where(m => !m.GetCustomAttributes(typeof(CompilerGeneratedAttribute), true).Any())
+                // Filter out methods that only support verbs that are exceptions.
+                .Where(m =>
+                {
+                    var attributes = m.GetCustomAttributes()
+                        .Where(a => typeof(ActionMethodSelectorAttribute).IsAssignableFrom(a.GetType()));
+
+                    return !(attributes
+                        .All(a =>
+                            a.GetType() == typeof(HttpGetAttribute) ||
+                            a.GetType() == typeof(HttpHeadAttribute) ||
+                            (a.GetType() == typeof(AcceptVerbsAttribute) &&
+                                (a as AcceptVerbsAttribute).Verbs.All(v =>
+                                    verbExceptions.Any(ve => v.Equals(ve.ToString(), StringComparison.InvariantCultureIgnoreCase))))));
+                })
+                // Filter out exceptions.
+                .Where(m =>
+                 {
+                     var possibleException = new AntiForgeryTokenException(m);
+                     return !actionExceptions.Any(a => a.Equals(possibleException));
+                 });
+
+            // Assert
+            var actionsMissingAntiForgeryToken = actions
+                .Where(m => !(m.GetCustomAttributes()
+                    .Any(a => a.GetType() == typeof(ValidateAntiForgeryTokenAttribute))));
+            
+            Assert.Empty(actionsMissingAntiForgeryToken);
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -395,6 +395,7 @@
     <Compile Include="Controllers\AppControllerFacts.cs" />
     <Compile Include="Controllers\AuthenticationControllerFacts.cs" />
     <Compile Include="Controllers\ApiControllerFacts.cs" />
+    <Compile Include="Controllers\ControllerTests.cs" />
     <Compile Include="Controllers\CuratedFeedsControllerFacts.cs" />
     <Compile Include="Controllers\CuratedPackagesControllerFacts.cs" />
     <Compile Include="Controllers\JsonApiControllerFacts.cs" />


### PR DESCRIPTION
Mostly admin routes.

These include
- LuceneController
- SupportRequestController
- SecurityPolicyController
- CuratedPackagesController
- UsersController

https://github.com/NuGet/Engineering/issues/638