### PR TITLE
Redirect preview.nuget.org to www.nuget.org

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -404,6 +404,13 @@
           </conditions>
           <action type="Redirect" url="{MapProtocol:{HTTPS}}www.nuget.org/{R:1}" redirectType="Permanent" />
         </rule>
+        <rule name="Redirect preview">
+          <match url="^(.*)$" />
+          <conditions>
+            <add input="{HTTP_HOST}" pattern="^preview\.nuget\.org$" />
+          </conditions>
+          <action type="Redirect" url="{MapProtocol:{HTTPS}}www.nuget.org/{R:1}" redirectType="Permanent" />
+        </rule>
         <rule name="Legacy feed root URL" stopProcessing="true">
           <match url="^$" />
           <conditions>


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/695

Tested locally by generating a cert for preview.nuget.org and www.nuget.org and adding a host file entry for these two names pointing to localhost.