### PR TITLE
Added credential key to AuditActor

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -472,7 +472,7 @@ namespace NuGetGallery
                 FileSystemFileStorageService.ResolvePath(configuration.Current.FileStorageDirectory),
                 FileSystemAuditingService.DefaultContainerName);
 
-            return new FileSystemAuditingService(auditingPath, AuditActor.GetAspNetOnBehalfOfAsync);
+            return new FileSystemAuditingService(auditingPath, AuditingHelper.GetAspNetOnBehalfOfAsync);
         }
 
         private static void ConfigureForAzureStorage(ContainerBuilder builder, IGalleryConfigurationService configuration)
@@ -567,7 +567,7 @@ namespace NuGetGallery
 
             var localIp = AuditActor.GetLocalIpAddressAsync().Result;
 
-            var service = new CloudAuditingService(instanceId, localIp, configuration.Current.AzureStorage_Auditing_ConnectionString, AuditActor.GetAspNetOnBehalfOfAsync);
+            var service = new CloudAuditingService(instanceId, localIp, configuration.Current.AzureStorage_Auditing_ConnectionString, AuditingHelper.GetAspNetOnBehalfOfAsync);
 
             builder.RegisterInstance(service)
                 .As<ICloudStorageStatusDependency>()

--- a/src/NuGetGallery/Authentication/NuGetClaims.cs
+++ b/src/NuGetGallery/Authentication/NuGetClaims.cs
@@ -10,5 +10,8 @@ namespace NuGetGallery.Authentication
         public const string ApiKey = "https://claims.nuget.org/apikey";
 
         public const string Scope = "https://claims.nuget.org/scope";
+
+        // Allows identifying the credential that was used by his DB key.
+        public const string CredentialKey = "https://claims.nuget.org/credentialkey";
     }
 }

--- a/src/NuGetGallery/Authentication/Providers/ApiKey/ApiKeyAuthenticationHandler.cs
+++ b/src/NuGetGallery/Authentication/Providers/ApiKey/ApiKeyAuthenticationHandler.cs
@@ -109,7 +109,8 @@ namespace NuGetGallery.Authentication.Providers.ApiKey
                                 authUser.User, 
                                 AuthenticationTypes.ApiKey, 
                                 new Claim(NuGetClaims.ApiKey, apiKey),
-                                new Claim(NuGetClaims.Scope, scopes)),
+                                new Claim(NuGetClaims.Scope, scopes),
+                                new Claim(NuGetClaims.CredentialKey, authUser.CredentialUsed.Key.ToString())),
                             new AuthenticationProperties());
                 }
                 else

