### PR TITLE
Modify ExtensionMethods.IsOwner to support Organizations

### DIFF
--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -50,7 +50,7 @@ namespace NuGetGallery
                 return Json(new { message = Strings.AddOwner_PackageNotFound });
             }
 
-            if (!package.IsOwnerOrAdmin(HttpContext.User))
+            if (!package.IsOwner(HttpContext.User, allowAdmin: true))
             {
                 return new HttpUnauthorizedResult();
             }
@@ -309,7 +309,7 @@ namespace NuGetGallery
                 model = new ManagePackageOwnerModel(Strings.AddOwner_PackageNotFound);
                 return false;
             }
-            if (!package.IsOwnerOrAdmin(HttpContext.User))
+            if (!package.IsOwner(HttpContext.User, allowAdmin: true))
             {
                 model = new ManagePackageOwnerModel(Strings.AddOwner_NotPackageOwner);
                 return false;

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -469,7 +469,7 @@ namespace NuGetGallery
             ViewBag.FacebookAppID = _config.FacebookAppId;
             return View(model);
         }
-        
+
         public virtual async Task<ActionResult> ListPackages(PackageListSearchViewModel searchAndListModel)
         {
             var page = searchAndListModel.Page;

--- a/src/NuGetGallery/ExtensionMethods.cs
+++ b/src/NuGetGallery/ExtensionMethods.cs
@@ -206,8 +206,8 @@ namespace NuGetGallery
                     .Where(u => u.Organization != null)
                     .Any(u =>
                     {
-                        var members = allowCollaborator ? u.Organization.Members : u.Organization.Administrators;
-                        return members.Any(m => m.Username == user.Identity.Name);
+                        var members = allowCollaborator ? u.Organization.Memberships : u.Organization.Memberships.Where(m => m.IsAdmin);
+                        return members.Any(m => m.Member.Username == user.Identity.Name);
                     });
         }
 
@@ -230,8 +230,8 @@ namespace NuGetGallery
                     .Where(u => u.Organization != null)
                     .Any(u =>
                     {
-                        var members = allowCollaborator ? u.Organization.Members : u.Organization.Administrators;
-                        return members.Any(m => m.Key == user.Key);
+                        var members = allowCollaborator ? u.Organization.Memberships : u.Organization.Memberships.Where(m => m.IsAdmin);
+                        return members.Any(m => m.Member.Key == user.Key);
                     });
         }
 

--- a/src/NuGetGallery/ExtensionMethods.cs
+++ b/src/NuGetGallery/ExtensionMethods.cs
@@ -177,40 +177,62 @@ namespace NuGetGallery
             return items.Any(predicate);
         }
 
-        public static bool IsOwnerOrAdmin(this Package package, IPrincipal user)
+        public static bool IsOwner(this Package package, IPrincipal user, bool allowAdmin = false, bool allowCollaborator = false)
         {
-            return package.PackageRegistration.IsOwnerOrAdmin(user);
+            return package.PackageRegistration.IsOwner(user, allowAdmin, allowCollaborator);
         }
 
-        public static bool IsOwner(this Package package, User user)
+        public static bool IsOwner(this Package package, User user, bool allowAdmin = false, bool allowCollaborator = false)
         {
-            return package.PackageRegistration.IsOwner(user);
+            return package.PackageRegistration.IsOwner(user, allowAdmin, allowCollaborator);
         }
 
-        public static bool IsOwnerOrAdmin(this PackageRegistration package, IPrincipal user)
+        public static bool IsOwner(this PackageRegistration package, IPrincipal user, bool allowAdmin = false, bool allowCollaborator = false)
         {
             if (package == null)
             {
                 throw new ArgumentNullException(nameof(package));
             }
-            if (user == null || user.Identity == null)
-            {
-                return false;
-            }
-            return user.IsAdministrator() || package.Owners.Any(u => u.Username == user.Identity.Name);
-        }
 
