### PR TITLE
Add missing FindPackagesById()/$count endpoints

### DIFF
--- a/src/NuGetGallery/Controllers/ODataV1FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV1FeedController.cs
@@ -84,6 +84,15 @@ namespace NuGetGallery.Controllers
             return await GetCore(options, id, version: null, return404NotFoundWhenNoResults: false);
         }
 
+        // /api/v1/FindPackagesById()/$count?id=
+        [HttpGet]
+        [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
+        public async Task<IHttpActionResult> FindPackagesByIdCount(ODataQueryOptions<V1FeedPackage> options, [FromODataUri]string id)
+        {
+            var result = await FindPackagesById(options, id);
+            return result.FormattedAsCountResult<V1FeedPackage>();
+        }
+
         private async Task<IHttpActionResult> GetCore(ODataQueryOptions<V1FeedPackage> options, string id, string version, bool return404NotFoundWhenNoResults)
         {
             var packages = _packagesRepository.GetAll()

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -112,6 +112,19 @@ namespace NuGetGallery.Controllers
             return await GetCore(options, curatedFeedName, id, normalizedVersion: null, return404NotFoundWhenNoResults: false, semVerLevel: semVerLevel);
         }
 
+        // /api/v2/curated-feed/curatedFeedName/FindPackagesById()/$count?id=&semVerLevel=
+        [HttpGet]
+        [CacheOutput(NoCache = true)]
+        public async Task<IHttpActionResult> FindPackagesByIdCount(
+            ODataQueryOptions<V2FeedPackage> options,
+            string curatedFeedName,
+            [FromODataUri] string id,
+            [FromUri] string semVerLevel = null)
+        {
+            var result = await FindPackagesById(options, curatedFeedName, id, semVerLevel);
+            return result.FormattedAsCountResult<V2FeedPackage>();
+        }
+
         private async Task<IHttpActionResult> GetCore(
             ODataQueryOptions<V2FeedPackage> options,
             string curatedFeedName,

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -179,6 +179,17 @@ namespace NuGetGallery.Controllers
                 return404NotFoundWhenNoResults: false);
         }
 
+        // /api/v2/FindPackagesById()/$count?semVerLevel=
+        [HttpGet]
+        [CacheOutput(NoCache = true)]
+        public async Task<IHttpActionResult> FindPackagesByIdCount(
+            ODataQueryOptions<V2FeedPackage> options,
+            [FromODataUri]string id,
+            [FromUri]string semVerLevel = null)
+        {
+            return (await FindPackagesById(options, id, semVerLevel)).FormattedAsCountResult<V2FeedPackage>();
+        }
+
         private async Task<IHttpActionResult> GetCore(
             ODataQueryOptions<V2FeedPackage> options, 
             string id, 

--- a/tests/NuGetGallery.Facts/Controllers/ODataV1FeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV1FeedControllerFacts.cs
@@ -52,6 +52,18 @@ namespace NuGetGallery.Controllers
         }
 
         [Fact]
+        public async Task FindPackagesByIdCount_FiltersSemVerV2PackageVersions()
+        {
+            // Act
+            var count = await GetInt<V1FeedPackage>(
+                async (controller, options) => await controller.FindPackagesByIdCount(options, TestPackageId),
+                $"/api/v1/FindPackagesById/$count?id='{TestPackageId}'");
+
+            // Assert
+            Assert.Equal(NonSemVer2Packages.Where(p => !p.IsPrerelease).Count(), count);
+        }
+
+        [Fact]
         public async Task Search_FiltersSemVerV2PackageVersions()
         {
             // Act

--- a/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
@@ -114,11 +114,39 @@ namespace NuGetGallery.Controllers
             // Act
             var resultSet = await GetCollection<V2FeedPackage>(
                 async (controller, options) => await controller.FindPackagesById(options, _curatedFeedName, id: TestPackageId, semVerLevel: semVerLevel),
-                $"/api/v2/curated-feed/{_curatedFeedName}/FindPackagesById?id='{TestPackageId}'?semVerLevel={semVerLevel}");
+                $"/api/v2/curated-feed/{_curatedFeedName}/FindPackagesById?id='{TestPackageId}'&semVerLevel={semVerLevel}");
 
             // Assert
             AssertSemVer2PackagesIncludedInResult(resultSet, includePrerelease: true);
             Assert.Equal(AvailablePackages.Count, resultSet.Count);
