### PR TITLE
Fix graph labels on statistics

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
+++ b/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
@@ -261,11 +261,22 @@ var GetChartData = function (rawData, filter) {
 }
 
 var GetShortNumberString = function (number) {
+    if (number == 0) {
+        return "0";
+    }
+
     var abbreviation = ["", "k", "M", "B", "T", "q", "Q", "s", "S", "o", "n"];
     var numDiv = 0;
     while (number >= 1000) {
-        number = Math.floor(number / 1000);
+        number = number / 1000.0;
         numDiv++;
+    }
+
+    rounded = Math.floor(number);
+    if (rounded >= 100) {
+        number = number.toPrecision(3);
+    } else {
+        number = number.toPrecision(2);
     }
 
     if (numDiv >= abbreviation.Length) {


### PR DESCRIPTION
Update number shortener to maintain enough sig figs for distinction.
Addresses https://github.com/NuGet/NuGetGallery/issues/4811

Before:
![image](https://user-images.githubusercontent.com/11051729/31968586-79683d96-b8c6-11e7-9128-3c24796ef4a8.png)

After:
![image](https://user-images.githubusercontent.com/11051729/31968622-90e4d4ac-b8c6-11e7-8b4f-3b443714fcf5.png)
