### PR TITLE
[Organizations] Support for UI upload for organizations

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -468,6 +468,7 @@ namespace NuGetGallery
                             id,
                             packageToPush,
                             packageStreamMetadata,
+                            user,
                             user);
 
                         await AutoCuratePackage.ExecuteAsync(package, packageToPush, commitChanges: false);

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -468,8 +468,8 @@ namespace NuGetGallery
                             id,
                             packageToPush,
                             packageStreamMetadata,
-                            user,
-                            user);
+                            owner: user,
+                            currentUser: user);
 
                         await AutoCuratePackage.ExecuteAsync(package, packageToPush, commitChanges: false);
 

--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -50,7 +50,7 @@ namespace NuGetGallery
                 return Json(new { message = Strings.AddOwner_PackageNotFound });
             }
 
-            if (!PermissionsService.IsActionAllowed(package, HttpContext.User, PackageActions.ManagePackageOwners))
+            if (!PermissionsService.IsActionAllowed(package, HttpContext.User, PackageActions.ManagePackageOwnership))
             {
                 return new HttpUnauthorizedResult();
             }
@@ -313,7 +313,7 @@ namespace NuGetGallery
                 model = new ManagePackageOwnerModel(Strings.AddOwner_PackageNotFound);
                 return false;
             }
-            if (!PermissionsService.IsActionAllowed(package, HttpContext.User, PackageActions.ManagePackageOwners))
+            if (!PermissionsService.IsActionAllowed(package, HttpContext.User, PackageActions.ManagePackageOwnership))
             {
                 model = new ManagePackageOwnerModel(Strings.AddOwner_NotPackageOwner);
                 return false;

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1591,7 +1591,8 @@ namespace NuGetGallery
         [ValidateAntiForgeryToken]
         public virtual async Task<JsonResult> CancelUpload()
         {
-            await _uploadFileService.DeleteUploadFileAsync(GetCurrentUser().Key);
+            var currentUser = GetCurrentUser();
+            await _uploadFileService.DeleteUploadFileAsync(currentUser.Key);
 
             return Json(null);
         }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -162,7 +162,7 @@ namespace NuGetGallery
 
                     var existingPackageRegistration = _packageService.FindPackageRegistrationById(packageMetadata.Id);
 
-                    if (!_reservedNamespaceService.IsPushAllowedOnBehalfOfOwner(packageMetadata.Id, currentUser, out var userOwnerMatchingNamespaces) ||
+                    if (existingPackageRegistration == null && !_reservedNamespaceService.IsPushAllowedOnBehalfOfOwner(packageMetadata.Id, currentUser, out var userOwnerMatchingNamespaces) ||
                         (existingPackageRegistration != null && !PermissionsService.IsActionAllowed(existingPackageRegistration, currentUser, PackageActions.UploadNewVersion)))
                     {
                         // This user no longer has the rights to upload to this package. Cancel this upload.

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -368,8 +368,6 @@ namespace NuGetGallery
                 {
                     _telemetryService.TraceException(ex);
 
-                    TempData["Message"] = ex.GetUserSafeMessage();
-
                     return Json(400, new[] { ex.GetUserSafeMessage() });
                 }
             }
@@ -1413,7 +1411,6 @@ namespace NuGetGallery
                 if (owner == null)
                 {
                     var message = string.Format(CultureInfo.CurrentCulture, Strings.VerifyPackage_UserNonExistent, formData.Edit.Owner);
-                    TempData["Message"] = message;
                     return Json(400, new[] { message });
                 }
 
@@ -1426,7 +1423,6 @@ namespace NuGetGallery
                         var message = string.Format(CultureInfo.CurrentCulture,
                             Strings.UploadPackage_NewVersionOnBehalfOfUserNotAllowed,
                             currentUser.Username, owner.Username);
-                        TempData["Message"] = message;
                         return Json(400, new[] { message });
                     }
 
@@ -1436,7 +1432,6 @@ namespace NuGetGallery
                         var message = string.Format(CultureInfo.CurrentCulture,
                             Strings.VerifyPackage_OwnerInvalid,
                             owner.Username, existingPackageRegistration.Id);
-                        TempData["Message"] = message;
                         return Json(400, new[] { message });
                     }
                 }
@@ -1446,7 +1441,6 @@ namespace NuGetGallery
                     var message = string.Format(CultureInfo.CurrentCulture,
                         Strings.UploadPackage_NewIdOnBehalfOfUserNotAllowed,
                         currentUser.Username, owner.Username);
-                    TempData["Message"] = message;
                     return Json(400, new[] { message });
                 }
 
@@ -1465,8 +1459,6 @@ namespace NuGetGallery
                 catch (InvalidPackageException ex)
                 {
                     _telemetryService.TraceException(ex);
-
-                    TempData["Message"] = ex.Message;
 
                     return Json(400, new[] { ex.GetUserSafeMessage() });
                 }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -160,7 +160,17 @@ namespace NuGetGallery
 
                     model.IsUploadInProgress = true;
 
-                    var verifyRequest = new VerifyPackageRequest(packageMetadata);
+                    var existingPackageRegistration = _packageService.FindPackageRegistrationById(packageMetadata.Id);
+
+                    if (!_reservedNamespaceService.IsPushAllowedOnBehalfOfOwner(packageMetadata.Id, currentUser, out var userOwnerMatchingNamespaces) ||
+                        (existingPackageRegistration != null && !PermissionsService.IsActionAllowed(existingPackageRegistration, currentUser, PackageActions.UploadNewVersion)))
+                    {
+                        // This user no longer has the rights to upload to this package. Cancel this upload.
+                        await CancelPendingUpload();
+                        return View();
+                    }
+
+                    var verifyRequest = new VerifyPackageRequest(packageMetadata, GetPossibleOwnersForUpload(packageMetadata.Id));
 
                     model.InProgressUpload = verifyRequest;
                 }
@@ -277,10 +287,7 @@ namespace NuGetGallery
                 // For a new package id verify if the user is allowed to use it.
                 if (packageRegistration == null)
                 {
-                    var isPushAllowed = _reservedNamespaceService
-                        .IsPushAllowed(id, currentUser, out IReadOnlyCollection<ReservedNamespace> matchingNamespaces);
-
-                    if (!isPushAllowed)
+                    if (!_reservedNamespaceService.IsPushAllowedOnBehalfOfOwner(id, currentUser, out var matchingNamespaces))
                     {
                         ModelState.AddModelError(
                             string.Empty, string.Format(CultureInfo.CurrentCulture, Strings.UploadPackage_IdNamespaceConflict));
@@ -292,7 +299,7 @@ namespace NuGetGallery
                     }
                 }
 
-                // For existing package id verify if it is owned by the current user
+                // For existing package ID verify that the current user has the rights to upload new versions
                 if (packageRegistration != null && !PermissionsService.IsActionAllowed(packageRegistration, currentUser, PackageActions.UploadNewVersion))
                 {
                     ModelState.AddModelError(
@@ -367,7 +374,7 @@ namespace NuGetGallery
                 }
             }
 
-            var model = new VerifyPackageRequest(packageMetadata);
+            var model = new VerifyPackageRequest(packageMetadata, GetPossibleOwnersForUpload(packageMetadata.Id));
 
             return Json(model);
         }
@@ -390,7 +397,7 @@ namespace NuGetGallery
             {
                 package = _packageService.FindPackageByIdAndVersion(id, version, SemVerLevelKey.SemVer2);
             }
-            
+
             // Validating packages should be hidden to everyone but the owners and admins.
             if (package == null
                 || ((package.PackageStatusKey == PackageStatus.Validating
@@ -427,7 +434,7 @@ namespace NuGetGallery
             }
 
             model.ReadMeHtml = await _readMeService.GetReadMeHtmlAsync(package, isReadMePending);
-            
+
             var externalSearchService = _searchService as ExternalSearchService;
             if (_searchService.ContainsAllVersions && externalSearchService != null)
             {
@@ -1032,7 +1039,10 @@ namespace NuGetGallery
             // Create edit model from the latest pending edit.
             var pendingMetadata = _editPackageService.GetPendingMetadata(package);
 
-            model.Edit = new EditPackageVersionRequest(package, pendingMetadata);
+            // No point in allowing users to specify the owner who edited the package: just show the first.
+            var possibleOwners = GetPossibleOwnersForUpload(package.PackageRegistration.Id).Take(1);
+
+            model.Edit = new EditPackageVersionRequest(package, pendingMetadata, possibleOwners);
 
             // Update edit model with the active or pending readme.md data.
             var isReadMePending = model.Edit.ReadMeState != PackageEditReadMeState.Unchanged;
@@ -1125,9 +1135,9 @@ namespace NuGetGallery
             {
                 return HttpNotFound();
             }
-            
+
             var user = _userService.FindByUsername(username);
-            if (!PermissionsService.IsActionAllowed(user, GetCurrentUser(), AccountActions.AcceptPackageOwnershipOnBehalfOf))
+            if (!PermissionsService.IsActionAllowed(user, GetCurrentUser(), AccountActions.ManagePackageOwnersOnBehalfOf))
             {
                 return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, user.Username, ConfirmOwnershipResult.NotYourRequest));
             }
@@ -1138,7 +1148,7 @@ namespace NuGetGallery
                 return HttpNotFound();
             }
 
