### PR TITLE
"A newer prerelease version is available" should also be shown when currently displayed version is a prerelease

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -185,7 +185,7 @@
                 )
             }
 
-            @if (Model.LatestStableVersionSemVer2 && Model.HasNewerPrerelease)
+            @if (Model.HasNewerPrerelease)
             {
                 @ViewHelpers.AlertInfo(
                     @<text>

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -160,6 +160,7 @@ namespace NuGetGallery.ViewModels
         [InlineData("1.0.0", "1.0.0-alpha", false)]
         [InlineData("1.0.0", "1.0.0-alpha+metadata", false)]
         [InlineData("1.0.0", "1.0.0-alpha.1", false)]
+        [InlineData("1.0.0-alpha", "1.0.0-alpha.1", true)]
         public void HasNewerPrereleaseReturnsTrueWhenNewerPrereleaseAvailable(
             string currentVersion, 
             string otherVersion, 
@@ -176,6 +177,7 @@ namespace NuGetGallery.ViewModels
             {
                 Dependencies = dependencies,
                 PackageRegistration = packageRegistration,
+                IsPrerelease = NuGetVersion.Parse(currentVersion).IsPrerelease,
                 Version = currentVersion
             };
 


### PR DESCRIPTION
Related to  #4619 and #4709 

"A newer prerelease version is available" should also be shown when currently displayed version is a prerelease.

Thus far, this was not the case. 
However, it seems more logical to me to also show it in this scenario.

Example: https://int.nugettest.org/packages/SemVer2MetadataTestPackage/1.2.0-alpha