--- a/src/NuGetGallery/Helpers/AuditingHelper.cs
+++ b/src/NuGetGallery/Helpers/AuditingHelper.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using System.Web;
+using NuGetGallery.Auditing;
+using NuGetGallery.Authentication;
+
+namespace NuGetGallery
+{
+    public static class AuditingHelper
+    {
+        public static Task<AuditActor> GetAspNetOnBehalfOfAsync()
+        {
+            // Use HttpContext to build an actor representing the user performing the action
+            var context = HttpContext.Current;
+            if (context == null)
+            {
+                return Task.FromResult<AuditActor>(null);
+            }
+
+            return GetAspNetOnBehalfOfAsync(new HttpContextWrapper(context));
+        }
+
+        public static Task<AuditActor> GetAspNetOnBehalfOfAsync(HttpContextBase context)
+        {
+            // Try to identify the client IP using various server variables
+            var clientIpAddress = context.Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
+            if (string.IsNullOrEmpty(clientIpAddress)) // Try REMOTE_ADDR server variable
+            {
+                clientIpAddress = context.Request.ServerVariables["REMOTE_ADDR"];
+            }
+
+            if (string.IsNullOrEmpty(clientIpAddress)) // Try UserHostAddress property
+            {
+                clientIpAddress = context.Request.UserHostAddress;
+            }
+
+            if (!string.IsNullOrEmpty(clientIpAddress) && clientIpAddress.IndexOf(".", StringComparison.Ordinal) > 0)
+            {
+                clientIpAddress = clientIpAddress.Substring(0, clientIpAddress.LastIndexOf(".", StringComparison.Ordinal)) + ".0";
+            }
+
+            string user = null;
+            string authType = null;
+            string credentialKey = null;
+
+            if (context.User != null)
+            {
+                user = context.User.Identity.Name;
+                authType = context.User.Identity.AuthenticationType;
+
+                var claimsIdentity = context.User.Identity as ClaimsIdentity;
+                credentialKey = claimsIdentity?.GetClaimOrDefault(NuGetClaims.CredentialKey);
+            }
+
+            return Task.FromResult(new AuditActor(
+                null,
+                clientIpAddress,
+                user,
+                authType,
+                credentialKey,
+                DateTime.UtcNow));
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -768,6 +768,7 @@
     <Compile Include="Controllers\PagesController.cs" />
     <Compile Include="Filters\ApiScopeRequiredAttribute.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Helpers\AuditingHelper.cs" />
     <Compile Include="Helpers\GravatarHelper.cs" />
     <Compile Include="Helpers\RegexEx.cs" />
     <Compile Include="Services\AsynchronousPackageValidationInitiator.cs" />

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditActorTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditActorTests.cs
@@ -3,15 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using System.Security.Principal;
 using System.Threading.Tasks;
-using System.Web;
-using Moq;
 using Xunit;
 
 namespace NuGetGallery.Auditing
@@ -26,6 +22,7 @@ namespace NuGetGallery.Auditing
                 machineIP: null,
                 userName: null,
                 authenticationType: null,
+                credentialKey: null,
                 timeStampUtc: DateTime.MinValue);
 
             Assert.Null(actor.MachineName);
@@ -41,6 +38,7 @@ namespace NuGetGallery.Auditing
                 machineIP: null,
                 userName: null,
                 authenticationType: null,
+                credentialKey: null,
                 timeStampUtc: DateTime.MinValue,
                 onBehalfOf: null);
 
@@ -55,33 +53,35 @@ namespace NuGetGallery.Auditing
         public void Constructor_WithoutOnBehalfOf_AcceptsEmptyStringValues()
         {
             var actor = new AuditActor(
-                machineName: "",
-                machineIP: "",
-                userName: "",
-                authenticationType: "",
+                machineName: string.Empty,
+                machineIP: string.Empty,
+                userName: string.Empty,
+                authenticationType: string.Empty,
+                credentialKey: string.Empty,
                 timeStampUtc: DateTime.MinValue);
 
-            Assert.Equal("", actor.MachineName);
-            Assert.Equal("", actor.MachineIP);
-            Assert.Equal("", actor.UserName);
-            Assert.Equal("", actor.AuthenticationType);
+            Assert.Equal(string.Empty, actor.MachineName);
+            Assert.Equal(string.Empty, actor.MachineIP);
+            Assert.Equal(string.Empty, actor.UserName);
+            Assert.Equal(string.Empty, actor.AuthenticationType);
         }
 
         [Fact]
         public void Constructor_WithOnBehalfOf_AcceptsEmptyStringValues()
         {
             var actor = new AuditActor(
-                machineName: "",
-                machineIP: "",
-                userName: "",
-                authenticationType: "",
+                machineName: string.Empty,
+                machineIP: string.Empty,
+                userName: string.Empty,
+                authenticationType: string.Empty,
+                credentialKey: string.Empty,
                 timeStampUtc: DateTime.MinValue,
                 onBehalfOf: null);
 
-            Assert.Equal("", actor.MachineName);
-            Assert.Equal("", actor.MachineIP);
-            Assert.Equal("", actor.UserName);
-            Assert.Equal("", actor.AuthenticationType);
+            Assert.Equal(string.Empty, actor.MachineName);
+            Assert.Equal(string.Empty, actor.MachineIP);
+            Assert.Equal(string.Empty, actor.UserName);
+            Assert.Equal(string.Empty, actor.AuthenticationType);
         }
 
         [Fact]
@@ -92,12 +92,14 @@ namespace NuGetGallery.Auditing
                 machineIP: "b",
                 userName: "c",
                 authenticationType: "d",
+                credentialKey: "e",
                 timeStampUtc: DateTime.MinValue);
 
             Assert.Equal("a", actor.MachineName);
             Assert.Equal("b", actor.MachineIP);
             Assert.Equal("c", actor.UserName);
             Assert.Equal("d", actor.AuthenticationType);
+            Assert.Equal("e", actor.CredentialKey);
             Assert.Equal(DateTime.MinValue, actor.TimestampUtc);
         }
 
@@ -109,12 +111,14 @@ namespace NuGetGallery.Auditing
                 machineIP: null,
                 userName: null,
                 authenticationType: null,
+                credentialKey: null,
                 timeStampUtc: DateTime.MinValue);
             var actor = new AuditActor(
                 machineName: "a",
                 machineIP: "b",
                 userName: "c",
                 authenticationType: "d",
+                credentialKey: "e",
                 timeStampUtc: DateTime.MinValue,
                 onBehalfOf: onBehalfOfActor);
 
