### PR TITLE
Add a hidden skip to content link.

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -260,6 +260,17 @@ img.package-icon {
 
   overflow-wrap: break-word;
 }
+.showOnFocus {
+  display: block;
+  height: 0;
+  overflow: hidden;
+  line-height: 0;
+}
+.showOnFocus:focus {
+  height: 2em;
+  line-height: 2em;
+  color: #e3ebf1;
+}
 #edit-metadata-form-container .loading:after {
   display: inline-block;
   /* ascii code for the ellipsis character */

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -330,3 +330,16 @@ img.package-icon {
   word-break: normal;
   word-break: break-word;
 }
+
+.showOnFocus {
+  display: block;
+  line-height:0;
+  height: 0;
+  overflow: hidden;
+}
+
+.showOnFocus:focus {
+  line-height:2em;
+  height: 2em;
+  color: @navbar-inverse-color;
+}

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -260,6 +260,17 @@ img.package-icon {
 
   overflow-wrap: break-word;
 }
+.showOnFocus {
+  display: block;
+  height: 0;
+  overflow: hidden;
+  line-height: 0;
+}
+.showOnFocus:focus {
+  height: 2em;
+  line-height: 2em;
+  color: #e3ebf1;
+}
 #edit-metadata-form-container .loading:after {
   display: inline-block;
   /* ascii code for the ellipsis character */

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -46,6 +46,11 @@
 <nav class="navbar navbar-inverse" role="navigation">
     <div class="container">
         <div class="row">
+            <div class="col-sm-12 text-center">
+                <a href="#skippedToContent" class="showOnFocus" aria-label="Skip To Content" role="navigation">Skip To Content</a>
+            </div>
+        </div>
+        <div class="row">
             <div class="col-sm-12">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -47,7 +47,7 @@
     <div class="container">
         <div class="row">
             <div class="col-sm-12 text-center">
-                <a href="#skippedToContent" class="showOnFocus" aria-label="Skip To Content" role="navigation">Skip To Content</a>
+                <a href="#skippedToContent" class="showOnFocus" title="Skip To Content" role="navigation">Skip To Content</a>
             </div>
         </div>
         <div class="row">

--- a/src/NuGetGallery/Views/Shared/Gallery/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Layout.cshtml
@@ -7,7 +7,7 @@
     @RenderSection("SocialMeta", required: false)
     @RenderSection("Meta", required: false)
 
-    <title>
+    <title>     
         @(Config.Current.Brand)
         @(String.IsNullOrWhiteSpace(ViewBag.Title) ? "" : "| " + ViewBag.Title)
     </title>
@@ -33,7 +33,9 @@
 </head>
 <body>
     @Html.Partial("Gallery/Header")
+    <div id="skippedToContent">
     @RenderBody()
+    </div>
     @Html.Partial("Gallery/Footer")
     @Scripts.Render("~/Scripts/gallery/site.min.js")
     @RenderSection("BottomScripts", required: false)


### PR DESCRIPTION
Page view on load:
![image](https://user-images.githubusercontent.com/11051729/31568405-0cc50c14-b029-11e7-9797-a2c82b754e34.png)

Page View on First tab
![image](https://user-images.githubusercontent.com/11051729/31568424-272d6218-b029-11e7-86c5-1d727ab77813.png)

This element is only reachable by tab navigation.

@joelverhagen @skofman1 @xavierdecoster