### PR TITLE
Add initial support for user deletion request

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -962,6 +962,9 @@ img.reserved-indicator-icon {
 .page-report-abuse .report-form #alreadycontactedowner-label {
   display: inline;
 }
+.page-report-abuse .report-form #form-field-confirm-delete {
+  margin: 20px 0;
+}
 .page-report-abuse .report-form .infringement-claim-requirements h2 {
   margin-top: 15px;
   margin-bottom: 15px;

--- a/src/Bootstrap/less/theme/page-report-abuse.less
+++ b/src/Bootstrap/less/theme/page-report-abuse.less
@@ -4,6 +4,10 @@
       display: inline;
     }
 
+    #form-field-confirm-delete {
+      margin: (@padding-large-vertical * 2) 0;
+    }
+
     .infringement-claim-requirements {
       h2 {
         margin-top: 15px;

--- a/src/NuGetGallery/Areas/Admin/Services/ISupportRequestService.cs
+++ b/src/NuGetGallery/Areas/Admin/Services/ISupportRequestService.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGetGallery.Areas.Admin.Models;
@@ -34,8 +33,14 @@ namespace NuGetGallery.Areas.Admin
         /// <returns>Returns a <see cref="IReadOnlyCollection{Issue}"/> that matches the provided filter parameters.</returns>
         IReadOnlyCollection<Issue> GetIssues(int? assignedTo = null, string reason = null, int? issueStatusId = null, string galleryUsername = null);
 
-        Task<bool> AddNewSupportRequestAsync(string subject, string message, string requestorEmailAddress, string reason,
-            User user, Package package = null);
+        Task<Issue> AddNewSupportRequestAsync(
+            string subject, 
+            string message,
+            string requestorEmailAddress,
+            string reason,
+            User user,
+            Package package = null);
+
         Task UpdateIssueAsync(int issueId, int? assignedToId, int issueStatusId, string comment, string editedBy);
         int GetIssueCount(int? assignedToId, string reason, int? issueStatusId);
 

--- a/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
+++ b/src/NuGetGallery/Content/gallery/css/bootstrap-theme.css
@@ -962,6 +962,9 @@ img.reserved-indicator-icon {
 .page-report-abuse .report-form #alreadycontactedowner-label {
   display: inline;
 }
+.page-report-abuse .report-form #form-field-confirm-delete {
+  margin: 20px 0;
+}
 .page-report-abuse .report-form .infringement-claim-requirements h2 {
   margin-top: 15px;
   margin-bottom: 15px;

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -19,6 +19,7 @@ using System.Web.Mvc;
 using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Areas.Admin;
+using NuGetGallery.Areas.Admin.Models;
 using NuGetGallery.AsyncFileUpload;
 using NuGetGallery.Auditing;
 using NuGetGallery.Configuration;
@@ -35,6 +36,29 @@ namespace NuGetGallery
     public partial class PackagesController
         : AppController
     {
+        private static readonly IReadOnlyList<ReportPackageReason> ReportAbuseReasons = new[]
+        {
+            ReportPackageReason.ViolatesALicenseIOwn,
+            ReportPackageReason.ContainsMaliciousCode,
+            ReportPackageReason.HasABugOrFailedToInstall,
+            ReportPackageReason.Other
+        };
+
+        private static readonly IReadOnlyList<ReportPackageReason> ReportMyPackageReasons = new[]
+        {
+            ReportPackageReason.ContainsPrivateAndConfidentialData,
+            ReportPackageReason.ReleasedInPublicByAccident,
+            ReportPackageReason.ContainsMaliciousCode,
+            ReportPackageReason.Other
+        };
+
+        private static readonly IReadOnlyList<ReportPackageReason> DeleteReasons = new[]
+        {
+            ReportPackageReason.ContainsPrivateAndConfidentialData,
+            ReportPackageReason.ReleasedInPublicByAccident,
+            ReportPackageReason.ContainsMaliciousCode,
+        };
+
         // TODO: add support for URL-based package submission
         // TODO: add support for uploading logos and screenshots
         // TODO: improve validation summary emphasis
@@ -564,14 +588,6 @@ namespace NuGetGallery
             return View(viewModel);
         }
 
-        // NOTE: Intentionally NOT requiring authentication
-        private static readonly ReportPackageReason[] ReportOtherPackageReasons = new[] {
-            ReportPackageReason.ViolatesALicenseIOwn,
-            ReportPackageReason.ContainsMaliciousCode,
-            ReportPackageReason.HasABugOrFailedToInstall,
-            ReportPackageReason.Other
-        };
-
         [HttpGet]
         public virtual ActionResult ReportAbuse(string id, string version)
         {
@@ -584,7 +600,7 @@ namespace NuGetGallery
 
             var model = new ReportAbuseViewModel
             {
-                ReasonChoices = ReportOtherPackageReasons,
+                ReasonChoices = ReportAbuseReasons,
                 PackageId = id,
                 PackageVersion = package.Version,
                 CopySender = true,
@@ -610,17 +626,10 @@ namespace NuGetGallery
             return View(model);
         }
 
-        private static readonly ReportPackageReason[] ReportMyPackageReasons = {
-            ReportPackageReason.ContainsPrivateAndConfidentialData,
-            ReportPackageReason.ReleasedInPublicByAccident,
-            ReportPackageReason.ContainsMaliciousCode,
-            ReportPackageReason.Other
-        };
-
         [HttpGet]
         [Authorize]
         [RequiresAccountConfirmation("contact support about your package")]
-        public virtual ActionResult ReportMyPackage(string id, string version)
+        public virtual async Task<ActionResult> ReportMyPackage(string id, string version)
         {
             var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
 
@@ -628,20 +637,23 @@ namespace NuGetGallery
             {
                 return HttpNotFound();
             }
-
-            // If user hit this url by constructing it manually but is not the owner, redirect them to ReportAbuse
+            
             if (!PermissionsService.IsActionAllowed(package, User, PackageActions.ReportMyPackage))
             {
-                return RedirectToAction("ReportAbuse", new { id, version });
+                return RedirectToAction(nameof(ReportAbuse), new { id, version });
             }
+
+            var allowDelete = await _packageDeleteService.CanPackageBeDeletedByUserAsync(package);
 
             var model = new ReportMyPackageViewModel
             {
                 ReasonChoices = ReportMyPackageReasons,
+                DeleteReasonChoices = DeleteReasons,
                 ConfirmedUser = GetCurrentUser().Confirmed,
                 PackageId = id,
                 PackageVersion = package.Version,
-                CopySender = true
+                CopySender = true,
+                AllowDelete = allowDelete,
             };
 
             return View(model);
@@ -652,16 +664,17 @@ namespace NuGetGallery
         [ValidateSpamPrevention]
         public virtual async Task<ActionResult> ReportAbuse(string id, string version, ReportAbuseViewModel reportForm)
         {
-            // Html Encode the message
-            reportForm.Message = System.Web.HttpUtility.HtmlEncode(reportForm.Message);
-
-            var modelIsValid = ModelState.IsValid;
-            if (reportForm.Reason == ReportPackageReason.ViolatesALicenseIOwn)
+            reportForm.Message = HttpUtility.HtmlEncode(reportForm.Message);
+            
+            if (reportForm.Reason == ReportPackageReason.ViolatesALicenseIOwn
+                && string.IsNullOrWhiteSpace(reportForm.Signature))
             {
-                modelIsValid = modelIsValid && !string.IsNullOrEmpty(reportForm.Signature);
+                ModelState.AddModelError(
+                    nameof(ReportAbuseViewModel.Signature),
+                    "The signature is required.");
             }
 
-            if (!modelIsValid)
+            if (!ModelState.IsValid)
             {
                 return ReportAbuse(id, version);
             }
@@ -716,23 +729,115 @@ namespace NuGetGallery
         [ValidateSpamPrevention]
         public virtual async Task<ActionResult> ReportMyPackage(string id, string version, ReportMyPackageViewModel reportForm)
         {
-            // Html Encode the message
-            reportForm.Message = System.Web.HttpUtility.HtmlEncode(reportForm.Message);
-
-            if (!ModelState.IsValid)
+            var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
+            
+            var failureResult = await ValidateReportMyPackageViewModel(reportForm, package);
+            if (failureResult != null)
             {
-                return ReportMyPackage(id, version);
+                return failureResult;
+            }
+            
+            // Override the copy sender and message fields if we are performing an auto-delete.
+            if (reportForm.DeleteDecision == PackageDeleteDecision.DeletePackage)
+            {
+                reportForm.CopySender = false;
+                reportForm.Message = Strings.UserPackageDeleteSupportRequestMessage;
             }
 
-            var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
+            var user = GetCurrentUser();
+            var from = user.ToMailAddress();
+            var subject = string.Format(
+                Strings.OwnerSupportRequestSubjectFormat,
+                package.PackageRegistration.Id,
+                package.NormalizedVersion);
+            var reason = EnumHelper.GetDescription(reportForm.Reason.Value);
+            var supportRequest = await _supportRequestService.AddNewSupportRequestAsync(
+                subject,
+                reportForm.Message,
+                from.Address,
+                reason,
+                user,
+                package);
+
+            var deleted = false;
+            if (supportRequest != null
+                && reportForm.DeleteDecision == PackageDeleteDecision.DeletePackage)
+            {
+                deleted = await DeletePackageOnBehalfOfUserAsync(package, user, reason, supportRequest);
+            }
+
+            if (!deleted)
+            {
+                NotifyReportMyPackageSupportRequest(reportForm, package, user, from);
+            }
+
+            return Redirect(Url.Package(package.PackageRegistration.Id, package.NormalizedVersion));
+        }
+
+        private async Task<ActionResult> ValidateReportMyPackageViewModel(ReportMyPackageViewModel reportForm, Package package)
+        {
             if (package == null)
             {
                 return HttpNotFound();
             }
 
-            var user = GetCurrentUser();
-            MailAddress from = user.ToMailAddress();
+            if (!PermissionsService.IsActionAllowed(package, User, PackageActions.ReportMyPackage))
+            {
+                return RedirectToAction(nameof(ReportAbuse), new { id = package.PackageRegistration.Id, version = package.NormalizedVersion });
+            }
 
+            reportForm.Message = HttpUtility.HtmlEncode(reportForm.Message);
+
+            // Enforce the auto-delete rules.
+            var allowDelete = false;
+            if (reportForm.DeleteDecision != PackageDeleteDecision.ContactSupport)
+            {
+                allowDelete = await _packageDeleteService.CanPackageBeDeletedByUserAsync(package);
+                if (!allowDelete)
+                {
+                    reportForm.DeleteDecision = null;
+                }
+            }
+
+            // Require a delete decision if auto-delete is allowed and implied by the reason.
+            if (allowDelete
+                && reportForm.Reason.HasValue
+                && DeleteReasons.Contains(reportForm.Reason.Value)
+                && !reportForm.DeleteDecision.HasValue)
+            {
+                ModelState.AddModelError(
+                    nameof(ReportMyPackageViewModel.DeleteDecision),
+                    Strings.UserPackageDeleteDecisionIsRequired);
+            }
+
+            // Require the confirmation checkbox if we are performing an auto-delete.
+            if (reportForm.DeleteDecision == PackageDeleteDecision.DeletePackage
+                && !reportForm.DeleteConfirmation)
+            {
+                ModelState.AddModelError(
+                    nameof(ReportMyPackageViewModel.DeleteConfirmation),
+                    Strings.UserPackageDeleteConfirmationIsRequired);
+            }
+
+            // Unless we're performing an auto-delete, require a message.
+            if (reportForm.DeleteDecision != PackageDeleteDecision.DeletePackage
+                && string.IsNullOrWhiteSpace(reportForm.Message))
+            {
+                ModelState.AddModelError(
+                    nameof(ReportMyPackageViewModel.Message),
+                    Strings.MessageIsRequired);
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return await ReportMyPackage(package.PackageRegistration.Id, package.NormalizedVersion);
+            }
+
+            return null;
+        }
+
+        private void NotifyReportMyPackageSupportRequest(ReportMyPackageViewModel reportForm, Package package, User user, MailAddress from)
+        {
             var request = new ReportPackageRequest
             {
                 FromAddress = from,
@@ -744,15 +849,53 @@ namespace NuGetGallery
                 CopySender = reportForm.CopySender
             };
 
-            var subject = $"Owner Support Request for '{package.PackageRegistration.Id}' version {package.Version}";
-            var reason = EnumHelper.GetDescription(reportForm.Reason.Value);
-
-            await _supportRequestService.AddNewSupportRequestAsync(subject, reportForm.Message, from.Address, reason, user, package);
-
             _messageService.ReportMyPackage(request);
 
-            TempData["Message"] = "Your support request has been sent to the gallery operators.";
-            return Redirect(Url.Package(id, version));
+            TempData["Message"] = Strings.SupportRequestSentTransientMessage;
+        }
+
+        private async Task<bool> DeletePackageOnBehalfOfUserAsync(
+            Package package,
+            User user,
+            string reason,
+            Issue supportRequest)
+        {
+            var deleted = false;
+            try
+            {
+                await _packageDeleteService.SoftDeletePackagesAsync(
+                    new[] { package },
+                    user,
+                    reason,
+                    signature: Strings.UserPackageDeleteSignature);
+                deleted = true;
+            }
+            catch (Exception e)
+            {
+                // Swallow exceptions that occur during the delete process. If this happens, we'll just
+                // send out the support request as usual and handle it manually.
+                QuietLog.LogHandledException(e);
+            }
+
+            if (deleted)
+            {
+                // Only close the support request if we have successfully deleted the package.
+                await _supportRequestService.UpdateIssueAsync(
+                    issueId: supportRequest.Key,
+                    assignedToId: null,
+                    issueStatusId: IssueStatusKeys.Resolved,
+                    comment: null,
+                    editedBy: user.Username);
+
+                _messageService.SendPackageDeletedNotice(
+                    package,
+                    Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
+                    Url.ReportPackage(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false));
+
+                TempData["Message"] = Strings.UserPackageDeleteCompleteTransientMessage;
+            }
+
+            return deleted;
         }
 
         [HttpGet]

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -143,11 +143,13 @@ namespace NuGetGallery
                 return HttpNotFound("User not found.");
             }
 
-            bool isSupportRequestCreated = await _supportRequestService.AddNewSupportRequestAsync(Strings.AccountDelete_SupportRequestTitle,
-                                                    Strings.AccountDelete_SupportRequestTitle,
-                                                    user.EmailAddress,
-                                                    "The user requested to have the account deleted.",
-                                                    user);
+            var supportRequest = await _supportRequestService.AddNewSupportRequestAsync(
+                Strings.AccountDelete_SupportRequestTitle,
+                Strings.AccountDelete_SupportRequestTitle,
+                user.EmailAddress,
+                "The user requested to have the account deleted.",
+                user);
+            var isSupportRequestCreated = supportRequest != null;
             if (!isSupportRequestCreated)
             {
                 TempData["RequestFailedMessage"] = Strings.AccountDelete_CreateSupportRequestFails;

--- a/src/NuGetGallery/ExtensionMethods.cs
+++ b/src/NuGetGallery/ExtensionMethods.cs
@@ -291,6 +291,19 @@ namespace NuGetGallery
         public static MvcHtmlString ShowEnumDropDownListFor<TModel, TEnum>(
             this HtmlHelper<TModel> html,
             Expression<Func<TModel, TEnum?>> expression,
+            string emptyItemText)
+          where TEnum : struct
+        {
+            var values = Enum
+                .GetValues(typeof(TEnum))
+                .Cast<TEnum>();
+
+            return ShowEnumDropDownListFor<TModel, TEnum>(html, expression, values, emptyItemText);
+        }
+
+        public static MvcHtmlString ShowEnumDropDownListFor<TModel, TEnum>(
+            this HtmlHelper<TModel> html,
+            Expression<Func<TModel, TEnum?>> expression,
             IEnumerable<TEnum> values,
             string emptyItemText)
           where TEnum : struct

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1585,12 +1585,14 @@
     <Compile Include="Services\ReflowPackageService.cs" />
     <Compile Include="Services\TelemetryService.cs" />
     <Compile Include="Areas\Admin\ViewModels\DeleteUserAccountViewModel.cs" />
+    <Compile Include="ViewModels\PackageDeleteDecision.cs" />
     <Compile Include="ViewModels\DeleteAccountViewModel.cs" />
     <Compile Include="ViewModels\PackageOwnersResultViewModel.cs" />
     <Compile Include="ViewModels\ManagePackagesListViewModel.cs" />
     <Compile Include="ViewModels\ApiKeyListViewModel.cs" />
     <Compile Include="ViewModels\ApiKeyViewModel.cs" />
     <Compile Include="ViewModels\OwnerRequestsListItemViewModel.cs" />
+    <Compile Include="ViewModels\ReportViewModel.cs" />
     <Compile Include="ViewModels\ReservedNamespaceListViewModel.cs" />
     <Compile Include="ViewModels\ReservedNamespaceListItemViewModel.cs" />
     <Compile Include="ViewModels\OwnerRequestsListViewModel.cs" />

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -25,5 +25,6 @@ namespace NuGetGallery
         void SendContactSupportEmail(ContactSupportRequest request);
         void SendPackageAddedNotice(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl);
         void SendAccountDeleteNotice(MailAddress mailAddress, string userName);
+        void SendPackageDeletedNotice(Package package, string packageUrl, string packageSupportUrl);
     }
 }

--- a/src/NuGetGallery/Services/IPackageDeleteService.cs
+++ b/src/NuGetGallery/Services/IPackageDeleteService.cs
@@ -8,6 +8,7 @@ namespace NuGetGallery
 {
     public interface IPackageDeleteService
     {
+        Task<bool> CanPackageBeDeletedByUserAsync(Package package);
         Task SoftDeletePackagesAsync(IEnumerable<Package> packages, User deletedBy, string reason, string signature);
         Task HardDeletePackagesAsync(IEnumerable<Package> packages, User deletedBy, string reason, string signature, bool deleteEmptyPackageRegistration);
         Task ReflowHardDeletedPackageAsync(string id, string version);

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -692,5 +692,47 @@ Thanks,
                 mailMessage.To.Add(owner.ToMailAddress());
             }
         }
+
+        public void SendPackageDeletedNotice(Package package, string packageUrl, string packageSupportUrl)
+        {
+            string subject = "[{0}] Package deleted - {1} {2}";
+            string body = @"The package [{1} {2}]({3}) was just deleted from {0}. If this was not intended, please [contact support]({4}).
+
+Thanks,
+The {0} Team";
+
+            body = String.Format(
+                CultureInfo.CurrentCulture,
+                body,
+                Config.GalleryOwner.DisplayName,
+                package.PackageRegistration.Id,
+                package.Version,
+                packageUrl,
+                packageSupportUrl);
+
+            subject = String.Format(
+                CultureInfo.CurrentCulture,
+                subject,
+                Config.GalleryOwner.DisplayName,
+                package.PackageRegistration.Id,
+                package.Version);
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+
+                foreach (var owner in package.PackageRegistration.Owners)
+                {
+                    mailMessage.To.Add(owner.ToMailAddress());
+                }
+
+                if (mailMessage.To.Any())
+                {
+                    SendMessage(mailMessage);
+                }
+            }
+        }
     }
 }

