### PR TITLE
File storage read URI generation

### DIFF
--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -110,6 +110,19 @@ namespace NuGetGallery
             await blob.SetPropertiesAsync();
         }
 
+        public async Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess)
+        {
+            folderName = folderName ?? throw new ArgumentNullException(nameof(folderName));
+            fileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            if (endOfAccess.HasValue && endOfAccess < DateTimeOffset.UtcNow)
+            {
+                throw new ArgumentOutOfRangeException(nameof(endOfAccess), $"{nameof(endOfAccess)} is in the past");
+            }
+            ICloudBlobContainer container = await GetContainer(folderName);
+            var blob = container.GetBlobReference(fileName);
+            return new Uri(blob.Uri, blob.GetSharedReadSignature(endOfAccess));
+        }
+
         protected async Task<ICloudBlobContainer> GetContainer(string folderName)
         {
             ICloudBlobContainer container;
@@ -226,19 +239,6 @@ namespace NuGetGallery
                 });
 
             return container;
-        }
-
-        public async Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess)
-        {
-            folderName = folderName ?? throw new ArgumentNullException(nameof(folderName));
-            fileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
-            if (endOfAccess.HasValue && endOfAccess < DateTimeOffset.UtcNow)
-            {
-                throw new ArgumentOutOfRangeException(nameof(endOfAccess), $"{nameof(endOfAccess)} is in the past");
-            }
-            ICloudBlobContainer container = await GetContainer(folderName);
-            var blob = container.GetBlobReference(fileName);
-            return blob.GetSharedReadUri(endOfAccess);
         }
 
         private struct StorageResult

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -232,6 +232,10 @@ namespace NuGetGallery
         {
             folderName = folderName ?? throw new ArgumentNullException(nameof(folderName));
             fileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            if (endOfAccess.HasValue && endOfAccess < DateTimeOffset.UtcNow)
+            {
+                throw new ArgumentOutOfRangeException(nameof(endOfAccess), $"{nameof(endOfAccess)} is in the past");
+            }
             ICloudBlobContainer container = await GetContainer(folderName);
             var blob = container.GetBlobReference(fileName);
             return blob.GetSharedReadUri(endOfAccess);

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -25,14 +25,14 @@ namespace NuGetGallery
 
         public async Task DeleteFileAsync(string folderName, string fileName)
         {
-            ICloudBlobContainer container = await GetContainer(folderName);
+            ICloudBlobContainer container = await GetContainerAsync(folderName);
             var blob = container.GetBlobReference(fileName);
             await blob.DeleteIfExistsAsync();
         }
 
         public async Task<bool> FileExistsAsync(string folderName, string fileName)
         {
-            ICloudBlobContainer container = await GetContainer(folderName);
+            ICloudBlobContainer container = await GetContainerAsync(folderName);
             var blob = container.GetBlobReference(fileName);
             return await blob.ExistsAsync();
         }
@@ -64,7 +64,7 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(fileName));
             }
 
-            ICloudBlobContainer container = await GetContainer(folderName);
+            ICloudBlobContainer container = await GetContainerAsync(folderName);
             var blob = container.GetBlobReference(fileName);
             var result = await GetBlobContentAsync(folderName, fileName, ifNoneMatch);
             if (result.StatusCode == HttpStatusCode.NotModified)
@@ -88,7 +88,7 @@ namespace NuGetGallery
 
         public async Task SaveFileAsync(string folderName, string fileName, Stream packageFile, bool overwrite = true)
         {
-            ICloudBlobContainer container = await GetContainer(folderName);
+            ICloudBlobContainer container = await GetContainerAsync(folderName);
             var blob = container.GetBlobReference(fileName);
 
             try
@@ -118,12 +118,12 @@ namespace NuGetGallery
             {
                 throw new ArgumentOutOfRangeException(nameof(endOfAccess), $"{nameof(endOfAccess)} is in the past");
             }
-            ICloudBlobContainer container = await GetContainer(folderName);
+            ICloudBlobContainer container = await GetContainerAsync(folderName);
             var blob = container.GetBlobReference(fileName);
             return new Uri(blob.Uri, blob.GetSharedReadSignature(endOfAccess));
         }
 