+        }
+
+        [Fact]
+        public async Task FindPackagesByIdCount_FiltersSemVerV2PackageVersions()
+        {
+            // Act
+            var count = await GetInt<V2FeedPackage>(
+                async (controller, options) => await controller.FindPackagesByIdCount(options, _curatedFeedName, TestPackageId),
+                $"/api/v2/curated-feed/{_curatedFeedName}/FindPackagesById/$count?id='{TestPackageId}'");
+
+            // Assert
+            Assert.Equal(NonSemVer2Packages.Count, count);
+        }
+
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task FindPackagesByIdCount_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var count = await GetInt<V2FeedPackage>(
+                async (controller, options) => await controller.FindPackagesByIdCount(options, _curatedFeedName, id: TestPackageId, semVerLevel: semVerLevel),
+                $"/api/v2/curated-feed/{_curatedFeedName}/FindPackagesById/$count?id='{TestPackageId}'&semVerLevel={semVerLevel}");
+
+            // Assert
+            Assert.Equal(AvailablePackages.Count, count);
         }
 
         [Fact]
@@ -183,7 +211,7 @@ namespace NuGetGallery.Controllers
                     searchTerm: TestPackageId,
                     includePrerelease: true,
                     semVerLevel: semVerLevel),
-                $"/api/v2/curated-feed/{_curatedFeedName}/Search?searchTerm='{TestPackageId}'?semVerLevel={semVerLevel}&includePrerelease=true");
+                $"/api/v2/curated-feed/{_curatedFeedName}/Search?searchTerm='{TestPackageId}'&semVerLevel={semVerLevel}&includePrerelease=true");
 
             // Assert
             AssertSemVer2PackagesIncludedInResult(resultSet, includePrerelease: true);

--- a/tests/NuGetGallery.Facts/Controllers/ODataV2FeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV2FeedControllerFacts.cs
@@ -95,11 +95,39 @@ namespace NuGetGallery.Controllers
             // Act
             var resultSet = await GetCollection<V2FeedPackage>(
                 (controller, options) => controller.FindPackagesById(options, id: TestPackageId, semVerLevel: semVerLevel),
-                $"/api/v2/FindPackagesById?id='{TestPackageId}'?semVerLevel={semVerLevel}");
+                $"/api/v2/FindPackagesById?id='{TestPackageId}'&semVerLevel={semVerLevel}");
 
             // Assert
             AssertSemVer2PackagesIncludedInResult(resultSet);
             Assert.Equal(AvailablePackages.Count, resultSet.Count);
+        }
+
+        [Fact]
+        public async Task FindPackagesByIdCount_FiltersSemVerV2PackageVersionsByDefault()
+        {
+            // Act
+            var count = await GetInt<V2FeedPackage>(
+                (controller, options) => controller.FindPackagesByIdCount(options, id: TestPackageId),
+                $"/api/v2/FindPackagesById/$count?id='{TestPackageId}'");
+
+            // Assert
+            Assert.Equal(NonSemVer2Packages.Count, count);
+        }
+
+        [Theory]
+        [InlineData("2.0.0")]
+        [InlineData("2.0.1")]
+        [InlineData("3.0.0-alpha")]
+        [InlineData("3.0.0")]
+        public async Task FindPackagesByIdCount_IncludesSemVerV2PackageVersionsWhenSemVerLevel2OrHigher(string semVerLevel)
+        {
+            // Act
+            var count = await GetInt<V2FeedPackage>(
+                (controller, options) => controller.FindPackagesByIdCount(options, id: TestPackageId, semVerLevel: semVerLevel),
+                $"/api/v2/FindPackagesById/$count?id='{TestPackageId}'&semVerLevel={semVerLevel}");
+
+            // Assert
+            Assert.Equal(AvailablePackages.Count, count);
         }
 
         [Fact]


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/4760. AI clearly shows many 404s on this endpoint for the past 90 days.

This has been broken since https://github.com/NuGet/NuGetGallery/commit/3f92c55e42f2905dd415a8bb765fe4adef714c5a (circa February, 2016). We simply forgot to add the `Count` methods required for this to work.