### PR TITLE
Hide enable password login flow until user verification

### DIFF
--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -575,7 +575,12 @@ namespace NuGetGallery
             if (oldPassword == null)
             {
                 // User is requesting a password set email
-                await _authService.GeneratePasswordResetToken(user, Constants.PasswordResetTokenExpirationHours * 60);
+                var result = await _authService.GeneratePasswordResetToken(user, Constants.PasswordResetTokenExpirationHours * 60);
+                if (result == PasswordResetResultType.UserNotConfirmed)
+                {
+                    ModelState.AddModelError("ChangePassword", Strings.UserIsNotYetConfirmed);
+                    return AccountView(model);
+                }
 
                 return SendPasswordResetEmail(user, forgotPassword: false);
             }

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -334,7 +334,7 @@ namespace NuGetGallery
                     case PasswordResetResultType.Success:
                         return SendPasswordResetEmail(result.User, forgotPassword: true);
                     default:
-                        throw new NotImplementedException($"The passwword reset result type '{result.Type}' is not supported.");
+                        throw new NotImplementedException($"The password reset result type '{result.Type}' is not supported.");
                 }
             }
 

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -575,8 +575,8 @@ namespace NuGetGallery
             if (oldPassword == null)
             {
                 // User is requesting a password set email
-                var result = await _authService.GeneratePasswordResetToken(user, Constants.PasswordResetTokenExpirationHours * 60);
-                if (result == PasswordResetResultType.UserNotConfirmed)
+                var resetResultType = await _authService.GeneratePasswordResetToken(user, Constants.PasswordResetTokenExpirationHours * 60);
+                if (resetResultType == PasswordResetResultType.UserNotConfirmed)
                 {
                     ModelState.AddModelError("ChangePassword", Strings.UserIsNotYetConfirmed);
                     return AccountView(model);

--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -309,7 +309,7 @@
                     }
                     else
                     {
-                        <p>To enable password login, please confirm your account.</p>
+                        <p>To enable password login, please <a href="@Url.ConfirmationRequired()">confirm</a> your account.</p>
                     }
                 </text>,
                 ViewData.ModelState.Keys.Any(x => x.StartsWith("ChangePassword")))

--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -252,57 +252,64 @@
                 @<text>Password Login</text>,
                 @<text><em>@(Model.HasPassword ? "(Enabled)" : "(Disabled)")</em></text>,
                 @<text>
