### PR TITLE
Add storage connection strings for each distinct purpose in the gallery

### DIFF
--- a/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
@@ -14,7 +14,7 @@ namespace NuGetGallery.Auditing
     /// <summary>
     /// Writes audit records to a specific container in the Cloud Storage Account provided
     /// </summary>
-    public class CloudAuditingService : AuditingService
+    public class CloudAuditingService : AuditingService, ICloudStorageStatusDependency
     {
         public static readonly string DefaultContainerName = "auditing";
 
@@ -26,7 +26,6 @@ namespace NuGetGallery.Auditing
         public CloudAuditingService(string instanceId, string localIP, string storageConnectionString, Func<Task<AuditActor>> getOnBehalfOf)
             : this(instanceId, localIP, GetContainer(storageConnectionString), getOnBehalfOf)
         {
-
         }
 
         public CloudAuditingService(string instanceId, string localIP, CloudBlobContainer auditContainer, Func<Task<AuditActor>> getOnBehalfOf)
@@ -120,6 +119,11 @@ namespace NuGetGallery.Auditing
                 }
                 throw;
             }
+        }
+
+        public Task<bool> IsAvailableAsync()
+        {
+            return _auditContainer.ExistsAsync();
         }
     }
 }

--- a/src/NuGetGallery.Core/ICloudStorageStatusDependency.cs
+++ b/src/NuGetGallery.Core/ICloudStorageStatusDependency.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Determines whether a cloud storage object (e.g. a blob container) is available. The purpose of this interface
+    /// is to assess a gallery instance's connection to Azure Storage.
+    /// </summary>
+    public interface ICloudStorageStatusDependency
+    {
+        Task<bool> IsAvailableAsync();
+    }
+}

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Entities\Scope.cs" />
     <Compile Include="Entities\UserSecurityPolicy.cs" />
     <Compile Include="Entities\User.cs" />
+    <Compile Include="ICloudStorageStatusDependency.cs" />
     <Compile Include="Infrastructure\AzureEntityList.cs" />
     <Compile Include="Infrastructure\TableErrorLog.cs" />
     <Compile Include="PackageReaderCoreExtensions.cs" />

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -9,12 +9,12 @@ using System.Linq;
 using System.Net;
 using System.Net.Mail;
 using System.Security.Principal;
-using System.Threading;
 using System.Web;
 using System.Web.Hosting;
 using System.Web.Mvc;
 using AnglicanGeek.MarkdownMailer;
 using Autofac;
+using Autofac.Core;
 using Elmah;
 using Microsoft.WindowsAzure.ServiceRuntime;
 using NuGetGallery.Areas.Admin;
@@ -71,30 +71,12 @@ namespace NuGetGallery
 
             ConfigureSearch(builder, configuration);
 
-            if (!string.IsNullOrEmpty(configuration.Current.AzureStorageConnectionString))
-            {
-                builder.RegisterInstance(new TableErrorLog(configuration.Current.AzureStorageConnectionString))
-                    .As<ErrorLog>()
-                    .SingleInstance();
-            }
-            else
-            {
-                builder.RegisterInstance(new SqlErrorLog(configuration.Current.SqlConnectionString))
-                    .As<ErrorLog>()
-                    .SingleInstance();
-            }
-
             builder.RegisterType<DateTimeProvider>().AsSelf().As<IDateTimeProvider>().SingleInstance();
 
             builder.RegisterType<HttpContextCacheService>()
                 .AsSelf()
                 .As<ICacheService>()
                 .InstancePerLifetimeScope();
-
-            builder.RegisterType<ContentService>()
-                .AsSelf()
-                .As<IContentService>()
-                .SingleInstance();
 
             builder.Register(c => new EntitiesContext(configuration.Current.SqlConnectionString, readOnly: configuration.Current.ReadOnlyMode))
                 .AsSelf()
@@ -194,11 +176,6 @@ namespace NuGetGallery
                 .As<ITempDataProvider>()
                 .InstancePerLifetimeScope();
 
-            builder.RegisterType<NuGetExeDownloaderService>()
-                .AsSelf()
-                .As<INuGetExeDownloaderService>()
-                .InstancePerLifetimeScope();
-
             builder.RegisterType<StatusService>()
                 .AsSelf()
                 .As<IStatusService>()
