### PR TITLE
[Organizations] Improvements to Manage Package Owners page for organizations

### DIFF
--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -104,7 +104,7 @@ namespace NuGetGallery
         public virtual ActionResult GetAddPackageOwnerConfirmation(string id, string username)
         {
             ManagePackageOwnerModel model;
-            if (TryGetManagePackageOwnerModel(id, username, add: true, model: out model))
+            if (TryGetManagePackageOwnerModel(id, username, isAddOwner: true, model: out model))
             {
                 return Json(new
                 {
@@ -125,7 +125,7 @@ namespace NuGetGallery
         public async Task<JsonResult> AddPackageOwner(string id, string username, string message)
         {
             ManagePackageOwnerModel model;
-            if (TryGetManagePackageOwnerModel(id, username, add: true, model: out model))
+            if (TryGetManagePackageOwnerModel(id, username, isAddOwner: true, model: out model))
             {
                 var encodedMessage = HttpUtility.HtmlEncode(message);
 
@@ -172,7 +172,7 @@ namespace NuGetGallery
         public async Task<JsonResult> RemovePackageOwner(string id, string username)
         {
             ManagePackageOwnerModel model;
-            if (TryGetManagePackageOwnerModel(id, username, add: false, model: out model))
+            if (TryGetManagePackageOwnerModel(id, username, isAddOwner: false, model: out model))
             {
                 var request = _packageOwnershipManagementService.GetPackageOwnershipRequests(package: model.Package, newOwner: model.User).FirstOrDefault();
 
@@ -290,7 +290,7 @@ namespace NuGetGallery
                 SecurePushSubscription.MinProtocolVersion, SecurePushSubscription.PushKeysExpirationInDays);
         }
 
-        private bool TryGetManagePackageOwnerModel(string id, string username, bool add, out ManagePackageOwnerModel model)
+        private bool TryGetManagePackageOwnerModel(string id, string username, bool isAddOwner, out ManagePackageOwnerModel model)
         {
             if (string.IsNullOrEmpty(id))
             {
@@ -330,13 +330,14 @@ namespace NuGetGallery
                 package.Owners.Any(o => o.MatchesUser(user)) ||
                 _packageOwnershipManagementService.GetPackageOwnershipRequests(package: package, newOwner: user).Any();
 
-            if (add && isOwner)
+            if (isAddOwner && isOwner)
             {
                 model = new ManagePackageOwnerModel(
                     string.Format(CultureInfo.CurrentCulture, Strings.AddOwner_AlreadyOwner, username));
                 return false;
             }
-            if (!add && !isOwner)
+
+            if (!isAddOwner && !isOwner)
             {
                 model = new ManagePackageOwnerModel(
                     string.Format(CultureInfo.CurrentCulture, Strings.RemoveOwner_NotOwner, username));

--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -327,8 +327,9 @@ namespace NuGetGallery
             }
 
             var isOwner = 
-                package.Owners.Any(u => u.MatchesUser(user)) ||
+                package.Owners.Any(o => o.MatchesUser(user)) ||
                 _packageOwnershipManagementService.GetPackageOwnershipRequests(package: package, newOwner: user).Any();
+
             if (add && isOwner)
             {
                 model = new ManagePackageOwnerModel(

--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -104,7 +104,7 @@ namespace NuGetGallery
         public virtual ActionResult GetAddPackageOwnerConfirmation(string id, string username)
         {
             ManagePackageOwnerModel model;
-            if (TryGetManagePackageOwnerModel(id, username, out model))
+            if (TryGetManagePackageOwnerModel(id, username, add: true, model: out model))
             {
                 return Json(new
                 {
@@ -125,7 +125,7 @@ namespace NuGetGallery
         public async Task<JsonResult> AddPackageOwner(string id, string username, string message)
         {
             ManagePackageOwnerModel model;
-            if (TryGetManagePackageOwnerModel(id, username, out model))
+            if (TryGetManagePackageOwnerModel(id, username, add: true, model: out model))
             {
                 var encodedMessage = HttpUtility.HtmlEncode(message);
 
@@ -172,7 +172,7 @@ namespace NuGetGallery
         public async Task<JsonResult> RemovePackageOwner(string id, string username)
         {
             ManagePackageOwnerModel model;
-            if (TryGetManagePackageOwnerModel(id, username, out model))
+            if (TryGetManagePackageOwnerModel(id, username, add: false, model: out model))
             {
                 var request = _packageOwnershipManagementService.GetPackageOwnershipRequests(package: model.Package, newOwner: model.User).FirstOrDefault();
 
@@ -290,7 +290,7 @@ namespace NuGetGallery
                 SecurePushSubscription.MinProtocolVersion, SecurePushSubscription.PushKeysExpirationInDays);
         }
 
-        private bool TryGetManagePackageOwnerModel(string id, string username, out ManagePackageOwnerModel model)
+        private bool TryGetManagePackageOwnerModel(string id, string username, bool add, out ManagePackageOwnerModel model)
         {
             if (string.IsNullOrEmpty(id))
             {
@@ -323,6 +323,22 @@ namespace NuGetGallery
             {
                 model = new ManagePackageOwnerModel(
                     string.Format(CultureInfo.CurrentCulture, Strings.AddOwner_OwnerNotConfirmed, username));
+                return false;
+            }
+
+            var isOwner = 
+                package.Owners.Any(u => u.MatchesUser(user)) ||
+                _packageOwnershipManagementService.GetPackageOwnershipRequests(package: package, newOwner: user).Any();
+            if (add && isOwner)
+            {
+                model = new ManagePackageOwnerModel(
+                    string.Format(CultureInfo.CurrentCulture, Strings.AddOwner_AlreadyOwner, username));
+                return false;
+            }
+            if (!add && !isOwner)
+            {
+                model = new ManagePackageOwnerModel(
+                    string.Format(CultureInfo.CurrentCulture, Strings.RemoveOwner_NotOwner, username));
                 return false;
             }
 

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1272,7 +1272,7 @@ namespace NuGetGallery
             }
             
             var user = _userService.FindByUsername(username);
-            if (!PermissionsService.IsActionAllowed(user, GetCurrentUser(), AccountActions.AcceptPackageOwnershipOnBehalfOf))
+            if (!PermissionsService.IsActionAllowed(user, GetCurrentUser(), AccountActions.ManagePackageOwnershipOnBehalfOf))
             {
                 return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, user.Username, ConfirmOwnershipResult.NotYourRequest));
             }

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -266,6 +266,17 @@
         return data;
     };
 
+    // Implementation of C#'s string.Format for use in Javascript
+    nuget.formatString = function (stringToFormat) {
+        var i = arguments.length - 1;
+
+        while (i--) {
+            stringToFormat = stringToFormat.replace(new RegExp('\\{' + i + '\\}', 'gm'), arguments[i + 1]);
+        }
+
+        return stringToFormat;
+    }
+
     window.nuget = nuget;
 
     initializeJQueryValidator();

--- a/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
@@ -16,7 +16,7 @@
         "Add Owner");
 
     var failHandler = function (jqXHR, textStatus, errorThrown) {
-        viewModel.message('An unexpected error occurred! "' + errorThrown + '"');
+        viewModel.message(window.nuget.formatString(errorThrown));
     };
 
     var viewModel = {
@@ -63,8 +63,13 @@
                     || (currentOwnerOwnsNamespace
                         && namespaceOwnerCount >= 2));
         },
-
+        
         IsOnlyUserGrantingAccessToCurrentUser: function () {
+            if (isUserAnAdmin.toLocaleLowerCase() === "True".toLocaleLowerCase()) {
+                // If user is an admin, removing any user will not remove their ability to manage package owners.
+                return false;
+            };
+
             var numUsersGrantingCurrentUserAccess = 0;
 
             ko.utils.arrayForEach(this.owners(), function (owner) {
@@ -91,7 +96,7 @@
 
             var newUsername = viewModel.newOwnerUsername();
             if (!newUsername) {
-                viewModel.message("Please enter a valid user name.");
+                viewModel.message(strings_InvalidUsername);
                 return;
             }
 
@@ -100,7 +105,7 @@
                 function (owner) { return owner.name().toUpperCase() == newUsername.toUpperCase() });
 
             if (existingOwner) {
-                viewModel.message("The user '" + newUsername + "' is already an owner or pending owner of this package.");
+                viewModel.message(window.nuget.formatString(strings_AlreadyPending, newUsername));
                 return;
             }
 
@@ -161,14 +166,14 @@
 
         removeOwner: function (item) {
             var isOnlyUserGrantingAccessToCurrentUser = viewModel.IsOnlyUserGrantingAccessToCurrentUser();
-            var isOnlyUserGrantingAccessToCurrentUserMessage = isOnlyUserGrantingAccessToCurrentUser ? " You will no longer be able to manage the package if you do!" : "";
+            var isOnlyUserGrantingAccessToCurrentUserMessage = isOnlyUserGrantingAccessToCurrentUser ? strings_RemovingOwnership : "";
 
             if (item.isCurrentUserMemberOfOrganization) {
-                if (!confirm("Are you sure you want to remove your organization as an owner of this package?" + isOnlyUserGrantingAccessToCurrentUserMessage)) {
+                if (!confirm(strings_RemovingOrganization + " " + isOnlyUserGrantingAccessToCurrentUserMessage)) {
                     return;
                 }
             } else if (item.grantsCurrentUserAccess) {
-                if (!confirm("Are you sure you want to remove yourself as an owner of this package?" + isOnlyUserGrantingAccessToCurrentUserMessage)) {
+                if (!confirm(strings_RemovingSelf + " " + isOnlyUserGrantingAccessToCurrentUserMessage)) {
                     return;
                 }
             }

--- a/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
@@ -118,13 +118,13 @@
         },
 
         removeOwner: function (item) {
-            if (item.currentUser) {
+            if (item.grantsCurrentUserAccess) {
                 if (!confirm("Are you sure you want to remove yourself from the owners?")) {
                     return;
                 }
             }
 
-            if (item.currentOrganization) {
+            if (item.isCurrentUserMemberOfOrganization) {
                 if (!confirm("Are you sure you want to remove your organization from the owners?")) {
                     return;
                 }
@@ -143,7 +143,7 @@
                         var numCurrent = 0;
 
                         ko.utils.arrayForEach(viewModel.owners(), function (owner) {
-                            if (owner !== item && owner.currentUser) {
+                            if (owner !== item && owner.grantsCurrentUserAccess) {
                                 numCurrent++;
                             }
                         });
@@ -184,7 +184,7 @@
                 approvedOwner++;
             }
 
-            if (owner.currentUser) {
+            if (owner.grantsCurrentUserAccess) {
                 currentOwnerOwnsNamespace = currentOwnerOwnsNamespace || owner.isNamespaceOwner();
             }
 
@@ -218,8 +218,8 @@
         this.profileUrl = ko.observable(data.ProfileUrl);
         this.imageUrl = ko.observable(data.ImageUrl);
         this.pending = ko.observable(data.Pending);
-        this.currentUser = data.CurrentUser;
-        this.currentOrganization = data.CurrentOrganization;
+        this.grantsCurrentUserAccess = data.GrantsCurrentUserAccess;
+        this.isCurrentUserMemberOfOrganization = data.IsCurrentUserMemberOfOrganization;
         this.isNamespaceOwner = ko.observable(data.IsNamespaceOwner);
     }
 });

--- a/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
@@ -64,7 +64,7 @@
                         && namespaceOwnerCount >= 2));
         },
 
-        IsOnlyUserGrantingAccessToCurrentUser: function (owner) {
+        IsOnlyUserGrantingAccessToCurrentUser: function () {
             var numUsersGrantingCurrentUserAccess = 0;
 
             ko.utils.arrayForEach(this.owners(), function (owner) {
@@ -160,7 +160,7 @@
         },
 
         removeOwner: function (item) {
-            var isOnlyUserGrantingAccessToCurrentUser = viewModel.IsOnlyUserGrantingAccessToCurrentUser(item);
+            var isOnlyUserGrantingAccessToCurrentUser = viewModel.IsOnlyUserGrantingAccessToCurrentUser();
             var isOnlyUserGrantingAccessToCurrentUserMessage = isOnlyUserGrantingAccessToCurrentUser ? " You will no longer be able to manage the package if you do!" : "";
 
             if (item.isCurrentUserMemberOfOrganization) {

--- a/src/NuGetGallery/Services/AccountActions.cs
+++ b/src/NuGetGallery/Services/AccountActions.cs
@@ -11,7 +11,7 @@ namespace NuGetGallery
         /// <summary>
         /// If an account is requested to be an owner of a package, the user can accept the request on behalf of the account.
         /// </summary>
-        public static PermissionLevel AcceptPackageOwnershipOnBehalfOf =
+        public static PermissionLevel ManagePackageOwnershipOnBehalfOf =
             PermissionLevel.Owner |
             PermissionLevel.OrganizationAdmin;
 

--- a/src/NuGetGallery/Services/AccountActions.cs
+++ b/src/NuGetGallery/Services/AccountActions.cs
@@ -9,10 +9,17 @@ namespace NuGetGallery
     public static class AccountActions
     {
         /// <summary>
-        /// If a user is requested to be an owner of a package, this user can accept the request on behalf of the other user.
+        /// If an account is requested to be an owner of a package, the user can accept the request on behalf of the account.
         /// </summary>
         public static PermissionLevel AcceptPackageOwnershipOnBehalfOf =
             PermissionLevel.Owner |
             PermissionLevel.OrganizationAdmin;
+
+        /// <summary>
+        /// The user can see private information about an organization account.
+        /// </summary>
+        public static PermissionLevel DisplayPrivateOrganization =
+            PermissionLevel.OrganizationAdmin |
+            PermissionLevel.OrganizationCollaborator;
     }
 }

--- a/src/NuGetGallery/Services/PermissionsService.cs
+++ b/src/NuGetGallery/Services/PermissionsService.cs
@@ -129,6 +129,7 @@ namespace NuGetGallery
             var matchingMembers = entityOwners
                 .Where(o => o is Organization)
                 .Cast<Organization>()
+                .Where(o => o.Members != null)
                 .SelectMany(o => o.Members)
                 .Where(m => isUserMatch(m.Member))
                 .ToArray();

--- a/src/NuGetGallery/Services/PermissionsService.cs
+++ b/src/NuGetGallery/Services/PermissionsService.cs
@@ -129,7 +129,6 @@ namespace NuGetGallery
             var matchingMembers = entityOwners
                 .Where(o => o is Organization)
                 .Cast<Organization>()
-                .Where(o => o.Members != null)
                 .SelectMany(o => o.Members)
                 .Where(m => isUserMatch(m.Member))
                 .ToArray();

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -106,7 +106,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The user &apos;{0}&apos; is already an owner or pending owner of the package!.
+        ///   Looks up a localized string similar to The user &apos;{0}&apos; is already an owner or pending owner of the package..
         /// </summary>
         public static string AddOwner_AlreadyOwner {
             get {
@@ -729,6 +729,60 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The user &apos;{0}&apos; is already an owner or pending owner of this package..
+        /// </summary>
+        public static string ManagePackageOwners_AlreadyPending {
+            get {
+                return ResourceManager.GetString("ManagePackageOwners_AlreadyPending", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An unexpected error occurred: {0}.
+        /// </summary>
+        public static string ManagePackageOwners_Error {
+            get {
+                return ResourceManager.GetString("ManagePackageOwners_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please enter a valid user name..
+        /// </summary>
+        public static string ManagePackageOwners_InvalidUsername {
+            get {
+                return ResourceManager.GetString("ManagePackageOwners_InvalidUsername", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to remove your organization as an owner of this package?.
+        /// </summary>
+        public static string ManagePackageOwners_RemovingOrganization {
+            get {
+                return ResourceManager.GetString("ManagePackageOwners_RemovingOrganization", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You will no longer be able to manage the package if you do..
+        /// </summary>
+        public static string ManagePackageOwners_RemovingOwnership {
+            get {
+                return ResourceManager.GetString("ManagePackageOwners_RemovingOwnership", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Are you sure you want to remove yourself as an owner of this package?.
+        /// </summary>
+        public static string ManagePackageOwners_RemovingSelf {
+            get {
+                return ResourceManager.GetString("ManagePackageOwners_RemovingSelf", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please enter a message..
         /// </summary>
         public static string MessageIsRequired {
@@ -1044,7 +1098,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The user &apos;{0}&apos; is not an owner or pending owner of the package!.
+        ///   Looks up a localized string similar to The user &apos;{0}&apos; is not an owner or pending owner of the package..
         /// </summary>
         public static string RemoveOwner_NotOwner {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -106,6 +106,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The user &apos;{0}&apos; is already an owner or pending owner of the package!.
+        /// </summary>
+        public static string AddOwner_AlreadyOwner {
+            get {
+                return ResourceManager.GetString("AddOwner_AlreadyOwner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Current user not found..
         /// </summary>
         public static string AddOwner_CurrentUserNotFound {
@@ -1031,6 +1040,15 @@ namespace NuGetGallery {
         public static string RemoveOwner_NotAllowed {
             get {
                 return ResourceManager.GetString("RemoveOwner_NotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The user &apos;{0}&apos; is not an owner or pending owner of the package!.
+        /// </summary>
+        public static string RemoveOwner_NotOwner {
+            get {
+                return ResourceManager.GetString("RemoveOwner_NotOwner", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -655,4 +655,10 @@ For more information, please contact '{2}'.</value>
   <data name="ApiKeyScopesNotAllowed" xml:space="preserve">
     <value>The current user does not have permission to create an ApiKey with the specified owner or scopes.</value>
   </data>
+  <data name="AddOwner_AlreadyOwner" xml:space="preserve">
+    <value>The user '{0}' is already an owner or pending owner of the package!</value>
+  </data>
+  <data name="RemoveOwner_NotOwner" xml:space="preserve">
+    <value>The user '{0}' is not an owner or pending owner of the package!</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -656,9 +656,27 @@ For more information, please contact '{2}'.</value>
     <value>The current user does not have permission to create an ApiKey with the specified owner or scopes.</value>
   </data>
   <data name="AddOwner_AlreadyOwner" xml:space="preserve">
-    <value>The user '{0}' is already an owner or pending owner of the package!</value>
+    <value>The user '{0}' is already an owner or pending owner of the package.</value>
   </data>
   <data name="RemoveOwner_NotOwner" xml:space="preserve">
-    <value>The user '{0}' is not an owner or pending owner of the package!</value>
+    <value>The user '{0}' is not an owner or pending owner of the package.</value>
+  </data>
+  <data name="ManagePackageOwners_AlreadyPending" xml:space="preserve">
+    <value>The user '{0}' is already an owner or pending owner of this package.</value>
+  </data>
+  <data name="ManagePackageOwners_Error" xml:space="preserve">
+    <value>An unexpected error occurred: {0}</value>
+  </data>
+  <data name="ManagePackageOwners_InvalidUsername" xml:space="preserve">
+    <value>Please enter a valid user name.</value>
+  </data>
+  <data name="ManagePackageOwners_RemovingOrganization" xml:space="preserve">
+    <value>Are you sure you want to remove your organization as an owner of this package?</value>
+  </data>
+  <data name="ManagePackageOwners_RemovingOwnership" xml:space="preserve">
+    <value>You will no longer be able to manage the package if you do.</value>
+  </data>
+  <data name="ManagePackageOwners_RemovingSelf" xml:space="preserve">
+    <value>Are you sure you want to remove yourself as an owner of this package?</value>
   </data>
 </root>

--- a/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
@@ -16,9 +16,9 @@ namespace NuGetGallery
 
         public string ImageUrl;
 
-        public bool CurrentUser;
+        public bool GrantsCurrentUserAccess;
 
-        public bool CurrentOrganization;
+        public bool IsCurrentUserMemberOfOrganization;
 
         public bool Pending;
 
@@ -30,8 +30,8 @@ namespace NuGetGallery
             EmailAddress = user.EmailAddress;
             ProfileUrl = url.User(user, relativeUrl: false);
             ImageUrl = GravatarHelper.Url(user.EmailAddress, size: Constants.GravatarImageSize);
-            CurrentUser = PermissionsService.IsActionAllowed(user, currentUser, AccountActions.AcceptPackageOwnershipOnBehalfOf);
-            CurrentOrganization = PermissionsService.IsActionAllowed(user, currentUser, AccountActions.DisplayPrivateOrganization);
+            GrantsCurrentUserAccess = PermissionsService.IsActionAllowed(user, currentUser, AccountActions.ManagePackageOwnershipOnBehalfOf);
+            IsCurrentUserMemberOfOrganization = PermissionsService.IsActionAllowed(user, currentUser, AccountActions.DisplayPrivateOrganization);
             Pending = isPending;
             IsNamespaceOwner = isNamespaceOwner;
         }

--- a/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Web.Mvc;
+using NuGetGallery.Helpers;
+
 namespace NuGetGallery
 {
     public class PackageOwnersResultViewModel
@@ -9,17 +12,26 @@ namespace NuGetGallery
 
         public string EmailAddress;
 
-        public bool Current;
+        public string ProfileUrl;
+
+        public string ImageUrl;
+
+        public bool CurrentUser;
+
+        public bool CurrentOrganization;
 
         public bool Pending;
 
         public bool IsNamespaceOwner;
 
-        public PackageOwnersResultViewModel(string username, string emailAddress, bool isCurrentUser, bool isPending, bool isNamespaceOwner)
+        public PackageOwnersResultViewModel(User user, User currentUser, UrlHelper url, bool isPending, bool isNamespaceOwner)
         {
-            Name = username;
-            EmailAddress = emailAddress;
-            Current = isCurrentUser;
+            Name = user.Username;
+            EmailAddress = user.EmailAddress;
+            ProfileUrl = url.User(user, relativeUrl: false);
+            ImageUrl = GravatarHelper.Url(user.EmailAddress, size: Constants.GravatarImageSize);
+            CurrentUser = PermissionsService.IsActionAllowed(user, currentUser, AccountActions.AcceptPackageOwnershipOnBehalfOf);
+            CurrentOrganization = PermissionsService.IsActionAllowed(user, currentUser, AccountActions.DisplayPrivateOrganization);
             Pending = isPending;
             IsNamespaceOwner = isNamespaceOwner;
         }

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -46,8 +46,8 @@
                             <a data-bind="attr: {href: profileUrl, title: name}, text: name"></a>
                         </span>
                         <span style="font-style:italic">
-                            <span data-bind="visible: currentUser && !currentOrganization">(that's you)</span>
-                            <span data-bind="visible: currentOrganization">(your organization)</span>
+                            <span data-bind="visible: grantsCurrentUserAccess && !isCurrentUserMemberOfOrganization">(that's you)</span>
+                            <span data-bind="visible: isCurrentUserMemberOfOrganization">(your organization)</span>
                             <span data-bind="visible: pending">(pending approval)</span>
                         </span>
                     </div>

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -46,7 +46,8 @@
                             <a data-bind="attr: {href: profileUrl, title: name}, text: name"></a>
                         </span>
                         <span style="font-style:italic">
-                            <span data-bind="visible: current">(that's you)</span>
+                            <span data-bind="visible: currentUser && !currentOrganization">(that's you)</span>
+                            <span data-bind="visible: currentOrganization">(your organization)</span>
                             <span data-bind="visible: pending">(pending approval)</span>
                         </span>
                     </div>

--- a/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ManagePackageOwners.cshtml
@@ -147,6 +147,14 @@
         var getAddPackageOwnerConfirmationUrl = "@Url.GetAddPackageOwnerConfirmation()";
         var addPackageOwnerUrl = "@Url.AddPackageOwner()";
         var removePackageOwnerUrl = "@Url.RemovePackageOwner()";
+
+        // Strings
+        var strings_Error = "@Html.Raw(Strings.ManagePackageOwners_Error)";
+        var strings_InvalidUsername = "@Html.Raw(Strings.ManagePackageOwners_InvalidUsername)";
+        var strings_AlreadyPending = "@Html.Raw(Strings.ManagePackageOwners_AlreadyPending)";
+        var strings_RemovingOwnership = "@Html.Raw(Strings.ManagePackageOwners_RemovingOwnership)";
+        var strings_RemovingOrganization = "@Html.Raw(Strings.ManagePackageOwners_RemovingOrganization)";
+        var strings_RemovingSelf = "@Html.Raw(Strings.ManagePackageOwners_RemovingSelf)";
     </script>
 
     @Scripts.Render("~/Scripts/gallery/page-manage-owners.min.js")

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -212,8 +212,9 @@ namespace NuGetGallery.Authentication
             {
                 // Arrange
                 var organization = _fakes.Organization;
-                var apiKey = Guid.Parse("1fdc96fe-0b41-4607-bc85-b6533b42d3f8");
-                organization.Credentials.Add(TestCredentialHelper.CreateV2ApiKey(apiKey, TimeSpan.FromDays(1)));
+                var apiKey = TestCredentialHelper.CreateV2ApiKey(Guid.NewGuid(), TimeSpan.FromDays(1));
+                apiKey.User = organization;
+                organization.Credentials.Add(apiKey);
 
                 // Act
                 var result = await _authenticationService.Authenticate(apiKey.ToString());

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -438,10 +438,11 @@ namespace NuGetGallery.Controllers
 
                 JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, "Hello World! Html Encoded <3");
                 dynamic data = result.Data;
+                PackageOwnersResultViewModel model = data.model;
 
                 Assert.True(data.success);
-                Assert.Equal(fakes.User.Username, data.name);
-                Assert.True(data.pending);
+                Assert.Equal(fakes.User.Username, model.Name);
+                Assert.True(model.Pending);
 
                 httpContextMock.Verify();
                 packageOwnershipManagementServiceMock.Verify();

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -1013,8 +1013,8 @@ namespace NuGetGallery.Controllers
             private static Func<Fakes, User> _getFakesUser = (Fakes fakes) => fakes.User;
             private static Func<Fakes, User> _getFakesOwner = (Fakes fakes) => fakes.Owner;
             private static Func<Fakes, User> _getFakesOrganizationOwner = (Fakes fakes) => fakes.OrganizationOwner;
-            private static Func<Fakes, User> _getFakesOrganizationAdminOwner = (Fakes fakes) => fakes.OrganizationAdminOwner;
-            private static Func<Fakes, User> _getFakesOrganizationCollaboratorOwner = (Fakes fakes) => fakes.OrganizationCollaboratorOwner;
+            private static Func<Fakes, User> _getFakesOrganizationAdminOwner = (Fakes fakes) => fakes.OrganizationOwnerAdmin;
+            private static Func<Fakes, User> _getFakesOrganizationCollaboratorOwner = (Fakes fakes) => fakes.OrganizationOwnerCollaborator;
 
             public static IEnumerable<string> _missingData = new[] { null, string.Empty };
 

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
 using System.Threading.Tasks;
@@ -17,566 +19,1021 @@ namespace NuGetGallery.Controllers
 {
     public class JsonApiControllerFacts
     {
-        public class TheGetAddPackageOwnerConfirmationMethod : TestContainer
+        public class ThePackageOwnerMethods : TestContainer
         {
-            [Theory]
-            [InlineData("")]
-            [InlineData(null)]
-            public void ThrowsArgumentNullIfPackageIdMissing(string id)
+            public class ThePackageOwnerModificationMethods : TestContainer
             {
-                // Arrange
-                var controller = GetController<JsonApiController>();
-
-                // Act & Assert
-                Assert.Throws<ArgumentException>(() => controller.GetAddPackageOwnerConfirmation(id, "user"));
-            }
-
-            [Theory]
-            [InlineData("")]
-            [InlineData(null)]
-            public void ThrowsArgumentNullIfUsernameMissing(string username)
-            {
-                // Arrange
-                var controller = GetController<JsonApiController>();
-
-                // Act & Assert
-                Assert.Throws<ArgumentException>(() => controller.GetAddPackageOwnerConfirmation("package", username));
-            }
-
-            [Fact]
-            public void ReturnsFailureIfPackageNotFound()
-            {
-                // Arrange
-                var controller = GetController<JsonApiController>();
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation("package", "user");
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.False(data.success);
-                Assert.Equal("Package not found.", data.message);
-            }
-
-            [Fact]
-            public void ReturnsFailureIfUserIsNotPackageOwner()
-            {
-                // Arrange
-                var controller = GetController<JsonApiController>();
-                GetMock<IPackageService>()
-                    .Setup(svc => svc.FindPackageRegistrationById("package"))
-                    .Returns(new PackageRegistration());
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation("package", "nonOwner");
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.False(data.success);
-                Assert.Equal("You are not the package owner.", data.message);
-            }
-
-            [Fact]
-            public void ReturnsFailureIfOwnerIsNotRealUser()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, "nonUser");
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.False(data.success);
-                Assert.Equal("Owner not found.", data.message);
-            }
-
-            [Fact]
-            public void ReturnsFailureIfNewOwnerIsNotConfirmed()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-                fakes.User.UnconfirmedEmailAddress = fakes.Owner.EmailAddress;
-                fakes.User.EmailAddress = null;
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.False(data.success);
-                Assert.Equal("Sorry, 'testUser' hasn't verified their email account yet and we cannot proceed with the request.", data.message);
-            }
-
-            [Fact]
-            public void ReturnsFailureIfCurrentUserNotFound()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-                GetMock<IUserService>()
-                    .Setup(s => s.FindByUsername(fakes.Owner.Username))
-                    .ReturnsNull();
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.False(data.success);
-                Assert.Equal("Current user not found.", data.message);
-            }
-
-            [Fact]
-            public void ReturnsDefaultConfirmationIfNoPolicyPropagation()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.True(data.success);
-                Assert.Equal("Please confirm if you would like to proceed adding 'testUser' as a co-owner of this package.", data.confirmation);
-            }
-
-            [Fact]
-            public void ReturnsDetailedConfirmationIfNewOwnerPropagatesPolicy()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-                fakes.User.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.True(data.success);
-                Assert.StartsWith(
-                    "User 'testUser' has the following requirements that will be enforced for all co-owners once the user accepts ownership of this package:",
-                    data.policyMessage);
-            }
-
-            [Fact]
-            public void ReturnsDetailedConfirmationIfCurrentOwnerPropagatesPolicy()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-                fakes.Owner.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.True(data.success);
-                Assert.StartsWith(
-                    "Owner(s) 'testPackageOwner' has (have) the following requirements that will be enforced for user 'testUser' once the user accepts ownership of this package:",
-                    data.policyMessage);
-            }
-
-            [Fact]
-            public void DoesNotReturnConfirmationIfCurrentOwnerPropagatesButNewOwnerIsSubscribed()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-                GetMock<ISecurityPolicyService>().Setup(s => s.IsSubscribed(fakes.User, SecurePushSubscription.Name)).Returns(true);
-                fakes.Owner.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.True(data.success);
-                Assert.StartsWith("Please confirm if you would like to proceed adding 'testUser' as a co-owner of this package.",
-                    data.confirmation);
-            }
-
-            [Fact]
-            public void ReturnsDetailedConfirmationIfPendingOwnerPropagatesPolicy()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-
-                fakes.ShaUser.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
-                var pendingOwner = new PackageOwnerRequest()
+                public static IEnumerable<object> ThrowsArgumentNullIfMissing_Data
                 {
-                    PackageRegistration = fakes.Package,
-                    PackageRegistrationKey = fakes.Package.Key,
-                    NewOwner = fakes.ShaUser,
-                    NewOwnerKey = fakes.ShaUser.Key
-                };
-
-                GetMock<IPackageOwnershipManagementService>()
-                    .Setup(p => p.GetPackageOwnershipRequests(fakes.Package, null, null))
-                    .Returns((new [] { pendingOwner }));
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.True(data.success);
-                Assert.StartsWith(
-                    "Pending owner(s) 'testShaUser' has (have) the following requirements that will be enforced for all co-owners, including 'testUser', once ownership requests are accepted:",
-                    data.policyMessage);
-            }
-            
-            [Fact]
-            public void DoesNotReturnConfirmationIfPendingOwnerPropagatesButNewOwnerIsSubscribed()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-                GetMock<ISecurityPolicyService>().Setup(s => s.IsSubscribed(fakes.User, SecurePushSubscription.Name)).Returns(true);
-
-                fakes.ShaUser.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
-                var pendingOwner = new PackageOwnerRequest()
-                {
-                    PackageRegistrationKey = fakes.Package.Key,
-                    NewOwner = fakes.ShaUser
-                };
-
-                GetMock<IPackageOwnerRequestService>()
-                    .Setup(p => p.GetPackageOwnershipRequests(fakes.Package, null, fakes.ShaUser))
-                    .Returns((new[] { pendingOwner }));
-
-                // Act
-                var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, fakes.User.Username);
-                dynamic data = ((JsonResult)result).Data;
-
-                // Assert
-                Assert.True(data.success);
-                Assert.StartsWith("Please confirm if you would like to proceed adding 'testUser' as a co-owner of this package.",
-                    data.confirmation);
-            }
-
-        }
-
-        public class TheAddPackageOwnerMethod : TestContainer
-        {
-            [Theory]
-            [InlineData("")]
-            [InlineData(null)]
-            public async Task ThrowsArgumentNullIfPackageIdMissing(string id)
-            {
-                // Arrange
-                var controller = GetController<JsonApiController>();
-
-                // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(() => controller.AddPackageOwner(id, "user", string.Empty));
-            }
-
-            [Theory]
-            [InlineData("")]
-            [InlineData(null)]
-            public async Task ThrowsArgumentNullIfUsernameMissing(string username)
-            {
-                // Arrange
-                var controller = GetController<JsonApiController>();
-
-                // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(() => controller.AddPackageOwner("package", username, string.Empty));
-            }
-
-            [Fact]
-            public async Task ReturnsFailureWhenPackageNotFound()
-            {
-                var controller = GetController<JsonApiController>();
-
-                JsonResult result = await controller.AddPackageOwner("foo", "steve", "message");
-                dynamic data = result.Data;
-
-                Assert.False(data.success);
-                Assert.Equal("Package not found.", data.message);
-            }
-
-            [Fact]
-            public async Task DoesNotAllowNonPackageOwnerToAddPackageOwner()
-            {
-                var controller = GetController<JsonApiController>();
-                GetMock<IPackageService>()
-                    .Setup(svc => svc.FindPackageRegistrationById("foo"))
-                    .Returns(new PackageRegistration());
-
-                JsonResult result = await controller.AddPackageOwner("foo", "steve", "message");
-                dynamic data = result.Data;
-
-                Assert.False(data.success);
-                Assert.Equal("You are not the package owner.", data.message);
-            }
-
-            [Fact]
-            public async Task ReturnsFailureWhenRequestedNewOwnerDoesNotExist()
-            {
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-
-                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, "notARealUser", "message");
-                dynamic data = result.Data;
-
-                Assert.False(data.success);
-                Assert.Equal("Owner not found.", data.message);
-            }
-
-            [Fact]
-            public async Task ReturnsFailureIfNewOwnerIsNotConfirmed()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-                fakes.User.UnconfirmedEmailAddress = fakes.Owner.EmailAddress;
-                fakes.User.EmailAddress = null;
-
-                // Act
-                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, "message");
-                dynamic data = result.Data;
-
-                // Assert
-                Assert.False(data.success);
-                Assert.Equal("Sorry, 'testUser' hasn't verified their email account yet and we cannot proceed with the request.", data.message);
-            }
-
-            [Fact]
-            public async Task ReturnsFailureIfCurrentUserNotFound()
-            {
-                // Arrange
-                var fakes = Get<Fakes>();
-                var controller = GetController<JsonApiController>();
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
-                GetMock<IUserService>()
-                    .Setup(s => s.FindByUsername(fakes.Owner.Username))
-                    .ReturnsNull();
-
-                // Act
-                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, "message");
-                dynamic data = result.Data;
-
-                // Assert
-                Assert.False(data.success);
-                Assert.Equal("Current user not found.", data.message);
-            }
-
-            [Fact]
-            public async Task CreatesPackageOwnerRequestSendsEmailAndReturnsPendingState()
-            {
-                var fakes = Get<Fakes>();
-
-                var controller = GetController<JsonApiController>();
-
-                var httpContextMock = GetMock<HttpContextBase>();
-                httpContextMock
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner))
-                    .Verifiable();
-
-                var packageOwnershipManagementServiceMock = GetMock<IPackageOwnershipManagementService>();
-                packageOwnershipManagementServiceMock
-                    .Setup(p => p.AddPackageOwnershipRequestAsync(fakes.Package, fakes.Owner, fakes.User))
-                    .Returns(Task.FromResult(new PackageOwnerRequest { ConfirmationCode = "confirmation-code" }))
-                    .Verifiable();
-
-                var messageServiceMock = GetMock<IMessageService>();
-                messageServiceMock
-                    .Setup(m => m.SendPackageOwnerRequest(
-                        fakes.Owner,
-                        fakes.User,
-                        fakes.Package,
-                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/",
-                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/owners/testUser/confirm/confirmation-code",
-                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/owners/testUser/reject/confirmation-code",
-                        "Hello World! Html Encoded &lt;3",
-                        ""))
-                    .Verifiable();
-
-                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, "Hello World! Html Encoded <3");
-                dynamic data = result.Data;
-                PackageOwnersResultViewModel model = data.model;
-
-                Assert.True(data.success);
-                Assert.Equal(fakes.User.Username, model.Name);
-                Assert.True(model.Pending);
-
-                httpContextMock.Verify();
-                packageOwnershipManagementServiceMock.Verify();
-                messageServiceMock.Verify();
-            }
-
-            [Fact]
-            public async Task SendsPackageOwnerRequestEmailWhereNewOwnerPropagatesPolicy()
-            {
-                // Arrange & Act
-                var fakes = Get<Fakes>();
-                var policyMessage = await GetSendPackageOwnerRequestPolicyMessage(fakes, fakes.User);
-
-                // Assert
-                Assert.StartsWith(
-                    "Note: The following policies will be enforced on package co-owners once you accept this request.",
-                    policyMessage);
-            }
-
-            [Fact]
-            public async Task SendsPackageOwnerRequestEmailWhereCurrentOwnerPropagatesPolicy()
-            {
-                // Arrange & Act
-                var fakes = Get<Fakes>();
-                var policyMessage = await GetSendPackageOwnerRequestPolicyMessage(fakes, fakes.Owner);
-
-                // Assert
-                Assert.StartsWith(
-                    "Note: Owner(s) 'testPackageOwner' has (have) the following policies that will be enforced on your account once you accept this request.",
-                    policyMessage);
-            }
-
-            [Fact]
-            public async Task SendsPackageOwnerRequestEmailWherePendingOwnerPropagatesPolicy()
-            {
-                // Arrange & Act
-                var fakes = Get<Fakes>();
-                
-                var packageOwnershipManagementServiceMock = GetMock<IPackageOwnershipManagementService>();
-                packageOwnershipManagementServiceMock
-                    .Setup(p => p.GetPackageOwnershipRequests(fakes.Package, null, null))
-                    .Returns(
-                        new[]
+                    get
+                    {
+                        foreach (var request in _requests)
                         {
-                            new PackageOwnerRequest
+                            foreach (var missingId in new[] { "", null })
                             {
-                                PackageRegistration = fakes.Package,
-                                NewOwner = fakes.ShaUser
+                                yield return new object[]
+                                {
+                                    request,
+                                    missingId,
+                                };
                             }
-                        })
-                    .Verifiable();
+                        }
+                    }
+                }
 
-                var policyMessage = await GetSendPackageOwnerRequestPolicyMessage(fakes, fakes.ShaUser);
+                [Theory]
+                [MemberData(nameof(ThrowsArgumentNullIfMissing_Data))]
+                public void ThrowsArgumentNullIfPackageIdMissing(InvokePackageOwnerModificationRequest request, string id)
+                {
+                    // Arrange
+                    var controller = GetController<JsonApiController>();
 
-                // Assert
-                Assert.StartsWith(
-                    "Note: Pending owner(s) 'testShaUser' has (have) the following policies that will be enforced on your account once ownership requests are accepted.",
-                    policyMessage);
+                    // Act & Assert
+                    Assert.ThrowsAsync<ArgumentException>(() => request(controller, id, "username"));
+                }
+
+                [Theory]
+                [MemberData(nameof(ThrowsArgumentNullIfMissing_Data))]
+                public void ThrowsArgumentNullIfUsernameMissing(InvokePackageOwnerModificationRequest request, string username)
+                {
+                    // Arrange
+                    var controller = GetController<JsonApiController>();
+
+                    // Act & Assert
+                    Assert.ThrowsAsync<ArgumentException>(() => request(controller, "package", username));
+                }
+
+                [Theory]
+                [MemberData(nameof(AllRequests_Data))]
+                public async Task ReturnsFailureIfPackageNotFound(InvokePackageOwnerModificationRequest request)
+                {
+                    // Arrange
+                    var controller = GetController<JsonApiController>();
+
+                    // Act
+                    var result = await request(controller, "package", "user");
+                    dynamic data = ((JsonResult)result).Data;
+
+                    // Assert
+                    Assert.False(data.success);
+                    Assert.Equal("Package not found.", data.message);
+                }
+
+                [Theory]
+                [MemberData(nameof(AllCannotManagePackageOwnersByRequests_Data))]
+                public async Task ReturnsFailureIfUserIsNotPackageOwner(InvokePackageOwnerModificationRequest request, Func<Fakes, User> getCurrentUser)
+                {
+                    // Arrange
+                    var fakes = Get<Fakes>();
+                    var currentUser = getCurrentUser(fakes);
+                    var controller = GetController<JsonApiController>();
+                    GetMock<HttpContextBase>()
+                        .Setup(c => c.User)
+                        .Returns(Fakes.ToPrincipal(currentUser));
+
+                    // Act
+                    var result = await request(controller, fakes.Package.Id, "nonUser");
+                    dynamic data = ((JsonResult)result).Data;
+
+                    // Assert
+                    Assert.False(data.success);
+                    Assert.Equal("You are not the package owner.", data.message);
+                }
+
+                [Theory]
+                [MemberData(nameof(AllCanManagePackageOwnersByRequests_Data))]
+                public async Task ReturnsFailureIfNewOwnerIsNotRealUser(InvokePackageOwnerModificationRequest request, Func<Fakes, User> getCurrentUser)
+                {
+                    // Arrange
+                    var fakes = Get<Fakes>();
+                    var currentUser = getCurrentUser(fakes);
+                    var controller = GetController<JsonApiController>();
+                    GetMock<HttpContextBase>()
+                        .Setup(c => c.User)
+                        .Returns(Fakes.ToPrincipal(currentUser));
+
+                    // Act
+                    var result = await request(controller, fakes.Package.Id, "nonUser");
+                    dynamic data = ((JsonResult)result).Data;
+
+                    // Assert
+                    Assert.False(data.success);
+                    Assert.Equal("Owner not found.", data.message);
+                }
+
+                [Theory]
+                [MemberData(nameof(AllCanManagePackageOwnersByRequests_Data))]
+                public async Task ReturnsFailureIfNewOwnerIsNotConfirmed(InvokePackageOwnerModificationRequest request, Func<Fakes, User> getCurrentUser)
+                {
+                    // Arrange
+                    var fakes = Get<Fakes>();
+                    var currentUser = getCurrentUser(fakes);
+                    var controller = GetController<JsonApiController>();
+                    GetMock<HttpContextBase>()
+                        .Setup(c => c.User)
+                        .Returns(Fakes.ToPrincipal(currentUser));
+                    fakes.User.UnconfirmedEmailAddress = fakes.User.EmailAddress;
+                    fakes.User.EmailAddress = null;
+
+                    // Act
+                    var result = await request(controller, fakes.Package.Id, fakes.User.Username);
+                    dynamic data = ((JsonResult)result).Data;
+
+                    // Assert
+                    Assert.False(data.success);
+                    Assert.Equal("Sorry, 'testUser' hasn't verified their email account yet and we cannot proceed with the request.", data.message);
+                }
+
+                public class TheAddPackageOwnerMethods : TestContainer
+                {
+                    private static IEnumerable<InvokePackageOwnerModificationRequest> _addRequests = new InvokePackageOwnerModificationRequest[]
+                    {
+                        new InvokePackageOwnerModificationRequest(GetAddPackageOwnerConfirmation),
+                        new InvokePackageOwnerModificationRequest(AddPackageOwner),
+                    };
+
+                    public static IEnumerable<object[]> AllAddRequests_Data
+                    {
+                        get
+                        {
+                            foreach (var request in _addRequests)
+                            {
+                                yield return new object[]
+                                {
+                                    request,
+                                };
+                            }
+                        }
+                    }
+                    
+                    public static IEnumerable<object[]> AllCanManagePackageOwnersByAddRequests_Data
+                    {
+                        get
+                        {
+                            foreach (var request in _addRequests)
+                            {
+                                foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                                {
+                                    yield return new object[]
+                                    {
+                                        request,
+                                        canManagePackageOwnersUser,
+                                    };
+                                }
+                            }
+                        }
+                    }
+
+                    public static IEnumerable<object[]> AllCanManagePackageOwnersPairedWithCanBeAddedByAddRequests_Data
+                    {
+                        get
+                        {
+                            foreach (var request in _addRequests)
+                            {
+                                foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                                {
+                                    foreach (var canBeAddedUser in _canBeAddedUsers)
+                                    {
+                                        yield return new object[]
+                                        {
+                                            request,
+                                            canManagePackageOwnersUser,
+                                            canBeAddedUser,
+                                        };
+                                    };
+                                }
+                            }
+                        }
+                    }
+
+                    public static IEnumerable<object[]> AllCanManagePackageOwnersPairedWithCannotBeAddedByAddRequests_Data
+                    {
+                        get
+                        {
+                            foreach (var request in _addRequests)
+                            {
+                                foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                                {
+                                    foreach (var cannotBeAddedUser in _cannotBeAddedUsers)
+                                    {
+                                        yield return new object[]
+                                        {
+                                            request,
+                                            canManagePackageOwnersUser,
+                                            cannotBeAddedUser,
+                                        };
+                                    };
+                                }
+                            }
+                        }
+                    }
+
+                    public static IEnumerable<object[]> AllCanManagePackageOwnersPairedWithCanBeAdded_Data
+                    {
+                        get
+                        {
+                            foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                            {
+                                foreach (var canBeAddedUser in _canBeAddedUsers)
+                                {
+                                    yield return new object[]
+                                    {
+                                            canManagePackageOwnersUser,
+                                            canBeAddedUser,
+                                    };
+                                };
+                            }
+                        }
+                    }
+
+                    public static IEnumerable<object[]> PendingOwnerPropagatesPolicy_Data
+                    {
+                        get
+                        {
+                            foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                            {
+                                foreach (var canBeAddedUser in _canBeAddedUsers)
+                                {
+                                    foreach (var canBePendingUser in _canBeAddedUsers)
+                                    {
+                                        if (canBeAddedUser == canBePendingUser)
+                                        {
+                                            continue;
+                                        }
+
+                                        yield return new object[]
+                                        {
+                                                canManagePackageOwnersUser,
+                                                canBeAddedUser,
+                                                canBePendingUser,
+                                        };
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    public static IEnumerable<object[]> ReturnsFailureIfCurrentUserNotFoundByAddRequests_Data
+                    {
+                        get
+                        {
+                            return AllCanManagePackageOwnersPairedWithCanBeAddedByAddRequests_Data.Where(o => o[1] != o[2]);
+                        }
+                    }
+
+                    [Theory]
+                    [MemberData(nameof(ReturnsFailureIfCurrentUserNotFoundByAddRequests_Data))]
+                    public async Task ReturnsFailureIfCurrentUserNotFound(InvokePackageOwnerModificationRequest request, Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd)
+                    {
+                        // Arrange
+                        var fakes = Get<Fakes>();
+                        var currentUser = getCurrentUser(fakes);
+                        var userToAdd = getUserToAdd(fakes);
+                        var controller = GetController<JsonApiController>();
+                        GetMock<HttpContextBase>()
+                            .Setup(c => c.User)
+                            .Returns(Fakes.ToPrincipal(currentUser));
+
+                        GetMock<IUserService>()
+                            .Setup(x => x.FindByUsername(currentUser.Username))
+                            .Returns<User>(null);
+
+                        // Act
+                        var result = await request(controller, fakes.Package.Id, userToAdd.Username);
+                        dynamic data = ((JsonResult)result).Data;
+
+                        // Assert
+                        Assert.False(data.success);
+                        Assert.Equal("Current user not found.", data.message);
+                    }
+
+                    [Theory]
+                    [MemberData(nameof(AllCanManagePackageOwnersPairedWithCannotBeAddedByAddRequests_Data))]
+                    public async Task ReturnsFailureIfNewOwnerIsAlreadyOwner(InvokePackageOwnerModificationRequest request, Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd)
+                    {
+                        // Arrange
+                        var fakes = Get<Fakes>();
+                        var currentUser = getCurrentUser(fakes);
+                        var userToAdd = getUserToAdd(fakes);
+                        var controller = GetController<JsonApiController>();
+                        GetMock<HttpContextBase>()
+                            .Setup(c => c.User)
+                            .Returns(Fakes.ToPrincipal(currentUser));
+
+                        // Act
+                        var result = await request(controller, fakes.Package.Id, userToAdd.Username);
+                        dynamic data = ((JsonResult)result).Data;
+
+                        // Assert
+                        Assert.False(data.success);
+                        Assert.Equal($"The user '{userToAdd.Username}' is already an owner or pending owner of the package!", data.message);
+                    }
+
+                    [Theory]
+                    [MemberData(nameof(AllCanManagePackageOwnersPairedWithCanBeAddedByAddRequests_Data))]
+                    public async Task ReturnsFailureIfNewOwnerIsAlreadyPending(InvokePackageOwnerModificationRequest request, Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd)
+                    {
+                        // Arrange
+                        var fakes = Get<Fakes>();
+                        var currentUser = getCurrentUser(fakes);
+                        var userToAdd = getUserToAdd(fakes);
+                        var package = fakes.Package;
+                        var controller = GetController<JsonApiController>();
+                        GetMock<HttpContextBase>()
+                            .Setup(c => c.User)
+                            .Returns(Fakes.ToPrincipal(currentUser));
+
+                        GetMock<IPackageOwnershipManagementService>()
+                            .Setup(x => x.GetPackageOwnershipRequests(package, null, userToAdd))
+                            .Returns(new PackageOwnerRequest[] { new PackageOwnerRequest() });
+
+                        // Act
+                        var result = await request(controller, package.Id, userToAdd.Username);
+                        dynamic data = ((JsonResult)result).Data;
+
+                        // Assert
+                        Assert.False(data.success);
+                        Assert.Equal($"The user '{userToAdd.Username}' is already an owner or pending owner of the package!", data.message);
+                    }
+
+                    public class TheGetAddPackageOwnerConfirmationMethod : TestContainer
+                    {
+                        public static IEnumerable<object[]> AllCanManagePackageOwnersPairedWithCanBeAdded_Data => TheAddPackageOwnerMethods.AllCanManagePackageOwnersPairedWithCanBeAdded_Data;
+                        public static IEnumerable<object[]> PendingOwnerPropagatesPolicy_Data => TheAddPackageOwnerMethods.PendingOwnerPropagatesPolicy_Data;
+
+                        [Theory]
+                        [MemberData(nameof(AllCanManagePackageOwnersPairedWithCanBeAdded_Data))]
+                        public void ReturnsDefaultConfirmationIfNoPolicyPropagation(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd)
+                        {
+                            // Arrange
+                            var fakes = Get<Fakes>();
+                            var currentUser = getCurrentUser(fakes);
+                            var userToAdd = getUserToAdd(fakes);
+                            var controller = GetController<JsonApiController>();
+                            GetMock<HttpContextBase>()
+                                .Setup(c => c.User)
+                                .Returns(Fakes.ToPrincipal(currentUser));
+
+                            // Act
+                            var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, userToAdd.Username);
+                            dynamic data = ((JsonResult)result).Data;
+
+                            // Assert
+                            Assert.True(data.success);
+                            Assert.Equal($"Please confirm if you would like to proceed adding '{userToAdd.Username}' as a co-owner of this package.", data.confirmation);
+                        }
+
+                        [Theory]
+                        [MemberData(nameof(AllCanManagePackageOwnersPairedWithCanBeAdded_Data))]
+                        public void ReturnsDetailedConfirmationIfNewOwnerPropagatesPolicy(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd)
+                        {
+                            // Arrange
+                            var fakes = Get<Fakes>();
+                            var currentUser = getCurrentUser(fakes);
+                            var userToAdd = getUserToAdd(fakes);
+                            var controller = GetController<JsonApiController>();
+
+                            GetMock<HttpContextBase>()
+                                .Setup(c => c.User)
+                                .Returns(Fakes.ToPrincipal(currentUser));
+
+                            userToAdd.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+
+                            // Act
+                            var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, userToAdd.Username);
+                            dynamic data = ((JsonResult)result).Data;
+
+                            // Assert
+                            Assert.True(data.success);
+                            Assert.StartsWith(
+                                $"User '{userToAdd.Username}' has the following requirements that will be enforced for all co-owners once the user accepts ownership of this package:",
+                                data.policyMessage);
+                        }
+
+                        public static IEnumerable<object[]> ReturnsDetailedConfirmationIfCurrentOwnerPropagatesPolicy_Data
+                        {
+                            get
+                            {
+                                foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                                {
+                                    foreach (var canBeAddedUser in _canBeAddedUsers)
+                                    {
+                                        foreach (var cannotBeAddedUser in _cannotBeAddedUsers)
+                                        {
+                                            yield return new object[]
+                                            {
+                                                canManagePackageOwnersUser,
+                                                canBeAddedUser,
+                                                cannotBeAddedUser,
+                                            };
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        [Theory]
+                        [MemberData(nameof(ReturnsDetailedConfirmationIfCurrentOwnerPropagatesPolicy_Data))]
+                        public void ReturnsDetailedConfirmationIfCurrentOwnerPropagatesPolicy(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd, Func<Fakes,User> getExistingOwner)
+                        {
+                            // Arrange
+                            var fakes = Get<Fakes>();
+                            var currentUser = getCurrentUser(fakes);
+                            var userToAdd = getUserToAdd(fakes);
+                            var existingOwner = getExistingOwner(fakes);
+                            var controller = GetController<JsonApiController>();
+                            GetMock<HttpContextBase>()
+                                .Setup(c => c.User)
+                                .Returns(Fakes.ToPrincipal(currentUser));
+                            existingOwner.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+
+                            // Act
+                            var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, userToAdd.Username);
+                            dynamic data = ((JsonResult)result).Data;
+
+                            // Assert
+                            Assert.True(data.success);
+                            Assert.StartsWith(
+                                $"Owner(s) '{existingOwner.Username}' has (have) the following requirements that will be enforced for user '{userToAdd.Username}' once the user accepts ownership of this package:",
+                                data.policyMessage);
+                        }
+
+                        [Theory]
+                        [MemberData(nameof(AllCanManagePackageOwnersPairedWithCanBeAdded_Data))]
+                        public void DoesNotReturnConfirmationIfCurrentOwnerPropagatesButNewOwnerIsSubscribed(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd)
+                        {
+                            // Arrange
+                            var fakes = Get<Fakes>();
+                            var currentUser = getCurrentUser(fakes);
+                            var userToAdd = getUserToAdd(fakes);
+                            var controller = GetController<JsonApiController>();
+                            GetMock<HttpContextBase>()
+                                .Setup(c => c.User)
+                                .Returns(Fakes.ToPrincipal(currentUser));
+                            GetMock<ISecurityPolicyService>().Setup(s => s.IsSubscribed(userToAdd, SecurePushSubscription.Name)).Returns(true);
+                            currentUser.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+
+                            // Act
+                            var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, userToAdd.Username);
+                            dynamic data = ((JsonResult)result).Data;
+
+                            // Assert
+                            Assert.True(data.success);
+                            Assert.StartsWith($"Please confirm if you would like to proceed adding '{userToAdd.Username}' as a co-owner of this package.",
+                                data.confirmation);
+                        }
+
+                        [Theory]
+                        [MemberData(nameof(PendingOwnerPropagatesPolicy_Data))]
+                        public void ReturnsDetailedConfirmationIfPendingOwnerPropagatesPolicy(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd, Func<Fakes, User> getPendingUser)
+                        {
+                            // Arrange
+                            var fakes = Get<Fakes>();
+                            var currentUser = getCurrentUser(fakes);
+                            var userToAdd = getUserToAdd(fakes);
+                            var pendingUser = getPendingUser(fakes);
+                            var controller = GetController<JsonApiController>();
+                            GetMock<HttpContextBase>()
+                                .Setup(c => c.User)
+                                .Returns(Fakes.ToPrincipal(currentUser));
+
+                            pendingUser.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+
+                            GetMock<IPackageOwnershipManagementService>()
+                                .Setup(p => p.GetPackageOwnershipRequests(fakes.Package, null, null))
+                                .Returns((new[] 
+                                {
+                                    new PackageOwnerRequest()
+                                    {
+                                        PackageRegistration = fakes.Package,
+                                        PackageRegistrationKey = fakes.Package.Key,
+                                        NewOwner = pendingUser,
+                                        NewOwnerKey = pendingUser.Key
+                                    }
+                                }));
+
+                            // Act
+                            var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, userToAdd.Username);
+                            dynamic data = ((JsonResult)result).Data;
+
+                            // Assert
+                            Assert.True(data.success);
+                            Assert.StartsWith(
+                                $"Pending owner(s) '{pendingUser.Username}' has (have) the following requirements that will be enforced for all co-owners, including '{userToAdd.Username}', once ownership requests are accepted:",
+                                data.policyMessage);
+                        }
+
+                        [Theory]
+                        [MemberData(nameof(PendingOwnerPropagatesPolicy_Data))]
+                        public void DoesNotReturnConfirmationIfPendingOwnerPropagatesButNewOwnerIsSubscribed(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd, Func<Fakes, User> getPendingUser)
+                        {
+                            // Arrange
+                            var fakes = Get<Fakes>();
+                            var currentUser = getCurrentUser(fakes);
+                            var userToAdd = getUserToAdd(fakes);
+                            var pendingUser = getPendingUser(fakes);
+                            var controller = GetController<JsonApiController>();
+                            GetMock<HttpContextBase>()
+                                .Setup(c => c.User)
+                                .Returns(Fakes.ToPrincipal(currentUser));
+                            GetMock<ISecurityPolicyService>().Setup(s => s.IsSubscribed(userToAdd, SecurePushSubscription.Name)).Returns(true);
+
+                            pendingUser.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+                            var pendingOwnerRequest = new PackageOwnerRequest()
+                            {
+                                PackageRegistrationKey = fakes.Package.Key,
+                                NewOwner = pendingUser
+                            };
+
+                            GetMock<IPackageOwnerRequestService>()
+                                .Setup(p => p.GetPackageOwnershipRequests(fakes.Package, null, null))
+                                .Returns((new[] { pendingOwnerRequest }));
+
+                            // Act
+                            var result = controller.GetAddPackageOwnerConfirmation(fakes.Package.Id, userToAdd.Username);
+                            dynamic data = ((JsonResult)result).Data;
+
+                            // Assert
+                            Assert.True(data.success);
+                            Assert.StartsWith($"Please confirm if you would like to proceed adding '{userToAdd.Username}' as a co-owner of this package.",
+                                data.confirmation);
+                        }
+
+                    }
+
+                    public class TheAddPackageOwnerMethod : TestContainer
+                    {
+                        public static IEnumerable<object[]> AllCanManagePackageOwnersPairedWithCanBeAdded_Data = TheAddPackageOwnerMethods.AllCanManagePackageOwnersPairedWithCanBeAdded_Data;
+                        public static IEnumerable<object[]> PendingOwnerPropagatesPolicy_Data => TheAddPackageOwnerMethods.PendingOwnerPropagatesPolicy_Data;
+
+                        [Theory]
+                        [MemberData(nameof(AllCanManagePackageOwnersPairedWithCanBeAdded_Data))]
+                        public async Task CreatesPackageOwnerRequestSendsEmailAndReturnsPendingState(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd)
+                        {
+                            var fakes = Get<Fakes>();
+
+                            var currentUser = getCurrentUser(fakes);
+                            var userToAdd = getUserToAdd(fakes);
+
+                            var controller = GetController<JsonApiController>();
+
+                            var httpContextMock = GetMock<HttpContextBase>();
+                            httpContextMock
+                                .Setup(c => c.User)
+                                .Returns(Fakes.ToPrincipal(currentUser))
+                                .Verifiable();
+
+                            var packageOwnershipManagementServiceMock = GetMock<IPackageOwnershipManagementService>();
+                            packageOwnershipManagementServiceMock
+                                .Setup(p => p.AddPackageOwnershipRequestAsync(fakes.Package, currentUser, userToAdd))
+                                .Returns(Task.FromResult(new PackageOwnerRequest { ConfirmationCode = "confirmation-code" }))
+                                .Verifiable();
+
+                            var messageServiceMock = GetMock<IMessageService>();
+                            messageServiceMock
+                                .Setup(m => m.SendPackageOwnerRequest(
+                                    currentUser,
+                                    userToAdd,
+                                    fakes.Package,
+                                    TestUtility.GallerySiteRootHttps + "packages/FakePackage/",
+                                    TestUtility.GallerySiteRootHttps + $"packages/FakePackage/owners/{userToAdd.Username}/confirm/confirmation-code",
+                                    TestUtility.GallerySiteRootHttps + $"packages/FakePackage/owners/{userToAdd.Username}/reject/confirmation-code",
+                                    "Hello World! Html Encoded &lt;3",
+                                    ""))
+                                .Verifiable();
+
+                            JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, userToAdd.Username, "Hello World! Html Encoded <3");
+                            dynamic data = result.Data;
+                            PackageOwnersResultViewModel model = data.model;
+
+                            Assert.True(data.success);
+                            Assert.Equal(userToAdd.Username, model.Name);
+                            Assert.True(model.Pending);
+
+                            httpContextMock.Verify();
+                            packageOwnershipManagementServiceMock.Verify();
+                            messageServiceMock.Verify();
+                        }
+
+                        [Theory]
+                        [MemberData(nameof(AllCanManagePackageOwnersPairedWithCanBeAdded_Data))]
+                        public async Task SendsPackageOwnerRequestEmailWhereNewOwnerPropagatesPolicy(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd)
+                        {
+                            // Arrange & Act
+                            var fakes = Get<Fakes>();
+                            var policyMessage = await GetSendPackageOwnerRequestPolicyMessage(fakes, getCurrentUser(fakes), getUserToAdd(fakes), getUserToAdd(fakes));
+
+                            // Assert
+                            Assert.StartsWith(
+                                "Note: The following policies will be enforced on package co-owners once you accept this request.",
+                                policyMessage);
+                        }
+
+                        [Theory]
+                        [MemberData(nameof(AllCanManagePackageOwnersPairedWithCanBeAdded_Data))]
+                        public async Task SendsPackageOwnerRequestEmailWhereCurrentOwnerPropagatesPolicy(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd)
+                        {
+                            // Arrange & Act
+                            var fakes = Get<Fakes>();
+                            var policyMessage = await GetSendPackageOwnerRequestPolicyMessage(fakes, getCurrentUser(fakes), getUserToAdd(fakes), fakes.Owner);
+
+                            // Assert
+                            Assert.StartsWith(
+                                "Note: Owner(s) 'testPackageOwner' has (have) the following policies that will be enforced on your account once you accept this request.",
+                                policyMessage);
+                        }
+
+                        [Theory]
+                        [MemberData(nameof(PendingOwnerPropagatesPolicy_Data))]
+                        public async Task SendsPackageOwnerRequestEmailWherePendingOwnerPropagatesPolicy(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToAdd, Func<Fakes, User> getPendingUser)
+                        {
+                            // Arrange & Act
+                            var fakes = Get<Fakes>();
+
+                            var currentUser = getCurrentUser(fakes);
+                            var userToAdd = getUserToAdd(fakes);
+                            var pendingUser = getPendingUser(fakes);
+
+                            var packageOwnershipManagementServiceMock = GetMock<IPackageOwnershipManagementService>();
+                            packageOwnershipManagementServiceMock
+                                .Setup(p => p.GetPackageOwnershipRequests(fakes.Package, null, null))
+                                .Returns(
+                                    new[]
+                                    {
+                                        new PackageOwnerRequest
+                                        {
+                                            PackageRegistration = fakes.Package,
+                                            RequestingOwner = currentUser,
+                                            NewOwner = pendingUser,
+                                            ConfirmationCode = "confirmation-code"
+                                        }
+                                    })
+                                .Verifiable();
+
+                            var policyMessage = await GetSendPackageOwnerRequestPolicyMessage(fakes, currentUser, userToAdd, pendingUser);
+
+                            // Assert
+                            Assert.StartsWith(
+                                $"Note: Pending owner(s) '{pendingUser.Username}' has (have) the following policies that will be enforced on your account once ownership requests are accepted.",
+                                policyMessage);
+                        }
+
+                        private async Task<string> GetSendPackageOwnerRequestPolicyMessage(Fakes fakes, User currentUser, User userToAdd, User userToSubscribe)
+                        {
+                            // Arrange
+                            var controller = GetController<JsonApiController>();
+
+                            GetMock<HttpContextBase>()
+                                .Setup(c => c.User)
+                                .Returns(Fakes.ToPrincipal(currentUser));
+
+                            userToSubscribe.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+
+                            var packageOwnershipManagementServiceMock = GetMock<IPackageOwnershipManagementService>();
+                            packageOwnershipManagementServiceMock
+                                .Setup(p => p.AddPackageOwnershipRequestAsync(fakes.Package, currentUser, userToAdd))
+                                .Returns(Task.FromResult(
+                                    new PackageOwnerRequest
+                                    {
+                                        PackageRegistration = fakes.Package,
+                                        RequestingOwner = currentUser,
+                                        NewOwner = userToAdd,
+                                        ConfirmationCode = "confirmation-code"
+                                    }))
+                                .Verifiable();
+
+                            string actualMessage = string.Empty;
+                            GetMock<IMessageService>()
+                                .Setup(m => m.SendPackageOwnerRequest(
+                                    currentUser,
+                                    userToAdd,
+                                    fakes.Package,
+                                    TestUtility.GallerySiteRootHttps + "packages/FakePackage/",
+                                    TestUtility.GallerySiteRootHttps + $"packages/FakePackage/owners/{userToAdd.Username}/confirm/confirmation-code",
+                                    TestUtility.GallerySiteRootHttps + $"packages/FakePackage/owners/{userToAdd.Username}/reject/confirmation-code",
+                                    string.Empty,
+                                    It.IsAny<string>()))
+                                .Callback<User, User, PackageRegistration, string, string, string, string, string>(
+                                    (from, to, pkg, pkgUrl, cnfUrl, rjUrl, msg, policyMsg) => actualMessage = policyMsg);
+
+                            // Act
+                            JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, userToAdd.Username, string.Empty);
+                            dynamic data = result.Data;
+
+                            // Assert
+                            Assert.True(data.success);
+                            Assert.False(String.IsNullOrEmpty(actualMessage));
+                            return actualMessage;
+                        }
+                    }
+                }
+
+                public class TheRemovePackageOwnerMethod : TestContainer
+                {
+                    private static IEnumerable<Func<Fakes, User>> _canBeRemovedUsers = _cannotBeAddedUsers;
+
+                    private static IEnumerable<Func<Fakes, User>> _cannotBeRemovedUsers = _canBeAddedUsers;
+
+                    public static IEnumerable<object[]> AllCanManagePackageOwners_Data => ThePackageOwnerMethods.AllCanManagePackageOwners_Data;
+
+                    public static IEnumerable<object[]> AllCanManagePackageOwnersPairedWithCanBeRemoved_Data
+                    {
+                        get
+                        {
+                            foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                            {
+                                foreach (var canBeRemovedUser in _canBeRemovedUsers)
+                                {
+                                    yield return new object[]
+                                    {
+                                        canManagePackageOwnersUser,
+                                        canBeRemovedUser,
+                                    };
+                                }
+                            }
+                        }
+                    }
+
+                    public static IEnumerable<object[]> AllCanManagePackageOwnersPairedWithCannotBeRemoved_Data
+                    {
+                        get
+                        {
+                            foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                            {
+                                foreach (var cannotBeRemovedUser in _cannotBeRemovedUsers)
+                                {
+                                    yield return new object[]
+                                    {
+                                        canManagePackageOwnersUser,
+                                        cannotBeRemovedUser,
+                                    };
+                                }
+                            }
+                        }
+                    }
+
+                    public static IEnumerable<object[]> ReturnsFailureIfCurrentUserNotFound_Data
+                    {
+                        get
+                        {
+                            return AllCanManagePackageOwnersPairedWithCanBeRemoved_Data.Where(o => o[0] != o[1]);
+                        }
+                    }
+
+                    [Theory]
+                    [MemberData(nameof(ReturnsFailureIfCurrentUserNotFound_Data))]
+                    public async Task ReturnsFailureIfCurrentUserNotFound(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToRemove)
+                    {
+                        // Arrange
+                        var fakes = Get<Fakes>();
+                        var currentUser = getCurrentUser(fakes);
+                        var userToRemove = getUserToRemove(fakes);
+                        var controller = GetController<JsonApiController>();
+                        GetMock<HttpContextBase>()
+                            .Setup(c => c.User)
+                            .Returns(Fakes.ToPrincipal(currentUser));
+
+                        GetMock<IUserService>()
+                            .Setup(x => x.FindByUsername(currentUser.Username))
+                            .Returns<User>(null);
+
+                        // Act
+                        var result = await controller.RemovePackageOwner(fakes.Package.Id, userToRemove.Username);
+                        dynamic data = result.Data;
+
+                        // Assert
+                        Assert.False(data.success);
+                        Assert.Equal("Current user not found.", data.message);
+                    }
+
+                    [Theory]
+                    [MemberData(nameof(AllCanManagePackageOwnersPairedWithCannotBeRemoved_Data))]
+                    public async Task ReturnsFailureIfUserIsNotAnOwner(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToRemove)
+                    {
+                        // Arrange
+                        var fakes = Get<Fakes>();
+                        var currentUser = getCurrentUser(fakes);
+                        var userToRemove = getUserToRemove(fakes);
+                        var controller = GetController<JsonApiController>();
+                        GetMock<HttpContextBase>()
+                            .Setup(c => c.User)
+                            .Returns(Fakes.ToPrincipal(currentUser));
+
+                        // Act
+                        var result = await controller.RemovePackageOwner(fakes.Package.Id, userToRemove.Username);
+                        dynamic data = result.Data;
+
+                        // Assert
+                        Assert.False(data.success);
+                        Assert.Equal($"The user '{userToRemove.Username}' is not an owner or pending owner of the package!", data.message);
+                    }
+
+                    [Theory]
+                    [MemberData(nameof(AllCanManagePackageOwnersPairedWithCannotBeRemoved_Data))]
+                    public async Task RemovesPackageOwnerRequest(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getPendingUser)
+                    {
+                        // Arrange
+                        var fakes = Get<Fakes>();
+                        var currentUser = getCurrentUser(fakes);
+                        var requestedUser = getPendingUser(fakes);
+                        var package = fakes.Package;
+                        var controller = GetController<JsonApiController>();
+                        GetMock<HttpContextBase>()
+                            .Setup(c => c.User)
+                            .Returns(Fakes.ToPrincipal(currentUser));
+
+                        var packageOwnershipManagementService = GetMock<IPackageOwnershipManagementService>();
+
+                        packageOwnershipManagementService
+                            .Setup(x => x.GetPackageOwnershipRequests(package, null, requestedUser))
+                            .Returns(new PackageOwnerRequest[] { new PackageOwnerRequest() });
+
+                        // Act
+                        var result = await controller.RemovePackageOwner(package.Id, requestedUser.Username);
+                        dynamic data = result.Data;
+
+                        // Assert
+                        Assert.True(data.success);
+
+                        packageOwnershipManagementService.Verify(x => x.DeletePackageOwnershipRequestAsync(package, requestedUser));
+
+                        GetMock<IMessageService>()
+                            .Verify(x => x.SendPackageOwnerRequestCancellationNotice(currentUser, requestedUser, package));
+                    }
+
+                    [Theory]
+                    [MemberData(nameof(AllCanManagePackageOwnersPairedWithCanBeRemoved_Data))]
+                    public async Task RemovesExistingOwner(Func<Fakes, User> getCurrentUser, Func<Fakes, User> getUserToRemove)
+                    {
+                        // Arrange
+                        var fakes = Get<Fakes>();
+                        var currentUser = getCurrentUser(fakes);
+                        var userToRemove = getUserToRemove(fakes);
+                        var package = fakes.Package;
+                        var controller = GetController<JsonApiController>();
+                        GetMock<HttpContextBase>()
+                            .Setup(c => c.User)
+                            .Returns(Fakes.ToPrincipal(currentUser));
+
+                        var packageOwnershipManagementService = GetMock<IPackageOwnershipManagementService>();
+
+                        packageOwnershipManagementService
+                            .Setup(x => x.GetPackageOwnershipRequests(package, null, userToRemove))
+                            .Returns(Enumerable.Empty<PackageOwnerRequest>());
+
+                        // Act
+                        var result = await controller.RemovePackageOwner(package.Id, userToRemove.Username);
+                        dynamic data = result.Data;
+
+                        // Assert
+                        Assert.True(data.success);
+
+                        packageOwnershipManagementService.Verify(x => x.RemovePackageOwnerAsync(package, currentUser, userToRemove, It.IsAny<bool>()));
+
+                        GetMock<IMessageService>()
+                            .Verify(x => x.SendPackageOwnerRemovedNotice(currentUser, userToRemove, package));
+                    }
+                }
+
+                public delegate Task<ActionResult> InvokePackageOwnerModificationRequest(JsonApiController jsonApiController, string packageId, string username);
+
+                private static Task<ActionResult> GetAddPackageOwnerConfirmation(JsonApiController jsonApiController, string packageId, string username)
+                {
+                    return Task.Run(() => jsonApiController.GetAddPackageOwnerConfirmation(packageId, username));
+                }
+
+                private static async Task<ActionResult> AddPackageOwner(JsonApiController jsonApiController, string packageId, string username)
+                {
+                    return await jsonApiController.AddPackageOwner(packageId, username, "message");
+                }
+
+                private static async Task<ActionResult> RemovePackageOwner(JsonApiController jsonApiController, string packageId, string username)
+                {
+                    return await jsonApiController.RemovePackageOwner(packageId, username);
+                }
+
+                private static IEnumerable<InvokePackageOwnerModificationRequest> _requests = new InvokePackageOwnerModificationRequest[]
+                {
+                    new InvokePackageOwnerModificationRequest(GetAddPackageOwnerConfirmation),
+                    new InvokePackageOwnerModificationRequest(AddPackageOwner),
+                    new InvokePackageOwnerModificationRequest(RemovePackageOwner),
+                };
+
+                public static IEnumerable<object[]> AllRequests_Data
+                {
+                    get
+                    {
+                        foreach (var request in _requests)
+                        {
+                            yield return new object[]
+                            {
+                                request
+                            };
+                        }
+                    }
+                }
+
+                public static IEnumerable<object[]> AllCanManagePackageOwnersByRequests_Data
+                {
+                    get
+                    {
+                        foreach (var request in _requests)
+                        {
+                            foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                            {
+                                yield return new object[]
+                                {
+                                    request,
+                                    canManagePackageOwnersUser,
+                                };
+                            }
+                        }
+                    }
+                }
+
+                public static IEnumerable<object[]> AllCannotManagePackageOwnersByRequests_Data
+                {
+                    get
+                    {
+                        foreach (var request in _requests)
+                        {
+                            foreach (var cannotManagePackageOwnersUser in _cannotManagePackageOwnersUsers)
+                            {
+                                yield return new object[]
+                                {
+                                    request,
+                                    cannotManagePackageOwnersUser,
+                                };
+                            }
+                        }
+                    }
+                }
             }
 
-            private async Task<string> GetSendPackageOwnerRequestPolicyMessage(Fakes fakes, User userToSubscribe)
+            private static Func<Fakes, User> _getFakesUser = (Fakes fakes) => fakes.User;
+            private static Func<Fakes, User> _getFakesOwner = (Fakes fakes) => fakes.Owner;
+            private static Func<Fakes, User> _getFakesOrganizationOwner = (Fakes fakes) => fakes.OrganizationOwner;
+            private static Func<Fakes, User> _getFakesOrganizationAdminOwner = (Fakes fakes) => fakes.OrganizationAdminOwner;
+            private static Func<Fakes, User> _getFakesOrganizationCollaboratorOwner = (Fakes fakes) => fakes.OrganizationCollaboratorOwner;
+
+            private static IEnumerable<Func<Fakes, User>> _canManagePackageOwnersUsers = new Func<Fakes, User>[]
             {
-                // Arrange
-                var controller = GetController<JsonApiController>();
-                
-                GetMock<HttpContextBase>()
-                    .Setup(c => c.User)
-                    .Returns(Fakes.ToPrincipal(fakes.Owner));
+                _getFakesOwner,
+                _getFakesOrganizationOwner,
+                _getFakesOrganizationAdminOwner,
+            };
 
-                userToSubscribe.SecurityPolicies = (new RequireSecurePushForCoOwnersPolicy().Policies).ToList();
+            private static IEnumerable<Func<Fakes, User>> _cannotManagePackageOwnersUsers = new Func<Fakes, User>[]
+            {
+                _getFakesUser,
+                _getFakesOrganizationCollaboratorOwner,
+            };
 
-                var packageOwnershipManagementServiceMock = GetMock<IPackageOwnershipManagementService>();
-                packageOwnershipManagementServiceMock
-                    .Setup(p => p.AddPackageOwnershipRequestAsync(fakes.Package, fakes.Owner, fakes.User))
-                    .Returns(Task.FromResult(
-                        new PackageOwnerRequest
+            private static IEnumerable<Func<Fakes, User>> _canBeAddedUsers = new Func<Fakes, User>[]
+            {
+                _getFakesUser,
+                _getFakesOrganizationAdminOwner,
+                _getFakesOrganizationCollaboratorOwner,
+            };
+
+            private static IEnumerable<Func<Fakes, User>> _cannotBeAddedUsers = new Func<Fakes, User>[]
+            {
+                _getFakesOwner,
+                _getFakesOrganizationOwner,
+            };
+
+            public static IEnumerable<object[]> AllCanManagePackageOwners_Data
+            {
+                get
+                {
+                    foreach (var canManagePackageOwnersUser in _canManagePackageOwnersUsers)
+                    {
+                        yield return new object[]
                         {
-                            PackageRegistration = fakes.Package,
-                            RequestingOwner = fakes.Owner,
-                            NewOwner = fakes.User,
-                            ConfirmationCode = "confirmation-code"
-                        }))
-                    .Verifiable();
+                            canManagePackageOwnersUser,
+                        };
+                    }
+                }
+            }
 
-                string actualMessage = string.Empty;
-                GetMock<IMessageService>()
-                    .Setup(m => m.SendPackageOwnerRequest(
-                        fakes.Owner,
-                        fakes.User,
-                        fakes.Package,
-                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/",
-                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/owners/testUser/confirm/confirmation-code",
-                        TestUtility.GallerySiteRootHttps + "packages/FakePackage/owners/testUser/reject/confirmation-code",
-                        string.Empty,
-                        It.IsAny<string>()))
-                    .Callback<User, User, PackageRegistration, string, string, string, string, string>(
-                        (from, to, pkg, pkgUrl, cnfUrl, rjUrl, msg, policyMsg) => actualMessage = policyMsg);
-
-                // Act
-                JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, fakes.User.Username, string.Empty);
-                dynamic data = result.Data;
-
-                // Assert
-                Assert.True(data.success);
-                Assert.False(String.IsNullOrEmpty(actualMessage));
-                return actualMessage;
+            public static IEnumerable<object[]> AllCannotManagePackageOwners_Data
+            {
+                get
+                {
+                    foreach (var cannotManagePackageOwnersUser in _cannotManagePackageOwnersUsers)
+                    {
+                        yield return new object[]
+                        {
+                            cannotManagePackageOwnersUser,
+                        };
+                    }
+                }
             }
         }
 
-        public class TheRemovePackageOwnerMethod : TestContainer
+        public class TheGetPackageOwnersMethod : TestContainer
         {
-            [Theory]
-            [InlineData("")]
-            [InlineData(null)]
-            public async Task ThrowsArgumentNullIfPackageIdMissing(string id)
-            {
-                // Arrange
-                var controller = GetController<JsonApiController>();
 
-                // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(() => controller.RemovePackageOwner(id, "user"));
-            }
-
-            [Theory]
-            [InlineData("")]
-            [InlineData(null)]
-            public async Task ThrowsArgumentNullIfUsernameMissing(string username)
-            {
-                // Arrange
-                var controller = GetController<JsonApiController>();
-
-                // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(() => controller.RemovePackageOwner("package", username));
-            }
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1092,14 +1092,16 @@ namespace NuGetGallery
                     Assert.Equal(0, fakes.Owner.SecurityPolicies.Count);
 
                     // Act & Assert
-                    var policyMessages = await AssertConfirmOwnerSubscribesUser(fakes, fakes.Owner, fakes.ShaUser);
-                    Assert.Equal(3, policyMessages.Count);
+                    var policyMessages = await AssertConfirmOwnerSubscribesUser(fakes, fakes.Owner, fakes.ShaUser, fakes.OrganizationOwner);
+                    Assert.Equal(4, policyMessages.Count);
 
                     // subscribed notification
                     Assert.StartsWith("Owner(s) 'testUser' has (have) the following requirements that are now enforced for your account:",
                         policyMessages[fakes.Owner.Username]);
                     Assert.StartsWith("Owner(s) 'testUser' has (have) the following requirements that are now enforced for your account:",
                         policyMessages[fakes.ShaUser.Username]);
+                    Assert.StartsWith("Owner(s) 'testUser' has (have) the following requirements that are now enforced for your account:",
+                        policyMessages[fakes.OrganizationOwner.Username]);
 
                     // propagator notification
                     Assert.StartsWith("Owner(s) 'testUser' has (have) the following requirements that are now enforced for co-owner(s) '",
@@ -1120,10 +1122,11 @@ namespace NuGetGallery
                     var policyMessages = await AssertConfirmOwnerSubscribesUser(fakes, fakes.User);
 
                     Assert.False(policyMessages.ContainsKey(fakes.User.Username));
-                    Assert.Equal(2, policyMessages.Count);
+                    Assert.Equal(3, policyMessages.Count);
                     Assert.StartsWith("Owner(s) 'testPackageOwner' has (have) the following requirements that are now enforced for co-owner(s) 'testUser':",
                         policyMessages[fakes.Owner.Username]);
                     Assert.Equal("", policyMessages[fakes.ShaUser.Username]);
+                    Assert.Equal("", policyMessages[fakes.OrganizationOwner.Username]);
                 }
 
                 private async Task<IDictionary<string, string>> AssertConfirmOwnerSubscribesUser(Fakes fakes, params User[] usersSubscribed)

--- a/tests/NuGetGallery.Facts/Framework/Fakes.cs
+++ b/tests/NuGetGallery.Facts/Framework/Fakes.cs
@@ -62,8 +62,8 @@ namespace NuGetGallery.Framework
 
             CreateOrganizationUsers(ref key, credentialBuilder, "Owner", out var organizationOwner, out var organizationAdminOwner, out var organizationCollaboratorOwner);
             OrganizationOwner = organizationOwner;
-            OrganizationAdminOwner = organizationAdminOwner;
-            OrganizationCollaboratorOwner = organizationCollaboratorOwner;
+            OrganizationOwnerAdmin = organizationAdminOwner;
+            OrganizationOwnerCollaborator = organizationCollaboratorOwner;
 
             Pbkdf2User = new User("testPbkdf2User")
             {
@@ -126,9 +126,9 @@ namespace NuGetGallery.Framework
 
         public Organization OrganizationOwner { get; }
 
-        public User OrganizationAdminOwner { get; }
+        public User OrganizationOwnerAdmin { get; }
 
-        public User OrganizationCollaboratorOwner { get; }
+        public User OrganizationOwnerCollaborator { get; }
 
         public User ShaUser { get; }
 


### PR DESCRIPTION
- Adds "(your organization)" to organizations accounts that you are a member of in the Current Owners list
- Fixes the "who I can remove" logic with respect to organization users
- Improves messaging when users try to add a package owner that already exists or remove a package owner that doesn't exist
- Adds organization users to `Fakes`
- **Vastly improved testing for `JsonApiController`** (will add more for `GetPackageOwners` later)