### PR TITLE
Improve Third-Party Installation Tabs' UI

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -642,18 +642,19 @@ img.package-icon {
 .page-package-details .install-tabs .nav-tabs > li.active > a {
   font-weight: 600;
   color: #fff;
-  text-decoration: underline;
   background-color: #002440;
   border: 0;
+
+  text-decoratinolo: underline;
 }
-.page-package-details .install-tabs .tab-firstparty {
-  padding-bottom: 37px;
+.page-package-details .install-tabs .tab-content {
+  height: 79px;
 }
-.page-package-details .install-tabs .tab-pane > div {
+.page-package-details .install-tabs .tab-content .tab-pane > div {
   display: table;
   height: 1px;
 }
-.page-package-details .install-tabs .tab-pane .install-script {
+.page-package-details .install-tabs .tab-content .tab-pane .install-script {
   display: table-cell;
   width: 100%;
   max-width: 1px;
@@ -666,16 +667,16 @@ img.package-icon {
   border-style: solid;
   border-width: 1px 0 1px 1px;
 }
-.page-package-details .install-tabs .tab-pane .copy-button {
+.page-package-details .install-tabs .tab-content .tab-pane .copy-button {
   display: table-cell;
 }
-.page-package-details .install-tabs .tab-pane .copy-button button {
+.page-package-details .install-tabs .tab-content .tab-pane .copy-button button {
   height: 100%;
   min-height: 42px;
   line-height: 1.5;
   vertical-align: baseline;
 }
-.page-package-details .install-tabs .tab-pane .alert {
+.page-package-details .install-tabs .tab-content .tab-pane .alert {
   width: 100%;
   margin: 0;
 }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -646,6 +646,9 @@ img.package-icon {
   background-color: #002440;
   border: 0;
 }
+.page-package-details .install-tabs .tab-firstparty {
+  padding-bottom: 37px;
+}
 .page-package-details .install-tabs .tab-pane > div {
   display: table;
   height: 1px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -642,10 +642,9 @@ img.package-icon {
 .page-package-details .install-tabs .nav-tabs > li.active > a {
   font-weight: 600;
   color: #fff;
+  text-decoration: underline;
   background-color: #002440;
   border: 0;
-
-  text-decoratinolo: underline;
 }
 .page-package-details .install-tabs .tab-content {
   height: 79px;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -81,6 +81,10 @@
       text-decoration: underline;
     }
 
+    .tab-firstparty {
+      padding-bottom: 37px;
+    }
+
     .tab-pane {
       > div {
         display: table;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -78,49 +78,49 @@
       border: 0;
       color: #fff;
       font-weight: 600;
-      text-decoration: underline;
+      text-decoratinolo: underline;
     }
 
-    .tab-firstparty {
-      padding-bottom: 37px;
-    }
+    .tab-content {
+      height: 79px;
 
-    .tab-pane {
-      > div {
-        display: table;
-        height: 1px;
-      }
-
-      .install-script {
-        display: table-cell;
-        background-color: @panel-footer-bg;
-        font-family: @font-family-monospace;
-        color: #fff;
-        padding: 0 10px 8px 10px;
-        width: 100%;
-        max-width: 1px;
-        line-height: 1.5;
-        // Add a border with the same color as the background to support visual callout
-        // in high contrast mode (since borders are shown).
-        border-color: @panel-footer-bg;
-        border-style: solid;
-        border-width: 1px 0 1px 1px;
-      }
-
-      .copy-button {
-        display: table-cell;
-
-        button {
-          height: 100%;
-          vertical-align: baseline;
-          min-height: 42px;
-          line-height: 1.5;
+      .tab-pane {
+        > div {
+          display: table;
+          height: 1px;
         }
-      }
 
-      .alert {
-        margin: 0;
-        width: 100%;
+        .install-script {
+          display: table-cell;
+          background-color: @panel-footer-bg;
+          font-family: @font-family-monospace;
+          color: #fff;
+          padding: 0 10px 8px 10px;
+          width: 100%;
+          max-width: 1px;
+          line-height: 1.5;
+          // Add a border with the same color as the background to support visual callout
+          // in high contrast mode (since borders are shown).
+          border-color: @panel-footer-bg;
+          border-style: solid;
+          border-width: 1px 0 1px 1px;
+        }
+
+        .copy-button {
+          display: table-cell;
+
+          button {
+            height: 100%;
+            vertical-align: baseline;
+            min-height: 42px;
+            line-height: 1.5;
+          }
+        }
+
+        .alert {
+          margin: 0;
+          width: 100%;
+        }
       }
     }
   }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -78,7 +78,7 @@
       border: 0;
       color: #fff;
       font-weight: 600;
-      text-decoratinolo: underline;
+      text-decoration: underline;
     }
 
     .tab-content {

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -642,18 +642,19 @@ img.package-icon {
 .page-package-details .install-tabs .nav-tabs > li.active > a {
   font-weight: 600;
   color: #fff;
-  text-decoration: underline;
   background-color: #002440;
   border: 0;
+
+  text-decoratinolo: underline;
 }
-.page-package-details .install-tabs .tab-firstparty {
-  padding-bottom: 37px;
+.page-package-details .install-tabs .tab-content {
+  height: 79px;
 }
-.page-package-details .install-tabs .tab-pane > div {
+.page-package-details .install-tabs .tab-content .tab-pane > div {
   display: table;
   height: 1px;
 }
-.page-package-details .install-tabs .tab-pane .install-script {
+.page-package-details .install-tabs .tab-content .tab-pane .install-script {
   display: table-cell;
   width: 100%;
   max-width: 1px;
@@ -666,16 +667,16 @@ img.package-icon {
   border-style: solid;
   border-width: 1px 0 1px 1px;
 }
-.page-package-details .install-tabs .tab-pane .copy-button {
+.page-package-details .install-tabs .tab-content .tab-pane .copy-button {
   display: table-cell;
 }
-.page-package-details .install-tabs .tab-pane .copy-button button {
+.page-package-details .install-tabs .tab-content .tab-pane .copy-button button {
   height: 100%;
   min-height: 42px;
   line-height: 1.5;
   vertical-align: baseline;
 }
-.page-package-details .install-tabs .tab-pane .alert {
+.page-package-details .install-tabs .tab-content .tab-pane .alert {
   width: 100%;
   margin: 0;
 }

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -646,6 +646,9 @@ img.package-icon {
   background-color: #002440;
   border: 0;
 }
+.page-package-details .install-tabs .tab-firstparty {
+  padding-bottom: 37px;
+}
 .page-package-details .install-tabs .tab-pane > div {
   display: table;
   height: 1px;

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -642,10 +642,9 @@ img.package-icon {
 .page-package-details .install-tabs .nav-tabs > li.active > a {
   font-weight: 600;
   color: #fff;
+  text-decoration: underline;
   background-color: #002440;
   border: 0;
-
-  text-decoratinolo: underline;
 }
 .page-package-details .install-tabs .tab-content {
   height: 79px;

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -65,7 +65,6 @@
     }
 }
 
-
 @helper CommandTab(PackageManagerViewModel packageManager, bool active)
 {
     <li role="presentation" class="@(active ? "active" : string.Empty)">
@@ -81,8 +80,9 @@
 @helper CommandPanel(PackageManagerViewModel packageManager, bool active)
 {
     var thirdPartyPackageManager = packageManager as ThirdPartyPackageManagerViewModel;
+    var isThirdPartyTab = thirdPartyPackageManager != null;
 
-    <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty)" id="@packageManager.Id">
+    <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty) @(isThirdPartyTab ? string.Empty : "tab-firstparty")" id="@packageManager.Id">
         <div>
             <div class="install-script" id="@packageManager.Id-text">
                 <span>
@@ -97,7 +97,7 @@
                 </button>
             </div>
         </div>
-        @if (thirdPartyPackageManager != null)
+        @if (isThirdPartyTab)
         {
             @ViewHelpers.AlertWarning(
                 @<text>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -80,9 +80,8 @@
 @helper CommandPanel(PackageManagerViewModel packageManager, bool active)
 {
     var thirdPartyPackageManager = packageManager as ThirdPartyPackageManagerViewModel;
-    var isThirdPartyTab = thirdPartyPackageManager != null;
 
-    <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty) @(isThirdPartyTab ? string.Empty : "tab-firstparty")" id="@packageManager.Id">
+    <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty)" id="@packageManager.Id">
         <div>
             <div class="install-script" id="@packageManager.Id-text">
                 <span>
@@ -97,7 +96,7 @@
                 </button>
             </div>
         </div>
-        @if (isThirdPartyTab)
+        @if (thirdPartyPackageManager != null)
         {
             @ViewHelpers.AlertWarning(
                 @<text>


### PR DESCRIPTION
Made the height of first-party vs third-party tabs consistent.

First-party tab (there is 37 more pixels of space below the tab):

![one](https://user-images.githubusercontent.com/737941/30562590-d5bc9cfa-9c73-11e7-8092-8398846ecd7b.png)

Third-party tab (no changes here):

![two](https://user-images.githubusercontent.com/737941/30562596-da100c6a-9c73-11e7-90b4-59bfb69fdc04.png)