@@ -279,28 +256,13 @@ namespace NuGetGallery
                     break;
                 case StorageType.AzureStorage:
                     ConfigureForAzureStorage(builder, configuration);
-                    defaultAuditingService = GetAuditingServiceForAzureStorage(configuration);
+                    defaultAuditingService = GetAuditingServiceForAzureStorage(builder, configuration);
                     break;
             }
 
             RegisterAuditingServices(builder, defaultAuditingService);
 
             RegisterCookieComplianceService(builder, configuration, diagnosticsService);
-
-            builder.RegisterType<FileSystemService>()
-                .AsSelf()
-                .As<IFileSystemService>()
-                .SingleInstance();
-
-            builder.RegisterType<PackageFileService>()
-                .AsSelf()
-                .As<IPackageFileService>()
-                .InstancePerLifetimeScope();
-
-            builder.RegisterType<UploadFileService>()
-                .AsSelf()
-                .As<IUploadFileService>()
-                .InstancePerLifetimeScope();
 
             // todo: bind all package curators by convention
             builder.RegisterType<WebMatrixPackageCurator>()
@@ -389,10 +351,23 @@ namespace NuGetGallery
 
         private static void ConfigureForLocalFileSystem(ContainerBuilder builder, IGalleryConfigurationService configuration)
         {
+            builder.RegisterType<FileSystemService>()
+                .AsSelf()
+                .As<IFileSystemService>()
+                .SingleInstance();
+
             builder.RegisterType<FileSystemFileStorageService>()
                 .AsSelf()
                 .As<IFileStorageService>()
                 .SingleInstance();
+
+            foreach (var dependent in StorageDependent.GetAll(configuration.Current))
+            {
+                builder.RegisterType(dependent.ImplementationType)
+                    .AsSelf()
+                    .As(dependent.InterfaceType)
+                    .InstancePerLifetimeScope();
+            }
 
             builder.RegisterInstance(NullReportService.Instance)
                 .AsSelf()
@@ -409,43 +384,9 @@ namespace NuGetGallery
                 .AsSelf()
                 .As<IAggregateStatsService>()
                 .InstancePerLifetimeScope();
-        }
 
-        private static void ConfigureForAzureStorage(ContainerBuilder builder, IGalleryConfigurationService configuration)
-        {
-            builder.RegisterInstance(new CloudBlobClientWrapper(configuration.Current.AzureStorageConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant))
-                .AsSelf()
-                .As<ICloudBlobClient>()
-                .SingleInstance();
-
-            builder.RegisterType<CloudBlobFileStorageService>()
-                .AsSelf()
-                .As<IFileStorageService>()
-                .SingleInstance();
-
-            // when running on Windows Azure, we use a back-end job to calculate stats totals and store in the blobs
-            builder.RegisterInstance(new JsonAggregateStatsService(configuration.Current.AzureStorageConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant))
-                .AsSelf()
-                .As<IAggregateStatsService>()
-                .SingleInstance();
-
-            // when running on Windows Azure, pull the statistics from the warehouse via storage
-            builder.RegisterInstance(new CloudReportService(configuration.Current.AzureStorageConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant))
-                .AsSelf()
-                .As<IReportService>()
-                .SingleInstance();
-
-            // when running on Windows Azure, download counts come from the downloads.v1.json blob
-            var downloadCountService = new CloudDownloadCountService(configuration.Current.AzureStorageConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant);
-            builder.RegisterInstance(downloadCountService)
-                .AsSelf()
-                .As<IDownloadCountService>()
-                .SingleInstance();
-            ObjectMaterializedInterception.AddInterceptor(new DownloadCountObjectMaterializedInterceptor(downloadCountService));
-
-            builder.RegisterType<JsonStatisticsService>()
-                .AsSelf()
-                .As<IStatisticsService>()
+            builder.RegisterInstance(new SqlErrorLog(configuration.Current.SqlConnectionString))
+                .As<ErrorLog>()
                 .SingleInstance();
         }
 
@@ -458,7 +399,77 @@ namespace NuGetGallery
             return new FileSystemAuditingService(auditingPath, AuditActor.GetAspNetOnBehalfOfAsync);
         }
 
