### PR TITLE
Fix test VerifyPackageKey_Returns404ForMissingPackage

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/PackageCreation/SecurityPolicyTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageCreation/SecurityPolicyTests.cs
@@ -123,7 +123,16 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
         [Category("P1Tests")]
         public async Task VerifyPackageKey_Returns404ForMissingPackage()
         {
-            Assert.Equal(HttpStatusCode.NotFound, await VerifyPackageKey(EnvironmentSettings.TestAccountApiKey, "VerifyPackageKeyReturns404ForMissingPackage", "1.0.0"));
+            // Arrange
+            var packageId = $"VerifyPackageKey_Returns404ForMissingPackage.{DateTimeOffset.UtcNow.Ticks}";
+            var packageVersion = "1.0.0";
+
+            await _clientSdkHelper.UploadNewPackage(packageId, packageVersion);
+
+            var verificationKey = await CreateVerificationKey(EnvironmentSettings.TestAccountApiKey, packageId, packageVersion);
+            
+            // Act & Assert
+            Assert.Equal(HttpStatusCode.NotFound, await VerifyPackageKey(verificationKey, packageId + "_bad", packageVersion));
         }
 
         [DefaultSecurityPoliciesEnforcedFact(runIfEnforced: false)]


### PR DESCRIPTION
The test broke due to default security policy flag being on. This is the fix.