### PR TITLE
Rename FindPackagesByOwner API

### DIFF
--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -111,7 +111,7 @@ namespace NuGetGallery
             }
 
             var listPackageItems = _packageService
-                 .FindPackagesByOwner(user, includeUnlisted: true)
+                 .FindPackagesByAnyMatchingOwner(user, includeUnlisted: true)
                  .Select(p => new ListPackageItemViewModel(p))
                  .ToList();
 
@@ -170,7 +170,7 @@ namespace NuGetGallery
             }
 
             var listPackageItems = _packageService
-                 .FindPackagesByOwner(user, includeUnlisted:true)
+                 .FindPackagesByAnyMatchingOwner(user, includeUnlisted:true)
                  .Select(p => new ListPackageItemViewModel(p))
                  .ToList();
             var model = new DeleteUserAccountViewModel
@@ -284,7 +284,7 @@ namespace NuGetGallery
         public virtual ActionResult Packages()
         {
             var user = GetCurrentUser();
-            var packages = _packageService.FindPackagesByOwner(user, includeUnlisted: true)
+            var packages = _packageService.FindPackagesByAnyMatchingOwner(user, includeUnlisted: true)
                 .Select(p => new ListPackageItemViewModel(p)).OrderBy(p => p.Id).ToList();
 
             var incoming = _packageOwnerRequestService.GetPackageOwnershipRequests(newOwner: user);
@@ -470,7 +470,7 @@ namespace NuGetGallery
                 return HttpNotFound();
             }
 
-            var packages = _packageService.FindPackagesByOwner(user, includeUnlisted: false)
+            var packages = _packageService.FindPackagesByAnyMatchingOwner(user, includeUnlisted: false)
                 .OrderByDescending(p => p.PackageRegistration.DownloadCount)
                 .Select(p => new ListPackageItemViewModel(p)
                 {

--- a/src/NuGetGallery/Services/DeleteAccountService.cs
+++ b/src/NuGetGallery/Services/DeleteAccountService.cs
@@ -144,7 +144,7 @@ namespace NuGetGallery
 
         private async Task DeleteGalleryUserAccountImplAsync(User useToBeDeleted, User admin, string signature, bool unlistOrphanPackages)
         {
-            var ownedPackages = _packageService.FindPackagesByOwner(useToBeDeleted, includeUnlisted: true).ToList();
+            var ownedPackages = _packageService.FindPackagesByAnyMatchingOwner(useToBeDeleted, includeUnlisted: true).ToList();
 
             await RemoveOwnership(useToBeDeleted, admin, unlistOrphanPackages, ownedPackages);
             await RemoveReservedNamespaces(useToBeDeleted);

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -29,7 +29,7 @@ namespace NuGetGallery
         Package FindPackageByIdAndVersion(string id, string version, int? semVerLevelKey = null, bool allowPrerelease = true);
 
         Package FindAbsoluteLatestPackageById(string id, int? semVerLevelKey);
-        IEnumerable<Package> FindPackagesByOwner(User user, bool includeUnlisted);
+        IEnumerable<Package> FindPackagesByAnyMatchingOwner(User user, bool includeUnlisted);
         IEnumerable<PackageRegistration> FindPackageRegistrationsByOwner(User user);
         IEnumerable<Package> FindDependentPackages(Package package);
 

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -214,7 +214,7 @@ namespace NuGetGallery
         /// <summary>
         /// Find packages by owner, including organization owners that the user belongs to.
         /// </summary>
-        public IEnumerable<Package> FindPackagesByOwner(User user, bool includeUnlisted)
+        public IEnumerable<Package> FindPackagesByAnyMatchingOwner(User user, bool includeUnlisted)
         {
             // Like DisplayPackage we should prefer to show you information from the latest stable version,
             // but show you the latest version (potentially latest UNLISTED version) otherwise.

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -1943,10 +1943,10 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(userName))
                     .Returns(testUser);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByOwner(testUser, It.IsAny<bool>()))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>()))
                     .Returns(userPackages);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByOwner(testUser, It.IsAny<bool>()))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>()))
                     .Returns(userPackages);
 
                 // act
@@ -2005,7 +2005,7 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(userName))
                     .Returns(testUser);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByOwner(testUser, It.IsAny<bool>()))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>()))
                     .Returns(userPackages);
                 GetMock<ISupportRequestService>()
                    .Setup(stub => stub.GetIssues(null, null, null, null))
@@ -2048,7 +2048,7 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(userName))
                     .Returns(testUser);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByOwner(testUser, It.IsAny<bool>()))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>()))
                     .Returns(userPackages);
                 GetMock<ISupportRequestService>()
                    .Setup(stub => stub.GetIssues(null, null, null, userName))

