### PR TITLE
Use SiteRoot config setting for generated URLs

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -44,6 +44,8 @@ namespace NuGetGallery
 
             var configuration = new ConfigurationService(new SecretReaderFactory(diagnosticsService));
 
+            UrlExtensions.SetConfigurationService(configuration);
+
             builder.RegisterInstance(configuration)
                 .AsSelf()
                 .As<PoliteCaptcha.IConfigurationSource>();

--- a/src/NuGetGallery/Configuration/ConfigurationService.cs
+++ b/src/NuGetGallery/Configuration/ConfigurationService.cs
@@ -147,12 +147,6 @@ namespace NuGetGallery.Configuration
             return value;
         }
 
-        protected virtual HttpRequestBase GetCurrentRequest()
-        {
-            return new HttpRequestWrapper(HttpContext.Current.Request);
-        }
-
-
         private ISecretInjector InitSecretInjector()
         {
             return _secretReaderFactory.CreateSecretInjector(_secretReaderFactory.CreateSecretReader(new ConfigurationService(new EmptySecretReaderFactory())));
@@ -213,7 +207,6 @@ namespace NuGetGallery.Configuration
       
         private string GetHttpSiteRoot()
         {
-            var request = GetCurrentRequest();
             var siteRoot = Current.SiteRoot;
 
             if (!siteRoot.StartsWith("http://", StringComparison.OrdinalIgnoreCase)

--- a/src/NuGetGallery/Configuration/ConfigurationService.cs
+++ b/src/NuGetGallery/Configuration/ConfigurationService.cs
@@ -122,7 +122,7 @@ namespace NuGetGallery.Configuration
             }
             return instance;
         }
-        
+
         public async Task<string> ReadSetting(string settingName)
         {
             string value;
@@ -145,6 +145,11 @@ namespace NuGetGallery.Configuration
             }
 
             return value;
+        }
+
+        protected virtual HttpRequestBase GetCurrentRequest()
+        {
+            return new HttpRequestWrapper(HttpContext.Current.Request);
         }
 
         private ISecretInjector InitSecretInjector()
@@ -204,10 +209,18 @@ namespace NuGetGallery.Configuration
         {
             return WebConfigurationManager.ConnectionStrings[settingName];
         }
-      
+
         private string GetHttpSiteRoot()
         {
             var siteRoot = Current.SiteRoot;
+
+            if (siteRoot == null)
+            {
+                // No SiteRoot configured in settings.
+                // Fallback to detected site root.
+                var request = GetCurrentRequest();
+                siteRoot = request.Url.GetLeftPart(UriPartial.Authority) + '/';
+            }
 
             if (!siteRoot.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
                 && !siteRoot.StartsWith("https://", StringComparison.OrdinalIgnoreCase))

--- a/src/NuGetGallery/Configuration/ConfigurationService.cs
+++ b/src/NuGetGallery/Configuration/ConfigurationService.cs
@@ -214,16 +214,7 @@ namespace NuGetGallery.Configuration
         private string GetHttpSiteRoot()
         {
             var request = GetCurrentRequest();
-            string siteRoot;
-
-            if (request.IsLocal)
-            {
-                siteRoot = request.Url.GetLeftPart(UriPartial.Authority) + '/';
-            }
-            else
-            {
-                siteRoot = Current.SiteRoot;
-            }
+            var siteRoot = Current.SiteRoot;
 
             if (!siteRoot.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
                 && !siteRoot.StartsWith("https://", StringComparison.OrdinalIgnoreCase))

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -151,14 +151,14 @@ namespace NuGetGallery
                 try
                 {
                     var package = PackageService.FindPackageByIdAndVersion(
-                        id, 
-                        version, 
-                        SemVerLevelKey.SemVer2, 
+                        id,
+                        version,
+                        SemVerLevelKey.SemVer2,
                         allowPrerelease: false);
 
                     if (package == null)
                     {
-                       return new HttpStatusCodeWithBodyResult(HttpStatusCode.NotFound, String.Format(CultureInfo.CurrentCulture, Strings.PackageWithIdAndVersionNotFound, id, version));
+                        return new HttpStatusCodeWithBodyResult(HttpStatusCode.NotFound, String.Format(CultureInfo.CurrentCulture, Strings.PackageWithIdAndVersionNotFound, id, version));
                     }
                     version = package.NormalizedVersion;
 
@@ -174,7 +174,7 @@ namespace NuGetGallery
                 {
                     QuietLog.LogHandledException(e);
 
-			        // Database was unavailable and we don't have a version, return a 503
+                    // Database was unavailable and we don't have a version, return a 503
                     return new HttpStatusCodeWithBodyResult(HttpStatusCode.ServiceUnavailable, Strings.DatabaseUnavailable_TrySpecificVersion);
                 }
             }
@@ -261,7 +261,7 @@ namespace NuGetGallery
             {
                 await AuthenticationService.RemoveCredential(user, credential);
             }
-            
+
             TelemetryService.TrackVerifyPackageKeyEvent(id, version, user, User.Identity, result?.StatusCode ?? 200);
 
             return (ActionResult)result ?? new EmptyResult();
@@ -285,7 +285,7 @@ namespace NuGetGallery
             {
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.Forbidden, Strings.ApiKeyNotAuthorized);
             }
-            
+
             if (CredentialTypes.IsPackageVerificationApiKey(credential.Type))
             {
                 // Secure path: verify that verification key matches package scope.
@@ -370,7 +370,7 @@ namespace NuGetGallery
                             {
                                 message = ex.Message;
                             }
-                            
+
                             return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, message);
                         }
 
@@ -399,7 +399,7 @@ namespace NuGetGallery
                         {
                             // Check if API key allows pushing a new package id
                             if (!ApiKeyScopeAllows(
-                                subject: nuspec.GetId(), 
+                                subject: nuspec.GetId(),
                                 requestedActions: NuGetScopes.PackagePush))
                             {
                                 // User cannot push a new package ID as the API key scope does not allow it
@@ -414,8 +414,8 @@ namespace NuGetGallery
                                 // Audit that a non-owner tried to push the package
                                 await AuditingService.SaveAuditRecordAsync(
                                     new FailedAuthenticatedOperationAuditRecord(
-                                        user.Username, 
-                                        AuditedAuthenticatedOperationAction.PackagePushAttemptByNonOwner, 
+                                        user.Username,
+                                        AuditedAuthenticatedOperationAction.PackagePushAttemptByNonOwner,
                                         attemptedPackage: new AuditedPackageIdentifier(
                                             nuspec.GetId(), nuspec.GetVersion().ToNormalizedStringSafe())));
 
@@ -427,7 +427,7 @@ namespace NuGetGallery
 
                             // Check if API key allows pushing the current package id
                             if (!ApiKeyScopeAllows(
-                                packageRegistration.Id, 
+                                packageRegistration.Id,
                                 NuGetScopes.PackagePushVersion, NuGetScopes.PackagePush))
                             {
                                 // User cannot push a package as the API key scope does not allow it
@@ -460,7 +460,7 @@ namespace NuGetGallery
                         };
 
                         var package = await PackageService.CreatePackageAsync(
-                            packageToPush, 
+                            packageToPush,
                             packageStreamMetadata,
                             user,
                             commitChanges: false);
@@ -495,16 +495,16 @@ namespace NuGetGallery
                         }
 
                         IndexingService.UpdatePackage(package);
-                        
+
                         // Write an audit record
                         await AuditingService.SaveAuditRecordAsync(
                             new PackageAuditRecord(package, AuditedPackageAction.Create, PackageCreatedVia.Api));
 
                         // Notify user of push
                         MessageService.SendPackageAddedNotice(package,
-                            Url.Action("DisplayPackage", "Packages", routeValues: new { id = package.PackageRegistration.Id, version = package.NormalizedVersion }, protocol: Request.Url.Scheme),
-                            Url.Action("ReportMyPackage", "Packages", routeValues: new { id = package.PackageRegistration.Id, version = package.NormalizedVersion }, protocol: Request.Url.Scheme),
-                            Url.Action("Account", "Users", routeValues: null, protocol: Request.Url.Scheme));
+                            Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, Request.Url.Scheme),
+                            Url.ReportPackage(package.PackageRegistration.Id, package.NormalizedVersion, Request.Url.Scheme),
+                            Url.AccountSettings(Request.Url.Scheme));
 
                         TelemetryService.TrackPackagePushEvent(package, user, User.Identity);
 
