### PR TITLE
Show VerifyPackage errors correctly in UI

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1589,7 +1589,16 @@ namespace NuGetGallery
 
                 if (pendEdit)
                 {
-                    _editPackageService.StartEditPackageRequest(package, formData.Edit, currentUser);
+                    try
+                    {
+                        _editPackageService.StartEditPackageRequest(package, formData.Edit, currentUser);
+                    }
+                    catch (EntityException ex)
+                    {
+                        _telemetryService.TraceException(ex);
+
+                        return Json(400, new[] { ex.Message });
+                    }
                 }
 
                 if (!formData.Listed)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1557,9 +1557,7 @@ namespace NuGetGallery
                 {
                     _telemetryService.TraceException(ex);
 
-                    TempData["Message"] = ex.Message;
-
-                    return Json(400, new[] { ex.GetUserSafeMessage() });
+                    return Json(400, new[] { ex.Message });
                 }
 
                 var pendEdit = false;

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -140,7 +140,8 @@ var AsyncFileUploadManager = new function () {
     }
 
     function cancelUploadAsync(callback, error) {
-        $('#warning-container').addClass("hidden");
+        clearErrors();
+
         $.ajax({
             url: _cancelUrl,
             type: 'POST',
@@ -192,6 +193,8 @@ var AsyncFileUploadManager = new function () {
             return;
         }
 
+        clearErrors()
+
         var failureContainer = $("#validation-failure-container");
         var failureListContainer = document.createElement("div");
         $(failureListContainer).attr("id", "validation-failure-list");
@@ -204,6 +207,10 @@ var AsyncFileUploadManager = new function () {
     function clearErrors() {
         $("#validation-failure-container").addClass("hidden");
         $("#validation-failure-list").remove();
+
+        var warnings = $('#warning-container');
+        warnings.addClass("hidden");
+        warnings.children().remove();
     }
 
     function bindData(model) {
@@ -245,7 +252,7 @@ var AsyncFileUploadManager = new function () {
                 $('#verify-submit-button').attr('disabled', 'disabled');
                 $('#verify-submit-button').attr('value', 'Submitting');
                 $('#verify-submit-button').addClass('.loading');
-                submitVerifyAsync(navigateToPage);
+                submitVerifyAsync(navigateToPage, bindData.bind(this, model));
             });
 
             $('#iconurl-field').on('change', function () {


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/4787

A couple fixes here:
1 - if starting an edit request fails (due to title/ID collision), return the error message in JSON
2 - keep the form open when verifying fails
3 - clear warnings when showing errors for an upload
4 - clear errors when canceling an upload