-            if (package.Owners.Any(o => o.Key == user.Key))
+            if (package.Owners.Any(o => o.MatchesUser(user)))
             {
                 return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, user.Username, ConfirmOwnershipResult.AlreadyOwner));
             }
@@ -1397,6 +1407,49 @@ namespace NuGetGallery
                     Size = uploadFile.Length,
                 };
 
+                // Check that the owner specified in the form is valid
+                var owner = _userService.FindByUsername(formData.Edit.Owner);
+
+                if (owner == null)
+                {
+                    var message = string.Format(CultureInfo.CurrentCulture, Strings.VerifyPackage_UserNonExistent, formData.Edit.Owner);
+                    TempData["Message"] = message;
+                    return Json(400, new[] { message });
+                }
+
+                var existingPackageRegistration = _packageService.FindPackageRegistrationById(packageMetadata.Id);
+                if (existingPackageRegistration != null)
+                {
+                    if (!PermissionsService.IsActionAllowed(owner, currentUser, AccountActions.UploadNewVersionOnBehalfOf))
+                    {
+                        // The user is not allowed to upload a new version on behalf of the owner specified in the form
+                        var message = string.Format(CultureInfo.CurrentCulture,
+                            Strings.UploadPackage_NewVersionOnBehalfOfUserNotAllowed,
+                            currentUser.Username, owner.Username);
+                        TempData["Message"] = message;
+                        return Json(400, new[] { message });
+                    }
+
+                    if (!PermissionsService.IsActionAllowed(existingPackageRegistration, owner, PackageActions.UploadNewVersion))
+                    {
+                        // The owner specified in the form is not allowed to upload a new version of the package
+                        var message = string.Format(CultureInfo.CurrentCulture,
+                            Strings.VerifyPackage_OwnerInvalid,
+                            owner.Username, existingPackageRegistration.Id);
+                        TempData["Message"] = message;
+                        return Json(400, new[] { message });
+                    }
+                }
+                else if (!PermissionsService.IsActionAllowed(owner, currentUser, AccountActions.UploadNewIdOnBehalfOf))
+                {
+                    // The user is not allowed to upload a new ID on behalf of the owner specified in the form
+                    var message = string.Format(CultureInfo.CurrentCulture,
+                        Strings.UploadPackage_NewIdOnBehalfOfUserNotAllowed,
+                        currentUser.Username, owner.Username);
+                    TempData["Message"] = message;
+                    return Json(400, new[] { message });
+                }
+
                 // update relevant database tables
                 try
                 {
@@ -1404,6 +1457,7 @@ namespace NuGetGallery
                         packageMetadata.Id,
                         nugetPackage,
                         packageStreamMetadata,
+                        owner,
                         currentUser);
 
                     Debug.Assert(package.PackageRegistration != null);
@@ -1425,7 +1479,7 @@ namespace NuGetGallery
                         pendEdit = true;
                         _telemetryService.TrackPackageReadMeChangeEvent(package, formData.Edit.ReadMe.SourceType, formData.Edit.ReadMeState);
                     }
-                    
+
                     pendEdit = pendEdit || formData.Edit.RequiresLicenseAcceptance != packageMetadata.RequireLicenseAcceptance;
 
                     pendEdit = pendEdit || IsDifferent(formData.Edit.IconUrl, packageMetadata.IconUrl.ToEncodedUrlStringOrNull());
@@ -1544,8 +1598,7 @@ namespace NuGetGallery
         [ValidateAntiForgeryToken]
         public virtual async Task<JsonResult> CancelUpload()
         {
-            var currentUser = GetCurrentUser();
-            await _uploadFileService.DeleteUploadFileAsync(currentUser.Key);
+            await CancelPendingUpload();
 
             return Json(null);
         }
@@ -1604,6 +1657,15 @@ namespace NuGetGallery
             return Redirect(urlFactory(package, /*relativeUrl:*/ true));
         }
 
+        /// <summary>
+        /// Deletes the current user's pending upload, deleting their uploaded file
+        /// </summary>
+        private Task CancelPendingUpload()
+        {
+            var currentUser = GetCurrentUser();
+            return _uploadFileService.DeleteUploadFileAsync(currentUser.Key);
+        }
+
         // this methods exist to make unit testing easier
         protected internal virtual PackageArchiveReader CreatePackage(Stream stream)
         {
@@ -1616,6 +1678,44 @@ namespace NuGetGallery
                 stream.Dispose();
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Determines the possible owners for a package that is being uploaded by the current user.
+        /// Assumes the current user has permissions to upload the package.
+        /// </summary>
+        /// <param name="id">The ID of the package being uploaded</param>
+        internal IEnumerable<User> GetPossibleOwnersForUpload(string id)
+        {
+            IEnumerable<User> possibleOwners;
+            var existingPackageRegistration = _packageService.FindPackageRegistrationById(id);
+            var currentUser = GetCurrentUser();
+
+            if (existingPackageRegistration != null)
+            {
+                possibleOwners = existingPackageRegistration.Owners
+                    .Where(u => PermissionsService.IsActionAllowed(u, currentUser, AccountActions.UploadNewVersionOnBehalfOf));
+                if (!possibleOwners.Any())
+                {
+                    // If the user has the right to upload to the package but they are not able to upload as any of the existing owners (e.g. site admin), allow the user to upload as themselves.
+                    possibleOwners = new User[] { currentUser };
+                }
+            }
+            else
+            {
+                var organizations =
+                   currentUser.Organizations
+                       .Select(m => m.Organization);
+
+                possibleOwners =
+                    new[] { currentUser }
+                        .Concat(organizations)
+                       .Where(u => PermissionsService.IsActionAllowed(u, currentUser, AccountActions.UploadNewIdOnBehalfOf))
+                       .Where(u => _reservedNamespaceService.IsPushAllowed(id, u, out var matchingNamespaces))
+                       .ToArray();
+            }
+
+            return possibleOwners;
         }
 
         private static string GetSortExpression(string sortOrder)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1675,7 +1675,8 @@ namespace NuGetGallery
             if (existingPackageRegistration != null)
             {
                 possibleOwners = existingPackageRegistration.Owners
-                    .Where(u => PermissionsService.IsActionAllowed(u, currentUser, AccountActions.UploadNewVersionOnBehalfOf));
+                    .Where(u => PermissionsService.IsActionAllowed(u, currentUser, AccountActions.UploadNewVersionOnBehalfOf))
+                    .Where(u => PermissionsService.IsActionAllowed(existingPackageRegistration, u, PackageActions.UploadNewVersion));
                 if (!possibleOwners.Any())
                 {
                     // If the user has the right to upload to the package but they are not able to upload as any of the existing owners, allow the user to upload as themselves.

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -824,7 +824,7 @@ namespace NuGetGallery
             {
                 return HttpNotFound();
             }
-            if (!PermissionsService.IsActionAllowed(package, User, PackageActions.ManagePackageOwners))
+            if (!PermissionsService.IsActionAllowed(package, User, PackageActions.ManagePackageOwnership))
             {
                 return new HttpStatusCodeResult(401, "Unauthorized");
             }
@@ -1123,7 +1123,7 @@ namespace NuGetGallery
             }
 
             var user = _userService.FindByUsername(username);
-            if (!PermissionsService.IsActionAllowed(user, GetCurrentUser(), AccountActions.ManagePackageOwnersOnBehalfOf))
+            if (!PermissionsService.IsActionAllowed(user, GetCurrentUser(), AccountActions.ManagePackageOwnershipOnBehalfOf))
             {
                 return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, user.Username, ConfirmOwnershipResult.NotYourRequest));
             }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -891,6 +891,7 @@
     <Compile Include="Services\IPackageUploadService.cs" />
     <Compile Include="Services\PermissionsService.cs" />
     <Compile Include="Services\PermissionLevel.cs" />
+    <Compile Include="Services\ReservedNamespaceActions.cs" />
     <Compile Include="Services\ReservedNamespaceService.cs" />
     <Compile Include="Services\ReadMeService.cs" />
     <Compile Include="Services\TelemetryClientWrapper.cs" />

--- a/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using NuGetGallery.Packaging;
 
 namespace NuGetGallery
@@ -23,7 +25,7 @@ namespace NuGetGallery
         {
         }
 
-        public EditPackageVersionRequest(PackageMetadata packageMetadata)
+        public EditPackageVersionRequest(PackageMetadata packageMetadata, IEnumerable<User> possibleOwners)
         {
 
             Authors = packageMetadata.Authors.Flatten();
@@ -38,10 +40,13 @@ namespace NuGetGallery
             Tags = PackageHelper.ParseTags(packageMetadata.Tags);
             VersionTitle = packageMetadata.Title;
 
+            PossibleOwners = possibleOwners.Select(u => u.Username);
+            Owner = PossibleOwners.First();
+
             ReadMe = new ReadMeRequest();
         }
 
