### PR TITLE
Restrict upload size for packages

### DIFF
--- a/src/NuGetGallery/Constants.cs
+++ b/src/NuGetGallery/Constants.cs
@@ -32,6 +32,9 @@ namespace NuGetGallery
         public const double AllowedLoginAttempts = 10;
 
         public const int MaxEmailSubjectLength = 255;
+        public const int MaxUploadFileSizeInMB = 250;
+        public const int MaxUploadFileSizeInBytes = MaxUploadFileSizeInMB * 1024 * 1024;
+
         internal static readonly NuGetVersion MaxSupportedMinClientVersion = new NuGetVersion("4.1.0.0");
         public const string PackageFileDownloadUriTemplate = "packages/{0}/{1}/download";
 

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -124,7 +124,7 @@ namespace NuGetGallery
             IPackageUploadService packageUploadService)
             : this(entitiesContext, packageService, packageFileService, userService, nugetExeDownloaderService, contentService,
                   indexingService, searchService, autoCuratePackage, statusService, messageService, auditingService,
-                  configurationService, telemetryService, authenticationService, credentialBuilder, securityPolicies, 
+                  configurationService, telemetryService, authenticationService, credentialBuilder, securityPolicies,
                   reservedNamespaceService, packageUploadService)
         {
             StatisticsService = statisticsService;
@@ -352,9 +352,9 @@ namespace NuGetGallery
                     if (packageStream.Length > Constants.MaxUploadFileSizeInBytes)
                     {
                         return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, string.Format(
-                               CultureInfo.CurrentCulture, 
-                               Strings.UploadFileSizeExceedsMaxLimit, 
-                               Constants.MaxUploadFileSizeInMB));
+                            CultureInfo.CurrentCulture,
+                            Strings.UploadFileSizeExceedsMaxLimit,
+                            Constants.MaxUploadFileSizeInMB));
                     }
 
                     using (var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true))
@@ -502,7 +502,7 @@ namespace NuGetGallery
                                 package,
                                 uploadStream.AsSeekableStream());
                         }
-                            
+
                         switch (commitResult)
                         {
                             case PackageCommitResult.Success:

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -349,6 +349,14 @@ namespace NuGetGallery
             {
                 try
                 {
+                    if (packageStream.Length > Constants.MaxUploadFileSizeInBytes)
+                    {
+                        return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, string.Format(
+                               CultureInfo.CurrentCulture, 
+                               Strings.UploadFileSizeExceedsMaxLimit, 
+                               Constants.MaxUploadFileSizeInMB));
+                    }
+
                     using (var archive = new ZipArchive(packageStream, ZipArchiveMode.Read, leaveOpen: true))
                     {
                         var reference = DateTime.UtcNow.AddDays(1); // allow "some" clock skew

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -236,6 +236,7 @@ namespace NuGetGallery
             var currentUser = GetCurrentUser();
             if (uploadFile != null && uploadFile.ContentLength > Constants.MaxUploadFileSizeInBytes)
             {
+                ModelState.AddModelError(String.Empty, string.Format(Strings.UploadFileSizeExceedsMaxLimit, Constants.MaxUploadFileSizeInMB));
                 return (Json(400, new[] { string.Format(Strings.UploadFileSizeExceedsMaxLimit, Constants.MaxUploadFileSizeInMB) }));
             }
 

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -234,7 +234,7 @@ namespace NuGetGallery
         public virtual async Task<JsonResult> UploadPackage(HttpPostedFileBase uploadFile)
         {
             var currentUser = GetCurrentUser();
-            if (uploadFile.ContentLength > Constants.MaxUploadFileSizeInBytes)
+            if (uploadFile != null && uploadFile.ContentLength > Constants.MaxUploadFileSizeInBytes)
             {
                 return (Json(400, new[] { string.Format(Strings.UploadFileSizeExceedsMaxLimit, Constants.MaxUploadFileSizeInMB) }));
             }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -234,6 +234,10 @@ namespace NuGetGallery
         public virtual async Task<JsonResult> UploadPackage(HttpPostedFileBase uploadFile)
         {
             var currentUser = GetCurrentUser();
+            if (uploadFile.ContentLength > Constants.MaxUploadFileSizeInBytes)
+            {
+                return (Json(400, new[] { string.Format(Strings.UploadFileSizeExceedsMaxLimit, Constants.MaxUploadFileSizeInMB) }));
+            }
 
             using (var existingUploadFile = await _uploadFileService.GetUploadFileAsync(currentUser.Key))
             {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1237,7 +1237,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The uploaded file is too big. Max allowed upload file size is {0} MB..
+        ///   Looks up a localized string similar to The uploaded file is too big. Maximum allowed size is {0}MB for the upload file..
         /// </summary>
         public static string UploadFileSizeExceedsMaxLimit {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1237,6 +1237,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The uploaded file is too big. Max allowed upload file size is {0} MB..
+        /// </summary>
+        public static string UploadFileSizeExceedsMaxLimit {
+            get {
+                return ResourceManager.GetString("UploadFileSizeExceedsMaxLimit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This package ID has been reserved. Please request access to upload to this reserved namespace from the owner of the reserved prefix, or re-upload the package with a different ID..
         /// </summary>
         public static string UploadPackage_IdNamespaceConflict {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -601,6 +601,6 @@ For more information, please contact '{2}'.</value>
     <value>Enqueuing unavailable: the gallery is currently in read only mode, with limited service. Please try again later.</value>
   </data>
   <data name="UploadFileSizeExceedsMaxLimit" xml:space="preserve">
-    <value>The uploaded file is too big. Max allowed upload file size is {0} MB.</value>
+    <value>The uploaded file is too big. Maximum allowed size is {0}MB for the upload file.</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -600,4 +600,7 @@ For more information, please contact '{2}'.</value>
   <data name="CannotEnqueueDueToReadOnly" xml:space="preserve">
     <value>Enqueuing unavailable: the gallery is currently in read only mode, with limited service. Please try again later.</value>
   </data>
+  <data name="UploadFileSizeExceedsMaxLimit" xml:space="preserve">
+    <value>The uploaded file is too big. Max allowed upload file size is {0} MB.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/4823. This should also prevent the index lag caused by humongous file sizes, like the issue that happened today.