### PR TITLE
Not using SAS tokens for public containers read URIs

### DIFF
--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -15,6 +16,19 @@ namespace NuGetGallery
 {
     public class CloudBlobCoreFileStorageService : ICoreFileStorageService
     {
+        private static readonly HashSet<string> KnownPublicFolders = new HashSet<string> {
+            CoreConstants.PackagesFolderName,
+            CoreConstants.PackageBackupsFolderName,
+            CoreConstants.DownloadsFolderName
+        };
+
+        private static readonly HashSet<string> KnownPrivateFolders = new HashSet<string> {
+            CoreConstants.ContentFolderName,
+            CoreConstants.UploadsFolderName,
+            CoreConstants.PackageReadMesFolderName,
+            CoreConstants.ValidationFolderName
+        };
+
         protected readonly ICloudBlobClient _client;
         protected readonly ConcurrentDictionary<string, ICloudBlobContainer> _containers = new ConcurrentDictionary<string, ICloudBlobContainer>();
 
@@ -118,8 +132,19 @@ namespace NuGetGallery
             {
                 throw new ArgumentOutOfRangeException(nameof(endOfAccess), $"{nameof(endOfAccess)} is in the past");
             }
+            bool isPublicFolder = IsPublicContainer(folderName);
+            if (!isPublicFolder && endOfAccess == null)
+            {
+                throw new ArgumentNullException(nameof(endOfAccess), $"{nameof(endOfAccess)} must not be null for non-public containers");
+            }
+
             ICloudBlobContainer container = await GetContainerAsync(folderName);
             var blob = container.GetBlobReference(fileName);
+            if (isPublicFolder)
+            {
+                return blob.Uri;
+            }
+
             return new Uri(blob.Uri, blob.GetSharedReadSignature(endOfAccess));
         }
 
@@ -131,30 +156,25 @@ namespace NuGetGallery
                 return container;
             }
 
-            Task<ICloudBlobContainer> creationTask;
-            switch (folderName)
-            {
-                case CoreConstants.PackagesFolderName:
-                case CoreConstants.PackageBackupsFolderName:
-                case CoreConstants.DownloadsFolderName:
-                    creationTask = PrepareContainer(folderName, isPublic: true);
-                    break;
-
-                case CoreConstants.ContentFolderName:
-                case CoreConstants.UploadsFolderName:
-                case CoreConstants.PackageReadMesFolderName:
-                case CoreConstants.ValidationFolderName:
-                    creationTask = PrepareContainer(folderName, isPublic: false);
-                    break;
-
-                default:
-                    throw new InvalidOperationException(
-                        String.Format(CultureInfo.CurrentCulture, "The folder name {0} is not supported.", folderName));
-            }
-
-            container = await creationTask;
+            container = await PrepareContainer(folderName, IsPublicContainer(folderName));
             _containers[folderName] = container;
             return container;
+        }
+
+        private bool IsPublicContainer(string folderName)
+        {
+            if (KnownPublicFolders.Contains(folderName))
+            {
+                return true;
+            }
+
+            if (KnownPrivateFolders.Contains(folderName))
+            {
+                return false;
+            }
+
+            throw new InvalidOperationException(
+                String.Format(CultureInfo.CurrentCulture, "The folder name {0} is not supported.", folderName));
         }
 
         private async Task<StorageResult> GetBlobContentAsync(string folderName, string fileName, string ifNoneMatch = null)

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -541,13 +541,15 @@ namespace NuGetGallery
                 Assert.Equal("endOfAccess", ex.ParamName);
             }
 
-            [Fact]
-            public async Task WillConcatenateSignatureWithUri()
+            private const string fileName = "theFileName";
+            private const string signature = "?secret=42";
+
+            [Theory]
+            [InlineData(CoreConstants.ValidationFolderName, "http://example.com/" + CoreConstants.ValidationFolderName + "/" + fileName + signature)]
+            [InlineData(CoreConstants.PackagesFolderName, "http://example.com/" + CoreConstants.PackagesFolderName + "/" + fileName)]
+            public async Task WillUseSasTokenDependingOnContainerAvailability(string containerName, string expectedUri)
             {
-                const string folderName = CoreConstants.ValidationFolderName;
-                const string fileName = "theFileName";
-                const string signature = "?secret=42";
-                var setupResult = Setup(folderName, fileName);
+                var setupResult = Setup(containerName, fileName);
                 var fakeBlobClient = setupResult.Item1;
                 var fakeBlob = setupResult.Item2;
                 var blobUri = setupResult.Item3;
@@ -555,10 +557,30 @@ namespace NuGetGallery
                 fakeBlob.Setup(b => b.GetSharedReadSignature(It.IsAny<DateTimeOffset?>())).Returns(signature);
                 var service = CreateService(fakeBlobClient);
 
-                var uri = await service.GetFileReadUriAsync(folderName, fileName, DateTimeOffset.Now.AddHours(3));
+                var uri = await service.GetFileReadUriAsync(containerName, fileName, DateTimeOffset.Now.AddHours(3));
 
-                string expectedUri = new Uri(blobUri, signature).AbsoluteUri;
                 Assert.Equal(expectedUri, uri.AbsoluteUri);
+            }
+
+            [Fact]
+            public async Task WillThrowIfNoEndOfAccessSpecifiedForNonPublicContainer()
+            {
+                var service = CreateService();
+
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.GetFileReadUriAsync(CoreConstants.ValidationFolderName, "theFileName", null));
+                Assert.Equal("endOfAccess", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillNotThrowIfNoEndOfAccessSpecifiedForPublicContainer()
+            {
+                const string packagesFolderName = CoreConstants.PackagesFolderName;
+                var setupResult = Setup(packagesFolderName, fileName);
+                var service = CreateService(setupResult.Item1);
+
+                var ex = await Record.ExceptionAsync(() => service.GetFileReadUriAsync(packagesFolderName, fileName, null));
+
+                Assert.Null(ex);
             }
 
             [Fact]
@@ -589,7 +611,10 @@ namespace NuGetGallery
             {
                 var fakeBlobClient = new Mock<ICloudBlobClient>();
                 var fakeContainer = new Mock<ICloudBlobContainer>();
-                fakeBlobClient.Setup(bc => bc.GetContainerReference(folderName)).Returns(fakeContainer.Object);
+                fakeBlobClient
+                    .Setup(bc => bc.GetContainerReference(folderName))
+                    .Returns(fakeContainer.Object)
+                    .Callback(() => { int i = 0; i = i + 1; });
                 var fakeBlob = new Mock<ISimpleCloudBlob>();
                 fakeContainer.Setup(c => c.GetBlobReference(fileName)).Returns(fakeBlob.Object);
 


### PR DESCRIPTION
With @joelverhagen's help found a nasty issue with SAS tokens for blob storage: if expiration time is not specified generated SAS token is invalid and causes HTTP 403 when blob is accessed with that token *even* in public container (which is accessible without any tokens).

It is unclear from documentation whether expiration time should be specified or not and the class that is used to pass that information uses `Nullable<DateTimeOffset>` for the expiration time, which assumes that it's optional. It isn't.