-        public EditPackageVersionRequest(Package package, PackageEdit pendingMetadata)
+        public EditPackageVersionRequest(Package package, PackageEdit pendingMetadata, IEnumerable<User> possibleOwners)
         {
             var metadata = pendingMetadata ?? new PackageEdit
             {
@@ -69,6 +74,9 @@ namespace NuGetGallery
             Tags = metadata.Tags;
             VersionTitle = metadata.Title;
             ReadMeState = metadata.ReadMeState;
+
+            PossibleOwners = possibleOwners.Select(u => u.Username);
+            Owner = PossibleOwners.FirstOrDefault();
 
             ReadMe = new ReadMeRequest();
         }
@@ -126,6 +134,9 @@ namespace NuGetGallery
 
         [Display(Name = RequiresLicenseAcceptanceStr)]
         public bool RequiresLicenseAcceptance { get; set; }
+
+        public string Owner { get; set; }
+        public IEnumerable<string> PossibleOwners { get; set; }
 
         public PackageEditReadMeState ReadMeState { get; set; }
 

--- a/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using NuGetGallery.Packaging;
 
 namespace NuGetGallery

--- a/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
@@ -25,7 +25,7 @@ namespace NuGetGallery
         {
         }
 
-        public EditPackageVersionRequest(PackageMetadata packageMetadata, IEnumerable<User> possibleOwners)
+        public EditPackageVersionRequest(PackageMetadata packageMetadata)
         {
 
             Authors = packageMetadata.Authors.Flatten();
@@ -40,13 +40,10 @@ namespace NuGetGallery
             Tags = PackageHelper.ParseTags(packageMetadata.Tags);
             VersionTitle = packageMetadata.Title;
 
-            PossibleOwners = possibleOwners.Select(u => u.Username);
-            Owner = PossibleOwners.First();
-
             ReadMe = new ReadMeRequest();
         }
 
-        public EditPackageVersionRequest(Package package, PackageEdit pendingMetadata, IEnumerable<User> possibleOwners)
+        public EditPackageVersionRequest(Package package, PackageEdit pendingMetadata)
         {
             var metadata = pendingMetadata ?? new PackageEdit
             {
@@ -74,9 +71,6 @@ namespace NuGetGallery
             Tags = metadata.Tags;
             VersionTitle = metadata.Title;
             ReadMeState = metadata.ReadMeState;
-
-            PossibleOwners = possibleOwners.Select(u => u.Username);
-            Owner = PossibleOwners.FirstOrDefault();
 
             ReadMe = new ReadMeRequest();
         }
@@ -134,9 +128,6 @@ namespace NuGetGallery
 
         [Display(Name = RequiresLicenseAcceptanceStr)]
         public bool RequiresLicenseAcceptance { get; set; }
-
-        public string Owner { get; set; }
-        public IEnumerable<string> PossibleOwners { get; set; }
 
         public PackageEditReadMeState ReadMeState { get; set; }
 

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -32,7 +32,7 @@ namespace NuGetGallery
             DevelopmentDependency = packageMetadata.GetValueFromMetadata("developmentDependency");
             Edit = new EditPackageVersionRequest(packageMetadata);
 
-            PossibleOwners = possibleOwners.Select(u => u.Username);
+            PossibleOwners = possibleOwners.Select(u => u.Username).ToList();
             Owner = PossibleOwners.First();
         }
 

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -30,7 +30,10 @@ namespace NuGetGallery
             FrameworkReferenceGroups = packageMetadata.GetFrameworkReferenceGroups();
             Dependencies = new DependencySetsViewModel(packageMetadata.GetDependencyGroups().AsPackageDependencyEnumerable());
             DevelopmentDependency = packageMetadata.GetValueFromMetadata("developmentDependency");
-            Edit = new EditPackageVersionRequest(packageMetadata, possibleOwners);
+            Edit = new EditPackageVersionRequest(packageMetadata);
+
+            PossibleOwners = possibleOwners.Select(u => u.Username);
+            Owner = PossibleOwners.First();
         }
 
         public string Id { get; set; }
@@ -44,6 +47,10 @@ namespace NuGetGallery
         /// The non-normalized, unmodified, original version as defined in the nuspec.
         /// </summary>
         public string OriginalVersion { get; set; }
+
+        public string Owner { get; set; }
+        public IEnumerable<string> PossibleOwners { get; set; }
+
         public bool IsSemVer2 => HasSemVer2Version || HasSemVer2Dependency;
         public bool HasSemVer2Version { get; set; }
         public bool HasSemVer2Dependency { get; set; }

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
     {
         public VerifyPackageRequest() { }
 
-        public VerifyPackageRequest(PackageMetadata packageMetadata)
+        public VerifyPackageRequest(PackageMetadata packageMetadata, IEnumerable<User> possibleOwners)
         {
             var dependencyGroups = packageMetadata.GetDependencyGroups();
 
@@ -30,7 +30,7 @@ namespace NuGetGallery
             FrameworkReferenceGroups = packageMetadata.GetFrameworkReferenceGroups();
             Dependencies = new DependencySetsViewModel(packageMetadata.GetDependencyGroups().AsPackageDependencyEnumerable());
             DevelopmentDependency = packageMetadata.GetValueFromMetadata("developmentDependency");
-            Edit = new EditPackageVersionRequest(packageMetadata);
+            Edit = new EditPackageVersionRequest(packageMetadata, possibleOwners);
         }
 
         public string Id { get; set; }

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -33,7 +33,6 @@ namespace NuGetGallery
             Edit = new EditPackageVersionRequest(packageMetadata);
 
             PossibleOwners = possibleOwners.Select(u => u.Username).ToList();
-            Owner = PossibleOwners.First();
         }
 
         public string Id { get; set; }
@@ -48,8 +47,15 @@ namespace NuGetGallery
         /// </summary>
         public string OriginalVersion { get; set; }
 
+        /// <summary>
+        /// The username of the <see cref="User"/> to upload the package as.
+        /// </summary>
         public string Owner { get; set; }
-        public IEnumerable<string> PossibleOwners { get; set; }
+
+        /// <summary>
+        /// The usernames of the <see cref="User"/>s that the current user can upload the package as.
+        /// </summary>
+        public IReadOnlyCollection<string> PossibleOwners { get; set; }
 
         public bool IsSemVer2 => HasSemVer2Version || HasSemVer2Dependency;
         public bool HasSemVer2Version { get; set; }

--- a/src/NuGetGallery/Services/AccountActions.cs
+++ b/src/NuGetGallery/Services/AccountActions.cs
@@ -36,7 +36,6 @@ namespace NuGetGallery
         /// </summary>
         public static PermissionLevel PushToReservedNamespaceOnBehalfOf =
             PermissionLevel.Owner |
-            PermissionLevel.OrganizationAdmin |
-            PermissionLevel.SiteAdmin;
+            PermissionLevel.OrganizationAdmin;
     }
 }

--- a/src/NuGetGallery/Services/AccountActions.cs
+++ b/src/NuGetGallery/Services/AccountActions.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
         /// The user can manage ownership of the package on behalf of the account.
         /// The user can accept, reject, and cancel package ownership requests on behalf of the account.
         /// </summary>
-        public static PermissionLevel ManagePackageOwnersOnBehalfOf =
+        public static PermissionLevel ManagePackageOwnershipOnBehalfOf =
             PermissionLevel.Owner |
             PermissionLevel.OrganizationAdmin;
 

--- a/src/NuGetGallery/Services/AccountActions.cs
+++ b/src/NuGetGallery/Services/AccountActions.cs
@@ -9,10 +9,34 @@ namespace NuGetGallery
     public static class AccountActions
     {
         /// <summary>
-        /// If a user is requested to be an owner of a package, this user can accept the request on behalf of the other user.
+        /// The user can manage ownership of the package on behalf of the account.
+        /// The user can accept, reject, and cancel package ownership requests on behalf of the account.
         /// </summary>
-        public static PermissionLevel AcceptPackageOwnershipOnBehalfOf =
+        public static PermissionLevel ManagePackageOwnersOnBehalfOf =
             PermissionLevel.Owner |
             PermissionLevel.OrganizationAdmin;
+
+        /// <summary>
+        /// The user can upload new package IDs on behalf of the account using the UI.
+        /// </summary>
+        public static PermissionLevel UploadNewIdOnBehalfOf =
+            PermissionLevel.Owner |
+            PermissionLevel.OrganizationAdmin;
+
+        /// <summary>
+        /// The user can upload new versions of an existing package on behalf of the account using the UI.
+        /// </summary>
+        public static PermissionLevel UploadNewVersionOnBehalfOf =
+            PermissionLevel.Owner |
+            PermissionLevel.OrganizationAdmin |
+            PermissionLevel.OrganizationCollaborator;
+
+        /// <summary>
+        /// The user can push to reserved namespaces on behalf of another owner.
+        /// </summary>
+        public static PermissionLevel PushToReservedNamespaceOnBehalfOf =
+            PermissionLevel.Owner |
+            PermissionLevel.OrganizationAdmin |
+            PermissionLevel.SiteAdmin;
     }
 }

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -42,10 +42,11 @@ namespace NuGetGallery
         /// </remarks>
         /// <param name="nugetPackage">The package to be created.</param>
         /// <param name="packageStreamMetadata">The package stream's metadata.</param>
-        /// <param name="user">The owner of the package</param>
+        /// <param name="owner">The owner of the package</param>
+        /// <param name="currentUser">The user that pushed the package on behalf of <paramref name="owner"/></param>
         /// <param name="isVerified">Mark the package registration as verified or not</param>
         /// <returns>The created package entity.</returns>
