### PR TITLE
Improve performance of the PermissionsService

### DIFF
--- a/src/NuGetGallery/Services/PermissionsService.cs
+++ b/src/NuGetGallery/Services/PermissionsService.cs
@@ -78,7 +78,7 @@ namespace NuGetGallery
         {
             if (currentUser == null)
             {
-                return PermissionLevelsMatch(PermissionLevel.Anonymous, actionPermissionLevel);
+                return PermissionLevelsIntersect(PermissionLevel.Anonymous, actionPermissionLevel);
             }
 
             return HasPermission(
@@ -92,7 +92,7 @@ namespace NuGetGallery
         {
             if (currentPrincipal == null)
             {
-                return PermissionLevelsMatch(PermissionLevel.Anonymous, actionPermissionLevel);
+                return PermissionLevelsIntersect(PermissionLevel.Anonymous, actionPermissionLevel);
             }
 
             return HasPermission(
@@ -105,19 +105,19 @@ namespace NuGetGallery
         private static bool HasPermission(IEnumerable<User> entityOwners, bool isUserAdmin, Func<User, bool> isUserMatch, PermissionLevel actionPermissionLevel)
         {
             if ((entityOwners == null || !entityOwners.Any()) &&
-                PermissionLevelsMatch(PermissionLevel.Anonymous, actionPermissionLevel))
-            {
-                return true;
-            }
-
-            if (isUserAdmin &&
-                PermissionLevelsMatch(PermissionLevel.SiteAdmin, actionPermissionLevel))
+                PermissionLevelsIntersect(PermissionLevel.Anonymous, actionPermissionLevel))
             {
                 return true;
             }
 
             if (entityOwners.Any(isUserMatch) &&
-                PermissionLevelsMatch(PermissionLevel.Owner, actionPermissionLevel))
+                PermissionLevelsIntersect(PermissionLevel.Owner, actionPermissionLevel))
+            {
+                return true;
+            }
+
+            if (isUserAdmin &&
+                PermissionLevelsIntersect(PermissionLevel.SiteAdmin, actionPermissionLevel))
             {
                 return true;
             }
@@ -130,21 +130,21 @@ namespace NuGetGallery
                 .ToArray();
 
             if (matchingMembers.Any(m => m.IsAdmin) &&
-                PermissionLevelsMatch(PermissionLevel.OrganizationAdmin, actionPermissionLevel))
+                PermissionLevelsIntersect(PermissionLevel.OrganizationAdmin, actionPermissionLevel))
             {
                 return true;
             }
 
             if (matchingMembers.Any() &&
-                PermissionLevelsMatch(PermissionLevel.OrganizationCollaborator, actionPermissionLevel))
+                PermissionLevelsIntersect(PermissionLevel.OrganizationCollaborator, actionPermissionLevel))
             {
                 return true;
             }
 
-            return PermissionLevelsMatch(PermissionLevel.Anonymous, actionPermissionLevel);
+            return PermissionLevelsIntersect(PermissionLevel.Anonymous, actionPermissionLevel);
         }
 
-        private static bool PermissionLevelsMatch(PermissionLevel first, PermissionLevel second)
+        private static bool PermissionLevelsIntersect(PermissionLevel first, PermissionLevel second)
         {
             return (first & second) > 0;
         }

--- a/src/NuGetGallery/Services/PermissionsService.cs
+++ b/src/NuGetGallery/Services/PermissionsService.cs
@@ -39,8 +39,7 @@ namespace NuGetGallery
         /// </summary>
         public static bool IsActionAllowed(IEnumerable<User> entityOwners, IPrincipal currentPrincipal, PermissionLevel actionPermissionLevel)
         {
-            var userPermissionLevel = GetPermissionLevel(entityOwners, currentPrincipal);
-            return IsAllowed(userPermissionLevel, actionPermissionLevel);
+            return HasPermission(entityOwners, currentPrincipal, actionPermissionLevel);
         }
 
         /// <summary>
