### PR TITLE
Fix "OwnerRequests.cshtml could not be found"

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1884,7 +1884,6 @@
     <Content Include="Views\Packages\_ImportReadMe.cshtml" />
     <Content Include="Views\Packages\_SubmitPackage.cshtml" />
     <Content Include="Views\Packages\_EditForm.cshtml" />
-    <Content Include="Views\Users\OwnerRequests.cshtml" />
     <Content Include="Views\Users\_OwnerRequestsList.cshtml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This was a file I used to have but got rid of. Not sure why VS and local build doesn't fail/alert on this, but it fails on the build machines.