### PR TITLE
Pakage URL generation method and checks whether package file exists

### DIFF
--- a/src/NuGetGallery.Core/Services/CorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageFileService.cs
@@ -34,6 +34,18 @@ namespace NuGetGallery
             return _fileStorageService.GetFileAsync(CoreConstants.PackagesFolderName, fileName);
         }
 
+        public Task<Uri> GetPackageUrlAsync(Package package)
+        {
+            var fileName = BuildFileName(package, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetPackageFileExtension);
+            return _fileStorageService.GetFileReadUriAsync(CoreConstants.PackagesFolderName, fileName, endOfAccess: null);
+        }
+
+        public Task<bool> DoesPackageFileExistAsync(Package package)
+        {
+            var fileName = BuildFileName(package, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetPackageFileExtension);
+            return _fileStorageService.FileExistsAsync(CoreConstants.PackagesFolderName, fileName);
+        }
+
         public Task SaveValidationPackageFileAsync(Package package, Stream packageFile)
         {
             if (packageFile == null)
@@ -108,6 +120,12 @@ namespace NuGetGallery
                 CoreConstants.NuGetPackageFileExtension);
 
             return _fileStorageService.GetFileReadUriAsync(CoreConstants.ValidationFolderName, fileName, endOfAccess);
+        }
+
+        public Task<bool> DoesValidationPackageFileExistAsync(Package package)
+        {
+            var fileName = BuildFileName(package, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetPackageFileExtension);
+            return _fileStorageService.FileExistsAsync(CoreConstants.ValidationFolderName, fileName);
         }
 
         protected static string BuildFileName(Package package, string format, string extension)

--- a/src/NuGetGallery.Core/Services/CorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageFileService.cs
@@ -34,7 +34,7 @@ namespace NuGetGallery
             return _fileStorageService.GetFileAsync(CoreConstants.PackagesFolderName, fileName);
         }
 
-        public Task<Uri> GetPackageUrlAsync(Package package)
+        public Task<Uri> GetPackageReadUriAsync(Package package)
         {
             var fileName = BuildFileName(package, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetPackageFileExtension);
             return _fileStorageService.GetFileReadUriAsync(CoreConstants.PackagesFolderName, fileName, endOfAccess: null);

--- a/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
@@ -20,6 +20,20 @@ namespace NuGetGallery
         Task<Stream> DownloadPackageFileAsync(Package package);
 
         /// <summary>
+        /// Generates the URL for the specified package.
+        /// </summary>
+        /// <param name="package">The package metadata.</param>
+        /// <returns>Package download URL</returns>
+        Task<Uri> GetPackageUrlAsync(Package package);
+
+        /// <summary>
+        /// Checks whether package file exists in the public container for available packages
+        /// </summary>
+        /// <param name="">The package metadata</param>
+        /// <returns>True if file exists, false otherwise</returns>
+        Task<bool> DoesPackageFileExistAsync(Package package);
+
+        /// <summary>
         /// Saves the contents of the package to the private container for packages that are being validated. If the
         /// file already exists, an exception will be thrown.
         /// </summary>
@@ -41,6 +55,13 @@ namespace NuGetGallery
         /// <param name="endOfAccess">The timestamp that limits the URI usage period.</param>
         /// <returns>Time limited (if implementation supports) URI for the validation package</returns>
         Task<Uri> GetValidationPackageReadUriAsync(Package package, DateTimeOffset endOfAccess);
+
+        /// <summary>
+        /// Checks whether package file exists in the private validation container
+        /// </summary>
+        /// <param name="">The package metadata</param>
+        /// <returns>True if file exists, false otherwise</returns>
+        Task<bool> DoesValidationPackageFileExistAsync(Package package);
 
         /// <summary>
         /// Deletes the validating package from the file storage. If the file does not exist this method will not throw

--- a/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
@@ -20,11 +20,15 @@ namespace NuGetGallery
         Task<Stream> DownloadPackageFileAsync(Package package);
 
         /// <summary>
-        /// Generates the URL for the specified package.
+        /// Generates the URL for the specified package in the public container for available packages.
         /// </summary>
         /// <param name="package">The package metadata.</param>
         /// <returns>Package download URL</returns>
-        Task<Uri> GetPackageUrlAsync(Package package);
+        /// <remarks>
+        /// The returned URL is only intended to be used by the internal tooling and not for the user:
+        /// it might not make any sense to external users as it can be, for example, a file:/// URL.
+        /// </remarks>
+        Task<Uri> GetPackageReadUriAsync(Package package);
 
         /// <summary>
         /// Checks whether package file exists in the public container for available packages

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -412,19 +412,19 @@ namespace NuGetGallery
             }
         }
 
-        public class TheGetPackageUrlMethod : FactsBase
+        public class TheGetPackageReadUriMethod : FactsBase
         {
             [Fact]
             public async Task WillThrowIfPackageIsNull()
             {
-                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.GetPackageUrlAsync(null));
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.GetPackageReadUriAsync(null));
                 Assert.Equal(ex.ParamName, "package");
             }
 
             [Fact]
             public async Task WillUseFileStorageService()
             {
-                await _service.GetPackageUrlAsync(_package);
+                await _service.GetPackageReadUriAsync(_package);
 
                 string filename = BuildFileName(_package.PackageRegistration.Id, _package.NormalizedVersion, CoreConstants.NuGetPackageFileExtension, CoreConstants.PackageFileSavePathTemplate);
 

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -405,10 +405,10 @@ namespace NuGetGallery
 
                 _fileStorageService.Verify(
                     x => x.GetFileReadUriAsync(ValidationFolderName, ValidationFileName, endOfAccess),
-                    Times.Once);
+                    Times.Once());
                 _fileStorageService.Verify(
                     x => x.GetFileReadUriAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTimeOffset>()),
