### PR TITLE
Fix two accessibility issues and fix hover underline on alerts

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -90,7 +90,8 @@ body h3 {
 .btn-search {
   height: 36px;
 }
-.icon-link .ms-Icon {
+.icon-link .ms-Icon,
+.icon-text .ms-Icon {
   position: relative;
   top: 2px;
 }
@@ -624,15 +625,11 @@ img.package-icon {
   border: 0;
 }
 .page-package-details .install-tabs .nav-tabs > li.active > a {
+  font-weight: 600;
   color: #fff;
+  text-decoration: underline;
   background-color: #002440;
   border: 0;
-}
-@media screen and (-ms-high-contrast: active) {
-  .page-package-details .install-tabs .nav-tabs > li.active > a {
-    font-weight: 600;
-    text-decoration: underline;
-  }
 }
 .page-package-details .install-tabs .tab-pane > div {
   display: table;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -114,7 +114,7 @@ body {
   height: 36px;
 }
 
-.icon-link {
+.icon-link, .icon-text {
   .ms-Icon {
     position: relative;
     top: 2px;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -71,13 +71,8 @@
       background-color: @panel-footer-bg;
       border: 0;
       color: #fff;
-
-      @media screen and (-ms-high-contrast: active){
-        & {
-          font-weight: 600;
-          text-decoration: underline;
-        }
-      }
+      font-weight: 600;
+      text-decoration: underline;
     }
 
     .tab-pane {

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -40,7 +40,7 @@
 
 @helper Alert(Func<MvcHtmlString, HelperResult> htmlContent, string subclass, string icon, bool isAlertRole = false)
 {
-    <div class="icon-link alert alert-@subclass" @if (isAlertRole) { <text> role="alert" aria-live="assertive" </text>   }>
+    <div class="icon-text alert alert-@subclass" @if (isAlertRole) { <text> role="alert" aria-live="assertive" </text>   }>
         <i class="ms-Icon ms-Icon--@icon" aria-hidden="true"></i>
         @htmlContent(MvcHtmlString.Empty)
     </div>

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -90,7 +90,8 @@ body h3 {
 .btn-search {
   height: 36px;
 }
-.icon-link .ms-Icon {
+.icon-link .ms-Icon,
+.icon-text .ms-Icon {
   position: relative;
   top: 2px;
 }
@@ -624,15 +625,11 @@ img.package-icon {
   border: 0;
 }
 .page-package-details .install-tabs .nav-tabs > li.active > a {
+  font-weight: 600;
   color: #fff;
+  text-decoration: underline;
   background-color: #002440;
   border: 0;
-}
-@media screen and (-ms-high-contrast: active) {
-  .page-package-details .install-tabs .nav-tabs > li.active > a {
-    font-weight: 600;
-    text-decoration: underline;
-  }
 }
 .page-package-details .install-tabs .tab-pane > div {
   display: table;

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -84,7 +84,7 @@
         window.nuget.configureExpanderHeading("upload-package-form");
         $(function () {
             $("#browse-for-package-button").on("keypress", function (e) {
-                var keyCode = (e.keyCode || e.which);
+                var code = (e.keyCode || e.which);
                 var isInteract = (code == 13 /*enter*/ || code == 32 /*space*/) && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
                 if (isInteract) {
                     $(this).click();

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -30,19 +30,19 @@
 
             <ul class="package-list">
                 <li>
-                    <span class="icon-link">
+                    <span class="icon-text">
                         <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
                         @Model.TotalDownloadCount.ToNuGetNumberString() total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
                     </span>
                 </li>
                 <li>
-                    <span class="icon-link">
+                    <span class="icon-text">
                         <i class="ms-Icon ms-Icon--History" aria-hidden="true"></i>
                         last updated <span data-datetime="@Model.LastUpdated.ToString("O")">@Model.LastUpdated.ToNuGetShortDateString()</span>
                     </span>
                 </li>
                 <li>
-                    <span class="icon-link">
+                    <span class="icon-text">
                         <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
                         Latest version: <span class="text-nowrap">@Model.FullVersion @(Model.Prerelease ? "(prerelease)" : "")</span>
                     </span>
@@ -50,7 +50,7 @@
                 @if (Model.Tags.AnySafe())
                 {
                     <li class="package-tags">
-                        <span class="icon-link">
+                        <span class="icon-text">
                             <i class="ms-Icon ms-Icon--Tag" aria-hidden="true"></i>
                             @foreach (var tag in Model.Tags)
                             {


### PR DESCRIPTION
1. Enable "enter" key press on Upload button
1. Make selected package command tab apparent on high-contrast Firefox
1. Add `icon-text` class for text with an icon that is NOT a link (`icon-link` has other undesired rules)

Fix accessibility issue 470376
Fix accessibility issue 476608