@@ -570,7 +570,7 @@ namespace NuGetGallery
 
             // Check if API key allows listing/unlisting the current package id
             if (!ApiKeyScopeAllows(
-                subject: id, 
+                subject: id,
                 requestedActions: NuGetScopes.PackageUnlist))
             {
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.Forbidden, Strings.ApiKeyNotAuthorized);
@@ -602,7 +602,7 @@ namespace NuGetGallery
 
             // Check if API key allows listing/unlisting the current package id
             if (!ApiKeyScopeAllows(
-                subject: id, 
+                subject: id,
                 requestedActions: NuGetScopes.PackageUnlist))
             {
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.Forbidden, Strings.ApiKeyNotAuthorized);
@@ -657,7 +657,7 @@ namespace NuGetGallery
         [HttpGet]
         [ActionName("PackageIDs")]
         public virtual async Task<ActionResult> GetPackageIds(
-            string partialId, 
+            string partialId,
             bool? includePrerelease,
             string semVerLevel = null)
         {
@@ -672,7 +672,7 @@ namespace NuGetGallery
         [HttpGet]
         [ActionName("PackageVersions")]
         public virtual async Task<ActionResult> GetPackageVersions(
-            string id, 
+            string id,
             bool? includePrerelease,
             string semVerLevel = null)
         {
@@ -701,7 +701,7 @@ namespace NuGetGallery
 
                     item.Add("PackageId", row.PackageId);
                     item.Add("PackageVersion", row.PackageVersion);
-                    item.Add("Gallery", Url.PackageGallery(row.PackageId, row.PackageVersion));
+                    item.Add("Gallery", Url.Package(row.PackageId, row.PackageVersion));
                     item.Add("PackageTitle", row.PackageTitle ?? row.PackageId);
                     item.Add("PackageDescription", row.PackageDescription);
                     item.Add("PackageIconUrl", row.PackageIconUrl ?? Url.PackageDefaultIcon());

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -180,7 +180,7 @@ namespace NuGetGallery
                     // Challenge authentication using the first required authentication provider
                     challenge = _authService.Challenge(
                         providers.First(),
-                        Url.Action("LinkExternalAccount", "Authentication", new { ReturnUrl = returnUrl }));
+                        Url.LinkExternalAccount(returnUrl));
 
                     return true;
                 }
@@ -308,9 +308,7 @@ namespace NuGetGallery
         [NonAction]
         public ActionResult ChallengeAuthentication(string returnUrl, string provider)
         {
-            return _authService.Challenge(
-                provider,
-                Url.Action("LinkExternalAccount", "Authentication", new { ReturnUrl = returnUrl }));
+            return _authService.Challenge(provider, Url.LinkExternalAccount(returnUrl));
         }
 
         public virtual async Task<ActionResult> LinkExternalAccount(string returnUrl)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -226,13 +226,13 @@ namespace NuGetGallery
             if (uploadFile == null)
             {
                 ModelState.AddModelError(String.Empty, Strings.UploadFileIsRequired);
-                return Json(400, new string [] { Strings.UploadFileIsRequired });
+                return Json(400, new string[] { Strings.UploadFileIsRequired });
             }
 
             if (!Path.GetExtension(uploadFile.FileName).Equals(Constants.NuGetPackageFileExtension, StringComparison.OrdinalIgnoreCase))
             {
                 ModelState.AddModelError(String.Empty, Strings.UploadFileMustBeNuGetPackage);
-                return Json(400, new string [] { Strings.UploadFileMustBeNuGetPackage });
+                return Json(400, new string[] { Strings.UploadFileMustBeNuGetPackage });
             }
 
             using (var uploadStream = uploadFile.InputStream)
@@ -250,8 +250,8 @@ namespace NuGetGallery
                            CultureInfo.CurrentCulture,
                            Strings.PackageEntryFromTheFuture,
                            entryInTheFuture.Name));
-                        
-                        return Json(400, new string [] { string.Format(
+
+                        return Json(400, new string[] { string.Format(
                            CultureInfo.CurrentCulture,
                            Strings.PackageEntryFromTheFuture,
                            entryInTheFuture.Name) });
@@ -277,7 +277,7 @@ namespace NuGetGallery
 
                     ModelState.AddModelError(String.Empty, message);
 
-                    return Json(400, new string [] { message });
+                    return Json(400, new string[] { message });
                 }
                 finally
                 {
@@ -294,7 +294,7 @@ namespace NuGetGallery
                         errorStrings.Add(error.ErrorMessage);
                         ModelState.AddModelError(String.Empty, error.ErrorMessage);
                     }
-                    
+
                     return Json(400, errorStrings);
                 }
 
@@ -307,8 +307,8 @@ namespace NuGetGallery
                             CultureInfo.CurrentCulture,
                             Strings.UploadPackage_MinClientVersionOutOfRange,
                             nuspec.GetMinClientVersion()));
-                    
-                    return Json(400, new string [] {
+
+                    return Json(400, new string[] {
                         string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.UploadPackage_MinClientVersionOutOfRange,
@@ -320,8 +320,8 @@ namespace NuGetGallery
                 {
                     ModelState.AddModelError(
                         string.Empty, string.Format(CultureInfo.CurrentCulture, Strings.PackageIdNotAvailable, packageRegistration.Id));
-                    
-                    return Json(409, new string [] { string.Format(CultureInfo.CurrentCulture, Strings.PackageIdNotAvailable, packageRegistration.Id) });
+
+                    return Json(409, new string[] { string.Format(CultureInfo.CurrentCulture, Strings.PackageIdNotAvailable, packageRegistration.Id) });
                 }
 
                 var nuspecVersion = nuspec.GetVersion();
@@ -353,8 +353,8 @@ namespace NuGetGallery
                     ModelState.AddModelError(
                         string.Empty,
                         message);
-                    
-                    return Json(409, new string [] { message });
+
+                    return Json(409, new string[] { message });
                 }
 
                 await _uploadFileService.SaveUploadFileAsync(currentUser.Key, uploadStream);
@@ -366,13 +366,13 @@ namespace NuGetGallery
                 if (uploadedFile == null)
                 {
                     ModelState.AddModelError(String.Empty, Strings.UploadFileIsRequired);
-                    return Json(400, new string [] { Strings.UploadFileIsRequired });
+                    return Json(400, new string[] { Strings.UploadFileIsRequired });
                 }
 
                 var package = await SafeCreatePackage(currentUser, uploadedFile);
                 if (package == null)
                 {
-                    return Json(400, new string [] { Strings.UploadFileIsRequired });
+                    return Json(400, new string[] { Strings.UploadFileIsRequired });
                 }
 
                 try
@@ -383,8 +383,8 @@ namespace NuGetGallery
                 catch (Exception ex)
                 {
                     TempData["Message"] = ex.GetUserSafeMessage();
-                    
-                    return Json(400, new string [] { ex.GetUserSafeMessage() });
+
+                    return Json(400, new string[] { ex.GetUserSafeMessage() });
                 }
             }
 
@@ -457,7 +457,7 @@ namespace NuGetGallery
                         sortOrder: null,
                         context: SearchFilter.ODataSearchContext,
                         semVerLevel: SemVerLevelKey.SemVerLevel2);
-                    
+
                     searchFilter.IncludeAllVersions = true;
 
                     var results = await externalSearchService.RawSearch(searchFilter);
@@ -637,7 +637,7 @@ namespace NuGetGallery
                 }
             }
 
-            ViewData[Constants.ReturnUrlViewDataKey] = Url.Action("ReportMyPackage", new { id, version });
+            ViewData[Constants.ReturnUrlViewDataKey] = Url.ReportPackage(id, version);
             return View(model);
         }
 
@@ -837,11 +837,7 @@ namespace NuGetGallery
                 fromAddress,
                 package,
                 contactForm.Message,
-                Url.Action(
-                    actionName: "Account",
-                    controllerName: "Users",
-                    routeValues: null,
-                    protocol: Request.Url.Scheme),
+                Url.AccountSettings(),
                 contactForm.CopySender);
 
             string message = String.Format(CultureInfo.CurrentCulture, "Your message has been sent to the owners of {0}.", id);
@@ -1267,15 +1263,15 @@ namespace NuGetGallery
                 if (uploadFile == null)
                 {
                     TempData["Message"] = Strings.VerifyPackage_UploadNotFound;
-                    
-                    return Json(400, new string [] { Strings.VerifyPackage_UploadNotFound });
+
+                    return Json(400, new string[] { Strings.VerifyPackage_UploadNotFound });
                 }
 
                 var nugetPackage = await SafeCreatePackage(currentUser, uploadFile);
                 if (nugetPackage == null)
                 {
                     // Send the user back
-                    return Json(400, new string [] { Strings.VerifyPackage_UnexpectedError });
+                    return Json(400, new string[] { Strings.VerifyPackage_UnexpectedError });
                 }
 
                 Debug.Assert(nugetPackage != null);
@@ -1292,8 +1288,8 @@ namespace NuGetGallery
                         && String.Equals(packageMetadata.Version.OriginalVersion, formData.OriginalVersion, StringComparison.OrdinalIgnoreCase)))
                     {
                         TempData["Message"] = Strings.VerifyPackage_PackageFileModified;
-                        
-                        return Json(400, new string [] { Strings.VerifyPackage_PackageFileModified });
+
+                        return Json(400, new string[] { Strings.VerifyPackage_PackageFileModified });
                     }
                 }
 
@@ -1330,8 +1326,8 @@ namespace NuGetGallery
                 catch (InvalidPackageException ex)
                 {
                     TempData["Message"] = ex.Message;
-                    
-                    return Json(400, new string [] { ex.GetUserSafeMessage() });
+
+                    return Json(400, new string[] { ex.GetUserSafeMessage() });
                 }
 
                 await _packageService.PublishPackageAsync(package, commitChanges: false);