@@ -122,172 +126,11 @@ namespace NuGetGallery.Auditing
             Assert.Equal("b", actor.MachineIP);
             Assert.Equal("c", actor.UserName);
             Assert.Equal("d", actor.AuthenticationType);
+            Assert.Equal("e", actor.CredentialKey);
             Assert.Equal(DateTime.MinValue, actor.TimestampUtc);
             Assert.Same(onBehalfOfActor, actor.OnBehalfOf);
         }
-
-        [Fact]
-        public async Task GetAspNetOnBehalfOfAsync_WithoutContext_ReturnsNullForNullHttpContext()
-        {
-            var actor = await AuditActor.GetAspNetOnBehalfOfAsync();
-
-            Assert.Null(actor);
-        }
-
-        [Fact]
-        public async Task GetAspNetOnBehalfOfAsync_WithContext_ReturnsActor_WithHttpXForwardedForHeader()
-        {
-            var request = new Mock<HttpRequestBase>();
-            var identity = new Mock<IIdentity>();
-            var user = new Mock<IPrincipal>();
-            var context = new Mock<HttpContextBase>();
-
-            request.SetupGet(x => x.ServerVariables)
-                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "a" } });
-            identity.Setup(x => x.Name)
-                .Returns("b");
-            identity.Setup(x => x.AuthenticationType)
-                .Returns("c");
-            user.Setup(x => x.Identity)
-                .Returns(identity.Object);
-            context.Setup(x => x.Request)
-                .Returns(request.Object);
-            context.Setup(x => x.User)
-                .Returns(user.Object);
-
-            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
-
-            Assert.NotNull(actor);
-            Assert.Equal("c", actor.AuthenticationType);
-            Assert.Equal("a", actor.MachineIP);
-            Assert.Null(actor.MachineName);
-            Assert.Null(actor.OnBehalfOf);
-            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
-            Assert.Equal("b", actor.UserName);
-        }
-
-        [Fact]
-        public async Task GetAspNetOnBehalfOfAsync_WithContext_ReturnsActor_WithRemoteAddrHeader()
-        {
-            var request = new Mock<HttpRequestBase>();
-            var identity = new Mock<IIdentity>();
-            var user = new Mock<IPrincipal>();
-            var context = new Mock<HttpContextBase>();
-
-            request.SetupGet(x => x.ServerVariables)
-                .Returns(new NameValueCollection() { { "REMOTE_ADDR", "a" } });
-            identity.Setup(x => x.Name)
-                .Returns("b");
-            identity.Setup(x => x.AuthenticationType)
-                .Returns("c");
-            user.Setup(x => x.Identity)
-                .Returns(identity.Object);
-            context.Setup(x => x.Request)
-                .Returns(request.Object);
-            context.Setup(x => x.User)
-                .Returns(user.Object);
-
-            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
-
-            Assert.NotNull(actor);
-            Assert.Equal("c", actor.AuthenticationType);
-            Assert.Equal("a", actor.MachineIP);
-            Assert.Null(actor.MachineName);
-            Assert.Null(actor.OnBehalfOf);
-            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
-            Assert.Equal("b", actor.UserName);
-        }
-
-        [Fact]
-        public async Task GetAspNetOnBehalfOfAsync_WithContext_ReturnsActor_WithUserHostAddress()
-        {
-            var request = new Mock<HttpRequestBase>();
-            var identity = new Mock<IIdentity>();
-            var user = new Mock<IPrincipal>();
-            var context = new Mock<HttpContextBase>();
-
-            request.SetupGet(x => x.ServerVariables)
-                .Returns(new NameValueCollection());
-            request.SetupGet(x => x.UserHostAddress)
-                .Returns("a");
-            identity.Setup(x => x.Name)
-                .Returns("b");
-            identity.Setup(x => x.AuthenticationType)
-                .Returns("c");
-            user.Setup(x => x.Identity)
-                .Returns(identity.Object);
-            context.Setup(x => x.Request)
-                .Returns(request.Object);
-            context.Setup(x => x.User)
-                .Returns(user.Object);
-
-            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
-
-            Assert.NotNull(actor);
-            Assert.Equal("c", actor.AuthenticationType);
-            Assert.Equal("a", actor.MachineIP);
-            Assert.Null(actor.MachineName);
-            Assert.Null(actor.OnBehalfOf);
-            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
-            Assert.Equal("b", actor.UserName);
-        }
-
-        [Fact]
-        public async Task GetAspNetOnBehalfOfAsync_WithContext_ObfuscatesLastIpAddressOctet()
-        {
-            var request = new Mock<HttpRequestBase>();
-            var identity = new Mock<IIdentity>();
-            var user = new Mock<IPrincipal>();
-            var context = new Mock<HttpContextBase>();
-
-            request.SetupGet(x => x.ServerVariables)
-                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "1.2.3.4" } });
-            identity.Setup(x => x.Name)
-                .Returns("b");
-            identity.Setup(x => x.AuthenticationType)
-                .Returns("c");
-            user.Setup(x => x.Identity)
-                .Returns(identity.Object);
-            context.Setup(x => x.Request)
-                .Returns(request.Object);
-            context.Setup(x => x.User)
-                .Returns(user.Object);
-
-            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
-
-            Assert.NotNull(actor);
-            Assert.Equal("c", actor.AuthenticationType);
-            Assert.Equal("1.2.3.0", actor.MachineIP);
-            Assert.Null(actor.MachineName);
-            Assert.Null(actor.OnBehalfOf);
-            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
-            Assert.Equal("b", actor.UserName);
-        }
-
-        [Fact]
-        public async Task GetAspNetOnBehalfOfAsync_WithContext_SupportsNullUser()
-        {
-            var request = new Mock<HttpRequestBase>();
-            var context = new Mock<HttpContextBase>();
-
-            request.SetupGet(x => x.ServerVariables)
-                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "1.2.3.4" } });
-            context.Setup(x => x.Request)
-                .Returns(request.Object);
-            context.Setup(x => x.User)
-                .Returns((IPrincipal)null);
-
-            var actor = await AuditActor.GetAspNetOnBehalfOfAsync(context.Object);
-
-            Assert.NotNull(actor);
-            Assert.Null(actor.AuthenticationType);
-            Assert.Equal("1.2.3.0", actor.MachineIP);
-            Assert.Null(actor.MachineName);
-            Assert.Null(actor.OnBehalfOf);
-            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
-            Assert.Null(actor.UserName);
-        }
-
+       
         [Fact]
         public async Task GetCurrentMachineActorAsync_WithoutOnBehalfOf()
         {

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditEntryTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditEntryTests.cs
@@ -27,6 +27,7 @@ namespace NuGetGallery.Auditing
                 machineIP: null,
                 userName: null,
                 authenticationType: null,
+                credentialKey: null,
                 timeStampUtc: DateTime.MinValue);
             var entry = new AuditEntry(record.Object, actor);
 