-        Task<Package> CreatePackageAsync(PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User user, bool isVerified);
+        Task<Package> CreatePackageAsync(PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User owner, User currentUser, bool isVerified);
 
         Package EnrichPackageFromNuGetPackage(Package package, PackageArchiveReader packageArchive, PackageMetadata packageMetadata, PackageStreamMetadata packageStreamMetadata, User user);
 

--- a/src/NuGetGallery/Services/IPackageUploadService.cs
+++ b/src/NuGetGallery/Services/IPackageUploadService.cs
@@ -30,7 +30,8 @@ namespace NuGetGallery
             string id,
             PackageArchiveReader nugetPackage,
             PackageStreamMetadata packageStreamMetadata,
-            User user);
+            User owner,
+            User currentUser);
 
         /// <summary>
         /// Commit the provided package metadata and stream to the package file storage and to the database. This

--- a/src/NuGetGallery/Services/IReservedNamespaceService.cs
+++ b/src/NuGetGallery/Services/IReservedNamespaceService.cs
@@ -90,13 +90,21 @@ namespace NuGetGallery
         IReadOnlyCollection<ReservedNamespace> GetReservedNamespacesForId(string id);
 
         /// <summary>
-        /// Verifies if the id is allowed to be pushed by the user or not and try to get 
-        /// user owned namespaces if any.
+        /// Verifies if the id is allowed to be pushed by the user or not.
         /// </summary>
         /// <param name="id">The package id to lookup</param>
         /// <param name="user">The user to verify for permission to push to new id</param>
-        /// <param name="userOwnedMatchingNamespaces">The out list of namespaces owned by the user</param>
+        /// <param name="userOwnedMatchingNamespaces">The out list of namespaces owned by the user that match <paramref name="id"/></param>
         /// <returns>True if the push is allowed for the specified user for the given id, false otherwise</returns>
         bool IsPushAllowed(string id, User user, out IReadOnlyCollection<ReservedNamespace> userOwnedMatchingNamespaces);
+
+        /// <summary>
+        /// Verifies if the id is allowed to be pushed by the user or any users that the user can push on behalf of.
+        /// </summary>
+        /// <param name="id">The package id to lookup</param>
+        /// <param name="user">The user to verify for permission to push to new id</param>
+        /// <param name="userOwnedMatchingNamespaces">The out list of namespaces owned by the user that match <paramref name="id"/></param>
+        /// <returns>True if the push is allowed for the specified user or any users that the user can push on behalf of for the given id, false otherwise</returns>
+        bool IsPushAllowedOnBehalfOfOwner(string id, User user, out IReadOnlyCollection<ReservedNamespace> userOwnedMatchingNamespaces);
     }
 }

--- a/src/NuGetGallery/Services/IReservedNamespaceService.cs
+++ b/src/NuGetGallery/Services/IReservedNamespaceService.cs
@@ -105,6 +105,6 @@ namespace NuGetGallery
         /// <param name="user">The user to verify for permission to push to new id</param>
         /// <param name="userOwnedMatchingNamespaces">The out list of namespaces owned by the user that match <paramref name="id"/></param>
         /// <returns>True if the push is allowed for the specified user or any users that the user can push on behalf of for the given id, false otherwise</returns>
-        bool IsPushAllowedOnBehalfOfOwner(string id, User user, out IReadOnlyCollection<ReservedNamespace> userOwnedMatchingNamespaces);
+        bool IsPushAllowedOnBehalfOfOwners(string id, User user, out IReadOnlyCollection<ReservedNamespace> userOwnedMatchingNamespaces);
     }
 }

--- a/src/NuGetGallery/Services/PackageActions.cs
+++ b/src/NuGetGallery/Services/PackageActions.cs
@@ -21,10 +21,7 @@ namespace NuGetGallery
         /// The user can upload new versions of the package from the UI.
         /// </summary>
         public static PermissionLevel UploadNewVersion =
-            PermissionLevel.Owner |
-            PermissionLevel.OrganizationAdmin |
-            PermissionLevel.SiteAdmin |
-            PermissionLevel.OrganizationCollaborator;
+            PermissionLevel.Owner;
 
         /// <summary>
         /// The user can edit existing versions of the package from the UI.

--- a/src/NuGetGallery/Services/PackageActions.cs
+++ b/src/NuGetGallery/Services/PackageActions.cs
@@ -44,7 +44,7 @@ namespace NuGetGallery
         /// <summary>
         /// The user can manage ownership of the package.
         /// </summary>
-        public static PermissionLevel ManagePackageOwners =
+        public static PermissionLevel ManagePackageOwnership =
             PermissionLevel.Owner |
             PermissionLevel.OrganizationAdmin |
             PermissionLevel.SiteAdmin;

--- a/src/NuGetGallery/Services/PackageActions.cs
+++ b/src/NuGetGallery/Services/PackageActions.cs
@@ -11,32 +11,32 @@ namespace NuGetGallery
         /// <summary>
         /// The user can see private information about the package.
         /// </summary>
-        public static PermissionLevel DisplayPrivatePackage = 
-            PermissionLevel.Owner | 
-            PermissionLevel.OrganizationAdmin | 
-            PermissionLevel.SiteAdmin | 
-            PermissionLevel.OrganizationCollaborator;
-
-        /// <summary>
-        /// The user can upload new versions of the package.
-        /// </summary>
-        public static PermissionLevel UploadNewVersion = 
-            PermissionLevel.Owner | 
-            PermissionLevel.OrganizationAdmin | 
-            PermissionLevel.SiteAdmin | 
-            PermissionLevel.OrganizationCollaborator;
-
-        /// <summary>
-        /// The user can edit existing versions of the package.
-        /// </summary>
-        public static PermissionLevel Edit = 
+        public static PermissionLevel DisplayPrivatePackage =
             PermissionLevel.Owner |
             PermissionLevel.OrganizationAdmin |
             PermissionLevel.SiteAdmin |
             PermissionLevel.OrganizationCollaborator;
 
         /// <summary>
-        /// The user can unlist and relist existing versions of the package.
+        /// The user can upload new versions of the package from the UI.
+        /// </summary>
+        public static PermissionLevel UploadNewVersion =
+            PermissionLevel.Owner |
+            PermissionLevel.OrganizationAdmin |
+            PermissionLevel.SiteAdmin |
+            PermissionLevel.OrganizationCollaborator;
+
+        /// <summary>
+        /// The user can edit existing versions of the package from the UI.
+        /// </summary>
+        public static PermissionLevel Edit =
+            PermissionLevel.Owner |
+            PermissionLevel.OrganizationAdmin |
+            PermissionLevel.SiteAdmin |
+            PermissionLevel.OrganizationCollaborator;
+
+        /// <summary>
+        /// The user can unlist and relist existing versions of the package from the UI.
         /// </summary>
         public static PermissionLevel Unlist =
             PermissionLevel.Owner |

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -69,13 +69,13 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="nugetPackage">A <see cref="PackageArchiveReader"/> instance from which package metadata can be read.</param>
         /// <param name="packageStreamMetadata">The <see cref="PackageStreamMetadata"/> instance providing metadata about the package stream.</param>
-        /// <param name="user">The <see cref="User"/> creating the package.</param>
+        /// <param name="owner">The <see cref="User"/> creating the package.</param>
         /// <param name="commitChanges"><c>True</c> to commit the changes to the data store and notify the indexing service; otherwise <c>false</c>.</param>
         /// <returns>Returns the created <see cref="Package"/> entity.</returns>
         /// <exception cref="InvalidPackageException">
         /// This exception will be thrown when a package metadata property violates a data validation constraint.
         /// </exception>
-        public async Task<Package> CreatePackageAsync(PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User user, bool isVerified)
+        public async Task<Package> CreatePackageAsync(PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User owner, User currentUser, bool isVerified)
         {
             PackageMetadata packageMetadata;
             PackageRegistration packageRegistration;
@@ -88,7 +88,7 @@ namespace NuGetGallery
 
                 ValidatePackageTitle(packageMetadata);
 
-                packageRegistration = CreateOrGetPackageRegistration(user, packageMetadata, isVerified);
+                packageRegistration = CreateOrGetPackageRegistration(owner, packageMetadata, isVerified);
             }
             catch (Exception exception) when (exception is EntityException || exception is PackagingException)
             {
@@ -96,7 +96,7 @@ namespace NuGetGallery
                 throw new InvalidPackageException(exception.Message, exception);
             }
 
-            var package = CreatePackageFromNuGetPackage(packageRegistration, nugetPackage, packageMetadata, packageStreamMetadata, user);
+            var package = CreatePackageFromNuGetPackage(packageRegistration, nugetPackage, packageMetadata, packageStreamMetadata, currentUser);
             packageRegistration.Packages.Add(package);
             await UpdateIsLatestAsync(packageRegistration, commitChanges: false);
 
@@ -353,7 +353,7 @@ namespace NuGetGallery
                 await _packageRepository.CommitChangesAsync();
             }
         }
-        
+
         public async Task AddPackageOwnerAsync(PackageRegistration package, User newOwner)
         {
             package.Owners.Add(newOwner);
@@ -432,11 +432,11 @@ namespace NuGetGallery
             }
         }
 
