### PR TITLE
OwinStartup NullRef fix

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -41,6 +41,7 @@ namespace NuGetGallery
         {
             var telemetryClient = TelemetryClientWrapper.Instance;
             builder.RegisterInstance(telemetryClient)
+                .AsSelf()
                 .As<ITelemetryClient>()
                 .SingleInstance();
 


### PR DESCRIPTION
I believe this should fix it. Haven't tested, as I'm not sure how to run Owin hosted locally. If anyone knows, please let me know :-)

```
[NullReferenceException: Object reference not set to an instance of an object.]
   NuGetGallery.<>c__DisplayClass4_1.<Configuration>b__2(ITelemetryProcessor next) in C:\vsts-agent\_work\3\s\src\Gallery\submodules\Gallery\src\NuGetGallery\App_Start\OwinStartup.cs:84
   Microsoft.ApplicationInsights.Extensibility.Implementation.TelemetryProcessorChainBuilder.Build() +231
   NuGetGallery.OwinStartup.Configuration(IAppBuilder app) in C:\vsts-agent\_work\3\s\src\Gallery\submodules\Gallery\src\NuGetGallery\App_Start\OwinStartup.cs:83

[TargetInvocationException: Exception has been thrown by the target of an invocation.]
   System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor) +0
   System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments) +128
   System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) +146
   Owin.Loader.<>c__DisplayClass12.<MakeDelegate>b__b(IAppBuilder builder) +93
   Owin.Loader.<>c__DisplayClass1.<LoadImplementation>b__0(IAppBuilder builder) +209
   Microsoft.Owin.Host.SystemWeb.OwinAppContext.Initialize(Action`1 startup) +842
   Microsoft.Owin.Host.SystemWeb.OwinBuilder.Build(Action`1 startup) +51
   Microsoft.Owin.Host.SystemWeb.OwinHttpModule.InitializeBlueprint() +101
   System.Threading.LazyInitializer.EnsureInitializedCore(T& target, Boolean& initialized, Object& syncLock, Func`1 valueFactory) +136
   Microsoft.Owin.Host.SystemWeb.OwinHttpModule.Init(HttpApplication context) +162
   System.Web.HttpApplication.RegisterEventSubscriptionsWithIIS(IntPtr appContext, HttpContext context, MethodInfo[] handlers) +583
   System.Web.HttpApplication.InitSpecial(HttpApplicationState state, MethodInfo[] handlers, IntPtr appContext, HttpContext context) +169
   System.Web.HttpApplicationFactory.GetSpecialApplicationInstance(IntPtr appContext, HttpContext context) +396
   System.Web.Hosting.PipelineRuntime.InitializeApplication(IntPtr appContext) +333

[HttpException (0x80004005): Exception has been thrown by the target of an invocation.]
   System.Web.HttpRuntime.FirstRequestInit(HttpContext context) +525
   System.Web.HttpRuntime.EnsureFirstRequestInit(HttpContext context) +124
   System.Web.HttpRuntime.ProcessRequestNotificationPrivate(IIS7WorkerRequest wr, HttpContext context) +700
```