-        private static IAuditingService GetAuditingServiceForAzureStorage(IGalleryConfigurationService configuration)
+        private static void ConfigureForAzureStorage(ContainerBuilder builder, IGalleryConfigurationService configuration)
+        {
+            /// The goal here is to initialize a <see cref="ICloudBlobClient"/> and <see cref="IFileStorageService"/>
+            /// instance for each unique connection string. Each dependent of <see cref="IFileStorageService"/> (that
+            /// is, each service that has a <see cref="IFileStorageService"/> constructor parameter) is registered in
+            /// <see cref="StorageDependent.GetAll(IAppConfiguration)"/> and is grouped by the respective storage
+            /// connection string. Each group is given a binding key which refers to the appropriate instance of the
+            /// <see cref="IFileStorageService"/>.
+            var completedBindingKeys = new HashSet<string>();
+            foreach (var dependent in StorageDependent.GetAll(configuration.Current))
+            {
+                if (completedBindingKeys.Add(dependent.BindingKey))
+                {
+                    builder.RegisterInstance(new CloudBlobClientWrapper(dependent.AzureStorageConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant))
+                       .AsSelf()
+                       .As<ICloudBlobClient>()
+                       .SingleInstance()
+                       .Keyed<ICloudBlobClient>(dependent.BindingKey);
+
+                    builder.RegisterType<CloudBlobFileStorageService>()
+                        .WithParameter(new ResolvedParameter(
+                           (pi, ctx) => pi.ParameterType == typeof(ICloudBlobClient),
+                           (pi, ctx) => ctx.ResolveKeyed<ICloudBlobClient>(dependent.BindingKey)))
+                        .AsSelf()
+                        .As<IFileStorageService>()
+                        .As<ICloudStorageStatusDependency>()
+                        .SingleInstance()
+                        .Keyed<IFileStorageService>(dependent.BindingKey);
+                }
+
+                builder.RegisterType(dependent.ImplementationType)
+                    .WithParameter(new ResolvedParameter(
+                       (pi, ctx) => pi.ParameterType == typeof(IFileStorageService),
+                       (pi, ctx) => ctx.ResolveKeyed<IFileStorageService>(dependent.BindingKey)))
+                    .AsSelf()
+                    .As(dependent.InterfaceType)
+                    .InstancePerLifetimeScope();
+            }
+
+            // when running on Windows Azure, we use a back-end job to calculate stats totals and store in the blobs
+            builder.RegisterInstance(new JsonAggregateStatsService(configuration.Current.AzureStorage_Statistics_ConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant))
+                .AsSelf()
+                .As<IAggregateStatsService>()
+                .SingleInstance();
+
+            // when running on Windows Azure, pull the statistics from the warehouse via storage
+            builder.RegisterInstance(new CloudReportService(configuration.Current.AzureStorage_Statistics_ConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant))
+                .AsSelf()
+                .As<IReportService>()
+                .As<ICloudStorageStatusDependency>()
+                .SingleInstance();
+
+            // when running on Windows Azure, download counts come from the downloads.v1.json blob
+            var downloadCountService = new CloudDownloadCountService(configuration.Current.AzureStorage_Statistics_ConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant);
+            builder.RegisterInstance(downloadCountService)
+                .AsSelf()
+                .As<IDownloadCountService>()
+                .SingleInstance();
+            ObjectMaterializedInterception.AddInterceptor(new DownloadCountObjectMaterializedInterceptor(downloadCountService));
+
+            builder.RegisterType<JsonStatisticsService>()
+                .AsSelf()
+                .As<IStatisticsService>()
+                .SingleInstance();
+
+            builder.RegisterInstance(new TableErrorLog(configuration.Current.AzureStorage_Errors_ConnectionString))
+                .As<ErrorLog>()
+                .SingleInstance();
+        }
+
+        private static IAuditingService GetAuditingServiceForAzureStorage(ContainerBuilder builder, IGalleryConfigurationService configuration)
         {
             string instanceId;
             try
@@ -472,10 +483,16 @@ namespace NuGetGallery
 
             var localIp = AuditActor.GetLocalIpAddressAsync().Result;
 
-            return new CloudAuditingService(instanceId, localIp, configuration.Current.AzureStorageConnectionString, AuditActor.GetAspNetOnBehalfOfAsync);
+            var service = new CloudAuditingService(instanceId, localIp, configuration.Current.AzureStorage_Auditing_ConnectionString, AuditActor.GetAspNetOnBehalfOfAsync);
+
+            builder.RegisterInstance(service)
+                .As<ICloudStorageStatusDependency>()
+                .SingleInstance();
+
+            return service;
         }
 