-        private PackageRegistration CreateOrGetPackageRegistration(User currentUser, PackageMetadata packageMetadata, bool isVerified)
+        private PackageRegistration CreateOrGetPackageRegistration(User owner, PackageMetadata packageMetadata, bool isVerified)
         {
             var packageRegistration = FindPackageRegistrationById(packageMetadata.Id);
 
-            if (packageRegistration != null && !PermissionsService.IsActionAllowed(packageRegistration, currentUser, PackageActions.UploadNewVersion))
+            if (packageRegistration != null && !PermissionsService.IsActionAllowed(packageRegistration, owner, PackageActions.UploadNewVersion))
             {
                 throw new EntityException(Strings.PackageIdNotAvailable, packageMetadata.Id);
             }
@@ -454,7 +454,7 @@ namespace NuGetGallery
                     IsVerified = isVerified
                 };
 
-                packageRegistration.Owners.Add(currentUser);
+                packageRegistration.Owners.Add(owner);
 
                 _packageRegistrationRepository.InsertOnCommit(packageRegistration);
             }

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -37,15 +37,17 @@ namespace NuGetGallery
             string id,
             PackageArchiveReader nugetPackage,
             PackageStreamMetadata packageStreamMetadata,
-            User user)
+            User owner,
+            User currentUser)
         {
-            var isPushAllowed = _reservedNamespaceService.IsPushAllowed(id, user, out IReadOnlyCollection<ReservedNamespace> userOwnedNamespaces);
+            var isPushAllowed = _reservedNamespaceService.IsPushAllowed(id, owner, out IReadOnlyCollection<ReservedNamespace> userOwnedNamespaces);
             var shouldMarkIdVerified = isPushAllowed && userOwnedNamespaces != null && userOwnedNamespaces.Any();
 
             var package = await _packageService.CreatePackageAsync(
                 nugetPackage,
                 packageStreamMetadata,
-                user,
+                owner,
+                currentUser,
                 isVerified: shouldMarkIdVerified);
 
             await _validationService.StartValidationAsync(package);

--- a/src/NuGetGallery/Services/PermissionsService.cs
+++ b/src/NuGetGallery/Services/PermissionsService.cs
@@ -60,11 +60,27 @@ namespace NuGetGallery
         }
 
         /// <summary>
+        /// Is <paramref name="currentPrincipal"/> allowed to perform <paramref name="actionPermissionLevel"/> on behalf of the owners of <paramref name="packageRegistration"/>?
+        /// </summary>
+        public static bool IsActionAllowedOnBehalfOfOwners(PackageRegistration packageRegistration, User currentUser, PermissionLevel actionPermissionLevel)
+        {
+            return IsActionAllowedOnBehalfOfOwners(packageRegistration.Owners, currentUser, actionPermissionLevel);
+        }
+
+        /// <summary>
         /// Is <paramref name="currentUser"/> allowed to perform <paramref name="actionPermissionLevel"/> on <paramref name="reservedNamespace"/>?
         /// </summary>
         public static bool IsActionAllowed(ReservedNamespace reservedNamespace, User currentUser, PermissionLevel actionPermissionLevel)
         {
             return IsActionAllowed(reservedNamespace.Owners, currentUser, actionPermissionLevel);
+        }
+
+        /// <summary>
+        /// Is <paramref name="currentPrincipal"/> allowed to perform <paramref name="actionPermissionLevel"/> on behalf of the owners of <paramref name="reservedNamespace"/>?
+        /// </summary>
+        public static bool IsActionAllowedOnBehalfOfOwners(ReservedNamespace reservedNamespace, User currentUser, PermissionLevel actionPermissionLevel)
+        {
+            return IsActionAllowedOnBehalfOfOwners(reservedNamespace.Owners, currentUser, actionPermissionLevel);
         }
 
         /// <summary>
@@ -82,6 +98,14 @@ namespace NuGetGallery
         {
             var userPermissionLevel = GetPermissionLevel(entityOwners, currentUser);
             return IsAllowed(userPermissionLevel, actionPermissionLevel);
+        }
+
+        /// <summary>
+        /// Is <paramref name="currentPrincipal"/> allowed to perform <paramref name="actionPermissionLevel"/> on behalf of the owners of the entity owned by <paramref name="entityOwners"/>?
+        /// </summary>
+        public static bool IsActionAllowedOnBehalfOfOwners(IEnumerable<User> entityOwners, User currentUser, PermissionLevel actionPermissionLevel)
+        {
+            return entityOwners.Any(o => IsActionAllowed(o, currentUser, actionPermissionLevel));
         }
 
         private static bool IsAllowed(PermissionLevel userPermissionLevel, PermissionLevel actionPermissionLevel)

--- a/src/NuGetGallery/Services/PermissionsService.cs
+++ b/src/NuGetGallery/Services/PermissionsService.cs
@@ -60,6 +60,14 @@ namespace NuGetGallery
         }
 
         /// <summary>
+        /// Is <paramref name="currentUser"/> allowed to perform <paramref name="actionPermissionLevel"/> on <paramref name="reservedNamespace"/>?
+        /// </summary>
+        public static bool IsActionAllowed(ReservedNamespace reservedNamespace, User currentUser, PermissionLevel actionPermissionLevel)
+        {
+            return IsActionAllowed(reservedNamespace.Owners, currentUser, actionPermissionLevel);
+        }
+
+        /// <summary>
         /// Is <paramref name="currentPrincipal"/> allowed to perform <paramref name="actionPermissionLevel"/> on <paramref name="account"/>?
         /// </summary>
         public static bool IsActionAllowed(User account, User currentUser, PermissionLevel action)

--- a/src/NuGetGallery/Services/ReservedNamespaceActions.cs
+++ b/src/NuGetGallery/Services/ReservedNamespaceActions.cs
@@ -9,7 +9,6 @@ namespace NuGetGallery
         /// The user can push to this reserved namespace.
         /// </summary>
         public static PermissionLevel PushToReservedNamespace =
-            PermissionLevel.Owner |
-            PermissionLevel.SiteAdmin;
+            PermissionLevel.Owner;
     }
 }

--- a/src/NuGetGallery/Services/ReservedNamespaceActions.cs
+++ b/src/NuGetGallery/Services/ReservedNamespaceActions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public static class ReservedNamespaceActions
+    {
+        /// <summary>
+        /// The user can push to this reserved namespace.
+        /// </summary>
+        public static PermissionLevel PushToReservedNamespace =
+            PermissionLevel.Owner |
+            PermissionLevel.SiteAdmin;
+    }
+}

--- a/src/NuGetGallery/Services/ReservedNamespaceService.cs
+++ b/src/NuGetGallery/Services/ReservedNamespaceService.cs
@@ -373,11 +373,11 @@ namespace NuGetGallery
                 out userOwnedMatchingNamespaces);
         }
 