@@ -1359,8 +1355,8 @@ namespace NuGetGallery
                 {
                     ex.Log();
                     TempData["Message"] = Strings.UploadPackage_IdVersionConflict;
-                    
-                    return Json(409, new string [] { Strings.UploadPackage_IdVersionConflict });
+
+                    return Json(409, new string[] { Strings.UploadPackage_IdVersionConflict });
                 }
 
                 try
@@ -1384,9 +1380,9 @@ namespace NuGetGallery
 
                 // notify user
                 _messageService.SendPackageAddedNotice(package,
-                    Url.Action("DisplayPackage", "Packages", routeValues: new { id = package.PackageRegistration.Id, version = package.NormalizedVersion }, protocol: Request.Url.Scheme),
-                    Url.Action("ReportMyPackage", "Packages", routeValues: new { id = package.PackageRegistration.Id, version = package.NormalizedVersion }, protocol: Request.Url.Scheme),
-                    Url.Action("Account", "Users", routeValues: null, protocol: Request.Url.Scheme));
+                    Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, Request.Url.Scheme),
+                    Url.ReportPackage(package.PackageRegistration.Id, package.NormalizedVersion, Request.Url.Scheme),
+                    Url.AccountSettings(Request.Url.Scheme));
             }
 
             // delete the uploaded binary in the Uploads container
@@ -1399,11 +1395,7 @@ namespace NuGetGallery
 
             return Json(new
             {
-                location = Url.RouteUrl(RouteName.DisplayPackage, new
-                {
-                    id = package.PackageRegistration.Id,
-                    version = package.NormalizedVersion
-                })
+                location = Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, Request.Url.Scheme)
             });
         }
 

--- a/src/NuGetGallery/Services/ReportPackageRequest.cs
+++ b/src/NuGetGallery/Services/ReportPackageRequest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Globalization;
 using System.Net.Mail;