-        public static bool IsOwner(this PackageRegistration package, User user)
-        {
-            if (package == null)
-            {
-                throw new ArgumentNullException(nameof(package));
-            }
             if (user == null)
             {
                 return false;
             }
-            return package.Owners.Any(u => u.Key == user.Key);
+
+            return
+                (allowAdmin && user.IsAdministrator()) ||
+                package.Owners.Any(u => u.Username == user.Identity.Name) ||
+                package.Owners
+                    .Where(u => u.Organization != null)
+                    .Any(u =>
+                    {
+                        var members = allowCollaborator ? u.Organization.Members : u.Organization.Administrators;
+                        return members.Any(m => m.Username == user.Identity.Name);
+                    });
+        }
+
+        public static bool IsOwner(this PackageRegistration package, User user, bool allowAdmin = false, bool allowCollaborator = false)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (user == null)
+            {
+                return false;
+            }
+
+            return
+                (allowAdmin && user.IsInRole(Constants.AdminRoleName)) ||
+                package.Owners.Any(u => u.Key == user.Key) ||
+                package.Owners
+                    .Where(u => u.Organization != null)
+                    .Any(u =>
+                    {
+                        var members = allowCollaborator ? u.Organization.Members : u.Organization.Administrators;
+                        return members.Any(m => m.Key == user.Key);
+                    });
         }
 
         // apple polish!

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -56,14 +56,14 @@ namespace NuGetGallery
                 return false;
             }
             return 
-                user.IsAdministrator() || 
+                (allowAdmin && user.IsAdministrator()) || 
                 Owners.Any(u => u.Username == user.Identity.Name) ||
                 Owners
                     .Where(u => u.Organization != null)
                     .Any(u =>
                     {
-                        var members = allowCollaborator ? u.Organization.Members : u.Organization.Administrators;
-                        return members.Any(u => u.Username == user.Identity.Name);
+                        var members = allowCollaborator ? u.Organization.Memberships : u.Organization.Memberships.Where(m => m.IsAdmin);
+                        return members.Any(m => m.Member.Username == user.Identity.Name);
                     });
         }
     }

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -49,18 +49,22 @@ namespace NuGetGallery
             }
         }
 
