### PR TITLE
Do not consider unlisted prerelease versions when showing "newer prerelease available" message.

### DIFF
--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -74,7 +74,7 @@ namespace NuGetGallery
             get
             {
                 var latestPrereleaseVersion = PackageVersions
-                    .Where(pv => pv.Prerelease && pv.Available)
+                    .Where(pv => pv.Prerelease && pv.Available && pv.Listed)
                     .Max(pv => pv.NuGetVersion);
 
                 return latestPrereleaseVersion > NuGetVersion;

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -199,5 +199,44 @@ namespace NuGetGallery.ViewModels
             // Assert
             Assert.Equal(expectedNewerPrereleaseAvailable, hasNewerPrerelease);
         }
+        
+        [Fact]
+        public void HasNewerPrereleaseDoesNotConsiderUnlistedVersions()
+        {
+            // Arrange
+            var dependencies = Enumerable.Empty<PackageDependency>().ToList();
+            var packageRegistration = new PackageRegistration
+            {
+                Owners = Enumerable.Empty<User>().ToList(),
+            };
+
+            var package = new Package
+            {
+                Dependencies = dependencies,
+                PackageRegistration = packageRegistration,
+                IsPrerelease = true,
+                Version = "1.0.0-alpha.1"
+            };
+
+            // This is a newer prerelease version, however unlisted.
+            var otherPackage = new Package
+            {
+                Dependencies = dependencies,
+                PackageRegistration = packageRegistration,
+                IsPrerelease = true,
+                Version = "1.0.0-alpha.2",
+                Listed = false
+            };
+
+            package.PackageRegistration.Packages = new[] { package, otherPackage };
+
+            var viewModel = new DisplayPackageViewModel(package, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)));
+
+            // Act
+            var hasNewerPrerelease = viewModel.HasNewerPrerelease;
+
+            // Assert
+            Assert.False(hasNewerPrerelease);
+        }
     }
 }


### PR DESCRIPTION
Fixes #4814