### PR TITLE
Use JsonRequestBehavior.AllowGet on endpoints that both return JSON and support GET

### DIFF
--- a/src/NuGetGallery/Controllers/AppController.cs
+++ b/src/NuGetGallery/Controllers/AppController.cs
@@ -54,7 +54,7 @@ namespace NuGetGallery
         /// <param name="statusCode">HTTP status code for response</param>
         /// <param name="obj">Object to Jsonify and return</param>
         /// <returns></returns>
-        protected internal JsonResult Json(int statusCode, object obj)
+        protected internal JsonResult Json(int statusCode, object obj, JsonRequestBehavior jsonRequestBehavior)
         {
             Response.StatusCode = statusCode;
             if (statusCode >= 400)
@@ -62,9 +62,13 @@ namespace NuGetGallery
                 Response.TrySkipIisCustomErrors = true;
             }
 
-            return Json(obj);
+            return Json(obj, jsonRequestBehavior);
         }
 
+        protected internal JsonResult Json(int statusCode, object obj)
+        {
+            return Json(statusCode, obj, JsonRequestBehavior.DenyGet);
+        }
 
         /// <summary>
         /// Called before the action method is invoked.

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -102,7 +102,7 @@ namespace NuGetGallery
             AsyncFileUploadProgress progress = _cacheService.GetProgress(username);
             if (progress == null)
             {
-                return Json(404, null);
+                return Json(404, null, JsonRequestBehavior.AllowGet);
             }
 
             return Json(progress, JsonRequestBehavior.AllowGet);
@@ -1001,12 +1001,18 @@ namespace NuGetGallery
             var package = _packageService.FindPackageByIdAndVersion(id, version);
             if (package == null)
             {
-                return Json(404, new string[] { string.Format(Strings.PackageWithIdAndVersionNotFound, id, version) });
+                return Json(
+                    404,
+                    new string[]
+                    {
+                        string.Format(Strings.PackageWithIdAndVersionNotFound, id, version)
+                    },
+                    JsonRequestBehavior.AllowGet);
             }
 
             if (!package.IsOwner(User))
             {
-                return Json(403, new string[] { Strings.Unauthorized });
+                return Json(403, new string[] { Strings.Unauthorized }, JsonRequestBehavior.AllowGet);
             }
 
             var packageRegistration = _packageService.FindPackageRegistrationById(id);

--- a/tests/NuGetGallery.Facts/Controllers/AppControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AppControllerFacts.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Web.Mvc;
 using NuGetGallery.Framework;
 using Xunit;
 
@@ -25,10 +26,37 @@ namespace NuGetGallery.Controllers
             }
         }
 
+        public class TheJsonMethod : TestContainer
+        {
+            [Fact]
+            public void AllowsJsonRequestBehaviorToBeSpecified()
+            {
+                // Arrange
+                var controller = GetController<TestableAppController>();
+
+                // Act
+                var output = controller.Json(400, null, JsonRequestBehavior.AllowGet);
+
+                // Assert
+                Assert.Equal(JsonRequestBehavior.AllowGet, output.JsonRequestBehavior);
+            }
+
+            [Fact]
+            public void DefaultsToDenyGet()
+            {
+                // Arrange
+                var controller = GetController<TestableAppController>();
+
+                // Act
+                var output = controller.Json(400, null);
+
+                // Assert
+                Assert.Equal(JsonRequestBehavior.DenyGet, output.JsonRequestBehavior);
+            }
+        }
+
         public class TestableAppController : AppController
         {
-            // Nothing but a concrete class to test an abstract class :)
-
             public User InvokeGetCurrentUser()
             {
                 return GetCurrentUser();

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1923,7 +1923,8 @@ namespace NuGetGallery
                 var result = controller.UploadPackageProgress();
 
                 // Assert
-                Assert.IsType<JsonResult>(result);
+                var jsonResult = Assert.IsType<JsonResult>(result);
+                Assert.Equal(JsonRequestBehavior.AllowGet, jsonResult.JsonRequestBehavior);
             }
 
             [Fact]


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/4597.