-        protected async Task<ICloudBlobContainer> GetContainer(string folderName)
+        protected async Task<ICloudBlobContainer> GetContainerAsync(string folderName)
         {
             ICloudBlobContainer container;
             if (_containers.TryGetValue(folderName, out container))
@@ -159,7 +159,7 @@ namespace NuGetGallery
 
         private async Task<StorageResult> GetBlobContentAsync(string folderName, string fileName, string ifNoneMatch = null)
         {
-            ICloudBlobContainer container = await GetContainer(folderName);
+            ICloudBlobContainer container = await GetContainerAsync(folderName);
 
             var blob = container.GetBlobReference(fileName);
 

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -234,7 +234,7 @@ namespace NuGetGallery
             fileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
             ICloudBlobContainer container = await GetContainer(folderName);
             var blob = container.GetBlobReference(fileName);
-            return await blob.GetSharedReadUriAsync(endOfAccess);
+            return blob.GetSharedReadUri(endOfAccess);
         }
 
         private struct StorageResult

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -228,6 +228,15 @@ namespace NuGetGallery
             return container;
         }
 
+        public async Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess)
+        {
+            folderName = folderName ?? throw new ArgumentNullException(nameof(folderName));
+            fileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            ICloudBlobContainer container = await GetContainer(folderName);
+            var blob = container.GetBlobReference(fileName);
+            return await blob.GetSharedReadUriAsync(endOfAccess);
+        }
+
         private struct StorageResult
         {
             private HttpStatusCode _statusCode;

--- a/src/NuGetGallery.Core/Services/CorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageFileService.cs
@@ -82,6 +82,8 @@ namespace NuGetGallery
 
         public Task<Uri> GetValidationPackageReadUriAsync(Package package, DateTimeOffset? endOfAccess)
         {
+            package = package ?? throw new ArgumentNullException(nameof(package));
+
             var fileName = BuildFileName(
                 package,
                 CoreConstants.PackageFileSavePathTemplate,

--- a/src/NuGetGallery.Core/Services/CorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageFileService.cs
@@ -80,7 +80,7 @@ namespace NuGetGallery
             return _fileStorageService.DeleteFileAsync(CoreConstants.ValidationFolderName, fileName);
         }
 
-        public Task<Uri> GetValidationPackageReadUriAsync(Package package, DateTimeOffset? endOfAccess)
+        public Task<Uri> GetValidationPackageReadUriAsync(Package package, DateTimeOffset endOfAccess)
         {
             package = package ?? throw new ArgumentNullException(nameof(package));
 

--- a/src/NuGetGallery.Core/Services/CorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageFileService.cs
@@ -80,6 +80,16 @@ namespace NuGetGallery
             return _fileStorageService.DeleteFileAsync(CoreConstants.ValidationFolderName, fileName);
         }
 
+        public Task<Uri> GetValidationPackageReadUriAsync(Package package, DateTimeOffset? endOfAccess)
+        {
+            var fileName = BuildFileName(
+                package,
+                CoreConstants.PackageFileSavePathTemplate,
+                CoreConstants.NuGetPackageFileExtension);
+
+            return _fileStorageService.GetFileReadUriAsync(CoreConstants.ValidationFolderName, fileName, endOfAccess);
+        }
+
         protected static string BuildFileName(Package package, string format, string extension)
         {
             if (package == null)

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -22,6 +23,15 @@ namespace NuGetGallery
         /// <param name="ifNoneMatch">The <see cref="IFileReference.ContentId"/> value to use in an If-None-Match request</param>
         /// <returns>A <see cref="IFileReference"/> representing the file reference</returns>
         Task<IFileReference> GetFileReferenceAsync(string folderName, string fileName, string ifNoneMatch = null);
+
+        /// <summary>
+        /// Generates the storage file URI (which is optionally time limited)
+        /// </summary>
+        /// <param name="folderName">The folder containing the file.</param>
+        /// <param name="fileName">The file within the <paramref name="folderName"/>.</param>
+        /// <param name="endOfAccess">Optional end of access timestamp.</param>
+        /// <returns>Time limited URI (if requested and implementation supports it) for the specified file.</returns>
+        Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess);
 
         Task SaveFileAsync(string folderName, string fileName, Stream packageFile, bool overwrite = true);
     }

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -29,7 +29,8 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="folderName">The folder containing the file.</param>
         /// <param name="fileName">The file within the <paramref name="folderName"/>.</param>
-        /// <param name="endOfAccess">Optional end of access timestamp.</param>
+        /// <param name="endOfAccess">End of access timestamp. Implementation should produce URIs that will become
+        /// invalid after that timestamp if it has support for it. If null then would be no time on URI availability.</param>
         /// <returns>Time limited URI (if requested and implementation supports it) for the specified file.</returns>
         Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess);
 

