### PR TITLE
Fix improper word breaking in long text fields

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -254,8 +254,11 @@ img.package-icon {
   margin-left: 20px;
 }
 .break-word {
-  word-break: break-all;
+  word-break: normal;
   word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 #edit-metadata-form-container .loading:after {
   display: inline-block;
@@ -325,13 +328,16 @@ img.package-icon {
   padding-top: 15px;
   padding-bottom: 15px;
   font-size: 15px;
+  word-break: normal;
+  word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 .list-packages .package .package-header .package-title {
   font-size: 24px;
   font-weight: 300;
   line-height: .9;
-  word-break: break-all;
-  word-break: break-word;
 }
 .list-packages .package .package-header .reserved-indicator {
   width: 20px;
@@ -361,8 +367,6 @@ img.package-icon {
   margin-top: 8px;
   line-height: 20px;
   color: #000;
-  word-break: break-all;
-  word-break: break-word;
 }
 @media (min-width: 768px) {
   .list-packages .package .package-list {
@@ -386,8 +390,11 @@ img.package-icon {
   vertical-align: middle;
 }
 .user-package-list .manage-package-listing .package-id {
-  word-break: break-all;
+  word-break: normal;
   word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 @media (min-width: 768px) {
   .user-package-list .manage-package-listing .package-controls {
@@ -602,8 +609,11 @@ img.package-icon {
   width: 25px;
 }
 .page-package-details .package-details-main {
-  word-break: break-all;
+  word-break: normal;
   word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 .page-package-details .package-details-info .ms-Icon-ul li {
   margin-bottom: 15px;
@@ -796,8 +806,11 @@ img.package-icon {
   margin-bottom: 33px;
 }
 .page-list-packages .row-heading .cell-heading h1 {
-  word-break: break-all;
+  word-break: normal;
   word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 @media (min-width: 992px) {
   .page-list-packages .row-heading {

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -325,6 +325,8 @@ img.package-icon {
 }
 
 .break-word {
-  word-break: break-all;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: normal;
   word-break: break-word;
 }

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -1,13 +1,13 @@
 .list-packages {
 
   .package {
+    .break-word;
     padding-top: (@padding-large-vertical * 1.5);
     padding-bottom: (@padding-large-vertical * 1.5);
     font-size: 15px;
 
     .package-header {
       .package-title {
-        .break-word;
         font-size: 24px;
         font-weight: 300;
         line-height: 0.9;
@@ -42,7 +42,6 @@
     }
 
     .package-details {
-      .break-word;
       margin-top: 8px;
       color: @text-color;
       line-height: 20px;

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -254,8 +254,11 @@ img.package-icon {
   margin-left: 20px;
 }
 .break-word {
-  word-break: break-all;
+  word-break: normal;
   word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 #edit-metadata-form-container .loading:after {
   display: inline-block;
@@ -325,13 +328,16 @@ img.package-icon {
   padding-top: 15px;
   padding-bottom: 15px;
   font-size: 15px;
+  word-break: normal;
+  word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 .list-packages .package .package-header .package-title {
   font-size: 24px;
   font-weight: 300;
   line-height: .9;
-  word-break: break-all;
-  word-break: break-word;
 }
 .list-packages .package .package-header .reserved-indicator {
   width: 20px;
@@ -361,8 +367,6 @@ img.package-icon {
   margin-top: 8px;
   line-height: 20px;
   color: #000;
-  word-break: break-all;
-  word-break: break-word;
 }
 @media (min-width: 768px) {
   .list-packages .package .package-list {
@@ -386,8 +390,11 @@ img.package-icon {
   vertical-align: middle;
 }
 .user-package-list .manage-package-listing .package-id {
-  word-break: break-all;
+  word-break: normal;
   word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 @media (min-width: 768px) {
   .user-package-list .manage-package-listing .package-controls {
@@ -602,8 +609,11 @@ img.package-icon {
   width: 25px;
 }
 .page-package-details .package-details-main {
-  word-break: break-all;
+  word-break: normal;
   word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 .page-package-details .package-details-info .ms-Icon-ul li {
   margin-bottom: 15px;
@@ -796,8 +806,11 @@ img.package-icon {
   margin-bottom: 33px;
 }
 .page-list-packages .row-heading .cell-heading h1 {
-  word-break: break-all;
+  word-break: normal;
   word-break: break-word;
+  word-wrap: break-word;
+
+  overflow-wrap: break-word;
 }
 @media (min-width: 992px) {
   .page-list-packages .row-heading {


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/4676.

`break-all` breaks in the middle of words. Instead use the different `break-word` forms (for maximum browser compatibility).

More details here:
https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/

Tested:
1. All browsers (Edge, IE, Firefox, Chrome)
1. Search results page and display page page
1. Long ID
1. Long Title
1. Long description
1. Long version
1. Small windows