### PR TITLE
Fix: no need to show both verify and edit warnings on edit package page.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -218,7 +218,6 @@ var AsyncFileUploadManager = new function () {
             $(reportContainerElement).attr("class", "collapse in");
             $(reportContainerElement).attr("aria-expanded", "true");
             $(reportContainerElement).attr("data-bind", "template: { name: 'edit-metadata-template', data: data }");
-            $("#verify-package-container").removeClass("hidden");
             $("#verify-package-container").append(reportContainerElement);
             ko.applyBindings({ data: model }, reportContainerElement);
 

--- a/src/NuGetGallery/Scripts/gallery/page-edit.js
+++ b/src/NuGetGallery/Scripts/gallery/page-edit.js
@@ -151,7 +151,6 @@ var EditViewManager = new function () {
             $(reportContainerElement).attr("class", "collapse in");
             $(reportContainerElement).attr("aria-expanded", "true");
             $(reportContainerElement).attr("data-bind", "template: { name: 'edit-metadata-template', data: data }");
-            $("#verify-package-container").removeClass("hidden");
             $("#verify-package-container").append(reportContainerElement);
             ko.applyBindings({ data: model }, reportContainerElement);
 

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -56,7 +56,8 @@
                     @ViewHelpers.AlertWarning(@<text>You had an upload in progress. You can continue it here or cancel to restart.</text>)
                 </div>
             }
-
+            
+            @ViewHelpers.AlertPackageVerifyRecommendation()
             @Html.Partial("_EditForm")
         </div>
     </div>

--- a/src/NuGetGallery/Views/Packages/_EditForm.cshtml
+++ b/src/NuGetGallery/Views/Packages/_EditForm.cshtml
@@ -11,8 +11,7 @@
         </h2>
     </div>
 
-    <div id="verify-package-container" class="hidden">
-        @ViewHelpers.AlertPackageVerifyRecommendation()
+    <div id="verify-package-container">
     </div>
 
     @Html.Partial("_EditMetadata")


### PR DESCRIPTION
Moved the warning out of the form to avoid showing both on regular edit page.