### PR TITLE
Fix PackageControllerFacts

### DIFF
--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1807,6 +1807,7 @@ namespace NuGetGallery
                     Message = "Mordor took my finger.",
                     Reason = ReportPackageReason.ViolatesALicenseIOwn,
                     AlreadyContactedOwner = true,
+                    Signature = "Frodo"
                 };
 
                 TestUtility.SetupUrlHelper(controller, httpContext);
@@ -1847,7 +1848,8 @@ namespace NuGetGallery
                 var model = new ReportAbuseViewModel
                 {
                     Message = "Mordor took my finger",
-                    Reason = ReportPackageReason.ViolatesALicenseIOwn
+                    Reason = ReportPackageReason.ViolatesALicenseIOwn,
+                    Signature = "Frodo"
                 };
 
                 TestUtility.SetupUrlHelper(controller, httpContext);
@@ -1913,6 +1915,7 @@ namespace NuGetGallery
                     Message = "I like the cut of your jib. It's <b>bold</b>.",
                     Reason = ReportPackageReason.ViolatesALicenseIOwn,
                     AlreadyContactedOwner = true,
+                    Signature = "Frodo"
                 };
 
                 TestUtility.SetupUrlHelper(controller, httpContext);


### PR DESCRIPTION
This broke with https://github.com/NuGet/NuGetGallery/pull/4956 because we updated the report reason in the test to ViolateALicense, but failed to update the mocked view model to reflect a valid model for this reason.

Update ReportAbuseViewModel in tests to include signature for new reason.

@skofman1 @cristinamanum @agr 