-        private static IAuditingService CombineServices(IEnumerable<IAuditingService> services)
+        private static IAuditingService CombineAuditingServices(IEnumerable<IAuditingService> services)
         {
             if (!services.Any())
             {
@@ -510,7 +527,7 @@ namespace NuGetGallery
                 services.Add(defaultAuditingService);
             }
 
-            var service = CombineServices(services);
+            var service = CombineAuditingServices(services);
 
             builder.RegisterInstance(service)
                 .AsSelf()

--- a/src/NuGetGallery/App_Start/StorageDependent.cs
+++ b/src/NuGetGallery/App_Start/StorageDependent.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGetGallery.Configuration;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Represents a type that depends on <see cref="IFileStorageService"/>.
+    /// </summary>
+    internal class StorageDependent
+    {
+        private StorageDependent(
+            string bindingKey,
+            string azureStorageConnectionString,
+            Type implementationType,
+            Type interfaceType)
+        {
+            BindingKey = bindingKey;
+            AzureStorageConnectionString = azureStorageConnectionString;
+            ImplementationType = implementationType;
+            InterfaceType = interfaceType;
+        }
+
+        public StorageDependent SetBindingKey(string bindingKey)
+        {
+            return new StorageDependent(
+                bindingKey,
+                AzureStorageConnectionString,
+                ImplementationType,
+                InterfaceType);
+        }
+
+        /// <summary>
+        /// A key to be used by Autofac's <see cref="ResolutionExtensions.ResolveKeyed(IComponentContext, object, Type)"/>.
+        /// </summary>
+        public string BindingKey { get; }
+
+        /// <summary>
+        /// The connection string to be used for a <see cref="CloudBlobClientWrapper"/> instance.
+        /// </summary>
+        public string AzureStorageConnectionString { get; }
+
+        /// <summary>
+        /// The storage dependent's implementation type.
+        /// </summary>
+        public Type ImplementationType { get; }
+
+        /// <summary>
+        /// The storage dependent's interface type.
+        /// </summary>
+        public Type InterfaceType { get; }
+
+        public static StorageDependent Create<TImplementation, TInterface>(
+            string azureStorageConnectionString) where TImplementation : TInterface
+        {
+            return new StorageDependent(
+                typeof(TImplementation).FullName,
+                azureStorageConnectionString,
+                typeof(TImplementation),
+                typeof(TInterface));
+        }
+
+        /// <summary>
+        /// Group the storage dependents by Azure Storage connection string then generate a binding key so that
+        /// <see cref="IFileStorageService"/> instances are shared.
+        /// </summary>
+        public static IEnumerable<StorageDependent> GetAll(IAppConfiguration configuration)
+        {
+            const string DefaultBindingKey = "Default";
+
+            /// This array must be added to as we implement more services that use <see cref="IFileStorageService"/>.
+            var dependents = new[]
+            {
+                Create<ContentService, IContentService>(configuration.AzureStorage_Content_ConnectionString),
+                Create<NuGetExeDownloaderService, INuGetExeDownloaderService>(configuration.AzureStorage_NuGetExe_ConnectionString),
+                Create<PackageFileService, IPackageFileService>(configuration.AzureStorage_Packages_ConnectionString),
+                Create<UploadFileService, IUploadFileService>(configuration.AzureStorage_Uploads_ConnectionString),
+            };
+
+            var connectionStringToBindingKey = dependents
+                .GroupBy(d => d.AzureStorageConnectionString ?? DefaultBindingKey)
+                .ToDictionary(g => g.Key, g => string.Join(" ", g.Select(d => d.BindingKey)));
+
+            foreach (var dependent in dependents)
+            {
+                var bindingKey = connectionStringToBindingKey[dependent.AzureStorageConnectionString ?? DefaultBindingKey];
+                yield return dependent.SetBindingKey(bindingKey);
+            }
+        }
+    }
+}

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -42,10 +42,27 @@ namespace NuGetGallery.Configuration
         [TypeConverter(typeof(StringArrayConverter))]
         public string[] ForceSslExclusion { get; set; }
 
