### PR TITLE
Update Report Reasons

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -566,7 +566,6 @@ namespace NuGetGallery
 
         // NOTE: Intentionally NOT requiring authentication
         private static readonly ReportPackageReason[] ReportOtherPackageReasons = new[] {
-            ReportPackageReason.IsFraudulent,
             ReportPackageReason.ViolatesALicenseIOwn,
             ReportPackageReason.ContainsMaliciousCode,
             ReportPackageReason.HasABugOrFailedToInstall,

--- a/src/NuGetGallery/ViewModels/ReportPackageReason.cs
+++ b/src/NuGetGallery/ViewModels/ReportPackageReason.cs
@@ -16,11 +16,8 @@ namespace NuGetGallery
         [Description("The package contains malicious code")]
         ContainsMaliciousCode,
 
-        [Description("The package violates a copyright I own")]
+        [Description("The package is infringing my copyright or trademark")]
         ViolatesALicenseIOwn,
-
-        [Description("The package owner is fraudulently claiming authorship")]
-        IsFraudulent,
 
         [Description("The package contains private/confidential data")]
         ContainsPrivateAndConfidentialData,

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -65,7 +65,7 @@
                     </div>
                     <div class="form-group @Html.HasErrorFor(m => m.Message)">
                         @Html.ShowLabelFor(m => m.Message)
-                        <p>Please provide a detailed description of the problem.</p>
+                        <p>Please provide a detailed description of the problem.<span class="infringement-claim-requirements"> If you are reporting copyright infringment, please describe the copyrighted material with particularity and provide us with information about your copyright (i.e. title of copyrighted work, URL where to view your copyrighted work, description of your copyrighted work, and any copyright registrations you may have, etc.). For trademark infringement, include the name of your trademark, registration number, and country where registered.</span></p>
                         @Html.ShowTextAreaFor(m => m.Message, 10, 50)
                         @Html.ShowValidationMessagesFor(m => m.Message)
                     </div>

--- a/src/NuGetGallery/Views/Packages/ReportMyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportMyPackage.cshtml
@@ -31,7 +31,7 @@
                 </div>
                 <div class="form-group @Html.HasErrorFor(m => m.Message)">
                     @Html.ShowLabelFor(m => m.Message)
-                    <p>Please provide a detailed description of the problem.</p>
+                    <p>Please provide a detailed description of the problem.<span class="infringement-claim-requirements"> If you are reporting copyright infringment, please describe the copyrighted material with particularity and provide us with information about your copyright (i.e. title of copyrighted work, URL where to view your copyrighted work, description of your copyrighted work, and any copyright registrations you may have, etc.). For trademark infringement, include the name of your trademark, registration number, and country where registered.</span></p>
                     @Html.ShowTextAreaFor(m => m.Message, 10, 50)
                     @Html.ShowValidationMessagesFor(m => m.Message)
                 </div>

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1727,7 +1727,7 @@ namespace NuGetGallery
                 {
                     Email = "frodo@hobbiton.example.com",
                     Message = "Mordor took my finger.",
-                    Reason = ReportPackageReason.IsFraudulent,
+                    Reason = ReportPackageReason.ViolatesALicenseIOwn,
                     AlreadyContactedOwner = true,
                 };
 
@@ -1740,7 +1740,7 @@ namespace NuGetGallery
                         It.Is<ReportPackageRequest>(
                             r => r.FromAddress.Address == "frodo@hobbiton.example.com"
                                  && r.Package == package
-                                 && r.Reason == EnumHelper.GetDescription(ReportPackageReason.IsFraudulent)
+                                 && r.Reason == EnumHelper.GetDescription(ReportPackageReason.ViolatesALicenseIOwn)
                                  && r.Message == "Mordor took my finger."
                                  && r.AlreadyContactedOwners)));
             }
@@ -1769,7 +1769,7 @@ namespace NuGetGallery
                 var model = new ReportAbuseViewModel
                 {
                     Message = "Mordor took my finger",
-                    Reason = ReportPackageReason.IsFraudulent
+                    Reason = ReportPackageReason.ViolatesALicenseIOwn
                 };
 
                 TestUtility.SetupUrlHelper(controller, httpContext);
@@ -1782,7 +1782,7 @@ namespace NuGetGallery
                             r => r.Message == "Mordor took my finger"
                                  && r.FromAddress.Address == "frodo@hobbiton.example.com"
                                  && r.FromAddress.DisplayName == "Frodo"
-                                 && r.Reason == EnumHelper.GetDescription(ReportPackageReason.IsFraudulent))));
+                                 && r.Reason == EnumHelper.GetDescription(ReportPackageReason.ViolatesALicenseIOwn))));
             }
 
             [Fact]
@@ -1833,7 +1833,7 @@ namespace NuGetGallery
                 {
                     Email = "frodo@hobbiton.example.com",
                     Message = "I like the cut of your jib. It's <b>bold</b>.",
-                    Reason = ReportPackageReason.IsFraudulent,
+                    Reason = ReportPackageReason.ViolatesALicenseIOwn,
                     AlreadyContactedOwner = true,
                 };
 
@@ -1845,7 +1845,7 @@ namespace NuGetGallery
                         It.Is<ReportPackageRequest>(
                             r => r.FromAddress.Address == "frodo@hobbiton.example.com"
                                  && r.Package == package
-                                 && r.Reason == EnumHelper.GetDescription(ReportPackageReason.IsFraudulent)
+                                 && r.Reason == EnumHelper.GetDescription(ReportPackageReason.ViolatesALicenseIOwn)
                                  && r.Message == "I like the cut of your jib. It&#39;s &lt;b&gt;bold&lt;/b&gt;."
                                  && r.AlreadyContactedOwners)));
             }
@@ -1905,7 +1905,7 @@ namespace NuGetGallery
                 var model = new ReportMyPackageViewModel
                 {
                     Message = "I like the cut of your jib. It's <b>bold</b>.",
-                    Reason = ReportPackageReason.IsFraudulent
+                    Reason = ReportPackageReason.ViolatesALicenseIOwn
                 };
 
                 TestUtility.SetupUrlHelper(controller, httpContext);
@@ -1914,7 +1914,7 @@ namespace NuGetGallery
                 Assert.NotNull(reportRequest);
                 Assert.Equal(user.EmailAddress, reportRequest.FromAddress.Address);
                 Assert.Same(package, reportRequest.Package);
-                Assert.Equal(EnumHelper.GetDescription(ReportPackageReason.IsFraudulent), reportRequest.Reason);
+                Assert.Equal(EnumHelper.GetDescription(ReportPackageReason.ViolatesALicenseIOwn), reportRequest.Reason);
                 Assert.Equal("I like the cut of your jib. It&#39;s &lt;b&gt;bold&lt;/b&gt;.", reportRequest.Message);
             }
         }


### PR DESCRIPTION
Updates the wording for some report reasons.
Adds text requesting additional details for trademark/copyright requests.

Addresses https://github.com/NuGet/NuGetGallery/issues/4716

@joelverhagen @karann-msft @skofman1 