-                    @using (Html.BeginForm("ChangePassword", "Users"))
+                    @if (CurrentUser.Confirmed)
                     {
-                        @Html.AntiForgeryToken()
-                        @Html.ShowValidationMessagesFor(m => m.ChangePassword)
+                        using (Html.BeginForm("ChangePassword", "Users"))
+                        {
+                            @Html.AntiForgeryToken()
+                            @Html.ShowValidationMessagesFor(m => m.ChangePassword)
 
-                        if (Model.SignInCredentialCount > 1)
-                        {
-                            <div class="form-group @Html.HasErrorFor(m => m.ChangePassword.EnablePasswordLogin)">
-                                @Html.ShowCheckboxFor(m => m.ChangePassword.EnablePasswordLogin)
-                                @Html.ShowLabelFor(m => m.ChangePassword.EnablePasswordLogin)
-                                @Html.ShowValidationMessagesFor(m => m.ChangePassword.EnablePasswordLogin)
-                            </div>
-                        }
-                        else
-                        {
-                            @Html.HiddenFor(m => m.ChangePassword.EnablePasswordLogin);
-                        }
+                            if (Model.SignInCredentialCount > 1)
+                            {
+                                <div class="form-group @Html.HasErrorFor(m => m.ChangePassword.EnablePasswordLogin)">
+                                    @Html.ShowCheckboxFor(m => m.ChangePassword.EnablePasswordLogin)
+                                    @Html.ShowLabelFor(m => m.ChangePassword.EnablePasswordLogin)
+                                    @Html.ShowValidationMessagesFor(m => m.ChangePassword.EnablePasswordLogin)
+                                </div>
+                            }
+                            else
+                            {
+                                @Html.HiddenFor(m => m.ChangePassword.EnablePasswordLogin);
+                            }
 
-                        if (Model.HasPassword)
-                        {
-                            <div class="form-group @Html.HasErrorFor(m => m.ChangePassword.OldPassword)">
-                                @Html.ShowLabelFor(m => m.ChangePassword.OldPassword)
-                                @Html.ShowPasswordFor(m => m.ChangePassword.OldPassword)
-                                @Html.ShowValidationMessagesFor(m => m.ChangePassword.OldPassword)
-                            </div>
-                            <div class="form-group @Html.HasErrorFor(m => m.ChangePassword.NewPassword)">
-                                @Html.ShowLabelFor(m => m.ChangePassword.NewPassword)
-                                @Html.ShowPasswordFor(m => m.ChangePassword.NewPassword)
-                                @Html.ShowValidationMessagesFor(m => m.ChangePassword.NewPassword)
-                            </div>
-                            <div class="form-group @Html.HasErrorFor(m => m.ChangePassword.VerifyPassword)">
-                                @Html.ShowLabelFor(m => m.ChangePassword.VerifyPassword)
-                                @Html.ShowPasswordFor(m => m.ChangePassword.VerifyPassword)
-                                @Html.ShowValidationMessagesFor(m => m.ChangePassword.VerifyPassword)
-                            </div>
-                        }
-                        else
-                        {
-                            <p>To enable password login, an email will be sent to '@(CurrentUser.EmailAddress ?? CurrentUser.UnconfirmedEmailAddress)'.</p>
-                        }
+                            if (Model.HasPassword)
+                            {
+                                <div class="form-group @Html.HasErrorFor(m => m.ChangePassword.OldPassword)">
+                                    @Html.ShowLabelFor(m => m.ChangePassword.OldPassword)
+                                    @Html.ShowPasswordFor(m => m.ChangePassword.OldPassword)
+                                    @Html.ShowValidationMessagesFor(m => m.ChangePassword.OldPassword)
+                                </div>
+                                <div class="form-group @Html.HasErrorFor(m => m.ChangePassword.NewPassword)">
+                                    @Html.ShowLabelFor(m => m.ChangePassword.NewPassword)
+                                    @Html.ShowPasswordFor(m => m.ChangePassword.NewPassword)
+                                    @Html.ShowValidationMessagesFor(m => m.ChangePassword.NewPassword)
+                                </div>
+                                <div class="form-group @Html.HasErrorFor(m => m.ChangePassword.VerifyPassword)">
+                                    @Html.ShowLabelFor(m => m.ChangePassword.VerifyPassword)
+                                    @Html.ShowPasswordFor(m => m.ChangePassword.VerifyPassword)
+                                    @Html.ShowValidationMessagesFor(m => m.ChangePassword.VerifyPassword)
+                                </div>
+                            }
+                            else
+                            {
+                                <p>To enable password login, an email will be sent to '@(CurrentUser.EmailAddress ?? CurrentUser.UnconfirmedEmailAddress)'.</p>
+                            }
 
-                        <div class="row form-group">
-                            <div class="col-sm-6">
-                                <input type="submit" class="btn btn-primary form-control" value="@(Model.HasPassword ? "Save" : "Enable Password Login")" />
+                            <div class="row form-group">
+                                <div class="col-sm-6">
+                                    <input type="submit" class="btn btn-primary form-control" value="@(Model.HasPassword ? "Save" : "Enable Password Login")" />
+                                </div>
+                                <div class="col-sm-6">
+                                    <a href="#" role="button" class="btn btn-default form-control" id="cancel-change-password">
+                                        Cancel
+                                    </a>
+                                </div>
                             </div>
-                            <div class="col-sm-6">
-                                <a href="#" role="button" class="btn btn-default form-control" id="cancel-change-password">
-                                    Cancel
-                                </a>
-                            </div>
-                        </div>
+                        }
+                    }
+                    else
+                    {
+                        <p>To enable password login, please confirm your account.</p>
                     }
                 </text>,
                 ViewData.ModelState.Keys.Any(x => x.StartsWith("ChangePassword")))

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -329,7 +329,7 @@ namespace NuGetGallery
                 var controller = GetController<UsersController>();
 
                 var model = new ForgotPasswordViewModel { Email = "user" };