@@ -72,58 +71,55 @@ namespace NuGetGallery
         /// </summary>
         public static bool IsActionAllowed(IEnumerable<User> entityOwners, User currentUser, PermissionLevel actionPermissionLevel)
         {
-            var userPermissionLevel = GetPermissionLevel(entityOwners, currentUser);
-            return IsAllowed(userPermissionLevel, actionPermissionLevel);
+            return HasPermission(entityOwners, currentUser, actionPermissionLevel);
         }
 
-        private static bool IsAllowed(PermissionLevel userPermissionLevel, PermissionLevel actionPermissionLevel)
-        {
-            return (userPermissionLevel & actionPermissionLevel) > 0;
-        }
-
-        internal static PermissionLevel GetPermissionLevel(IEnumerable<User> owners, User currentUser)
+        private static bool HasPermission(IEnumerable<User> owners, User currentUser, PermissionLevel actionPermissionLevel)
         {
             if (currentUser == null)
             {
-                return PermissionLevel.Anonymous;
+                return PermissionLevelsMatch(PermissionLevel.Anonymous, actionPermissionLevel);
             }
 
-            return GetPermissionLevel(
-                owners, 
-                currentUser.IsAdministrator(), 
-                u => currentUser.MatchesUser(u));
+            return HasPermission(
+                owners,
+                currentUser.IsAdministrator(),
+                u => currentUser.MatchesUser(u),
+                actionPermissionLevel);
         }
 
-        internal static PermissionLevel GetPermissionLevel(IEnumerable<User> entityOwners, IPrincipal currentPrincipal)
+        private static bool HasPermission(IEnumerable<User> entityOwners, IPrincipal currentPrincipal, PermissionLevel actionPermissionLevel)
         {
             if (currentPrincipal == null)
             {
-                return PermissionLevel.Anonymous;
+                return PermissionLevelsMatch(PermissionLevel.Anonymous, actionPermissionLevel);
             }
 
-            return GetPermissionLevel(
-                entityOwners, 
-                currentPrincipal.IsAdministrator(), 
-                u => currentPrincipal.MatchesUser(u));
+            return HasPermission(
+                entityOwners,
+                currentPrincipal.IsAdministrator(),
+                u => currentPrincipal.MatchesUser(u),
+                actionPermissionLevel);
         }
 