-        public bool IsPushAllowedOnBehalfOfOwner(string id, User user, out IReadOnlyCollection<ReservedNamespace> userOwnedMatchingNamespaces)
+        public bool IsPushAllowedOnBehalfOfOwners(string id, User user, out IReadOnlyCollection<ReservedNamespace> userOwnedMatchingNamespaces)
         {
             return IsPushAllowedInternal(id,
                 user,
-                rn => rn.Owners.Any(o => PermissionsService.IsActionAllowed(o, user, AccountActions.PushToReservedNamespaceOnBehalfOf)),
+                rn => PermissionsService.IsActionAllowedOnBehalfOfOwners(rn, user, AccountActions.PushToReservedNamespaceOnBehalfOf),
                 out userOwnedMatchingNamespaces);
         }
 

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -1345,7 +1345,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User &apos;{0}&apos; does not have the rights to upload a package with a new ID on behalf of user &apos;{1}&apos;!.
+        ///   Looks up a localized string similar to User &apos;{0}&apos; does not have the rights to upload a package with a new ID on behalf of user &apos;{1}&apos;..
         /// </summary>
         public static string UploadPackage_NewIdOnBehalfOfUserNotAllowed {
             get {
@@ -1354,7 +1354,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User &apos;{0}&apos; does not have the rights to upload a new version of an existing package on behalf of user &apos;{1}&apos;!.
+        ///   Looks up a localized string similar to User &apos;{0}&apos; does not have the rights to upload a new version of an existing package on behalf of user &apos;{1}&apos;..
         /// </summary>
         public static string UploadPackage_NewVersionOnBehalfOfUserNotAllowed {
             get {
@@ -1426,7 +1426,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User &apos;{0}&apos; does not have the rights to upload new versions of package &apos;{1}&apos;!.
+        ///   Looks up a localized string similar to User &apos;{0}&apos; does not have the rights to upload new versions of package &apos;{1}&apos;..
         /// </summary>
         public static string VerifyPackage_OwnerInvalid {
             get {
@@ -1462,7 +1462,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You do not have permission to upload packages as user &apos;{0}&apos;!.
+        ///   Looks up a localized string similar to You do not have permission to upload packages as user &apos;{0}&apos;..
         /// </summary>
         public static string VerifyPackage_UserInvalid {
             get {
@@ -1471,7 +1471,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The user &apos;{0}&apos; doesn&apos;t exist! You cannot upload a package as a user that doesn&apos;t exist..
+        ///   Looks up a localized string similar to The user &apos;{0}&apos; doesn&apos;t exist. You cannot upload a package as a user that doesn&apos;t exist..
         /// </summary>
         public static string VerifyPackage_UserNonExistent {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -1345,6 +1345,24 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to User &apos;{0}&apos; does not have the rights to upload a package with a new ID on behalf of user &apos;{1}&apos;!.
+        /// </summary>
+        public static string UploadPackage_NewIdOnBehalfOfUserNotAllowed {
+            get {
+                return ResourceManager.GetString("UploadPackage_NewIdOnBehalfOfUserNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to User &apos;{0}&apos; does not have the rights to upload a new version of an existing package on behalf of user &apos;{1}&apos;!.
+        /// </summary>
+        public static string UploadPackage_NewVersionOnBehalfOfUserNotAllowed {
+            get {
+                return ResourceManager.GetString("UploadPackage_NewVersionOnBehalfOfUserNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot upload file because an upload is already in progress..
         /// </summary>
         public static string UploadPackage_UploadInProgress {
@@ -1408,6 +1426,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to User &apos;{0}&apos; does not have the rights to upload new versions of package &apos;{1}&apos;!.
+        /// </summary>
+        public static string VerifyPackage_OwnerInvalid {
+            get {
+                return ResourceManager.GetString("VerifyPackage_OwnerInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Your attempt to verify the package submission failed, because the package file appears to have changed. Please try again..
         /// </summary>
         public static string VerifyPackage_PackageFileModified {
@@ -1431,6 +1458,24 @@ namespace NuGetGallery {
         public static string VerifyPackage_UploadNotFound {
             get {
                 return ResourceManager.GetString("VerifyPackage_UploadNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You do not have permission to upload packages as user &apos;{0}&apos;!.
+        /// </summary>
+        public static string VerifyPackage_UserInvalid {
+            get {
+                return ResourceManager.GetString("VerifyPackage_UserInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The user &apos;{0}&apos; doesn&apos;t exist! You cannot upload a package as a user that doesn&apos;t exist..
+        /// </summary>
+        public static string VerifyPackage_UserNonExistent {
+            get {
+                return ResourceManager.GetString("VerifyPackage_UserNonExistent", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -619,18 +619,18 @@ For more information, please contact '{2}'.</value>
     <value>The account:{0} was deleted succesfully.</value>
   </data>
   <data name="UploadPackage_NewIdOnBehalfOfUserNotAllowed" xml:space="preserve">
-    <value>User '{0}' does not have the rights to upload a package with a new ID on behalf of user '{1}'!</value>
+    <value>User '{0}' does not have the rights to upload a package with a new ID on behalf of user '{1}'.</value>
   </data>
   <data name="UploadPackage_NewVersionOnBehalfOfUserNotAllowed" xml:space="preserve">
-    <value>User '{0}' does not have the rights to upload a new version of an existing package on behalf of user '{1}'!</value>
+    <value>User '{0}' does not have the rights to upload a new version of an existing package on behalf of user '{1}'.</value>
   </data>
   <data name="VerifyPackage_OwnerInvalid" xml:space="preserve">
-    <value>User '{0}' does not have the rights to upload new versions of package '{1}'!</value>
+    <value>User '{0}' does not have the rights to upload new versions of package '{1}'.</value>
   </data>
   <data name="VerifyPackage_UserInvalid" xml:space="preserve">
-    <value>You do not have permission to upload packages as user '{0}'!</value>
+    <value>You do not have permission to upload packages as user '{0}'.</value>
   </data>
   <data name="VerifyPackage_UserNonExistent" xml:space="preserve">
-    <value>The user '{0}' doesn't exist! You cannot upload a package as a user that doesn't exist.</value>
+    <value>The user '{0}' doesn't exist. You cannot upload a package as a user that doesn't exist.</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -618,4 +618,19 @@ For more information, please contact '{2}'.</value>
   <data name="AccountDelete_Success" xml:space="preserve">
     <value>The account:{0} was deleted succesfully.</value>
   </data>
+  <data name="UploadPackage_NewIdOnBehalfOfUserNotAllowed" xml:space="preserve">
+    <value>User '{0}' does not have the rights to upload a package with a new ID on behalf of user '{1}'!</value>
+  </data>
+  <data name="UploadPackage_NewVersionOnBehalfOfUserNotAllowed" xml:space="preserve">
+    <value>User '{0}' does not have the rights to upload a new version of an existing package on behalf of user '{1}'!</value>
+  </data>
+  <data name="VerifyPackage_OwnerInvalid" xml:space="preserve">
+    <value>User '{0}' does not have the rights to upload new versions of package '{1}'!</value>
+  </data>
+  <data name="VerifyPackage_UserInvalid" xml:space="preserve">
+    <value>You do not have permission to upload packages as user '{0}'!</value>
+  </data>
+  <data name="VerifyPackage_UserNonExistent" xml:space="preserve">
+    <value>The user '{0}' doesn't exist! You cannot upload a package as a user that doesn't exist.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -569,7 +569,7 @@
                         <a href="@Url.EditPackage(Model.Id, Model.Version)">Edit package</a>
                     </li>
                 }
-                @if (Model.IsActionAllowed(User, PackageActions.ManagePackageOwners))
+                @if (Model.IsActionAllowed(User, PackageActions.ManagePackageOwnership))
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>

--- a/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
@@ -61,13 +61,13 @@
                 <div class="verify-package-field form-group editable">
                     <label for="Owner" class="verify-package-field-heading">Owner</label>
                     <!-- ko if: $data.PossibleOwners.length > 1 -->
-                    <select aria-required="true" class="form-control" data-val="true" data-val-required="You must select an owner for your package!" name="$data.Owner" data-bind="foreach: $data.PossibleOwners">
+                    <select aria-required="true" class="form-control" data-val="true" data-val-required="You must select an owner for your package!" name="Owner" data-bind="foreach: $data.PossibleOwners">
                         <option data-bind="value: $data, text: $data"></option>
                     </select>
                     <!-- /ko -->
                     <!-- ko if: $data.PossibleOwners.length == 1 -->
-                    <p data-bind="text: $data.Owner"></p>
-                    <input data-bind="value: $data.Owner" type="hidden" name="$data.Owner" class="form-control" />
+                    <p data-bind="text: $data.PossibleOwners[0]"></p>
+                    <input data-bind="value: $data.PossibleOwners[0]" type="hidden" name="Owner" class="form-control" />
                     <!-- /ko -->
                 </div>
                 <!-- /ko -->

--- a/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
@@ -57,6 +57,19 @@
                     <input data-bind="value: $data.Version" type="hidden" name="Version" class="form-control" />
                 </div>
 
+                <div class="verify-package-field form-group editable">
+                    <label for="Owner" class="verify-package-field-heading">Owner</label>
+                    <!-- ko if: Edit.PossibleOwners.length > 1 -->
+                    <select aria-required="true" class="form-control" data-val="true" data-val-required="You must select an owner for your package!" name="Edit.Owner" data-bind="foreach: Edit.PossibleOwners">
+                        <option data-bind="value: $data, text: $data"></option>
+                    </select>
+                    <!-- /ko -->
+                    <!-- ko if: Edit.PossibleOwners.length == 1 -->
+                    <p data-bind="text: Edit.Owner"></p>
+                    <input data-bind="value: Edit.Owner" type="hidden" name="Edit.Owner" class="form-control" />
+                    <!-- /ko -->
+                </div>
+
                 <div class="verify-package-field form-group readonly">
                     <label for="MinClientVersionDisplay" class="verify-package-field-heading">Minimum NuGet Client Version</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.MinClientVersionDisplay }}"></div>

--- a/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_EditMetadata.cshtml
@@ -57,18 +57,20 @@
                     <input data-bind="value: $data.Version" type="hidden" name="Version" class="form-control" />
                 </div>
 
+                <!-- ko if: $data.PossibleOwners -->
                 <div class="verify-package-field form-group editable">
                     <label for="Owner" class="verify-package-field-heading">Owner</label>
-                    <!-- ko if: Edit.PossibleOwners.length > 1 -->
-                    <select aria-required="true" class="form-control" data-val="true" data-val-required="You must select an owner for your package!" name="Edit.Owner" data-bind="foreach: Edit.PossibleOwners">
+                    <!-- ko if: $data.PossibleOwners.length > 1 -->
+                    <select aria-required="true" class="form-control" data-val="true" data-val-required="You must select an owner for your package!" name="$data.Owner" data-bind="foreach: $data.PossibleOwners">
                         <option data-bind="value: $data, text: $data"></option>
                     </select>
                     <!-- /ko -->
-                    <!-- ko if: Edit.PossibleOwners.length == 1 -->
-                    <p data-bind="text: Edit.Owner"></p>
-                    <input data-bind="value: Edit.Owner" type="hidden" name="Edit.Owner" class="form-control" />
+                    <!-- ko if: $data.PossibleOwners.length == 1 -->
+                    <p data-bind="text: $data.Owner"></p>
+                    <input data-bind="value: $data.Owner" type="hidden" name="$data.Owner" class="form-control" />
                     <!-- /ko -->
                 </div>
+                <!-- /ko -->
 
                 <div class="verify-package-field form-group readonly">
                     <label for="MinClientVersionDisplay" class="verify-package-field-heading">Minimum NuGet Client Version</label>

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -78,7 +78,7 @@
             </div>
             
             @if (Model.IsActionAllowed(User, PackageActions.Edit) ||
-                Model.IsActionAllowed(User, PackageActions.ManagePackageOwners) ||
+                Model.IsActionAllowed(User, PackageActions.ManagePackageOwnership) ||
                 Model.IsActionAllowed(User, PackageActions.Unlist))
             {
                 <ul class="package-list manage-package">
@@ -91,7 +91,7 @@
                             </a>
                         </li>
                     }
-                    @if (Model.IsActionAllowed(User, PackageActions.ManagePackageOwners))
+                    @if (Model.IsActionAllowed(User, PackageActions.ManagePackageOwnership))
                     {
                         <li>
                             <a href="@Url.ManagePackageOwners(Model)" class="icon-link">

--- a/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
@@ -57,7 +57,7 @@
                                         <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
                                     </a>
                                 }
-                                @if (package.IsActionAllowed(User, PackageActions.ManagePackageOwners))
+                                @if (package.IsActionAllowed(User, PackageActions.ManagePackageOwnership))
                                 {
                                     <a href="@Url.ManagePackageOwners(package)" class="btn" title="Manage Owners" aria-label="Manage Owners for Package @package.Id">
                                         <i class="ms-Icon ms-Icon--People" aria-hidden="true"></i>

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -91,8 +91,8 @@ namespace NuGetGallery
                 .Setup(r => r.IsPushAllowed(It.IsAny<string>(), It.IsAny<User>(), out matchingNamespaces))
                 .Returns(true);
 
-            MockPackageUploadService.Setup(x => x.GeneratePackageAsync(It.IsAny<string>(), It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>()))
-                .Returns((string id, PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User user) => {
+            MockPackageUploadService.Setup(x => x.GeneratePackageAsync(It.IsAny<string>(), It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<User>()))
+                .Returns((string id, PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User owner, User currentUser) => {
                     var packageMetadata = PackageMetadata.FromNuspecReader(nugetPackage.GetNuspecReader());
 
                     var package = new Package();
@@ -167,6 +167,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<PackageArchiveReader>(),
                         It.IsAny<PackageStreamMetadata>(),
+                        It.IsAny<User>(),
                         It.IsAny<User>()))
                     .Returns(Task.FromResult(package));
 
@@ -205,6 +206,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<PackageArchiveReader>(),
                         It.IsAny<PackageStreamMetadata>(),
+                        It.IsAny<User>(),
                         It.IsAny<User>()))
                     .Returns(Task.FromResult(package));
 
@@ -503,6 +505,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<PackageArchiveReader>(),
                         It.IsAny<PackageStreamMetadata>(),
+                        It.IsAny<User>(),
                         It.IsAny<User>()),
                     Times.Once);
             }
@@ -544,6 +547,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<PackageArchiveReader>(),
                         It.IsAny<PackageStreamMetadata>(),
+                        It.IsAny<User>(),
                         It.IsAny<User>()));
             }
 
@@ -583,6 +587,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<PackageArchiveReader>(),
                         It.IsAny<PackageStreamMetadata>(),
+                        It.IsAny<User>(),
                         It.IsAny<User>()),
                     Times.Once);
             }
@@ -649,6 +654,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<PackageArchiveReader>(),
                         It.IsAny<PackageStreamMetadata>(),
+                        user,
                         user),
                     Times.Once);
             }
@@ -677,6 +683,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<PackageArchiveReader>(),
                         It.IsAny<PackageStreamMetadata>(),
+                        user,
                         user))
                     .ReturnsAsync(package);
 
@@ -691,6 +698,7 @@ namespace NuGetGallery
                             It.IsAny<string>(),
                             It.IsAny<PackageArchiveReader>(),
                             It.IsAny<PackageStreamMetadata>(),
+                            user,
                             user));
                 }
                 else
@@ -700,6 +708,7 @@ namespace NuGetGallery
                             It.IsAny<string>(),
                             It.IsAny<PackageArchiveReader>(),
                             It.IsAny<PackageStreamMetadata>(),
+                            It.IsAny<User>(),
                             It.IsAny<User>()),
                         Times.Never);
 
@@ -742,6 +751,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<PackageArchiveReader>(),
                         It.IsAny<PackageStreamMetadata>(),
+                        user,
                         user))
                     .ReturnsAsync(package);
 
@@ -756,6 +766,7 @@ namespace NuGetGallery
                             It.IsAny<string>(),
                             It.IsAny<PackageArchiveReader>(),
                             It.IsAny<PackageStreamMetadata>(),
+                            user,
                             user));
                 }
                 else
@@ -765,6 +776,7 @@ namespace NuGetGallery
                             It.IsAny<string>(),
                             It.IsAny<PackageArchiveReader>(),
                             It.IsAny<PackageStreamMetadata>(),
+                            It.IsAny<User>(),
                             It.IsAny<User>()),
                         Times.Never);
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -3597,13 +3597,10 @@ namespace NuGetGallery
 
                 var packageRegistration = new PackageRegistration { Id = packageId, Owners = owners };
 
-                var fakePackageService = new Mock<IPackageService>();
-                fakePackageService.Setup(x => x.FindPackageRegistrationById(packageId)).Returns(packageRegistration);
-
-                var controller = CreateController(GetConfigurationService(), packageService: fakePackageService);
+                var controller = CreateController(GetConfigurationService());
                 controller.SetCurrentUser(currentUser);
 
-                var possibleOwners = controller.GetPossibleOwnersForUpload(packageId);
+                var possibleOwners = controller.GetPossibleOwnersForUpload(packageId, packageRegistration);
                 Assert.True(possibleOwners.SequenceEqual(expectedPossibleOwners));
             }
 
@@ -3695,7 +3692,7 @@ namespace NuGetGallery
                 var controller = CreateController(GetConfigurationService(), reservedNamespaceService: fakeReservedNamespaceService);
                 controller.SetCurrentUser(currentUser);
 
-                var possibleOwners = controller.GetPossibleOwnersForUpload(packageId);
+                var possibleOwners = controller.GetPossibleOwnersForUpload(packageId, null);
                 Assert.True(possibleOwners.SequenceEqual(expectedPossibleOwners.Distinct()));
             }
 

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -79,14 +79,14 @@ namespace NuGetGallery
             {
                 var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
                 var service = CreateService(packageRegistrationRepository: packageRegistrationRepository, setup: mockPackageService =>
-                    {
-                        mockPackageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
-                    });
+                {
+                    mockPackageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
+                });
 
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 packageRegistrationRepository.Verify(x => x.InsertOnCommit(It.Is<PackageRegistration>(pr => pr.Id == "theId")));
             }