-                
+
                 try
                 {
                     // Act 
@@ -414,7 +414,7 @@ namespace NuGetGallery
                     ConfirmPassword = "pwd",
                     NewPassword = "newpwd"
                 };
-                
+
                 await controller.ResetPassword("user", "token", model, forgot: false);
 
                 GetMock<IMessageService>()
@@ -436,7 +436,7 @@ namespace NuGetGallery
                 Assert.IsType<ViewResult>(result);
 
                 var viewResult = result as ViewResult;
-                Assert.Equal(forgot, viewResult.ViewBag.ForgotPassword); 
+                Assert.Equal(forgot, viewResult.ViewBag.ForgotPassword);
             }
         }
 
@@ -776,10 +776,10 @@ namespace NuGetGallery
                 await controller.GenerateApiKey(
                     description: "my new api key",
                     owner: user.Username,
-                    scopes: new [] { NuGetScopes.PackageUnlist },
+                    scopes: new[] { NuGetScopes.PackageUnlist },
                     subjects: null,
                     expirationInDays: inputExpirationInDays);
-                
+
                 // Assert
                 var apiKey = user.Credentials.FirstOrDefault(x => x.Type == CredentialTypes.ApiKey.V2);
 
@@ -836,7 +836,7 @@ namespace NuGetGallery
                             new []
                             {
                                 new Scope("*", NuGetScopes.All)
-                            } 
+                            }
                         },
                         new object[]
                         {
@@ -852,7 +852,7 @@ namespace NuGetGallery
                     };
                 }
             }
-                
+
             [MemberData(nameof(CreatesNewApiKeyCredential_Input))]
             [Theory]
             public async Task CreatesNewApiKeyCredential(string description, string[] scopes, string[] subjects, Scope[] expectedScopes)
@@ -907,8 +907,8 @@ namespace NuGetGallery
                 var result = await controller.GenerateApiKey(
                     description: "description",
                     owner: user.Username,
-                    scopes: new [] { NuGetScopes.PackageUnlist, NuGetScopes.PackagePush },
-                    subjects: new [] { "a" },
+                    scopes: new[] { NuGetScopes.PackageUnlist, NuGetScopes.PackagePush },
+                    subjects: new[] { "a" },
                     expirationInDays: 90);
 
                 var credentialViewModel = result.Data as ApiKeyViewModel;
@@ -1108,14 +1108,14 @@ namespace NuGetGallery
                 {
                     Username = "theUsername",
                     EmailAddress = "test@example.com",
-                    Credentials = new [] { new Credential(CredentialTypes.Password.V3, "abc") }
+                    Credentials = new[] { new Credential(CredentialTypes.Password.V3, "abc") }
                 };
 
                 Credential credential;
                 GetMock<AuthenticationService>()
                     .Setup(u => u.ValidatePasswordCredential(It.IsAny<IEnumerable<Credential>>(), It.IsAny<string>(), out credential))
                     .Returns(false);
-               
+
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
@@ -1131,7 +1131,7 @@ namespace NuGetGallery
                 var result = await controller.ChangeEmail(model);
 
                 Assert.IsType<ViewResult>(result);
-                Assert.IsType<AccountViewModel>(((ViewResult) result).Model);
+                Assert.IsType<AccountViewModel>(((ViewResult)result).Model);
             }
         }
 
@@ -1255,7 +1255,7 @@ namespace NuGetGallery
                 user.Credentials.Add(cred);
                 user.Credentials.Add(new CredentialBuilder()
                     .CreateExternalCredential("MicrosoftAccount", "blorg", "bloog"));
-                
+
                 GetMock<AuthenticationService>()
                     .Setup(a => a.RemoveCredential(user, cred))
                     .Completes()