-        private static PermissionLevel GetPermissionLevel(IEnumerable<User> entityOwners, bool isUserAdmin, Func<User, bool> isUserMatch)
+        private static bool HasPermission(IEnumerable<User> entityOwners, bool isUserAdmin, Func<User, bool> isUserMatch, PermissionLevel actionPermissionLevel)
         {
-            var permissionLevel = PermissionLevel.Anonymous;
-
-            if (entityOwners == null)
+            if ((entityOwners == null || !entityOwners.Any()) &&
+                PermissionLevelsMatch(PermissionLevel.Anonymous, actionPermissionLevel))
             {
-                return permissionLevel;
+                return true;
             }
 
-            if (isUserAdmin)
+            if (isUserAdmin &&
+                PermissionLevelsMatch(PermissionLevel.SiteAdmin, actionPermissionLevel))
             {
-                permissionLevel |= PermissionLevel.SiteAdmin;
+                return true;
             }
 
-            if (entityOwners.Any(isUserMatch))
+            if (entityOwners.Any(isUserMatch) &&
+                PermissionLevelsMatch(PermissionLevel.Owner, actionPermissionLevel))
             {
-                permissionLevel |= PermissionLevel.Owner;
+                return true;
             }
 
             var matchingMembers = entityOwners
@@ -133,17 +129,24 @@ namespace NuGetGallery
                 .Where(m => isUserMatch(m.Member))
                 .ToArray();
 
-            if (matchingMembers.Any(m => m.IsAdmin))
+            if (matchingMembers.Any(m => m.IsAdmin) &&
+                PermissionLevelsMatch(PermissionLevel.OrganizationAdmin, actionPermissionLevel))
             {
-                permissionLevel |= PermissionLevel.OrganizationAdmin;
+                return true;
             }
 
-            if (matchingMembers.Any())
+            if (matchingMembers.Any() &&
+                PermissionLevelsMatch(PermissionLevel.OrganizationCollaborator, actionPermissionLevel))
             {
-                permissionLevel |= PermissionLevel.OrganizationCollaborator;
+                return true;
             }
 
-            return permissionLevel;
+            return PermissionLevelsMatch(PermissionLevel.Anonymous, actionPermissionLevel);
+        }
+
+        private static bool PermissionLevelsMatch(PermissionLevel first, PermissionLevel second)
+        {
+            return (first & second) > 0;
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/PermissionsServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PermissionsServiceFacts.cs
@@ -103,10 +103,17 @@ namespace NuGetGallery.Services
 
             private void AssertPermissionLevels(IEnumerable<User> owners, User user, PermissionLevel expectedLevel)
             {
-                Assert.Equal(expectedLevel, PermissionsService.GetPermissionLevel(owners, user));
+                for (int i = 0; i < Enum.GetValues(typeof(PermissionLevel)).Cast<int>().Max() * 2; i++)
+                {
+                    var permissionLevel = (PermissionLevel)i;
 
-                var principal = GetPrincipal(user);
-                Assert.Equal(expectedLevel, PermissionsService.GetPermissionLevel(owners, principal));
+                    var shouldSucceed = (permissionLevel & expectedLevel) > 0;
+
+                    Assert.Equal(shouldSucceed, PermissionsService.IsActionAllowed(owners, user, permissionLevel));
+
+                    var principal = GetPrincipal(user);
+                    Assert.Equal(shouldSucceed, PermissionsService.IsActionAllowed(owners, principal, permissionLevel));
+                }
             }
 
             private IPrincipal GetPrincipal(User u)

--- a/tests/NuGetGallery.Facts/Services/PermissionsServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PermissionsServiceFacts.cs
@@ -28,11 +28,17 @@ namespace NuGetGallery.Services
             private static readonly IEnumerable<ReturnsExpectedPermissionLevels_State> _stateValues = 
                 Enum.GetValues(typeof(ReturnsExpectedPermissionLevels_State)).Cast<ReturnsExpectedPermissionLevels_State>();
 
+            private static readonly int _maxStateValue =
+                Enum.GetValues(typeof(ReturnsExpectedPermissionLevels_State)).Cast<int>().Max();
+
+            private static readonly int _maxPermissionLevel =
+                Enum.GetValues(typeof(PermissionLevel)).Cast<int>().Max();
+
             public static IEnumerable<object[]> ReturnsExpectedPermissionLevels_Data
             {
                 get
                 {
-                    for (int i = 0; i < Enum.GetValues(typeof(ReturnsExpectedPermissionLevels_State)).Cast<int>().Max() * 2; i++)
+                    for (int i = 0; i < _maxStateValue * 2; i++)
                     {
                         yield return new object[]
                         {
@@ -103,7 +109,7 @@ namespace NuGetGallery.Services
 
             private void AssertPermissionLevels(IEnumerable<User> owners, User user, PermissionLevel expectedLevel)
             {
-                for (int i = 0; i < Enum.GetValues(typeof(PermissionLevel)).Cast<int>().Max() * 2; i++)
+                for (int i = 0; i < _maxPermissionLevel * 2; i++)
                 {
                     var permissionLevel = (PermissionLevel)i;
 


### PR DESCRIPTION
Previously, the `PermissionsService` would
1 - Get a list of all permissions that the user has
2 - Check that list with the permissions required by the action

This PR now allows the `PermissionsService` to short-circuit and stop checking permissions when it finds that the user has a permission that's required.

E.g. if I am an owner of the package and this action is allowed if I have owner permissions, I don't need to check if I am a member of any organizations that own the package.