@@ -25,6 +26,7 @@ namespace NuGetGallery
         {
             // note, format blocks {xxx} are matched by ordinal-case-sensitive comparison
             var builder = new StringBuilder(subject);
+            var protocol = config.RequireSSL ? Uri.UriSchemeHttps: Uri.UriSchemeHttp;
 
             Substitute(builder, "{GalleryOwnerName}", config.GalleryOwner.DisplayName);
             Substitute(builder, "{Id}", Package.PackageRegistration.Id);
@@ -38,7 +40,7 @@ namespace NuGetGallery
                     RequestingUser.Username,
                     RequestingUser.EmailAddress,
                     Environment.NewLine,
-                    Url.User(RequestingUser, scheme: "http")));
+                    Url.User(RequestingUser, scheme: protocol)));
             }
             else
             {
@@ -47,8 +49,8 @@ namespace NuGetGallery
             Substitute(builder, "{Name}", FromAddress.DisplayName);
             Substitute(builder, "{Address}", FromAddress.Address);
             Substitute(builder, "{AlreadyContactedOwners}", AlreadyContactedOwners ? "Yes" : "No");
-            Substitute(builder, "{PackageUrl}", Url.Package(Package.PackageRegistration.Id, null, scheme: "http"));
-            Substitute(builder, "{VersionUrl}", Url.Package(Package.PackageRegistration.Id, Package.Version, scheme: "http"));
+            Substitute(builder, "{PackageUrl}", Url.Package(Package.PackageRegistration.Id, version: null, scheme: protocol));
+            Substitute(builder, "{VersionUrl}", Url.Package(Package.PackageRegistration.Id, Package.Version, protocol));
             Substitute(builder, "{Reason}", Reason);
             Substitute(builder, "{Signature}", Signature);
             Substitute(builder, "{Message}", Message);

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -25,20 +25,9 @@ namespace NuGetGallery
 
         private static string GetProtocol(UrlHelper url)
         {
-            return url.RequestContext.HttpContext.Request.IsSecureConnection ? "https" : "http";
+            return url.RequestContext.HttpContext.Request.IsSecureConnection ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
         }
-
-        private static string GetConfiguredSiteRoot(UrlHelper url)
-        {
-            if (_configuration == null)
-            {
-                SetConfigurationService(new ConfigurationService(new SecretReaderFactory(new DiagnosticsService())));
-            }
-
-            return _configuration.GetSiteRoot(useHttps: url.RequestContext.HttpContext.Request.IsSecureConnection);
-        }
-
-        // For testing purposes only!
+                
         internal static void SetConfigurationService(ConfigurationService configurationService)
         {
             _configuration = configurationService;
@@ -46,7 +35,7 @@ namespace NuGetGallery
 
         private static string GetConfiguredSiteHostName(UrlHelper url)
         {
-            var siteRoot = GetConfiguredSiteRoot(url);
+            var siteRoot = _configuration.GetSiteRoot(useHttps: url.RequestContext.HttpContext.Request.IsSecureConnection);
             return new Uri(siteRoot).Host;
         }
 

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGetGallery.Configuration;
-using NuGetGallery.Configuration.SecretReader;
-using NuGetGallery.Diagnostics;
 using System;
 using System.Globalization;
 using System.Web;

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -87,6 +87,15 @@ namespace NuGetGallery
             return result + "?groupby=Version";
         }
 
+        public static string StatisticsPackageDownloadByVersionReport(this UrlHelper url)
+        {
+            return url.RouteUrl(
+                RouteName.StatisticsPackageDownloadsByVersionReport,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
         public static string StatisticsPackageDownloadsDetail(this UrlHelper url, string id, string version)
         {
             string result = url.RouteUrl(
@@ -100,6 +109,15 @@ namespace NuGetGallery
                 hostName: GetConfiguredSiteHostName(url));
 
             return result + "?groupby=ClientName";
+        }
+
+        public static string StatisticsPackageDownloadsDetailReport(this UrlHelper url)
+        {
+            return url.RouteUrl(
+                RouteName.StatisticsPackageDownloadsDetailReport,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string PackageList(this UrlHelper url, int page, string q, bool includePrerelease)
@@ -377,6 +395,15 @@ namespace NuGetGallery
                 hostName: GetConfiguredSiteHostName(url));
         }
 
+        public static string UploadPackageProgress(this UrlHelper url)
+        {
+            return url.RouteUrl(
+                RouteName.UploadPackageProgress,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
         public static string User(this UrlHelper url, User user, int page = 1, string scheme = null)
         {
             var configuredSiteHostName = GetConfiguredSiteHostName(url);
@@ -527,7 +554,6 @@ namespace NuGetGallery
                 hostName: GetConfiguredSiteHostName(url));
         }
 
-
         public static string ManageMyApiKeys(this UrlHelper url)
         {
             return url.Action(
@@ -557,6 +583,46 @@ namespace NuGetGallery
                 {
                     { "id", package.Id}
                 },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
+        public static string GetAddPackageOwnerConfirmation(this UrlHelper url)
+        {
+            return url.Action(
+                "GetAddPackageOwnerConfirmation", 
+                "JsonApi",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
+        public static string GetPackageOwners(this UrlHelper url)
+        {
+            return url.Action(
+                "GetPackageOwners",                 
+                "JsonApi",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
+        public static string AddPackageOwner(this UrlHelper url)
+        {
+            return url.Action(
+                "AddPackageOwner", 
+                "JsonApi",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
+        public static string RemovePackageOwner(this UrlHelper url)
+        {
+            return url.Action(
+                "RemovePackageOwner", 
+                "JsonApi",
+                routeValues: null,
                 protocol: GetProtocol(url),
                 hostName: GetConfiguredSiteHostName(url));
         }
@@ -618,6 +684,19 @@ namespace NuGetGallery
                 hostName: GetConfiguredSiteHostName(url));
         }
 
+        public static string ContactOwners(this UrlHelper url, string id)
+        {
+            return url.Action(
+                actionName: "ContactOwners",
+                controllerName: "Packages",
+                routeValues: new RouteValueDictionary
+                {
+                    { "id", id }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
         public static string Terms(this UrlHelper url)
         {
             return url.Action(
@@ -656,6 +735,20 @@ namespace NuGetGallery
                 routeValues: new RouteValueDictionary
                 {
                     { "area", "Admin" }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
+        public static string Authenticate(this UrlHelper url, string providerName, string returnUrl)
+        {
+            return url.Action(
+                actionName: "Authenticate",
+                controllerName: "Authentication",
+                routeValues: new RouteValueDictionary
+                {
+                    { "provider", providerName },
+                    { "returnUrl", returnUrl }
                 },
                 protocol: GetProtocol(url),
                 hostName: GetConfiguredSiteHostName(url));

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -29,6 +29,11 @@ namespace NuGetGallery
             builder.Path = path;
             return builder.Uri.AbsoluteUri;
         }
+        
+        private static string GetProtocol(UrlHelper url)
+        {
+            return url.RequestContext.HttpContext.Request.IsSecureConnection ? "https" : "http";
+        }
 
         public static string Home(this UrlHelper url)
         {
@@ -137,7 +142,7 @@ namespace NuGetGallery
 
         public static string PackageGallery(this UrlHelper url, string id, string version)
         {
-            string protocol = url.RequestContext.HttpContext.Request.IsSecureConnection ? "https" : "http";
+            var protocol = GetProtocol(url);
             string result = url.RouteUrl(RouteName.DisplayPackage, new { Id = id, Version = version }, protocol: protocol);
 
             // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions
@@ -146,7 +151,7 @@ namespace NuGetGallery
 
         public static string PackageDefaultIcon(this UrlHelper url)
         {
-            string protocol = url.RequestContext.HttpContext.Request.IsSecureConnection ? "https" : "http";
+            var protocol = GetProtocol(url);
             string result = url.RouteUrl(RouteName.Home, null, protocol: protocol);
             result = result.TrimEnd('/') + VirtualPathUtility.ToAbsolute("~/Content/Images/packageDefaultIcon-50x50.png", url.RequestContext.HttpContext.Request.ApplicationPath);
             return result;
@@ -155,7 +160,7 @@ namespace NuGetGallery
         public static string PackageDownload(this UrlHelper url, int feedVersion, string id, string version)
         {
             string routeName = "v" + feedVersion + RouteName.DownloadPackage;
-            string protocol = url.RequestContext.HttpContext.Request.IsSecureConnection ? "https" : "http";
+            var protocol = GetProtocol(url);
             string result = url.RouteUrl(routeName, new { Id = id, Version = version }, protocol: protocol);
 
             // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions
@@ -165,7 +170,7 @@ namespace NuGetGallery
         public static string ExplorerDeepLink(this UrlHelper url, int feedVersion, string id, string version)
         {
             string routeName = "v" + feedVersion + RouteName.DownloadPackage;
-            string protocol = url.RequestContext.HttpContext.Request.IsSecureConnection ? "https" : "http";
+            var protocol = GetProtocol(url);
             string urlResult = url.RouteUrl(routeName, new { Id = id }, protocol: protocol);
 
             urlResult = EnsureTrailingSlash(urlResult);

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGetGallery.Configuration;
+using NuGetGallery.Configuration.SecretReader;
+using NuGetGallery.Diagnostics;
 using System;
 using System.Globalization;
 using System.Web;
@@ -11,6 +14,7 @@ namespace NuGetGallery
 {
     public static class UrlExtensions
     {
+        private static ConfigurationService _configuration;
         private const string PackageExplorerDeepLink = @"https://npe.codeplex.com/releases/clickonce/NuGetPackageExplorer.application?url={0}&id={1}&version={2}";
 
         // Shorthand for current url
@@ -29,42 +33,95 @@ namespace NuGetGallery
             builder.Path = path;
             return builder.Uri.AbsoluteUri;
         }
-        
+
         private static string GetProtocol(UrlHelper url)
         {
             return url.RequestContext.HttpContext.Request.IsSecureConnection ? "https" : "http";
         }
 
+        private static string GetConfiguredSiteRoot(UrlHelper url)
+        {
+            if (_configuration == null)
+            {
+                SetConfigurationService(new ConfigurationService(new SecretReaderFactory(new DiagnosticsService())));
+            }
+
+            return _configuration.GetSiteRoot(useHttps: url.RequestContext.HttpContext.Request.IsSecureConnection);
+        }
+
+        // For testing purposes only!
+        internal static void SetConfigurationService(ConfigurationService configurationService)
+        {
+            _configuration = configurationService;
+        }
+
+        private static string GetConfiguredSiteHostName(UrlHelper url)
+        {
+            var siteRoot = GetConfiguredSiteRoot(url);
+            return new Uri(siteRoot).Host;
+        }
+
         public static string Home(this UrlHelper url)
         {
-            return url.RouteUrl(RouteName.Home);
+            return url.RouteUrl(
+                RouteName.Home,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string Statistics(this UrlHelper url)
         {
-            return url.RouteUrl(RouteName.StatisticsHome);
+            return url.RouteUrl(
+                RouteName.StatisticsHome,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string StatisticsAllPackageDownloads(this UrlHelper url)
         {
-            return url.RouteUrl(RouteName.StatisticsPackages);
+            return url.RouteUrl(
+                RouteName.StatisticsPackages,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string StatisticsAllPackageVersionDownloads(this UrlHelper url)
         {
-            return url.RouteUrl(RouteName.StatisticsPackageVersions);
+            return url.RouteUrl(
+                RouteName.StatisticsPackageVersions,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string StatisticsPackageDownloadByVersion(this UrlHelper url, string id)
         {
-            string result = url.RouteUrl(RouteName.StatisticsPackageDownloadsByVersion, new { id });
+            string result = url.RouteUrl(
+                RouteName.StatisticsPackageDownloadsByVersion,
+                routeValues: new RouteValueDictionary
+                {
+                    { "id", id }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
 
             return result + "?groupby=Version";
         }
 
         public static string StatisticsPackageDownloadsDetail(this UrlHelper url, string id, string version)
         {
-            string result = url.RouteUrl(RouteName.StatisticsPackageDownloadsDetail, new { id, version });
+            string result = url.RouteUrl(
+                RouteName.StatisticsPackageDownloadsDetail,
+                routeValues: new RouteValueDictionary
+                {
+                    { "id", id },
+                    { "version", version }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
 
             return result + "?groupby=ClientName";
         }
@@ -88,28 +145,76 @@ namespace NuGetGallery
                 routeValues["prerel"] = "false";
             }
 
-            return url.Action("ListPackages", "Packages", routeValues);
+            return url.Action(
+                actionName: "ListPackages",
+                controllerName: "Packages",
+                routeValues: routeValues,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
+        public static string CuratedPackage(this UrlHelper url, string curatedFeedName, string id, string scheme = null)
+        {
+            return url.RouteUrl(
+                RouteName.CuratedPackage,
+                new RouteValueDictionary
+                {
+                    { "curatedFeedName", curatedFeedName },
+                    { "curatedPackageId", id }
+                },
+                protocol: scheme ?? GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string CuratedPackageList(this UrlHelper url, int page, string q, string curatedFeedName)
         {
-            return url.Action("ListPackages", "CuratedFeeds", new
-            {
-                q,
-                page,
-                curatedFeedName
-            });
+            return url.Action(
+                actionName: "ListPackages",
+                controllerName: "CuratedFeeds",
+                routeValues: new RouteValueDictionary
+                {
+                    { "q", q },
+                    { "page", page },
+                    { "curatedFeedName", curatedFeedName }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
 
+        }
+
+        public static string CuratedFeed(this UrlHelper url, string curatedFeedName)
+        {
+            return url.RouteUrl(
+                RouteName.CuratedFeed,
+                routeValues: new RouteValueDictionary
+                {
+                    { "name", curatedFeedName }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string PackageList(this UrlHelper url)
         {
-            return url.RouteUrl(RouteName.ListPackages);
+            return url.RouteUrl(
+                RouteName.ListPackages,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string UndoPendingEdits(this UrlHelper url, IPackageVersionModel package)
         {
-            return url.Action(actionName: "UndoPendingEdits", controllerName: "Packages", routeValues: new { id = package.Id, version = package.Version });
+            return url.Action(
+                actionName: "UndoPendingEdits",
+                controllerName: "Packages",
+                routeValues: new RouteValueDictionary
+                {
+                    { "id", package.Id },
+                    { "version", package.Version }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string Package(this UrlHelper url, string id)
@@ -119,7 +224,15 @@ namespace NuGetGallery
 
         public static string Package(this UrlHelper url, string id, string version, string scheme = null)
         {
-            string result = url.RouteUrl(RouteName.DisplayPackage, new { id, version }, protocol: scheme);
+            string result = url.RouteUrl(
+                RouteName.DisplayPackage,
+                new RouteValueDictionary
+                {
+                    { "id", id },
+                    { "version", version }
+                },
+                protocol: scheme ?? GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
 
             // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions
             return version == null ? EnsureTrailingSlash(result) : result;
@@ -140,28 +253,22 @@ namespace NuGetGallery
             return url.Package(package.Id);
         }
 
-        public static string PackageGallery(this UrlHelper url, string id, string version)
-        {
-            var protocol = GetProtocol(url);
-            string result = url.RouteUrl(RouteName.DisplayPackage, new { Id = id, Version = version }, protocol: protocol);
-
-            // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions
-            return version == null ? EnsureTrailingSlash(result) : result;
-        }
-
         public static string PackageDefaultIcon(this UrlHelper url)
         {
-            var protocol = GetProtocol(url);
-            string result = url.RouteUrl(RouteName.Home, null, protocol: protocol);
-            result = result.TrimEnd('/') + VirtualPathUtility.ToAbsolute("~/Content/Images/packageDefaultIcon-50x50.png", url.RequestContext.HttpContext.Request.ApplicationPath);
-            return result;
+            return url.Home().TrimEnd('/') + VirtualPathUtility.ToAbsolute("~/Content/Images/packageDefaultIcon-50x50.png", url.RequestContext.HttpContext.Request.ApplicationPath);
         }
 
         public static string PackageDownload(this UrlHelper url, int feedVersion, string id, string version)
         {
-            string routeName = "v" + feedVersion + RouteName.DownloadPackage;
-            var protocol = GetProtocol(url);
-            string result = url.RouteUrl(routeName, new { Id = id, Version = version }, protocol: protocol);
+            string result = url.RouteUrl(
+                routeName: $"v{feedVersion}{RouteName.DownloadPackage}",
+                routeValues: new RouteValueDictionary
+                {
+                    { "Id", id },
+                    { "Version", version }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
 
             // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions
             return version == null ? EnsureTrailingSlash(result) : result;
@@ -169,9 +276,14 @@ namespace NuGetGallery
 
         public static string ExplorerDeepLink(this UrlHelper url, int feedVersion, string id, string version)
         {
-            string routeName = "v" + feedVersion + RouteName.DownloadPackage;
-            var protocol = GetProtocol(url);
-            string urlResult = url.RouteUrl(routeName, new { Id = id }, protocol: protocol);
+            string urlResult = url.RouteUrl(
+                routeName: $"v{feedVersion}{RouteName.DownloadPackage}",
+                routeValues: new RouteValueDictionary
+                {
+                    { "Id", id }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
 
             urlResult = EnsureTrailingSlash(urlResult);
 
@@ -180,27 +292,62 @@ namespace NuGetGallery
 
         public static string LogOn(this UrlHelper url)
         {
-            return url.RouteUrl(RouteName.Authentication, new { action = "LogOn" });
+            return url.RouteUrl(
+                RouteName.Authentication,
+                routeValues: new RouteValueDictionary
+                {
+                    { "action", "LogOn" }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string LogOn(this UrlHelper url, string returnUrl)
         {
-            return url.RouteUrl(RouteName.Authentication, new { action = "LogOn", returnUrl = returnUrl });
+            return url.RouteUrl(
+                RouteName.Authentication,
+                routeValues: new RouteValueDictionary
+                {
+                    { "action", "LogOn" },
+                    { "returnUrl", returnUrl }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string SignUp(this UrlHelper url)
         {
-            return url.RouteUrl(RouteName.Authentication, new { action = "SignUp" });
+            return url.RouteUrl(
+                RouteName.Authentication,
+                routeValues: new RouteValueDictionary
+                {
+                    { "action", "SignUp" }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string SignUp(this UrlHelper url, string returnUrl)
         {
-            return url.RouteUrl(RouteName.Authentication, new { action = "SignUp", returnUrl = returnUrl });
+            return url.RouteUrl(
+                RouteName.Authentication,
+                routeValues: new RouteValueDictionary
+                {
+                    { "action", "SignUp" },
+                    { "returnUrl", returnUrl }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string ConfirmationRequired(this UrlHelper url)
         {
-            return url.Action("ConfirmationRequired", controllerName: "Users");
+            return url.Action(
+                "ConfirmationRequired",
+                controllerName: "Users",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string LogOff(this UrlHelper url)
@@ -211,58 +358,118 @@ namespace NuGetGallery
             {
                 returnUrl = String.Empty;
             }
-            return url.Action("LogOff", "Authentication", new { returnUrl, area = "" });
+            return url.Action(
+                "LogOff",
+                "Authentication",
+                routeValues: new RouteValueDictionary
+                {
+                    { "returnUrl", returnUrl },
+                    { "area", string.Empty }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string Register(this UrlHelper url)
         {
-            return url.Action(actionName: "LogOn", controllerName: "Authentication");
+            return url.Action(
+                actionName: "LogOn",
+                controllerName: "Authentication",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string Search(this UrlHelper url, string searchTerm)
         {
-            return url.RouteUrl(RouteName.ListPackages, new { q = searchTerm });
+            return url.RouteUrl(
+                RouteName.ListPackages,
+                routeValues: new RouteValueDictionary
+                {
+                    { "q", searchTerm }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string UploadPackage(this UrlHelper url)
         {
-            return url.RouteUrl(RouteName.UploadPackage);
+            return url.RouteUrl(
+                RouteName.UploadPackage,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string User(this UrlHelper url, User user, int page = 1, string scheme = null)
         {
+            var configuredSiteHostName = GetConfiguredSiteHostName(url);
             if (page == 1)
             {
-                return url.Action(actionName: "Profiles",
-                                    controllerName: "Users",
-                                    routeValues: new { username = user.Username.TrimEnd() },
-                                    protocol: scheme);
+                return url.Action(
+                    actionName: "Profiles",
+                    controllerName: "Users",
+                    routeValues: new RouteValueDictionary
+                    {
+                        { "username", user.Username.TrimEnd() }
+                    },
+                    protocol: scheme ?? GetProtocol(url),
+                    hostName: configuredSiteHostName);
             }
             else
             {
-                return url.Action(actionName: "Profiles",
-                                    controllerName: "Users",
-                                    routeValues: new { username = user.Username.TrimEnd(), page = page },
-                                    protocol: scheme);
+                return url.Action(
+                    actionName: "Profiles",
+                    controllerName: "Users",
+                    routeValues: new RouteValueDictionary
+                    {
+                        { "username", user.Username.TrimEnd() },
+                        { "page", page }
+                    },
+                    protocol: scheme ?? GetProtocol(url),
+                    hostName: configuredSiteHostName);
             }
         }
 
         public static string User(this UrlHelper url, string username, string scheme = null)
         {
-            return url.Action(actionName: "Profiles",
-                                    controllerName: "Users",
-                                    routeValues: new { username = username },
-                                    protocol: scheme);
+            return url.Action(
+                actionName: "Profiles",
+                controllerName: "Users",
+                routeValues: new RouteValueDictionary
+                {
+                    { "username", username }
+                },
+                protocol: scheme ?? GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string EditPackage(this UrlHelper url, string id, string version)
         {
             if (String.IsNullOrEmpty(version))
             {
-                return EnsureTrailingSlash(url.RouteUrl(RouteName.PackageAction, new { action = "Edit", id }));
+                return EnsureTrailingSlash(
+                    url.RouteUrl(
+                        RouteName.PackageAction,
+                        routeValues: new RouteValueDictionary
+                        {
+                            { "action", "Edit" },
+                            { "id", id }
+                        },
+                        protocol: GetProtocol(url),
+                        hostName: GetConfiguredSiteHostName(url)));
             }
 
-            return url.RouteUrl(RouteName.PackageVersionAction, new { action = "Edit", id, version });
+            return url.RouteUrl(
+                RouteName.PackageVersionAction,
+                routeValues: new RouteValueDictionary
+                {
+                    { "action", "Edit" },
+                    { "id", id },
+                    { "version", version }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string ReflowPackage(this UrlHelper url, IPackageVersionModel package)
@@ -270,11 +477,13 @@ namespace NuGetGallery
             return url.Action(
                 actionName: "Reflow",
                 controllerName: "Packages",
-                routeValues: new
+                routeValues: new RouteValueDictionary
                 {
-                    id = package.Id,
-                    version = package.Version
-                });
+                    { "id", package.Id },
+                    { "version", package.Version }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string DeletePackage(this UrlHelper url, IPackageVersionModel package)
@@ -282,26 +491,85 @@ namespace NuGetGallery
             return url.Action(
                 actionName: "Delete",
                 controllerName: "Packages",
-                routeValues: new
+                routeValues: new RouteValueDictionary
                 {
-                    id = package.Id,
-                    version = package.Version
-                });
+                    { "id", package.Id },
+                    { "version", package.Version }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
-        public static string AccountSettings(this UrlHelper url)
+        public static string AccountSettings(this UrlHelper url, string scheme = null)
         {
-            return url.Action(actionName: "Account", controllerName: "Users");
+            return url.Action(
+                actionName: "Account",
+                controllerName: "Users",
+                routeValues: null,
+                protocol: scheme ?? GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
+
+        public static string ReportPackage(this UrlHelper url, string id, string version, string scheme = null)
+        {
+            return url.Action(
+                actionName: "ReportMyPackage",
+                controllerName: "Packages",
+                routeValues: new RouteValueDictionary
+                {
+                    { "id", id },
+                    { "version", version }
+                },
+                protocol: scheme ?? GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
+        public static string ReportAbuse(this UrlHelper url, string id, string version, string scheme = null)
+        {
+            return url.Action(
+                actionName: "ReportAbuse",
+                controllerName: "Packages",
+                routeValues: new RouteValueDictionary
+                {
+                    { "id", id },
+                    { "version", version }
+                },
+                protocol: scheme ?? GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
+        public static string LinkExternalAccount(this UrlHelper url, string returnUrl)
+        {
+            return url.Action(
+                actionName: "LinkExternalAccount",
+                controllerName: "Authentication",
+                routeValues: new RouteValueDictionary
+                {
+                    { "ReturnUrl", returnUrl }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
 
         public static string ManageMyApiKeys(this UrlHelper url)
         {
-            return url.Action(actionName: "ApiKeys", controllerName: "Users");
+            return url.Action(
+                actionName: "ApiKeys",
+                controllerName: "Users",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string ManageMyPackages(this UrlHelper url)
         {
-            return url.Action(actionName: "Packages", controllerName: "Users");
+            return url.Action(
+                actionName: "Packages",
+                controllerName: "Users",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string ManagePackageOwners(this UrlHelper url, IPackageVersionModel package)
@@ -309,10 +577,12 @@ namespace NuGetGallery
             return url.Action(
                 actionName: "ManagePackageOwners",
                 controllerName: "Packages",
-                routeValues: new
+                routeValues: new RouteValueDictionary
                 {
-                    id = package.Id
-                });
+                    { "id", package.Id}
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string ConfirmationUrl(this UrlHelper url, string action, string controller, string username, string token)
@@ -330,42 +600,89 @@ namespace NuGetGallery
                 controller,
                 rvd,
                 url.RequestContext.HttpContext.Request.Url.Scheme,
-                url.RequestContext.HttpContext.Request.Url.Host);
+                GetConfiguredSiteHostName(url));
         }
 
         public static string VerifyPackage(this UrlHelper url)
         {
-            return url.Action(actionName: "VerifyPackage", controllerName: "Packages");
+            return url.Action(
+                actionName: "VerifyPackage",
+                controllerName: "Packages",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string CancelUpload(this UrlHelper url)
         {
-            return url.Action(actionName: "CancelUpload", controllerName: "Packages");
+            return url.Action(
+                actionName: "CancelUpload",
+                controllerName: "Packages",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string Downloads(this UrlHelper url)
         {
-            return url.RouteUrl(RouteName.Downloads);
+            return url.RouteUrl(
+                RouteName.Downloads,
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string Contact(this UrlHelper url)
         {
-            return url.Action(actionName: "Contact", controllerName: "Pages");
+            return url.Action(
+                actionName: "Contact",
+                controllerName: "Pages",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string Terms(this UrlHelper url)
         {
-            return url.Action(actionName: "Terms", controllerName: "Pages");
+            return url.Action(
+                actionName: "Terms",
+                controllerName: "Pages",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string Privacy(this UrlHelper url)
         {
-            return url.Action(actionName: "Privacy", controllerName: "Pages");
+            return url.Action(
+                actionName: "Privacy",
+                controllerName: "Pages",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         public static string About(this UrlHelper url)
         {
-            return url.Action(actionName: "About", controllerName: "Pages");
+            return url.Action(
+                actionName: "About",
+                controllerName: "Pages",
+                routeValues: null,
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
+        }
+
+        public static string Admin(this UrlHelper url)
+        {
+            return url.Action(
+                "Index",
+                "Home",
+                routeValues: new RouteValueDictionary
+                {
+                    { "area", "Admin" }
+                },
+                protocol: GetProtocol(url),
+                hostName: GetConfiguredSiteHostName(url));
         }
 
         private static UriBuilder GetCanonicalUrl(UrlHelper url)

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -23,17 +23,6 @@ namespace NuGetGallery
             return url.RequestContext.HttpContext.Request.RawUrl;
         }
 
-        public static string Absolute(this UrlHelper url, string path)
-        {
-            UriBuilder builder = GetCanonicalUrl(url);
-            if (path.StartsWith("~/", StringComparison.OrdinalIgnoreCase))
-            {
-                path = VirtualPathUtility.ToAbsolute(path, url.RequestContext.HttpContext.Request.ApplicationPath);
-            }
-            builder.Path = path;
-            return builder.Uri.AbsoluteUri;
-        }
-
         private static string GetProtocol(UrlHelper url)
         {
             return url.RequestContext.HttpContext.Request.IsSecureConnection ? "https" : "http";
@@ -684,18 +673,7 @@ namespace NuGetGallery
                 protocol: GetProtocol(url),
                 hostName: GetConfiguredSiteHostName(url));
         }
-
-        private static UriBuilder GetCanonicalUrl(UrlHelper url)
-        {
-            UriBuilder builder = new UriBuilder(url.RequestContext.HttpContext.Request.Url);
-            builder.Query = String.Empty;
-            if (builder.Host.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
-            {
-                builder.Host = builder.Host.Substring(4);
-            }
-            return builder;
-        }
-
+        
         internal static string EnsureTrailingSlash(string url)
         {
             if (url != null && !url.EndsWith("/", StringComparison.OrdinalIgnoreCase))

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -21,6 +21,17 @@ namespace NuGetGallery
             return url.RequestContext.HttpContext.Request.RawUrl;
         }
 
+        public static string Absolute(this UrlHelper url, string path)
+        {
+            UriBuilder builder = GetCanonicalUrl(url);
+            if (path.StartsWith("~/", StringComparison.OrdinalIgnoreCase))
+            {
+                path = VirtualPathUtility.ToAbsolute(path, url.RequestContext.HttpContext.Request.ApplicationPath);
+            }
+            builder.Path = path;
+            return builder.Uri.AbsoluteUri;
+        }
+
         private static string GetProtocol(UrlHelper url)
         {
             return url.RequestContext.HttpContext.Request.IsSecureConnection ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
@@ -754,6 +765,17 @@ namespace NuGetGallery
                 hostName: GetConfiguredSiteHostName(url));
         }
         
+        private static UriBuilder GetCanonicalUrl(UrlHelper url)
+        {
+            UriBuilder builder = new UriBuilder(url.RequestContext.HttpContext.Request.Url);
+            builder.Query = String.Empty;
+            if (builder.Host.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
+            {
+                builder.Host = builder.Host.Substring(4);
+            }
+            return builder;
+        }
+
         internal static string EnsureTrailingSlash(string url)
         {
             if (url != null && !url.EndsWith("/", StringComparison.OrdinalIgnoreCase))

--- a/src/NuGetGallery/Views/Authentication/Register.cshtml
+++ b/src/NuGetGallery/Views/Authentication/Register.cshtml
@@ -19,7 +19,7 @@
         <div class="row">
             <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
                 <a role="button" class="btn btn-default btn-block provider-button"
-                   href="@Url.Action("Authenticate", new {provider = provider.ProviderName, returnUrl = ViewData[Constants.ReturnUrlViewDataKey]})">
+                   href="@Url.Authenticate(provider.ProviderName, (string)ViewData[Constants.ReturnUrlViewDataKey])">
                     @if (!string.IsNullOrEmpty(@provider.UI.IconImagePath))
                     {
                         <img height="24" width="24" alt="" aria-hidden="true"

--- a/src/NuGetGallery/Views/Authentication/SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/SignIn.cshtml
@@ -19,7 +19,7 @@
         <div class="row">
             <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
                 <a role="button" class="btn btn-default btn-block provider-button"
-                   href="@Url.Action("Authenticate", new {provider = provider.ProviderName, returnUrl = ViewData[Constants.ReturnUrlViewDataKey]})">
+                   href="@Url.Authenticate(provider.ProviderName, (string)ViewData[Constants.ReturnUrlViewDataKey])">
                     @if (!string.IsNullOrEmpty(@provider.UI.IconImagePath))
                     {
                         <img height="24" width="24" alt="" aria-hidden="true"

--- a/src/NuGetGallery/Views/Authentication/_Register.cshtml
+++ b/src/NuGetGallery/Views/Authentication/_Register.cshtml
@@ -39,7 +39,7 @@
     <div class="panel panel-default text-center">
         <div class="panel-body">
             By clicking Register you agree that you have read and accept our
-            <a href="@Url.Action("Terms", "Pages")">Terms of Use</a> and <a href="@Url.Action("Privacy", "Pages")">Privacy Policy</a>.
+            <a href="@Url.Terms()">Terms of Use</a> and <a href="@Url.Privacy()">Privacy Policy</a>.
         </div>
     </div>
     if (Model.External != null)

--- a/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
+++ b/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
@@ -127,7 +127,7 @@
 
 @section BottomScripts {
     <script>
-        var urlFormat = "@Url.RouteUrl(RouteName.CuratedPackage, new { curatedFeedName = Model.Name, curatedPackageId = "PACKAGE_ID" })";
+        var urlFormat = "@Url.CuratedPackage(curatedFeedName: Model.Name, id: "PACKAGE_ID" })";
 
         function deleteCuratedPackage(packageId) {
             $.ajax({

--- a/src/NuGetGallery/Views/Packages/Delete.cshtml
+++ b/src/NuGetGallery/Views/Packages/Delete.cshtml
@@ -74,7 +74,7 @@
                         However, the package will still be available for download through <a href="https://docs.nuget.org/docs/reference/package-restore">NuGet Package Restore</a> so that existing projects referencing the package don't become broken.
                     </p>
                     <p>
-                        If you need the package permanently removed, click on the <a href="@Url.Action(actionName: "ReportAbuse", controllerName: "Packages", routeValues: new {id = Model.Id, version = Model.Version})" title="Contact Support">Contact Support</a> link and we'll take care
+                        If you need the package permanently removed, click on the <a href="@Url.ReportAbuse(Model.Id, Model.Version)" title="Contact Support">Contact Support</a> link and we'll take care
                         of it for you. <b>PLEASE ONLY DO THIS IF THERE IS AN URGENT PROBLEM WITH THE PACKAGE.</b>
                         (Passwords, malicious code, etc). Even if you remove it, it's prudent to immediately
                         reset any passwords/sensitive data you accidentally pushed instead of waiting for us to delete

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -472,7 +472,7 @@
                 }
                 <li>
                     <i class="ms-Icon ms-Icon--Mail" aria-hidden="true"></i>
-                    <a href="@Url.Action(actionName: "ContactOwners", controllerName: "Packages", routeValues: new { id = Model.Id })" title="Ask the package owners a question">Contact owners</a>
+                    <a href="@Url.ContactOwners(Model.Id)" title="Ask the package owners a question">Contact owners</a>
                 </li>
                 @if ((Model.IsOwner(User) || User.IsAdministrator()))
                 {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -478,7 +478,7 @@
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
-                        <a href="@Url.Action(actionName: "ReportMyPackage", controllerName: "Packages", routeValues: new { id = Model.Id, version = Model.Version })" title="Contact the NuGet team for help with your package">
+                        <a href="@Url.ReportPackage(Model.Id, Model.Version)" title="Contact the NuGet team for help with your package">
                             Contact support
                         </a>
                     </li>
@@ -487,7 +487,7 @@
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
-                        <a href="@Url.Action(actionName: "ReportAbuse", controllerName: "Packages", routeValues: new { id = Model.Id, version = Model.Version })" title="Report the package as abusive">
+                        <a href="@Url.ReportAbuse(Model.Id, Model.Version)" title="Report the package as abusive">
                             Report
                         </a>
                     </li>

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -127,10 +127,10 @@
     <script type="text/javascript">
         var packageId = "@Model.Id";
         var packageUrl = "@Url.Package(Model.Id)";
-        var getPackageOwnersUrl = "@Url.Action("GetPackageOwners", "JsonApi")";
-        var getAddPackageOwnerConfirmationUrl = "@Url.Action("GetAddPackageOwnerConfirmation", "JsonApi")";
-        var addPackageOwnerUrl = "@Url.Action("AddPackageOwner", "JsonApi")";
-        var removePackageOwnerUrl = "@Url.Action("RemovePackageOwner", "JsonApi")";
+        var getPackageOwnersUrl = "@Url.GetPackageOwners()";
+        var getAddPackageOwnerConfirmationUrl = "@Url.GetAddPackageOwnerConfirmation()";
+        var addPackageOwnerUrl = "@Url.AddPackageOwner()";
+        var removePackageOwnerUrl = "@Url.RemovePackageOwner()";
     </script>
 
     @Scripts.Render("~/Scripts/gallery/page-manage-owners.min.js")

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -25,7 +25,7 @@
                     This form is for reporting abusive packages such as
                     packages containing malicious code or spam. If "@Model.PackageId" simply doesn't
                     work, or if you need help getting the package installed, please
-                    <a href="@Url.Action(actionName: "ContactOwners", controllerName: "Packages", routeValues: new { id = Model.PackageId })" title="contact the owners">contact the owners instead.</a>
+                    <a href="@Url.ContactOwners(Model.PackageId)" title="contact the owners">contact the owners instead.</a>
                 </text>
             )
 

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -92,12 +92,12 @@
             });
 
             AsyncFileUploadManager.init(
-                '@Url.Action(actionName: "UploadPackageProgress", controllerName: "Packages")',
+                '@Url.UploadPackageProgress()',
                 'uploadForm',
                 '@Scripts.Url("~/Scripts/jquery")',
-                '@Url.Action(actionName: "UploadPackage", controllerName: "Packages")',
-                '@Url.Action(actionName: "CancelUpload", controllerName: "Packages")',
-                '@Url.Action(actionName: "VerifyPackage", controllerName: "Packages")');
+                '@Url.UploadPackage()',
+                '@Url.CancelUpload()',
+                '@Url.VerifyPackage()');
         });
     </script>
 }

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -83,7 +83,7 @@
                             @DisplayNavigationItem("Admin", Url.Action("Index", "Home", new { area = "Admin" }))
                         }
                         @DisplayNavigationItem("Documentation", "https://docs.microsoft.com/en-us/nuget/")
-                        @DisplayNavigationItem("Downloads", Url.RouteUrl(RouteName.Downloads))
+                        @DisplayNavigationItem("Downloads", Url.Downloads())
                         @DisplayNavigationItem("Blog", "http://blog.nuget.org/")
                     </ul>
                     <ul class="nav navbar-nav navbar-right navbar-seperated" role="menu">

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -116,7 +116,7 @@
                                     @if (Request.IsAuthenticated && User.IsInRole(Constants.AdminRoleName))
                                     {
                                         <li class="divider"></li>
-                                        <li role="presentation"><a href="@Url.Action("Index", "Home", new { area = "Admin" })" role="menuitem">Admin</a></li>
+                                        <li role="presentation"><a href="@Url.Admin()" role="menuitem">Admin</a></li>
                                     }
                                     <li class="divider"></li>
                                     <li role="presentation"><a href="@Url.User(CurrentUser.Username)" role="menuitem">View Profile</a></li>

--- a/src/NuGetGallery/Views/Shared/LayoutFooter.cshtml
+++ b/src/NuGetGallery/Views/Shared/LayoutFooter.cshtml
@@ -24,9 +24,9 @@
     <a title=".NET Foundation" href="https://www.dotnetfoundation.org"><img src="@Href("~/Content/Logos/dnf.png")" alt=".NET Foundation" /></a>
     <p>
         &copy; @DateTime.UtcNow.Year .NET Foundation -
-        <a href="@Url.Action("About", "Pages")">About</a> -
-        <a href="@Url.Action("Terms", "Pages")">Terms of Use</a> -
-        <a href="@Url.Action("Privacy", "Pages")">Privacy Policy</a> -
+        <a href="@Url.About()">About</a> -
+        <a href="@Url.Terms()">Terms of Use</a> -
+        <a href="@Url.Privacy()">Privacy Policy</a> -
         <a href="https://status.nuget.org">Service status</a>
     </p>
     <p>

--- a/src/NuGetGallery/Views/Shared/SiteMenu.cshtml
+++ b/src/NuGetGallery/Views/Shared/SiteMenu.cshtml
@@ -16,9 +16,9 @@
     }
     @if (Request.IsAuthenticated && User.IsInRole(Constants.AdminRoleName))
     {
-        <li class="@classes["Admin"]"><a href="@Url.Action("Index", "Home", new { area="Admin" })">Admin</a></li>
+        <li class="@classes["Admin"]"><a href="@Url.Admin()">Admin</a></li>
     }
     <li><a href="https://docs.nuget.org">Documentation</a></li>
-    <li><a href="@Url.RouteUrl(RouteName.Downloads)">Downloads</a></li>
-    <li><a href="http://blog.nuget.org">Blog</a></li>
+    <li><a href="@Url.Downloads()">Downloads</a></li>
+    <li><a href="https://blog.nuget.org">Blog</a></li>
 </ul>

--- a/src/NuGetGallery/Views/Shared/UserDisplay.cshtml
+++ b/src/NuGetGallery/Views/Shared/UserDisplay.cshtml
@@ -8,7 +8,7 @@
     }
     else
     {
-        <span class="welcome"><a href="@Url.Action("Account", "Users", new { area = "" })">@(User.Identity.Name)</a></span>
+        <span class="welcome"><a href="@Url.AccountSettings()">@(User.Identity.Name)</a></span>
         <text>/</text>
         <span class="user-actions">
             <a href="@Url.LogOff()">Sign out</a>

--- a/src/NuGetGallery/Views/Statistics/PackageDownloadsByVersion.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageDownloadsByVersion.cshtml
@@ -21,7 +21,7 @@
     <script>
         $(document)
             .ready(function () {
-                renderGraph('@Url.Action("PackageDownloadsByVersionReport", "Statistics")', location.search);
+                renderGraph('@Url.StatisticsPackageDownloadByVersionReport()', location.search);
             });
     </script>
 }

--- a/src/NuGetGallery/Views/Statistics/PackageDownloadsDetail.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageDownloadsDetail.cshtml
@@ -21,7 +21,7 @@
     <script>
         $(document)
             .ready(function () {
-                renderGraph('@Url.Action("PackageDownloadsDetailReport", "Statistics")', location.search);
+                renderGraph('@Url.PackageDownloadsDetailReport()', location.search);
             });
     </script>
 }

--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -336,7 +336,7 @@
                     @<text>
                         <div class="row form-group">
                             <div class="col-sm-6">
-                                <a role="button" href="@Url.RouteUrl(RouteName.CuratedFeed, new {name = curatedFeed})"
+                                <a role="button" href="@Url.CuratedFeed(curatedFeed)"
                                    class="btn btn-primary form-control">Manage</a>
                             </div>
                             <div class="col-sm-6">

--- a/tests/NuGetGallery.Facts/App_Start/ConfigurationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/App_Start/ConfigurationServiceFacts.cs
@@ -70,15 +70,16 @@ namespace NuGetGallery.App_Start
             }
 
             [Fact]
-            public void WillUseTheActualRootWhenTheRequestIsLocal()
+            public void WillUseTheConfiguredSiteRootWhenTheRequestIsLocal()
             {
                 var configuration = new TestableConfigurationService();
+                configuration.StubConfiguredSiteRoot = "https://theSiteRoot/";
                 configuration.StubRequest.Setup(stub => stub.IsLocal).Returns(true);
                 configuration.StubRequest.Setup(stub => stub.Url).Returns(new Uri("http://theLocalSiteRoot/aPath"));
 
                 var siteRoot = configuration.GetSiteRoot(useHttps: true);
 
-                Assert.Equal("https://thelocalsiteroot/", siteRoot);
+                Assert.Equal("https://theSiteRoot/", siteRoot);
             }
 
             [Fact]
@@ -99,17 +100,6 @@ namespace NuGetGallery.App_Start
                 configuration.StubConfiguredSiteRoot = "ftp://theSiteRoot/";
 
                 Assert.Throws<InvalidOperationException>(() => configuration.GetSiteRoot(useHttps: false));
-            }
-
-            [Fact]
-            public void WillCacheTheSiteRootLookup()
-            {
-                var configuration = new TestableConfigurationService();
-                configuration.GetSiteRoot(useHttps: false);
-
-                configuration.GetSiteRoot(useHttps: true);
-
-                configuration.StubRequest.Verify(stub => stub.IsLocal, Times.Once());
             }
         }
 

--- a/tests/NuGetGallery.Facts/App_Start/ConfigurationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/App_Start/ConfigurationServiceFacts.cs
@@ -40,11 +40,6 @@ namespace NuGetGallery.App_Start
 
                     return string.Empty;
                 }
-
-                protected override HttpRequestBase GetCurrentRequest()
-                {
-                    return StubRequest.Object;
-                }
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -504,6 +504,7 @@
     <Compile Include="ViewModels\ListPackageItemViewModelFacts.cs" />
     <Compile Include="ViewModels\PackageViewModelFacts.cs" />
     <Compile Include="ViewModels\PreviousNextPagerViewModelFacts.cs" />
+    <Compile Include="Views\UrlHelperFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config">

--- a/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
@@ -14,6 +14,7 @@ using System.Web.Mvc;
 using System.Web.Routing;
 using Moq;
 using NuGet;
+using NuGetGallery.Framework;
 
 namespace NuGetGallery
 {
@@ -51,14 +52,17 @@ namespace NuGetGallery
 
         public static UrlHelper MockUrlHelper()
         {
+            var siteRoot = "http://unittest.nuget.org/";
+
             var mockHttpContext = new Mock<HttpContextBase>(MockBehavior.Loose);
             var mockHttpRequest = new Mock<HttpRequestBase>(MockBehavior.Strict);
             var mockHttpResponse = new Mock<HttpResponseBase>(MockBehavior.Strict);
             mockHttpContext.Setup(httpContext => httpContext.Request).Returns(mockHttpRequest.Object);
             mockHttpContext.Setup(httpContext => httpContext.Response).Returns(mockHttpResponse.Object);
-            mockHttpRequest.Setup(httpRequest => httpRequest.Url).Returns(new Uri("http://unittest.nuget.org/"));
-            mockHttpRequest.Setup(httpRequest => httpRequest.ApplicationPath).Returns("http://unittest.nuget.org/");
+            mockHttpRequest.Setup(httpRequest => httpRequest.Url).Returns(new Uri(siteRoot));
+            mockHttpRequest.Setup(httpRequest => httpRequest.ApplicationPath).Returns(siteRoot);
             mockHttpRequest.Setup(httpRequest => httpRequest.ServerVariables).Returns(new NameValueCollection());
+            mockHttpRequest.Setup(httpRequest => httpRequest.IsSecureConnection).Returns(false);
 
             string value = null;
             Action<string> saveValue = x =>
@@ -71,6 +75,12 @@ namespace NuGetGallery
             var requestContext = new RequestContext(mockHttpContext.Object, new RouteData());
             var routes = new RouteCollection();
             Routes.RegisterRoutes(routes);
+
+            var configurationService = new TestGalleryConfigurationService();
+            configurationService.Current.SiteRoot = siteRoot;
+
+            UrlExtensions.SetConfigurationService(configurationService);
+
             return new UrlHelper(requestContext, routes);
         }
 

--- a/tests/NuGetGallery.Facts/Views/UrlHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Views/UrlHelperFacts.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetGallery.Views
+{
+    public class UrlHelperFacts
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public UrlHelperFacts(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Theory]
+        [InlineData("@Url.Action")]
+        [InlineData("@Url.Route")]
+        public void ViewsDoNotUseUrlActionHelper(string unsupportedTerm)
+        {
+            // We should not use Url.Action or Url.Route in our views as the gallery
+            // may be deployed behind a proxy (such as APIM),
+            // in which case the resolved host name would not match the
+            // DNS record pointing to the proxy.
+            // 
+            // To assert that, we look for textual occurrences of Url.Action or Url.Route
+            // in all razor files of the NuGetGallery web project.
+            AssertNoViolationsOfUnsupportedTermInRazorFiles(unsupportedTerm);
+        }
+
+        private void AssertNoViolationsOfUnsupportedTermInRazorFiles(string unsupportedTerm)
+        {
+            var violations = new ConcurrentBag<Tuple<int, string, string>>();
+
+            Parallel.ForEach(
+                GetRazorFiles(),
+                file =>
+                {
+                    var lineNumber = 0;
+                    foreach (var line in File.ReadLines(file))
+                    {
+                        lineNumber++;
+
+                        if (line.Contains(unsupportedTerm))
+                        {
+                            violations.Add(new Tuple<int, string, string>(lineNumber, file, line.TrimStart(' ').TrimEnd(' ')));
+                        }
+                    }
+                });
+
+            if (violations.Any())
+            {
+                _testOutputHelper.WriteLine(
+                    $"Avoid usage of '{unsupportedTerm}' in .cshtml files! Consider using a method from 'UrlExtensions.cs' to ensure usage of configured 'SiteRoot' setting.");
+
+                // Pretty-print any violations: group by file
+                foreach (var violationsInFile in violations.GroupBy(t => t.Item2).OrderBy(g => g.Key))
+                {
+                    _testOutputHelper.WriteLine($"Violation(s) in file '{violationsInFile.Key}':");
+
+                    // Order by line number
+                    foreach (var violation in violationsInFile.OrderBy(v => v.Item1))
+                    {
+                        _testOutputHelper.WriteLine(
+                            $"  Line #{violation.Item1}: \"{violation.Item3}\"");
+                    }
+                }
+
+                // Fail the test
+                Assert.Empty(violations);
+            }
+        }
+
+        private static IReadOnlyCollection<string> GetRazorFiles()
+        {
+            // $(SolutionDir)\tests\NuGetGallery.Facts\bin\Debug
+            var pathToViewsFolder = Path.Combine(
+                Directory.GetCurrentDirectory(),
+                @"..\..\..\..\src\NuGetGallery\Views");
+
+            return Directory.GetFiles(
+                pathToViewsFolder,
+                "*.cshtml",
+                SearchOption.AllDirectories)
+                .Select(f => Path.GetFullPath(f))
+                .ToList();
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Views/UrlHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Views/UrlHelperFacts.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery.Views
         [Theory]
         [InlineData("@Url.Action")]
         [InlineData("@Url.Route")]
-        public void ViewsDoNotUseUrlActionHelper(string unsupportedTerm)
+        public void ViewsDoNotUseDefaultUrlHelperRoutes(string unsupportedTerm)
         {
             // We should not use Url.Action or Url.Route in our views as the gallery
             // may be deployed behind a proxy (such as APIM),

--- a/tests/NuGetGallery.Facts/Views/UrlHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Views/UrlHelperFacts.cs
@@ -55,7 +55,7 @@ namespace NuGetGallery.Views
 
                         if (line.Contains(unsupportedTerm))
                         {
-                            violations.Add(new Tuple<int, string, string>(lineNumber, file, line.TrimStart(' ').TrimEnd(' ')));
+                            violations.Add(Tuple.Create(lineNumber, file, line.TrimStart(' ').TrimEnd(' ')));
                         }
                     }
                 });

--- a/tests/NuGetGallery.Facts/Views/UrlHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Views/UrlHelperFacts.cs
@@ -39,9 +39,13 @@ namespace NuGetGallery.Views
         private void AssertNoViolationsOfUnsupportedTermInRazorFiles(string unsupportedTerm)
         {
             var violations = new ConcurrentBag<Tuple<int, string, string>>();
+            var razorFiles = GetRazorFiles();
+
+            // Catch working directory issues.
+            Assert.NotEmpty(razorFiles);
 
             Parallel.ForEach(
-                GetRazorFiles(),
+                razorFiles,
                 file =>
                 {
                     var lineNumber = 0;


### PR DESCRIPTION
When having a proxy in front of the gallery deployment, the gallery currently generates hyperlinks (e.g. in emails, UI, ...) that use the deployment host name instead of the proxy's.

This fix leverages the `SiteRoot` config setting instead of the resolved host name of the deployment's environment.