### PR TITLE
Not showing "indexing" message while validation is in progress.

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -194,7 +194,7 @@
                 )
             }
 
-            @if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value)
+            @if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && !Model.Validating)
             {
                 @ViewHelpers.AlertWarning(
                     @<text>


### PR DESCRIPTION
Preventing showing the 

>This package has not been indexed yet. It will appear in search results and will be available for install/restore after indexing is complete. 

message while validation is in progress, as package is not available in V2, so no indexing is happening.