--- a/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -32,6 +33,14 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="package">The package metadata.</param>
         Task<Stream> DownloadValidationPackageFileAsync(Package package);
+
+        /// <summary>
+        /// Generates the URI for the specified validating package, which can be used to download it.
+        /// </summary>
+        /// <param name="package">The package metadata.</param>
+        /// <param name="endOfAccess">The optional timestamp that limits the URI usage period.</param>
+        /// <returns>Time limited (if requested and implementation supports) URI for the validation package</returns>
+        Task<Uri> GetValidationPackageReadUriAsync(Package package, DateTimeOffset? endOfAccess);
 
         /// <summary>
         /// Deletes the validating package from the file storage. If the file does not exist this method will not throw

--- a/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
@@ -38,9 +38,9 @@ namespace NuGetGallery
         /// Generates the URI for the specified validating package, which can be used to download it.
         /// </summary>
         /// <param name="package">The package metadata.</param>
-        /// <param name="endOfAccess">The optional timestamp that limits the URI usage period.</param>
-        /// <returns>Time limited (if requested and implementation supports) URI for the validation package</returns>
-        Task<Uri> GetValidationPackageReadUriAsync(Package package, DateTimeOffset? endOfAccess);
+        /// <param name="endOfAccess">The timestamp that limits the URI usage period.</param>
+        /// <returns>Time limited (if implementation supports) URI for the validation package</returns>
+        Task<Uri> GetValidationPackageReadUriAsync(Package package, DateTimeOffset endOfAccess);
 
         /// <summary>
         /// Deletes the validating package from the file storage. If the file does not exist this method will not throw

--- a/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
@@ -26,5 +26,16 @@ namespace NuGetGallery
         Task UploadFromStreamAsync(Stream packageFile, bool overwrite);
 
         Task FetchAttributesAsync();
+
+        /// <summary>
+        /// Generates the URI that can be used to read the contents of the blob
+        /// using the produced URI only (without storage account credentials).
+        /// </summary>
+        /// <param name="endOfAccess">
+        /// Optional "end of access" timestamp. After the specified time, 
+        /// the returned URI becomes invalid.
+        /// </param>
+        /// <returns>Shared access URI.</returns>
+        Task<Uri> GetSharedReadUriAsync(DateTimeOffset? endOfAccess);
     }
 }

--- a/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
@@ -36,6 +36,6 @@ namespace NuGetGallery
         /// the returned URI becomes invalid.
         /// </param>
         /// <returns>Shared access URI.</returns>
-        Task<Uri> GetSharedReadUriAsync(DateTimeOffset? endOfAccess);
+        Uri GetSharedReadUri(DateTimeOffset? endOfAccess);
     }
 }

--- a/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
@@ -28,15 +28,16 @@ namespace NuGetGallery
         Task FetchAttributesAsync();
 
         /// <summary>
-        /// Generates the URI that can be used to read the contents of the blob
-        /// using the produced URI only (without storage account credentials).
+        /// Generates the shared read signature that if appended to the blob URI
+        /// would allow reading the contents of the blob using the produced URI 
+        /// only (without storage account credentials).
         /// </summary>
         /// <param name="endOfAccess">
-        /// "End of access" timestamp. After the specified time, 
-        /// the returned URI becomes invalid if implementation supports it.
+        /// "End of access" timestamp. After the specified timestamp, 
+        /// the returned signature becomes invalid if implementation supports it.
         /// Null for no time limit.
         /// </param>