@@ -1341,6 +1341,32 @@ namespace NuGetGallery
                 // Assert
                 Assert.Equal(TestUtility.GallerySiteRootHttps + "account/setpassword/test/t0k3n", actualConfirmUrl);
                 GetMock<IMessageService>().VerifyAll();
+            }
+
+            [Fact]
+            public async Task GivenNoOldPasswordForUnconfirmedAccount_ItAddsModelError()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+                var user = fakes.CreateUser("test");
+                user.UnconfirmedEmailAddress = "unconfirmed@example.com";
+                GetMock<AuthenticationService>()
+                    .Setup(a => a.GeneratePasswordResetToken(user, It.IsAny<int>()))
+                    .ReturnsAsync(PasswordResetResultType.UserNotConfirmed);
+
+                var controller = GetController<UsersController>();
+                controller.SetCurrentUser(user);
+
+                // Act
+                await controller.ChangePassword(new AccountViewModel());
+
+                // Assert
+                var errorMessages = controller
+                    .ModelState["ChangePassword"]
+                    .Errors
+                    .Select(e => e.ErrorMessage)
+                    .ToArray();
+                Assert.Equal(errorMessages, new[] { Strings.UserIsNotYetConfirmed });
             }
         }
 
@@ -1525,7 +1551,8 @@ namespace NuGetGallery
                 // Arrange
                 var fakes = Get<Fakes>();
                 var creds = new Credential[5];
-                for (int i = 0; i < creds.Length; i++) {
+                for (int i = 0; i < creds.Length; i++)
+                {
                     creds[i] = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "blorg", "bloog" + i);
                     creds[i].Key = i + 1;
                 }
@@ -1646,9 +1673,11 @@ namespace NuGetGallery
                     .Setup(u => u.AddCredential(
                         user,
                         It.Is<Credential>(c => c.Type == CredentialTypes.ApiKey.V2)))
-                    .Callback<User, Credential>((u, c) => {
+                    .Callback<User, Credential>((u, c) =>
+                    {
                         u.Credentials.Add(c);
-                        c.User = u; })
+                        c.User = u;
+                    })
                     .Completes()
                     .Verifiable();
 
@@ -1897,11 +1926,11 @@ namespace NuGetGallery
                 // Arrange
                 string userName = "DeletedUser";
                 var controller = GetController<UsersController>();
-           
+
                 var fakes = Get<Fakes>();
                 var testUser = fakes.CreateUser(userName);
                 testUser.IsDeleted = true;
-               
+
                 GetMock<IUserService>()
                     .Setup(stub => stub.FindByUsername(userName))
                     .Returns(testUser);
@@ -1925,7 +1954,7 @@ namespace NuGetGallery
 
                 PackageRegistration packageRegistration = new PackageRegistration();
                 packageRegistration.Owners.Add(testUser);
-                
+
                 Package userPackage = new Package()
                 {
                     Description = "TestPackage",
@@ -1949,7 +1978,7 @@ namespace NuGetGallery
 
                 // act
                 var model = ResultAssert.IsView<DeleteUserAccountViewModel>(controller.Delete(accountName: userName), viewName: "DeleteUserAccount");
-               
+
                 // Assert
                 Assert.Equal(userName, model.AccountName);
                 Assert.Equal<int>(1, model.Packages.Count());
@@ -1988,7 +2017,7 @@ namespace NuGetGallery
 
                 List<Package> userPackages = new List<Package>() { userPackage };
                 List<Issue> issues = new List<Issue>();
-                if ( withPendingIssues )
+                if (withPendingIssues)
                 {
                     issues.Add(new Issue()
                     {


### PR DESCRIPTION
Fix for #4984 - Password reset for accounts created with MSA login is broken

Also, added a redundant server side check which would send invalid password reset links. 

use `?w=1` to ignore whitespace changes.

[UPDATE]
Before confirmation:
![image](https://user-images.githubusercontent.com/1646506/33049884-f016f5e4-ce16-11e7-9084-a83deeca469b.png)

After confirmation:
![image](https://user-images.githubusercontent.com/1646506/33049950-39f78ebc-ce17-11e7-8172-339f1f953c47.png)

