### PR TITLE
Redirect /nuget.exe endpoint to dist.nuget.org, nuget.exe 2.8.6

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -31,6 +31,8 @@ namespace NuGetGallery
     public partial class ApiController
         : AppController
     {
+        private const string NuGetExeUrl = "https://dist.nuget.org/win-x86-commandline/v2.8.6/nuget.exe";
+
         public IApiScopeEvaluator ApiScopeEvaluator { get; set; }
         public IEntitiesContext EntitiesContext { get; set; }
         public INuGetExeDownloaderService NugetExeDownloaderService { get; set; }
@@ -204,10 +206,9 @@ namespace NuGetGallery
 
         [HttpGet]
         [ActionName("GetNuGetExeApi")]
-        [OutputCache(VaryByParam = "none", Location = OutputCacheLocation.ServerAndClient, Duration = 600)]
-        public virtual Task<ActionResult> GetNuGetExe()
+        public virtual ActionResult GetNuGetExe()
         {
-            return NugetExeDownloaderService.CreateNuGetExeDownloadActionResultAsync(HttpContext.Request.Url);
+            return new RedirectResult(NuGetExeUrl, permanent: false);
         }
 
         [HttpGet]

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -1641,5 +1641,24 @@ namespace NuGetGallery
                 Assert.True(result.Count == 3, "unexpected content");
             }
         }
+
+        public class TheGetNuGetExeAction
+            : TestContainer
+        {
+            [Fact]
+            public void RedirectsToDist()
+            {
+                // Arrange
+                var controller = new TestableApiController(GetConfigurationService());
+
+                // Act
+                var result = controller.GetNuGetExe();
+
+                // Assert
+                var redirect = Assert.IsType<RedirectResult>(result);
+                Assert.False(redirect.Permanent, "The redirect should not be permanent");
+                Assert.Equal("https://dist.nuget.org/win-x86-commandline/v2.8.6/nuget.exe", redirect.Url);
+            }
+        }
     }
 }

--- a/tests/NuGetGallery.FunctionalTests/DistIntegrationTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/DistIntegrationTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetGallery.FunctionalTests
+{
+    public class DistIntegrationTests : GalleryTestBase
+    {
+        private const string Version = "2.8.6";
+
+        public DistIntegrationTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        [Description("Ensures the nuget.exe endpoint redirects to an assembly with version " + Version + ".")]
+        [Priority(1)]
+        [Category("P1Tests")]
+        public async Task NuGetExeReturnsExpectedVersion()
+        {
+            // Arrange
+            using (var client = new HttpClient())
+            using (var networkStream = await client.GetStreamAsync(UrlHelper.BaseUrl + "nuget.exe"))
+            using (var memoryStream = new MemoryStream())
+            {
+                await networkStream.CopyToAsync(memoryStream);
+                var assembly = Assembly.Load(memoryStream.ToArray());
+
+                // Act
+                var attributes = assembly
+                    .GetCustomAttributes<AssemblyInformationalVersionAttribute>()
+                    .ToList();
+
+                // Assert
+                Assert.Equal(1, attributes.Count);
+                Assert.Equal(Version, attributes[0].InformationalVersion);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ODataFeeds\SearchTest.cs" />
     <Compile Include="ODataFeeds\V2FeedExtendedTests.cs" />
     <Compile Include="PackageCreation\ApiPushTests.cs" />
+    <Compile Include="DistIntegrationTests.cs" />
     <Compile Include="PackageCreation\SecurityPolicyTests.cs" />
     <Compile Include="Security\HttpToHttpsRedirectTests.cs" />
     <Compile Include="Statistics\PackageStatisticsTests.cs" />


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/4558.

I will not merge this until @anangaur has posted about this on the announcements repo.