--- a/tests/NuGetGallery.Core.Facts/Auditing/FileSystemAuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/FileSystemAuditingServiceTests.cs
@@ -36,7 +36,7 @@ namespace NuGetGallery.Auditing
         {
             var service = new FileSystemAuditingService(
                 auditingPath: "a",
-                getOnBehalfOf: AuditActor.GetAspNetOnBehalfOfAsync);
+                getOnBehalfOf: GetOnBehalfOf);
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                 await service.SaveAuditRecordAsync(record: null));
@@ -141,6 +141,7 @@ namespace NuGetGallery.Auditing
                 machineIP: "b",
                 userName: "c",
                 authenticationType: "d",
+                credentialKey: "e",
                 timeStampUtc: DateTime.MinValue);
 
             return Task.FromResult<AuditActor>(actor);

--- a/tests/NuGetGallery.Facts/Helpers/AuditingHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/AuditingHelperFacts.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading.Tasks;
+using System.Web;
+using Moq;
+using NuGetGallery.Authentication;
+using Xunit;
+
+namespace NuGetGallery.Helpers
+{
+    public class AuditingHelperFacts
+    {
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithoutContext_ReturnsNullForNullHttpContext()
+        {
+            var actor = await AuditingHelper.GetAspNetOnBehalfOfAsync();
+
+            Assert.Null(actor);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_ReturnsActor_WithHttpXForwardedForHeader()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var identity = new Mock<IIdentity>();
+            var user = new Mock<IPrincipal>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "a" } });
+            identity.Setup(x => x.Name)
+                .Returns("b");
+            identity.Setup(x => x.AuthenticationType)
+                .Returns("c");
+            user.Setup(x => x.Identity)
+                .Returns(identity.Object);
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns(user.Object);
+
+            var actor = await AuditingHelper.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Equal("c", actor.AuthenticationType);
+            Assert.Equal("a", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal("b", actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_ReturnsActor_WithRemoteAddrHeader()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var identity = new Mock<IIdentity>();
+            var user = new Mock<IPrincipal>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection() { { "REMOTE_ADDR", "a" } });
+            identity.Setup(x => x.Name)
+                .Returns("b");
+            identity.Setup(x => x.AuthenticationType)
+                .Returns("c");
+            user.Setup(x => x.Identity)
+                .Returns(identity.Object);
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns(user.Object);
+
+            var actor = await AuditingHelper.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Equal("c", actor.AuthenticationType);
+            Assert.Equal("a", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal("b", actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_ReturnsActor_WithUserHostAddress()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var identity = new Mock<IIdentity>();
+            var user = new Mock<IPrincipal>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection());
+            request.SetupGet(x => x.UserHostAddress)
+                .Returns("a");
+            identity.Setup(x => x.Name)
+                .Returns("b");
+            identity.Setup(x => x.AuthenticationType)
+                .Returns("c");
+            user.Setup(x => x.Identity)
+                .Returns(identity.Object);
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns(user.Object);
+
+            var actor = await AuditingHelper.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Equal("c", actor.AuthenticationType);
+            Assert.Equal("a", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal("b", actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_ObfuscatesLastIpAddressOctet()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var identity = new Mock<IIdentity>();
+            var user = new Mock<IPrincipal>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "1.2.3.4" } });
+            identity.Setup(x => x.Name)
+                .Returns("b");
+            identity.Setup(x => x.AuthenticationType)
+                .Returns("c");
+            user.Setup(x => x.Identity)
+                .Returns(identity.Object);
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns(user.Object);
+
+            var actor = await AuditingHelper.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Equal("c", actor.AuthenticationType);
+            Assert.Equal("1.2.3.0", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal("b", actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_ResturnActorWithCredentialKey()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var identity = new Mock<IIdentity>();
+            var user = new Mock<IPrincipal>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "1.2.3.4" } });
+            identity.Setup(x => x.Name)
+                .Returns("b");
+            identity.Setup(x => x.AuthenticationType)
+                .Returns("c");
+
+            var cliamsIdentity = new ClaimsIdentity(identity.Object, new List<Claim> { new Claim(NuGetClaims.CredentialKey, "99") });
+            user.Setup(x => x.Identity)
+                .Returns(cliamsIdentity);
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns(user.Object);
+
+            var actor = await AuditingHelper.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Equal("c", actor.AuthenticationType);
+            Assert.Equal("99", actor.CredentialKey);
+            Assert.Equal("1.2.3.0", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Equal("b", actor.UserName);
+        }
+
+        [Fact]
+        public async Task GetAspNetOnBehalfOfAsync_WithContext_SupportsNullUser()
+        {
+            var request = new Mock<HttpRequestBase>();
+            var context = new Mock<HttpContextBase>();
+
+            request.SetupGet(x => x.ServerVariables)
+                .Returns(new NameValueCollection() { { "HTTP_X_FORWARDED_FOR", "1.2.3.4" } });
+            context.Setup(x => x.Request)
+                .Returns(request.Object);
+            context.Setup(x => x.User)
+                .Returns((IPrincipal)null);
+
+            var actor = await AuditingHelper.GetAspNetOnBehalfOfAsync(context.Object);
+
+            Assert.NotNull(actor);
+            Assert.Null(actor.AuthenticationType);
+            Assert.Equal("1.2.3.0", actor.MachineIP);
+            Assert.Null(actor.MachineName);
+            Assert.Null(actor.OnBehalfOf);
+            Assert.InRange(actor.TimestampUtc, DateTime.UtcNow.AddMinutes(-1), DateTime.UtcNow.AddMinutes(1));
+            Assert.Null(actor.UserName);
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -423,6 +423,7 @@
     <Compile Include="Controllers\StatisticsControllerFacts.cs" />
     <Compile Include="Controllers\UsersControllerFacts.cs" />
     <Compile Include="Framework\TestGalleryConfigurationService.cs" />
+    <Compile Include="Helpers\AuditingHelperFacts.cs" />
     <Compile Include="Helpers\HtmlExtensionsFacts.cs" />
     <Compile Include="Security\RequireMinProtocolVersionForPushPolicyFacts.cs" />
     <Compile Include="Services\PackageOwnerRequestServiceFacts.cs" />


### PR DESCRIPTION
Moved some of the AuditActor creation code from NuGetGallery.Core to NuGetGallery to allow usage of NuGetClaims.
Let me know if this looks good, and I will apply changes to Shims.