### PR TITLE
Update NuGet.Services.Validation to 2.3.0 (stable, signed)

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -446,7 +446,7 @@
       <HintPath>..\..\packages\NuGet.Protocol.4.3.0-preview1-2524\lib\net45\NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.Contracts, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Contracts.2.3.0-dev-14813\lib\net45\NuGet.Services.Contracts.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Contracts.2.3.0\lib\net45\NuGet.Services.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.KeyVault, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.0.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
@@ -465,10 +465,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.ServiceBus, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.ServiceBus.2.3.0-dev-14813\lib\net45\NuGet.Services.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.ServiceBus.2.3.0\lib\net45\NuGet.Services.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.Validation, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Validation.2.3.0-dev-14813\lib\net45\NuGet.Services.Validation.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Validation.2.3.0\lib\net45\NuGet.Services.Validation.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2524\lib\net45\NuGet.Versioning.dll</HintPath>

--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -89,13 +89,13 @@
   <package id="NuGet.Packaging" version="4.3.0-preview1-2524" targetFramework="net46" />
   <package id="NuGet.Packaging.Core" version="4.3.0-preview1-2524" targetFramework="net46" />
   <package id="NuGet.Protocol" version="4.3.0-preview1-2524" targetFramework="net46" />
-  <package id="NuGet.Services.Contracts" version="2.3.0-dev-14813" targetFramework="net46" />
+  <package id="NuGet.Services.Contracts" version="2.3.0" targetFramework="net46" />
   <package id="NuGet.Services.KeyVault" version="1.0.0.0" targetFramework="net46" />
   <package id="NuGet.Services.Logging" version="2.2.3.0" targetFramework="net46" />
   <package id="NuGet.Services.Owin" version="2.2.3" targetFramework="net46" />
   <package id="NuGet.Services.Platform.Client" version="3.0.29-r-master" targetFramework="net46" />
-  <package id="NuGet.Services.ServiceBus" version="2.3.0-dev-14813" targetFramework="net46" />
-  <package id="NuGet.Services.Validation" version="2.3.0-dev-14813" targetFramework="net46" />
+  <package id="NuGet.Services.ServiceBus" version="2.3.0" targetFramework="net46" />
+  <package id="NuGet.Services.Validation" version="2.3.0" targetFramework="net46" />
   <package id="NuGet.Versioning" version="4.3.0-preview1-2524" targetFramework="net46" />
   <package id="ODataNullPropagationVisitor" version="0.5.4237.2641" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net46" />

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -223,17 +223,17 @@
       <HintPath>..\..\packages\NuGet.Protocol.4.3.0-preview1-2524\lib\net45\NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.Contracts, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Contracts.2.3.0-dev-14813\lib\net45\NuGet.Services.Contracts.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Contracts.2.3.0\lib\net45\NuGet.Services.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.KeyVault, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.0.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.ServiceBus, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.ServiceBus.2.3.0-dev-14813\lib\net45\NuGet.Services.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.ServiceBus.2.3.0\lib\net45\NuGet.Services.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.Validation, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Validation.2.3.0-dev-14813\lib\net45\NuGet.Services.Validation.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Validation.2.3.0\lib\net45\NuGet.Services.Validation.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2524\lib\net45\NuGet.Versioning.dll</HintPath>

--- a/tests/NuGetGallery.Facts/packages.config
+++ b/tests/NuGetGallery.Facts/packages.config
@@ -45,10 +45,10 @@
   <package id="NuGet.Packaging" version="4.3.0-preview1-2524" targetFramework="net46" />
   <package id="NuGet.Packaging.Core" version="4.3.0-preview1-2524" targetFramework="net46" />
   <package id="NuGet.Protocol" version="4.3.0-preview1-2524" targetFramework="net46" />
-  <package id="NuGet.Services.Contracts" version="2.3.0-dev-14813" targetFramework="net46" />
+  <package id="NuGet.Services.Contracts" version="2.3.0" targetFramework="net46" />
   <package id="NuGet.Services.KeyVault" version="1.0.0.0" targetFramework="net46" />
-  <package id="NuGet.Services.ServiceBus" version="2.3.0-dev-14813" targetFramework="net46" />
-  <package id="NuGet.Services.Validation" version="2.3.0-dev-14813" targetFramework="net46" />
+  <package id="NuGet.Services.ServiceBus" version="2.3.0" targetFramework="net46" />
+  <package id="NuGet.Services.Validation" version="2.3.0" targetFramework="net46" />
   <package id="NuGet.Versioning" version="4.3.0-preview1-2524" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net46" />
   <package id="PoliteCaptcha" version="0.4.0.1" targetFramework="net46" />


### PR DESCRIPTION
The current dependency is prerelease and unsigned. The API surface area and implementation has not changed at all.