-        /// <summary>
-        /// Gets the connection string to use when connecting to azure storage
-        /// </summary>
-        public string AzureStorageConnectionString { get; set; }
+
+        [DisplayName("AzureStorage.Auditing.ConnectionString")]
+        public string AzureStorage_Auditing_ConnectionString { get; set; }
+
+        [DisplayName("AzureStorage.Content.ConnectionString")]
+        public string AzureStorage_Content_ConnectionString { get; set; }
+
+        [DisplayName("AzureStorage.Errors.ConnectionString")]
+        public string AzureStorage_Errors_ConnectionString { get; set; }
+
+        [DisplayName("AzureStorage.NuGetExe.ConnectionString")]
+        public string AzureStorage_NuGetExe_ConnectionString { get; set; }
+
+        [DisplayName("AzureStorage.Packages.ConnectionString")]
+        public string AzureStorage_Packages_ConnectionString { get; set; }
+
+        [DisplayName("AzureStorage.Statistics.ConnectionString")]
+        public string AzureStorage_Statistics_ConnectionString { get; set; }
+
+        [DisplayName("AzureStorage.Uploads.ConnectionString")]
+        public string AzureStorage_Uploads_ConnectionString { get; set; }
 
         /// <summary>
         /// Gets a setting if Read Access Geo Redundant is enabled in azure storage

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -51,9 +51,39 @@ namespace NuGetGallery.Configuration
         string[] ForceSslExclusion { get; set; }
 
         /// <summary>
-        /// Gets the connection string to use when connecting to azure storage
+        /// The Azure Storage connection string used for auditing.
         /// </summary>
-        string AzureStorageConnectionString { get; set; }
+        string AzureStorage_Auditing_ConnectionString { get; set; }
+        
+        /// <summary>
+        /// The Azure Storage connection string used for static content.
+        /// </summary>
+        string AzureStorage_Content_ConnectionString { get; set; }
+
+        /// <summary>
+        /// The Azure Storage connection string used for Elmah error logs.
+        /// </summary>
+        string AzureStorage_Errors_ConnectionString { get; set; }
+
+        /// <summary>
+        /// The Azure Storage connection string used for downloading nuget.exe.
+        /// </summary>
+        string AzureStorage_NuGetExe_ConnectionString { get; set; }
+
+        /// <summary>
+        /// The Azure Storage connection string used for packages, after upload.
+        /// </summary>
+        string AzureStorage_Packages_ConnectionString { get; set; }
+
+        /// <summary>
+        /// The Azure Storage connection string used for statistics.
+        /// </summary>
+        string AzureStorage_Statistics_ConnectionString { get; set; }
+
+        /// <summary>
+        /// The Azure Storage connection string used for package uploads, before publishing.
+        /// </summary>
+        string AzureStorage_Uploads_ConnectionString { get; set; }
 
         /// <summary>
         /// Gets a setting if Read Access Geo Redundant is enabled in azure storage

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -643,6 +643,7 @@
     <Compile Include="App_Start\NuGetODataV1FeedConfig.cs" />
     <Compile Include="App_Start\NuGetODataConfig.cs" />
     <Compile Include="App_Start\RuntimeServiceProvider.cs" />
+    <Compile Include="App_Start\StorageDependent.cs" />
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="App_Start\AutofacConfig.cs" />
     <Compile Include="Areas\Admin\Controllers\DeleteController.cs" />

