### PR TITLE
Disable custom pages for 400 errors

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -304,7 +304,6 @@
     <customErrors mode="RemoteOnly" defaultRedirect="~/Errors/500" redirectMode="ResponseRedirect">
       <!-- Adding ? at the end of the redirect URL prevents the illegal request to be passed
            as a query parameter to the redirect URL and causing additional failures -->
-      <error statusCode="400" redirect="~/Errors/400?" />
       <error statusCode="404" redirect="~/Errors/404" />
       <error statusCode="500" redirect="~/Errors/500" />
     </customErrors>
@@ -348,10 +347,8 @@
     </modules>
     <validation validateIntegratedModeConfiguration="false" />
     <httpErrors errorMode="DetailedLocalOnly">
-      <remove statusCode="400" />
       <remove statusCode="404" />
       <remove statusCode="500" />
-      <error statusCode="400" path="/Errors/400?" responseMode="ExecuteURL" />
       <error statusCode="404" path="/Errors/404" responseMode="ExecuteURL" />
       <error statusCode="500" path="/Errors/500" responseMode="ExecuteURL" />
     </httpErrors>


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/4793

This is a regression introduced by https://github.com/NuGet/NuGetGallery/commit/f08ce16bb524666add5a961f84574562af7ae763

We never had custom pages for 400 errors.