### PR TITLE
[Statistics] Introduce Community Statistics Reports

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -982,6 +982,9 @@ img.reserved-indicator-icon {
 .page-sign-in .or-row {
   margin: 20px;
 }
+.page-statistics-most-downloaded .show-all-packages-toggle {
+  font-weight: bold;
+}
 .page-statistics-most-downloaded .table {
   margin-top: 40px;
   table-layout: fixed;

--- a/src/Bootstrap/less/theme/page-statistics-most-downloaded.less
+++ b/src/Bootstrap/less/theme/page-statistics-most-downloaded.less
@@ -1,4 +1,8 @@
 .page-statistics-most-downloaded {
+    .show-all-packages-toggle {
+        font-weight: bold;
+    }
+
     .table {
         margin-top: 40px;
         table-layout: fixed;

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -982,6 +982,9 @@ img.reserved-indicator-icon {
 .page-sign-in .or-row {
   margin: 20px;
 }
+.page-statistics-most-downloaded .show-all-packages-toggle {
+  font-weight: bold;
+}
 .page-statistics-most-downloaded .table {
   margin-top: 40px;
   table-layout: fixed;

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -666,9 +666,9 @@ namespace NuGetGallery
         [ActionName("StatisticsDownloadsApi")]
         public virtual async Task<ActionResult> GetStatsDownloads(int? count)
         {
-            var result = await StatisticsService.LoadDownloadPackageVersions();
+            await StatisticsService.Refresh();
 
-            if (result.Loaded)
+            if (StatisticsService.DownloadPackageVersionsResult.Loaded)
             {
                 int i = 0;
 

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -668,12 +668,12 @@ namespace NuGetGallery
         {
             await StatisticsService.Refresh();
 
-            if (StatisticsService.DownloadPackageVersionsResult.Loaded)
+            if (StatisticsService.PackageVersionDownloadsResult.IsLoaded)
             {
                 int i = 0;
 
                 JArray content = new JArray();
-                foreach (StatisticsPackagesItemViewModel row in StatisticsService.DownloadPackageVersionsAll)
+                foreach (StatisticsPackagesItemViewModel row in StatisticsService.PackageVersionDownloads)
                 {
                     JObject item = new JObject();
 

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -79,16 +79,16 @@ namespace NuGetGallery
 
             var model = new StatisticsPackagesViewModel
             {
-                IsDownloadPackageAvailable = _statisticsService.DownloadCommunityPackagesResult.Loaded,
-                DownloadPackagesSummary = _statisticsService.DownloadCommunityPackagesSummary,
+                IsDownloadPackageAvailable = _statisticsService.CommunityPackageDownloadsResult.IsLoaded,
+                DownloadPackagesSummary = _statisticsService.CommunityPackageDownloadsSummary,
 
-                IsDownloadPackageVersionsAvailable = _statisticsService.DownloadCommunityPackageVersionsResult.Loaded,
-                DownloadPackageVersionsSummary = _statisticsService.DownloadCommunityPackageVersionsSummary,
+                IsDownloadPackageVersionsAvailable = _statisticsService.CommunityPackageVersionDownloadsResult.IsLoaded,
+                DownloadPackageVersionsSummary = _statisticsService.CommunityPackageVersionDownloadsSummary,
 
-                IsNuGetClientVersionAvailable = _statisticsService.NuGetClientVersionResult.Loaded,
+                IsNuGetClientVersionAvailable = _statisticsService.NuGetClientVersionResult.IsLoaded,
                 NuGetClientVersion = _statisticsService.NuGetClientVersion,
 
-                IsLast6WeeksAvailable = _statisticsService.Last6WeeksResult.Loaded,
+                IsLast6WeeksAvailable = _statisticsService.Last6WeeksResult.IsLoaded,
                 Last6Weeks = _statisticsService.Last6Weeks,
 
                 LastUpdatedUtc = _statisticsService.LastUpdatedUtc,
@@ -113,16 +113,16 @@ namespace NuGetGallery
 
             await _statisticsService.Refresh();
 
-            var allPackagesUpdateTime = _statisticsService.DownloadPackagesResult.LastUpdatedUtc;
-            var communityPackagesUpdateTime = _statisticsService.DownloadCommunityPackagesResult.LastUpdatedUtc;
+            var allPackagesUpdateTime = _statisticsService.PackageDownloadsResult.LastUpdatedUtc;
+            var communityPackagesUpdateTime = _statisticsService.CommunityPackageDownloadsResult.LastUpdatedUtc;
 
             var model = new StatisticsPackagesViewModel
             {
-                IsDownloadPackageAvailable = _statisticsService.DownloadPackagesResult.Loaded,
-                DownloadPackagesAll = _statisticsService.DownloadPackagesAll,
+                IsDownloadPackageAvailable = _statisticsService.PackageDownloadsResult.IsLoaded,
+                DownloadPackagesAll = _statisticsService.PackageDownloads,
 
-                IsDownloadCommunityPackageAvailable = _statisticsService.DownloadCommunityPackagesResult.Loaded,
-                DownloadCommunityPackagesAll = _statisticsService.DownloadCommunityPackagesAll,
+                IsDownloadCommunityPackageAvailable = _statisticsService.CommunityPackageDownloadsResult.IsLoaded,
+                DownloadCommunityPackagesAll = _statisticsService.CommunityPackageDownloads,
 
                 LastUpdatedUtc = (allPackagesUpdateTime > communityPackagesUpdateTime)
                                     ? allPackagesUpdateTime
@@ -144,16 +144,16 @@ namespace NuGetGallery
 
             await _statisticsService.Refresh();
 
-            var allPackagesUpdateTime = _statisticsService.DownloadPackageVersionsResult.LastUpdatedUtc;
-            var communityPackagesUpdateTime = _statisticsService.DownloadCommunityPackageVersionsResult.LastUpdatedUtc;
+            var allPackagesUpdateTime = _statisticsService.PackageVersionDownloadsResult.LastUpdatedUtc;
+            var communityPackagesUpdateTime = _statisticsService.CommunityPackageVersionDownloadsResult.LastUpdatedUtc;
 
             var model = new StatisticsPackagesViewModel
             {
-                IsDownloadPackageVersionsAvailable = _statisticsService.DownloadPackageVersionsResult.Loaded,
-                DownloadPackageVersionsAll = _statisticsService.DownloadPackageVersionsAll,
+                IsDownloadPackageVersionsAvailable = _statisticsService.PackageVersionDownloadsResult.IsLoaded,
+                DownloadPackageVersionsAll = _statisticsService.PackageVersionDownloads,
 
-                IsDownloadCommunityPackageVersionsAvailable = _statisticsService.DownloadCommunityPackageVersionsResult.Loaded,
-                DownloadCommunityPackageVersionsAll = _statisticsService.DownloadCommunityPackageVersionsAll,
+                IsDownloadCommunityPackageVersionsAvailable = _statisticsService.CommunityPackageVersionDownloadsResult.IsLoaded,
+                DownloadCommunityPackageVersionsAll = _statisticsService.CommunityPackageVersionDownloads,
 
                 LastUpdatedUtc = (allPackagesUpdateTime > communityPackagesUpdateTime)
                                     ? allPackagesUpdateTime

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -73,27 +73,29 @@ namespace NuGetGallery
                 return new HttpStatusCodeResult(HttpStatusCode.NotFound);
             }
 
-            var availablity = await Task.WhenAll(
-                _statisticsService.LoadDownloadPackages(),
-                _statisticsService.LoadDownloadPackageVersions(),
-                _statisticsService.LoadNuGetClientVersion(),
-                _statisticsService.LoadLast6Weeks());
+            await _statisticsService.Refresh();
 
             var model = new StatisticsPackagesViewModel
             {
-                IsDownloadPackageAvailable = availablity[0].Loaded,
+                IsDownloadPackageAvailable = _statisticsService.DownloadPackagesResult.Loaded,
                 DownloadPackagesSummary = _statisticsService.DownloadPackagesSummary,
-                IsDownloadPackageDetailAvailable = availablity[1].Loaded,
+
+                IsDownloadPackageVersionsAvailable = _statisticsService.DownloadPackageVersionsResult.Loaded,
                 DownloadPackageVersionsSummary = _statisticsService.DownloadPackageVersionsSummary,
-                IsNuGetClientVersionAvailable = availablity[2].Loaded,
+
+                IsDownloadCommunityPackageAvailable = _statisticsService.DownloadCommunityPackagesResult.Loaded,
+                DownloadCommunityPackagesSummary = _statisticsService.DownloadPackagesSummary,
+
+                IsDownloadCommunityPackageVersionsAvailable = _statisticsService.DownloadCommunityPackageVersionsResult.Loaded,
+                DownloadCommunityPackageVersionsSummary = _statisticsService.DownloadCommunityPackageVersionsSummary,
+
+                IsNuGetClientVersionAvailable = _statisticsService.NuGetClientVersionResult.Loaded,
                 NuGetClientVersion = _statisticsService.NuGetClientVersion,
-                IsLast6WeeksAvailable = availablity[3].Loaded,
+
+                IsLast6WeeksAvailable = _statisticsService.Last6WeeksResult.Loaded,
                 Last6Weeks = _statisticsService.Last6Weeks,
-                LastUpdatedUtc = availablity
-                    .Where(r => r.LastUpdatedUtc.HasValue)
-                    .OrderByDescending(r => r.LastUpdatedUtc.Value)
-                    .Select(r => r.LastUpdatedUtc)
-                    .FirstOrDefault()
+
+                LastUpdatedUtc = _statisticsService.LastUpdatedUtc,
             };
 
             model.Update();
@@ -113,13 +115,13 @@ namespace NuGetGallery
                 return new HttpStatusCodeResult(HttpStatusCode.NotFound);
             }
 
-            var result = await _statisticsService.LoadDownloadPackages();
+            await _statisticsService.Refresh();
 
             var model = new StatisticsPackagesViewModel
             {
-                IsDownloadPackageAvailable = result.Loaded,
+                IsDownloadPackageAvailable = _statisticsService.DownloadPackagesResult.Loaded,
                 DownloadPackagesAll = _statisticsService.DownloadPackagesAll,
-                LastUpdatedUtc = result.LastUpdatedUtc
+                LastUpdatedUtc = _statisticsService.DownloadPackagesResult.LastUpdatedUtc,
             };
 
             return View(model);
@@ -135,13 +137,13 @@ namespace NuGetGallery
                 return new HttpStatusCodeResult(HttpStatusCode.NotFound);
             }
 
-            var result = await _statisticsService.LoadDownloadPackageVersions();
+            await _statisticsService.Refresh();
 
             var model = new StatisticsPackagesViewModel
             {
-                IsDownloadPackageDetailAvailable = result.Loaded,
+                IsDownloadPackageVersionsAvailable = _statisticsService.DownloadPackageVersionsResult.Loaded,
                 DownloadPackageVersionsAll = _statisticsService.DownloadPackageVersionsAll,
-                LastUpdatedUtc = result.LastUpdatedUtc
+                LastUpdatedUtc = _statisticsService.DownloadPackagesResult.LastUpdatedUtc,
             };
 
             return View(model);

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -79,17 +79,11 @@ namespace NuGetGallery
 
             var model = new StatisticsPackagesViewModel
             {
-                IsDownloadPackageAvailable = _statisticsService.DownloadPackagesResult.Loaded,
-                DownloadPackagesSummary = _statisticsService.DownloadPackagesSummary,
+                IsDownloadPackageAvailable = _statisticsService.DownloadCommunityPackagesResult.Loaded,
+                DownloadPackagesSummary = _statisticsService.DownloadCommunityPackagesSummary,
 
-                IsDownloadPackageVersionsAvailable = _statisticsService.DownloadPackageVersionsResult.Loaded,
-                DownloadPackageVersionsSummary = _statisticsService.DownloadPackageVersionsSummary,
-
-                IsDownloadCommunityPackageAvailable = _statisticsService.DownloadCommunityPackagesResult.Loaded,
-                DownloadCommunityPackagesSummary = _statisticsService.DownloadCommunityPackagesSummary,
-
-                IsDownloadCommunityPackageVersionsAvailable = _statisticsService.DownloadCommunityPackageVersionsResult.Loaded,
-                DownloadCommunityPackageVersionsSummary = _statisticsService.DownloadCommunityPackageVersionsSummary,
+                IsDownloadPackageVersionsAvailable = _statisticsService.DownloadCommunityPackageVersionsResult.Loaded,
+                DownloadPackageVersionsSummary = _statisticsService.DownloadCommunityPackageVersionsSummary,
 
                 IsNuGetClientVersionAvailable = _statisticsService.NuGetClientVersionResult.Loaded,
                 NuGetClientVersion = _statisticsService.NuGetClientVersion,
@@ -110,7 +104,7 @@ namespace NuGetGallery
         //
         // GET: /stats/packages
 
-        public virtual async Task<ActionResult> Packages(string set = null)
+        public virtual async Task<ActionResult> Packages()
         {
             if (_statisticsService == NullStatisticsService.Instance)
             {
@@ -119,13 +113,11 @@ namespace NuGetGallery
 
             await _statisticsService.Refresh();
 
-            var isAllPackageSet = (AllPackageSet == set);
             var allPackagesUpdateTime = _statisticsService.DownloadPackagesResult.LastUpdatedUtc;
             var communityPackagesUpdateTime = _statisticsService.DownloadCommunityPackagesResult.LastUpdatedUtc;
 
             var model = new StatisticsPackagesViewModel
             {
-                IsCommunityPackageSet = !isAllPackageSet,
                 IsDownloadPackageAvailable = _statisticsService.DownloadPackagesResult.Loaded,
                 DownloadPackagesAll = _statisticsService.DownloadPackagesAll,
 
@@ -143,7 +135,7 @@ namespace NuGetGallery
         //
         // GET: /stats/packageversions
 
-        public virtual async Task<ActionResult> PackageVersions(string set = null)
+        public virtual async Task<ActionResult> PackageVersions()
         {
             if (_statisticsService == NullStatisticsService.Instance)
             {
@@ -152,13 +144,11 @@ namespace NuGetGallery
 
             await _statisticsService.Refresh();
 
-            var isAllPackageSet = (AllPackageSet == set);
             var allPackagesUpdateTime = _statisticsService.DownloadPackageVersionsResult.LastUpdatedUtc;
             var communityPackagesUpdateTime = _statisticsService.DownloadCommunityPackageVersionsResult.LastUpdatedUtc;
 
             var model = new StatisticsPackagesViewModel
             {
-                IsCommunityPackageSet = !isAllPackageSet,
                 IsDownloadPackageVersionsAvailable = _statisticsService.DownloadPackageVersionsResult.Loaded,
                 DownloadPackageVersionsAll = _statisticsService.DownloadPackageVersionsAll,
 

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -14,6 +14,8 @@ namespace NuGetGallery
     public partial class StatisticsController
         : AppController
     {
+        private const string AllPackageSet = "all";
+
         private readonly IStatisticsService _statisticsService = null;
         private readonly IAggregateStatsService _aggregateStatsService = null;
 
@@ -108,7 +110,7 @@ namespace NuGetGallery
         //
         // GET: /stats/packages
 
-        public virtual async Task<ActionResult> Packages()
+        public virtual async Task<ActionResult> Packages(string set = null)
         {
             if (_statisticsService == NullStatisticsService.Instance)
             {
@@ -117,12 +119,31 @@ namespace NuGetGallery
 
             await _statisticsService.Refresh();
 
-            var model = new StatisticsPackagesViewModel
+            StatisticsPackagesViewModel model;
+
+            if (AllPackageSet == set)
             {
-                IsDownloadPackageAvailable = _statisticsService.DownloadPackagesResult.Loaded,
-                DownloadPackagesAll = _statisticsService.DownloadPackagesAll,
-                LastUpdatedUtc = _statisticsService.DownloadPackagesResult.LastUpdatedUtc,
-            };
+                model = new StatisticsPackagesViewModel
+                {
+                    IsCommunityPackageSet = false,
+                    IsDownloadPackageAvailable = _statisticsService.DownloadPackagesResult.Loaded,
+                    DownloadPackagesAll = _statisticsService.DownloadPackagesAll,
+
+                    LastUpdatedUtc = _statisticsService.DownloadPackagesResult.LastUpdatedUtc,
+                };
+            }
+            else
+            {
+                model = new StatisticsPackagesViewModel
+                {
+                    IsCommunityPackageSet = true,
+                    IsDownloadPackageAvailable = _statisticsService.DownloadCommunityPackagesResult.Loaded,
+                    DownloadPackagesAll = _statisticsService.DownloadCommunityPackagesAll,
+
+                    LastUpdatedUtc = _statisticsService.DownloadCommunityPackagesResult.LastUpdatedUtc,
+                };
+            }
+
 
             return View(model);
         }
@@ -130,7 +151,7 @@ namespace NuGetGallery
         //
         // GET: /stats/packageversions
 
-        public virtual async Task<ActionResult> PackageVersions()
+        public virtual async Task<ActionResult> PackageVersions(string set = null)
         {
             if (_statisticsService == NullStatisticsService.Instance)
             {
@@ -139,12 +160,30 @@ namespace NuGetGallery
 
             await _statisticsService.Refresh();
 
-            var model = new StatisticsPackagesViewModel
+            StatisticsPackagesViewModel model;
+
+            if (AllPackageSet == set)
             {
-                IsDownloadPackageVersionsAvailable = _statisticsService.DownloadPackageVersionsResult.Loaded,
-                DownloadPackageVersionsAll = _statisticsService.DownloadPackageVersionsAll,
-                LastUpdatedUtc = _statisticsService.DownloadPackagesResult.LastUpdatedUtc,
-            };
+                model = new StatisticsPackagesViewModel
+                {
+                    IsCommunityPackageSet = false,
+                    IsDownloadPackageVersionsAvailable = _statisticsService.DownloadPackageVersionsResult.Loaded,
+                    DownloadPackageVersionsAll = _statisticsService.DownloadPackageVersionsAll,
+
+                    LastUpdatedUtc = _statisticsService.DownloadPackagesResult.LastUpdatedUtc,
+                };
+            }
+            else
+            {
+                model = new StatisticsPackagesViewModel
+                {
+                    IsCommunityPackageSet = true,
+                    IsDownloadPackageVersionsAvailable = _statisticsService.DownloadCommunityPackageVersionsResult.Loaded,
+                    DownloadPackageVersionsAll = _statisticsService.DownloadCommunityPackageVersionsAll,
+
+                    LastUpdatedUtc = _statisticsService.DownloadCommunityPackageVersionsResult.LastUpdatedUtc,
+                };
+            }
 
             return View(model);
         }

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -86,7 +86,7 @@ namespace NuGetGallery
                 DownloadPackageVersionsSummary = _statisticsService.DownloadPackageVersionsSummary,
 
                 IsDownloadCommunityPackageAvailable = _statisticsService.DownloadCommunityPackagesResult.Loaded,
-                DownloadCommunityPackagesSummary = _statisticsService.DownloadPackagesSummary,
+                DownloadCommunityPackagesSummary = _statisticsService.DownloadCommunityPackagesSummary,
 
                 IsDownloadCommunityPackageVersionsAvailable = _statisticsService.DownloadCommunityPackageVersionsResult.Loaded,
                 DownloadCommunityPackageVersionsSummary = _statisticsService.DownloadCommunityPackageVersionsSummary,

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -133,8 +133,8 @@ namespace NuGetGallery
                 DownloadCommunityPackagesAll = _statisticsService.DownloadCommunityPackagesAll,
 
                 LastUpdatedUtc = (allPackagesUpdateTime > communityPackagesUpdateTime)
-                                    ? communityPackagesUpdateTime
-                                    : allPackagesUpdateTime,
+                                    ? allPackagesUpdateTime
+                                    : communityPackagesUpdateTime,
             };
 
             return View(model);
@@ -166,8 +166,8 @@ namespace NuGetGallery
                 DownloadCommunityPackageVersionsAll = _statisticsService.DownloadCommunityPackageVersionsAll,
 
                 LastUpdatedUtc = (allPackagesUpdateTime > communityPackagesUpdateTime)
-                                    ? communityPackagesUpdateTime
-                                    : allPackagesUpdateTime,
+                                    ? allPackagesUpdateTime
+                                    : communityPackagesUpdateTime,
             };
 
             return View(model);

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -119,31 +119,23 @@ namespace NuGetGallery
 
             await _statisticsService.Refresh();
 
-            StatisticsPackagesViewModel model;
+            var isAllPackageSet = (AllPackageSet == set);
+            var allPackagesUpdateTime = _statisticsService.DownloadPackagesResult.LastUpdatedUtc;
+            var communityPackagesUpdateTime = _statisticsService.DownloadCommunityPackagesResult.LastUpdatedUtc;
 
-            if (AllPackageSet == set)
+            var model = new StatisticsPackagesViewModel
             {
-                model = new StatisticsPackagesViewModel
-                {
-                    IsCommunityPackageSet = false,
-                    IsDownloadPackageAvailable = _statisticsService.DownloadPackagesResult.Loaded,
-                    DownloadPackagesAll = _statisticsService.DownloadPackagesAll,
+                IsCommunityPackageSet = !isAllPackageSet,
+                IsDownloadPackageAvailable = _statisticsService.DownloadPackagesResult.Loaded,
+                DownloadPackagesAll = _statisticsService.DownloadPackagesAll,
 
-                    LastUpdatedUtc = _statisticsService.DownloadPackagesResult.LastUpdatedUtc,
-                };
-            }
-            else
-            {
-                model = new StatisticsPackagesViewModel
-                {
-                    IsCommunityPackageSet = true,
-                    IsDownloadPackageAvailable = _statisticsService.DownloadCommunityPackagesResult.Loaded,
-                    DownloadPackagesAll = _statisticsService.DownloadCommunityPackagesAll,
+                IsDownloadCommunityPackageAvailable = _statisticsService.DownloadCommunityPackagesResult.Loaded,
+                DownloadCommunityPackagesAll = _statisticsService.DownloadCommunityPackagesAll,
 
-                    LastUpdatedUtc = _statisticsService.DownloadCommunityPackagesResult.LastUpdatedUtc,
-                };
-            }
-
+                LastUpdatedUtc = (allPackagesUpdateTime > communityPackagesUpdateTime)
+                                    ? communityPackagesUpdateTime
+                                    : allPackagesUpdateTime,
+            };
 
             return View(model);
         }
@@ -160,30 +152,23 @@ namespace NuGetGallery
 
             await _statisticsService.Refresh();
 
-            StatisticsPackagesViewModel model;
+            var isAllPackageSet = (AllPackageSet == set);
+            var allPackagesUpdateTime = _statisticsService.DownloadPackagesResult.LastUpdatedUtc;
+            var communityPackagesUpdateTime = _statisticsService.DownloadCommunityPackagesResult.LastUpdatedUtc;
 
-            if (AllPackageSet == set)
+            var model = new StatisticsPackagesViewModel
             {
-                model = new StatisticsPackagesViewModel
-                {
-                    IsCommunityPackageSet = false,
-                    IsDownloadPackageVersionsAvailable = _statisticsService.DownloadPackageVersionsResult.Loaded,
-                    DownloadPackageVersionsAll = _statisticsService.DownloadPackageVersionsAll,
+                IsCommunityPackageSet = !isAllPackageSet,
+                IsDownloadPackageVersionsAvailable = _statisticsService.DownloadPackageVersionsResult.Loaded,
+                DownloadPackageVersionsAll = _statisticsService.DownloadPackageVersionsAll,
 
-                    LastUpdatedUtc = _statisticsService.DownloadPackagesResult.LastUpdatedUtc,
-                };
-            }
-            else
-            {
-                model = new StatisticsPackagesViewModel
-                {
-                    IsCommunityPackageSet = true,
-                    IsDownloadPackageVersionsAvailable = _statisticsService.DownloadCommunityPackageVersionsResult.Loaded,
-                    DownloadPackageVersionsAll = _statisticsService.DownloadCommunityPackageVersionsAll,
+                IsDownloadCommunityPackageVersionsAvailable = _statisticsService.DownloadCommunityPackageVersionsResult.Loaded,
+                DownloadCommunityPackageVersionsAll = _statisticsService.DownloadCommunityPackageVersionsAll,
 
-                    LastUpdatedUtc = _statisticsService.DownloadCommunityPackageVersionsResult.LastUpdatedUtc,
-                };
-            }
+                LastUpdatedUtc = (allPackagesUpdateTime > communityPackagesUpdateTime)
+                                    ? communityPackagesUpdateTime
+                                    : allPackagesUpdateTime,
+            };
 
             return View(model);
         }

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -153,8 +153,8 @@ namespace NuGetGallery
             await _statisticsService.Refresh();
 
             var isAllPackageSet = (AllPackageSet == set);
-            var allPackagesUpdateTime = _statisticsService.DownloadPackagesResult.LastUpdatedUtc;
-            var communityPackagesUpdateTime = _statisticsService.DownloadCommunityPackagesResult.LastUpdatedUtc;
+            var allPackagesUpdateTime = _statisticsService.DownloadPackageVersionsResult.LastUpdatedUtc;
+            var communityPackagesUpdateTime = _statisticsService.DownloadCommunityPackageVersionsResult.LastUpdatedUtc;
 
             var model = new StatisticsPackagesViewModel
             {

--- a/src/NuGetGallery/Services/IStatisticsService.cs
+++ b/src/NuGetGallery/Services/IStatisticsService.cs
@@ -9,21 +9,21 @@ namespace NuGetGallery
 {
     public interface IStatisticsService
     {
-        StatisticsReportResult DownloadPackagesResult { get; }
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesAll { get; }
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary { get; }
+        StatisticsReportResult PackageDownloadsResult { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> PackageDownloads { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> PackageDownloadsSummary { get; }
 
-        StatisticsReportResult DownloadPackageVersionsResult { get; }
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsAll { get; }
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary { get; }
+        StatisticsReportResult PackageVersionDownloadsResult { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> PackageVersionDownloads { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> PackageVersionDownloadsSummary { get; }
 
-        StatisticsReportResult DownloadCommunityPackagesResult { get; }
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesAll { get; }
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesSummary { get; }
+        StatisticsReportResult CommunityPackageDownloadsResult { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageDownloads { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageDownloadsSummary { get; }
 
-        StatisticsReportResult DownloadCommunityPackageVersionsResult { get; }
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsAll { get; }
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsSummary { get; }
+        StatisticsReportResult CommunityPackageVersionDownloadsResult { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageVersionDownloads { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageVersionDownloadsSummary { get; }
 
         StatisticsReportResult NuGetClientVersionResult { get; }
         IEnumerable<StatisticsNuGetUsageItem> NuGetClientVersion { get; }

--- a/src/NuGetGallery/Services/IStatisticsService.cs
+++ b/src/NuGetGallery/Services/IStatisticsService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,17 +9,30 @@ namespace NuGetGallery
 {
     public interface IStatisticsService
     {
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary { get; }
-        IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary { get; }
+        StatisticsReportResult DownloadPackagesResult { get; }
         IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesAll { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary { get; }
+
+        StatisticsReportResult DownloadPackageVersionsResult { get; }
         IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsAll { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary { get; }
+
+        StatisticsReportResult DownloadCommunityPackagesResult { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesAll { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesSummary { get; }
+
+        StatisticsReportResult DownloadCommunityPackageVersionsResult { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsAll { get; }
+        IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsSummary { get; }
+
+        StatisticsReportResult NuGetClientVersionResult { get; }
         IEnumerable<StatisticsNuGetUsageItem> NuGetClientVersion { get; }
+
+        StatisticsReportResult Last6WeeksResult { get; }
         IEnumerable<StatisticsWeeklyUsageItem> Last6Weeks { get; }
 
-        Task<StatisticsReportResult> LoadDownloadPackages();
-        Task<StatisticsReportResult> LoadDownloadPackageVersions();
-        Task<StatisticsReportResult> LoadNuGetClientVersion();
-        Task<StatisticsReportResult> LoadLast6Weeks();
+        DateTime? LastUpdatedUtc { get; }
+        Task Refresh();
 
         Task<StatisticsPackagesReport> GetPackageDownloadsByVersion(string packageId);
         Task<StatisticsPackagesReport> GetPackageVersionDownloadsByClient(string packageId, string packageVersion);

--- a/src/NuGetGallery/Services/JsonStatisticsService.cs
+++ b/src/NuGetGallery/Services/JsonStatisticsService.cs
@@ -175,8 +175,6 @@ namespace NuGetGallery
 
         private Task<StatisticsReportResult> LoadDownloadPackageVersions()
         {
-            var statisticsPackagesItemViewModels = (List<StatisticsPackagesItemViewModel>)DownloadPackageVersionsAll;
-
             return LoadDownloadPackageVersions(
                 StatisticsReportName.RecentPopularityDetail,
                 _downloadPackageVersionsAll,

--- a/src/NuGetGallery/Services/JsonStatisticsService.cs
+++ b/src/NuGetGallery/Services/JsonStatisticsService.cs
@@ -37,17 +37,17 @@ namespace NuGetGallery
         /// </summary>
         private readonly SemaphoreSlim _reportSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
-        private readonly List<StatisticsPackagesItemViewModel> _downloadPackagesAll = new List<StatisticsPackagesItemViewModel>();
-        private readonly List<StatisticsPackagesItemViewModel> _downloadPackagesSummary = new List<StatisticsPackagesItemViewModel>();
+        private readonly List<StatisticsPackagesItemViewModel> _packageDownloads = new List<StatisticsPackagesItemViewModel>();
+        private readonly List<StatisticsPackagesItemViewModel> _packageDownloadsSummary = new List<StatisticsPackagesItemViewModel>();
 
-        private readonly List<StatisticsPackagesItemViewModel> _downloadPackageVersionsAll = new List<StatisticsPackagesItemViewModel>();
-        private readonly List<StatisticsPackagesItemViewModel> _downloadPackageVersionsSummary = new List<StatisticsPackagesItemViewModel>();
+        private readonly List<StatisticsPackagesItemViewModel> _packageVersionDownloads = new List<StatisticsPackagesItemViewModel>();
+        private readonly List<StatisticsPackagesItemViewModel> _packageVersionDownloadsSummary = new List<StatisticsPackagesItemViewModel>();
 
-        private readonly List<StatisticsPackagesItemViewModel> _downloadCommunityPackagesAll = new List<StatisticsPackagesItemViewModel>();
-        private readonly List<StatisticsPackagesItemViewModel> _downloadCommunityPackagesSummary = new List<StatisticsPackagesItemViewModel>();
+        private readonly List<StatisticsPackagesItemViewModel> _communityPackageDownloads = new List<StatisticsPackagesItemViewModel>();
+        private readonly List<StatisticsPackagesItemViewModel> _communityPackageDownloadsSummary = new List<StatisticsPackagesItemViewModel>();
 
-        private readonly List<StatisticsPackagesItemViewModel> _downloadCommunityPackageVersionsAll = new List<StatisticsPackagesItemViewModel>();
-        private readonly List<StatisticsPackagesItemViewModel> _downloadCommunityPackageVersionsSummary = new List<StatisticsPackagesItemViewModel>();
+        private readonly List<StatisticsPackagesItemViewModel> _communityPackageVersionDownloads = new List<StatisticsPackagesItemViewModel>();
+        private readonly List<StatisticsPackagesItemViewModel> _communityPackageVersionDownloadsSummary = new List<StatisticsPackagesItemViewModel>();
 
         private readonly List<StatisticsNuGetUsageItem> _nuGetClientVersion = new List<StatisticsNuGetUsageItem>();
         private readonly List<StatisticsWeeklyUsageItem> _last6Weeks = new List<StatisticsWeeklyUsageItem>();
@@ -57,21 +57,21 @@ namespace NuGetGallery
             _reportService = reportService;
         }
 
-        public StatisticsReportResult DownloadPackagesResult { get; private set; }
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesAll => _downloadPackagesAll;
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary => _downloadPackagesSummary;
+        public StatisticsReportResult PackageDownloadsResult { get; private set; }
+        public IEnumerable<StatisticsPackagesItemViewModel> PackageDownloads => _packageDownloads;
+        public IEnumerable<StatisticsPackagesItemViewModel> PackageDownloadsSummary => _packageDownloadsSummary;
 
-        public StatisticsReportResult DownloadPackageVersionsResult { get; private set; }
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsAll => _downloadPackageVersionsAll;
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary => _downloadPackageVersionsSummary;
+        public StatisticsReportResult PackageVersionDownloadsResult { get; private set; }
+        public IEnumerable<StatisticsPackagesItemViewModel> PackageVersionDownloads => _packageVersionDownloads;
+        public IEnumerable<StatisticsPackagesItemViewModel> PackageVersionDownloadsSummary => _packageVersionDownloadsSummary;
 
-        public StatisticsReportResult DownloadCommunityPackagesResult { get; private set; }
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesAll => _downloadCommunityPackagesAll;
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesSummary => _downloadCommunityPackagesSummary;
+        public StatisticsReportResult CommunityPackageDownloadsResult { get; private set; }
+        public IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageDownloads => _communityPackageDownloads;
+        public IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageDownloadsSummary => _communityPackageDownloadsSummary;
 
-        public StatisticsReportResult DownloadCommunityPackageVersionsResult { get; private set; }
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsAll => _downloadCommunityPackageVersionsAll;
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsSummary => _downloadCommunityPackageVersionsSummary;
+        public StatisticsReportResult CommunityPackageVersionDownloadsResult { get; private set; }
+        public IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageVersionDownloads => _communityPackageVersionDownloads;
+        public IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageVersionDownloadsSummary => _communityPackageVersionDownloadsSummary;
 
         public StatisticsReportResult NuGetClientVersionResult { get; private set; }
         public IEnumerable<StatisticsNuGetUsageItem> NuGetClientVersion => _nuGetClientVersion;
@@ -113,10 +113,10 @@ namespace NuGetGallery
                     LoadNuGetClientVersion(),
                     LoadLast6Weeks());
 
-                DownloadPackagesResult = availablity[0];
-                DownloadPackageVersionsResult = availablity[1];
-                DownloadCommunityPackagesResult = availablity[2];
-                DownloadCommunityPackageVersionsResult = availablity[3];
+                PackageDownloadsResult = availablity[0];
+                PackageVersionDownloadsResult = availablity[1];
+                CommunityPackageDownloadsResult = availablity[2];
+                CommunityPackageVersionDownloadsResult = availablity[3];
                 NuGetClientVersionResult = availablity[4];
                 Last6WeeksResult = availablity[5];
 
@@ -150,16 +150,16 @@ namespace NuGetGallery
         {
             return LoadDownloadPackages(
                 StatisticsReportName.RecentPopularity,
-                _downloadPackagesAll,
-                _downloadPackagesSummary);
+                _packageDownloads,
+                _packageDownloadsSummary);
         }
 
         private Task<StatisticsReportResult> LoadDownloadCommunityPackages()
         {
             return LoadDownloadPackages(
                 StatisticsReportName.RecentCommunityPopularity,
-                _downloadCommunityPackagesAll,
-                _downloadCommunityPackagesSummary);
+                _communityPackageDownloads,
+                _communityPackageDownloadsSummary);
         }
 
         /// <summary>
@@ -210,16 +210,16 @@ namespace NuGetGallery
         {
             return LoadDownloadPackageVersions(
                 StatisticsReportName.RecentPopularityDetail,
-                _downloadPackageVersionsAll,
-                _downloadPackageVersionsSummary);
+                _packageVersionDownloads,
+                _packageVersionDownloadsSummary);
         }
 
         private Task<StatisticsReportResult> LoadDownloadCommunityPackageVersions()
         {
             return LoadDownloadPackageVersions(
                 StatisticsReportName.RecentCommunityPopularityDetail,
-                _downloadCommunityPackageVersionsAll,
-                _downloadCommunityPackageVersionsSummary);
+                _communityPackageVersionDownloads,
+                _communityPackageVersionDownloadsSummary);
         }
 
         /// <summary>

--- a/src/NuGetGallery/Services/NullStatisticsService.cs
+++ b/src/NuGetGallery/Services/NullStatisticsService.cs
@@ -16,21 +16,21 @@ namespace NuGetGallery
 
         private NullStatisticsService() { }
 
-        public StatisticsReportResult DownloadPackagesResult => StatisticsReportResult.Failed;
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesAll => Enumerable.Empty<StatisticsPackagesItemViewModel>();
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public StatisticsReportResult PackageDownloadsResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsPackagesItemViewModel> PackageDownloads => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public IEnumerable<StatisticsPackagesItemViewModel> PackageDownloadsSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
 
-        public StatisticsReportResult DownloadPackageVersionsResult => StatisticsReportResult.Failed;
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsAll => Enumerable.Empty<StatisticsPackagesItemViewModel>();
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public StatisticsReportResult PackageVersionDownloadsResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsPackagesItemViewModel> PackageVersionDownloads => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public IEnumerable<StatisticsPackagesItemViewModel> PackageVersionDownloadsSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
 
-        public StatisticsReportResult DownloadCommunityPackagesResult => StatisticsReportResult.Failed;
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesAll => Enumerable.Empty<StatisticsPackagesItemViewModel>();
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public StatisticsReportResult CommunityPackageDownloadsResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageDownloads => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageDownloadsSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
 
-        public StatisticsReportResult DownloadCommunityPackageVersionsResult => StatisticsReportResult.Failed;
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsAll => Enumerable.Empty<StatisticsPackagesItemViewModel>();
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public StatisticsReportResult CommunityPackageVersionDownloadsResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageVersionDownloads => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public IEnumerable<StatisticsPackagesItemViewModel> CommunityPackageVersionDownloadsSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
 
         public StatisticsReportResult NuGetClientVersionResult => StatisticsReportResult.Failed;
         public IEnumerable<StatisticsNuGetUsageItem> NuGetClientVersion => Enumerable.Empty<StatisticsNuGetUsageItem>();

--- a/src/NuGetGallery/Services/NullStatisticsService.cs
+++ b/src/NuGetGallery/Services/NullStatisticsService.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -15,55 +16,31 @@ namespace NuGetGallery
 
         private NullStatisticsService() { }
 
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary
-        {
-            get { return Enumerable.Empty<StatisticsPackagesItemViewModel>(); }
-        }
+        public StatisticsReportResult DownloadPackagesResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesAll => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
 
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary
-        {
-            get { return Enumerable.Empty<StatisticsPackagesItemViewModel>(); }
-        }
+        public StatisticsReportResult DownloadPackageVersionsResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsAll => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
 
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesAll
-        {
-            get { return Enumerable.Empty<StatisticsPackagesItemViewModel>(); }
-        }
+        public StatisticsReportResult DownloadCommunityPackagesResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesAll => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
 
-        public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsAll
-        {
-            get { return Enumerable.Empty<StatisticsPackagesItemViewModel>(); }
-        }
+        public StatisticsReportResult DownloadCommunityPackageVersionsResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsAll => Enumerable.Empty<StatisticsPackagesItemViewModel>();
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsSummary => Enumerable.Empty<StatisticsPackagesItemViewModel>();
 
-        public IEnumerable<StatisticsNuGetUsageItem> NuGetClientVersion
-        {
-            get { return Enumerable.Empty<StatisticsNuGetUsageItem>(); }
-        }
+        public StatisticsReportResult NuGetClientVersionResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsNuGetUsageItem> NuGetClientVersion => Enumerable.Empty<StatisticsNuGetUsageItem>();
 
-        public IEnumerable<StatisticsWeeklyUsageItem> Last6Weeks
-        {
-            get { return Enumerable.Empty<StatisticsWeeklyUsageItem>(); }
-        }
+        public StatisticsReportResult Last6WeeksResult => StatisticsReportResult.Failed;
+        public IEnumerable<StatisticsWeeklyUsageItem> Last6Weeks => Enumerable.Empty<StatisticsWeeklyUsageItem>();
 
-        public Task<StatisticsReportResult> LoadDownloadPackages()
-        {
-            return Task.FromResult(StatisticsReportResult.Failed);
-        }
+        public DateTime? LastUpdatedUtc => null;
 
-        public Task<StatisticsReportResult> LoadDownloadPackageVersions()
-        {
-            return Task.FromResult(StatisticsReportResult.Failed);
-        }
-
-        public Task<StatisticsReportResult> LoadNuGetClientVersion()
-        {
-            return Task.FromResult(StatisticsReportResult.Failed);
-        }
-
-        public Task<StatisticsReportResult> LoadLast6Weeks()
-        {
-            return Task.FromResult(StatisticsReportResult.Failed);
-        }
+        public Task Refresh() => Task.CompletedTask;
 
         public Task<StatisticsPackagesReport> GetPackageDownloadsByVersion(string packageId)
         {

--- a/src/NuGetGallery/Services/StatisticsReportName.cs
+++ b/src/NuGetGallery/Services/StatisticsReportName.cs
@@ -18,6 +18,21 @@ namespace NuGetGallery
         /// </summary>
         RecentPopularityDetail_,
         /// <summary>
+        /// Most frequently downloaded community package registration in last 6 weeks.
+        /// This excludes Microsoft and ASP.NET packages.
+        /// </summary>
+        RecentCommunityPopularity,
+        /// <summary>
+        /// Most frequently downloaded community package, specific to actual version.
+        /// This excludes Microsoft and ASP.NET packages.
+        /// </summary>
+        RecentCommunityPopularityDetail,
+        /// <summary>
+        /// Breakout by version for a community package (drill down from RecentPopularity).
+        /// This excludes Microsoft and ASP.NET packages.
+        /// </summary>
+        RecentCommunityPopularityDetail_,
+        /// <summary>
         /// Downloads that have been done by the various NuGet client versions.
         /// </summary>
         NuGetClientVersion,

--- a/src/NuGetGallery/Services/StatisticsReportName.cs
+++ b/src/NuGetGallery/Services/StatisticsReportName.cs
@@ -28,11 +28,6 @@ namespace NuGetGallery
         /// </summary>
         RecentCommunityPopularityDetail,
         /// <summary>
-        /// Breakout by version for a community package (drill down from RecentPopularity).
-        /// This excludes Microsoft and ASP.NET packages.
-        /// </summary>
-        RecentCommunityPopularityDetail_,
-        /// <summary>
         /// Downloads that have been done by the various NuGet client versions.
         /// </summary>
         NuGetClientVersion,

--- a/src/NuGetGallery/Services/StatisticsReportResult.cs
+++ b/src/NuGetGallery/Services/StatisticsReportResult.cs
@@ -12,15 +12,15 @@ namespace NuGetGallery
     {
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "This object is immutable")]
         public static readonly StatisticsReportResult Failed = new StatisticsReportResult(
-            loaded: false, 
+            isLoaded: false,
             lastUpdatedUtc: null);
 
-        public bool Loaded { get; private set; }
+        public bool IsLoaded { get; private set; }
         public DateTime? LastUpdatedUtc { get; private set; }
 
-        private StatisticsReportResult(bool loaded, DateTime? lastUpdatedUtc)
+        private StatisticsReportResult(bool isLoaded, DateTime? lastUpdatedUtc)
         {
-            Loaded = loaded;
+            IsLoaded = isLoaded;
             LastUpdatedUtc = lastUpdatedUtc;
         }
 
@@ -31,7 +31,7 @@ namespace NuGetGallery
 
         public static StatisticsReportResult Success(DateTime? lastUpdatedUtc)
         {
-            return new StatisticsReportResult(loaded: true, lastUpdatedUtc: lastUpdatedUtc);
+            return new StatisticsReportResult(isLoaded: true, lastUpdatedUtc: lastUpdatedUtc);
         }
     }
 }

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -72,28 +72,20 @@ namespace NuGetGallery
             return GetRouteLink(url, RouteName.StatisticsHome, relativeUrl);
         }
 
-        public static string StatisticsAllPackageDownloads(this UrlHelper url, bool communityPackages = true, bool relativeUrl = true)
+        public static string StatisticsAllPackageDownloads(this UrlHelper url, bool relativeUrl = true)
         {
             return GetRouteLink(
                 url,
                 RouteName.StatisticsPackages,
-                relativeUrl,
-                routeValues: new RouteValueDictionary
-                {
-                    { "set", communityPackages ? "community" : "all" }
-                });
+                relativeUrl);
         }
 
-        public static string StatisticsAllPackageVersionDownloads(this UrlHelper url, bool communityPackages = true, bool relativeUrl = true)
+        public static string StatisticsAllPackageVersionDownloads(this UrlHelper url, bool relativeUrl = true)
         {
             return GetRouteLink(
                 url,
                 RouteName.StatisticsPackageVersions,
-                relativeUrl,
-                routeValues: new RouteValueDictionary
-                {
-                    { "set", communityPackages ? "community" : "all" }
-                });
+                relativeUrl);
         }
 
         public static string StatisticsPackageDownloadByVersion(this UrlHelper url, string id, bool relativeUrl = true)

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -72,14 +72,28 @@ namespace NuGetGallery
             return GetRouteLink(url, RouteName.StatisticsHome, relativeUrl);
         }
 
-        public static string StatisticsAllPackageDownloads(this UrlHelper url, bool relativeUrl = true)
+        public static string StatisticsAllPackageDownloads(this UrlHelper url, bool communityPackages = true, bool relativeUrl = true)
         {
-            return GetRouteLink(url, RouteName.StatisticsPackages, relativeUrl);
+            return GetRouteLink(
+                url,
+                RouteName.StatisticsPackages,
+                relativeUrl,
+                routeValues: new RouteValueDictionary
+                {
+                    { "set", communityPackages ? "community" : "all" }
+                });
         }
 
-        public static string StatisticsAllPackageVersionDownloads(this UrlHelper url, bool relativeUrl = true)
+        public static string StatisticsAllPackageVersionDownloads(this UrlHelper url, bool communityPackages = true, bool relativeUrl = true)
         {
-            return GetRouteLink(url, RouteName.StatisticsPackageVersions, relativeUrl);
+            return GetRouteLink(
+                url,
+                RouteName.StatisticsPackageVersions,
+                relativeUrl,
+                routeValues: new RouteValueDictionary
+                {
+                    { "set", communityPackages ? "community" : "all" }
+                });
         }
 
         public static string StatisticsPackageDownloadByVersion(this UrlHelper url, string id, bool relativeUrl = true)

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -26,8 +26,6 @@ namespace NuGetGallery
         {
         }
 
-        public bool IsCommunityPackageSet { get; set; }
-
         public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary { get; set; }
 
         public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary { get; set; }

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -26,6 +26,8 @@ namespace NuGetGallery
         {
         }
 
+        public bool IsCommunityPackageSet { get; set; }
+
         public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary { get; set; }
 
         public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary { get; set; }

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -29,10 +29,16 @@ namespace NuGetGallery
         public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesSummary { get; set; }
 
         public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsSummary { get; set; }
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesSummary { get; set; }
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsSummary { get; set; }
 
         public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackagesAll { get; set; }
 
         public IEnumerable<StatisticsPackagesItemViewModel> DownloadPackageVersionsAll { get; set; }
+
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackagesAll { get; set; }
+
+        public IEnumerable<StatisticsPackagesItemViewModel> DownloadCommunityPackageVersionsAll { get; set; }
 
         public IEnumerable<StatisticsNuGetUsageItem> NuGetClientVersion { get; set; }
 
@@ -40,7 +46,11 @@ namespace NuGetGallery
 
         public bool IsDownloadPackageAvailable { get; set; }
 
-        public bool IsDownloadPackageDetailAvailable { get; set; }
+        public bool IsDownloadPackageVersionsAvailable { get; set; }
+        
+        public bool IsDownloadCommunityPackageAvailable { get; set; }
+
+        public bool IsDownloadCommunityPackageVersionsAvailable { get; set; }
 
         public bool IsNuGetClientVersionAvailable { get; set; }
 

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -24,7 +24,7 @@
         @if (Model.IsDownloadPackageAvailable && Model.IsDownloadCommunityPackageAvailable)
         {
             <div class="col-md-6 col-xs-12">
-                <h2 class="stats-title-text">Package Downloads</h2>
+                <h2 class="stats-title-text" data-bind="text: (showAllPackageDownloads() ? 'Package Downloads' : 'Community Package Downloads')"></h2>
 
                 <p>
                     Show all packages:
@@ -95,7 +95,7 @@
         @if (Model.IsDownloadPackageVersionsAvailable && Model.IsDownloadCommunityPackageVersionsAvailable)
         {
             <div class="col-md-6 col-xs-12">
-                <h2 class="stats-title-text">Version Downloads</h2>
+                <h2 class="stats-title-text" data-bind="text: (showAllPackageVersionDownloads() ? 'Version Downloads' : 'Community Package Version Downloads')">Version Downloads</h2>
 
                 <p>
                     Show all packages:

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -16,20 +16,19 @@
 
 <section role="main" class="container main-container page-statistics-overview">
     <h1>Statistics</h1>
+
     <span class="page-subheading ms-fontSize-l">
         @Html.Partial("_LastUpdated", Model)
     </span>
-
+    <p>
+        Show all packages:
+        <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
+    </p>
     <div class="row">
         @if (Model.IsDownloadPackageAvailable && Model.IsDownloadCommunityPackageAvailable)
         {
             <div class="col-md-6 col-xs-12">
                 <h2 class="stats-title-text" data-bind="text: (showAllPackageDownloads() ? 'Package Downloads' : 'Community Package Downloads')"></h2>
-
-                <p>
-                    Show all packages:
-                    <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
-                </p>
 
                 <table class="table col-xs-12 borderless" style="display: none;" data-bind="visible: showAllPackageDownloads">
                     <thead>
@@ -95,14 +94,9 @@
         @if (Model.IsDownloadPackageVersionsAvailable && Model.IsDownloadCommunityPackageVersionsAvailable)
         {
             <div class="col-md-6 col-xs-12">
-                <h2 class="stats-title-text" data-bind="text: (showAllPackageVersionDownloads() ? 'Version Downloads' : 'Community Package Version Downloads')">Version Downloads</h2>
+                <h2 class="stats-title-text" data-bind="text: (showAllPackageDownloads() ? 'Version Downloads' : 'Community Package Version Downloads')">Version Downloads</h2>
 
-                <p>
-                    Show all packages:
-                    <input type="checkbox" data-bind="checked: showAllPackageVersionDownloads" />
-                </p>
-
-                <table class="table col-xs-12 borderless" style="display:none;" data-bind="visible: showAllPackageVersionDownloads">
+                <table class="table col-xs-12 borderless" style="display:none;" data-bind="visible: showAllPackageDownloads">
                     <thead>
                         <tr>
                             <th class="text-left">Name</th>
@@ -134,7 +128,7 @@
                     </tfoot>
                 </table>
 
-                <table class="table col-xs-12 borderless" data-bind="visible: !showAllPackageVersionDownloads()">
+                <table class="table col-xs-12 borderless" data-bind="visible: !showAllPackageDownloads()">
                     <thead>
                         <tr>
                             <th class="text-left">Name</th>
@@ -333,7 +327,6 @@
 
             var viewModel = {
                 showAllPackageDownloads: ko.observable(false),
-                showAllPackageVersionDownloads: ko.observable(false),
             };
 
             ko.applyBindings(viewModel);

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -21,11 +21,17 @@
     </span>
 
     <div class="row">
-        @if (Model.IsDownloadPackageAvailable)
+        @if (Model.IsDownloadPackageAvailable && Model.IsDownloadCommunityPackageAvailable)
         {
             <div class="col-md-6 col-xs-12">
                 <h2 class="stats-title-text">Package Downloads</h2>
-                <table class="table col-xs-12 borderless">
+
+                <p>
+                    Show all packages:
+                    <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
+                </p>
+
+                <table class="table col-xs-12 borderless" style="display: none;" data-bind="visible: showAllPackageDownloads">
                     <thead>
                         <tr>
                             <th class="text-left">Name</th>
@@ -49,18 +55,54 @@
                     <tfoot>
                         <tr>
                             <td colspan="2">
-                                <a href="@Url.StatisticsAllPackageDownloads()">More...<span class="sr-only">View more package download statistics</span></a>
+                                <a href="@Url.StatisticsAllPackageDownloads(communityPackages: false)">More...<span class="sr-only">View more package download statistics</span></a>
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+
+                <table class="table col-xs-12 borderless" data-bind="visible: !showAllPackageDownloads()">
+                    <thead>
+                        <tr>
+                            <th class="text-left">Name</th>
+                            <th class="text-right">Downloads</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @{
+                            index = 0;
+                            foreach (var item in Model.DownloadCommunityPackagesSummary)
+                            {
+                                index++;
+
+                                <tr>
+                                    <td class="text-left"><a href="@Url.Package(item.PackageId)" title="@item.PackageId">@item.PackageId</a></td>
+                                    <td class="text-right"><a href="@Url.StatisticsPackageDownloadByVersion(item.PackageId)">@Model.DisplayDownloads(item.Downloads)</a></td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td colspan="2">
+                                <a href="@Url.StatisticsAllPackageDownloads(communityPackages: true)">More...<span class="sr-only">View more package download statistics</span></a>
                             </td>
                         </tr>
                     </tfoot>
                 </table>
             </div>
         }
-        @if (Model.IsDownloadPackageVersionsAvailable)
+        @if (Model.IsDownloadPackageVersionsAvailable && Model.IsDownloadCommunityPackageVersionsAvailable)
         {
             <div class="col-md-6 col-xs-12">
                 <h2 class="stats-title-text">Version Downloads</h2>
-                <table class="table col-xs-12 borderless">
+
+                <p>
+                    Show all packages:
+                    <input type="checkbox" data-bind="checked: showAllPackageVersionDownloads" />
+                </p>
+
+                <table class="table col-xs-12 borderless" style="display:none;" data-bind="visible: showAllPackageVersionDownloads">
                     <thead>
                         <tr>
                             <th class="text-left">Name</th>
@@ -86,7 +128,39 @@
                     <tfoot>
                         <tr>
                             <td colspan="3">
-                                <a href="@Url.StatisticsAllPackageVersionDownloads()">More...<span class="sr-only">View more package version download statistics</span></a>
+                                <a href="@Url.StatisticsAllPackageVersionDownloads(communityPackages: false)">More...<span class="sr-only">View more package version download statistics</span></a>
+                            </td>
+                        </tr>
+                    </tfoot>
+                </table>
+
+                <table class="table col-xs-12 borderless" data-bind="visible: !showAllPackageVersionDownloads()">
+                    <thead>
+                        <tr>
+                            <th class="text-left">Name</th>
+                            <th class="text-center">Version</th>
+                            <th class="text-right">Downloads</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @{
+                            index = 0;
+                            foreach (var item in Model.DownloadCommunityPackageVersionsSummary)
+                            {
+                                index++;
+
+                                <tr>
+                                    <td class="text-left"><a href="@Url.Package(item.PackageId)" title="@item.PackageId">@item.PackageId</a></td>
+                                    <td class="text-center"><a href="@Url.Package(item.PackageId, item.PackageVersion)">@item.PackageVersion</a></td>
+                                    <td class="text-right"><a href="@Url.StatisticsPackageDownloadsDetail(item.PackageId, item.PackageVersion)">@Model.DisplayDownloads(item.Downloads)</a></td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td colspan="3">
+                                <a href="@Url.StatisticsAllPackageVersionDownloads(communityPackages: true)">More...<span class="sr-only">View more package version download statistics</span></a>
                             </td>
                         </tr>
                     </tfoot>
@@ -250,3 +324,19 @@
          }
     </div>
 </section>
+
+@section BottomScripts
+{
+    <script>
+        $(function () {
+            'use strict';
+
+            var viewModel = {
+                showAllPackageDownloads: ko.observable(false),
+                showAllPackageVersionDownloads: ko.observable(false),
+            };
+
+            ko.applyBindings(viewModel);
+        });
+    </script>
+}

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -20,17 +20,14 @@
     <span class="page-subheading ms-fontSize-l">
         @Html.Partial("_LastUpdated", Model)
     </span>
-    <p>
-        Show all packages:
-        <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
-    </p>
+
     <div class="row">
-        @if (Model.IsDownloadPackageAvailable && Model.IsDownloadCommunityPackageAvailable)
+        @if (Model.IsDownloadPackageAvailable)
         {
             <div class="col-md-6 col-xs-12">
-                <h2 class="stats-title-text" data-bind="text: (showAllPackageDownloads() ? 'Package Downloads' : 'Community Package Downloads')"></h2>
+                <h2 class="stats-title-text">Package Downloads</h2>
 
-                <table class="table col-xs-12 borderless" style="display: none;" data-bind="visible: showAllPackageDownloads">
+                <table class="table col-xs-12 borderless">
                     <thead>
                         <tr>
                             <th class="text-left">Name</th>
@@ -54,49 +51,19 @@
                     <tfoot>
                         <tr>
                             <td colspan="2">
-                                <a href="@Url.StatisticsAllPackageDownloads(communityPackages: false)">More...<span class="sr-only">View more package download statistics</span></a>
-                            </td>
-                        </tr>
-                    </tfoot>
-                </table>
-
-                <table class="table col-xs-12 borderless" data-bind="visible: !showAllPackageDownloads()">
-                    <thead>
-                        <tr>
-                            <th class="text-left">Name</th>
-                            <th class="text-right">Downloads</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @{
-                            index = 0;
-                            foreach (var item in Model.DownloadCommunityPackagesSummary)
-                            {
-                                index++;
-
-                                <tr>
-                                    <td class="text-left"><a href="@Url.Package(item.PackageId)" title="@item.PackageId">@item.PackageId</a></td>
-                                    <td class="text-right"><a href="@Url.StatisticsPackageDownloadByVersion(item.PackageId)">@Model.DisplayDownloads(item.Downloads)</a></td>
-                                </tr>
-                            }
-                        }
-                    </tbody>
-                    <tfoot>
-                        <tr>
-                            <td colspan="2">
-                                <a href="@Url.StatisticsAllPackageDownloads(communityPackages: true)">More...<span class="sr-only">View more package download statistics</span></a>
+                                <a href="@Url.StatisticsAllPackageDownloads()">More...<span class="sr-only">View more package download statistics</span></a>
                             </td>
                         </tr>
                     </tfoot>
                 </table>
             </div>
         }
-        @if (Model.IsDownloadPackageVersionsAvailable && Model.IsDownloadCommunityPackageVersionsAvailable)
+        @if (Model.IsDownloadPackageVersionsAvailable)
         {
             <div class="col-md-6 col-xs-12">
-                <h2 class="stats-title-text" data-bind="text: (showAllPackageDownloads() ? 'Version Downloads' : 'Community Package Version Downloads')">Version Downloads</h2>
+                <h2 class="stats-title-text">Version Downloads</h2>
 
-                <table class="table col-xs-12 borderless" style="display:none;" data-bind="visible: showAllPackageDownloads">
+                <table class="table col-xs-12 borderless">
                     <thead>
                         <tr>
                             <th class="text-left">Name</th>
@@ -122,39 +89,7 @@
                     <tfoot>
                         <tr>
                             <td colspan="3">
-                                <a href="@Url.StatisticsAllPackageVersionDownloads(communityPackages: false)">More...<span class="sr-only">View more package version download statistics</span></a>
-                            </td>
-                        </tr>
-                    </tfoot>
-                </table>
-
-                <table class="table col-xs-12 borderless" data-bind="visible: !showAllPackageDownloads()">
-                    <thead>
-                        <tr>
-                            <th class="text-left">Name</th>
-                            <th class="text-center">Version</th>
-                            <th class="text-right">Downloads</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @{
-                            index = 0;
-                            foreach (var item in Model.DownloadCommunityPackageVersionsSummary)
-                            {
-                                index++;
-
-                                <tr>
-                                    <td class="text-left"><a href="@Url.Package(item.PackageId)" title="@item.PackageId">@item.PackageId</a></td>
-                                    <td class="text-center"><a href="@Url.Package(item.PackageId, item.PackageVersion)">@item.PackageVersion</a></td>
-                                    <td class="text-right"><a href="@Url.StatisticsPackageDownloadsDetail(item.PackageId, item.PackageVersion)">@Model.DisplayDownloads(item.Downloads)</a></td>
-                                </tr>
-                            }
-                        }
-                    </tbody>
-                    <tfoot>
-                        <tr>
-                            <td colspan="3">
-                                <a href="@Url.StatisticsAllPackageVersionDownloads(communityPackages: true)">More...<span class="sr-only">View more package version download statistics</span></a>
+                                <a href="@Url.StatisticsAllPackageVersionDownloads()">More...<span class="sr-only">View more package version download statistics</span></a>
                             </td>
                         </tr>
                     </tfoot>
@@ -318,18 +253,3 @@
          }
     </div>
 </section>
-
-@section BottomScripts
-{
-    <script>
-        $(function () {
-            'use strict';
-
-            var viewModel = {
-                showAllPackageDownloads: ko.observable(false),
-            };
-
-            ko.applyBindings(viewModel);
-        });
-    </script>
-}

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -56,8 +56,8 @@
                 </table>
             </div>
         }
-        @if (Model.IsDownloadPackageDetailAvailable)
-            {
+        @if (Model.IsDownloadPackageVersionsAvailable)
+        {
             <div class="col-md-6 col-xs-12">
                 <h2 class="stats-title-text">Version Downloads</h2>
                 <table class="table col-xs-12 borderless">

--- a/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
@@ -63,7 +63,7 @@
                 </table>
 
                 <table @ShowIfCommunityPackageSet() class="table borderless">
-                    <caption class="sr-only">The non-Microsoft packages with the most downloads.</caption>
+                    <caption class="sr-only">The community packages with the most downloads.</caption>
 
                     <thead>
                         <tr class="package-versions">

--- a/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
@@ -20,8 +20,8 @@
         <div class="col-xs-12">
             <h1>Most Downloaded Package Versions</h1>
 
-            <span class="page-subheading ms-fontSize-l" data-bind="text: showAllPackageDownloads() ? 'Top 500 Over the Last 6 Weeks' : 'Top 500 Community Packages Over the Last 6 Weeks'">
-                Top 500 Over the Last 6 Weeks
+            <span class="page-subheading ms-fontSize-l" data-bind="text: showAllPackageDownloads() ? 'Top 500 Packages Over the Last 6 Weeks' : 'Top 500 Community Packages Over the Last 6 Weeks'">
+                Top 500 Community Packages Over the Last 6 Weeks
             </span>
         </div>
         </div>

--- a/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
@@ -5,67 +5,116 @@
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
+@helper ShowIfAllPackageSet()
+{
+    if (Model.IsCommunityPackageSet)
+    {
+        @:style="display:none;" data-bind="visible: showAllPackageDownloads"
+    }
+    else
+    {
+        @:data-bind="visible: showAllPackageDownloads"
+    }
+}
+
+@helper ShowIfCommunityPackageSet()
+{
+    if (Model.IsCommunityPackageSet)
+    {
+        @:data-bind="visible: !showAllPackageDownloads()"
+    }
+    else
+    {
+        @:style="display:none;" data-bind="visible: !showAllPackageDownloads()"
+    }
+}
+
 <section role="main" class="container main-container page-statistics-most-downloaded">
     <div class="row">
         <div class="col-xs-12">
-            @if (Model.IsCommunityPackageSet)
-            {
-                <h1>Most Downloaded Community Package Versions</h1>
-                <span class="page-subheading ms-fontSize-l">Top 500 Non-Microsoft Packages Over the Last 6 Weeks</span>
-            }
-            else
-            {
+            <div @ShowIfAllPackageSet()>
                 <h1>Most Downloaded Package Versions</h1>
                 <span class="page-subheading ms-fontSize-l">Top 500 Over the Last 6 Weeks</span>
-            }
+            </div>
+            <div @ShowIfCommunityPackageSet()>
+                <h1>Most Downloaded Community Package Versions</h1>
+                <span class="page-subheading ms-fontSize-l">Top 500 Non-Microsoft Packages Over the Last 6 Weeks</span>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-xs-12">
-            <table class="table borderless">
-                @if (Model.IsCommunityPackageSet)
-                {
-                     <caption class="sr-only">
-                        The non-Microsoft packages with the most downloads.
+        </div>
+        <div class="row">
+            <div class="col-xs-12">
+                <table class="table borderless">
+                    <caption class="sr-only" data-bind="text: showAllPackageDownloads() ? 'The packages with the most downloads.' : 'The non-Microsoft packages with the most downloads.'">
                     </caption>
-                }
-                else
-                {
-                    <caption class="sr-only">
-                        The packages with the most downloads.
-                    </caption>
-                }
-                <thead>
-                    <tr class="package-versions">
-                        <th scope="col">&nbsp;<span class="sr-only">#</span></th>
-                        <th scope="col">Package</th>
-                        <th scope="col">Version</th>
-                        <th scope="col">Downloads</th>
-                    </tr>
-                </thead>
 
-                <tbody>
-                    @{
-                        var index = 0;
-                        foreach (var item in Model.DownloadPackageVersionsAll)
-                        {
-                            index++;
+                    <p>
+                        Show all packages:
+                        <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
+                    </p>
 
-                            <tr>
-                                <td scope="row">@index</td>
-                                <td><a href="@Url.Package(item.PackageId)">@item.PackageId</a></td>
-                                <td><a href="@Url.Package(item.PackageId, item.PackageVersion)">@item.PackageVersion</a></td>
-                                <td><a href="@Url.StatisticsPackageDownloadsDetail(item.PackageId, item.PackageVersion)">@Model.DisplayDownloads(item.Downloads)</a></td>
-                            </tr>
+                    <thead>
+                        <tr class="package-versions">
+                            <th scope="col">&nbsp;<span class="sr-only">#</span></th>
+                            <th scope="col">Package</th>
+                            <th scope="col">Version</th>
+                            <th scope="col">Downloads</th>
+                        </tr>
+                    </thead>
+
+                    <tbody @ShowIfAllPackageSet()>
+                        @{
+                            var index = 0;
+                            foreach (var item in Model.DownloadPackageVersionsAll)
+                            {
+                                index++;
+
+                                <tr>
+                                    <td scope="row">@index</td>
+                                    <td><a href="@Url.Package(item.PackageId)">@item.PackageId</a></td>
+                                    <td><a href="@Url.Package(item.PackageId, item.PackageVersion)">@item.PackageVersion</a></td>
+                                    <td><a href="@Url.StatisticsPackageDownloadsDetail(item.PackageId, item.PackageVersion)">@Model.DisplayDownloads(item.Downloads)</a></td>
+                                </tr>
+                            }
                         }
-                    }
-                </tbody>
-            </table>
+                    </tbody>
+                    <tbody @ShowIfCommunityPackageSet()>
+                        @{
+                            index = 0;
+                            foreach (var item in Model.DownloadCommunityPackageVersionsAll)
+                            {
+                                index++;
+
+                                <tr>
+                                    <td scope="row">@index</td>
+                                    <td><a href="@Url.Package(item.PackageId)">@item.PackageId</a></td>
+                                    <td><a href="@Url.Package(item.PackageId, item.PackageVersion)">@item.PackageVersion</a></td>
+                                    <td><a href="@Url.StatisticsPackageDownloadsDetail(item.PackageId, item.PackageVersion)">@Model.DisplayDownloads(item.Downloads)</a></td>
+                                </tr>
+                            }
+                        }
+                    </tbody>
+                </table>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-xs-12">
-            @Html.Partial("_LastUpdated", Model)
+        <div class="row">
+            <div class="col-xs-12">
+                @Html.Partial("_LastUpdated", Model)
+            </div>
         </div>
-    </div>
 </section>
+
+@section BottomScripts
+{
+    <script>
+        $(function () {
+            'use strict';
+
+            var viewModel = {
+                showAllPackageDownloads: ko.observable(@(Model.IsCommunityPackageSet ? "false" : "true")),
+            };
+
+            ko.applyBindings(viewModel);
+        });
+    </script>
+}

--- a/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
@@ -23,15 +23,14 @@
             <span class="page-subheading ms-fontSize-l" data-bind="text: showAllPackageDownloads() ? 'Top 500 Packages Over the Last 6 Weeks' : 'Top 500 Community Packages Over the Last 6 Weeks'">
                 Top 500 Community Packages Over the Last 6 Weeks
             </span>
+            <label class="show-all-packages-toggle pull-right">
+                <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
+                Show all packages
+            </label>
         </div>
         </div>
         <div class="row">
             <div class="col-xs-12">
-                <p>
-                    Show all packages:
-                    <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
-                </p>
-
                 <table @ShowIfAllPackageSet() class="table borderless">
                     <caption class="sr-only">The packages with the most downloads.</caption>
 

--- a/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
@@ -8,16 +8,33 @@
 <section role="main" class="container main-container page-statistics-most-downloaded">
     <div class="row">
         <div class="col-xs-12">
-            <h1>Most Downloaded Package Versions</h1>
-            <span class="page-subheading ms-fontSize-l">Top 500 Over the Last 6 Weeks</span>
+            @if (Model.IsCommunityPackageSet)
+            {
+                <h1>Most Downloaded Community Package Versions</h1>
+                <span class="page-subheading ms-fontSize-l">Top 500 Non-Microsoft Packages Over the Last 6 Weeks</span>
+            }
+            else
+            {
+                <h1>Most Downloaded Package Versions</h1>
+                <span class="page-subheading ms-fontSize-l">Top 500 Over the Last 6 Weeks</span>
+            }
         </div>
     </div>
     <div class="row">
         <div class="col-xs-12">
             <table class="table borderless">
-                <caption class="sr-only">
-                    The package versions with the most downloads.
-                </caption>
+                @if (Model.IsCommunityPackageSet)
+                {
+                     <caption class="sr-only">
+                        The non-Microsoft packages with the most downloads.
+                    </caption>
+                }
+                else
+                {
+                    <caption class="sr-only">
+                        The packages with the most downloads.
+                    </caption>
+                }
                 <thead>
                     <tr class="package-versions">
                         <th scope="col">&nbsp;<span class="sr-only">#</span></th>

--- a/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
@@ -7,39 +7,22 @@
 
 @helper ShowIfAllPackageSet()
 {
-    if (Model.IsCommunityPackageSet)
-    {
-        @:style="display:none;" data-bind="visible: showAllPackageDownloads"
-    }
-    else
-    {
-        @:data-bind="visible: showAllPackageDownloads"
-    }
+    @:style="display:none;" data-bind="visible: showAllPackageDownloads"
 }
 
 @helper ShowIfCommunityPackageSet()
 {
-    if (Model.IsCommunityPackageSet)
-    {
-        @:data-bind="visible: !showAllPackageDownloads()"
-    }
-    else
-    {
-        @:style="display:none;" data-bind="visible: !showAllPackageDownloads()"
-    }
+    @:data-bind="visible: !showAllPackageDownloads()"
 }
 
 <section role="main" class="container main-container page-statistics-most-downloaded">
     <div class="row">
         <div class="col-xs-12">
-            <div @ShowIfAllPackageSet()>
-                <h1>Most Downloaded Package Versions</h1>
-                <span class="page-subheading ms-fontSize-l">Top 500 Over the Last 6 Weeks</span>
-            </div>
-            <div @ShowIfCommunityPackageSet()>
-                <h1>Most Downloaded Community Package Versions</h1>
-                <span class="page-subheading ms-fontSize-l">Top 500 Non-Microsoft Packages Over the Last 6 Weeks</span>
-            </div>
+            <h1>Most Downloaded Package Versions</h1>
+
+            <span class="page-subheading ms-fontSize-l" data-bind="text: showAllPackageDownloads() ? 'Top 500 Over the Last 6 Weeks' : 'Top 500 Community Packages Over the Last 6 Weeks'">
+                Top 500 Over the Last 6 Weeks
+            </span>
         </div>
         </div>
         <div class="row">
@@ -124,7 +107,7 @@
             'use strict';
 
             var viewModel = {
-                showAllPackageDownloads: ko.observable(@(Model.IsCommunityPackageSet ? "false" : "true")),
+                showAllPackageDownloads: ko.observable(false),
             };
 
             ko.applyBindings(viewModel);

--- a/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
@@ -44,14 +44,13 @@
         </div>
         <div class="row">
             <div class="col-xs-12">
-                <table class="table borderless">
-                    <caption class="sr-only" data-bind="text: showAllPackageDownloads() ? 'The packages with the most downloads.' : 'The non-Microsoft packages with the most downloads.'">
-                    </caption>
+                <p>
+                    Show all packages:
+                    <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
+                </p>
 
-                    <p>
-                        Show all packages:
-                        <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
-                    </p>
+                <table @ShowIfAllPackageSet() class="table borderless">
+                    <caption class="sr-only">The packages with the most downloads.</caption>
 
                     <thead>
                         <tr class="package-versions">
@@ -62,7 +61,7 @@
                         </tr>
                     </thead>
 
-                    <tbody @ShowIfAllPackageSet()>
+                    <tbody>
                         @{
                             var index = 0;
                             foreach (var item in Model.DownloadPackageVersionsAll)
@@ -78,7 +77,21 @@
                             }
                         }
                     </tbody>
-                    <tbody @ShowIfCommunityPackageSet()>
+                </table>
+
+                <table @ShowIfCommunityPackageSet() class="table borderless">
+                    <caption class="sr-only">The non-Microsoft packages with the most downloads.</caption>
+
+                    <thead>
+                        <tr class="package-versions">
+                            <th scope="col">&nbsp;<span class="sr-only">#</span></th>
+                            <th scope="col">Package</th>
+                            <th scope="col">Version</th>
+                            <th scope="col">Downloads</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
                         @{
                             index = 0;
                             foreach (var item in Model.DownloadCommunityPackageVersionsAll)

--- a/src/NuGetGallery/Views/Statistics/Packages.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Packages.cshtml
@@ -44,14 +44,13 @@
     </div>
     <div class="row">
         <div class="col-xs-12">
-            <table class="table borderless">
-                <caption class="sr-only" data-bind="text: showAllPackageDownloads() ? 'The packages with the most downloads.' : 'The non-Microsoft packages with the most downloads.'">
-                </caption>
+            <p>
+                Show all packages:
+                <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
+            </p>
 
-                <p>
-                    Show all packages:
-                    <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
-                </p>
+            <table @ShowIfAllPackageSet() class="table borderless">
+                <caption class="sr-only">The packages with the most downloads.</caption>
 
                 <thead>
                     <tr class="packages">
@@ -61,7 +60,7 @@
                     </tr>
                 </thead>
 
-                <tbody @ShowIfAllPackageSet()>
+                <tbody>
                     @{
                         var index = 0;
                         foreach (var item in Model.DownloadPackagesAll)
@@ -76,8 +75,20 @@
                         }
                     }
                 </tbody>
+            </table>
 
-                <tbody @ShowIfCommunityPackageSet()>
+            <table @ShowIfCommunityPackageSet() class="table borderless">
+                <caption class="sr-only">The non-Microsoft packages with the most downloads.</caption>
+
+                <thead>
+                    <tr class="packages">
+                        <th scope="col">&nbsp;<span class="sr-only">#</span></th>
+                        <th scope="col">Package</th>
+                        <th scope="col">Downloads</th>
+                    </tr>
+                </thead>
+
+                <tbody>
                     @{
                         index = 0;
                         foreach (var item in Model.DownloadCommunityPackagesAll)
@@ -92,6 +103,7 @@
                         }
                     }
                 </tbody>
+
             </table>
         </div>
     </div>

--- a/src/NuGetGallery/Views/Statistics/Packages.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Packages.cshtml
@@ -61,7 +61,7 @@
             </table>
 
             <table @ShowIfCommunityPackageSet() class="table borderless">
-                <caption class="sr-only">The non-Microsoft packages with the most downloads.</caption>
+                <caption class="sr-only">The community packages with the most downloads.</caption>
 
                 <thead>
                     <tr class="packages">

--- a/src/NuGetGallery/Views/Statistics/Packages.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Packages.cshtml
@@ -5,36 +5,53 @@
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
+@helper ShowIfAllPackageSet()
+    {
+        if (Model.IsCommunityPackageSet)
+        {
+            @:style="display:none;" data-bind="visible: showAllPackageDownloads"
+        }
+        else
+        {
+            @:data-bind="visible: showAllPackageDownloads"
+        }
+}
+
+@helper ShowIfCommunityPackageSet()
+    {
+        if (Model.IsCommunityPackageSet)
+        {
+            @:data-bind="visible: !showAllPackageDownloads()"
+        }
+        else
+        {
+            @:style="display:none;" data-bind="visible: !showAllPackageDownloads()"
+        }
+}
+
 <section role="main" class="container main-container page-statistics-most-downloaded">
     <div class="row">
         <div class="col-xs-12">
-            @if (Model.IsCommunityPackageSet)
-            {
-                <h1>Most Downloaded Community Packages</h1>
-                <span class="page-subheading ms-fontSize-l">Top 100 Non-Microsoft Packages Over the Last 6 Weeks</span>
-            }
-            else
-            {
+            <div @ShowIfAllPackageSet()>
                 <h1>Most Downloaded Packages</h1>
                 <span class="page-subheading ms-fontSize-l">Top 100 Over the Last 6 Weeks</span>
-            }
+            </div>
+            <div @ShowIfCommunityPackageSet()>
+                <h1>Most Downloaded Community Packages</h1>
+                <span class="page-subheading ms-fontSize-l">Top 100 Non-Microsoft Packages Over the Last 6 Weeks</span>
+            </div>
         </div>
     </div>
     <div class="row">
         <div class="col-xs-12">
             <table class="table borderless">
-                @if (Model.IsCommunityPackageSet)
-                {
-                     <caption class="sr-only">
-                        The non-Microsoft packages with the most downloads.
-                    </caption>
-                }
-                else
-                {
-                    <caption class="sr-only">
-                        The packages with the most downloads.
-                    </caption>
-                }
+                <caption class="sr-only" data-bind="text: showAllPackageDownloads() ? 'The packages with the most downloads.' : 'The non-Microsoft packages with the most downloads.'">
+                </caption>
+
+                <p>
+                    Show all packages:
+                    <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
+                </p>
 
                 <thead>
                     <tr class="packages">
@@ -44,10 +61,26 @@
                     </tr>
                 </thead>
 
-                <tbody>
+                <tbody @ShowIfAllPackageSet()>
                     @{
                         var index = 0;
                         foreach (var item in Model.DownloadPackagesAll)
+                        {
+                            index++;
+
+                            <tr>
+                                <td scope="row">@index</td>
+                                <td><a href="@Url.Package(item.PackageId)">@item.PackageId</a></td>
+                                <td><a href="@Url.StatisticsPackageDownloadByVersion(item.PackageId)">@Model.DisplayDownloads(item.Downloads)</a></td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+
+                <tbody @ShowIfCommunityPackageSet()>
+                    @{
+                        index = 0;
+                        foreach (var item in Model.DownloadCommunityPackagesAll)
                         {
                             index++;
 
@@ -69,3 +102,17 @@
     </div>
 </section>
 
+@section BottomScripts
+{
+    <script>
+        $(function () {
+            'use strict';
+
+            var viewModel = {
+                showAllPackageDownloads: ko.observable(@(Model.IsCommunityPackageSet ? "false" : "true")),
+            };
+
+            ko.applyBindings(viewModel);
+        });
+    </script>
+}

--- a/src/NuGetGallery/Views/Statistics/Packages.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Packages.cshtml
@@ -6,40 +6,23 @@
 }
 
 @helper ShowIfAllPackageSet()
-    {
-        if (Model.IsCommunityPackageSet)
-        {
-            @:style="display:none;" data-bind="visible: showAllPackageDownloads"
-        }
-        else
-        {
-            @:data-bind="visible: showAllPackageDownloads"
-        }
+{
+    @:style="display:none;" data-bind="visible: showAllPackageDownloads"
 }
 
 @helper ShowIfCommunityPackageSet()
-    {
-        if (Model.IsCommunityPackageSet)
-        {
-            @:data-bind="visible: !showAllPackageDownloads()"
-        }
-        else
-        {
-            @:style="display:none;" data-bind="visible: !showAllPackageDownloads()"
-        }
+{
+    @:data-bind="visible: !showAllPackageDownloads()"
 }
 
 <section role="main" class="container main-container page-statistics-most-downloaded">
     <div class="row">
         <div class="col-xs-12">
-            <div @ShowIfAllPackageSet()>
-                <h1>Most Downloaded Packages</h1>
-                <span class="page-subheading ms-fontSize-l">Top 100 Over the Last 6 Weeks</span>
-            </div>
-            <div @ShowIfCommunityPackageSet()>
-                <h1>Most Downloaded Community Packages</h1>
-                <span class="page-subheading ms-fontSize-l">Top 100 Non-Microsoft Packages Over the Last 6 Weeks</span>
-            </div>
+            <h1>Most Downloaded Packages</h1>
+
+            <span class="page-subheading ms-fontSize-l" data-bind="text: showAllPackageDownloads() ? 'Top 100 Over the Last 6 Weeks' : 'Top 100 Community Packages Over the Last 6 Weeks'">
+                Top 100 Over the Last 6 Weeks
+            </span>
         </div>
     </div>
     <div class="row">
@@ -121,7 +104,7 @@
             'use strict';
 
             var viewModel = {
-                showAllPackageDownloads: ko.observable(@(Model.IsCommunityPackageSet ? "false" : "true")),
+                showAllPackageDownloads: ko.observable(false),
             };
 
             ko.applyBindings(viewModel);

--- a/src/NuGetGallery/Views/Statistics/Packages.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Packages.cshtml
@@ -20,8 +20,8 @@
         <div class="col-xs-12">
             <h1>Most Downloaded Packages</h1>
 
-            <span class="page-subheading ms-fontSize-l" data-bind="text: showAllPackageDownloads() ? 'Top 100 Over the Last 6 Weeks' : 'Top 100 Community Packages Over the Last 6 Weeks'">
-                Top 100 Over the Last 6 Weeks
+            <span class="page-subheading ms-fontSize-l" data-bind="text: showAllPackageDownloads() ? 'Top 100 Packages Over the Last 6 Weeks' : 'Top 100 Community Packages Over the Last 6 Weeks'">
+                Top 100 Community Packages Over the Last 6 Weeks
             </span>
         </div>
     </div>

--- a/src/NuGetGallery/Views/Statistics/Packages.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Packages.cshtml
@@ -8,16 +8,34 @@
 <section role="main" class="container main-container page-statistics-most-downloaded">
     <div class="row">
         <div class="col-xs-12">
-            <h1>Most Downloaded Packages</h1>
-            <span class="page-subheading ms-fontSize-l">Top 100 Over the Last 6 Weeks</span>
+            @if (Model.IsCommunityPackageSet)
+            {
+                <h1>Most Downloaded Community Packages</h1>
+                <span class="page-subheading ms-fontSize-l">Top 100 Non-Microsoft Packages Over the Last 6 Weeks</span>
+            }
+            else
+            {
+                <h1>Most Downloaded Packages</h1>
+                <span class="page-subheading ms-fontSize-l">Top 100 Over the Last 6 Weeks</span>
+            }
         </div>
     </div>
     <div class="row">
         <div class="col-xs-12">
             <table class="table borderless">
-                <caption class="sr-only">
-                    The packages with the most downloads.
-                </caption>
+                @if (Model.IsCommunityPackageSet)
+                {
+                     <caption class="sr-only">
+                        The non-Microsoft packages with the most downloads.
+                    </caption>
+                }
+                else
+                {
+                    <caption class="sr-only">
+                        The packages with the most downloads.
+                    </caption>
+                }
+
                 <thead>
                     <tr class="packages">
                         <th scope="col">&nbsp;<span class="sr-only">#</span></th>

--- a/src/NuGetGallery/Views/Statistics/Packages.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Packages.cshtml
@@ -23,15 +23,14 @@
             <span class="page-subheading ms-fontSize-l" data-bind="text: showAllPackageDownloads() ? 'Top 100 Packages Over the Last 6 Weeks' : 'Top 100 Community Packages Over the Last 6 Weeks'">
                 Top 100 Community Packages Over the Last 6 Weeks
             </span>
+            <label class="show-all-packages-toggle pull-right">
+                <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
+                Show all packages
+            </label>
         </div>
     </div>
     <div class="row">
         <div class="col-xs-12">
-            <p>
-                Show all packages:
-                <input type="checkbox" data-bind="checked: showAllPackageDownloads" />
-            </p>
-
             <table @ShowIfAllPackageSet() class="table borderless">
                 <caption class="sr-only">The packages with the most downloads.</caption>
 

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -1593,7 +1593,7 @@ namespace NuGetGallery
             public async Task VerifyStatsDownloadsReturnsNotFoundWhenStatsNotAvailable()
             {
                 var controller = new TestableApiController(GetConfigurationService());
-                controller.MockStatisticsService.Setup(x => x.DownloadPackageVersionsResult).Returns(StatisticsReportResult.Failed);
+                controller.MockStatisticsService.Setup(x => x.PackageVersionDownloadsResult).Returns(StatisticsReportResult.Failed);
 
                 TestUtility.SetupUrlHelperForUrlGeneration(controller);
 

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -1593,7 +1593,7 @@ namespace NuGetGallery
             public async Task VerifyStatsDownloadsReturnsNotFoundWhenStatsNotAvailable()
             {
                 var controller = new TestableApiController(GetConfigurationService());
-                controller.MockStatisticsService.Setup(x => x.LoadDownloadPackageVersions()).Returns(Task.FromResult(StatisticsReportResult.Failed));
+                controller.MockStatisticsService.Setup(x => x.DownloadPackageVersionsResult).Returns(StatisticsReportResult.Failed);
 
                 TestUtility.SetupUrlHelperForUrlGeneration(controller);
 

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -118,7 +118,7 @@ namespace NuGetGallery
                 }
             }
 
-            if (model.IsDownloadPackageDetailAvailable)
+            if (model.IsDownloadPackageVersionsAvailable)
             {
                 foreach (var item in model.DownloadPackageVersionsSummary)
                 {
@@ -234,7 +234,7 @@ namespace NuGetGallery
                 }
             }
 
-            if (model.IsDownloadPackageDetailAvailable)
+            if (model.IsDownloadPackageVersionsAvailable)
             {
                 foreach (var item in model.DownloadPackageVersionsSummary)
                 {

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -320,9 +320,11 @@ namespace NuGetGallery
             var fakePackageVersionReport = report.ToString();
 
             var fakeReportService = new Mock<IReportService>();
-            var updatedUtc = new DateTime(2001, 01, 01, 10, 20, 30);
+            var updatedUtc1 = new DateTime(2002, 01, 01, 10, 20, 30);
+            var updatedUtc2 = new DateTime(2001, 01, 01, 10, 20, 30);
 
-            fakeReportService.Setup(x => x.Load("recentpopularitydetail.json")).Returns(Task.FromResult(new StatisticsReport(fakePackageVersionReport, updatedUtc)));
+            fakeReportService.Setup(x => x.Load("recentpopularitydetail.json")).Returns(Task.FromResult(new StatisticsReport(fakePackageVersionReport, updatedUtc1)));
+            fakeReportService.Setup(x => x.Load("recentcommunitypopularitydetail.json")).Returns(Task.FromResult(new StatisticsReport(fakePackageVersionReport, updatedUtc2)));
 
             var controller = new StatisticsController(new JsonStatisticsService(fakeReportService.Object));
 
@@ -337,7 +339,7 @@ namespace NuGetGallery
 
             Assert.Equal(106, sum);
             Assert.True(model.LastUpdatedUtc.HasValue);
-            Assert.Equal(updatedUtc, model.LastUpdatedUtc.Value);
+            Assert.Equal(updatedUtc2, model.LastUpdatedUtc.Value);
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -101,6 +101,9 @@ namespace NuGetGallery
 
             fakeReportService.Setup(x => x.Load("recentpopularity.json")).Returns(Task.FromResult(new StatisticsReport(fakePackageReport, DateTime.MinValue)));
             fakeReportService.Setup(x => x.Load("recentpopularitydetail.json")).Returns(Task.FromResult(new StatisticsReport(fakePackageVersionReport, null)));
+            fakeReportService.Setup(x => x.Load("recentcommunitypopularity.json")).Returns(Task.FromResult(new StatisticsReport(fakePackageReport, DateTime.MinValue)));
+            fakeReportService.Setup(x => x.Load("recentcommunitypopularitydetail.json")).Returns(Task.FromResult(new StatisticsReport(fakePackageVersionReport, null)));
+
             fakeReportService.Setup(x => x.Load("nugetclientversion.json")).Returns(Task.FromResult(new StatisticsReport(fakeNuGetClientVersion, DateTime.MinValue)));
             fakeReportService.Setup(x => x.Load("last6weeks.json")).Returns(Task.FromResult(new StatisticsReport(fakeLast6Weeks, updatedUtc)));
 

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -339,7 +339,7 @@ namespace NuGetGallery
 
             Assert.Equal(106, sum);
             Assert.True(model.LastUpdatedUtc.HasValue);
-            Assert.Equal(updatedUtc2, model.LastUpdatedUtc.Value);
+            Assert.Equal(updatedUtc1, model.LastUpdatedUtc.Value);
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -432,6 +432,7 @@
     <Compile Include="HttpContextBaseExtensionsFacts.cs" />
     <Compile Include="Security\RequireMinProtocolVersionForPushPolicyFacts.cs" />
     <Compile Include="Services\DeleteAccountServiceFacts.cs" />
+    <Compile Include="Services\JsonStatisticsServiceFacts.cs" />
     <Compile Include="Services\PackageOwnerRequestServiceFacts.cs" />
     <Compile Include="Services\PackageOwnershipManagementServiceFacts.cs" />
     <Compile Include="Services\PermissionsServiceFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/JsonStatisticsServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/JsonStatisticsServiceFacts.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
+using System.Linq;
 
 namespace NuGetGallery.Services
 {
@@ -21,6 +22,209 @@ namespace NuGetGallery.Services
                 await _target.Refresh();
 
                 // Assert
+                Assert.True(_target.DownloadPackagesResult.Loaded);
+                Assert.True(_target.DownloadPackageVersionsResult.Loaded);
+                Assert.True(_target.DownloadCommunityPackagesResult.Loaded);
+                Assert.True(_target.DownloadCommunityPackageVersionsResult.Loaded);
+
+                Assert.NotNull(_target.DownloadPackagesResult.LastUpdatedUtc);
+                Assert.NotNull(_target.DownloadPackageVersionsResult.LastUpdatedUtc);
+                Assert.NotNull(_target.DownloadCommunityPackagesResult.LastUpdatedUtc);
+                Assert.NotNull(_target.DownloadCommunityPackageVersionsResult.LastUpdatedUtc);
+
+                Assert.Equal(LastUpdatedUtcDefault, _target.DownloadPackagesResult.LastUpdatedUtc);
+                Assert.Equal(LastUpdatedUtcDefault, _target.DownloadPackageVersionsResult.LastUpdatedUtc);
+                Assert.Equal(LastUpdatedUtcDefault, _target.DownloadCommunityPackagesResult.LastUpdatedUtc);
+                Assert.Equal(LastUpdatedUtcDefault, _target.DownloadCommunityPackageVersionsResult.LastUpdatedUtc);
+
+                Assert.Equal(2, _target.DownloadPackagesAll.Count());
+                Assert.Equal(3, _target.DownloadPackageVersionsAll.Count());
+                Assert.Equal(2, _target.DownloadCommunityPackagesAll.Count());
+                Assert.Equal(3, _target.DownloadCommunityPackageVersionsAll.Count());
+
+                VerifyReportsLoadedOnce();
+            }
+
+            [Fact]
+            public async Task DoesntReloadReportsIfCached()
+            {
+                // Arrange
+                Mock();
+
+                // Act
+                await _target.Refresh();
+                await _target.Refresh();
+
+                // Assert - The reports should only be loaded once due to caching.
+                VerifyReportsLoadedOnce();
+            }
+
+            [Fact]
+            public async Task LastUpdatedIsGreatestNonNullReportUpdateTime()
+            {
+                // Arrange
+                Mock(
+                    packagesLastUpdateTimeUtc: LastUpdatedUtcDefault,
+                    packageVersionsLastUpdateTimeUtc: LastUpdatedUtcDefault.AddHours(1),
+                    communityPackagesLastUpdateTimeUtc: null,
+                    communityPackageVersionsLastUpdateTimeUtc: LastUpdatedUtcDefault.AddHours(-1));
+
+                // Act
+                await _target.Refresh();
+
+                // Assert
+                Assert.Equal(LastUpdatedUtcDefault.AddHours(1), _target.LastUpdatedUtc);
+            }
+
+            [Fact]
+            public async Task LoadReportsFailsIfDownloadsIsMissingOrNotInteger()
+            {
+                // Arrange
+                var packagesReport = PackageDownloadsReport;
+                var packageVersionsReport = PackageVersionDownloadsReport;
+                var communityPackagesReport = PackageDownloadsReport;
+                var communityPackageVersionsReport = PackageVersionDownloadsReport;
+
+                packagesReport[0].Remove("Downloads");
+                packageVersionsReport[0].Remove("Downloads");
+                communityPackagesReport[1]["Downloads"] = "A lot of downloads";
+                communityPackageVersionsReport[1]["Downloads"] = "A lot of downloads";
+
+                Mock(
+                    packageDownloadsReport: packagesReport,
+                    packageVersionDownloadsReport: packageVersionsReport,
+                    communityPackageDownloadsReport: communityPackagesReport,
+                    communityPackageVersionDownloadsReport: communityPackageVersionsReport);
+
+                // Act
+                await _target.Refresh();
+
+                // Assert
+                Assert.False(_target.DownloadPackagesResult.Loaded);
+                Assert.False(_target.DownloadPackageVersionsResult.Loaded);
+                Assert.False(_target.DownloadCommunityPackagesResult.Loaded);
+                Assert.False(_target.DownloadCommunityPackageVersionsResult.Loaded);
+
+                VerifyReportsLoadedOnce();
+            }
+        }
+
+        public class FactsBase
+        {
+            public readonly DateTime LastUpdatedUtcDefault = DateTime.UtcNow;
+
+            public readonly string Package1Id = "A.Fantastic.Package";
+            public readonly string Package1Version1 = "1.0.0";
+            public readonly string Package1Version2 = "2.0.0";
+            public readonly int Package1Version1Downloads = 123;
+            public readonly int Package1Version2Downloads = 456;
+
+            public readonly string Package2Id = "Foo.Bar";
+            public readonly string Package2Version = "1.0.0";
+            public readonly int Package2Downloads = 789;
+
+            protected readonly Mock<IReportService> _reportService;
+            protected readonly JsonStatisticsService _target;
+
+            protected Dictionary<string, object>[] PackageDownloadsReport => new[]
+            {
+                new Dictionary<string, object>()
+                {
+                    { "PackageId", Package1Id },
+                    { "Downloads", Package1Version1Downloads + Package1Version2Downloads },
+                },
+
+                new Dictionary<string, object>()
+                {
+                    { "PackageId", Package2Id },
+                    { "Downloads", Package2Downloads },
+                },
+            };
+
+            protected Dictionary<string, object>[] PackageVersionDownloadsReport => new[]
+            {
+                new Dictionary<string, object>()
+                {
+                    { "PackageId", Package1Id },
+                    { "PackageVersion", Package1Version1 },
+                    { "Downloads", Package1Version1Downloads },
+                },
+
+                new Dictionary<string, object>()
+                {
+                    { "PackageId", Package1Id },
+                    { "PackageVersion", Package1Version2 },
+                    { "Downloads", Package1Version2Downloads },
+                },
+
+                new Dictionary<string, object>()
+                {
+                    { "PackageId", Package2Id },
+                    { "PackageVersion", Package2Version },
+                    { "Downloads", Package2Downloads },
+                },
+            };
+
+            public FactsBase()
+            {
+                _reportService = new Mock<IReportService>();
+
+                _target = new JsonStatisticsService(_reportService.Object);
+            }
+
+            protected void Mock(
+                IEnumerable<Dictionary<string, object>> packageDownloadsReport = null,
+                IEnumerable<Dictionary<string, object>> packageVersionDownloadsReport = null,
+                IEnumerable<Dictionary<string, object>> communityPackageDownloadsReport = null,
+                IEnumerable<Dictionary<string, object>> communityPackageVersionDownloadsReport = null,
+
+                DateTime? packagesLastUpdateTimeUtc = null,
+                DateTime? packageVersionsLastUpdateTimeUtc = null,
+                DateTime? communityPackagesLastUpdateTimeUtc = null,
+                DateTime? communityPackageVersionsLastUpdateTimeUtc = null)
+            {
+                packageDownloadsReport = packageDownloadsReport ?? PackageDownloadsReport;
+                packageVersionDownloadsReport = packageVersionDownloadsReport ?? PackageVersionDownloadsReport;
+                communityPackageDownloadsReport = communityPackageDownloadsReport ?? PackageDownloadsReport;
+                communityPackageVersionDownloadsReport = communityPackageVersionDownloadsReport ?? PackageVersionDownloadsReport;
+
+                // Set the default last updated timestamps only if all timestamps are null.
+                if (!packagesLastUpdateTimeUtc.HasValue && !packageVersionsLastUpdateTimeUtc.HasValue &&
+                    !communityPackagesLastUpdateTimeUtc.HasValue && !communityPackageVersionsLastUpdateTimeUtc.HasValue)
+                {
+                    packagesLastUpdateTimeUtc = packagesLastUpdateTimeUtc ?? LastUpdatedUtcDefault;
+                    packageVersionsLastUpdateTimeUtc = packageVersionsLastUpdateTimeUtc ?? LastUpdatedUtcDefault;
+                    communityPackagesLastUpdateTimeUtc = communityPackagesLastUpdateTimeUtc ?? LastUpdatedUtcDefault;
+                    communityPackageVersionsLastUpdateTimeUtc = communityPackageVersionsLastUpdateTimeUtc ?? LastUpdatedUtcDefault;
+                }
+
+                Task<StatisticsReport> CreateReport(IEnumerable<Dictionary<string, object>> report, DateTime? lastUpdatedUtc)
+                {
+                    var content = JsonConvert.SerializeObject(report);
+                    var result = new StatisticsReport(content, lastUpdatedUtc);
+
+                    return Task.FromResult(result);
+                }
+
+                _reportService
+                    .Setup(s => s.Load(It.Is<string>(n => n == "recentpopularity.json")))
+                    .Returns(CreateReport(packageDownloadsReport, packagesLastUpdateTimeUtc));
+
+                _reportService
+                    .Setup(s => s.Load(It.Is<string>(n => n == "recentcommunitypopularity.json")))
+                    .Returns(CreateReport(communityPackageDownloadsReport, communityPackagesLastUpdateTimeUtc));
+
+                _reportService
+                    .Setup(s => s.Load(It.Is<string>(n => n == "recentpopularitydetail.json")))
+                    .Returns(CreateReport(packageVersionDownloadsReport, packageVersionsLastUpdateTimeUtc));
+
+                _reportService
+                    .Setup(s => s.Load(It.Is<string>(n => n == "recentcommunitypopularitydetail.json")))
+                    .Returns(CreateReport(communityPackageVersionDownloadsReport, communityPackageVersionsLastUpdateTimeUtc));
+            }
+
+            protected void VerifyReportsLoadedOnce()
+            {
                 _reportService
                     .Verify(s => s.Load(It.Is<string>(n => n == "recentpopularity.json")), Times.Once);
 
@@ -32,144 +236,6 @@ namespace NuGetGallery.Services
 
                 _reportService
                     .Verify(s => s.Load(It.Is<string>(n => n == "recentcommunitypopularitydetail.json")), Times.Once);
-            }
-
-            [Fact]
-            public void DoesntReloadReportsIfCached()
-            {
-                // Refresh method doesn't do anything second time
-            }
-
-            [Fact]
-            public void LastUpdatedIsSmallestNonNullReportUpdateTime()
-            {
-                // LastUpdatedUtc is smallest non-null value
-            }
-
-            [Fact]
-            public void LoadDownloadPackagesFailsIfPackageIdIsMissingOrNotString()
-            {
-            }
-
-            [Fact]
-            public void LoadDownloadPackagesFailsIDownloadsIsMissingOrNotInteger()
-            {
-            }
-
-            [Fact]
-            public void LoadDownloadPackageVersionsFailsIfPackageIdIsMissingOrNotString()
-            {
-            }
-
-            [Fact]
-            public void LoadDownloadPackageVersionsFailsIfVersionIsMissingOrNotString()
-            {
-            }
-
-            [Fact]
-            public void LoadDownloadPackageVersionsFailsIfDownloadsIsMissingOrNotInteger()
-            {
-            }
-        }
-
-        public class FactsBase
-        {
-            protected readonly Mock<IReportService> _reportService;
-            protected readonly JsonStatisticsService _target;
-
-            protected readonly IEnumerable<Dictionary<string, object>> _downloadPackagesReport;
-            protected readonly IEnumerable<Dictionary<string, object>> _downloadPackageVersionsReport;
-
-            public FactsBase()
-            {
-                _reportService = new Mock<IReportService>();
-
-                _target = new JsonStatisticsService(_reportService.Object);
-
-                _downloadPackagesReport = new[]
-                {
-                    new Dictionary<string, object>()
-                    {
-                        { "PackageId", "A.Fantastic.Package" },
-                        { "Downloads", 123 },
-                    },
-
-                    new Dictionary<string, object>()
-                    {
-                        { "PackageId", "Foo.Bar" },
-                        { "Downloads", 456 },
-                    },
-                };
-
-                _downloadPackageVersionsReport = new[]
-                {
-                    new Dictionary<string, object>()
-                    {
-                        { "PackageId", "A.Fantastic.Package" },
-                        { "Version", "1.0.0" },
-                        { "Downloads", 100 },
-                    },
-
-                    new Dictionary<string, object>()
-                    {
-                        { "PackageId", "A.Fantastic.Package" },
-                        { "Version", "2.0.0" },
-                        { "Downloads", 23 },
-                    },
-
-                    new Dictionary<string, object>()
-                    {
-                        { "PackageId", "Foo.Bar" },
-                        { "Version", "1.0.0" },
-                        { "Downloads", 456 },
-                    },
-                };
-            }
-
-            protected void Mock(
-                IEnumerable<Dictionary<string, object>> packageDownloadsReport = null,
-                IEnumerable<Dictionary<string, object>> packageVersionDownloadsReport = null,
-                IEnumerable<Dictionary<string, object>> communityPackageDownloadsReport = null,
-                IEnumerable<Dictionary<string, object>> communityPackageVersionDownloadsReport = null,
-
-                DateTime? packageDownloadsReportLastUpdateTimeUtc = null,
-                DateTime? packageVersionDownloadsReportLastUpdateTimeUtc = null,
-                DateTime? communityPackageDownloadsReportLastUpdateTimeUtc = null,
-                DateTime? communityPackageVersionDownloadsReportLastUpdateTimeUtc = null)
-            {
-                packageDownloadsReport = packageDownloadsReport ?? _downloadPackagesReport;
-                packageVersionDownloadsReport = packageVersionDownloadsReport ?? _downloadPackageVersionsReport;
-                communityPackageDownloadsReport = communityPackageDownloadsReport ?? _downloadPackagesReport;
-                communityPackageVersionDownloadsReport = communityPackageVersionDownloadsReport ?? _downloadPackageVersionsReport;
-
-                packageDownloadsReportLastUpdateTimeUtc = packageDownloadsReportLastUpdateTimeUtc ?? DateTime.UtcNow;
-                packageVersionDownloadsReportLastUpdateTimeUtc = packageVersionDownloadsReportLastUpdateTimeUtc ?? DateTime.UtcNow;
-                communityPackageDownloadsReportLastUpdateTimeUtc = communityPackageDownloadsReportLastUpdateTimeUtc ?? DateTime.UtcNow;
-                communityPackageVersionDownloadsReportLastUpdateTimeUtc = communityPackageVersionDownloadsReportLastUpdateTimeUtc ?? DateTime.UtcNow;
-
-                _reportService
-                    .Setup(s => s.Load(It.Is<string>(n => n == "recentpopularity.json")))
-                    .Returns(CreateReport(packageDownloadsReport, packageDownloadsReportLastUpdateTimeUtc.Value));
-
-                _reportService
-                    .Setup(s => s.Load(It.Is<string>(n => n == "recentcommunitypopularity.json")))
-                    .Returns(CreateReport(communityPackageDownloadsReport, communityPackageDownloadsReportLastUpdateTimeUtc.Value));
-
-                _reportService
-                    .Setup(s => s.Load(It.Is<string>(n => n == "recentpopularitydetail.json")))
-                    .Returns(CreateReport(packageVersionDownloadsReport, packageVersionDownloadsReportLastUpdateTimeUtc.Value));
-
-                _reportService
-                    .Setup(s => s.Load(It.Is<string>(n => n == "recentcommunitypopularitydetail.json")))
-                    .Returns(CreateReport(communityPackageVersionDownloadsReport, communityPackageVersionDownloadsReportLastUpdateTimeUtc.Value));
-            }
-
-            private Task<StatisticsReport> CreateReport(IEnumerable<Dictionary<string, object>> report, DateTime lastUpdatedUtc)
-            {
-                var content = JsonConvert.SerializeObject(report);
-                var result = new StatisticsReport(content, lastUpdatedUtc);
-
-                return Task.FromResult(result);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Services/JsonStatisticsServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/JsonStatisticsServiceFacts.cs
@@ -1,0 +1,176 @@
+﻿using Moq;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGetGallery.Services
+{
+    public class JsonStatisticsServiceFacts
+    {
+        public class TheRefreshMethod : FactsBase
+        {
+            [Fact]
+            public async Task LoadsReports()
+            {
+                // Arrange
+                Mock();
+
+                // Act
+                await _target.Refresh();
+
+                // Assert
+                _reportService
+                    .Verify(s => s.Load(It.Is<string>(n => n == "recentpopularity.json")), Times.Once);
+
+                _reportService
+                    .Verify(s => s.Load(It.Is<string>(n => n == "recentcommunitypopularity.json")), Times.Once);
+
+                _reportService
+                    .Verify(s => s.Load(It.Is<string>(n => n == "recentpopularitydetail.json")), Times.Once);
+
+                _reportService
+                    .Verify(s => s.Load(It.Is<string>(n => n == "recentcommunitypopularitydetail.json")), Times.Once);
+            }
+
+            [Fact]
+            public void DoesntReloadReportsIfCached()
+            {
+                // Refresh method doesn't do anything second time
+            }
+
+            [Fact]
+            public void LastUpdatedIsSmallestNonNullReportUpdateTime()
+            {
+                // LastUpdatedUtc is smallest non-null value
+            }
+
+            [Fact]
+            public void LoadDownloadPackagesFailsIfPackageIdIsMissingOrNotString()
+            {
+            }
+
+            [Fact]
+            public void LoadDownloadPackagesFailsIDownloadsIsMissingOrNotInteger()
+            {
+            }
+
+            [Fact]
+            public void LoadDownloadPackageVersionsFailsIfPackageIdIsMissingOrNotString()
+            {
+            }
+
+            [Fact]
+            public void LoadDownloadPackageVersionsFailsIfVersionIsMissingOrNotString()
+            {
+            }
+
+            [Fact]
+            public void LoadDownloadPackageVersionsFailsIfDownloadsIsMissingOrNotInteger()
+            {
+            }
+        }
+
+        public class FactsBase
+        {
+            protected readonly Mock<IReportService> _reportService;
+            protected readonly JsonStatisticsService _target;
+
+            protected readonly IEnumerable<Dictionary<string, object>> _downloadPackagesReport;
+            protected readonly IEnumerable<Dictionary<string, object>> _downloadPackageVersionsReport;
+
+            public FactsBase()
+            {
+                _reportService = new Mock<IReportService>();
+
+                _target = new JsonStatisticsService(_reportService.Object);
+
+                _downloadPackagesReport = new[]
+                {
+                    new Dictionary<string, object>()
+                    {
+                        { "PackageId", "A.Fantastic.Package" },
+                        { "Downloads", 123 },
+                    },
+
+                    new Dictionary<string, object>()
+                    {
+                        { "PackageId", "Foo.Bar" },
+                        { "Downloads", 456 },
+                    },
+                };
+
+                _downloadPackageVersionsReport = new[]
+                {
+                    new Dictionary<string, object>()
+                    {
+                        { "PackageId", "A.Fantastic.Package" },
+                        { "Version", "1.0.0" },
+                        { "Downloads", 100 },
+                    },
+
+                    new Dictionary<string, object>()
+                    {
+                        { "PackageId", "A.Fantastic.Package" },
+                        { "Version", "2.0.0" },
+                        { "Downloads", 23 },
+                    },
+
+                    new Dictionary<string, object>()
+                    {
+                        { "PackageId", "Foo.Bar" },
+                        { "Version", "1.0.0" },
+                        { "Downloads", 456 },
+                    },
+                };
+            }
+
+            protected void Mock(
+                IEnumerable<Dictionary<string, object>> packageDownloadsReport = null,
+                IEnumerable<Dictionary<string, object>> packageVersionDownloadsReport = null,
+                IEnumerable<Dictionary<string, object>> communityPackageDownloadsReport = null,
+                IEnumerable<Dictionary<string, object>> communityPackageVersionDownloadsReport = null,
+
+                DateTime? packageDownloadsReportLastUpdateTimeUtc = null,
+                DateTime? packageVersionDownloadsReportLastUpdateTimeUtc = null,
+                DateTime? communityPackageDownloadsReportLastUpdateTimeUtc = null,
+                DateTime? communityPackageVersionDownloadsReportLastUpdateTimeUtc = null)
+            {
+                packageDownloadsReport = packageDownloadsReport ?? _downloadPackagesReport;
+                packageVersionDownloadsReport = packageVersionDownloadsReport ?? _downloadPackageVersionsReport;
+                communityPackageDownloadsReport = communityPackageDownloadsReport ?? _downloadPackagesReport;
+                communityPackageVersionDownloadsReport = communityPackageVersionDownloadsReport ?? _downloadPackageVersionsReport;
+
+                packageDownloadsReportLastUpdateTimeUtc = packageDownloadsReportLastUpdateTimeUtc ?? DateTime.UtcNow;
+                packageVersionDownloadsReportLastUpdateTimeUtc = packageVersionDownloadsReportLastUpdateTimeUtc ?? DateTime.UtcNow;
+                communityPackageDownloadsReportLastUpdateTimeUtc = communityPackageDownloadsReportLastUpdateTimeUtc ?? DateTime.UtcNow;
+                communityPackageVersionDownloadsReportLastUpdateTimeUtc = communityPackageVersionDownloadsReportLastUpdateTimeUtc ?? DateTime.UtcNow;
+
+                _reportService
+                    .Setup(s => s.Load(It.Is<string>(n => n == "recentpopularity.json")))
+                    .Returns(CreateReport(packageDownloadsReport, packageDownloadsReportLastUpdateTimeUtc.Value));
+
+                _reportService
+                    .Setup(s => s.Load(It.Is<string>(n => n == "recentcommunitypopularity.json")))
+                    .Returns(CreateReport(communityPackageDownloadsReport, communityPackageDownloadsReportLastUpdateTimeUtc.Value));
+
+                _reportService
+                    .Setup(s => s.Load(It.Is<string>(n => n == "recentpopularitydetail.json")))
+                    .Returns(CreateReport(packageVersionDownloadsReport, packageVersionDownloadsReportLastUpdateTimeUtc.Value));
+
+                _reportService
+                    .Setup(s => s.Load(It.Is<string>(n => n == "recentcommunitypopularitydetail.json")))
+                    .Returns(CreateReport(communityPackageVersionDownloadsReport, communityPackageVersionDownloadsReportLastUpdateTimeUtc.Value));
+            }
+
+            private Task<StatisticsReport> CreateReport(IEnumerable<Dictionary<string, object>> report, DateTime lastUpdatedUtc)
+            {
+                var content = JsonConvert.SerializeObject(report);
+                var result = new StatisticsReport(content, lastUpdatedUtc);
+
+                return Task.FromResult(result);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Services/JsonStatisticsServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/JsonStatisticsServiceFacts.cs
@@ -22,25 +22,25 @@ namespace NuGetGallery.Services
                 await _target.Refresh();
 
                 // Assert
-                Assert.True(_target.DownloadPackagesResult.Loaded);
-                Assert.True(_target.DownloadPackageVersionsResult.Loaded);
-                Assert.True(_target.DownloadCommunityPackagesResult.Loaded);
-                Assert.True(_target.DownloadCommunityPackageVersionsResult.Loaded);
+                Assert.True(_target.PackageDownloadsResult.IsLoaded);
+                Assert.True(_target.PackageVersionDownloadsResult.IsLoaded);
+                Assert.True(_target.CommunityPackageDownloadsResult.IsLoaded);
+                Assert.True(_target.CommunityPackageVersionDownloadsResult.IsLoaded);
 
-                Assert.NotNull(_target.DownloadPackagesResult.LastUpdatedUtc);
-                Assert.NotNull(_target.DownloadPackageVersionsResult.LastUpdatedUtc);
-                Assert.NotNull(_target.DownloadCommunityPackagesResult.LastUpdatedUtc);
-                Assert.NotNull(_target.DownloadCommunityPackageVersionsResult.LastUpdatedUtc);
+                Assert.NotNull(_target.PackageDownloadsResult.LastUpdatedUtc);
+                Assert.NotNull(_target.PackageVersionDownloadsResult.LastUpdatedUtc);
+                Assert.NotNull(_target.CommunityPackageDownloadsResult.LastUpdatedUtc);
+                Assert.NotNull(_target.CommunityPackageVersionDownloadsResult.LastUpdatedUtc);
 
-                Assert.Equal(LastUpdatedUtcDefault, _target.DownloadPackagesResult.LastUpdatedUtc);
-                Assert.Equal(LastUpdatedUtcDefault, _target.DownloadPackageVersionsResult.LastUpdatedUtc);
-                Assert.Equal(LastUpdatedUtcDefault, _target.DownloadCommunityPackagesResult.LastUpdatedUtc);
-                Assert.Equal(LastUpdatedUtcDefault, _target.DownloadCommunityPackageVersionsResult.LastUpdatedUtc);
+                Assert.Equal(LastUpdatedUtcDefault, _target.PackageDownloadsResult.LastUpdatedUtc);
+                Assert.Equal(LastUpdatedUtcDefault, _target.PackageVersionDownloadsResult.LastUpdatedUtc);
+                Assert.Equal(LastUpdatedUtcDefault, _target.CommunityPackageDownloadsResult.LastUpdatedUtc);
+                Assert.Equal(LastUpdatedUtcDefault, _target.CommunityPackageVersionDownloadsResult.LastUpdatedUtc);
 
-                Assert.Equal(2, _target.DownloadPackagesAll.Count());
-                Assert.Equal(3, _target.DownloadPackageVersionsAll.Count());
-                Assert.Equal(2, _target.DownloadCommunityPackagesAll.Count());
-                Assert.Equal(3, _target.DownloadCommunityPackageVersionsAll.Count());
+                Assert.Equal(2, _target.PackageDownloads.Count());
+                Assert.Equal(3, _target.PackageVersionDownloads.Count());
+                Assert.Equal(2, _target.CommunityPackageDownloads.Count());
+                Assert.Equal(3, _target.CommunityPackageVersionDownloads.Count());
 
                 VerifyReportsLoadedOnce();
             }
@@ -100,10 +100,10 @@ namespace NuGetGallery.Services
                 await _target.Refresh();
 
                 // Assert
-                Assert.False(_target.DownloadPackagesResult.Loaded);
-                Assert.False(_target.DownloadPackageVersionsResult.Loaded);
-                Assert.False(_target.DownloadCommunityPackagesResult.Loaded);
-                Assert.False(_target.DownloadCommunityPackageVersionsResult.Loaded);
+                Assert.False(_target.PackageDownloadsResult.IsLoaded);
+                Assert.False(_target.PackageVersionDownloadsResult.IsLoaded);
+                Assert.False(_target.CommunityPackageDownloadsResult.IsLoaded);
+                Assert.False(_target.CommunityPackageVersionDownloadsResult.IsLoaded);
 
                 VerifyReportsLoadedOnce();
             }


### PR DESCRIPTION
# Introduce Community Statistics Reports

This change introduces the concept of "community" statistics report that will be displayed by default. These reports filter out packages owned by Microsoft and .NET Framework. Users can choose to "Show all packages" to view reports that include Microsoft's and .NET Framework's packages. With this change, packages like `System.Globalization` will no longer clutter our default statistic reports! 😄 

Note: The `JsonStatisticsService` had some serious concurrency issue and did not cache reports that it loaded from blob storage. This pull request fixes that by loading reports once an hour.

This change depends on https://github.com/NuGet/NuGet.Jobs/pull/239.
Fixes https://github.com/NuGet/NuGetGallery/issues/3417.

# Screenshots

## Statistics Homepage

<img width="600" alt="one" src="https://user-images.githubusercontent.com/737941/32504494-ce9475f4-c394-11e7-9943-887d705169d0.png">

## Detailed Report

Clicking on the "Show more..." links at the bottom of the homepage will take you to the following reports:

### Most Downloaded Packages

![most-downloaded-packages](https://user-images.githubusercontent.com/737941/32573984-afce299e-c484-11e7-992f-46f836dd2d58.png)

### Most Downloaded Package Versions

![most-downloaded-package-versions](https://user-images.githubusercontent.com/737941/32573986-b232b844-c484-11e7-8f0d-91ac838a3437.png)
