### PR TITLE
Add model validation for package upload

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1291,13 +1291,13 @@ namespace NuGetGallery
         [ValidateInput(false)] // Security note: Disabling ASP.Net input validation which does things like disallow angle brackets in submissions. See http://go.microsoft.com/fwlink/?LinkID=212874
         public virtual async Task<JsonResult> VerifyPackage(VerifyPackageRequest formData)
         {
-            var currentUser = GetCurrentUser();
-
             if (!ModelState.IsValid)
             {
                 var errorMessages = ModelState.Values.SelectMany(v => v.Errors.Select(e => e.ErrorMessage));
                 return Json(400, errorMessages);
             }
+
+            var currentUser = GetCurrentUser();
 
             Package package;
             using (Stream uploadFile = await _uploadFileService.GetUploadFileAsync(currentUser.Key))

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1293,6 +1293,12 @@ namespace NuGetGallery
         {
             var currentUser = GetCurrentUser();
 
+            if (!ModelState.IsValid)
+            {
+                var errorMessages = ModelState.Values.SelectMany(v => v.Errors.Select(e => e.ErrorMessage));
+                return Json(400, errorMessages);
+            }
+
             Package package;
             using (Stream uploadFile = await _uploadFileService.GetUploadFileAsync(currentUser.Key))
             {


### PR DESCRIPTION
Adding model validation to VerifyPackage, same as done for Edit

Issue is #4706. Note that Edit/Upload currently would require refresh on validation errors because handleErrors does a bindData(null). Isn't ideal, but leaving as-is because:
- Upload uses single error handler for cancel, submit, upload failure
- Upload/Edit form is long, so it's not apparent that validation failed unless user scrolls up