### PR TITLE
Add support for third-party tabs on package details page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -676,12 +676,6 @@ img.package-icon {
   width: 100%;
   margin: 0;
 }
-.page-package-details .install-tabs #package-manager .install-script span::before {
-  content: "PM> ";
-}
-.page-package-details .install-tabs #dotnet-cli .install-script span::before {
-  content: "> ";
-}
 .page-downloads .list-tools li {
   margin-top: 20px;
 }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -672,6 +672,10 @@ img.package-icon {
   line-height: 1.5;
   vertical-align: baseline;
 }
+.page-package-details .install-tabs .tab-pane .alert {
+  width: 100%;
+  margin: 0;
+}
 .page-package-details .install-tabs #package-manager .install-script span::before {
   content: "PM> ";
 }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -119,13 +119,5 @@
         width: 100%;
       }
     }
-
-    #package-manager .install-script span::before {
-      content: "PM> ";
-    }
-
-    #dotnet-cli .install-script span::before {
-      content: "> ";
-    }
   }
 }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -113,6 +113,11 @@
           line-height: 1.5;
         }
       }
+
+      .alert {
+        margin: 0;
+        width: 100%;
+      }
     }
 
     #package-manager .install-script span::before {

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -676,12 +676,6 @@ img.package-icon {
   width: 100%;
   margin: 0;
 }
-.page-package-details .install-tabs #package-manager .install-script span::before {
-  content: "PM> ";
-}
-.page-package-details .install-tabs #dotnet-cli .install-script span::before {
-  content: "> ";
-}
 .page-downloads .list-tools li {
   margin-top: 20px;
 }

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -672,6 +672,10 @@ img.package-icon {
   line-height: 1.5;
   vertical-align: baseline;
 }
+.page-package-details .install-tabs .tab-pane .alert {
+  width: 100%;
+  margin: 0;
+}
 .page-package-details .install-tabs #package-manager .install-script span::before {
   content: "PM> ";
 }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1503,9 +1503,11 @@
     <Compile Include="ViewModels\ApiKeyListViewModel.cs" />
     <Compile Include="ViewModels\ApiKeyViewModel.cs" />
     <Compile Include="ViewModels\PackageHeadingModel.cs" />
+    <Compile Include="ViewModels\PackageManagerViewModel.cs" />
     <Compile Include="ViewModels\ReportMyPackageViewModel.cs" />
     <Compile Include="ViewModels\ScopeViewModel.cs" />
     <Compile Include="ViewModels\PackageListSearchViewModel.cs" />
+    <Compile Include="ViewModels\ThirdPartyPackageManagerViewModel.cs" />
     <Compile Include="WebApi\PlainTextResult.cs" />
     <Compile Include="WebApi\QueryResult.cs" />
     <Compile Include="WebApi\QueryResultDefaults.cs" />

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -24,8 +24,10 @@ $(function () {
         "CalculatorSubtract",
         "Show more");    
 
-    configureCopyButton('package-manager');
-    configureCopyButton('dotnet-cli');
+    for (var i in packageManagers)
+    {
+        configureCopyButton(packageManagers[i]);
+    }
 
     // Enable the undo edit link.
     $("#undo-pending-edits").click(function (e) {

--- a/src/NuGetGallery/ViewModels/PackageManagerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageManagerViewModel.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// The basic model for a client that conforms to the NuGet protocol.
+    /// </summary>
+    public class PackageManagerViewModel
+    {
+        /// <summary>
+        /// The package manager's name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A unique identifier that represents this package manager.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The non-selectable prefix displayed on before the package manager's commands.
+        /// </summary>
+        public string CommandPrefix { get; set; }
+
+        /// <summary>
+        /// A string that represents the command used to install a specific package.
+        /// </summary>
+        public string InstallPackageCommand { get; set; }
+    }
+}

--- a/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
@@ -4,14 +4,14 @@
 namespace NuGetGallery
 {
     /// <summary>
-    /// A Package Manager that conforms to the NuGet protocol but isn't
-    /// maintained by the NuGet team.
+    /// A Package Manager that conforms to the NuGet protocol but isn't maintained
+    /// by the NuGet team.
     /// </summary>
     public class ThirdPartyPackageManagerViewModel : PackageManagerViewModel
     {
         /// <summary>
-        /// The URL that links should be used to contact the package manager's
-        /// maintainers for support.
+        /// The URL that should be used to contact this package manager's maintainers
+        /// for support.
         /// </summary>
         public string ContactUrl { get; set; }
     }

--- a/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// A Package Manager that conforms to the NuGet protocol but isn't
+    /// maintained by the NuGet team.
+    /// </summary>
+    public class ThirdPartyPackageManagerViewModel : PackageManagerViewModel
+    {
+        /// <summary>
+        /// The URL that links should be used to contact the package manager's
+        /// maintainers for support.
+        /// </summary>
+        public string ContactUrl { get; set; }
+    }
+}

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -49,7 +49,7 @@
     </li>
 }
 
-@helper CommandPanel(Func<MvcHtmlString, HelperResult> htmlContent, string label, string id, bool active)
+@helper CommandPanel(Func<MvcHtmlString, HelperResult> htmlContent, string label, string id, bool active, string thirdPartyUrl = null)
 {
     <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty)" id="@id">
         <div>
@@ -66,6 +66,13 @@
                 </button>
             </div>
         </div>
+        @if (!string.IsNullOrEmpty(thirdPartyUrl))
+        {
+            @ViewHelpers.AlertWarning(
+                @<text>
+                    This client is not supported by the NuGet team. <a href="@thirdPartyUrl">Contact its maintainers for support</a>
+                </text>)
+        }
     </div>
 }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -3,7 +3,27 @@
     ViewBag.Title = Model.Id + " " + Model.Version;
     ViewBag.Tab = "Packages";
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
+
     var absolutePackageUrl = Url.Absolute(Url.Package(Model.Id));