--- a/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
+++ b/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
@@ -17,7 +17,7 @@ using NuGetGallery.Configuration;
 
 namespace NuGetGallery
 {
-    public class CloudBlobFileStorageService : IFileStorageService
+    public class CloudBlobFileStorageService : IFileStorageService, ICloudStorageStatusDependency
     {
         private readonly ICloudBlobClient _client;
         private readonly IAppConfiguration _configuration;

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -26,8 +26,16 @@
     <!-- These should change on every deployment (to rotate credentials, etc.) -->
     <add key="Gallery.StorageType" value="FileSystem" />
     <!-- The storage type to use. Can be FileSystem (default) or AzureStorage -->
-    <add key="Gallery.AzureStorageConnectionString" value="" />
-    <!-- The connection string for the Azure Storage Account used for Package Storage IF Gallery.StorageType is AzureStorage -->
+
+    <add key="Gallery.AzureStorage.Auditing.ConnectionString" value="" />
+    <add key="Gallery.AzureStorage.Content.ConnectionString" value="" />
+    <add key="Gallery.AzureStorage.Errors.ConnectionString" value="" />
+    <add key="Gallery.AzureStorage.NuGetExe.ConnectionString" value="" />
+    <add key="Gallery.AzureStorage.Packages.ConnectionString" value="" />
+    <add key="Gallery.AzureStorage.Statistics.ConnectionString" value="" />
+    <add key="Gallery.AzureStorage.Uploads.ConnectionString" value="" />
+    <!-- The various Azure Storage connection strings to use. If the Gallery.StorageType is AzureStorage, all must be defined. -->
+    
     <add key="Gallery.AzureStorageReadAccessGeoRedundant" value="false" />
     <!-- If the storage account has to fall-back to a secondary (when Read Access Geo Redundant is enabled in Azure storage), change Gallery.AzureStorageReadAccessGeoRedundant to true -->
     

--- a/tests/NuGetGallery.Facts/App_Start/StorageDependentFacts.cs
+++ b/tests/NuGetGallery.Facts/App_Start/StorageDependentFacts.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NuGetGallery.Configuration;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class StorageDependentFacts
+    {
+        [Fact]
+        public void AllTypesDependingOnIFileStorageServiceAreReturnedByGetStorageDependents()
+        {
+            // Arrange
+            var config = GetConfiguration();
+
+            // Act
+            var dependents = StorageDependent.GetAll(config);
+
+            // Assert
+            var actual = new HashSet<Type>(dependents.Select(x => x.ImplementationType));
+            var allTypes = typeof(DefaultDependenciesModule).Assembly.GetTypes();
+            var expected = new HashSet<Type>();
+            foreach (var type in allTypes)
+            {
+                var constructors = type.GetConstructors();
+                foreach (var constructor in constructors)
+                {
+                    var parameters = constructor.GetParameters();
+                    if (parameters.Any(p => p.ParameterType == typeof(IFileStorageService)))
+                    {
+                        expected.Add(type);
+                    }
+                }
+            }
+            
+            Assert.Subset(expected, actual);
+            Assert.Subset(actual, expected);
+        }
+
+        [Fact]
+        public void StorageDependentsHaveExpectedTypes()
+        {
+            // Arrange
+            var config = GetConfiguration();
+
+            // Act
+            var dependents = StorageDependent.GetAll(config);
+
+            // Assert
+            var implementationToInterface = dependents.ToDictionary(x => x.ImplementationType, x => x.InterfaceType);
+            Assert.Contains(typeof(ContentService), implementationToInterface.Keys);
+            Assert.Contains(typeof(NuGetExeDownloaderService), implementationToInterface.Keys);
+            Assert.Contains(typeof(PackageFileService), implementationToInterface.Keys);
+            Assert.Contains(typeof(UploadFileService), implementationToInterface.Keys);
+            Assert.Equal(4, implementationToInterface.Count);
+            Assert.Equal(implementationToInterface[typeof(ContentService)], typeof(IContentService));
+            Assert.Equal(implementationToInterface[typeof(NuGetExeDownloaderService)], typeof(INuGetExeDownloaderService));
+            Assert.Equal(implementationToInterface[typeof(PackageFileService)], typeof(IPackageFileService));
+            Assert.Equal(implementationToInterface[typeof(UploadFileService)], typeof(IUploadFileService));
+        }
+
+        [Fact]
+        public void StorageDependentsUseCorrectConnectionString()
+        {
+            // Arrange
+            var config = GetConfiguration();
+
+            // Act
+            var dependents = StorageDependent.GetAll(config);
+
+            // Assert
+            var typeToConnectionString = dependents.ToDictionary(x => x.ImplementationType, x => x.AzureStorageConnectionString);
+            Assert.Equal(typeToConnectionString[typeof(ContentService)], config.AzureStorage_Content_ConnectionString);
+            Assert.Equal(typeToConnectionString[typeof(NuGetExeDownloaderService)], config.AzureStorage_NuGetExe_ConnectionString);
+            Assert.Equal(typeToConnectionString[typeof(PackageFileService)], config.AzureStorage_Packages_ConnectionString);
+            Assert.Equal(typeToConnectionString[typeof(UploadFileService)], config.AzureStorage_Uploads_ConnectionString);
+        }
+
+        [Fact]
+        public void StorageDependentsAreGroupedByConnectionString()
+        {
+            // Arrange
+            var mock = new Mock<IAppConfiguration>();
+            mock.Setup(x => x.AzureStorage_Content_ConnectionString).Returns("Content and NuGetExe");
+            mock.Setup(x => x.AzureStorage_NuGetExe_ConnectionString).Returns("Content and NuGetExe");
+            mock.Setup(x => x.AzureStorage_Packages_ConnectionString).Returns("Packages and Uploads");
+            mock.Setup(x => x.AzureStorage_Uploads_ConnectionString).Returns("Packages and Uploads");
+            var config = mock.Object;
+
+            // Act
+            var dependents = StorageDependent.GetAll(config);
+
+            // Assert
+            var typeToBindingKey = dependents.ToDictionary(x => x.ImplementationType, x => x.BindingKey);
+            Assert.Equal(typeToBindingKey[typeof(ContentService)], typeToBindingKey[typeof(NuGetExeDownloaderService)]);
+            Assert.Equal(typeToBindingKey[typeof(PackageFileService)], typeToBindingKey[typeof(UploadFileService)]);
+        }
+
+        private static IAppConfiguration GetConfiguration()
+        {
+            var mock = new Mock<IAppConfiguration>();
+            mock.Setup(x => x.AzureStorage_Content_ConnectionString).Returns("Content");
+            mock.Setup(x => x.AzureStorage_NuGetExe_ConnectionString).Returns("NuGetExe");
+            mock.Setup(x => x.AzureStorage_Packages_ConnectionString).Returns("Packages");
+            mock.Setup(x => x.AzureStorage_Uploads_ConnectionString).Returns("Uploads");
+            return mock.Object;
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -380,6 +380,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppConfigIsCorrectlyApplied.cs" />
+    <Compile Include="App_Start\StorageDependentFacts.cs" />
     <Compile Include="App_Start\RuntimeServiceProviderTests.cs" />
     <Compile Include="Areas\Admin\Controllers\SecurityPolicyControllerFacts.cs" />
     <Compile Include="Authentication\AuthenticatorFacts.cs" />


### PR DESCRIPTION
Replaced configuration `Gallery.AzureStorageConnectionString` with new variables:

- `Gallery.AzureStorage.Auditing.ConnectionString`
- `Gallery.AzureStorage.Content.ConnectionString`
- `Gallery.AzureStorage.Errors.ConnectionString`
- `Gallery.AzureStorage.NuGetExe.ConnectionString`
- `Gallery.AzureStorage.Packages.ConnectionString`
- `Gallery.AzureStorage.Statistics.ConnectionString`
- `Gallery.AzureStorage.Uploads.ConnectionString`

Why the dots in the configuration name? I think the proper mental model here is that each storage purpose (e.g. `Errors`) may eventually have additional properties. For example, the `Gallery.AzureStorageReadAccessGeoRedundant` setting could become account-specific or we could configure the table/container name that `Uploads` go into (for example). For that reason, I imagined the future where `Gallery.AzureStorage.Statistics` would refer to an object with a set of properties. Today there is only one property: `ConnectionString`.

Why the underscores in the property names? Today, the code that populates the `AppConfiguration` instance does not work on complex objects -- just simple properties. The underscore is basically a way to mimic complex objects in a flat list of properties like `IAppConfiguration`.

The basis of this implementation is telling our DI container (Autofac) which connection string to use for different services. We now need N instances of `CloudBlobFileStorageService`, instead of just one. Since this means we will have multiple implementations of `IFileStorageService` available in the DI container, we need a way to differentiate between them. We do this with **keyed services**. For more information about this general DI project, see here:
http://docs.autofac.org/en/latest/faq/select-by-context.html

After this PR is approved and before I merge the PR, I will add the new configuration values to our DEV, INT, and PROD configuration files (.cscfg).

Fix https://github.com/NuGet/NuGetGallery/issues/4554.