### PR TITLE
Move package commit logic to IPackageUploadService

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -486,31 +486,25 @@ namespace NuGetGallery
 
                         await AutoCuratePackage.ExecuteAsync(package, packageToPush, commitChanges: false);
 
+                        PackageCommitResult commitResult;
                         using (Stream uploadStream = packageStream)
                         {
                             uploadStream.Position = 0;
-
-                            try
-                            {
-                                await PackageFileService.SavePackageFileAsync(package, uploadStream.AsSeekableStream());
-                            }
-                            catch (InvalidOperationException ex)
-                            {
-                                ex.Log();
-
-                                return new HttpStatusCodeWithBodyResult(HttpStatusCode.Conflict, Strings.UploadPackage_IdVersionConflict);
-                            }
+                            commitResult = await PackageUploadService.CommitPackageAsync(
+                                package,
+                                uploadStream.AsSeekableStream());
                         }
-
-                        try
+                            
+                        switch (commitResult)
                         {
-                            await EntitiesContext.SaveChangesAsync();
-                        }
-                        catch
-                        {
-                            // If saving to the DB fails for any reason, we need to delete the package we just saved.
-                            await PackageFileService.DeletePackageFileAsync(nuspec.GetId(), nuspec.GetVersion().ToNormalizedString());
-                            throw;
+                            case PackageCommitResult.Success:
+                                break;
+                            case PackageCommitResult.Conflict:
+                                return new HttpStatusCodeWithBodyResult(
+                                    HttpStatusCode.Conflict,
+                                    Strings.UploadPackage_IdVersionConflict);
+                            default:
+                                throw new NotImplementedException($"The package commit result {commitResult} is not supported.");
                         }
 
                         IndexingService.UpdatePackage(package);

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1494,30 +1494,21 @@ namespace NuGetGallery
 
                 await _autoCuratedPackageCmd.ExecuteAsync(package, nugetPackage, commitChanges: false);
 
-                // save package to blob storage
+                // Commit the package to storage and to the database.
                 uploadFile.Position = 0;
-                try
-                {
-                    await _packageFileService.SavePackageFileAsync(package, uploadFile.AsSeekableStream());
-                }
-                catch (InvalidOperationException ex)
-                {
-                    ex.Log();
-                    TempData["Message"] = Strings.UploadPackage_IdVersionConflict;
-                    
-                    return Json(409, new [] { Strings.UploadPackage_IdVersionConflict });
-                }
+                var commitResult = await _packageUploadService.CommitPackageAsync(
+                    package,
+                    uploadFile.AsSeekableStream());
 
-                try
+                switch (commitResult)
                 {
-                    // commit all changes to database as an atomic transaction
-                    await _entitiesContext.SaveChangesAsync();
-                }
-                catch
-                {
-                    // If saving to the DB fails for any reason we need to delete the package we just saved.
-                    await _packageFileService.DeletePackageFileAsync(packageMetadata.Id, packageMetadata.Version.ToNormalizedString());
-                    throw;
+                    case PackageCommitResult.Success:
+                        break;
+                    case PackageCommitResult.Conflict:
+                        TempData["Message"] = Strings.UploadPackage_IdVersionConflict;
+                        return Json(409, new[] { Strings.UploadPackage_IdVersionConflict });
+                    default:
+                        throw new NotImplementedException($"The package commit result {commitResult} is not supported.");
                 }
 
                 // tell Lucene to update index for the new package

