### PR TITLE
Improve manage package page handling of long IDs

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -368,10 +368,20 @@ img.package-icon {
   margin-bottom: 0;
 }
 .user-package-list .manage-package-listing .package-icon {
+  min-width: 20px;
   max-height: 2em;
 }
 .user-package-list .manage-package-listing .align-middle {
   vertical-align: middle;
+}
+.user-package-list .manage-package-listing .package-id {
+  word-break: break-all;
+  word-break: break-word;
+}
+@media (min-width: 768px) {
+  .user-package-list .manage-package-listing .package-controls {
+    white-space: nowrap;
+  }
 }
 .user-package-list .table {
   border-bottom: 1px solid #ddd;

--- a/src/Bootstrap/less/theme/common-user-package-list.less
+++ b/src/Bootstrap/less/theme/common-user-package-list.less
@@ -2,10 +2,22 @@
     .manage-package-listing {
         .package-icon {
             max-height: 2em;
+            min-width: 20px;
         }
 
         .align-middle {
             vertical-align: middle;
+        }
+
+        .package-id {
+            word-break: break-all;
+            word-break: break-word;
+        }
+
+        .package-controls {
+            @media (min-width: @screen-sm-min) {
+                white-space: nowrap;
+            }
         }
     }
 

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -368,10 +368,20 @@ img.package-icon {
   margin-bottom: 0;
 }
 .user-package-list .manage-package-listing .package-icon {
+  min-width: 20px;
   max-height: 2em;
 }
 .user-package-list .manage-package-listing .align-middle {
   vertical-align: middle;
+}
+.user-package-list .manage-package-listing .package-id {
+  word-break: break-all;
+  word-break: break-word;
+}
+@media (min-width: 768px) {
+  .user-package-list .manage-package-listing .package-controls {
+    white-space: nowrap;
+  }
 }
 .user-package-list .table {
   border-bottom: 1px solid #ddd;

--- a/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
@@ -24,45 +24,42 @@
                 <table class="table">
                     <thead>
                         <tr class="manage-package-headings">
-                            <th class="col-sm-1"></th>
-                            <th class="col-sm-3">Package ID</th>
-                            <th class="col-sm-2">Owners</th>
-                            <th class="col-sm-2">Downloads</th>
-                            <th class="col-sm-2">Latest Version</th>
-                            <th class="col-sm-2"></th>
+                            <th class="hidden-xs"></th>
+                            <th>Package ID</th>
+                            <th>Owners</th>
+                            <th>Downloads</th>
+                            <th>Latest Version</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody>
                     @foreach (var package in @Model.Packages)
                     {
-                        //@Html.Partial("_ListPackage", package)
                         <tr class="manage-package-listing">
-                            <td class="col-sm-1 align-middle">
+                            <td class="align-middle hidden-xs">
                                 <img class="package-icon img-responsive" aria-hidden="true" alt="" 
                                      src="@(PackageHelper.ShouldRenderUrl(package.IconUrl) ? package.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))" 
                                      @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
                             </td>
-                            <td class="col-sm-3 align-middle"><a href="@Url.Package(package.Id)">@package.Id</a></td>
-                            <td class="col-sm-2 align-middle">
+                            <td class="align-middle package-id"><a href="@Url.Package(package.Id)">@Html.BreakWord(package.Id)</a></td>
+                            <td class="align-middle">
                             @foreach (var owner in package.Owners)
                             {
                                 <a href="@Url.User(owner.Username)">@owner.Username</a>
                             }
                             </td>
-                            <td class="col-sm-2 align-middle">@package.TotalDownloadCount.ToNuGetNumberString()</td>
-                            <td class="col-sm-2 align-middle">@package.Version</td>
-                            <td class="col-sm-2 text-right align-middle">
-                                <div class="btn-group">
-                                    <a href="@Url.EditPackage(package.Id, package.Version)" class="btn" title="Edit Package" aria-label="Edit Package @package.Id  Version @package.Version">
-                                        <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
-                                    </a>
-                                    <a href="@Url.ManagePackageOwners(package)" class="btn" title="Manage Owners" aria-label="Manage Owners for Package @package.Id">
-                                        <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>
-                                    </a>
-                                    <a href="@Url.DeletePackage(package)" class="btn" title="Delete Package" aria-lable="Delete Package @package.Id  Version @package.Version">
-                                        <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
-                                    </a>
-                                </div>
+                            <td class="align-middle text-nowrap">@package.TotalDownloadCount.ToNuGetNumberString()</td>
+                            <td class="align-middle text-nowrap">@package.Version</td>
+                            <td class="text-right align-middle package-controls">
+                                <a href="@Url.EditPackage(package.Id, package.Version)" class="btn" title="Edit Package" aria-label="Edit Package @package.Id  Version @package.Version">
+                                    <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
+                                </a>
+                                <a href="@Url.ManagePackageOwners(package)" class="btn" title="Manage Owners" aria-label="Manage Owners for Package @package.Id">
+                                    <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>
+                                </a>
+                                <a href="@Url.DeletePackage(package)" class="btn" title="Delete Package" aria-lable="Delete Package @package.Id  Version @package.Version">
+                                    <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
+                                </a>
                             </td>
                         </tr>
                     }


### PR DESCRIPTION
1. Allow long IDs to wrap on the manage packages package
1. Don't let the package controls to wrap unless screen size is xs
1. Hide images on xs
1. Allow browser to control column widths

Fix https://github.com/NuGet/NuGetGallery/issues/4527

Normal display:
![screencapture-localhost-account-packages-1502292959515](https://user-images.githubusercontent.com/94054/29130139-d1089b9c-7cdd-11e7-99d2-eb659f42835d.png)


Long IDs simulated by displaying `ID + ID`:
![screencapture-localhost-account-packages-1502292578159](https://user-images.githubusercontent.com/94054/29129820-e8a8464a-7cdc-11e7-8150-675b931a1397.png)
