### PR TITLE
Autofocus the search bar on the front page

### DIFF
--- a/src/NuGetGallery/Views/Pages/Home.cshtml
+++ b/src/NuGetGallery/Views/Pages/Home.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     ViewBag.Title = "Home";
     ViewBag.ShowSearchInNavbar = false;
+    ViewBag.AutofocusSearch = true;
     ViewBag.HasJumbotron = true;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }

--- a/src/NuGetGallery/Views/Shared/_SearchBar.cshtml
+++ b/src/NuGetGallery/Views/Shared/_SearchBar.cshtml
@@ -1,7 +1,8 @@
 ﻿<div class="input-group">
     <input name="q" type="text" class="form-control" id="search"
            placeholder="Search for packages..." autocomplete="off"
-           value="@(String.IsNullOrEmpty(ViewBag.SearchTerm) ? "" : ViewBag.SearchTerm)" />
+           value="@(String.IsNullOrEmpty(ViewBag.SearchTerm) ? "" : ViewBag.SearchTerm)"
+           @(ViewBag.AutofocusSearch == true ? "autofocus" : string.Empty) />
     <span class="input-group-btn">
         <button class="btn btn-default btn-warning btn-search" type="submit"
                 title="Search for packages" aria-label="Search">


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/4575

/cc @microsoftsam - what are your thoughts on the accessibility here? The only drawback I can think of is inconsistent tab start point:
- Home page: first <kbd>Tab</kbd> goes to the search button.
- All other pages: first <kbd>Tab</kbd> goes to logo in navbar.

The tab sequence is the same, but the start point is now different.

All pages still focus the search bar when you start typing (including the home page).