### PR TITLE
Fix and consolidate routing in NuGetGallery unit test configurations.

### DIFF
--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -121,7 +121,7 @@ namespace NuGetGallery
                     model.User.Username,
                     ownerRequest.ConfirmationCode,
                     new { id = model.Package.Id });
-                var packageUrl = Url.Package(model.Package.Id, null, scheme: "http");
+                var packageUrl = Url.Package(model.Package.Id, null, scheme: _appConfiguration.RequireSSL ? Uri.UriSchemeHttps : Uri.UriSchemeHttp);
                 var policyMessage = GetNoticeOfPoliciesRequiredMessage(model.Package, model.User, model.CurrentUser);
 
                 _messageService.SendPackageOwnerRequest(model.CurrentUser, model.User, model.Package, packageUrl,

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
 {
     public static class UrlExtensions
     {
-        private static ConfigurationService _configuration;
+        private static IGalleryConfigurationService _configuration;
         private const string PackageExplorerDeepLink = @"https://npe.codeplex.com/releases/clickonce/NuGetPackageExplorer.application?url={0}&id={1}&version={2}";
 
         // Shorthand for current url
@@ -37,7 +37,7 @@ namespace NuGetGallery
             return url.RequestContext.HttpContext.Request.IsSecureConnection ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
         }
                 
-        internal static void SetConfigurationService(ConfigurationService configurationService)
+        internal static void SetConfigurationService(IGalleryConfigurationService configurationService)
         {
             _configuration = configurationService;
         }
@@ -778,7 +778,9 @@ namespace NuGetGallery
 
         internal static string EnsureTrailingSlash(string url)
         {
-            if (url != null && !url.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+            if (url != null 
+                && !url.EndsWith("/", StringComparison.OrdinalIgnoreCase)
+                && !url.Contains("?"))
             {
                 return url + '/';
             }

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticatorFacts.cs
@@ -46,11 +46,12 @@ namespace NuGetGallery.Authentication
             public async Task LoadsConfigFromConfigurationService()
             {
                 // Arrange
+                var configurationService = GetConfigurationService();
                 var authConfig = new AuthenticatorConfiguration();
                 var auther = new ATestAuthenticator();
 
                 // Act
-                await auther.Startup(Get<IGalleryConfigurationService>(), Get<IAppBuilder>());
+                await auther.Startup(configurationService, Get<IAppBuilder>());
 
                 // Assert
                 Assert.Equal(authConfig.Enabled, auther.BaseConfig.Enabled);
@@ -65,11 +66,11 @@ namespace NuGetGallery.Authentication
 
                 var tempAuthConfig = new AuthenticatorConfiguration();
 
-                var mockConfiguration = (TestGalleryConfigurationService)Get<IGalleryConfigurationService>();
+                var mockConfiguration = GetConfigurationService();
                 mockConfiguration.Settings[$"{Authenticator.AuthPrefix}{auther.Name}.{nameof(tempAuthConfig.Enabled)}"] = "false";
 
                 // Act
-                await auther.Startup(Get<IGalleryConfigurationService>(), Get<IAppBuilder>());
+                await auther.Startup(mockConfiguration, Get<IAppBuilder>());
 
                 // Assert
                 Assert.Null(auther.AttachedTo);
@@ -83,8 +84,8 @@ namespace NuGetGallery.Authentication
 
                 var tempAuthConfig = new AuthenticatorConfiguration();
 
-                var mockConfiguration = (TestGalleryConfigurationService)Get<IGalleryConfigurationService>();
-                mockConfiguration.Settings[$"{Authenticator.AuthPrefix}{auther.Name}.{nameof(tempAuthConfig.Enabled)}"] = "true"; 
+                var mockConfiguration = GetConfigurationService();
+                mockConfiguration.Settings[$"{Authenticator.AuthPrefix}{auther.Name}.{nameof(tempAuthConfig.Enabled)}"] = "true";
 
                 // Act
                 await auther.Startup(mockConfiguration, Get<IAppBuilder>());
@@ -100,7 +101,7 @@ namespace NuGetGallery.Authentication
             public void IgnoresAbstractAndNonAuthenticatorTypes()
             {
                 // Act
-                var authers = Authenticator.GetAllAvailable(new [] {
+                var authers = Authenticator.GetAllAvailable(new[] {
                     typeof(ATestAuthenticator),
                     typeof(Authenticator),
                     typeof(TheGetAllAvailableMethod)
@@ -120,7 +121,8 @@ namespace NuGetGallery.Authentication
             }
         }
 
-        private class ATestAuthenticator : Authenticator {
+        private class ATestAuthenticator : Authenticator
+        {
             public IAppBuilder AttachedTo { get; private set; }
 
             protected override void AttachToOwinApp(IGalleryConfigurationService config, IAppBuilder app)

--- a/tests/NuGetGallery.Facts/Authentication/Providers/ApiKey/ApiKeyAuthenticationHandlerFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Providers/ApiKey/ApiKeyAuthenticationHandlerFacts.cs
@@ -126,7 +126,7 @@ namespace NuGetGallery.Authentication.Providers.ApiKey
 
                 var authenticateValues = handler.OwinContext.Response.Headers.GetCommaSeparatedValues("WWW-Authenticate");
                 Assert.Contains(
-                    "ApiKey realm=\"nuget.local\"",
+                    "ApiKey realm=\"localhost\"",
                     authenticateValues);
                 Assert.Contains(
                     "existing",

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -163,7 +163,7 @@ namespace NuGetGallery.Controllers
                 // Arrange
                 var fakes = Get<Fakes>();
                 var controller = GetController<JsonApiController>();
-                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
+
                 GetMock<HttpContextBase>()
                     .Setup(c => c.User)
                     .Returns(Fakes.ToPrincipal(fakes.Owner));
@@ -186,7 +186,6 @@ namespace NuGetGallery.Controllers
                 // Arrange
                 var fakes = Get<Fakes>();
                 var controller = GetController<JsonApiController>();
-                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
                 GetMock<HttpContextBase>()
                     .Setup(c => c.User)
                     .Returns(Fakes.ToPrincipal(fakes.Owner));
@@ -209,7 +208,6 @@ namespace NuGetGallery.Controllers
                 // Arrange
                 var fakes = Get<Fakes>();
                 var controller = GetController<JsonApiController>();
-                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
                 GetMock<HttpContextBase>()
                     .Setup(c => c.User)
                     .Returns(Fakes.ToPrincipal(fakes.Owner));
@@ -232,7 +230,6 @@ namespace NuGetGallery.Controllers
                 // Arrange
                 var fakes = Get<Fakes>();
                 var controller = GetController<JsonApiController>();
-                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
                 GetMock<HttpContextBase>()
                     .Setup(c => c.User)
                     .Returns(Fakes.ToPrincipal(fakes.Owner));
@@ -264,7 +261,6 @@ namespace NuGetGallery.Controllers
                 // Arrange
                 var fakes = Get<Fakes>();
                 var controller = GetController<JsonApiController>();
-                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
                 GetMock<HttpContextBase>()
                     .Setup(c => c.User)
                     .Returns(Fakes.ToPrincipal(fakes.Owner));
@@ -429,8 +425,8 @@ namespace NuGetGallery.Controllers
                         fakes.Owner,
                         fakes.User,
                         fakes.Package,
-                        "http://nuget.local/packages/FakePackage/",
-                        "https://nuget.local/packages/FakePackage/owners/testUser/confirm/confirmation-code",
+                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/",
+                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/owners/testUser/confirm/confirmation-code",
                         "Hello World! Html Encoded &lt;3",
                         ""))
                     .Verifiable();
@@ -500,10 +496,11 @@ namespace NuGetGallery.Controllers
             {
                 // Arrange
                 var controller = GetController<JsonApiController>();
-                GetMock<IAppConfiguration>().Setup(c => c.GalleryOwner).Returns(new MailAddress("support@example.com"));
+                
                 GetMock<HttpContextBase>()
                     .Setup(c => c.User)
                     .Returns(Fakes.ToPrincipal(fakes.Owner));
+
                 userToSubscribe.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
 
                 var packageServiceMock = GetMock<IPackageService>();
@@ -518,8 +515,8 @@ namespace NuGetGallery.Controllers
                         fakes.Owner,
                         fakes.User,
                         fakes.Package,
-                        "http://nuget.local/packages/FakePackage/",
-                        "https://nuget.local/packages/FakePackage/owners/testUser/confirm/confirmation-code",
+                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/",
+                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/owners/testUser/confirm/confirmation-code",
                         string.Empty,
                         It.IsAny<string>()))
                     .Callback<User, User, PackageRegistration, string, string, string, string>(

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -12,7 +12,6 @@ using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 using Moq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -350,7 +349,7 @@ namespace NuGetGallery
 
             var controller = new StatisticsController(new JsonStatisticsService(fakeReportService.Object));
 
-            TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
+            TestUtility.SetupUrlHelperForUrlGeneration(controller);
 
             var model = (StatisticsPackagesViewModel)((ViewResult)await controller.PackageDownloadsByVersion(PackageId, new[] { Constants.StatisticsDimensions.Version })).Model;
 
@@ -422,7 +421,7 @@ namespace NuGetGallery
 
             var controller = new StatisticsController(new JsonStatisticsService(fakeReportService.Object));
 
-            TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
+            TestUtility.SetupUrlHelperForUrlGeneration(controller);
 
             var actualReport = (StatisticsPackagesReport)((JsonResult)await controller.PackageDownloadsByVersionReport(PackageId, new[] { Constants.StatisticsDimensions.Version })).Data;
 
@@ -504,7 +503,7 @@ namespace NuGetGallery
 
             var controller = new StatisticsController(new JsonStatisticsService(fakeReportService.Object));
 
-            TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
+            TestUtility.SetupUrlHelperForUrlGeneration(controller);
 
             var invalidDimension = "this_dimension_does_not_exist";
             
@@ -534,7 +533,7 @@ namespace NuGetGallery
 
             var controller = new StatisticsController(new JsonStatisticsService(fakeReportService.Object));
 
-            TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
+            TestUtility.SetupUrlHelperForUrlGeneration(controller);
             
             var model = (StatisticsPackagesViewModel)((ViewResult)await controller.PackageDownloadsDetail(PackageId, PackageVersion, new string[] { "ClientName" })).Model;
 
@@ -608,7 +607,7 @@ namespace NuGetGallery
 
             var controller = new StatisticsController(new JsonStatisticsService(fakeReportService.Object));
 
-            TestUtility.SetupUrlHelperForUrlGeneration(controller, new Uri("http://nuget.org"));
+            TestUtility.SetupUrlHelperForUrlGeneration(controller);
             
             var actualReport = (StatisticsPackagesReport)((JsonResult)await controller.PackageDownloadsDetailReport(PackageId, PackageVersion, new string[] { "ClientName" })).Data;
 

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -155,7 +155,7 @@ namespace NuGetGallery
 
                 // We use a catch-all route for unit tests so we can see the parameters
                 // are passed correctly.
-                Assert.Equal("https://nuget.local/account/confirm/theUsername/confirmation", sentConfirmationUrl);
+                Assert.Equal(TestUtility.GallerySiteRootHttps + "account/confirm/theUsername/confirmation", sentConfirmationUrl);
                 Assert.Equal("to@example.com", sentToAddress.Address);
             }
         }
@@ -196,9 +196,8 @@ namespace NuGetGallery
             [Fact]
             public void ShowsDefaultThanksView()
             {
-                GetMock<IAppConfiguration>()
-                    .Setup(x => x.ConfirmEmailAddresses)
-                    .Returns(true);
+                var configurationService = GetConfigurationService();
+                configurationService.Current.ConfirmEmailAddresses = true;
                 var controller = GetController<UsersController>();
 
                 var result = controller.Thanks() as ViewResult;
@@ -210,9 +209,9 @@ namespace NuGetGallery
             [Fact]
             public void ShowsConfirmViewWithModelWhenConfirmingEmailAddressIsNotRequired()
             {
-                GetMock<IAppConfiguration>()
-                    .Setup(x => x.ConfirmEmailAddresses)
-                    .Returns(false);
+                var configurationService = GetConfigurationService();
+                configurationService.Current.ConfirmEmailAddresses = false;
+
                 var controller = GetController<UsersController>();
 
                 ResultAssert.IsView(controller.Thanks());
@@ -224,7 +223,7 @@ namespace NuGetGallery
             [Fact]
             public async Task SendsEmailWithPasswordResetUrl()
             {
-                const string resetUrl = "https://nuget.local/account/forgotpassword/somebody/confirmation";
+                string resetUrl = TestUtility.GallerySiteRootHttps + "account/forgotpassword/somebody/confirmation";
                 var user = new User("somebody")
                 {
                     EmailAddress = "some@example.com",
@@ -651,11 +650,11 @@ namespace NuGetGallery
                 // Arrange 
                 var user = new User("the-username");
 
+                var configurationService = GetConfigurationService();
+                configurationService.Current.ExpirationInDaysForApiKeyV1 = 365;
+
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
-
-                var config = GetMock<IAppConfiguration>();
-                config.SetupGet(x => x.ExpirationInDaysForApiKeyV1).Returns(365);
 
                 // Act
                 await controller.GenerateApiKey(
@@ -775,9 +774,8 @@ namespace NuGetGallery
             {
                 var user = new User { Username = "the-username" };
 
-                GetMock<IAppConfiguration>()
-                    .Setup(x => x.ExpirationInDaysForApiKeyV1)
-                    .Returns(365);
+                var configurationService = GetConfigurationService();
+                configurationService.Current.ExpirationInDaysForApiKeyV1 = 365;
 
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
@@ -1212,7 +1210,7 @@ namespace NuGetGallery
                 await controller.ChangePassword(new AccountViewModel());
 
                 // Assert
-                Assert.Equal("https://nuget.local/account/setpassword/test/t0k3n", actualConfirmUrl);
+                Assert.Equal(TestUtility.GallerySiteRootHttps + "account/setpassword/test/t0k3n", actualConfirmUrl);
                 GetMock<IMessageService>().VerifyAll();
             }
         }

--- a/tests/NuGetGallery.Facts/Framework/Fakes.cs
+++ b/tests/NuGetGallery.Facts/Framework/Fakes.cs
@@ -153,7 +153,7 @@ namespace NuGetGallery.Framework
         {
             var ctx = new OwinContext();
 
-            ctx.Request.SetUrl("http://nuget.local/");
+            ctx.Request.SetUrl(TestUtility.GallerySiteRootHttps);
 
             // Fill in some values that cause exceptions if not present
             ctx.Set<Action<Action<object>, object>>("server.OnSendingHeaders", (_, __) => { });

--- a/tests/NuGetGallery.Facts/Framework/TestContainer.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestContainer.cs
@@ -23,7 +23,8 @@ namespace NuGetGallery.Framework
             Container = container;
         }
 
-        protected TController GetController<TController>() where TController : Controller
+        protected TController GetController<TController>()
+            where TController : Controller
         {
             if (!Container.IsRegistered(typeof(TController)))
             {
@@ -47,10 +48,15 @@ namespace NuGetGallery.Framework
             if (appCtrl != null)
             {
                 appCtrl.SetOwinContextOverride(Fakes.CreateOwinContext());
-                appCtrl.NuGetContext.Config = Container.Resolve<IGalleryConfigurationService>();
+                appCtrl.NuGetContext.Config = GetConfigurationService();
             }
 
             return c;
+        }
+
+        protected TestGalleryConfigurationService GetConfigurationService()
+        {
+            return Container.Resolve<IGalleryConfigurationService>() as TestGalleryConfigurationService;
         }
 
         protected TService GetService<TService>()
@@ -90,7 +96,8 @@ namespace NuGetGallery.Framework
 
         protected T Get<T>()
         {
-            if (typeof(Controller).IsAssignableFrom(typeof(T))) {
+            if (typeof(Controller).IsAssignableFrom(typeof(T)))
+            {
                 throw new InvalidOperationException("Use GetController<T> to get a controller instance");
             }
 
@@ -100,7 +107,7 @@ namespace NuGetGallery.Framework
         protected Mock<T> GetMock<T>() where T : class
         {
             bool registerMock = false;
-            if (Container.IsRegistered(typeof (T)))
+            if (Container.IsRegistered(typeof(T)))
             {
                 try
                 {
@@ -114,7 +121,7 @@ namespace NuGetGallery.Framework
 
             if (registerMock || !Container.IsRegistered(typeof(T)))
             {
-                var mockInstance = (new Mock<T>() {CallBase = true}).Object;
+                var mockInstance = (new Mock<T>() { CallBase = true }).Object;
 
                 var updater = new ContainerBuilder();
                 updater.RegisterInstance(mockInstance).As<T>();
@@ -140,4 +147,3 @@ namespace NuGetGallery.Framework
         }
     }
 }
-

--- a/tests/NuGetGallery.Facts/Framework/TestGalleryConfigurationService.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestGalleryConfigurationService.cs
@@ -11,7 +11,8 @@ namespace NuGetGallery.Framework
     {
         public IDictionary<string, string> Settings = new Dictionary<string, string>();
 
-        public TestGalleryConfigurationService() : base(new EmptySecretReaderFactory())
+        public TestGalleryConfigurationService() 
+            : base(new EmptySecretReaderFactory())
         {
         }
 


### PR DESCRIPTION
This PR contains various fixes in NuGetGallery test infrastructure, which surface now as the gallery is checking for the `Gallery.SiteRoot` config setting. In other words: test routing and config setup must reflect a real possible scenario. 

In addition, `FormatException` were thrown due to invalid, dummy values for e-mail fields, as well as `NullReferenceException` due to service mocks that did not have all dependencies injected.

Tests are now more consistent:
* `Gallery.SiteRoot` = "http://localhost/"
* `IAppConfiguration.RequireSSL` = "true"
* all requests are HTTPS, assertions assume HTTPS (unless otherwise specified)
* we target fewer service mocks, more real implementations