### PR TITLE
[Prefix]Fix external search service to reflect the verified flag

### DIFF
--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -267,6 +267,7 @@ namespace NuGetGallery.Infrastructure.Lucene
                        .Select(v => new User { Username = v.Value<string>() })
                        .ToArray(),
                     DownloadCount = reg.Value<int>("DownloadCount"),
+                    IsVerified = reg.Value<bool>("Verified"),
                     Key = reg.Value<int>("Key")
                 };
             }


### PR DESCRIPTION
Missed adding the `IsVerified` flag to the search results in the external search service in the previous PR.