--- a/src/NuGetGallery/Services/PackageDeleteService.cs
+++ b/src/NuGetGallery/Services/PackageDeleteService.cs
@@ -61,6 +61,13 @@ namespace NuGetGallery
             _auditingService = auditingService;
         }
 
+        public Task<bool> CanPackageBeDeletedByUserAsync(Package package)
+        {
+            // For now, don't allow user's to delete their packages.
+            // https://github.com/NuGet/Engineering/issues/921
+            return Task.FromResult(false);
+        }
+
         public async Task SoftDeletePackagesAsync(IEnumerable<Package> packages, User deletedBy, string reason, string signature)
         {
             using (var strategy = new SuspendDbExecutionStrategy())

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -702,6 +702,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please enter a message..
+        /// </summary>
+        public static string MessageIsRequired {
+            get {
+                return ResourceManager.GetString("MessageIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot send added/removed email for credentials of type &apos;{0}&apos;.
         /// </summary>
         public static string MessageService_CannotSendEmailForCredential {
@@ -806,6 +815,15 @@ namespace NuGetGallery {
         public static string OrganizationsCannotCreateCredentials {
             get {
                 return ResourceManager.GetString("OrganizationsCannotCreateCredentials", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Owner Support Request for &apos;{0}&apos; version {1}.
+        /// </summary>
+        public static string OwnerSupportRequestSubjectFormat {
+            get {
+                return ResourceManager.GetString("OwnerSupportRequestSubjectFormat", resourceCulture);
             }
         }
         
@@ -1246,6 +1264,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your support request has been sent to the gallery operators..
+        /// </summary>
+        public static string SupportRequestSentTransientMessage {
+            get {
+                return ResourceManager.GetString("SupportRequestSentTransientMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The title of your package, &apos;{0}&apos;, is similar to the ID of an existing package, which can cause confusion with our users. Please modify the title of your package and try uploading again..
         /// </summary>
         public static string TitleMatchesExistingRegistration {
@@ -1422,6 +1449,51 @@ namespace NuGetGallery {
         public static string UserNotFound {
             get {
                 return ResourceManager.GetString("UserNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to We&apos;re performing the package delete right now. It may take a while for this change to propagate through our system..
+        /// </summary>
+        public static string UserPackageDeleteCompleteTransientMessage {
+            get {
+                return ResourceManager.GetString("UserPackageDeleteCompleteTransientMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You must confirm the package deletion request..
+        /// </summary>
+        public static string UserPackageDeleteConfirmationIsRequired {
+            get {
+                return ResourceManager.GetString("UserPackageDeleteConfirmationIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You must choose whether to delete the package or contact support..
+        /// </summary>
+        public static string UserPackageDeleteDecisionIsRequired {
+            get {
+                return ResourceManager.GetString("UserPackageDeleteDecisionIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (automated).
+        /// </summary>
+        public static string UserPackageDeleteSignature {
+            get {
+                return ResourceManager.GetString("UserPackageDeleteSignature", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This support request is intended for automatic package deletion..
+        /// </summary>
+        public static string UserPackageDeleteSupportRequestMessage {
+            get {
+                return ResourceManager.GetString("UserPackageDeleteSupportRequestMessage", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -624,4 +624,29 @@ For more information, please contact '{2}'.</value>
   <data name="AccountDelete_SupportRequestTitle" xml:space="preserve">
     <value>DeleteAccountRequest</value>
   </data>
+  <data name="MessageIsRequired" xml:space="preserve">
+    <value>Please enter a message.</value>
+  </data>
+  <data name="OwnerSupportRequestSubjectFormat" xml:space="preserve">
+    <value>Owner Support Request for '{0}' version {1}</value>
+    <comment>{0} is the package ID. {1} is the normalized package version.</comment>
+  </data>
+  <data name="SupportRequestSentTransientMessage" xml:space="preserve">
+    <value>Your support request has been sent to the gallery operators.</value>
+  </data>
+  <data name="UserPackageDeleteCompleteTransientMessage" xml:space="preserve">
+    <value>We're performing the package delete right now. It may take a while for this change to propagate through our system.</value>
+  </data>
+  <data name="UserPackageDeleteConfirmationIsRequired" xml:space="preserve">
+    <value>You must confirm the package deletion request.</value>
+  </data>
+  <data name="UserPackageDeleteDecisionIsRequired" xml:space="preserve">
+    <value>You must choose whether to delete the package or contact support.</value>
+  </data>
+  <data name="UserPackageDeleteSignature" xml:space="preserve">
+    <value>(automated)</value>
+  </data>
+  <data name="UserPackageDeleteSupportRequestMessage" xml:space="preserve">
+    <value>This support request is intended for automatic package deletion.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/ViewModels/DeletePackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DeletePackageViewModel.cs
@@ -11,13 +11,20 @@ namespace NuGetGallery
 {
     public class DeletePackageViewModel : DisplayPackageViewModel
     {
-        public DeletePackageViewModel(Package package, ReportPackageReason[] reportOtherPackageReasons)
+        public DeletePackageViewModel(Package package, IReadOnlyList<ReportPackageReason> reasons)
             : base(package, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)))
         {
             DeletePackagesRequest = new DeletePackagesRequest
             {
-                Packages = new List<string> { string.Format(CultureInfo.InvariantCulture, "{0}|{1}", package.PackageRegistration.Id, package.Version) },
-                ReasonChoices = reportOtherPackageReasons
+                Packages = new List<string>
+                {
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0}|{1}",
+                        package.PackageRegistration.Id,
+                        package.Version)
+                },
+                ReasonChoices = reasons
             };
         }
 

--- a/src/NuGetGallery/ViewModels/PackageDeleteDecision.cs
+++ b/src/NuGetGallery/ViewModels/PackageDeleteDecision.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel;
+
+namespace NuGetGallery
+{
+    public enum PackageDeleteDecision
+    {
+        /// <summary>
+        /// The user would like to delete the package.
+        /// </summary>
+        [Description("Delete this package")]
+        DeletePackage,
+
+        /// <summary>
+        /// The user would like to contact support instead of deleting the package.
+        /// </summary>
+        [Description("Contact support")]
+        ContactSupport,
+    }
+}

--- a/src/NuGetGallery/ViewModels/ReportAbuseViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ReportAbuseViewModel.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Web.Mvc;
-using NuGetGallery.Infrastructure;
 
 namespace NuGetGallery
 {
-    public class ReportAbuseViewModel : ReportMyPackageViewModel
+    public class ReportAbuseViewModel : ReportViewModel
     {
         [Display(Name = "I have already tried to contact the package owner about this problem.")]
         public bool AlreadyContactedOwner { get; set; }
@@ -16,7 +14,6 @@ namespace NuGetGallery
         [Required(ErrorMessage = "Please enter your email address.")]
         [StringLength(4000)]
         [Display(Name = "Your Email Address")]
-        //[DataType(DataType.EmailAddress)] - does not work with client side validation
         [RegularExpression(RegisterViewModel.EmailValidationRegex,
             ErrorMessage = "This doesn't appear to be a valid email address.")]
         public string Email { get; set; }
@@ -25,8 +22,10 @@ namespace NuGetGallery
         [Display(Name = "Signature")]
         public string Signature { get; set; }
 
-        public ReportAbuseViewModel()
-        {
-        }
+        [Required(ErrorMessage = "Please enter a message.")]
+        [AllowHtml]
+        [StringLength(4000)]
+        [Display(Name = "Details")]
+        public string Message { get; set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/ReportMyPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ReportMyPackageViewModel.cs
@@ -1,35 +1,25 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Web.Mvc;
-using NuGetGallery.Infrastructure;
 
 namespace NuGetGallery
 {
-    public class ReportMyPackageViewModel
+    public class ReportMyPackageViewModel : ReportViewModel
     {
-        public string PackageId { get; set; }
-        public string PackageVersion { get; set; }
+        public bool AllowDelete { get; set; }
+        
+        public PackageDeleteDecision? DeleteDecision { get; set; }
 
-        [NotEqual(ReportPackageReason.HasABugOrFailedToInstall, ErrorMessage = "Unfortunately we cannot provide support for bugs in NuGet Packages. Please contact owner(s) for assistance.")]
-        [Required(ErrorMessage = "You must select a reason for reporting the package.")]
-        [Display(Name = "Reason")]
-        public ReportPackageReason? Reason { get; set; }
-
-        [Display(Name = "Send me a copy")]
-        public bool CopySender { get; set; }
-
-        [Required(ErrorMessage = "Please enter a message.")]
+        public bool DeleteConfirmation { get; set; }
+                
         [AllowHtml]
         [StringLength(4000)]
         [Display(Name = "Details")]
         public string Message { get; set; }
 
-        public bool ConfirmedUser { get; set; }
-
-        public IEnumerable<ReportPackageReason> ReasonChoices { get; set; }
-
-        public ReportMyPackageViewModel()
-        {
-        }
+        public IReadOnlyList<ReportPackageReason> DeleteReasonChoices { get; set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/ReportViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ReportViewModel.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using NuGetGallery.Infrastructure;
+
+namespace NuGetGallery
+{
+    public abstract class ReportViewModel
+    {
+        public string PackageId { get; set; }
+
+        public string PackageVersion { get; set; }
+
+        [NotEqual(ReportPackageReason.HasABugOrFailedToInstall, ErrorMessage = "Unfortunately we cannot provide support for bugs in NuGet Packages. Please contact owner(s) for assistance.")]
+        [Required(ErrorMessage = "You must select a reason for reporting the package.")]
+        [Display(Name = "Reason")]
+        public ReportPackageReason? Reason { get; set; }
+
+        [Display(Name = "Send me a copy")]
+        public bool CopySender { get; set; }
+
+        public bool ConfirmedUser { get; set; }
+
+        public IReadOnlyList<ReportPackageReason> ReasonChoices { get; set; }
+    }
+}

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -11,13 +11,13 @@
     <div class="row report-form">
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @Html.Partial("_PackageHeading", new PackageHeadingModel
-                   {
-                       PageHeading = "Report Abuse by",
-                       PackageDisplay = Model.PackageId + " " + Model.PackageVersion,
-                       Id = Model.PackageId,
-                       Version = Model.PackageVersion,
-                       LinkIdOnly = false
-                   })
+            {
+                PageHeading = "Report Abuse by",
+                PackageDisplay = Model.PackageId + " " + Model.PackageVersion,
+                Id = Model.PackageId,
+                Version = Model.PackageVersion,
+                LinkIdOnly = false
+            })
 
             @ViewHelpers.AlertWarning(isAlertRole: true, htmlContent:
                 @<text>

--- a/src/NuGetGallery/Views/Packages/ReportMyPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportMyPackage.cshtml
@@ -11,13 +11,13 @@
     <div class="row report-form">
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             @Html.Partial("_PackageHeading", new PackageHeadingModel
-                   {
-                       PageHeading = "Contact Support about",
-                       PackageDisplay = Model.PackageId + " " + Model.PackageVersion,
-                       Id = Model.PackageId,
-                       Version = Model.PackageVersion,
-                       LinkIdOnly = false
-                   })
+            {
+                PageHeading = "Contact Support about",
+                PackageDisplay = Model.PackageId + " " + Model.PackageVersion,
+                Id = Model.PackageId,
+                Version = Model.PackageVersion,
+                LinkIdOnly = false
+            })
             @using (Html.BeginForm())
             {
                 @Html.AntiForgeryToken()
@@ -26,21 +26,45 @@
                 <div id="form-field-reason" class="form-group @Html.HasErrorFor(m => m.Reason)">
                     @Html.ShowLabelFor(m => m.Reason)
                     <p>Please select the reason for contacting support about this package.</p>
-                    @Html.ShowEnumDropDownListFor(m => m.Reason, Model.ReasonChoices, "<Choose a Reason>")
+                    @Html.ShowEnumDropDownListFor(m => m.Reason, Model.ReasonChoices, "<Choose a reason>")
                     @Html.ShowValidationMessagesFor(m => m.Reason)
                 </div>
-                <div class="form-group @Html.HasErrorFor(m => m.Message)">
+                <div id="form-field-delete-decision" class="hidden form-group @Html.HasErrorFor(m => m.DeleteDecision)">
+                    <p>Please select how you would like to proceed.</p>
+                    @Html.ShowEnumDropDownListFor(m => m.DeleteDecision, "<Choose how to proceed>")
+                    @Html.ShowValidationMessagesFor(m => m.DeleteDecision)
+                </div>
+                <div id="form-field-confirm-delete" class="hidden checkbox">
+                    <label>
+                        @Html.ShowCheckboxFor(m => m.DeleteConfirmation)
+                        I understand that this action cannot be undone. This will permanently delete the package
+                        @Model.PackageId @Model.PackageVersion and make it unavailable for download and package restore.
+                        This does not allow uploading a new package with the same version.
+                    </label>
+                    <div class="@Html.HasErrorFor(m => m.DeleteConfirmation)">
+                        @Html.ShowValidationMessagesFor(m => m.DeleteConfirmation)
+                    </div>
+                </div>
+                <div id="form-field-message" class="form-group @Html.HasErrorFor(m => m.Message)">
                     @Html.ShowLabelFor(m => m.Message)
-                    <p>Please provide a detailed description of the problem.<span class="infringement-claim-requirements"> If you are reporting copyright infringment, please describe the copyrighted material with particularity and provide us with information about your copyright (i.e. title of copyrighted work, URL where to view your copyrighted work, description of your copyrighted work, and any copyright registrations you may have, etc.). For trademark infringement, include the name of your trademark, registration number, and country where registered.</span></p>
+                    <p>
+                        Please provide a detailed description of the problem. <span class="infringement-claim-requirements">
+                        If you are reporting copyright infringment, please describe the copyrighted material with
+                        particularity and provide us with information about your copyright (i.e. title of copyrighted
+                        work, URL where to view your copyrighted work, description of your copyrighted work, and any
+                        copyright registrations you may have, etc.). For trademark infringement, include the name of
+                        your trademark, registration number, and country where registered.</span>
+                    </p>
                     @Html.ShowTextAreaFor(m => m.Message, 10, 50)
                     @Html.ShowValidationMessagesFor(m => m.Message)
                 </div>
-                <div class="form-group @Html.HasErrorFor(m => m.CopySender)">
+                <div id="form-field-copy-sender" class="form-group @Html.HasErrorFor(m => m.CopySender)">
                     @Html.ShowCheckboxFor(m => m.CopySender)
                     @Html.ShowLabelFor(m => m.CopySender)
                     @Html.ShowValidationMessagesFor(m => m.CopySender)
                 </div>
-                <input type="submit" class="btn btn-primary form-control" value="Submit" title="Submit your problem with '@Model.PackageId'" />
+                <input type="submit" class="btn btn-primary form-control" value="Submit"
+                       title="Submit your problem with '@Model.PackageId'" id="Submit" />
             }
         </div>
     </div>
@@ -49,16 +73,81 @@
 @section BottomScripts {
     @Html.SpamPreventionScript()
     <script type="text/javascript">
-        function reasonSelected() {
-            var $reason = $('#Reason');
-            if ($reason.val()) {
-                $reason.parents('form').validate().element($reason);
-            }
-        }
-
         $(function () {
-            $('#Reason').change(reasonSelected);
-            reasonSelected(); // Run once in case it starts with the bad selection
+            var $reason = $('#Reason');
+            var $deleteDecision = $('#DeleteDecision');
+            var $deleteConfirmation = $('#DeleteConfirmation');
+            var $submit = $('#Submit');
+
+            var $form = $reason.parents('form');
+
+            var $deleteDecisionForm = $('#form-field-delete-decision');
+            var $confirmDeleteForm = $('#form-field-confirm-delete');
+            var $messageForm = $('#form-field-message');
+            var $copySenderForm = $('#form-field-copy-sender');
+
+            var DeleteReasonChoices = @Html.Raw(Json.Encode(Model.DeleteReasonChoices.Select(x => x.ToString())));
+            var DeleteThisPackage = @Html.Raw(Json.Encode(PackageDeleteDecision.DeletePackage.ToString()));
+            var allowDelete = @Html.Raw(Json.Encode(Model.AllowDelete));
+
+            function isSubmitDisabled() {
+                return !$deleteConfirmation.prop('checked')
+                    && $deleteDecision.val() == DeleteThisPackage;
+            }
+
+            function reasonSelected() {
+                var reason = $reason.val();
+                if (reason) {
+                    $form.validate().element($reason);
+                }
+                
+                if (allowDelete
+                    && DeleteReasonChoices.indexOf(reason) > -1) {
+                    $deleteDecisionForm.removeClass('hidden');
+                    $confirmDeleteForm.removeClass('hidden');
+                } else {
+                    $deleteDecisionForm.addClass('hidden');
+                    $confirmDeleteForm.addClass('hidden');
+                }
+                
+                deleteDecisionSelected();
+            }
+
+            function deleteDecisionSelected() {
+                var reason = $reason.val();
+                var deleteDecision = $deleteDecision.val();
+                if (allowDelete
+                    && DeleteReasonChoices.indexOf(reason) > -1
+                    && deleteDecision == DeleteThisPackage) {
+                    $messageForm.addClass('hidden');
+                    $copySenderForm.addClass('hidden');
+                    $confirmDeleteForm.removeClass('hidden');
+                } else {
+                    $messageForm.removeClass('hidden');
+                    $copySenderForm.removeClass('hidden');
+                    $confirmDeleteForm.addClass('hidden');
+                }
+
+                $deleteConfirmation.prop('checked', false);
+                deleteConfirmationChanged();
+            }
+
+            function deleteConfirmationChanged() {
+                $submit.prop('disabled', isSubmitDisabled());
+                $submit.toggleClass('disabled', isSubmitDisabled());
+            }
+
+            $reason.change(reasonSelected);
+            $deleteDecision.change(deleteDecisionSelected);
+            $deleteConfirmation.change(deleteConfirmationChanged);
+            $form.submit(function () {
+                if (isSubmitDisabled()) {
+                    return false;
+                }
+            })
+
+            // Run custom rules to initialize the page.
+            reasonSelected();
         });
     </script>
 }

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -16,6 +16,7 @@ using Moq;
 using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Areas.Admin;
+using NuGetGallery.Areas.Admin.Models;
 using NuGetGallery.AsyncFileUpload;
 using NuGetGallery.Auditing;
 using NuGetGallery.Configuration;
@@ -1935,68 +1936,463 @@ namespace NuGetGallery
         public class TheReportMyPackageMethod
             : TestContainer
         {
-            [Fact]
-            public void FormRedirectsNonOwnersToReportAbuse()
-            {
-                var package = new Package
-                {
-                    PackageRegistration = new PackageRegistration { Id = "Mordor", Owners = { new User { Username = "Sauron", Key = 1 } } },
-                    Version = "2.0.1"
-                };
-                var user = new User { EmailAddress = "frodo@hobbiton.example.com", Username = "Frodo", Key = 2 };
-                var packageService = new Mock<IPackageService>();
-                packageService.Setup(p => p.FindPackageByIdAndVersionStrict("Mordor", It.IsAny<string>())).Returns(package);
-                var httpContext = new Mock<HttpContextBase>();
-                var controller = CreateController(
-                    GetConfigurationService(),
-                    packageService: packageService,
-                    httpContext: httpContext);
-                controller.SetCurrentUser(user);
+            private Package _package;
+            private ReportMyPackageViewModel _viewModel;
+            private Issue _supportRequest;
+            private User _user;
+            private Mock<IPackageService> _packageService;
+            private Mock<IMessageService> _messageService;
+            private Mock<IPackageDeleteService> _packageDeleteService;
+            private Mock<ISupportRequestService> _supportRequestService;
+            private PackagesController _controller;
 
-                TestUtility.SetupUrlHelper(controller, httpContext);
-                ActionResult result = controller.ReportMyPackage("Mordor", "2.0.1");
+            public TheReportMyPackageMethod()
+            {
+                _user = new User
+                {
+                    EmailAddress = "frodo@hobbiton.example.com",
+                    Username = "Frodo",
+                    Key = 2
+                };
+                _package = new Package
+                {
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "Mordor",
+                        Owners = { _user },
+                    },
+                    Version = "2.00.1",
+                    NormalizedVersion = "2.0.1",
+                };
+                _viewModel = new ReportMyPackageViewModel
+                {
+                    Reason = ReportPackageReason.ContainsPrivateAndConfidentialData,
+                    Message = "Message!",
+                };
+                _supportRequest = new Issue
+                {
+                    Key = 23,
+                };
+
+                _packageService = new Mock<IPackageService>();
+                _packageService
+                    .Setup(p => p.FindPackageByIdAndVersionStrict(_package.PackageRegistration.Id, _package.Version))
+                    .Returns(_package);
+
+                _messageService = new Mock<IMessageService>();
+                _packageDeleteService = new Mock<IPackageDeleteService>();
+
+                _supportRequestService = new Mock<ISupportRequestService>();
+                _supportRequestService
+                    .Setup(x => x.AddNewSupportRequestAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<User>(),
+                        It.IsAny<Package>()))
+                    .ReturnsAsync(() => _supportRequest);
+
+                var httpContext = new Mock<HttpContextBase>();
+                _controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: _packageService,
+                    messageService: _messageService,
+                    packageDeleteService: _packageDeleteService,
+                    supportRequestService: _supportRequestService,
+                    httpContext: httpContext);
+                _controller.SetCurrentUser(_user);
+
+                TestUtility.SetupUrlHelper(_controller, httpContext);
+            }
+
+            [Fact]
+            public async Task GetRedirectsNonOwnersToReportAbuse()
+            {
+                await RedirectsNonOwnersToReportAbuse(
+                    () => _controller.ReportMyPackage(
+                        _package.PackageRegistration.Id,
+                        _package.Version));
+            }
+
+            [Fact]
+            public async Task PostRedirectsNonOwnersToReportAbuse()
+            {
+                await RedirectsNonOwnersToReportAbuse(
+                    () => _controller.ReportMyPackage(
+                        _package.PackageRegistration.Id,
+                        _package.Version,
+                        _viewModel));
+            }
+
+            private async Task RedirectsNonOwnersToReportAbuse(Func<Task<ActionResult>> actAsync)
+            {
+                // Arrange
+                _package.PackageRegistration.Owners.Clear();
+
+                // Act
+                var result = await actAsync();
+
+                // Assert
                 Assert.IsType<RedirectToRouteResult>(result);
                 Assert.Equal("ReportAbuse", ((RedirectToRouteResult)result).RouteValues["Action"]);
+            }
+
+
+            [Fact]
+            public async Task GetRedirectsMissingPackageToNotFound()
+            {
+                await RedirectsMissingPackageToNotFound(
+                    () => _controller.ReportMyPackage(
+                        _package.PackageRegistration.Id,
+                        _package.Version));
+            }
+
+            [Fact]
+            public async Task PostRedirectsMissingPackageToNotFound()
+            {
+                await RedirectsMissingPackageToNotFound(
+                    () => _controller.ReportMyPackage(
+                        _package.PackageRegistration.Id,
+                        _package.Version,
+                        _viewModel));
+            }
+
+            private async Task RedirectsMissingPackageToNotFound(Func<Task<ActionResult>> actAsync)
+            {
+                // Arrange
+                _packageService
+                    .Setup(x => x.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns<Package>(null);
+
+                // Act
+                var result = await actAsync();
+
+                // Assert
+                Assert.IsType<HttpNotFoundResult>(result);
             }
 
             [Fact]
             public async Task HtmlEncodesMessageContent()
             {
-                var user = new User { Username = "Sauron", Key = 1, EmailAddress = "sauron@mordor.example.com" };
-                var package = new Package
-                {
-                    PackageRegistration = new PackageRegistration { Id = "mordor", Owners = { user } },
-                    Version = "2.0.1"
-                };
-                var packageService = new Mock<IPackageService>();
-                packageService.Setup(p => p.FindPackageByIdAndVersionStrict("mordor", "2.0.1")).Returns(package);
+                // Arrange
+                _viewModel.Message = "I like the cut of your jib. It's <b>bold</b>.";
+                _viewModel.Reason = ReportPackageReason.ViolatesALicenseIOwn;
 
                 ReportPackageRequest reportRequest = null;
-                var messageService = new Mock<IMessageService>();
-                messageService
+                _messageService
                     .Setup(s => s.ReportMyPackage(It.IsAny<ReportPackageRequest>()))
                     .Callback<ReportPackageRequest>(r => reportRequest = r);
-                var httpContext = new Mock<HttpContextBase>();
-                var controller = CreateController(
-                    GetConfigurationService(),
-                    packageService: packageService,
-                    messageService: messageService,
-                    httpContext: httpContext);
-                controller.SetCurrentUser(user);
-                var model = new ReportMyPackageViewModel
-                {
-                    Message = "I like the cut of your jib. It's <b>bold</b>.",
-                    Reason = ReportPackageReason.ViolatesALicenseIOwn
-                };
 
-                TestUtility.SetupUrlHelper(controller, httpContext);
-                await controller.ReportMyPackage("mordor", "2.0.1", model);
+                // Act
+                await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    _viewModel);
 
+                // Assert
                 Assert.NotNull(reportRequest);
-                Assert.Equal(user.EmailAddress, reportRequest.FromAddress.Address);
-                Assert.Same(package, reportRequest.Package);
+                Assert.Equal(_user.EmailAddress, reportRequest.FromAddress.Address);
+                Assert.Same(_package, reportRequest.Package);
                 Assert.Equal(EnumHelper.GetDescription(ReportPackageReason.ViolatesALicenseIOwn), reportRequest.Reason);
                 Assert.Equal("I like the cut of your jib. It&#39;s &lt;b&gt;bold&lt;/b&gt;.", reportRequest.Message);
+            }
+
+            [Fact]
+            public async Task DoesNotCheckDeleteAllowedIfDeleteWasNotRequested()
+            {
+                // Arrange
+                _viewModel.DeleteDecision = PackageDeleteDecision.ContactSupport;
+                _viewModel.Message = "Test message!";
+
+                // Act
+                var result = await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    _viewModel);
+
+                // Assert
+                _packageDeleteService.Verify(
+                    x => x.CanPackageBeDeletedByUserAsync(
+                        It.IsAny<Package>()),
+                    Times.Never);
+                _supportRequestService.Verify(
+                    x => x.AddNewSupportRequestAsync(
+                        string.Format(
+                            Strings.OwnerSupportRequestSubjectFormat,
+                            _package.PackageRegistration.Id,
+                            _package.NormalizedVersion),
+                        "Test message!",
+                        _user.EmailAddress,
+                        EnumHelper.GetDescription(_viewModel.Reason.Value),
+                        _user,
+                        _package),
+                    Times.Once);
+                Assert.Equal(Strings.SupportRequestSentTransientMessage, _controller.TempData["Message"]);
+            }
+
+            [Fact]
+            public async Task AllowsPackageDelete()
+            {
+                // Arrange
+                _viewModel.DeleteDecision = PackageDeleteDecision.DeletePackage;
+                _viewModel.DeleteConfirmation = true;
+                _packageDeleteService
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .ReturnsAsync(true);
+
+                // Act
+                var result = await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    _viewModel);
+
+                // Assert
+                Assert.IsType<RedirectResult>(result);
+
+                _supportRequestService.Verify(
+                    x => x.AddNewSupportRequestAsync(
+                        string.Format(
+                            Strings.OwnerSupportRequestSubjectFormat,
+                            _package.PackageRegistration.Id,
+                            _package.NormalizedVersion),
+                        Strings.UserPackageDeleteSupportRequestMessage,
+                        _user.EmailAddress,
+                        EnumHelper.GetDescription(_viewModel.Reason.Value),
+                        _user,
+                        _package),
+                    Times.Once);
+                _packageDeleteService.Verify(
+                    x => x.SoftDeletePackagesAsync(
+                        It.Is<IEnumerable<Package>>(p => p.First() == _package),
+                        _user,
+                        EnumHelper.GetDescription(_viewModel.Reason.Value),
+                        Strings.UserPackageDeleteSignature),
+                    Times.Once);
+                _supportRequestService.Verify(
+                    x => x.UpdateIssueAsync(
+                        _supportRequest.Key,
+                        null,
+                        IssueStatusKeys.Resolved,
+                        null,
+                        _user.Username),
+                    Times.Once);
+                _messageService.Verify(
+                    x => x.SendPackageDeletedNotice(
+                        _package,
+                        It.IsAny<string>(),
+                        It.IsAny<string>()),
+                    Times.Once);
+                Assert.Equal(Strings.UserPackageDeleteCompleteTransientMessage, _controller.TempData["Message"]);
+
+                _messageService.Verify(
+                    x => x.ReportMyPackage(It.IsAny<ReportPackageRequest>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task TreatsDeleteFailureAsNormalRequest()
+            {
+                // Arrange
+                _viewModel.DeleteDecision = PackageDeleteDecision.DeletePackage;
+                _viewModel.DeleteConfirmation = true;
+                _viewModel.CopySender = true;
+                _packageDeleteService
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .ReturnsAsync(true);
+                _packageDeleteService
+                    .Setup(x => x.SoftDeletePackagesAsync(
+                        It.IsAny<IEnumerable<Package>>(),
+                        It.IsAny<User>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()))
+                    .Throws(new Exception("bad!"));
+
+                // Act
+                var result = await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    _viewModel);
+
+                // Assert
+                Assert.IsType<RedirectResult>(result);
+                Assert.False(_viewModel.CopySender, "The sender is not copied when an automatic delete fails.");
+                _packageDeleteService.Verify(
+                    x => x.SoftDeletePackagesAsync(
+                        It.Is<IEnumerable<Package>>(p => p.First() == _package),
+                        _user,
+                        EnumHelper.GetDescription(_viewModel.Reason.Value),
+                        Strings.UserPackageDeleteSignature),
+                    Times.Once);
+                _supportRequestService.Verify(
+                    x => x.UpdateIssueAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<int?>(),
+                        It.IsAny<int>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()),
+                    Times.Never);
+                _messageService.Verify(
+                    x => x.SendPackageDeletedNotice(
+                        It.IsAny<Package>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()),
+                    Times.Never);
+                _messageService.Verify(
+                    x => x.ReportMyPackage(It.IsAny<ReportPackageRequest>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task RequiresMessageWhenNotDeleting()
+            {
+                // Arrange
+                _viewModel.DeleteDecision = PackageDeleteDecision.ContactSupport;
+                _viewModel.Message = null;
+                _packageDeleteService
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .ReturnsAsync(true);
+
+                // Act
+                var result = await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    _viewModel);
+
+                // Assert
+                Assert.Contains(
+                    Strings.MessageIsRequired,
+                    _controller
+                        .ModelState
+                        .Values
+                        .SelectMany(x => x.Errors)
+                        .Select(x => x.ErrorMessage));
+            }
+
+            [Fact]
+            public async Task RequiresConfirmationWhenDeleting()
+            {
+                // Arrange
+                _viewModel.DeleteDecision = PackageDeleteDecision.DeletePackage;
+                _viewModel.DeleteConfirmation = false;
+                _packageDeleteService
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .ReturnsAsync(true);
+
+                // Act
+                var result = await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    _viewModel);
+
+                // Assert
+                Assert.Contains(
+                    Strings.UserPackageDeleteConfirmationIsRequired,
+                    _controller
+                        .ModelState
+                        .Values
+                        .SelectMany(x => x.Errors)
+                        .Select(x => x.ErrorMessage));
+            }
+
+            [Theory]
+            [InlineData(ReportPackageReason.ContainsMaliciousCode)]
+            [InlineData(ReportPackageReason.ContainsPrivateAndConfidentialData)]
+            [InlineData(ReportPackageReason.ReleasedInPublicByAccident)]
+            public async Task RequiresDeleteDecision(ReportPackageReason reason)
+            {
+                // Arrange
+                _viewModel.Reason = reason;
+                _viewModel.DeleteDecision = null;
+                _viewModel.DeleteConfirmation = true;
+                _packageDeleteService
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .ReturnsAsync(true);
+
+                // Act
+                var result = await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    _viewModel);
+
+                // Assert
+                Assert.Contains(
+                    Strings.UserPackageDeleteDecisionIsRequired,
+                    _controller
+                        .ModelState
+                        .Values
+                        .SelectMany(x => x.Errors)
+                        .Select(x => x.ErrorMessage));
+            }
+            
+            [Theory]
+            [InlineData(ReportPackageReason.Other)]
+            public async Task DoesNotRequireDeleteDecision(ReportPackageReason reason)
+            {
+                // Arrange
+                _viewModel.Reason = reason;
+                _viewModel.DeleteDecision = null;
+                _packageDeleteService
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .ReturnsAsync(false);
+
+                // Act
+                var result = await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    _viewModel);
+
+                // Assert
+                Assert.IsType<RedirectResult>(result);
+                Assert.Equal(
+                    Strings.SupportRequestSentTransientMessage,
+                    _controller.TempData["Message"]);
+
+                _packageDeleteService.Verify(
+                    x => x.SoftDeletePackagesAsync(
+                        It.IsAny<IEnumerable<Package>>(),
+                        It.IsAny<User>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()),
+                    Times.Never);
+                _messageService.Verify(
+                    x => x.ReportMyPackage(It.IsAny<ReportPackageRequest>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task IgnoresDeleteRequestWhenNotAllowed()
+            {
+                // Arrange
+                _viewModel.Reason = ReportPackageReason.ContainsPrivateAndConfidentialData;
+                _viewModel.DeleteDecision = PackageDeleteDecision.DeletePackage;
+                _viewModel.DeleteConfirmation = true;
+                _packageDeleteService
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .ReturnsAsync(false);
+
+                // Act
+                var result = await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    _viewModel);
+
+                // Assert
+                Assert.IsType<RedirectResult>(result);
+                Assert.Equal(
+                    Strings.SupportRequestSentTransientMessage,
+                    _controller.TempData["Message"]);
+
+                _packageDeleteService.Verify(
+                    x => x.SoftDeletePackagesAsync(
+                        It.IsAny<IEnumerable<Package>>(),
+                        It.IsAny<User>(),
+                        It.IsAny<string>(),
+                        It.IsAny<string>()),
+                    Times.Never);
+                _messageService.Verify(
+                    x => x.ReportMyPackage(It.IsAny<ReportPackageRequest>()),
+                    Times.Once);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -1924,7 +1924,7 @@ namespace NuGetGallery
                    .Returns(issues);
                 GetMock<ISupportRequestService>()
                   .Setup(stub => stub.AddNewSupportRequestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), testUser, null))
-                  .Returns(Task<bool>.FromResult(successOnSentRequest));
+                  .ReturnsAsync(successOnSentRequest ? new Issue() : (Issue)null);
 
                 // act
                 var result = await controller.RequestAccountDeletion() as RedirectToRouteResult;

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -860,6 +860,51 @@ namespace NuGetGallery
             }
         }
 
+        public class TheSendPackageDeletedNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailToAllOwners()
+            {
+                // Arrange
+                var nugetVersion = new NuGetVersion("3.1.0");
+                var packageRegistration = new PackageRegistration
+                {
+                    Id = "smangit",
+                    Owners = new[]
+                    {
+                        new User { EmailAddress = "yung@example.com" },
+                        new User { EmailAddress = "flynt@example.com" }
+                    }
+                };
+                var package = new Package
+                {
+                    Version = "3.1.0",
+                    PackageRegistration = packageRegistration
+                };
+                packageRegistration.Packages.Add(package);
+                
+                var messageService = TestableMessageService.Create(
+                    GetService<AuthenticationService>(),
+                    GetConfigurationService());
+                var packageUrl = $"https://localhost/packages/{packageRegistration.Id}/{nugetVersion.ToNormalizedString()}";
+                var supportUrl = $"https://localhost/packages/{packageRegistration.Id}/{nugetVersion.ToNormalizedString()}/ReportMyPackage";
+
+                // Act
+                messageService.SendPackageDeletedNotice(package, packageUrl, supportUrl);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal("yung@example.com", message.To[0].Address);
+                Assert.Equal("flynt@example.com", message.To[1].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Contains($"[Joe Shmoe] Package deleted - {packageRegistration.Id} {nugetVersion.ToNormalizedString()}", message.Subject);
+                Assert.Contains(
+                    $"The package [{packageRegistration.Id} {nugetVersion.ToFullString()}]({packageUrl}) was just deleted from Joe Shmoe. If this was not intended, please [contact support]({supportUrl}).", message.Body);
+            }
+        }
+
         public class TestableMessageService 
             : MessageService
         {


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/921.

The changes were getting big so I stopped and made a PR. Hopefully easier to review.

This PR:

1. Update the "report my package" form to support a new hidden drop-down (delete decision) and confirmation checkbox.
1. Add new notification message so that all owners know a version was deleted.
1. Add method to `IPackageDeleteService` to determine if a package can be deleted. It always returns false right now.
1. Add logic to soft delete the package and auto-close the support request.

TODO:

1. Implement "can I delete this?" logic.
1. Introduce configuration for the aforementioned logic.
1. Functional test (hopefully)

Without these TODOs, the new code paths introduced by this PR will not be available yet.
