### PR TITLE
Fix new Login UI validation errors missing bug and add telemetry

### DIFF
--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -461,6 +461,8 @@ namespace NuGetGallery.Authentication
             await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.AddCredential, credential));
             user.Credentials.Add(credential);
             await Entities.SaveChangesAsync();
+
+            _telemetryService.TrackNewCredentialCreated(user, credential);
         }
 
         public virtual CredentialViewModel DescribeCredential(Credential credential)

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -144,7 +144,7 @@ namespace NuGetGallery
                     modelErrorMessage = string.Format(CultureInfo.CurrentCulture, Strings.UserAccountLocked, timeRemaining);
                 }
 
-                ModelState.AddModelError("SignInNuGetAccount", modelErrorMessage);
+                ModelState.AddModelError("SignIn", modelErrorMessage);
 
                 return SignInOrExternalLinkView(model, linkingAccount);
             }

--- a/src/NuGetGallery/Services/ITelemetryService.cs
+++ b/src/NuGetGallery/Services/ITelemetryService.cs
@@ -23,6 +23,8 @@ namespace NuGetGallery
 
         void TrackNewUserRegistrationEvent(User user, Credential identity);
 
+        void TrackNewCredentialCreated(User user, Credential credential);
+
         /// <summary>
         /// Create a trace for an exception. These are informational for support requests.
         /// </summary>

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -22,6 +22,7 @@ namespace NuGetGallery
             public const string PackageReadMeChanged = "PackageReadMeChanged";
             public const string PackagePushNamespaceConflict = "PackagePushNamespaceConflict";
             public const string NewUserRegistration = "NewUserRegistration";
+            public const string CredentialAdded = "CredentialAdded";
         }
 
         private IDiagnosticsSource _diagnosticsSource;
@@ -159,6 +160,16 @@ namespace NuGetGallery
 
         public void TrackNewUserRegistrationEvent(User user, Credential credential)
         {
+            TrackAccountActivityForEvent(Events.NewUserRegistration, user, credential);
+        }
+
+        public void TrackNewCredentialCreated(User user, Credential credential)
+        {
+            TrackAccountActivityForEvent(Events.CredentialAdded, user, credential);
+        }
+
+        private void TrackAccountActivityForEvent(string eventName, User user, Credential credential)
+        {
             if (user == null)
             {
                 throw new ArgumentNullException(nameof(user));
@@ -169,7 +180,7 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(credential));
             }
 
-            TrackEvent(Events.NewUserRegistration, properties => {
+            TrackEvent(eventName, properties => {
                 properties.Add(ClientVersion, GetClientVersion());
                 properties.Add(ProtocolVersion, GetProtocolVersion());
                 properties.Add(AccountCreationDate, GetAccountCreationDate(user));

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -143,7 +143,7 @@ namespace NuGetGallery.Controllers
 
                 ResultAssert.IsView(result, viewName: SignInViewNuGetName);
                 Assert.False(controller.ModelState.IsValid);
-                Assert.Equal(Strings.UsernameAndPasswordNotFound, controller.ModelState[SignInViewNuGetName].Errors[0].ErrorMessage);
+                Assert.Equal(Strings.UsernameAndPasswordNotFound, controller.ModelState[SignInViewName].Errors[0].ErrorMessage);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -63,6 +63,10 @@ namespace NuGetGallery
                     yield return new object[] { "NewUserRegistration",
                         (TrackAction)(s => s.TrackNewUserRegistrationEvent(fakes.User, fakes.User.Credentials.First()))
                     };
+
+                    yield return new object[] { "CredentialAdded",
+                        (TrackAction)(s => s.TrackNewUserRegistrationEvent(fakes.User, fakes.User.Credentials.First()))
+                    };
                 }
             }
 


### PR DESCRIPTION
This PR fixes https://github.com/NuGet/NuGetGallery/issues/5020 where new Login UI wouldn't show validation errors for bad username and password. Also added telemetry for credential added(for getting data on MSA account linking)