### PR TITLE
Properly generate relative/absolute URLs.

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -522,9 +522,9 @@ namespace NuGetGallery
 
                         // Notify user of push
                         MessageService.SendPackageAddedNotice(package,
-                            Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, Request.Url.Scheme),
-                            Url.ReportPackage(package.PackageRegistration.Id, package.NormalizedVersion, Request.Url.Scheme),
-                            Url.AccountSettings(Request.Url.Scheme));
+                            Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
+                            Url.ReportPackage(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
+                            Url.AccountSettings(relativeUrl: false));
 
                         TelemetryService.TrackPackagePushEvent(package, user, User.Identity);
 

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -259,7 +259,8 @@ namespace NuGetGallery
                         "Confirm",
                         "Users",
                         user.User.Username,
-                        user.User.EmailConfirmationToken));
+                        user.User.EmailConfirmationToken,
+                        relativeUrl: false));
             }
 
             // If we are an administrator and Gallery.EnforcedAuthProviderForAdmin is set

--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -77,7 +77,7 @@ namespace NuGetGallery
             var result = owners.Union(pending).Select(o => new
             {
                 name = o.Name,
-                profileUrl = Url.User(o.Name),
+                profileUrl = Url.User(o.Name, relativeUrl: false),
                 imageUrl = GravatarHelper.Url(o.EmailAddress, size: Constants.GravatarImageSize),
                 current = o.Current,
                 pending = o.Pending,
@@ -120,8 +120,9 @@ namespace NuGetGallery
                     "Packages",
                     model.User.Username,
                     ownerRequest.ConfirmationCode,
-                    new { id = model.Package.Id });
-                var packageUrl = Url.Package(model.Package.Id, null, scheme: _appConfiguration.RequireSSL ? Uri.UriSchemeHttps : Uri.UriSchemeHttp);
+                    new { id = model.Package.Id },
+                    relativeUrl: false);
+                var packageUrl = Url.Package(model.Package.Id, version: null, relativeUrl: false);
                 var policyMessage = GetNoticeOfPoliciesRequiredMessage(model.Package, model.User, model.CurrentUser);
 
                 _messageService.SendPackageOwnerRequest(model.CurrentUser, model.User, model.Package, packageUrl,
@@ -131,7 +132,7 @@ namespace NuGetGallery
                 {
                     success = true,
                     name = model.User.Username,
-                    profileUrl = Url.User(model.User.Username),
+                    profileUrl = Url.User(model.User.Username, relativeUrl: false),
                     imageUrl = GravatarHelper.Url(model.User.EmailAddress, size: Constants.GravatarImageSize),
                     pending = true
                 });

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -59,7 +59,7 @@ namespace NuGetGallery
         {
             User user = GetCurrentUser();
             var confirmationUrl = Url.ConfirmationUrl(
-                "Confirm", "Users", user.Username, user.EmailConfirmationToken);
+                "Confirm", "Users", user.Username, user.EmailConfirmationToken, relativeUrl: false);
 
             var alreadyConfirmed = user.UnconfirmedEmailAddress == null;
 
@@ -390,7 +390,7 @@ namespace NuGetGallery
             if (user.Confirmed)
             {
                 var confirmationUrl = Url.ConfirmationUrl(
-                    "Confirm", "Users", user.Username, user.EmailConfirmationToken);
+                    "Confirm", "Users", user.Username, user.EmailConfirmationToken, relativeUrl: false);
                 _messageService.SendEmailChangeConfirmationNotice(new MailAddress(user.UnconfirmedEmailAddress, user.Username), confirmationUrl);
 
                 TempData["Message"] = Strings.EmailUpdated_ConfirmationRequired;
@@ -756,7 +756,8 @@ namespace NuGetGallery
                 "Users",
                 user.Username,
                 user.PasswordResetToken,
-                new { forgot = forgotPassword });
+                new { forgot = forgotPassword },
+                relativeUrl: false);
             _messageService.SendPasswordResetInstructions(user, resetPasswordUrl, forgotPassword);
 
             return RedirectToAction(actionName: "PasswordSent", controllerName: "Users");

--- a/src/NuGetGallery/Filters/RequiresAccountConfirmationAttribute.cs
+++ b/src/NuGetGallery/Filters/RequiresAccountConfirmationAttribute.cs
@@ -36,8 +36,8 @@ namespace NuGetGallery.Filters
                 controller.TempData["ConfirmationRequiredMessage"] = string.Format(
                     CultureInfo.CurrentCulture,
                     "Before you can {0} you must first confirm your email address.", _inOrderTo);