--- a/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
@@ -275,7 +275,7 @@ namespace NuGetGallery
             private Mock<IPackageService> SetupPackageService()
             {
                 var packageService = new Mock<IPackageService>();
-                packageService.Setup(m => m.FindPackagesByOwner(_user, true)).Returns(_userPackages);
+                packageService.Setup(m => m.FindPackagesByAnyMatchingOwner(_user, true)).Returns(_userPackages);
                 //the .Returns(Task.CompletedTask) to avoid NullRef exception by the Mock infrastructure when invoking async operations
                 packageService.Setup(m => m.MarkPackageUnlistedAsync(It.IsAny<Package>(), true))
                               .Returns(Task.CompletedTask)

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -916,7 +916,7 @@ namespace NuGetGallery
             }
         }
 
-        public class TheFindPackagesByOwnerMethod : TestContainer
+        public class TheFindPackagesByAnyMatchingOwnerMethod : TestContainer
         {
             public static IEnumerable<object[]> TestData_PackageOwnerVariants
             {
@@ -964,7 +964,7 @@ namespace NuGetGallery
                 context.Packages.Add(package);
                 var service = Get<PackageService>();
 
-                var packages = service.FindPackagesByOwner(currentUser, includeUnlisted: false);
+                var packages = service.FindPackagesByAnyMatchingOwner(currentUser, includeUnlisted: false);
                 Assert.Equal(1, packages.Count());
             }
 
@@ -982,7 +982,7 @@ namespace NuGetGallery
                 context.Packages.Add(package);
                 var service = Get<PackageService>();
 
-                var packages = service.FindPackagesByOwner(currentUser, includeUnlisted: false);
+                var packages = service.FindPackagesByAnyMatchingOwner(currentUser, includeUnlisted: false);
                 Assert.Equal(0, packages.Count());
             }
 
@@ -1000,7 +1000,7 @@ namespace NuGetGallery
                 context.Packages.Add(package);
                 var service = Get<PackageService>();
 
-                var packages = service.FindPackagesByOwner(currentUser, includeUnlisted: true);
+                var packages = service.FindPackagesByAnyMatchingOwner(currentUser, includeUnlisted: true);
                 Assert.Equal(1, packages.Count());
             }
 
@@ -1023,7 +1023,7 @@ namespace NuGetGallery
                 context.Packages.Add(packageB);
                 var service = Get<PackageService>();
 
-                var packages = service.FindPackagesByOwner(currentUser, includeUnlisted: false).ToList();
+                var packages = service.FindPackagesByAnyMatchingOwner(currentUser, includeUnlisted: false).ToList();
                 Assert.Equal(2, packages.Count);
                 Assert.Contains(packageA, packages);
                 Assert.Contains(packageB, packages);
@@ -1047,7 +1047,7 @@ namespace NuGetGallery
                 context.Packages.Add(latestStablePackage);
                 var service = Get<PackageService>();
 
-                var packages = service.FindPackagesByOwner(currentUser, includeUnlisted: false).ToList();
+                var packages = service.FindPackagesByAnyMatchingOwner(currentUser, includeUnlisted: false).ToList();
                 Assert.Equal(1, packages.Count);
                 Assert.Contains(latestStablePackage, packages);
             }
@@ -1069,7 +1069,7 @@ namespace NuGetGallery
                 context.Packages.Add(latestStablePackage);
                 var service = Get<PackageService>();
 
-                var packages = service.FindPackagesByOwner(currentUser, includeUnlisted: false).ToList();
+                var packages = service.FindPackagesByAnyMatchingOwner(currentUser, includeUnlisted: false).ToList();
                 Assert.Equal(1, packages.Count);
                 Assert.Contains(latestStablePackage, packages);
             }
@@ -1092,7 +1092,7 @@ namespace NuGetGallery
                 context.Packages.Add(package1);
                 var service = Get<PackageService>();
 
-                var packages = service.FindPackagesByOwner(currentUser, includeUnlisted: false);
+                var packages = service.FindPackagesByAnyMatchingOwner(currentUser, includeUnlisted: false);
                 Assert.Equal(1, packages.Count());
                 Assert.Contains(package2, packages);
             }


### PR DESCRIPTION
Renaming `FindPackagesByOwner` to `FindPackagesByAnyMatchingOwner`, so it's more obvious how this differs from the `FindPackageRegistrationsByOwner` which will continue to only look for direct ownership.

@scottbommarito @shishirx34 - based on our discussion of PR #5022 feedback.