### PR TITLE
Adding a search hint if query results in no items

### DIFF
--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -48,6 +48,20 @@
         </div>
     </div>
 
+    @if (!Model.Items.Any())
+    {
+        <div class="row">
+            <div class="col-xs-12 clearfix">
+                <div class="panel panel-default" aria-expanded="true" >
+                    <div class="panel-body">
+                        NuGet package search works the same on nuget.org, from the NuGet CLI, and within the NuGet Package Manager extension in Visual Studio. <br />
+                        Check out our <strong><a href="https://docs.microsoft.com/nuget/consume-packages/finding-and-choosing-packages#search-syntax">Search Syntax</a></strong>.
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+
     <div class="list-packages" role="list">
         @foreach (var package in Model.Items)
         {


### PR DESCRIPTION
Based on the idea posted here: https://github.com/NuGet/NuGetGallery/issues/782 

Maybe the issue then already solved that way - nothing to fancy. It should look like this:

![image](https://user-images.githubusercontent.com/756703/30084914-a6c13f2a-9294-11e7-95c7-c112650af7fe.png)

The link points to this location:
https://docs.microsoft.com/nuget/consume-packages/finding-and-choosing-packages#search-syntax