-                    Times.Once);
+                    Times.Once());
             }
         }
 
@@ -418,7 +418,7 @@ namespace NuGetGallery
             public async Task WillThrowIfPackageIsNull()
             {
                 var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.GetPackageReadUriAsync(null));
-                Assert.Equal(ex.ParamName, "package");
+                Assert.Equal("package", ex.ParamName);
             }
 
             [Fact]
@@ -430,10 +430,10 @@ namespace NuGetGallery
 
                 _fileStorageService.Verify(
                     x => x.GetFileReadUriAsync(PackagesFolderName, filename, null),
-                    Times.Once);
+                    Times.Once());
                 _fileStorageService.Verify(
                     x => x.GetFileReadUriAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTimeOffset?>()),
-                    Times.Once);
+                    Times.Once());
             }
         }
 
@@ -443,7 +443,7 @@ namespace NuGetGallery
             public async Task WillThrowIfPackageIsNull()
             {
                 var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.DoesPackageFileExistAsync(null));
-                Assert.Equal(ex.ParamName, "package");
+                Assert.Equal("package", ex.ParamName);
             }
 
             [Fact]
@@ -460,10 +460,10 @@ namespace NuGetGallery
                 Assert.True(result);
                 _fileStorageService.Verify(
                     x => x.FileExistsAsync(PackagesFolderName, filename),
-                    Times.Once);
+                    Times.Once());
                 _fileStorageService.Verify(
                     x => x.FileExistsAsync(It.IsAny<string>(), It.IsAny<string>()),
-                    Times.Once);
+                    Times.Once());
             }
         }
 
@@ -473,7 +473,7 @@ namespace NuGetGallery
             public async Task WillThrowIfPackageIsNull()
             {
                 var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.DoesValidationPackageFileExistAsync(null));
-                Assert.Equal(ex.ParamName, "package");
+                Assert.Equal("package", ex.ParamName);
             }
 
             [Fact]
@@ -488,10 +488,10 @@ namespace NuGetGallery
                 Assert.True(result);
                 _fileStorageService.Verify(
                     x => x.FileExistsAsync(ValidationFolderName, ValidationFileName),
-                    Times.Once);
+                    Times.Once());
                 _fileStorageService.Verify(
                     x => x.FileExistsAsync(It.IsAny<string>(), It.IsAny<string>()),
-                    Times.Once);
+                    Times.Once());
             }
         }
 

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -412,6 +412,89 @@ namespace NuGetGallery
             }
         }
 
+        public class TheGetPackageUrlMethod : FactsBase
+        {
+            [Fact]
+            public async Task WillThrowIfPackageIsNull()
+            {
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.GetPackageUrlAsync(null));
+                Assert.Equal(ex.ParamName, "package");
+            }
+
+            [Fact]
+            public async Task WillUseFileStorageService()
+            {
+                await _service.GetPackageUrlAsync(_package);
+
+                string filename = BuildFileName(_package.PackageRegistration.Id, _package.NormalizedVersion, CoreConstants.NuGetPackageFileExtension, CoreConstants.PackageFileSavePathTemplate);
+
+                _fileStorageService.Verify(
+                    x => x.GetFileReadUriAsync(PackagesFolderName, filename, null),
+                    Times.Once);
+                _fileStorageService.Verify(
+                    x => x.GetFileReadUriAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTimeOffset?>()),
+                    Times.Once);
+            }
+        }
+
+        public class TheDoesPackageFileExistMethod : FactsBase
+        {
+            [Fact]
+            public async Task WillThrowIfPackageIsNull()
+            {
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.DoesPackageFileExistAsync(null));
+                Assert.Equal(ex.ParamName, "package");
+            }
+
+            [Fact]
+            public async Task WillUseFileStorageService()
+            {
+                string filename = BuildFileName(_package.PackageRegistration.Id, _package.NormalizedVersion, CoreConstants.NuGetPackageFileExtension, CoreConstants.PackageFileSavePathTemplate);
+
+                _fileStorageService
+                    .Setup(x => x.FileExistsAsync(PackagesFolderName, filename))
+                    .ReturnsAsync(true);
+
+                var result = await _service.DoesPackageFileExistAsync(_package);
+
+                Assert.True(result);
+                _fileStorageService.Verify(
+                    x => x.FileExistsAsync(PackagesFolderName, filename),
+                    Times.Once);
+                _fileStorageService.Verify(
+                    x => x.FileExistsAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+            }
+        }
+
+        public class TheDoesValidationPackageFileExistMethod : FactsBase
+        {
+            [Fact]
+            public async Task WillThrowIfPackageIsNull()
+            {
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.DoesValidationPackageFileExistAsync(null));
+                Assert.Equal(ex.ParamName, "package");
+            }
+
+            [Fact]
+            public async Task WillUseFileStorageService()
+            {
+                _fileStorageService
+                    .Setup(x => x.FileExistsAsync(ValidationFolderName, ValidationFileName))
+                    .ReturnsAsync(true);
+
+                var result = await _service.DoesValidationPackageFileExistAsync(_package);
+
+                Assert.True(result);
+                _fileStorageService.Verify(
+                    x => x.FileExistsAsync(ValidationFolderName, ValidationFileName),
+                    Times.Once);
+                _fileStorageService.Verify(
+                    x => x.FileExistsAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+            }
+        }
+
         static string BuildFileName(
             string id,
             string version, string extension, string path)


### PR DESCRIPTION
Validation.Orchestrator needs a way to get public package URL, too (for the revalidation case when we don't have a package in validation container, also needed for the non-blocking validation case).
Also, methods that check for package file existence would allow to figure out where package file is located on Orchestrator side without trying to download either file.