### PR TITLE
Remove usage of ApiKey Type for distinguishing between Scoped/non-scoped ApiKeys

### DIFF
--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -55,9 +55,9 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="credential"></param>
         /// <returns></returns>
-        public static bool IsSupportedCredential(Credential credential)
+        public static bool IsSupportedCredential(this Credential credential)
         {
-            return IsViewSupportedCredential(credential) || IsPackageVerificationApiKey(credential.Type);
+            return credential.IsViewSupportedCredential() || IsPackageVerificationApiKey(credential.Type);
         }
 
         /// <summary>
@@ -66,10 +66,15 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="credential"></param>
         /// <returns></returns>
-        public static bool IsViewSupportedCredential(Credential credential)
+        public static bool IsViewSupportedCredential(this Credential credential)
         {
             return SupportedCredentialTypes.Any(credType => string.Compare(credential.Type, credType, StringComparison.OrdinalIgnoreCase) == 0)
                     || credential.Type.StartsWith(ExternalPrefix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsScopedApiKey(this Credential credential)
+        {
+            return IsApiKey(credential.Type) && credential.Scopes != null && credential.Scopes.Any();
         }
     }
 }

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -200,8 +200,9 @@ namespace NuGetGallery.Authentication
                     return null;
                 }
 
-                if (matched.Type == CredentialTypes.ApiKey.V1
-                    && !matched.HasBeenUsedInLastDays(_config.ExpirationInDaysForApiKeyV1))
+                if (CredentialTypes.IsApiKey(matched.Type) &&
+                    !matched.IsScopedApiKey() &&
+                    !matched.HasBeenUsedInLastDays(_config.ExpirationInDaysForApiKeyV1))
                 {
                     // API key credential was last used a long, long time ago - expire it
                     await Auditing.SaveAuditRecordAsync(
@@ -498,10 +499,10 @@ namespace NuGetGallery.Authentication
             };
 
             credentialViewModel.HasExpired = credential.HasExpired ||
-                                             (credentialViewModel.IsNonScopedV1ApiKey &&
+                                             (credentialViewModel.IsNonScopedApiKey &&
                                               !credential.HasBeenUsedInLastDays(_config.ExpirationInDaysForApiKeyV1));
 
-            credentialViewModel.Description = credentialViewModel.IsNonScopedV1ApiKey
+            credentialViewModel.Description = credentialViewModel.IsNonScopedApiKey
                 ? Strings.NonScopedApiKeyDescription : credentialViewModel.Description;
 
             return credentialViewModel;

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -645,12 +645,6 @@ namespace NuGetGallery
         [ValidateAntiForgeryToken]
         public virtual async Task<JsonResult> RegenerateCredential(string credentialType, int? credentialKey)
         {
-            if (credentialType != CredentialTypes.ApiKey.V2)
-            {
-                Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                return Json(Strings.Unsupported);
-            }
-
             var user = GetCurrentUser();
             var cred = user.Credentials.SingleOrDefault(
                 c => string.Equals(c.Type, credentialType, StringComparison.OrdinalIgnoreCase)
@@ -660,6 +654,12 @@ namespace NuGetGallery
             {
                 Response.StatusCode = (int)HttpStatusCode.NotFound;
                 return Json(Strings.CredentialNotFound);
+            }
+
+            if (!cred.IsScopedApiKey())
+            {
+                Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                return Json(Strings.Unsupported);
             }
            
             var newCredential = await GenerateApiKeyInternal(
@@ -746,12 +746,6 @@ namespace NuGetGallery
         [ValidateAntiForgeryToken]
         public virtual async Task<JsonResult> EditCredential(string credentialType, int? credentialKey, string[] subjects)
         {
-            if (credentialType != CredentialTypes.ApiKey.V2)
-            {
-                Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                return Json(Strings.Unsupported);
-            }
-
             var user = GetCurrentUser();
             var cred = user.Credentials.SingleOrDefault(
                 c => string.Equals(c.Type, credentialType, StringComparison.OrdinalIgnoreCase)
@@ -761,6 +755,12 @@ namespace NuGetGallery
             {
                 Response.StatusCode = (int)HttpStatusCode.NotFound;
                 return Json(Strings.CredentialNotFound);
+            }
+
+            if (!cred.IsScopedApiKey())
+            {
+                Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                return Json(Strings.Unsupported);
             }
 
             var scopeOwner = cred.Scopes.GetOwnerScope();

--- a/src/NuGetGallery/Scripts/gallery/page-api-keys.js
+++ b/src/NuGetGallery/Scripts/gallery/page-api-keys.js
@@ -87,7 +87,7 @@
                 this.Description(data.Description || null);
                 this.Expires(data.Expires || null);
                 this.HasExpired(data.HasExpired || false);
-                this.IsNonScopedV1ApiKey(data.IsNonScopedV1ApiKey || false);
+                this.IsNonScopedApiKey(data.IsNonScopedApiKey || false);
                 this.Owner(data.Owner || null);
                 this.Scopes(data.Scopes || []);
                 this.Packages(data.Packages || []);
@@ -100,7 +100,7 @@
             this.Description = ko.observable();
             this.Expires = ko.observable();
             this.HasExpired = ko.observable();
-            this.IsNonScopedV1ApiKey = ko.observable();
+            this.IsNonScopedApiKey = ko.observable();
             this.Owner = ko.observable();
             this.Scopes = ko.observableArray();
             this.Packages = ko.observableArray();
@@ -184,7 +184,7 @@
             this.IconUrl = ko.pureComputed(function () {
                 if (this.HasExpired()) {
                     return initialData.ImageUrls.ApiKeyExpired;
-                } else if (this.IsNonScopedV1ApiKey()) {
+                } else if (this.IsNonScopedApiKey()) {
                     return initialData.ImageUrls.ApiKeyLegacy;
                 } else if (this.Value()) {
                     return initialData.ImageUrls.ApiKeyNew;
@@ -196,7 +196,7 @@
                 var url;
                 if (this.HasExpired()) {
                     url = initialData.ImageUrls.ApiKeyExpiredFallback;
-                } else if (this.IsNonScopedV1ApiKey()) {
+                } else if (this.IsNonScopedApiKey()) {
                     url =  initialData.ImageUrls.ApiKeyLegacyFallback;
                 } else if (this.Value()) {
                     url =  initialData.ImageUrls.ApiKeyNewFallback;

--- a/src/NuGetGallery/ViewModels/AccountViewModel.cs
+++ b/src/NuGetGallery/ViewModels/AccountViewModel.cs
@@ -96,11 +96,11 @@ namespace NuGetGallery
         public string Value { get; set; }
         public TimeSpan? ExpirationDuration { get; set; }
 
-        public bool IsNonScopedV1ApiKey
+        public bool IsNonScopedApiKey
         {
             get
             {
-                return string.Equals(Type, CredentialTypes.ApiKey.V1, StringComparison.OrdinalIgnoreCase);
+                return CredentialTypes.IsApiKey(Type) && !Scopes.AnySafe();
             }
         }
     }

--- a/src/NuGetGallery/ViewModels/ApiKeyViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ApiKeyViewModel.cs
@@ -54,14 +54,14 @@ namespace NuGetGallery
             Description = cred.Description;
             Expires = cred.Expires?.ToString("O");
             HasExpired = cred.HasExpired;
-            IsNonScopedV1ApiKey = cred.IsNonScopedApiKey;
+            IsNonScopedApiKey = cred.IsNonScopedApiKey;
             Owner = owner;
             Scopes = scopes;
             Packages = packages;
             GlobPattern = globPattern;
         }
 
-        public bool IsNonScopedV1ApiKey { get; set; }
+        public bool IsNonScopedApiKey { get; set; }
         public bool HasExpired { get; set; }
         public string Expires { get; set; }
         public string Owner { get; set; }

--- a/src/NuGetGallery/ViewModels/ApiKeyViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ApiKeyViewModel.cs
@@ -54,7 +54,7 @@ namespace NuGetGallery
             Description = cred.Description;
             Expires = cred.Expires?.ToString("O");
             HasExpired = cred.HasExpired;
-            IsNonScopedV1ApiKey = cred.IsNonScopedV1ApiKey;
+            IsNonScopedV1ApiKey = cred.IsNonScopedApiKey;
             Owner = owner;
             Scopes = scopes;
             Packages = packages;

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -210,7 +210,7 @@
                         </a>
                     </li>
                     <!-- /ko -->
-                    <!-- ko ifnot: IsNonScopedV1ApiKey -->
+                    <!-- ko ifnot: IsNonScopedApiKey -->
                     <li>
                         <a class="icon-link" href="#" role="button" data-toggle="collapse"
                            data-bind="attr: { 'data-target': '#' + EditContainerId(),

--- a/tests/NuGetGallery.Facts/Authentication/TestCredentialHelper.cs
+++ b/tests/NuGetGallery.Facts/Authentication/TestCredentialHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Web.Helpers;
 using NuGetGallery.Services.Authentication;
 
@@ -10,7 +11,7 @@ namespace NuGetGallery.Authentication
     /// <summary>
     /// Builds all kinds of supported credentials for test purposes.
     /// </summary>
-    public class TestCredentialHelper
+    public static class TestCredentialHelper
     {
         public static Credential CreatePbkdf2Password(string plaintextPassword)
         {
@@ -34,6 +35,17 @@ namespace NuGetGallery.Authentication
         public static Credential CreateV2ApiKey(Guid apiKey, TimeSpan? expiration)
         {
             return CreateApiKey(CredentialTypes.ApiKey.V2, apiKey.ToString(), expiration);
+        }
+
+        public static Credential WithDefaultScopes(this Credential credential)
+        {
+            credential.Scopes = new List<Scope>() {
+                  new Scope("*", NuGetScopes.PackageUnlist),
+                  new Scope("*", NuGetScopes.PackagePush),
+                  new Scope("*", NuGetScopes.PackagePushVersion)
+            };
+
+            return credential;
         }
 
         public static Credential CreateV2VerificationApiKey(Guid apiKey)

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -1580,26 +1580,51 @@ namespace NuGetGallery
                 Assert.True(user.Credentials.Contains(cred));
             }
 
+            public static IEnumerable<object[]> GivenANonScopedApiKeyCredential_ReturnsUnsupported_Input
+            {
+                get
+                {
+                    return new[]
+                    {
+                        new object[]
+                        {
+                            TestCredentialHelper.CreateV1ApiKey(Guid.NewGuid(), TimeSpan.FromDays(1))
+                        },
+                        new object[]
+                        {
+                            TestCredentialHelper.CreateExternalCredential("abc")
+                        },
+                        new object[]
+                        {
+                            TestCredentialHelper.CreateSha1Password("abcd")
+                        }
+                    };
+                }
+            }
+
             [Theory]
-            [InlineData(CredentialTypes.ApiKey.V1)]
-            [InlineData(CredentialTypes.Password.V3)]
-            [InlineData(CredentialTypes.ExternalPrefix + "bla")]
-            public async Task GivenANonApiKeyV2Credential_ReturnsUnsupported(string credentialType)
+            [MemberData(nameof(GivenANonScopedApiKeyCredential_ReturnsUnsupported_Input))]
+            public async Task GivenANonScopedApiKeyCredential_ReturnsUnsupported(Credential credential)
             {
                 // Arrange
+                var fakes = Get<Fakes>();
+                var user = fakes.CreateUser("test", credential);
+                credential.Key = 1;
+
                 var controller = GetController<UsersController>();
+                controller.SetCurrentUser(user);
 
                 // Act
                 var result = await controller.RegenerateCredential(
-                    credentialType: credentialType,
-                    credentialKey: CredentialKey);
+                    credentialType: credential.Type,
+                    credentialKey: credential.Key);
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
                 Assert.True(string.Compare((string)result.Data, Strings.Unsupported) == 0);
             }
 
-            public static IEnumerable<object[]> RegenerateApiKeyCredential_Input
+            public static IEnumerable<object[]> GivenValidRequest_ItGeneratesNewCredAndRemovesOldCredAndSendsNotificationToUser_Input
             {
                 get
                 {
@@ -1628,7 +1653,7 @@ namespace NuGetGallery
                 }
             }
 
-            [MemberData(nameof(RegenerateApiKeyCredential_Input))]
+            [MemberData(nameof(GivenValidRequest_ItGeneratesNewCredAndRemovesOldCredAndSendsNotificationToUser_Input))]
             [Theory]
             public async Task GivenValidRequest_ItGeneratesNewCredAndRemovesOldCredAndSendsNotificationToUser(
                 string description, Scope[] scopes)
@@ -1699,20 +1724,44 @@ namespace NuGetGallery
 
         public class TheEditCredentialAction : TestContainer
         {
+            public static IEnumerable<object[]> GivenANonApiKeyV2Credential_ReturnsUnsupported_Input
+            {
+                get
+                {
+                    return new[]
+                    {
+                        new object[]
+                        {
+                            TestCredentialHelper.CreateV1ApiKey(Guid.NewGuid(), TimeSpan.FromDays(1))
+                        },
+                        new object[]
+                        {
+                            TestCredentialHelper.CreateExternalCredential("abc")
+                        },
+                        new object[]
+                        {
+                            TestCredentialHelper.CreateSha1Password("abcd")
+                        }
+                    };
+                }
+            }
 
             [Theory]
-            [InlineData(CredentialTypes.ApiKey.V1)]
-            [InlineData(CredentialTypes.Password.V3)]
-            [InlineData(CredentialTypes.ExternalPrefix + "bla")]
-            public async Task GivenANonApiKeyV2Credential_ReturnsUnsupported(string credentialType)
+            [MemberData(nameof(GivenANonApiKeyV2Credential_ReturnsUnsupported_Input))]
+            public async Task GivenANonApiKeyV2Credential_ReturnsUnsupported(Credential credential)
             {
                 // Arrange
+                var fakes = Get<Fakes>();
+                var user = fakes.CreateUser("test", credential);
+                credential.Key = 1;
+
                 var controller = GetController<UsersController>();
+                controller.SetCurrentUser(user);
 
                 // Act
                 var result = await controller.EditCredential(
-                    credentialType: credentialType,
-                    credentialKey: CredentialKey,
+                    credentialType: credential.Type,
+                    credentialKey: credential.Key,
                     subjects: new[] { "a", "b" });
 
                 // Assert

--- a/tests/NuGetGallery.Facts/Framework/Fakes.cs
+++ b/tests/NuGetGallery.Facts/Framework/Fakes.cs
@@ -33,7 +33,7 @@ namespace NuGetGallery.Framework
                     TestCredentialHelper.CreateV1ApiKey(Guid.Parse("669e180e-335c-491a-ac26-e83c4bd31d65"),
                         ExpirationForApiKeyV1),
                     TestCredentialHelper.CreateV2ApiKey(Guid.Parse("779e180e-335c-491a-ac26-e83c4bd31d87"),
-                        ExpirationForApiKeyV1),
+                        ExpirationForApiKeyV1).WithDefaultScopes(),
                     TestCredentialHelper.CreateV2VerificationApiKey(Guid.Parse("b0c51551-823f-4701-8496-43980b4b3913")),
                     TestCredentialHelper.CreateExternalCredential("abc")
                 }

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -670,8 +670,9 @@ namespace NuGetGallery
             public void ApiKeyRemovedMessageIsCorrect()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
-                var cred = new CredentialBuilder().CreateApiKey(TimeSpan.FromDays(1));
+                var cred = TestCredentialHelper.CreateV2ApiKey(Guid.NewGuid(), TimeSpan.FromDays(1)).WithDefaultScopes();
                 cred.Description = "new api key";
+                cred.User = user;
 
                 var messageService = TestableMessageService.Create(
                     GetService<AuthenticationService>(),
@@ -730,8 +731,9 @@ namespace NuGetGallery
             public void ApiKeyAddedMessageIsCorrect()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
-                var cred = new CredentialBuilder().CreateApiKey(TimeSpan.FromDays(1));
+                var cred = TestCredentialHelper.CreateV2ApiKey(Guid.NewGuid(), TimeSpan.FromDays(1)).WithDefaultScopes();
                 cred.Description = "new api key";
+                cred.User = user;
 
                 var messageService = TestableMessageService.Create(
                     GetService<AuthenticationService>(),


### PR DESCRIPTION
This is a preparation step for this work: https://github.com/NuGet/Engineering/issues/927

Since we are going to have V3, V4 ApiKeys doesn't make sense using ApiKey type (V1/V2) to distinguish between scoped/non-scopedm keys.