-                controller.HttpContext.SetConfirmationReturnUrl(controller.Url.Current());
-                filterContext.Result = new RedirectResult(controller.Url.ConfirmationRequired());
+                controller.HttpContext.SetConfirmationReturnUrl(controller.Url.RequestContext.HttpContext.Request.RawUrl);
+                filterContext.Result = new RedirectResult(controller.Url.ConfirmationRequired(relativeUrl: false));
             }
         }
     }

--- a/src/NuGetGallery/Services/ReportPackageRequest.cs
+++ b/src/NuGetGallery/Services/ReportPackageRequest.cs
@@ -26,7 +26,6 @@ namespace NuGetGallery
         {
             // note, format blocks {xxx} are matched by ordinal-case-sensitive comparison
             var builder = new StringBuilder(subject);
-            var protocol = config.RequireSSL ? Uri.UriSchemeHttps: Uri.UriSchemeHttp;
 
             Substitute(builder, "{GalleryOwnerName}", config.GalleryOwner.DisplayName);
             Substitute(builder, "{Id}", Package.PackageRegistration.Id);
@@ -40,7 +39,7 @@ namespace NuGetGallery
                     RequestingUser.Username,
                     RequestingUser.EmailAddress,
                     Environment.NewLine,
-                    Url.User(RequestingUser, scheme: protocol)));
+                    Url.User(RequestingUser, relativeUrl: false)));
             }
             else
             {
@@ -49,8 +48,8 @@ namespace NuGetGallery
             Substitute(builder, "{Name}", FromAddress.DisplayName);
             Substitute(builder, "{Address}", FromAddress.Address);
             Substitute(builder, "{AlreadyContactedOwners}", AlreadyContactedOwners ? "Yes" : "No");
-            Substitute(builder, "{PackageUrl}", Url.Package(Package.PackageRegistration.Id, version: null, scheme: protocol));
-            Substitute(builder, "{VersionUrl}", Url.Package(Package.PackageRegistration.Id, Package.Version, protocol));
+            Substitute(builder, "{PackageUrl}", Url.Package(Package.PackageRegistration.Id, version: null, relativeUrl: false));
+            Substitute(builder, "{VersionUrl}", Url.Package(Package.PackageRegistration.Id, Package.Version, relativeUrl: false));
             Substitute(builder, "{Reason}", Reason);
             Substitute(builder, "{Signature}", Signature);
             Substitute(builder, "{Message}", Message);

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -52,6 +52,9 @@ namespace NuGetGallery
 
         private static string GetConfiguredSiteHostName()
         {
+            // It doesn't matter which value we pass on here for the useHttps parameter.
+            // We're just interested in the host, which is the same for both, 
+            // as it all results from the same 'NuGetGallery.SiteRoot' URL value.
             var siteRoot = GetSiteRoot(useHttps: true);
             return new Uri(siteRoot).Host;
         }
@@ -744,13 +747,12 @@ namespace NuGetGallery
         {
             var protocol = GetProtocol(url);
             var hostName = GetConfiguredSiteHostName();
-            var siteRoot = $"{protocol}://{hostName}";
 
             var actionLink = url.Action(actionName, controllerName, routeValues, protocol, hostName);
 
             if (relativeUrl)
             {
-                return actionLink.Replace(siteRoot, string.Empty);
+                return actionLink.Replace($"{protocol}://{hostName}", string.Empty);
             }
 
             return actionLink;
@@ -764,13 +766,12 @@ namespace NuGetGallery
         {
             var protocol = GetProtocol(url);
             var hostName = GetConfiguredSiteHostName();
-            var siteRoot = $"{protocol}://{hostName}";
 
             var routeLink = url.RouteUrl(routeName, routeValues, protocol, hostName);
 
             if (relativeUrl)
             {
-                return routeLink.Replace(siteRoot, string.Empty);
+                return routeLink.Replace($"{protocol}://{hostName}", string.Empty);
             }
 
             return routeLink;

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -34,104 +34,93 @@ namespace NuGetGallery
 
         private static string GetProtocol(UrlHelper url)
         {
-            return url.RequestContext.HttpContext.Request.IsSecureConnection ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
+            if (_configuration.Current.RequireSSL || url.RequestContext.HttpContext.Request.IsSecureConnection)
+                return Uri.UriSchemeHttps;
+
+            return Uri.UriSchemeHttp;
         }
-                
+
         internal static void SetConfigurationService(IGalleryConfigurationService configurationService)
         {
             _configuration = configurationService;
         }
 
-        private static string GetConfiguredSiteHostName(UrlHelper url)
+        internal static string GetSiteRoot(bool useHttps)
         {
-            var siteRoot = _configuration.GetSiteRoot(useHttps: url.RequestContext.HttpContext.Request.IsSecureConnection);
+            return _configuration.GetSiteRoot(useHttps);
+        }
+
+        private static string GetConfiguredSiteHostName()
+        {
+            var siteRoot = GetSiteRoot(useHttps: true);
             return new Uri(siteRoot).Host;
         }
 
-        public static string Home(this UrlHelper url)
+        public static string Home(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.Home,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.Home, relativeUrl);
         }
 
-        public static string Statistics(this UrlHelper url)
+        public static string Statistics(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.StatisticsHome,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.StatisticsHome, relativeUrl);
         }
 
-        public static string StatisticsAllPackageDownloads(this UrlHelper url)
+        public static string StatisticsAllPackageDownloads(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.StatisticsPackages,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.StatisticsPackages, relativeUrl);
         }
 
