### PR TITLE
Add APIs to upload, download, and delete a package from the validation container

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -21,5 +21,6 @@ namespace NuGetGallery
         public const string PackageReadMesFolderName = "readmes";
         public const string PackagesFolderName = "packages";        
         public const string UploadsFolderName = "uploads";
+        public const string ValidationFolderName = "validation";
     }
 }

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -130,6 +130,7 @@ namespace NuGetGallery
                 case CoreConstants.ContentFolderName:
                 case CoreConstants.UploadsFolderName:
                 case CoreConstants.PackageReadMesFolderName:
+                case CoreConstants.ValidationFolderName:
                     creationTask = PrepareContainer(folderName, isPublic: false);
                     break;
 
@@ -199,6 +200,7 @@ namespace NuGetGallery
                 case CoreConstants.PackagesFolderName:
                 case CoreConstants.PackageBackupsFolderName:
                 case CoreConstants.UploadsFolderName:
+                case CoreConstants.ValidationFolderName:
                     return CoreConstants.PackageContentType;
 
                 case CoreConstants.DownloadsFolderName:

--- a/src/NuGetGallery.Core/Services/CorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageFileService.cs
@@ -34,6 +34,52 @@ namespace NuGetGallery
             return _fileStorageService.GetFileAsync(CoreConstants.PackagesFolderName, fileName);
         }
 
+        public Task SaveValidationPackageFileAsync(Package package, Stream packageFile)
+        {
+            if (packageFile == null)
+            {
+                throw new ArgumentNullException(nameof(packageFile));
+            }
+
+            var fileName = BuildFileName(
+                package,
+                CoreConstants.PackageFileSavePathTemplate,
+                CoreConstants.NuGetPackageFileExtension);
+
+            return _fileStorageService.SaveFileAsync(
+                CoreConstants.ValidationFolderName,
+                fileName,
+                packageFile,
+                overwrite: false);
+        }
+
+        public Task<Stream> DownloadValidationPackageFileAsync(Package package)
+        {
+            var fileName = BuildFileName(
+                package,
+                CoreConstants.PackageFileSavePathTemplate,
+                CoreConstants.NuGetPackageFileExtension);
+
+            return _fileStorageService.GetFileAsync(CoreConstants.ValidationFolderName, fileName);
+        }
+
+        public Task DeleteValidationPackageFileAsync(string id, string version)
+        {
+            if (version == null)
+            {
+                throw new ArgumentNullException(nameof(version));
+            }
+
+            var normalizedVersion = NuGetVersionFormatter.Normalize(version);
+            var fileName = BuildFileName(
+                id,
+                normalizedVersion,
+                CoreConstants.PackageFileSavePathTemplate,
+                CoreConstants.NuGetPackageFileExtension);
+            
+            return _fileStorageService.DeleteFileAsync(CoreConstants.ValidationFolderName, fileName);
+        }
+
         protected static string BuildFileName(Package package, string format, string extension)
         {
             if (package == null)

--- a/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
@@ -17,5 +17,28 @@ namespace NuGetGallery
         /// Downloads the package from the file storage and reads it into a stream.
         /// </summary>
         Task<Stream> DownloadPackageFileAsync(Package package);
+
+        /// <summary>
+        /// Saves the contents of the package to the private container for packages that are being validated. If the
+        /// file already exists, an exception will be thrown.
+        /// </summary>
+        /// <param name="package">The package metadata.</param>
+        /// <param name="packageFile">The stream containing the package itself (the .nupkg).</param>
+        Task SaveValidationPackageFileAsync(Package package, Stream packageFile);
+
+        /// <summary>
+        /// Downloads the validating package from the file storage and reads it into a stream. If the file does not
+        /// exist, an exception will be thrown.
+        /// </summary>
+        /// <param name="package">The package metadata.</param>
+        Task<Stream> DownloadValidationPackageFileAsync(Package package);
+
+        /// <summary>
+        /// Deletes the validating package from the file storage. If the file does not exist this method will not throw
+        /// any exception.
+        /// </summary>
+        /// <param name="id">The package ID. This value is case-insensitive.</param>
+        /// <param name="version">The package version. This value is case-insensitive and need not be normalized.</param>
+        Task DeleteValidationPackageFileAsync(string id, string version);
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -12,6 +12,14 @@ namespace NuGetGallery
 {
     public class CorePackageFileServiceFacts
     {
+        private const string ValidationFolderName = "validation";
+        private const string Id = "NuGet.Versioning";
+        private const string Version = "4.3.0.0-BETA+1";
+        private const string NormalizedVersion = "4.3.0-BETA";
+        private const string LowercaseId = "nuget.versioning";
+        private const string LowercaseVersion = "4.3.0-beta";
+        private static readonly string ValidationFileName = $"{LowercaseId}.{LowercaseVersion}.nupkg";
+
         public class TheSavePackageFileMethod
         {
             [Fact]
@@ -76,7 +84,7 @@ namespace NuGetGallery
             public async Task WillUseNormalizedRegularVersionIfNormalizedVersionMissing()
             {
                 var fileStorageSvc = new Mock<ICoreFileStorageService>();
-                var service = CreateService(fileStorageSvc: fileStorageSvc);
+                var service = CreateService(fileStorageService: fileStorageSvc);
                 var packageRegistraion = new PackageRegistration { Id = "theId" };
                 var package = new Package { PackageRegistration = packageRegistraion, NormalizedVersion = null, Version = "01.01.01" };
 
@@ -93,7 +101,7 @@ namespace NuGetGallery
             public async Task WillSaveTheFileViaTheFileStorageServiceUsingThePackagesFolder()
             {
                 var fileStorageSvc = new Mock<ICoreFileStorageService>();
-                var service = CreateService(fileStorageSvc: fileStorageSvc);
+                var service = CreateService(fileStorageService: fileStorageSvc);
                 fileStorageSvc.Setup(x => x.SaveFileAsync(CoreConstants.PackagesFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => !b)))
                     .Completes()
                     .Verifiable();
@@ -107,7 +115,7 @@ namespace NuGetGallery
             public async Task WillSaveTheFileViaTheFileStorageServiceUsingAFileNameWithIdAndNormalizedersion()
             {
                 var fileStorageSvc = new Mock<ICoreFileStorageService>();
-                var service = CreateService(fileStorageSvc: fileStorageSvc);
+                var service = CreateService(fileStorageService: fileStorageSvc);
                 fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), BuildFileName("theId", "theNormalizedVersion", CoreConstants.NuGetPackageFileExtension, CoreConstants.PackageFileSavePathTemplate), It.IsAny<Stream>(), It.Is<bool>(b => !b)))
                     .Completes()
                     .Verifiable();
@@ -122,7 +130,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<ICoreFileStorageService>();
                 var fakeStream = new MemoryStream();
-                var service = CreateService(fileStorageSvc: fileStorageSvc);
+                var service = CreateService(fileStorageService: fileStorageSvc);
                 fileStorageSvc.Setup(x => x.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), fakeStream, It.Is<bool>(b => !b)))
                     .Completes()
                     .Verifiable();
@@ -133,6 +141,213 @@ namespace NuGetGallery
             }
         }
         