@@ -128,7 +128,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: idThatMatchesExistingTitle);
 
                 // Assert
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NewRegistrationIdMatchesExistingPackageTitle, idThatMatchesExistingTitle), ex.Message);
             }
@@ -142,7 +142,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 packageRegistrationRepository.Verify(x => x.InsertOnCommit(It.Is<PackageRegistration>(pr => pr.Owners.Contains(currentUser))));
             }
@@ -156,7 +156,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 // Note that there is no assertion on package identifier, because that's at the package registration level (and covered in another test).
                 Assert.Equal("01.0.42.0", package.Version);
@@ -193,7 +193,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(language: "fr");
                 var currentUser = new User();
 
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 // Assert
                 Assert.Equal("fr", package.Language);
@@ -212,7 +212,7 @@ namespace NuGetGallery
                 var currentUser = new User();
 
                 // Act
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 // Assert
                 Assert.True(package.IsPrerelease);
@@ -232,7 +232,7 @@ namespace NuGetGallery
                 var currentUser = new User();
 
                 // Act
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 // Assert
                 packageRegistrationRepository.Verify();
@@ -255,7 +255,7 @@ namespace NuGetGallery
                     HashAlgorithm = Constants.Sha512HashAlgorithmId,
                     Size = packageStream.Length
                 };
-                var package = await service.CreatePackageAsync(nugetPackage.Object, packageStreamMetadata, currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, packageStreamMetadata, currentUser, currentUser, isVerified: false);
 
                 Assert.Equal(expectedHash, package.Hash);
                 Assert.Equal(Constants.Sha512HashAlgorithmId, package.HashAlgorithm);
@@ -269,7 +269,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 Assert.NotNull(package.Published);
             }
@@ -282,7 +282,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 Assert.Equal(DateTime.MinValue, package.Created);
             }
@@ -295,7 +295,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 Assert.NotEqual(DateTime.MinValue, package.LastUpdated);
             }
@@ -316,7 +316,7 @@ namespace NuGetGallery
                     HashAlgorithm = Constants.Sha512HashAlgorithmId,
                     Size = 618
                 };
-                var package = await service.CreatePackageAsync(nugetPackage.Object, packageStreamMetadata, currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, packageStreamMetadata, currentUser, currentUser, isVerified: false);
 
                 Assert.Equal(618, package.PackageFileSize);
             }
