### PR TITLE
Use date format "d" for week start and ends on the stat pages

### DIFF
--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -99,13 +99,13 @@ namespace NuGetGallery
                 case WeekFormats.YearWeekNumber:
                     return string.Format(CultureInfo.CurrentCulture, "{0} wk {1}", year, weekOfYear);
                 case WeekFormats.StartOnly:
-                    outputStringTemplate = "{0:MM/dd/yy}";
+                    outputStringTemplate = "{0:d}";
                     break;
                 case WeekFormats.EndOnly:
-                    outputStringTemplate = "{1:MM/dd/yy}";
+                    outputStringTemplate = "{1:d}";
                     break;
                 case WeekFormats.FullDate:
-                    outputStringTemplate = "{0:MM/dd/yy} - {1:MM/dd/yy}";
+                    outputStringTemplate = "{0:d} - {1:d}";
                     break;
                 default:
                     break;


### PR DESCRIPTION
Previously this was using a locale-unaware format `MM/dd/yy`.

Fix https://github.com/NuGet/NuGetGallery/issues/4529