--- a/src/NuGetGallery/Services/IPackageUploadService.cs
+++ b/src/NuGetGallery/Services/IPackageUploadService.cs
@@ -1,14 +1,44 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Threading.Tasks;
 using NuGet.Packaging;
 using NuGetGallery.Packaging;
 
 namespace NuGetGallery
 {
+    /// <summary>
+    /// Non-exceptional results of calling <see cref="IPackageUploadService.CommitPackageAsync(Package, Stream)"/>.
+    /// </summary>
+    public enum PackageCommitResult
+    {
+        /// <summary>
+        /// The package was successfully committed to the package file storage and to the database.
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// The package file conflicts with an existing package file. The package was not committed to the database.
+        /// </summary>
+        Conflict,
+    }
+
     public interface IPackageUploadService
     {
-        Task<Package> GeneratePackageAsync(string id, PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User user);
+        Task<Package> GeneratePackageAsync(
+            string id,
+            PackageArchiveReader nugetPackage,
+            PackageStreamMetadata packageStreamMetadata,
+            User user);
+
+        /// <summary>
+        /// Commit the provided package metadata and stream to the package file storage and to the database. This
+        /// method commits the shared <see cref="IEntitiesContext"/>. This method can throw exceptions in exceptional
+        /// cases (such as database failures). This method does not dispose the provided stream but does read it.
+        /// </summary>
+        /// <param name="package">The package metadata. This is assumed to already be added to the context.</param>
+        /// <param name="packageFile">The seekable stream containing the package content (.nupkg).</param>
+        Task<PackageCommitResult> CommitPackageAsync(Package package, Stream packageFile);
     }
 }

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Packaging;
@@ -12,20 +14,30 @@ namespace NuGetGallery
     public class PackageUploadService : IPackageUploadService
     {
         private readonly IPackageService _packageService;
+        private readonly IPackageFileService _packageFileService;
+        private readonly IEntitiesContext _entitiesContext;
         private readonly IReservedNamespaceService _reservedNamespaceService;
         private readonly IValidationService _validationService;
 
         public PackageUploadService(
             IPackageService packageService,
+            IPackageFileService packageFileService,
+            IEntitiesContext entitiesContext,
             IReservedNamespaceService reservedNamespaceService,
             IValidationService validationService)
         {
-            _packageService = packageService;
-            _reservedNamespaceService = reservedNamespaceService;
-            _validationService = validationService;
+            _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
+            _packageFileService = packageFileService ?? throw new ArgumentNullException(nameof(packageFileService));
+            _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
+            _reservedNamespaceService = reservedNamespaceService ?? throw new ArgumentNullException(nameof(reservedNamespaceService));
+            _validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
         }
 
-        public async Task<Package> GeneratePackageAsync(string id, PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User user)
+        public async Task<Package> GeneratePackageAsync(
+            string id,
+            PackageArchiveReader nugetPackage,
+            PackageStreamMetadata packageStreamMetadata,
+            User user)
         {
             var isPushAllowed = _reservedNamespaceService.IsPushAllowed(id, user, out IReadOnlyCollection<ReservedNamespace> userOwnedNamespaces);
             var shouldMarkIdVerified = isPushAllowed && userOwnedNamespaces != null && userOwnedNamespaces.Any();
@@ -50,6 +62,36 @@ namespace NuGetGallery
             }
 
             return package;
+        }
+
+        public async Task<PackageCommitResult> CommitPackageAsync(Package package, Stream packageFile)
+        {
+            try
+            {
+                await _packageFileService.SavePackageFileAsync(package, packageFile);
+            }
+            catch (InvalidOperationException ex)
+            {
+                ex.Log();
+                return PackageCommitResult.Conflict;
+            }
+
+            try
+            {
+                // commit all changes to database as an atomic transaction
+                await _entitiesContext.SaveChangesAsync();
+            }
+            catch
+            {
+                // If saving to the DB fails for any reason we need to delete the package we just saved.
+                await _packageFileService.DeletePackageFileAsync(
+                    package.PackageRegistration.Id,
+                    package.Version);
+
+                throw;
+            }
+
+            return PackageCommitResult.Success;
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Moq;
@@ -15,6 +16,9 @@ namespace NuGetGallery
 {
     public class PackageUploadServiceFacts
     {
+        private const string Id = "NuGet.Versioning";
+        private const string Version = "3.4.0.0-ALPHA+1";
+
         public Mock<IPackageService> MockPackageService { get; private set; }
 
         private static PackageUploadService CreateService(
@@ -59,6 +63,8 @@ namespace NuGetGallery
 
             var packageUploadService = new Mock<PackageUploadService>(
                 packageService.Object,
+                new Mock<IPackageFileService>().Object,
+                new Mock<IEntitiesContext>().Object,
                 reservedNamespaceService.Object,
                 validationService.Object);
 
@@ -162,6 +168,120 @@ namespace NuGetGallery
                 var package = await packageUploadService.GeneratePackageAsync(id, nugetPackage.Object, new PackageStreamMetadata(), lastUser);
 
                 Assert.False(package.PackageRegistration.IsVerified);
+            }
+        }
+
+        public class TheCommitPackageMethod : FactsBase
+        {
+            [Fact]
+            public async Task SavesPackageToStorageAndDatabase()
+            {
+                var result = await _target.CommitPackageAsync(_package, _packageFile);
+
+                _packageFileService.Verify(
+                    x => x.SavePackageFileAsync(_package, _packageFile),
+                    Times.Once);
+                _packageFileService.Verify(
+                    x => x.SavePackageFileAsync(It.IsAny<Package>(), It.IsAny<Stream>()),
+                    Times.Once);
+                _entitiesContext.Verify(
+                    x => x.SaveChangesAsync(),
+                    Times.Once);
+                Assert.Equal(PackageCommitResult.Success, result);
+            }
+
+            [Fact]
+            public async Task DoesNotCommitToDatabaseWhenSavingTheFileFails()
+            {
+                _packageFileService
+                    .Setup(x => x.SavePackageFileAsync(It.IsAny<Package>(), It.IsAny<Stream>()))
+                    .Throws(_unexpectedException);
+
+                var exception = await Assert.ThrowsAsync(
+                    _unexpectedException.GetType(),
+                    () => _target.CommitPackageAsync(_package, _packageFile));
+
+                _entitiesContext.Verify(
+                    x => x.SaveChangesAsync(),
+                    Times.Never);
+                Assert.Same(_unexpectedException, exception);
+            }
+
+            [Fact]
+            public async Task DoesNotCommitToDatabaseWhenTheFileConflicts()
+            {
+                _packageFileService
+                    .Setup(x => x.SavePackageFileAsync(It.IsAny<Package>(), It.IsAny<Stream>()))
+                    .Throws(_conflictException);
+
+                var result = await _target.CommitPackageAsync(_package, _packageFile);
+
+                _entitiesContext.Verify(
+                    x => x.SaveChangesAsync(),
+                    Times.Never);
+                Assert.Equal(PackageCommitResult.Conflict, result);
+            }
+
+            [Fact]
+            public async Task DeletesPackageIfDatabaseCommitFails()
+            {
+                _entitiesContext
+                    .Setup(x => x.SaveChangesAsync())
+                    .Throws(_unexpectedException);
+
+                var exception = await Assert.ThrowsAsync(
+                    _unexpectedException.GetType(),
+                    () => _target.CommitPackageAsync(_package, _packageFile));
+
+                _packageFileService.Verify(
+                    x => x.DeletePackageFileAsync(Id, Version),
+                    Times.Once);
+                _packageFileService.Verify(
+                    x => x.DeletePackageFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+                Assert.Same(_unexpectedException, exception);
+            }
+        }
+
+        public abstract class FactsBase
+        {
+            protected readonly Mock<IPackageService> _packageService;
+            protected readonly Mock<IPackageFileService> _packageFileService;
+            protected readonly Mock<IEntitiesContext> _entitiesContext;
+            protected readonly Mock<IReservedNamespaceService> _reservedNamespaceService;
+            protected readonly Mock<IValidationService> _validationService;
+            protected Package _package;
+            protected Stream _packageFile;
+            protected ArgumentException _unexpectedException;
+            protected InvalidOperationException _conflictException;
+            protected readonly PackageUploadService _target;
+
+            public FactsBase()
+            {
+                _packageService = new Mock<IPackageService>();
+                _packageFileService = new Mock<IPackageFileService>();
+                _entitiesContext = new Mock<IEntitiesContext>();
+                _reservedNamespaceService = new Mock<IReservedNamespaceService>();
+                _validationService = new Mock<IValidationService>();
+
+                _package = new Package
+                {
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = Id,
+                    },
+                    Version = Version,
+                };
+                _packageFile = Stream.Null;
+                _unexpectedException = new ArgumentException("Fail!");
+                _conflictException = new InvalidOperationException("Conflict!");
+
+                _target = new PackageUploadService(
+                    _packageService.Object,
+                    _packageFileService.Object,
+                    _entitiesContext.Object,
+                    _reservedNamespaceService.Object,
+                    _validationService.Object);
             }
         }
     }


### PR DESCRIPTION
Right now, `ApiController` and `PackagesController` both have the logic where we reliably write to `packages` container and to the database whilst still handling failures. This logic is duplicated.

I have moved this logic to `IPackageUploadService.CommitPackageAsync`. Right now, this is just a refactoring but the goal in a subsequent PR is to write (and delete in failure cases) packages to the `validating` container if the package has `PackageStatus.Validating`. Otherwise, existing behavior is maintained.

Progress on https://github.com/NuGet/NuGetGallery/issues/4646.