### PR TITLE
Specify the empty string area in UrlExtensions unless otherwise specified

### DIFF
--- a/src/NuGetGallery/Areas/Admin/AdminAreaRegistration.cs
+++ b/src/NuGetGallery/Areas/Admin/AdminAreaRegistration.cs
@@ -9,13 +9,9 @@ namespace NuGetGallery.Areas.Admin
 {
     public class AdminAreaRegistration : AreaRegistration
     {
-        public override string AreaName
-        {
-            get
-            {
-                return "Admin";
-            }
-        }
+        public const string Name = "Admin";
+
+        public override string AreaName => Name;
 
         public override void RegisterArea(AreaRegistrationContext context)
         {

--- a/src/NuGetGallery/Areas/Admin/Controllers/DeleteController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/DeleteController.cs
@@ -117,7 +117,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
                     .Select(username => new UserViewModel
                     {
                         Username = username,
-                        ProfileUrl = Url.User(username, area: string.Empty),
+                        ProfileUrl = Url.User(username),
                     })
                     .ToList()
             };

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -7,11 +7,13 @@ using System.Globalization;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
+using NuGetGallery.Areas.Admin;
 
 namespace NuGetGallery
 {
     public static class UrlExtensions
     {
+        private const string Area = "area";
         private static IGalleryConfigurationService _configuration;
         private const string PackageExplorerDeepLink = @"https://npe.codeplex.com/releases/clickonce/NuGetPackageExplorer.application?url={0}&id={1}&version={2}";
 
@@ -367,7 +369,7 @@ namespace NuGetGallery
         {
             string returnUrl = url.Current();
             // If we're logging off from the Admin Area, don't set a return url
-            if (string.Equals(url.RequestContext.RouteData.DataTokens["area"].ToStringOrNull(), "Admin", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(url.RequestContext.RouteData.DataTokens[Area].ToStringOrNull(), AdminAreaRegistration.Name, StringComparison.OrdinalIgnoreCase))
             {
                 returnUrl = string.Empty;
             }
@@ -379,8 +381,7 @@ namespace NuGetGallery
                 relativeUrl,
                 routeValues: new RouteValueDictionary
                 {
-                    { "returnUrl", returnUrl },
-                    { "area", string.Empty }
+                    { "returnUrl", returnUrl }
                 });
         }
 
@@ -434,25 +435,18 @@ namespace NuGetGallery
             this UrlHelper url,
             string username,
             string scheme = null,
-            string area = null,
             bool relativeUrl = true)
         {
-            var routeValues = new RouteValueDictionary
-            {
-                { "username", username },
-            };
-
-            if (area != null)
-            {
-                routeValues["area"] = area;
-            }
-
             return GetActionLink(
                 url,
                 "Profiles",
                 "Users",
                 relativeUrl,
-                routeValues);
+                routeValues:
+                new RouteValueDictionary
+                {
+                    { "username", username },
+                });
         }
 
         public static string EditPackage(
@@ -776,10 +770,7 @@ namespace NuGetGallery
                 "Index",
                 "Home",
                 relativeUrl,
-                routeValues: new RouteValueDictionary
-                {
-                    { "area", "Admin" }
-                });
+                area: AdminAreaRegistration.Name);
         }
 
         public static string Authenticate(this UrlHelper url, string providerName, string returnUrl, bool relativeUrl = true)
@@ -845,11 +836,18 @@ namespace NuGetGallery
             string controllerName,
             bool relativeUrl,
             RouteValueDictionary routeValues = null,
-            bool interceptReturnUrl = true
+            bool interceptReturnUrl = true,
+            string area = "" // Default to no area. Admin links should specify the "Admin" area explicitly.
             )
         {
             var protocol = GetProtocol(url);
             var hostName = GetConfiguredSiteHostName();
+
+            routeValues = routeValues ?? new RouteValueDictionary();
+            if (!routeValues.ContainsKey(Area))
+            {
+                routeValues[Area] = area;
+            }
             
             if (interceptReturnUrl && routeValues != null && routeValues.ContainsKey("ReturnUrl"))
             {


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/4786.

/cc @xavierdecoster, could you approve this one? You've been doing a lot of work in this area.

/cc @loic-sharma, we talked about this before. I dug into the code via ILSpy and read online. Looks like always specifying the empty area is the right move.