+
+    var packageManagers = new PackageManagerViewModel[]
+    {
+        new PackageManagerViewModel()
+        {
+            Id = "package-manager",
+            Name = "Package Manager",
+            CommandPrefix = "PM> ",
+            InstallPackageCommand = string.Format("Install-Package {0} -Version {1}", Model.Id, Model.Version)
+        },
+
+        new PackageManagerViewModel()
+        {
+            Id = "dotnet-cli",
+            Name = ".NET CLI",
+            CommandPrefix = "> ",
+            InstallPackageCommand = string.Format("dotnet add package {0} --version {1}", Model.Id, Model.Version)
+        },
+    };
 }
 @section SocialMeta {
     @if (!String.IsNullOrWhiteSpace(ViewBag.FacebookAppID))
@@ -37,40 +57,43 @@
 }
 
 
-@helper CommandTab(string label, string id, bool active)
+@helper CommandTab(PackageManagerViewModel packageManager, bool active)
 {
     <li role="presentation" class="@(active ? "active" : string.Empty)">
-        <a href="#@id" aria-expanded="@(active ? "true" : "false")"
+        <a href="#@packageManager.Id" aria-expanded="@(active ? "true" : "false")"
            aria-selected="@(active ? "true" : "false")"
-           aria-controls="@id" role="tab" data-toggle="tab"
-           title="Switch to tab panel which contains package installation command for @label">
-            @label
+           aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
+           title="Switch to tab panel which contains package installation command for @packageManager.Name">
+            @packageManager.Name
         </a>
     </li>
 }
 
-@helper CommandPanel(Func<MvcHtmlString, HelperResult> htmlContent, string label, string id, bool active, string thirdPartyUrl = null)
+@helper CommandPanel(PackageManagerViewModel packageManager, bool active)
 {
-    <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty)" id="@id">
+    var thirdPartyPackageManager = packageManager as ThirdPartyPackageManagerViewModel;
+
+    <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty)" id="@packageManager.Id">
         <div>
-            <div class="install-script" id="@id-text">
+            <div class="install-script" id="@packageManager.Id-text">
                 <span>
-                    @htmlContent(MvcHtmlString.Empty)
+                    @packageManager.InstallPackageCommand
                 </span>
             </div>
             <div class="copy-button">
-                <button id="@id-button" class="btn btn-default btn-warning" type="button"
+                <button id="@packageManager.Id-button" class="btn btn-default btn-warning" type="button"
                         data-toggle="popover" data-placement="bottom" data-content="Copied."
-                        aria-label="Copy the @label command">
+                        aria-label="Copy the @packageManager.Name command">
                     <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
                 </button>
             </div>
         </div>
-        @if (!string.IsNullOrEmpty(thirdPartyUrl))
+        @if (thirdPartyPackageManager != null)
         {
             @ViewHelpers.AlertWarning(
                 @<text>
-                    This client is not supported by the NuGet team. <a href="@thirdPartyUrl">Contact its maintainers for support</a>
+                    This client is not supported by the NuGet team.
+                    <a href="@thirdPartyPackageManager.ContactUrl">Contact its maintainers for support</a>.
                 </text>)
         }
     </div>
@@ -224,12 +247,22 @@
 
             <div class="install-tabs">
                 <ul class="nav nav-tabs" role="tablist">
-                    @CommandTab("Package Manager", "package-manager", active: true)
-                    @CommandTab(".NET CLI", "dotnet-cli", active: false)
+                    @{ var firstPackageManager = true; }
+                    @foreach (var packageManager in packageManagers)
+                    {
+                        @CommandTab(packageManager, active: firstPackageManager)
+
+                        firstPackageManager = false;
+                    }
                 </ul>
                 <div class="tab-content">
-                    @CommandPanel(@<text>Install-Package @Model.Id -Version @Model.Version</text>, "Package Manager", "package-manager", active: true)
-                    @CommandPanel(@<text>dotnet add package @Model.Id --version @Model.Version</text>, ".NET CLI", "dotnet-cli", active: false)
+                    @{ firstPackageManager = true; }
+                    @foreach (var packageManager in packageManagers)
+                    {
+                        @CommandPanel(packageManager, active: firstPackageManager)
+
+                        firstPackageManager = false;
+                    }
                 </div>
             </div>
 
@@ -584,6 +617,27 @@
     </div>
 </section>
 
+
+
 @section BottomScripts {
+    @{
+        var packageManagersCss = string.Empty;
+
+        foreach (var packageManager in packageManagers)
+        {
+            packageManagersCss += "#" + packageManager.Id + " .install-script span::before {";
+            packageManagersCss += "    content: \"" + packageManager.CommandPrefix + "\"";
+            packageManagersCss += "}";
+        }
+    }
+
+    <style type="text/css">
+        @Html.Raw(packageManagersCss)
+    </style>
+
+    <script type="text/javascript">
+        var packageManagers = [@Html.Raw(string.Join(",", packageManagers.Select(pm => "\"" + pm.Id + "\"")))];
+    </script>
+
     @Scripts.Render("~/Scripts/gallery/page-display-package.min.js")
 }


### PR DESCRIPTION
Fixes #4589. Note that this doesn't actually add any third-party tabs, it simply adds the necessary styling to support third-party tabs. This [gist](https://gist.github.com/loic-sharma/43ac56a07d59cea430fb658a5961cad5) shows the necessary changes needed to add Paket.

![thirdparty](https://user-images.githubusercontent.com/737941/29949707-62200824-8e6b-11e7-9999-06761e689b44.png)
