### PR TITLE
Show normalized version (incl metadata) in edit/delete package dropdown.

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1080,6 +1080,13 @@ namespace NuGetGallery
                     .ToList()
             };
 
+            // Create version selection.
+            model.VersionSelectList = new SelectList(model.PackageVersions.Select(e => new
+            {
+                text = NuGetVersion.Parse(e.Version).ToFullString() + (e.IsLatestSemVer2 ? " (Latest)" : string.Empty),
+                url = UrlExtensions.EditPackage(Url, model.PackageId, e.NormalizedVersion)
+            }), "url", "text", UrlExtensions.EditPackage(Url, model.PackageId, model.Version));
+
             // Create edit model from the latest pending edit.
             var pendingMetadata = _editPackageService.GetPendingMetadata(package);
 

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1074,7 +1074,7 @@ namespace NuGetGallery
             {
                 PackageId = package.PackageRegistration.Id,
                 PackageTitle = package.Title,
-                Version = package.Version,
+                Version = package.NormalizedVersion,
                 PackageVersions = packageRegistration.Packages
                     .OrderByDescending(p => new NuGetVersion(p.Version), Comparer<NuGetVersion>.Create((a, b) => a.CompareTo(b)))
                     .ToList()

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -18,7 +18,6 @@ using System.Web.Caching;
 using System.Web.Mvc;
 using NuGet.Packaging;
 using NuGet.Versioning;
-using NuGetGallery;
 using NuGetGallery.Areas.Admin;
 using NuGetGallery.AsyncFileUpload;
 using NuGetGallery.Auditing;
@@ -922,6 +921,16 @@ namespace NuGetGallery
             }
 
             var model = new DeletePackageViewModel(package, ReportMyPackageReasons);
+
+            model.VersionSelectList = new SelectList(
+                model.PackageVersions
+                .Where(p => p.Deleted == false)
+                .Select(p => new
+                {
+                    text = p.NuGetVersion.ToFullString() + (p.LatestVersionSemVer2 ? " (Latest)" : string.Empty),
+                    url = Url.DeletePackage(p)
+                }), "url", "text", Url.DeletePackage(model));
+
             return View(model);
         }
 

--- a/src/NuGetGallery/RequestModels/EditPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageRequest.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
+using System.Web.Mvc;
 
 namespace NuGetGallery
 {
     public class EditPackageRequest
     {
+        public SelectList VersionSelectList { get; set; }
+
         public EditPackageVersionRequest Edit { get; set; }
 
         public string PackageId { get; set; }

--- a/src/NuGetGallery/ViewModels/DeletePackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DeletePackageViewModel.cs
@@ -1,10 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.Versioning;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using NuGet.Versioning;
+using System.Web.Mvc;
 
 namespace NuGetGallery
 {
@@ -19,6 +20,8 @@ namespace NuGetGallery
                 ReasonChoices = reportOtherPackageReasons
             };
         }
+
+        public SelectList VersionSelectList { get; set; }
 
         public DeletePackagesRequest DeletePackagesRequest { get; set; }
     }

--- a/src/NuGetGallery/Views/Packages/Delete.cshtml
+++ b/src/NuGetGallery/Views/Packages/Delete.cshtml
@@ -29,15 +29,7 @@
                 <div class="form-group">
                     <label for="input-select-version" id="package-version-label">Select Package Version</label>
 