-        /// <returns>Shared access URI.</returns>
-        Uri GetSharedReadUri(DateTimeOffset? endOfAccess);
+        /// <returns>Shared access signature in form of URI query portion.</returns>
+        string GetSharedReadSignature(DateTimeOffset? endOfAccess);
     }
 }

--- a/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
@@ -32,8 +32,9 @@ namespace NuGetGallery
         /// using the produced URI only (without storage account credentials).
         /// </summary>
         /// <param name="endOfAccess">
-        /// Optional "end of access" timestamp. After the specified time, 
-        /// the returned URI becomes invalid.
+        /// "End of access" timestamp. After the specified time, 
+        /// the returned URI becomes invalid if implementation supports it.
+        /// Null for no time limit.
         /// </param>
         /// <returns>Shared access URI.</returns>
         Uri GetSharedReadUri(DateTimeOffset? endOfAccess);

--- a/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
+++ b/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery
 
         public async Task<ActionResult> CreateDownloadFileActionResultAsync(Uri requestUrl, string folderName, string fileName)
         {
-            ICloudBlobContainer container = await GetContainer(folderName);
+            ICloudBlobContainer container = await GetContainerAsync(folderName);
             var blob = container.GetBlobReference(fileName);
 
             var redirectUri = GetRedirectUri(requestUrl, blob.Uri);
@@ -36,7 +36,7 @@ namespace NuGetGallery
             string folderName,
             string fileName)
         {
-            var container = await GetContainer(folderName);
+            var container = await GetContainerAsync(folderName);
             var blob = container.GetBlobReference(fileName);
 
             var redirectUri = GetRedirectUri(httpContext.Request.Url, blob.Uri);
@@ -93,7 +93,7 @@ namespace NuGetGallery
 
         public async Task<bool> IsAvailableAsync()
         {
-            var container = await GetContainer(CoreConstants.PackagesFolderName);
+            var container = await GetContainerAsync(CoreConstants.PackagesFolderName);
             return await container.ExistsAsync();
         }
     }

--- a/src/NuGetGallery/Services/CloudBlobWrapper.cs
+++ b/src/NuGetGallery/Services/CloudBlobWrapper.cs
@@ -124,7 +124,7 @@ namespace NuGetGallery
                 state: null);
         }
 
-        public Task<Uri> GetSharedReadUriAsync(DateTimeOffset? endOfAccess)
+        public Uri GetSharedReadUri(DateTimeOffset? endOfAccess)
         {
             var accessPolicy = new SharedAccessBlobPolicy
             {
@@ -134,7 +134,7 @@ namespace NuGetGallery
 
             var token = this._blob.GetSharedAccessSignature(accessPolicy);
 
-            return Task.FromResult(new Uri(this._blob.Uri.AbsoluteUri + token));
+            return new Uri(this._blob.Uri.AbsoluteUri + token);
         }
 
         // The default retry policy treats a 304 as an error that requires a retry. We don't want that!

--- a/src/NuGetGallery/Services/CloudBlobWrapper.cs
+++ b/src/NuGetGallery/Services/CloudBlobWrapper.cs
@@ -124,6 +124,19 @@ namespace NuGetGallery
                 state: null);
         }
 
+        public Task<Uri> GetSharedReadUriAsync(DateTimeOffset? endOfAccess)
+        {
+            var accessPolicy = new SharedAccessBlobPolicy
+            {
+                SharedAccessExpiryTime = endOfAccess,
+                Permissions = SharedAccessBlobPermissions.Read
+            };
+
+            var token = this._blob.GetSharedAccessSignature(accessPolicy);
+
+            return Task.FromResult(new Uri(this._blob.Uri.AbsoluteUri + token));
+        }
+
         // The default retry policy treats a 304 as an error that requires a retry. We don't want that!
         private class DontRetryOnNotModifiedPolicy : IRetryPolicy
         {

--- a/src/NuGetGallery/Services/CloudBlobWrapper.cs
+++ b/src/NuGetGallery/Services/CloudBlobWrapper.cs
@@ -124,7 +124,7 @@ namespace NuGetGallery
                 state: null);
         }
 
