### PR TITLE
Fixing ApiScopeRequiredAttribute regression

### DIFF
--- a/src/NuGetGallery/Filters/ApiScopeRequiredAttribute.cs
+++ b/src/NuGetGallery/Filters/ApiScopeRequiredAttribute.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery.Filters
     public sealed class ApiScopeRequiredAttribute 
         : AuthorizeAttribute
     {
-        public string[] ScopeActions { get; set; }
+        private string[] ScopeActions { get; set; }
         
         public ApiScopeRequiredAttribute(params string[] scopeActions)
         {

--- a/src/NuGetGallery/Filters/ApiScopeRequiredAttribute.cs
+++ b/src/NuGetGallery/Filters/ApiScopeRequiredAttribute.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery.Filters
     public sealed class ApiScopeRequiredAttribute 
         : AuthorizeAttribute
     {
-        private string[] ScopeActions { get; set; }
+        public string[] ScopeActions { get; private set; }
         
         public ApiScopeRequiredAttribute(params string[] scopeActions)
         {

--- a/tests/NuGetGallery.Facts/Filters/ApiScopeRequiredAttributeFacts.cs
+++ b/tests/NuGetGallery.Facts/Filters/ApiScopeRequiredAttributeFacts.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Autofac;
+using NuGetGallery.Authentication;
+using Xunit;
+
+namespace NuGetGallery.Filters
+{
+    public class ApiScopeRequiredAttributeFacts
+    {
+        public class TheScopeActionsProperty
+        {
+            [Fact]
+            public void NotOverwrittenByAutofacPropertyInjection()
+            {
+                // Arrange
+                var autofacBuilder = new ContainerBuilder();
+                autofacBuilder.RegisterInstance(new ApiScopeRequiredAttribute(NuGetScopes.PackagePush))
+                    .AsSelf()
+                    .PropertiesAutowired(); // enable property injection
+                var container = autofacBuilder.Build();
+
+                // Act
+                var resolvedAttribute = container.Resolve<ApiScopeRequiredAttribute>();
+
+                // Assert
+                Assert.Equal(1, resolvedAttribute.ScopeActions.Length);
+                Assert.Equal(NuGetScopes.PackagePush, resolvedAttribute.ScopeActions.First());
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -426,6 +426,7 @@
     <Compile Include="Extensions\PrincipalExtensionsFacts.cs" />
     <Compile Include="Extensions\ScopeExtensionsFacts.cs" />
     <Compile Include="Extensions\UserExtensionsFacts.cs" />
+    <Compile Include="Filters\ApiScopeRequiredAttributeFacts.cs" />
     <Compile Include="Framework\TestGalleryConfigurationService.cs" />
     <Compile Include="Helpers\HtmlExtensionsFacts.cs" />
     <Compile Include="HttpContextBaseExtensionsFacts.cs" />


### PR DESCRIPTION
Regression from PR #4945 
https://github.com/NuGet/NuGetGallery/pull/4945/files#diff-1463a262f19818464c6a4983b635e94aL18

When I changed type from `List<string>` to `string[]`, the property was getting overwritten by AutofacFilterProvider property injection. Fix is to make the property private.