-                    @Html.DropDownList("version-selection",
-                        new SelectList(
-                            Model.PackageVersions
-                                 .Where(p => p.Deleted == false)
-                                 .Select(p => new
-                                 {
-                                     text = p.Version + (p.LatestVersionSemVer2 ? " (latest)" : string.Empty),
-                                     url = Url.DeletePackage(p)
-                                 }), "url", "text", Url.DeletePackage(Model)),
+                    @Html.DropDownList("version-selection", Model.VersionSelectList,
                                  new
                                  {
                                      @class = "form-control",

--- a/src/NuGetGallery/Views/Packages/Edit.cshtml
+++ b/src/NuGetGallery/Views/Packages/Edit.cshtml
@@ -1,4 +1,6 @@
-﻿@model EditPackageRequest
+﻿@using NuGet.Versioning
+
+@model EditPackageRequest
 @{
     ViewBag.Title = "Editing: " + Model.PackageId + " " + Model.Version;
     ViewBag.Tab = "Packages";
@@ -39,8 +41,8 @@
                                 @Html.DropDownList("version-selection",
                             new SelectList(Model.PackageVersions.Select(e => new
                             {
-                                text = e.NormalizedVersion + (e.IsLatestSemVer2 ? " (Latest)" : ""),
-                                url = Url.EditPackage(Model.PackageId, e.Version)
+                                text = NuGetVersion.Parse(e.Version).ToFullString() + (e.IsLatestSemVer2 ? " (Latest)" : ""),
+                                url = Url.EditPackage(Model.PackageId, e.NormalizedVersion)
                             }), "url", "text", Url.EditPackage(Model.PackageId, Model.Version)),
                            new
                            {

--- a/src/NuGetGallery/Views/Packages/Edit.cshtml
+++ b/src/NuGetGallery/Views/Packages/Edit.cshtml
@@ -1,6 +1,4 @@
-﻿@using NuGet.Versioning
-
-@model EditPackageRequest
+﻿@model EditPackageRequest
 @{
     ViewBag.Title = "Editing: " + Model.PackageId + " " + Model.Version;
     ViewBag.Tab = "Packages";
@@ -38,12 +36,7 @@
                         <div class="row">
                             <label for="input-select-version" id="package-version-label" class="col-xs-12">
                                 <span>Select a package version</span>
-                                @Html.DropDownList("version-selection",
-                            new SelectList(Model.PackageVersions.Select(e => new
-                            {
-                                text = NuGetVersion.Parse(e.Version).ToFullString() + (e.IsLatestSemVer2 ? " (Latest)" : ""),
-                                url = Url.EditPackage(Model.PackageId, e.NormalizedVersion)
-                            }), "url", "text", Url.EditPackage(Model.PackageId, Model.Version)),
+                                @Html.DropDownList("version-selection", Model.VersionSelectList,
                            new
                            {
                                @class = "form-control selectpicker show-tick show-menu-arrow btn-block",

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -14,7 +14,7 @@ using System.Web.Mvc;
 using System.Web.Routing;
 using Moq;
 using NuGet.Packaging;
-using NuGetGallery;
+using NuGet.Versioning;
 using NuGetGallery.Areas.Admin;
 using NuGetGallery.AsyncFileUpload;
 using NuGetGallery.Auditing;
@@ -23,9 +23,7 @@ using NuGetGallery.Framework;
 using NuGetGallery.Helpers;
 using NuGetGallery.Packaging;
 using NuGetGallery.Security;
-using NuGetGallery.TestUtils;
 using Xunit;
-using NuGet.Versioning;
 
 namespace NuGetGallery
 {

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -25,6 +25,7 @@ using NuGetGallery.Packaging;
 using NuGetGallery.Security;
 using NuGetGallery.TestUtils;
 using Xunit;
+using NuGet.Versioning;
 
 namespace NuGetGallery
 {
@@ -502,7 +503,7 @@ namespace NuGetGallery
             {
                 // Arrange
                 var readMeMd = "# Hello World!";
-                
+
                 // Act
                 var result = await GetDisplayPackageResult(readMeMd, true);
 
@@ -1212,6 +1213,93 @@ namespace NuGetGallery
                 Assert.Equal(@"~\Bar.cshtml", ((RedirectResult)result).Url);
             }
 
+            [Fact]
+            public async Task UsesNormalizedVersionsInUrlsInSelectList()
+            {
+                // Arrange
+                var user = new User("Frodo") { Key = 1 };
+                var packageRegistration = new PackageRegistration { Id = "Foo" };
+                packageRegistration.Owners.Add(user);
+
+                var package = new Package
+                {
+                    Key = 2,
+                    PackageRegistration = packageRegistration,
+                    Version = "1.0.0+metadata",
+                    Listed = true,
+                    IsLatestSemVer2 = true,
+                    HasReadMe = false
+                };
+                var olderPackageVersion = new Package
+                {
+                    Key = 1,
+                    PackageRegistration = packageRegistration,
+                    Version = "1.0.0-alpha",
+                    IsLatest = true,
+                    IsLatestSemVer2 = true,
+                    Listed = true,
+                    HasReadMe = false
+                };
+                
+                packageRegistration.Packages.Add(package);
+                packageRegistration.Packages.Add(olderPackageVersion);
+
+                var packageEdit = new PackageEdit
+                {
+                    PackageKey = package.Key,
+                    Package = package,
+                    User = user,
+                    UserKey = user.Key
+                };
+
+                var packageService = new Mock<IPackageService>(MockBehavior.Strict);
+                packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0.0", SemVerLevelKey.Unknown, true))
+                    .Returns(package).Verifiable();
+                packageService.Setup(svc => svc.FindPackageRegistrationById("Foo"))
+                    .Returns(package.PackageRegistration).Verifiable();
+
+                var editPackageService = new Mock<EditPackageService>(MockBehavior.Strict);
+                editPackageService.Setup(svc => svc.GetPendingMetadata(package))
+                    .Returns(packageEdit).Verifiable();
+                
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService,
+                    editPackageService: editPackageService);
+                controller.SetCurrentUser(user);
+
+                var routeCollection = new RouteCollection();
+                Routes.RegisterRoutes(routeCollection);
+                controller.Url = new UrlHelper(controller.ControllerContext.RequestContext, routeCollection);
+
+                // Act
+                var result = await controller.Edit("Foo", "1.0.0");
+
+                // Assert
+                packageService.Verify();
+                editPackageService.Verify();
+
+                Assert.IsType<ViewResult>(result);
+                var model = ((ViewResult)result).Model as EditPackageRequest;
+                Assert.NotNull(model);
+
+                // Verify version select list
+                Assert.Equal(packageRegistration.Packages.Count, model.VersionSelectList.Count());
+                
+                foreach (var pkg in packageRegistration.Packages)
+                {
+                    var valueField = UrlExtensions.EditPackage(controller.Url, model.PackageId, pkg.NormalizedVersion);
+                    var textField = NuGetVersion.Parse(pkg.Version).ToFullString() + (pkg.IsLatestSemVer2 ? " (Latest)" : string.Empty);
+
+                    var selectListItem = model.VersionSelectList
+                        .SingleOrDefault(i => string.Equals(i.Text, textField) && string.Equals(i.Value, valueField));
+
+                    Assert.NotNull(selectListItem);
+                    Assert.Equal(valueField, selectListItem.Value);
+                    Assert.Equal(textField, selectListItem.Text);
+                }
+            }
+
             [Theory]
             [InlineData(PackageEditReadMeState.Changed)]
             [InlineData(PackageEditReadMeState.Deleted)]
@@ -1219,7 +1307,7 @@ namespace NuGetGallery
             {
                 // Arrange
                 var packageEdit = new PackageEdit { ReadMeState = readMeState };
-                
+
                 var packageFileService = new Mock<IPackageFileService>();
                 packageFileService.Setup(s => s.DownloadReadMeMdFileAsync(It.IsAny<Package>(), It.IsAny<bool>()))
                     .Returns(Task.FromResult("markdown"))
@@ -2670,7 +2758,7 @@ namespace NuGetGallery
                     controller.SetCurrentUser(TestUtility.FakeUser);
 
                     // Act
-                    await controller.VerifyPackage(new VerifyPackageRequest { Listed = true, Edit = edit});
+                    await controller.VerifyPackage(new VerifyPackageRequest { Listed = true, Edit = edit });
 
                     // Assert 
                     fakeEditPackageService.Verify(x => x.StartEditPackageRequest(fakePackage, edit, TestUtility.FakeUser), Times.Once);
@@ -2736,7 +2824,7 @@ namespace NuGetGallery
                     packageFileService: fakePackageFileService);
 
                 controller.SetCurrentUser(TestUtility.FakeUser);
-                
+
                 // Act
                 await controller.VerifyPackage(new VerifyPackageRequest { Listed = true, Edit = edit });
 
@@ -2744,7 +2832,7 @@ namespace NuGetGallery
                 fakePackageFileService.Verify(x => x.SavePendingReadMeMdFileAsync(fakePackage, "markdown"), Times.Exactly(hasReadMe ? 1 : 0));
             }
         }
-        
+
         public class TheUploadProgressAction : TestContainer
         {
             private static readonly string FakeUploadName = "upload-" + TestUtility.FakeUserName;
@@ -2845,7 +2933,7 @@ namespace NuGetGallery
 
         public class TheRevalidateMethod : TestContainer
         {
-            private  Package _package;
+            private Package _package;
             private readonly Mock<IPackageService> _packageService;
             private readonly Mock<IValidationService> _validationService;
             private readonly TestGalleryConfigurationService _configurationService;

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1476,6 +1476,10 @@ namespace NuGetGallery
                     packageFileService: packageFileService);
                 controller.SetCurrentUser(new User("user"));
 
+                var routeCollection = new RouteCollection();
+                Routes.RegisterRoutes(routeCollection);
+                controller.Url = new UrlHelper(controller.ControllerContext.RequestContext, routeCollection);
+
                 return controller;
             }
         }


### PR DESCRIPTION
Fixes #4756 

Show normalized version (incl metadata) in edit package dropdown.
Fix semver2 package edit navigation (URLs must always use normalized version).