### PR TITLE
Fix an issue with a check on dependency set length that always failed.

### DIFF
--- a/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
@@ -85,10 +85,10 @@
 
                 <div class="verify-package-field form-group readonly">
                     <div class="verify-package-field-heading">Dependencies</div>
-                    <!-- ko if: $data.Dependencies && $data.Dependencies.DependencySets.length > 0 -->
+                    <!-- ko if: $data.Dependencies && Object.keys($data.Dependencies.DependencySets).length > 0 -->
                     <div data-bind="template: {name: 'display-dependencysets', data: { DependencySets: Dependencies.DependencySets, OnlyHasAllFrameworks: Dependencies.OnlyHasAllFrameworks }}"></div>
                     <!-- /ko -->
-                    <!-- ko ifnot: $data.Dependencies && $data.Dependencies.DependencySets.length > 0  -->
+                    <!-- ko ifnot: $data.Dependencies && Object.keys($data.Dependencies.DependencySets).length > 0  -->
                     <p><i>(none specified)</i></p>
                     <!-- /ko -->
                 </div>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/4614

The old check always failed because DependencySets was a object and didn't have a length property.

@joelverhagen @jonwchu 