### PR TITLE
Move pager to center of the page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -374,7 +374,6 @@ img.package-icon {
   }
 }
 .pager {
-  float: right;
   margin-top: 75px;
   margin-bottom: 0;
 }

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -66,5 +66,4 @@
 .pager {
   margin-top: 75px;
   margin-bottom: 0px;
-  float: right;
 }

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -374,7 +374,6 @@ img.package-icon {
   }
 }
 .pager {
-  float: right;
   margin-top: 75px;
   margin-bottom: 0;
 }


### PR DESCRIPTION
I just think this

![image](https://user-images.githubusercontent.com/582487/29818070-e9ed651a-8cba-11e7-9af9-59b231589ee1.png)

looks much better than this

![image](https://user-images.githubusercontent.com/582487/29818075-ef6667d0-8cba-11e7-89fd-2e784ed5b8b6.png)

Also, I couldn't find the pager at first, cause I expected it to be in the center (which is also the Bootstrap default.)