+        public class TheSaveValidationPackageFileMethod : FactsBase
+        {
+            [Fact]
+            public async Task WillThrowIfPackageIsNull()
+            {
+                _package = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => _service.SaveValidationPackageFileAsync(_package, _packageFile));
+
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfPackageFileIsNull()
+            {
+                _packageFile = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => _service.SaveValidationPackageFileAsync(_package, _packageFile));
+
+                Assert.Equal("packageFile", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfPackageIsMissingPackageRegistration()
+            {
+                _package.PackageRegistration = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(
+                    () => _service.SaveValidationPackageFileAsync(_package, _packageFile));
+
+                Assert.StartsWith("The package is missing required data.", ex.Message);
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfPackageIsMissingPackageRegistrationId()
+            {
+                _package.PackageRegistration.Id = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(
+                    () => _service.SaveValidationPackageFileAsync(_package, _packageFile));
+
+                Assert.StartsWith("The package is missing required data.", ex.Message);
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfPackageIsMissingNormalizedVersionAndVersion()
+            {
+                _package.Version = null;
+                _package.NormalizedVersion = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(
+                    () => _service.SaveValidationPackageFileAsync(_package, _packageFile));
+
+                Assert.StartsWith("The package is missing required data.", ex.Message);
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillUseNormalizedRegularVersionIfNormalizedVersionMissing()
+            {
+                _package.NormalizedVersion = null;
+
+                await _service.SaveValidationPackageFileAsync(_package, _packageFile);
+
+                _fileStorageService.Verify(
+                    x => x.SaveFileAsync(ValidationFolderName, ValidationFileName, _packageFile, false),
+                    Times.Once);
+                _fileStorageService.Verify(
+                    x => x.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<bool>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task WillSaveTheFileViaTheFileStorageService()
+            {
+                await _service.SaveValidationPackageFileAsync(_package, _packageFile);
+
+                _fileStorageService.Verify(
+                    x => x.SaveFileAsync(ValidationFolderName, ValidationFileName, _packageFile, false),
+                    Times.Once);
+                _fileStorageService.Verify(
+                    x => x.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<bool>()),
+                    Times.Once);
+            }
+        }
+
+        public class TheDownloadValidationPackageFileMethod : FactsBase
+        {
+            [Fact]
+            public async Task WillThrowIfPackageIsNull()
+            {
+                _package = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => _service.DownloadValidationPackageFileAsync(_package));
+
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfPackageIsMissingPackageRegistration()
+            {
+                _package.PackageRegistration = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(
+                    () => _service.DownloadValidationPackageFileAsync(_package));
+
+                Assert.StartsWith("The package is missing required data.", ex.Message);
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfPackageIsMissingPackageRegistrationId()
+            {
+                _package.PackageRegistration.Id = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(
+                    () => _service.DownloadValidationPackageFileAsync(_package));
+
+                Assert.StartsWith("The package is missing required data.", ex.Message);
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfPackageIsMissingNormalizedVersionAndVersion()
+            {
+                _package.Version = null;
+                _package.NormalizedVersion = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(
+                    () => _service.DownloadValidationPackageFileAsync(_package));
+
+                Assert.StartsWith("The package is missing required data.", ex.Message);
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillUseNormalizedRegularVersionIfNormalizedVersionMissing()
+            {
+                _package.NormalizedVersion = null;
+
+                await _service.DownloadValidationPackageFileAsync(_package);
+
+                _fileStorageService.Verify(
+                    x => x.GetFileAsync(ValidationFolderName, ValidationFileName),
+                    Times.Once);
+                _fileStorageService.Verify(
+                    x => x.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task WillDownloadTheFileViaTheFileStorageService()
+            {
+                await _service.DownloadValidationPackageFileAsync(_package);
+
+                _fileStorageService.Verify(
+                    x => x.GetFileAsync(ValidationFolderName, ValidationFileName),
+                    Times.Once);
+                _fileStorageService.Verify(
+                    x => x.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+            }
+        }
+
+        public class TheDeletePackageFileMethod : FactsBase
+        {
+            [Fact]
+            public async Task WillThrowIfIdIsNull()
+            {
+                string id = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => _service.DeleteValidationPackageFileAsync(id, Version));
+
+                Assert.Equal("id", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfVersionIsNull()
+            {
+                string version = null;
+
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => _service.DeleteValidationPackageFileAsync(Id, version));
+
+                Assert.Equal("version", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillDeleteTheFileViaTheFileStorageService()
+            {
+                await _service.DeleteValidationPackageFileAsync(Id, Version);
+
+                _fileStorageService.Verify(
+                    x => x.DeleteFileAsync(ValidationFolderName, ValidationFileName),
+                    Times.Once);
+                _fileStorageService.Verify(
+                    x => x.DeleteFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+            }
+        }
+
         static string BuildFileName(
             string id,
             string version, string extension, string path)
@@ -157,12 +372,36 @@ namespace NuGetGallery
             return new MemoryStream(new byte[] { 0, 0, 1, 0, 1, 0, 1, 0 }, 0, 8, true, true);
         }
 
-        static CorePackageFileService CreateService(Mock<ICoreFileStorageService> fileStorageSvc = null)
+        static CorePackageFileService CreateService(Mock<ICoreFileStorageService> fileStorageService = null)
         {
-            fileStorageSvc = fileStorageSvc ?? new Mock<ICoreFileStorageService>();
+            fileStorageService = fileStorageService ?? new Mock<ICoreFileStorageService>();
 
             return new CorePackageFileService(
-                fileStorageSvc.Object);
+                fileStorageService.Object);
+        }
+
+        public abstract class FactsBase
+        {
+            protected readonly Mock<ICoreFileStorageService> _fileStorageService;
+            protected readonly CorePackageFileService _service;
+            protected Package _package;
+            protected Stream _packageFile;
+
+            public FactsBase()
+            {
+                _fileStorageService = new Mock<ICoreFileStorageService>();
+                _service = CreateService(fileStorageService: _fileStorageService);
+                _package = new Package
+                {
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = Id,
+                    },
+                    Version = Version,
+                    NormalizedVersion = NormalizedVersion,
+                };
+                _packageFile = Stream.Null;
+            }
         }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGetGallery/pull/4759.

This introduces a new private container which is a sibling to the existing `packages` container. The file name pattern is the same as the packages container. The reason I did this is that currently we are using the file storage service to synchronously (with respect to push) reject cases where `{id}.{version}.nupkg` collides with another package. If a package is pushed into the `validation` container, we should still detect this case synchronously instead of having the collision occur asychronously and beyond the user's control. When we move `packages` to a better format, then we can do the same with `validation`.

These APIs will be called by gallery (save) and orchestrator (download and delete).