### PR TITLE
Fix NullReferenceException on GET Users/Packages

### DIFF
--- a/src/NuGetGallery/Services/PackageOwnerRequestService.cs
+++ b/src/NuGetGallery/Services/PackageOwnerRequestService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -45,7 +46,7 @@ namespace NuGetGallery
 
         public IEnumerable<PackageOwnerRequest> GetPackageOwnershipRequests(PackageRegistration package = null, User requestingOwner = null, User newOwner = null)
         {
-            var query = _packageOwnerRequestRepository.GetAll();
+            var query = _packageOwnerRequestRepository.GetAll().Include(e => e.PackageRegistration);
 
             if (package != null)
             {

--- a/src/NuGetGallery/ViewModels/OwnerRequestsListItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/OwnerRequestsListItemViewModel.cs
@@ -1,23 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 namespace NuGetGallery
 {
     public class OwnerRequestsListItemViewModel
     {
-        public PackageOwnerRequest Request { get; }
-
-        public Package Package { get; }
-        
         public OwnerRequestsListItemViewModel(PackageOwnerRequest request, IPackageService packageService)
         {
             Request = request;
             Package = packageService.FindPackageByIdAndVersion(request.PackageRegistration.Id, version: null, semVerLevelKey: SemVerLevelKey.SemVer2, allowPrerelease: true);
         }
+
+        public PackageOwnerRequest Request { get; }
+
+        public Package Package { get; }
     }
 }

--- a/src/NuGetGallery/ViewModels/OwnerRequestsListViewModel.cs
+++ b/src/NuGetGallery/ViewModels/OwnerRequestsListViewModel.cs
@@ -8,17 +8,17 @@ namespace NuGetGallery
 {
     public class OwnerRequestsListViewModel
     {
-        public IEnumerable<OwnerRequestsListItemViewModel> RequestItems { get; }
-
-        public string Name { get; }
-
-        public User CurrentUser { get; }
-        
         public OwnerRequestsListViewModel(IEnumerable<PackageOwnerRequest> requests, string name, User currentUser, IPackageService packageService)
         {
             RequestItems = requests.Select(r => new OwnerRequestsListItemViewModel(r, packageService)).ToArray();
             Name = name;
             CurrentUser = currentUser;
         }
+
+        public IEnumerable<OwnerRequestsListItemViewModel> RequestItems { get; }
+
+        public string Name { get; }
+
+        public User CurrentUser { get; }
     }
 }


### PR DESCRIPTION
The EF queries for retrieving `PackageOwnerRequest` did not include the `PackageRegistration` relationship, which the view models now seem to rely on.

cc @scottbommarito 