### PR TITLE
Add ApiKey owner scope auditing

### DIFF
--- a/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
@@ -43,7 +43,8 @@ namespace NuGetGallery.Auditing
             Scopes = new List<ScopeAuditRecord>();
             foreach (var scope in credential.Scopes)
             {
-                Scopes.Add(new ScopeAuditRecord(scope.Subject, scope.AllowedAction));
+                var ownerScope = scope.Owner?.Username;
+                Scopes.Add(new ScopeAuditRecord(ownerScope, scope.Subject, scope.AllowedAction));
             }
         }
     }

--- a/src/NuGetGallery.Core/Auditing/ScopeAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/ScopeAuditRecord.cs
@@ -5,11 +5,13 @@ namespace NuGetGallery.Auditing
 {
     public class ScopeAuditRecord
     {
+        public string OwnerUsername { get; set; }
         public string Subject { get; set; }
         public string AllowedAction { get; set; }
 
-        public ScopeAuditRecord(string subject, string allowedAction)
+        public ScopeAuditRecord(string ownerUsername, string subject, string allowedAction)
         {
+            OwnerUsername = ownerUsername;
             Subject = subject;
             AllowedAction = allowedAction;
         }

--- a/tests/NuGetGallery.Core.Facts/Auditing/ScopeAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/ScopeAuditRecordTests.cs
@@ -8,13 +8,14 @@ namespace NuGetGallery.Auditing
     public class ScopeAuditRecordTests
     {
         [Theory]
-        [InlineData(null, null)]
-        [InlineData("", "")]
-        [InlineData("a", "b")]
-        public void Constructor_SetsProperties(string subject, string allowedAction)
+        [InlineData(null, null, null)]
+        [InlineData("", "", "")]
+        [InlineData("a", "b", "c")]
+        public void Constructor_SetsProperties(string owner, string subject, string allowedAction)
         {
-            var entry = new ScopeAuditRecord(subject, allowedAction);
+            var entry = new ScopeAuditRecord(owner, subject, allowedAction);
 
+            Assert.Equal(owner, entry.OwnerUsername);
             Assert.Equal(subject, entry.Subject);
             Assert.Equal(allowedAction, entry.AllowedAction);
         }


### PR DESCRIPTION
Issue #4958 

Shims change doesn't seem to be necessary, since IfxAuditingService only records the AffectedCredential key and type (e.g., DB PK and "apikey.v2"). This change will ensure that the owner scope is included in CloudBlobAuditingService audit records.
