### PR TITLE
Introduce a type to represent the different password reset results (instead of null and exceptions)

### DIFF
--- a/src/NuGetGallery/Authentication/PasswordResetResult.cs
+++ b/src/NuGetGallery/Authentication/PasswordResetResult.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery.Authentication
+{
+    public class PasswordResetResult
+    {
+        public PasswordResetResult(PasswordResetResultType type, User user)
+        {
+            if (type != PasswordResetResultType.UserNotFound && user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            Type = type;
+            User = user;
+        }
+
+        public PasswordResetResultType Type { get; }
+        public User User { get; }
+    }
+
+    public enum PasswordResetResultType
+    {
+        UserNotFound,
+        UserNotConfirmed,
+        Success,
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -694,6 +694,7 @@
     <Compile Include="Authentication\NuGetPackagePattern.cs" />
     <Compile Include="Authentication\PasswordAuthenticationResult.cs" />
     <Compile Include="Authentication\NuGetScopes.cs" />
+    <Compile Include="Authentication\PasswordResetResult.cs" />
     <Compile Include="Authentication\Providers\AuthenticatorT.cs" />
     <Compile Include="Authentication\Providers\AzureActiveDirectory\AzureActiveDirectoryAuthenticator.cs" />
     <Compile Include="Authentication\Providers\AzureActiveDirectory\AzureActiveDirectoryAuthenticatorConfiguration.cs" />

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -352,11 +352,11 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not find anyone with that email..
+        ///   Looks up a localized string similar to Could not find anyone with that username or email..
         /// </summary>
-        public static string CouldNotFindAnyoneWithThatEmail {
+        public static string CouldNotFindAnyoneWithThatUsernameOrEmail {
             get {
-                return ResourceManager.GetString("CouldNotFindAnyoneWithThatEmail", resourceCulture);
+                return ResourceManager.GetString("CouldNotFindAnyoneWithThatUsernameOrEmail", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -329,8 +329,8 @@ The {1} Team</value>
   <data name="UserKeyIsRequired" xml:space="preserve">
     <value>A user key is required.</value>
   </data>
-  <data name="CouldNotFindAnyoneWithThatEmail" xml:space="preserve">
-    <value>Could not find anyone with that email.</value>
+  <data name="CouldNotFindAnyoneWithThatUsernameOrEmail" xml:space="preserve">
+    <value>Could not find anyone with that username or email.</value>
   </data>
   <data name="InvalidOrExpiredPasswordResetToken" xml:space="preserve">
     <value>The Password Reset Token is not valid or expired.</value>

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -238,7 +238,7 @@ namespace NuGetGallery
                     .Returns(user);
                 GetMock<AuthenticationService>()
                     .Setup(s => s.GeneratePasswordResetToken("user", Constants.PasswordResetTokenExpirationHours * 60))
-                    .CompletesWith(user);
+                    .CompletesWith(new PasswordResetResult(PasswordResetResultType.Success, user));
                 var controller = GetController<UsersController>();
                 var model = new ForgotPasswordViewModel { Email = "user" };
 
@@ -254,7 +254,7 @@ namespace NuGetGallery
                 var user = new User { EmailAddress = "some@example.com", Username = "somebody" };
                 GetMock<AuthenticationService>()
                     .Setup(s => s.GeneratePasswordResetToken("user", Constants.PasswordResetTokenExpirationHours * 60))
-                    .CompletesWith(user)
+                    .CompletesWith(new PasswordResetResult(PasswordResetResultType.Success, user))
                     .Verifiable();
                 var controller = GetController<UsersController>();
 
@@ -268,11 +268,11 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task ReturnsSameViewIfTokenGenerationFails()
+            public async Task ShowsErrorIfUserWasNotFound()
             {
                 GetMock<AuthenticationService>()
                     .Setup(s => s.GeneratePasswordResetToken("user", Constants.PasswordResetTokenExpirationHours * 60))
-                    .CompletesWithNull();
+                    .ReturnsAsync(new PasswordResetResult(PasswordResetResultType.UserNotFound, user: null));
                 var controller = GetController<UsersController>();
 
                 var model = new ForgotPasswordViewModel { Email = "user" };
@@ -281,6 +281,7 @@ namespace NuGetGallery
 
                 Assert.NotNull(result);
                 Assert.IsNotType(typeof(RedirectResult), result);
+                Assert.Contains(Strings.CouldNotFindAnyoneWithThatUsernameOrEmail, result.ViewData.ModelState["Email"].Errors.Select(e => e.ErrorMessage));
             }
 
             [Fact]
@@ -298,7 +299,57 @@ namespace NuGetGallery
 
                 Assert.NotNull(result);
                 Assert.IsNotType(typeof(RedirectResult), result);
-                Assert.Equal("You cannot reset your password until you confirm your account.", controller.ModelState["Email"].Errors[0].ErrorMessage);
+                Assert.Contains(Strings.UserIsNotYetConfirmed, result.ViewData.ModelState["Email"].Errors.Select(e => e.ErrorMessage));
+            }
+
+            [Fact]
+            public async Task ThrowsNotImplementedExceptionWhenResultTypeIsUnknown()
+            {
+                // Arrange
+                GetMock<AuthenticationService>()
+                    .Setup(s => s.GeneratePasswordResetToken("user", Constants.PasswordResetTokenExpirationHours * 60))
+                    .ReturnsAsync(new PasswordResetResult((PasswordResetResultType)(-1), user: new User()));
+                var controller = GetController<UsersController>();
+
+                var model = new ForgotPasswordViewModel { Email = "user" };
+
+                // Act & Assert
+                await Assert.ThrowsAsync<NotImplementedException>(() => controller.ForgotPassword(model));
+            }
+
+            [Theory]
+            [MemberData(nameof(ResultTypes))]
+            public async Task NoResultsTypesThrow(PasswordResetResultType resultType)
+            {
+                // Arrange
+                GetMock<AuthenticationService>()
+                    .Setup(s => s.GeneratePasswordResetToken("user", Constants.PasswordResetTokenExpirationHours * 60))
+                    .ReturnsAsync(new PasswordResetResult(resultType, user: new User()));
+                var controller = GetController<UsersController>();
+
+                var model = new ForgotPasswordViewModel { Email = "user" };
+                
+                try
+                {
+                    // Act 
+                    await controller.ForgotPassword(model);
+                }
+                catch (Exception e)
+                {
+                    // Assert
+                    Assert.True(false, $"No exception should be thrown for result type {resultType}: {e}");
+                }
+            }
+
+            public static IEnumerable<object[]> ResultTypes
+            {
+                get
+                {
+                    return Enum
+                        .GetValues(typeof(PasswordResetResultType))
+                        .Cast<PasswordResetResultType>()
+                        .Select(v => new object[] { v });
+                }
             }
         }
 
@@ -1145,8 +1196,8 @@ namespace NuGetGallery
 
                 GetMock<AuthenticationService>()
                     .Setup(a => a.GeneratePasswordResetToken(user, It.IsAny<int>()))
-                    .Callback<User, int>((u, _) => u.PasswordResetToken = "t0k3n")
-                    .Completes();
+                    .ReturnsAsync(PasswordResetResultType.Success)
+                    .Callback<User, int>((u, _) => u.PasswordResetToken = "t0k3n");
 
                 string actualConfirmUrl = null;
                 GetMock<IMessageService>()


### PR DESCRIPTION
I'm only submitting this PR because the work was already done on my devbox. It should have no functional different from @loic-sharma's https://github.com/NuGet/NuGetGallery/pull/4551 aside from a clarified message to the user. I poorly communicated my intent to fix issue https://github.com/NuGet/NuGetGallery/issues/4548.

There are three potential outcomes from this reset flow:
1. Success (the user exists and is confirmed)
1. User not found
1. User not confirmed (the user exists but has not confirmed his email)

I have added a type to clearly represent these three states. In general we should not be using exceptions as non-exceptional signals. Additionally, null is ambiguous signal in many cases so it should be avoided especially in a tri(/N)-state outcomes like this. 