-        public Uri GetSharedReadUri(DateTimeOffset? endOfAccess)
+        public string GetSharedReadSignature(DateTimeOffset? endOfAccess)
         {
             var accessPolicy = new SharedAccessBlobPolicy
             {
@@ -132,9 +132,9 @@ namespace NuGetGallery
                 Permissions = SharedAccessBlobPermissions.Read
             };
 
-            var token = this._blob.GetSharedAccessSignature(accessPolicy);
+            var signature = this._blob.GetSharedAccessSignature(accessPolicy);
 
-            return new Uri(this._blob.Uri.AbsoluteUri + token);
+            return signature;
         }
 
         // The default retry policy treats a 304 as an error that requires a retry. We don't want that!

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -173,6 +173,18 @@ namespace NuGetGallery
             return Task.FromResult(Directory.Exists(_configuration.FileStorageDirectory));
         }
 
+        public Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess)
+        {
+            // technically, we would be able to generate the file:/// url here, but we don't need it right now
+            // and implementation would be a bit non-trivial: System.Uri handles the "%" character in paths 
+            // in a funny way: 
+            // new Uri(@"c:\%41foo%20bar%25.baz")
+            // produces the
+            // file:///c:/Afoo%20bar%2525.baz
+            // which is not particularly correct, so we'd need to work around that to have a correct implementation
+            throw new NotImplementedException();
+        }
+
         private static string BuildPath(string fileStorageDirectory, string folderName, string fileName)
         {
             // Resolve the file storage directory

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -540,6 +540,8 @@ namespace NuGetGallery
                 var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => service.GetFileReadUriAsync("theFolder", "theFileName", inThePast));
                 Assert.Equal("endOfAccess", ex.ParamName);
             }
+
+
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -510,5 +510,36 @@ namespace NuGetGallery
                 fakeBlob.Verify(x => x.SetPropertiesAsync());
             }
         }
+
+        public class TheGetFileReadUriAsyncMethod
+        {
+            [Fact]
+            public async Task WillThrowIfFolderIsNull()
+            {
+                var service = CreateService();
+
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.GetFileReadUriAsync(null, "theFileName", DateTimeOffset.UtcNow.AddHours(3)));
+                Assert.Equal("folderName", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfFilenameIsNull()
+            {
+                var service = CreateService();
+
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.GetFileReadUriAsync("theFolder", null, DateTimeOffset.UtcNow.AddHours(3)));
+                Assert.Equal("fileName", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillThrowIfEndOfAccessIsInThePast()
+            {
+                var service = CreateService();
+
+                DateTimeOffset inThePast = DateTimeOffset.UtcNow.AddSeconds(-1);
+                var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => service.GetFileReadUriAsync("theFolder", "theFileName", inThePast));
+                Assert.Equal("endOfAccess", ex.ParamName);
+            }
+        }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -348,6 +348,31 @@ namespace NuGetGallery
             }
         }
 
+        public class TheGetValidationPackageReadUriAsyncMethod : FactsBase
+        {
+            [Fact]
+            public async Task WillThrowIfPackageIsNull()
+            {
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.GetValidationPackageReadUriAsync(null, DateTimeOffset.UtcNow.AddHours(3)));
+
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillUseTheFileStorageService()
+            {
+                DateTimeOffset endOfAccess = DateTimeOffset.UtcNow.AddHours(3);
+                await _service.GetValidationPackageReadUriAsync(_package, endOfAccess);
+
+                _fileStorageService.Verify(
+                    x => x.GetFileReadUriAsync(ValidationFolderName, ValidationFileName, endOfAccess),
+                    Times.Once);
+                _fileStorageService.Verify(
+                    x => x.GetFileReadUriAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTimeOffset>()),
+                    Times.Once);
+            }
+        }
+
         static string BuildFileName(
             string id,
             string version, string extension, string path)


### PR DESCRIPTION
Need a URI to an uploaded package for the validation orchestrator to know how to obtain the file to validate.
This change implements SAS-enabled URI generation for the cloud storage, the local file storage leaves it not implemented.