-        public bool IsOwner(IPrincipal user)
+        public bool IsOwner(IPrincipal user, bool allowAdmin = false, bool allowCollaborator = false)
         {
             if (user == null || user.Identity == null)
             {
                 return false;
             }
-            return Owners.Any(u => u.Username == user.Identity.Name);
-        }
-
-        public bool IsOwnerOrAdmin(IPrincipal user)
-        {
-            return IsOwner(user) || user.IsAdministrator();
+            return 
+                user.IsAdministrator() || 
+                Owners.Any(u => u.Username == user.Identity.Name) ||
+                Owners
+                    .Where(u => u.Organization != null)
+                    .Any(u =>
+                    {
+                        var members = allowCollaborator ? u.Organization.Members : u.Organization.Administrators;
+                        return members.Any(u => u.Username == user.Identity.Name);
+                    });
         }
     }
 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -211,7 +211,7 @@
 
             @if (!Model.Listed && Model.Available)
             {
-                if ((Model.IsOwnerOrAdmin(User)))
+                if ((Model.IsOwner(User, allowAdmin: true)))
                 {
                     @ViewHelpers.AlertWarning(
                         @<text>
@@ -298,7 +298,7 @@
 
             @if (Model.Dependencies.DependencySets == null)
             {
-                if ((Model.IsOwnerOrAdmin(User)))
+                if ((Model.IsOwner(User, allowAdmin: true)))
                 {
                     <h2>Dependencies</h2>
                     <p>
@@ -374,7 +374,7 @@
                             <th>Version</th>
                             <th>Downloads</th>
                             <th>Last updated</th>
-                            @if (Model.IsOwnerOrAdmin(User))
+                            @if (Model.IsOwner(User, allowAdmin: true))
                             {
                                 <th>Listed</th>
                                 if (Config.Current.AsynchronousPackageValidationEnabled)
@@ -395,7 +395,7 @@
                         @foreach (var packageVersion in Model.PackageVersions)
                         {
                             if ((packageVersion.Available && packageVersion.Listed)
-                                || (!packageVersion.Deleted && Model.IsOwnerOrAdmin(User)))
+                                || (!packageVersion.Deleted && Model.IsOwner(User, allowAdmin: true)))
                             {
                                 rowCount++;
                                 @VersionListDivider(rowCount, versionsExpanded)
@@ -426,7 +426,7 @@
                                     <td>
                                         <span data-datetime="@packageVersion.LastUpdated.ToString("O")">@packageVersion.LastUpdated.ToNuGetShortDateString()</span>
                                     </td>
-                                    @if (packageVersion.IsOwnerOrAdmin(User))
+                                    @if (packageVersion.IsOwner(User, allowAdmin: true))
                                     {
                                         <td>
                                             <a href="@Url.DeletePackage(packageVersion)">@(packageVersion.Listed ? "yes" : "no")</a>
@@ -451,7 +451,7 @@
                                     }
                                 </tr>
                             }
-                            else if (packageVersion.Deleted && packageVersion.IsOwnerOrAdmin(User))
+                            else if (packageVersion.Deleted && packageVersion.IsOwner(User, allowAdmin: true))
                             {
                                 rowCount++;
                                 @VersionListDivider(rowCount, versionsExpanded)
@@ -528,7 +528,7 @@
                     <i class="ms-Icon ms-Icon--Mail" aria-hidden="true"></i>
                     <a href="@Url.ContactOwners(Model.Id)" title="Ask the package owners a question">Contact owners</a>
                 </li>
-                @if (Model.IsOwnerOrAdmin(User))
+                @if (Model.IsOwner(User, allowAdmin: true))
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
@@ -559,21 +559,21 @@
                     </li>
                 }
 
-                @if ((Model.Available || Model.Validating) && Model.IsOwnerOrAdmin(User))
+                @if ((Model.Available || Model.Validating) && Model.IsOwner(User, allowAdmin: true))
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
                         <a href="@Url.EditPackage(Model.Id, Model.Version)">Edit package</a>
                     </li>
                 }
-                @if (Model.IsOwnerOrAdmin(User))
+                @if (Model.IsOwner(User, allowAdmin: true))
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>
                         <a href="@Url.ManagePackageOwners(Model)">Manage owners</a>
                     </li>
                 }
-                @if (!Model.Deleted && Model.IsOwnerOrAdmin(User))
+                @if (!Model.Deleted && Model.IsOwner(User, allowAdmin: true))
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>

--- a/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
+++ b/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
@@ -65,8 +65,8 @@ namespace NuGetGallery
                 var organizationCollaboratorAdminMembership = new Membership() { Organization = organization, Member = organizationCollaboratorAdmin, IsAdmin = false };
                 organization.Memberships.Add(organizationCollaboratorAdminMembership);
 
-                var packageRegistration = new PackageRegistration() { Owners = new[] { owner, organizationOwner } };
-                var package = new Package() { PackageRegistration = packageRegistration };
+                var packageRegistration = new PackageRegistration() { Owners = new[] { owner, organizationOwner }, Id = "testpackage" };
+                var package = new Package() { PackageRegistration = packageRegistration, Version = "1.0.0" };
 
                 // Assert
                 // Co-owner is owner
@@ -108,6 +108,9 @@ namespace NuGetGallery
                 var principal = GetPrincipal(user);
                 Assert.Equal(shouldSucceed, packageRegistration.IsOwner(principal, allowAdmin, allowCollaborator));
                 Assert.Equal(shouldSucceed, package.IsOwner(principal, allowAdmin, allowCollaborator));
+
+                var listPackageItemOwnersViewModel = new ListPackageItemViewModel(package);
+                Assert.Equal(shouldSucceed, listPackageItemOwnersViewModel.IsOwner(principal, allowAdmin, allowCollaborator));
             }
         }
 

--- a/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
+++ b/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Claims;
+using System.Security.Principal;
+using Moq;
 using NuGet.Frameworks;
 using NuGetGallery.Authentication;
 using Xunit;
@@ -9,6 +14,103 @@ namespace NuGetGallery
 {
     public class ExtensionMethodsFacts
     {
+        public class TheIsOwnerMethod
+        {
+            [Flags]
+            private enum IsOwner_Data_States
+            {
+                AllowAdmin = 1,
+                AllowCollaborator = 2
+            }
+
+            public static IEnumerable<object[]> IsOwner_Data
+            {
+                get
+                {
+                    for (int i = 0; i < (int)Enum.GetValues(typeof(IsOwner_Data_States)).Cast<int>().Max() * 2; i++)
+                    {
+                        var allowAdmin = (i & (int)IsOwner_Data_States.AllowAdmin) == 0;
+                        var allowCollaborator = (i & (int)IsOwner_Data_States.AllowCollaborator) == 0;
+
+                        yield return new object[] { allowAdmin, allowCollaborator };
+                    }
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(IsOwner_Data))]
+            public void IsOwner(bool allowAdmin, bool allowCollaborator)
+            {
+                // Arrange
+                var key = 0;
+
+                var owner = new User("testuser") { Key = key++ };
+
+                var admin = new User("testadmin") { Key = key++ };
+                admin.Roles.Add(new Role { Name = Constants.AdminRoleName });
+
+                var organization = new Organization() { Memberships = new List<Membership>() };
+                var organizationOwner = new User("testorganization") { Key = key++, Organization = organization };
+
+                var organizationAdmin = new User("testorganizationadmin") { Key = key++ };
+                var organizationAdminMembership = new Membership() { Organization = organization, Member = organizationAdmin, IsAdmin = true };
+                organization.Memberships.Add(organizationAdminMembership);
+
+                var organizationCollaborator = new User("testorganizationcollaborator") { Key = key++ };
+                var organizationCollaboratorMembership = new Membership() { Organization = organization, Member = organizationCollaborator, IsAdmin = false };
+                organization.Memberships.Add(organizationCollaboratorMembership);
+
+                var organizationCollaboratorAdmin = new User("testorganizationcollaboratoradmin") { Key = key++ };
+                organizationCollaboratorAdmin.Roles.Add(new Role { Name = Constants.AdminRoleName });
+                var organizationCollaboratorAdminMembership = new Membership() { Organization = organization, Member = organizationCollaboratorAdmin, IsAdmin = false };
+                organization.Memberships.Add(organizationCollaboratorAdminMembership);
+
+                var packageRegistration = new PackageRegistration() { Owners = new[] { owner, organizationOwner } };
+                var package = new Package() { PackageRegistration = packageRegistration };
+
+                // Assert
+                // Co-owner is owner
+                AssertIsOwner(owner, package, packageRegistration, allowAdmin, allowCollaborator, true);
+
+                // Admin is owner if allowAdmin
+                AssertIsOwner(admin, package, packageRegistration, allowAdmin, allowCollaborator, allowAdmin);
+
+                // Organization is owner
+                AssertIsOwner(organizationOwner, package, packageRegistration, allowAdmin, allowCollaborator, true);
+
+                // Organization admin is owner
+                AssertIsOwner(organizationAdmin, package, packageRegistration, allowAdmin, allowCollaborator, true);
+
+                // Organization collaborator is owner if allowCollaborator
+                AssertIsOwner(organizationCollaborator, package, packageRegistration, allowAdmin, allowCollaborator, allowCollaborator);
+
+                // Admin and organization collaborator is owner if either allowAdmin or allowCollaborator
+                AssertIsOwner(organizationCollaboratorAdmin, package, packageRegistration, allowAdmin, allowCollaborator, allowAdmin || allowCollaborator);
+            }
+
+            private IPrincipal GetPrincipal(User u)
+            {
+                var identityMock = new Mock<IIdentity>();
+                identityMock.Setup(x => x.Name).Returns(u.Username);
+                identityMock.Setup(x => x.IsAuthenticated).Returns(true);
+
+                var principalMock = new Mock<IPrincipal>();
+                principalMock.Setup(x => x.Identity).Returns(identityMock.Object);
+                principalMock.Setup(x => x.IsInRole(It.IsAny<string>())).Returns<string>(role => u.IsInRole(role));
+                return principalMock.Object;
+            }
+
+            private void AssertIsOwner(User user, Package package, PackageRegistration packageRegistration, bool allowAdmin, bool allowCollaborator, bool shouldSucceed)
+            {
+                Assert.Equal(shouldSucceed, packageRegistration.IsOwner(user, allowAdmin, allowCollaborator));
+                Assert.Equal(shouldSucceed, package.IsOwner(user, allowAdmin, allowCollaborator));
+
+                var principal = GetPrincipal(user);
+                Assert.Equal(shouldSucceed, packageRegistration.IsOwner(principal, allowAdmin, allowCollaborator));
+                Assert.Equal(shouldSucceed, package.IsOwner(principal, allowAdmin, allowCollaborator));
+            }
+        }
+
         public class TheGetCurrentApiKeyCredentialMethod
         {
             [Theory]


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/4886

`ExtensionMethods.IsOwner` will now return true if the user is an admin of an organization that owns the package.

Added a parameter (`allowCollaborator`) to return true if the user is a collaborator of an organization that owns the package.

Removed the old `IsOwnerOrAdmin` method and replaced it with `IsOwner`'s `allowAdmin` parameter.

Also did the same for `ListPackageItemViewModel.IsOwner`.