-        public static string StatisticsAllPackageVersionDownloads(this UrlHelper url)
+        public static string StatisticsAllPackageVersionDownloads(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.StatisticsPackageVersions,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.StatisticsPackageVersions, relativeUrl);
         }
 
-        public static string StatisticsPackageDownloadByVersion(this UrlHelper url, string id)
+        public static string StatisticsPackageDownloadByVersion(this UrlHelper url, string id, bool relativeUrl = true)
         {
-            string result = url.RouteUrl(
+            var result = GetRouteLink(
+                url,
                 RouteName.StatisticsPackageDownloadsByVersion,
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "id", id }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
 
             return result + "?groupby=Version";
         }
 
-        public static string StatisticsPackageDownloadByVersionReport(this UrlHelper url)
+        public static string StatisticsPackageDownloadByVersionReport(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.StatisticsPackageDownloadsByVersionReport,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.StatisticsPackageDownloadsByVersionReport, relativeUrl);
         }
 
-        public static string StatisticsPackageDownloadsDetail(this UrlHelper url, string id, string version)
+        public static string StatisticsPackageDownloadsDetail(this UrlHelper url, string id, string version, bool relativeUrl = true)
         {
-            string result = url.RouteUrl(
-                RouteName.StatisticsPackageDownloadsDetail,
+            var result = GetRouteLink(
+                url, 
+                RouteName.StatisticsPackageDownloadsDetail, 
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "id", id },
                     { "version", version }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
 
             return result + "?groupby=ClientName";
         }
 
-        public static string StatisticsPackageDownloadsDetailReport(this UrlHelper url)
+        public static string StatisticsPackageDownloadsDetailReport(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.StatisticsPackageDownloadsDetailReport,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.StatisticsPackageDownloadsDetailReport, relativeUrl);
         }
 
-        public static string PackageList(this UrlHelper url, int page, string q, bool includePrerelease)
+        public static string PackageList(
+            this UrlHelper url,
+            int page,
+            string q,
+            bool includePrerelease,
+            bool relativeUrl = true)
         {
             var routeValues = new RouteValueDictionary();
 
@@ -150,621 +139,578 @@ namespace NuGetGallery
                 routeValues["prerel"] = "false";
             }
 
-            return url.Action(
-                actionName: "ListPackages",
-                controllerName: "Packages",
-                routeValues: routeValues,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(
+                url,
+                "ListPackages",
+                "Packages",
+                relativeUrl,
+                routeValues);
         }
 
