### PR TITLE
Do not toggle doc chevron on clamp (#4812)

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -143,6 +143,10 @@
         var showIcon = $('#show-' + prefix + ' i');
         var showText = $('#show-' + prefix + ' span');
         hidden.on('hide.bs.collapse', function (e) {
+            if (e.target !== e.currentTarget) {
+                return;
+            }
+
             showIcon.removeClass('ms-Icon--' + moreIcon);
             showIcon.addClass('ms-Icon--' + lessIcon);
             if (moreMessage !== null) {
@@ -151,6 +155,10 @@
             e.stopPropagation();
         });
         hidden.on('show.bs.collapse', function (e) {
+            if (e.target !== e.currentTarget) {
+                return;
+            }
+
             showIcon.removeClass('ms-Icon--' + lessIcon);
             showIcon.addClass('ms-Icon--' + moreIcon);
             if (lessMessage !== null) {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -271,15 +271,13 @@
 
             @if (Model.ReadMeHtml != null)
             {
-                <div id="readme-collapser-container">
-                    <h2>
-                        <a href="#" role="button" data-toggle="collapse" data-target="#readme-container"
-                           aria-expanded="true" aria-controls="readme-container" id="show-readme-container">
-                            <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
-                            <span>Documentation</span>
-                        </a>
-                    </h2>
-                </div>
+                <h2>
+                    <a href="#" role="button" data-toggle="collapse" data-target="#readme-container"
+                        aria-expanded="true" aria-controls="readme-container" id="show-readme-container">
+                        <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                        <span>Documentation</span>
+                    </a>
+                </h2>
                 <div id="readme-container" class="collapse in">
                     <div id="readme-clamped" class="readme collapse in">
                         @Html.Raw(Model.ReadMeHtmlClamped)


### PR DESCRIPTION
The documentation section (expander heading) contains a nested expander which toggles between the full and clamped versions. Clicking 'show [more|less]' for the inner expander was triggering the parent's hide/show collapse handlers and causing the Documentation chevron to toggle incorrectly. This change only toggles icons when the current target is the one that triggered the event.