### PR TITLE
Do not rewrite return URL for MSA/AAD auth

### DIFF
--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -583,7 +583,8 @@ namespace NuGetGallery
                 routeValues: new RouteValueDictionary
                 {
                     { "ReturnUrl", returnUrl }
-                });
+                },
+                interceptReturnUrl: false);
         }
 
         public static string ManageMyApiKeys(this UrlHelper url, bool relativeUrl = true)
@@ -835,14 +836,14 @@ namespace NuGetGallery
             string actionName,
             string controllerName,
             bool relativeUrl,
-            RouteValueDictionary routeValues = null
+            RouteValueDictionary routeValues = null,
+            bool interceptReturnUrl = true
             )
         {
             var protocol = GetProtocol(url);
             var hostName = GetConfiguredSiteHostName();
-
-
-            if (routeValues != null && routeValues.ContainsKey("ReturnUrl"))
+            
+            if (interceptReturnUrl && routeValues != null && routeValues.ContainsKey("ReturnUrl"))
             {
                 routeValues["ReturnUrl"] = GetAbsoluteReturnUrl(
                     routeValues["ReturnUrl"]?.ToString(),

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -728,16 +728,12 @@ namespace NuGetGallery.Controllers
                 const string returnUrl = "/theReturnUrl";
                 EnableAllAuthenticators(Get<AuthenticationService>());
                 var controller = GetController<AuthenticationController>();
-                var absoluteReturnUrl = UrlExtensions.GetAbsoluteReturnUrl(
-                    returnUrl,
-                    "https",
-                    new Uri(GetConfigurationService().GetSiteRoot(useHttps: true)).Host);
-
+                
                 // Act
                 var result = controller.ChallengeAuthentication(returnUrl, "MicrosoftAccount");
 
                 // Assert
-                ResultAssert.IsChallengeResult(result, "MicrosoftAccount", "/users/account/authenticate/return?ReturnUrl=" + HttpUtility.UrlEncode(absoluteReturnUrl));
+                ResultAssert.IsChallengeResult(result, "MicrosoftAccount", "/users/account/authenticate/return?ReturnUrl=" + HttpUtility.UrlEncode(returnUrl));
             }
         }
 


### PR DESCRIPTION
Don't rewrite return URL when linking external accounts, as it likely breaks MSA/AAD state during auth.