-        public static string CuratedPackage(this UrlHelper url, string curatedFeedName, string id, string scheme = null)
+        public static string CuratedPackage(
+            this UrlHelper url,
+            string curatedFeedName,
+            string id,
+            bool relativeUrl = true)
         {
-            return url.RouteUrl(
+            return GetRouteLink(
+                url,
                 RouteName.CuratedPackage,
+                relativeUrl,
                 new RouteValueDictionary
                 {
                     { "curatedFeedName", curatedFeedName },
                     { "curatedPackageId", id }
-                },
-                protocol: scheme ?? GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string CuratedPackageList(this UrlHelper url, int page, string q, string curatedFeedName)
+        public static string CuratedPackageList(
+            this UrlHelper url,
+            int page,
+            string q,
+            string curatedFeedName,
+            bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "ListPackages",
-                controllerName: "CuratedFeeds",
+            return GetActionLink(
+                url,
+                "ListPackages",
+                "CuratedFeeds",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "q", q },
                     { "page", page },
                     { "curatedFeedName", curatedFeedName }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
-
+                });
         }
 
-        public static string CuratedFeed(this UrlHelper url, string curatedFeedName)
+        public static string CuratedFeed(this UrlHelper url, string curatedFeedName, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.CuratedFeed,
+            return GetRouteLink(
+                url, 
+                RouteName.CuratedFeed, 
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "name", curatedFeedName }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string PackageList(this UrlHelper url)
+        public static string PackageList(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.ListPackages,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.ListPackages, relativeUrl);
         }
 
-        public static string UndoPendingEdits(this UrlHelper url, IPackageVersionModel package)
+        public static string UndoPendingEdits(
+            this UrlHelper url,
+            IPackageVersionModel package,
+            bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "UndoPendingEdits",
-                controllerName: "Packages",
+            return GetActionLink(
+                url,
+                "UndoPendingEdits",
+                "Packages",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "id", package.Id },
                     { "version", package.Version }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string Package(this UrlHelper url, string id)
+        public static string Package(this UrlHelper url, string id, bool relativeUrl = true)
         {
-            return url.Package(id, null, scheme: null);
+            return url.Package(id, version: null, relativeUrl: relativeUrl);
         }
 
-        public static string Package(this UrlHelper url, string id, string version, string scheme = null)
+        public static string Package(
+            this UrlHelper url,
+            string id,
+            string version,
+            bool relativeUrl = true)
         {
-            string result = url.RouteUrl(
+            string result = GetRouteLink(
+                url,
                 RouteName.DisplayPackage,
-                new RouteValueDictionary
+                relativeUrl,
+                routeValues: new RouteValueDictionary
                 {
                     { "id", id },
                     { "version", version }
-                },
-                protocol: scheme ?? GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
 
             // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions
             return version == null ? EnsureTrailingSlash(result) : result;
         }
 
-        public static string Package(this UrlHelper url, Package package)
+        public static string Package(this UrlHelper url, Package package, bool relativeUrl = true)
         {
-            return url.Package(package.PackageRegistration.Id, package.NormalizedVersion);
+            return url.Package(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl);
         }
 
-        public static string Package(this UrlHelper url, IPackageVersionModel package)
+        public static string Package(this UrlHelper url, IPackageVersionModel package, bool relativeUrl = true)
         {
-            return url.Package(package.Id, package.Version);
+            return url.Package(package.Id, package.Version, relativeUrl);
         }
 
-        public static string Package(this UrlHelper url, PackageRegistration package)
+        public static string Package(this UrlHelper url, PackageRegistration package, bool relativeUrl = true)
         {
-            return url.Package(package.Id);
+            return url.Package(package.Id, relativeUrl);
         }
 
         public static string PackageDefaultIcon(this UrlHelper url)
         {
-            return url.Home().TrimEnd('/') + VirtualPathUtility.ToAbsolute("~/Content/Images/packageDefaultIcon-50x50.png", url.RequestContext.HttpContext.Request.ApplicationPath);
+            return url.Home(relativeUrl: false).TrimEnd('/')
+                + VirtualPathUtility.ToAbsolute("~/Content/Images/packageDefaultIcon-50x50.png", url.RequestContext.HttpContext.Request.ApplicationPath);
         }
 
-        public static string PackageDownload(this UrlHelper url, int feedVersion, string id, string version)
+        public static string PackageDownload(
+            this UrlHelper url,
+            int feedVersion,
+            string id,
+            string version,
+            bool relativeUrl = true)
         {
-            string result = url.RouteUrl(
+            string result = GetRouteLink(
+                url,
                 routeName: $"v{feedVersion}{RouteName.DownloadPackage}",
+                relativeUrl: false,
                 routeValues: new RouteValueDictionary
                 {
                     { "Id", id },
                     { "Version", version }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
 
             // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions
             return version == null ? EnsureTrailingSlash(result) : result;
         }
 
-        public static string ExplorerDeepLink(this UrlHelper url, int feedVersion, string id, string version)
+        public static string ExplorerDeepLink(
+            this UrlHelper url,
+            int feedVersion,
+            string id,
+            string version)
         {
-            string urlResult = url.RouteUrl(
+            var urlResult = GetRouteLink(
+                url,
                 routeName: $"v{feedVersion}{RouteName.DownloadPackage}",
+                relativeUrl: false,
                 routeValues: new RouteValueDictionary
                 {
                     { "Id", id }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
 
             urlResult = EnsureTrailingSlash(urlResult);
 
-            return String.Format(CultureInfo.InvariantCulture, PackageExplorerDeepLink, urlResult, id, version);
+            return string.Format(CultureInfo.InvariantCulture, PackageExplorerDeepLink, urlResult, id, version);
         }
 
-        public static string LogOn(this UrlHelper url)
+        public static string LogOn(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
+            return GetRouteLink(
+                url,
                 RouteName.Authentication,
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
-                    { "action", "LogOn" }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                    { "action", "LogOn" },
+                });
         }
 
-        public static string LogOn(this UrlHelper url, string returnUrl)
+        public static string LogOn(this UrlHelper url, string returnUrl, bool relativeUrl = true)
         {
-            return url.RouteUrl(
+            return GetRouteLink(
+                url,
                 RouteName.Authentication,
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "action", "LogOn" },
                     { "returnUrl", returnUrl }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string SignUp(this UrlHelper url)
+        public static string SignUp(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
+            return GetRouteLink(
+                url,
                 RouteName.Authentication,
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "action", "SignUp" }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string SignUp(this UrlHelper url, string returnUrl)
+        public static string SignUp(this UrlHelper url, string returnUrl, bool relativeUrl = true)
         {
-            return url.RouteUrl(
+            return GetRouteLink(
+                url,
                 RouteName.Authentication,
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "action", "SignUp" },
                     { "returnUrl", returnUrl }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string ConfirmationRequired(this UrlHelper url)
+        public static string ConfirmationRequired(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                "ConfirmationRequired",
-                controllerName: "Users",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "ConfirmationRequired", "Users", relativeUrl);
         }
 
-        public static string LogOff(this UrlHelper url)
+        public static string LogOff(this UrlHelper url, bool relativeUrl = true)
         {
             string returnUrl = url.Current();
             // If we're logging off from the Admin Area, don't set a return url
-            if (String.Equals(url.RequestContext.RouteData.DataTokens["area"].ToStringOrNull(), "Admin", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(url.RequestContext.RouteData.DataTokens["area"].ToStringOrNull(), "Admin", StringComparison.OrdinalIgnoreCase))
             {
-                returnUrl = String.Empty;
+                returnUrl = string.Empty;
             }
-            return url.Action(
+
+            return GetActionLink(
+                url,
                 "LogOff",
                 "Authentication",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "returnUrl", returnUrl },
                     { "area", string.Empty }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string Register(this UrlHelper url)
+        public static string Register(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "LogOn",
-                controllerName: "Authentication",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "LogOn", "Authentication", relativeUrl);
         }
 
-        public static string Search(this UrlHelper url, string searchTerm)
+        public static string Search(this UrlHelper url, string searchTerm, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.ListPackages,
+            return GetRouteLink(
+                url, 
+                RouteName.ListPackages, 
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "q", searchTerm }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string UploadPackage(this UrlHelper url)
+        public static string UploadPackage(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.UploadPackage,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.UploadPackage, relativeUrl);
         }
 
-        public static string UploadPackageProgress(this UrlHelper url)
+        public static string UploadPackageProgress(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.UploadPackageProgress,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.UploadPackageProgress, relativeUrl);
         }
 
-        public static string User(this UrlHelper url, User user, int page = 1, string scheme = null)
+        public static string User(
+            this UrlHelper url,
+            User user,
+            int page = 1,
+            bool relativeUrl = true)
         {
-            var configuredSiteHostName = GetConfiguredSiteHostName(url);
-            if (page == 1)
+            var routeValues = new RouteValueDictionary
             {
-                return url.Action(
-                    actionName: "Profiles",
-                    controllerName: "Users",
-                    routeValues: new RouteValueDictionary
-                    {
-                        { "username", user.Username.TrimEnd() }
-                    },
-                    protocol: scheme ?? GetProtocol(url),
-                    hostName: configuredSiteHostName);
-            }
-            else
+                { "username", user.Username.TrimEnd() }
+            };
+
+            if (page != 1)
             {
-                return url.Action(
-                    actionName: "Profiles",
-                    controllerName: "Users",
-                    routeValues: new RouteValueDictionary
-                    {
-                        { "username", user.Username.TrimEnd() },
-                        { "page", page }
-                    },
-                    protocol: scheme ?? GetProtocol(url),
-                    hostName: configuredSiteHostName);
+                routeValues.Add("page", page);
             }
+
+            return GetActionLink(url, "Profiles", "Users", relativeUrl, routeValues);
         }
 
-        public static string User(this UrlHelper url, string username, string scheme = null)
+        public static string User(
+            this UrlHelper url,
+            string username,
+            string scheme = null,
+            bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "Profiles",
-                controllerName: "Users",
+            return GetActionLink(
+                url,
+                "Profiles",
+                "Users",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "username", username }
-                },
-                protocol: scheme ?? GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string EditPackage(this UrlHelper url, string id, string version)
+        public static string EditPackage(
+            this UrlHelper url,
+            string id,
+            string version,
+            bool relativeUrl = true)
         {
-            if (String.IsNullOrEmpty(version))
+            if (string.IsNullOrEmpty(version))
             {
                 return EnsureTrailingSlash(
-                    url.RouteUrl(
+                    GetRouteLink(
+                        url,
                         RouteName.PackageAction,
+                        relativeUrl,
                         routeValues: new RouteValueDictionary
                         {
                             { "action", "Edit" },
                             { "id", id }
-                        },
-                        protocol: GetProtocol(url),
-                        hostName: GetConfiguredSiteHostName(url)));
+                        }));
             }
 
-            return url.RouteUrl(
+            return GetRouteLink(
+                url,
                 RouteName.PackageVersionAction,
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "action", "Edit" },
                     { "id", id },
                     { "version", version }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string ReflowPackage(this UrlHelper url, IPackageVersionModel package)
+        public static string ReflowPackage(
+            this UrlHelper url,
+            IPackageVersionModel package,
+            bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "Reflow",
-                controllerName: "Packages",
+            return GetActionLink(
+                url,
+                "Reflow",
+                "Packages",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "id", package.Id },
                     { "version", package.Version }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string DeletePackage(this UrlHelper url, IPackageVersionModel package)
+        public static string DeletePackage(
+            this UrlHelper url,
+            IPackageVersionModel package,
+            bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "Delete",
-                controllerName: "Packages",
+            return GetActionLink(
+                url,
+                "Delete",
+                "Packages",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "id", package.Id },
                     { "version", package.Version }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string AccountSettings(this UrlHelper url, string scheme = null)
+        public static string AccountSettings(
+            this UrlHelper url,
+            bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "Account",
-                controllerName: "Users",
-                routeValues: null,
-                protocol: scheme ?? GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "Account", "Users", relativeUrl);
         }
 
-        public static string ReportPackage(this UrlHelper url, string id, string version, string scheme = null)
+        public static string ReportPackage(
+            this UrlHelper url,
+            string id,
+            string version,
+            bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "ReportMyPackage",
-                controllerName: "Packages",
+            return GetActionLink(
+                url,
+                "ReportMyPackage",
+                "Packages",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "id", id },
                     { "version", version }
-                },
-                protocol: scheme ?? GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string ReportAbuse(this UrlHelper url, string id, string version, string scheme = null)
+        public static string ReportAbuse(
+            this UrlHelper url,
+            string id,
+            string version,
+            bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "ReportAbuse",
-                controllerName: "Packages",
+            return GetActionLink(
+                url,
+                "ReportAbuse",
+                "Packages",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "id", id },
                     { "version", version }
-                },
-                protocol: scheme ?? GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string LinkExternalAccount(this UrlHelper url, string returnUrl)
+        public static string LinkExternalAccount(this UrlHelper url, string returnUrl, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "LinkExternalAccount",
-                controllerName: "Authentication",
+            return GetActionLink(
+                url,
+                "LinkExternalAccount",
+                "Authentication",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "ReturnUrl", returnUrl }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string ManageMyApiKeys(this UrlHelper url)
+        public static string ManageMyApiKeys(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "ApiKeys",
-                controllerName: "Users",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "ApiKeys", "Users", relativeUrl);
         }
 
-        public static string ManageMyPackages(this UrlHelper url)
+        public static string ManageMyPackages(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "Packages",
-                controllerName: "Users",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "Packages", "Users", relativeUrl);
         }
 
-        public static string ManagePackageOwners(this UrlHelper url, IPackageVersionModel package)
+        public static string ManagePackageOwners(this UrlHelper url, IPackageVersionModel package, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "ManagePackageOwners",
-                controllerName: "Packages",
+            return GetActionLink(
+                url,
+                "ManagePackageOwners",
+                "Packages",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "id", package.Id}
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string GetAddPackageOwnerConfirmation(this UrlHelper url)
+        public static string GetAddPackageOwnerConfirmation(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                "GetAddPackageOwnerConfirmation", 
-                "JsonApi",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "GetAddPackageOwnerConfirmation", "JsonApi", relativeUrl);
         }
 
-        public static string GetPackageOwners(this UrlHelper url)
+        public static string GetPackageOwners(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                "GetPackageOwners",                 
-                "JsonApi",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "GetPackageOwners", "JsonApi", relativeUrl);
         }
 
-        public static string AddPackageOwner(this UrlHelper url)
+        public static string AddPackageOwner(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                "AddPackageOwner", 
-                "JsonApi",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "AddPackageOwner", "JsonApi", relativeUrl);
         }
 
-        public static string RemovePackageOwner(this UrlHelper url)
+        public static string RemovePackageOwner(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                "RemovePackageOwner", 
-                "JsonApi",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "RemovePackageOwner", "JsonApi", relativeUrl);
         }
 
-        public static string ConfirmationUrl(this UrlHelper url, string action, string controller, string username, string token)
+        public static string ConfirmationUrl(
+            this UrlHelper url,
+            string action,
+            string controller,
+            string username,
+            string token,
+            bool relativeUrl = true)
         {
-            return ConfirmationUrl(url, action, controller, username, token, null);
+            return ConfirmationUrl(url, action, controller, username, token, routeValues: null, relativeUrl: relativeUrl);
         }
 
-        public static string ConfirmationUrl(this UrlHelper url, string action, string controller, string username, string token, object routeValues)
+        public static string ConfirmationUrl(
+            this UrlHelper url,
+            string action,
+            string controller,
+            string username,
+            string token,
+            object routeValues,
+            bool relativeUrl = true)
         {
             var rvd = routeValues == null ? new RouteValueDictionary() : new RouteValueDictionary(routeValues);
             rvd["username"] = username;
             rvd["token"] = token;
-            return url.Action(
-                action,
-                controller,
-                rvd,
-                url.RequestContext.HttpContext.Request.Url.Scheme,
-                GetConfiguredSiteHostName(url));
+
+            return GetActionLink(url, action, controller, relativeUrl, rvd);
         }
 
-        public static string VerifyPackage(this UrlHelper url)
+        public static string VerifyPackage(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "VerifyPackage",
-                controllerName: "Packages",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "VerifyPackage", "Packages", relativeUrl);
         }
 
-        public static string CancelUpload(this UrlHelper url)
+        public static string CancelUpload(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "CancelUpload",
-                controllerName: "Packages",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "CancelUpload", "Packages", relativeUrl);
         }
 
-        public static string Downloads(this UrlHelper url)
+        public static string Downloads(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.RouteUrl(
-                RouteName.Downloads,
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetRouteLink(url, RouteName.Downloads, relativeUrl);
         }
 
-        public static string Contact(this UrlHelper url)
+        public static string Contact(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "Contact",
-                controllerName: "Pages",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "Contact", "Pages", relativeUrl);
         }
 
-        public static string ContactOwners(this UrlHelper url, string id)
+        public static string ContactOwners(this UrlHelper url, string id, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "ContactOwners",
-                controllerName: "Packages",
+            return GetActionLink(
+                url,
+                "ContactOwners",
+                "Packages",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "id", id }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string Terms(this UrlHelper url)
+        public static string Terms(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "Terms",
-                controllerName: "Pages",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "Terms", "Pages", relativeUrl);
         }
 
-        public static string Privacy(this UrlHelper url)
+        public static string Privacy(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "Privacy",
-                controllerName: "Pages",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "Privacy", "Pages", relativeUrl);
         }
 
-        public static string About(this UrlHelper url)
+        public static string About(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "About",
-                controllerName: "Pages",
-                routeValues: null,
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+            return GetActionLink(url, "About", "Pages", relativeUrl);
         }
 
-        public static string Admin(this UrlHelper url)
+        public static string Admin(this UrlHelper url, bool relativeUrl = true)
         {
-            return url.Action(
+            return GetActionLink(
+                url,
                 "Index",
                 "Home",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "area", "Admin" }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
 
-        public static string Authenticate(this UrlHelper url, string providerName, string returnUrl)
+        public static string Authenticate(this UrlHelper url, string providerName, string returnUrl, bool relativeUrl = true)
         {
-            return url.Action(
-                actionName: "Authenticate",
-                controllerName: "Authentication",
+            return GetActionLink(
+                url,
+                "Authenticate",
+                "Authentication",
+                relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
                     { "provider", providerName },
                     { "returnUrl", returnUrl }
-                },
-                protocol: GetProtocol(url),
-                hostName: GetConfiguredSiteHostName(url));
+                });
         }
-        
+
         private static UriBuilder GetCanonicalUrl(UrlHelper url)
         {
             UriBuilder builder = new UriBuilder(url.RequestContext.HttpContext.Request.Url);
@@ -778,7 +724,7 @@ namespace NuGetGallery
 
         internal static string EnsureTrailingSlash(string url)
         {
-            if (url != null 
+            if (url != null
                 && !url.EndsWith("/", StringComparison.OrdinalIgnoreCase)
                 && !url.Contains("?"))
             {
@@ -786,6 +732,48 @@ namespace NuGetGallery
             }
 
             return url;
+        }
+
+        private static string GetActionLink(
+            UrlHelper url,
+            string actionName,
+            string controllerName,
+            bool relativeUrl,
+            RouteValueDictionary routeValues = null
+            )
+        {
+            var protocol = GetProtocol(url);
+            var hostName = GetConfiguredSiteHostName();
+            var siteRoot = $"{protocol}://{hostName}";
+
+            var actionLink = url.Action(actionName, controllerName, routeValues, protocol, hostName);
+
+            if (relativeUrl)
+            {
+                return actionLink.Replace(siteRoot, string.Empty);
+            }
+
+            return actionLink;
+        }
+
+        private static string GetRouteLink(
+            UrlHelper url,
+            string routeName,
+            bool relativeUrl,
+            RouteValueDictionary routeValues = null)
+        {
+            var protocol = GetProtocol(url);
+            var hostName = GetConfiguredSiteHostName();
+            var siteRoot = $"{protocol}://{hostName}";
+
+            var routeLink = url.RouteUrl(routeName, routeValues, protocol, hostName);
+
+            if (relativeUrl)
+            {
+                return routeLink.Replace(siteRoot, string.Empty);
+            }
+
+            return routeLink;
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -1557,7 +1557,7 @@ namespace NuGetGallery
 
                 JArray result = JArray.Parse(contentResult.Content);
 
-                Assert.True((string)result[3]["Gallery"] == TestUtility.GallerySiteRootHttps + "packages/B/1.1", "unexpected content result[3].Gallery");
+                Assert.True((string)result[3]["Gallery"] == "/packages/B/1.1", "unexpected content result[3].Gallery");
                 Assert.True((int)result[2]["Downloads"] == 5, "unexpected content result[2].Downloads");
             }
 

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -731,7 +731,7 @@ namespace NuGetGallery.Controllers
                 var result = controller.ChallengeAuthentication("/theReturnUrl", "MicrosoftAccount");
 
                 // Assert
-                ResultAssert.IsChallengeResult(result, "MicrosoftAccount", TestUtility.GallerySiteRootHttps + "users/account/authenticate/return?ReturnUrl=%2FtheReturnUrl");
+                ResultAssert.IsChallengeResult(result, "MicrosoftAccount", "/users/account/authenticate/return?ReturnUrl=%2FtheReturnUrl");
             }
         }
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -21,7 +21,6 @@ using NuGetGallery.Packaging;
 using NuGetGallery.Security;
 using Xunit;
 using NuGetGallery.Configuration;
-using NuGetGallery.TestUtils;
 
 namespace NuGetGallery
 {
@@ -814,7 +813,7 @@ namespace NuGetGallery
                 controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
 
                 // Act
-                var result = await controller.Edit("Foo", "1.0", listed: false, urlFactory: p => @"~\Bar.cshtml");
+                var result = await controller.Edit("Foo", "1.0", listed: false, urlFactory: (pkg, relativeUrl) => @"~\Bar.cshtml");
 
                 // Assert
                 packageService.Verify();
@@ -853,7 +852,7 @@ namespace NuGetGallery
                 controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
 
                 // Act
-                var result = await controller.Edit("Foo", "1.0", listed: true, urlFactory: p => @"~\Bar.cshtml");
+                var result = await controller.Edit("Foo", "1.0", listed: true, urlFactory: (pkg, relativeUrl) => @"~\Bar.cshtml");
 
                 // Assert
                 packageService.Verify();
@@ -1980,7 +1979,7 @@ namespace NuGetGallery
                     Assert.NotNull(result);
                     Assert.NotNull(result.Data);
                     Assert.Equal(
-                        "{ location = " + TestUtility.GallerySiteRootHttps + "?id=theId }",
+                        "{ location = /?id=theId }",
                         result.Data.ToString());
                 }
             }
@@ -2224,7 +2223,7 @@ namespace NuGetGallery
                 controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
 
                 // Act
-                var result = await controller.SetLicenseReportVisibility("Foo", "1.0", visible: false, urlFactory: p => @"~\Bar.cshtml");
+                var result = await controller.SetLicenseReportVisibility("Foo", "1.0", visible: false, urlFactory: (pkg, relativeUrl) => @"~\Bar.cshtml");
 
                 // Assert
                 packageService.Verify();


### PR DESCRIPTION
Follow-up PR for https://github.com/NuGet/NuGetGallery/pull/4661.

The change to rely on the `Gallery.SiteRoot` config setting had the side-effect of no longer returning any relative URLs. This broke some functional tests that relied on the assumption that these URLs were relative. As the `Gallery.SiteRoot` setting is the same for both staging and production slots in any environment, this became a hard to solve problem. Properly using relative URLs (and absolute ones where applicable, e.g. in outbound e-mails) fixes this and works around the test infrastructure complexity.