@@ -324,15 +324,19 @@ namespace NuGetGallery
             [Fact]
             private async Task WillSaveTheCreatedPackageWhenANewPackageRegistrationIsCreated()
             {
+                var key = 0;
                 var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
                 var service = CreateService(packageRegistrationRepository: packageRegistrationRepository, setup:
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null); });
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
-                var currentUser = new User();
+                var owner = new User { Key = key++, Username = "owner" };
+                var currentUser = new User { Key = key++, Username = "currentUser" };
 
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner, currentUser, isVerified: false);
 
                 packageRegistrationRepository.Verify(x => x.InsertOnCommit(It.Is<PackageRegistration>(pr => pr.Packages.ElementAt(0) == package)));
+                Assert.True(package.PackageRegistration.Owners.SequenceEqual(new[] { owner }));
+                Assert.Equal(currentUser, package.User);
             }
 
             [Fact]
@@ -349,7 +353,7 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns(packageRegistration); });
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
 
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 Assert.Same(packageRegistration.Packages.ElementAt(0), package);
             }
@@ -368,7 +372,7 @@ namespace NuGetGallery
                         mockPackageService => { mockPackageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns(packageRegistration); });
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.PackageIdNotAvailable, "theId"), ex.Message);
             }
@@ -396,7 +400,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(title: newPackageTitle);
 
                 // Assert
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.TitleMatchesExistingRegistration, newPackageTitle), ex.Message);
             }
@@ -407,7 +411,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: "theId".PadRight(131, '_'));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Id", CoreConstants.MaxPackageIdLength), ex.Message);
             }
@@ -418,7 +422,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: "theId", version: "1.2.3-alpha.0");
 
-                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false);
+                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false);
             }
 
             [Fact]
@@ -427,7 +431,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: "theId", version: "1.2.3-12345");
 
-                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false);
+                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false);
             }
 
             [Fact]
@@ -436,7 +440,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(authors: "theFirstAuthor".PadRight(2001, '_') + ", " + "theSecondAuthor".PadRight(2001, '_'));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Authors", "4000"), ex.Message);
             }
@@ -447,7 +451,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(copyright: "theCopyright".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Copyright", "4000"), ex.Message);
             }
@@ -459,7 +463,7 @@ namespace NuGetGallery
                 var versionString = "1.0.0-".PadRight(65, 'a');
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(version: versionString);
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Version", "64"), ex.Message);
             }
@@ -484,7 +488,7 @@ namespace NuGetGallery
                         packageDependencies),
                 });
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Dependencies", Int16.MaxValue), ex.Message);
             }
@@ -506,7 +510,7 @@ namespace NuGetGallery
                                 })
                     });
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Dependency.Id", CoreConstants.MaxPackageIdLength), ex.Message);
             }
@@ -528,7 +532,7 @@ namespace NuGetGallery
                                 })
                     });
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Dependency.VersionSpec", 256), ex.Message);
             }
@@ -539,7 +543,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(description: null);
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyMissing, "Description"), ex.Message);
             }
@@ -551,7 +555,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(description: "theDescription".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Description", "4000"), ex.Message);
             }
@@ -562,7 +566,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(iconUrl: new Uri("http://theIconUrl/".PadRight(4001, '-'), UriKind.Absolute));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "IconUrl", "4000"), ex.Message);
             }
@@ -573,7 +577,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(licenseUrl: new Uri("http://theLicenseUrl/".PadRight(4001, '-'), UriKind.Absolute));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "LicenseUrl", "4000"), ex.Message);
             }
@@ -584,7 +588,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(projectUrl: new Uri("http://theProjectUrl/".PadRight(4001, '-'), UriKind.Absolute));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "ProjectUrl", "4000"), ex.Message);
             }
@@ -595,7 +599,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(summary: "theSummary".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Summary", "4000"), ex.Message);
             }
@@ -606,7 +610,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(tags: "theTags".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Tags", "4000"), ex.Message);
             }
@@ -617,7 +621,7 @@ namespace NuGetGallery
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(title: "theTitle".PadRight(4001, '_'));
 
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Title", "256"), ex.Message);
             }
@@ -630,7 +634,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(language: new string('a', 21));
 
                 // Act
-                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), user: null, isVerified: false));
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
                 // Assert
                 Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Language", "20"), ex.Message);
@@ -641,19 +645,19 @@ namespace NuGetGallery
             {
                 var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
                 var service = CreateService(packageRegistrationRepository: packageRegistrationRepository, setup: mockPackageService =>
-                               {
-                                   mockPackageService.Setup(p => p.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
-                                   mockPackageService.Setup(p => p.GetSupportedFrameworks(It.IsAny<PackageArchiveReader>())).Returns(
-                                       new[]
-                                       {
+                {
+                    mockPackageService.Setup(p => p.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
+                    mockPackageService.Setup(p => p.GetSupportedFrameworks(It.IsAny<PackageArchiveReader>())).Returns(
+                        new[]
+                        {
                                            NuGetFramework.Parse("net40"),
                                            NuGetFramework.Parse("net35")
-                                       });
-                               });
+                        });
+                });
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 Assert.Equal("net40", package.SupportedFrameworks.First().TargetFramework);
                 Assert.Equal("net35", package.SupportedFrameworks.ElementAt(1).TargetFramework);
@@ -676,7 +680,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, isVerified: false);
+                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 Assert.Empty(package.SupportedFrameworks);
             }

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -33,8 +33,8 @@ namespace NuGetGallery
 
             packageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
             packageService.Setup(x => x
-                .CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()))
-                .Returns((PackageArchiveReader packageArchiveReader, PackageStreamMetadata packageStreamMetadata, User user, bool isVerified) =>
+                .CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<User>(), It.IsAny<bool>()))
+                .Returns((PackageArchiveReader packageArchiveReader, PackageStreamMetadata packageStreamMetadata, User owner, User currentUser, bool isVerified) =>
                 {
                     var packageMetadata = PackageMetadata.FromNuspecReader(packageArchiveReader.GetNuspecReader());
 
@@ -87,6 +87,7 @@ namespace NuGetGallery
                     id,
                     nugetPackage.Object,
                     new PackageStreamMetadata(),
+                    currentUser,
                     currentUser);
 
                 validationService.Verify(
@@ -97,17 +98,19 @@ namespace NuGetGallery
             [Fact]
             public async Task WillCallCreatePackageAsyncCorrectly()
             {
+                var key = 0;
                 var packageService = new Mock<IPackageService>();
                 packageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
 
                 var id = "Microsoft.Aspnet.Mvc";
                 var packageUploadService = CreateService(packageService);
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: id);
-                var currentUser = new User();
+                var owner = new User { Key = key++, Username = "owner" };
+                var currentUser = new User { Key = key++, Username = "user" };
 
-                var package = await packageUploadService.GeneratePackageAsync(id, nugetPackage.Object, new PackageStreamMetadata(), currentUser);
+                var package = await packageUploadService.GeneratePackageAsync(id, nugetPackage.Object, new PackageStreamMetadata(), owner, currentUser);
 
-                packageService.Verify(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), It.IsAny<User>(), It.IsAny<bool>()), Times.Once);
+                packageService.Verify(x => x.CreatePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageStreamMetadata>(), owner, currentUser, false), Times.Once);
                 Assert.False(package.PackageRegistration.IsVerified);
             }
 
@@ -137,7 +140,7 @@ namespace NuGetGallery
                 var packageUploadService = CreateService(reservedNamespaceService: reservedNamespaceService);
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: id);
 
-                var package = await packageUploadService.GeneratePackageAsync(id, nugetPackage.Object, new PackageStreamMetadata(), firstUser);
+                var package = await packageUploadService.GeneratePackageAsync(id, nugetPackage.Object, new PackageStreamMetadata(), firstUser, firstUser);
 
                 Assert.Equal(shouldMarkIdVerified, package.PackageRegistration.IsVerified);
             }
@@ -165,7 +168,7 @@ namespace NuGetGallery
                 var packageUploadService = CreateService(reservedNamespaceService: reservedNamespaceService);
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: id);
 
-                var package = await packageUploadService.GeneratePackageAsync(id, nugetPackage.Object, new PackageStreamMetadata(), lastUser);
+                var package = await packageUploadService.GeneratePackageAsync(id, nugetPackage.Object, new PackageStreamMetadata(), lastUser, lastUser);
 
                 Assert.False(package.PackageRegistration.IsVerified);
             }
@@ -185,7 +188,7 @@ namespace NuGetGallery
                 .Concat(new[] { (PackageStatus)(-1) })
                 .Where(s => !SupportedPackageStatuses.Any(o => s.Equals(o[0])))
                 .Select(s => new object[] { s });
-            
+
             [Theory]
             [MemberData(nameof(SupportedPackageStatuses))]
             public async Task CommitsAfterSavingSupportedPackageStatuses(PackageStatus packageStatus)


### PR DESCRIPTION
The changes to allow organization members to upload packages on behalf of their organization from the UI.

**only one possible owner**
![image](https://user-images.githubusercontent.com/18014088/33101394-0122b7ea-cecd-11e7-9fa5-f5cacca377c0.png)

**multiple possible owners**
![image](https://user-images.githubusercontent.com/18014088/33101728-46d418f0-cece-11e7-9210-ed2b2cb88271.png)

(mostly ported from https://github.com/NuGet/NuGetGallery/pull/4963)