### PR TITLE
Add configuration for user package deletes

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -72,6 +72,9 @@ namespace NuGetGallery
                .AsSelf()
                .As<FeatureConfiguration>();
 
+            builder.Register(c => configuration.PackageDelete)
+                .As<IPackageDeleteConfiguration>();
+
             builder.RegisterType<TelemetryService>().As<ITelemetryService>().SingleInstance();
             builder.RegisterType<CredentialBuilder>().As<ICredentialBuilder>().SingleInstance();
             builder.RegisterType<CredentialValidator>().As<ICredentialValidator>().SingleInstance();

--- a/src/NuGetGallery/Configuration/ConfigurationService.cs
+++ b/src/NuGetGallery/Configuration/ConfigurationService.cs
@@ -22,6 +22,8 @@ namespace NuGetGallery.Configuration
         protected const string SettingPrefix = "Gallery.";
         protected const string FeaturePrefix = "Feature.";
         protected const string ServiceBusPrefix = "AzureServiceBus.";
+        protected const string PackageDeletePrefix = "PackageDelete.";
+
         private bool _notInCloud;
         private readonly Lazy<string> _httpSiteRootThunk;
         private readonly Lazy<string> _httpsSiteRootThunk;
@@ -30,6 +32,7 @@ namespace NuGetGallery.Configuration
         private readonly Lazy<IAppConfiguration> _lazyAppConfiguration;
         private readonly Lazy<FeatureConfiguration> _lazyFeatureConfiguration;
         private readonly Lazy<IServiceBusConfiguration> _lazyServiceBusConfiguration;
+        private readonly Lazy<IPackageDeleteConfiguration> _lazyPackageDeleteConfiguration;
 
         public ConfigurationService(ISecretReaderFactory secretReaderFactory)
         {
@@ -41,7 +44,8 @@ namespace NuGetGallery.Configuration
 
             _lazyAppConfiguration = new Lazy<IAppConfiguration>(() => ResolveSettings().Result);
             _lazyFeatureConfiguration = new Lazy<FeatureConfiguration>(() => ResolveFeatures().Result);
-            _lazyServiceBusConfiguration  = new Lazy<IServiceBusConfiguration>(() => ResolveServiceBus().Result);
+            _lazyServiceBusConfiguration = new Lazy<IServiceBusConfiguration>(() => ResolveServiceBus().Result);
+            _lazyPackageDeleteConfiguration = new Lazy<IPackageDeleteConfiguration>(() => ResolvePackageDelete().Result);
         }
 
         public static IEnumerable<PropertyDescriptor> GetConfigProperties<T>(T instance)
@@ -64,6 +68,8 @@ namespace NuGetGallery.Configuration
         public FeatureConfiguration Features => _lazyFeatureConfiguration.Value;
 
         public IServiceBusConfiguration ServiceBus => _lazyServiceBusConfiguration.Value;
+
+        public IPackageDeleteConfiguration PackageDelete => _lazyPackageDeleteConfiguration.Value;
 
         /// <summary>
         /// Gets the site root using the specified protocol
@@ -170,6 +176,11 @@ namespace NuGetGallery.Configuration
         private async Task<IServiceBusConfiguration> ResolveServiceBus()
         {
             return await ResolveConfigObject(new ServiceBusConfiguration(), ServiceBusPrefix);
+        }
+
+        private async Task<IPackageDeleteConfiguration> ResolvePackageDelete()
+        {
+            return await ResolveConfigObject(new PackageDeleteConfiguration(), PackageDeletePrefix);
         }
 
         protected virtual string GetCloudSetting(string settingName)

--- a/src/NuGetGallery/Configuration/IPackageDeleteConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IPackageDeleteConfiguration.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Configuration
+{
+    /// <summary>
+    /// Settings concerning when users can delete their own packages. This configuration does not effect the admin
+    /// package delete flow.
+    /// </summary>
+    public interface IPackageDeleteConfiguration
+    {
+        /// <summary>
+        /// Whether or not users can delete their new packages through the "Contact Support" flow.
+        /// </summary>
+        bool AllowUsersToDeletePackages { get; }
+
+        /// <summary>
+        /// If the package ID has more than this many downloads, the user cannot delete new versions no matter what.
+        /// The <see cref="AllowUsersToDeletePackages"/> option takes precedence over this option. If this value is
+        /// null, this download count restriction does not apply.
+        /// </summary>
+        int? MaximumDownloadsForPackageId { get; }
+
+        /// <summary>
+        /// How frequently download statistics are updated in hours. This value may not be exact, but is used as an
+        /// "early" delete criteria. If a package was pushed less than this many hours ago, the package can be deleted
+        /// regardless of the number of downloads. Since the download counts for packages are not updated immediately,
+        /// there is a window of time when a new package won't have any recorded downloads. Note that
+        /// <see cref="AllowUsersToDeletePackages"/> and <see cref="MaximumDownloadsForPackageVersion"/> take
+        /// precedence over this option.
+        /// </summary>
+        int? StatisticsUpdateFrequencyInHours { get; }
+
+        /// <summary>
+        /// The hour threshold for the "late" delete criteria. If a package was pushed less than this many hours ago
+        /// and if the package version has less than <see cref="MaximumDownloadsForPackageVersion"/> downloads, the
+        /// package can be deleted. If this value is null, the package cannot be deleted after
+        /// <see cref="StatisticsUpdateFrequencyInHours"/> hours. Also, if the package has not had its download
+        /// statistics updated in the last <see cref="StatisticsUpdateFrequencyInHours"/> hours, the delete is not
+        /// allowed since the download data is too stale. If <see cref="StatisticsUpdateFrequencyInHours"/> is null,
+        /// download statistics are never considered stale.
+        /// </summary>
+        int? HourLimitWithMaximumDownloads { get; }
+
+        /// <summary>
+        /// If the number of downloads on a package is greater than this value, the package was published less than
+        /// <see cref="StatisticsUpdateFrequencyInHours"/> hours ago, and the package was downloaded more than
+        /// <see cref="StatisticsUpdateFrequencyInHours"/> hours ago, the package can be deleted. If this value is
+        /// null, this download count restriction is not applied.
+        /// </summary>
+        int? MaximumDownloadsForPackageVersion { get; }
+    }
+}

--- a/src/NuGetGallery/Configuration/PackageDeleteConfiguration.cs
+++ b/src/NuGetGallery/Configuration/PackageDeleteConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Configuration
+{
+    public class PackageDeleteConfiguration : IPackageDeleteConfiguration
+    {
+        public bool AllowUsersToDeletePackages { get; set; }
+        public int? MaximumDownloadsForPackageId { get; set; }
+        public int? StatisticsUpdateFrequencyInHours { get; set; }
+        public int? HourLimitWithMaximumDownloads { get; set; }
+        public int? MaximumDownloadsForPackageVersion { get; set; }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -732,7 +732,9 @@
     <Compile Include="Authentication\Providers\AzureActiveDirectory\AzureActiveDirectoryAuthenticator.cs" />
     <Compile Include="Authentication\Providers\AzureActiveDirectory\AzureActiveDirectoryAuthenticatorConfiguration.cs" />
     <Compile Include="Configuration\IGalleryConfigurationService.cs" />
+    <Compile Include="Configuration\IPackageDeleteConfiguration.cs" />
     <Compile Include="Configuration\IServiceBusConfiguration.cs" />
+    <Compile Include="Configuration\PackageDeleteConfiguration.cs" />
     <Compile Include="Configuration\SecretReader\CachingSecretReader.cs" />
     <Compile Include="Configuration\SecretReader\EmptySecretReaderFactory.cs" />
     <Compile Include="Configuration\SecretReader\ISecretReaderFactory.cs" />

--- a/src/NuGetGallery/Services/PackageDeleteService.cs
+++ b/src/NuGetGallery/Services/PackageDeleteService.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
+using NuGetGallery.Configuration;
 
 namespace NuGetGallery
 {
@@ -40,6 +41,7 @@ namespace NuGetGallery
         private readonly IIndexingService _indexingService;
         private readonly IPackageFileService _packageFileService;
         private readonly IAuditingService _auditingService;
+        private readonly IPackageDeleteConfiguration _config;
 
         public PackageDeleteService(
             IEntityRepository<Package> packageRepository,
@@ -49,7 +51,8 @@ namespace NuGetGallery
             IPackageService packageService,
             IIndexingService indexingService,
             IPackageFileService packageFileService,
-            IAuditingService auditingService)
+            IAuditingService auditingService,
+            IPackageDeleteConfiguration config)
         {
             _packageRepository = packageRepository;
             _packageRegistrationRepository = packageRegistrationRepository;
@@ -59,10 +62,25 @@ namespace NuGetGallery
             _indexingService = indexingService;
             _packageFileService = packageFileService;
             _auditingService = auditingService;
+            _config = config;
+
+            if (config.HourLimitWithMaximumDownloads.HasValue
+                && config.StatisticsUpdateFrequencyInHours.HasValue
+                && config.HourLimitWithMaximumDownloads.Value <= config.StatisticsUpdateFrequencyInHours.Value)
+            {
+                throw new ArgumentException($"{nameof(_config.StatisticsUpdateFrequencyInHours)} must be less than " +
+                    $"{nameof(_config.HourLimitWithMaximumDownloads)}.",
+                    nameof(config));
+            }
         }
 
         public Task<bool> CanPackageBeDeletedByUserAsync(Package package)
         {
+            if (package.PackageStatusKey == PackageStatus.Deleted)
+            {
+                return Task.FromResult(false);
+            }
+
             // For now, don't allow user's to delete their packages.
             // https://github.com/NuGet/Engineering/issues/921
             return Task.FromResult(false);

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -169,6 +169,14 @@
     <add key="KeyVault.VaultName" value="" />
     <add key="KeyVault.ClientId" value="" />
     <add key="KeyVault.CertificateThumbprint" value="" />
+    <!-- *********************** -->
+    <!-- PACKAGE DELETE SETTINGS -->
+    <!-- *********************** -->
+    <add key="PackageDelete.AllowUsersToDeletePackages" value="false" />
+    <add key="PackageDelete.MaximumDownloadsForPackageId" value="" />
+    <add key="PackageDelete.StatisticsUpdateFrequencyInHours" value="" />
+    <add key="PackageDelete.HourLimitWithMaximumDownloads" value="" />
+    <add key="PackageDelete.MaximumDownloadsForPackageVersion" value="" />
   </appSettings>
   <connectionStrings>
     <add name="Gallery.SqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=NuGetGallery; Integrated Security=True; MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/921.

This PR has no functional impact on the gallery but should give a good picture of what the user package delete feature looks like.

NuGet.org's will probably look like this:
```xml
    <add key="PackageDelete.AllowUsersToDeletePackages" value="true" />
    <add key="PackageDelete.MaximumDownloadsForPackageId" value="125000" />
    <add key="PackageDelete.StatisticsUpdateFrequencyInHours" value="24" />
    <add key="PackageDelete.HourLimitWithMaximumDownloads" value="72" />
    <add key="PackageDelete.MaximumDownloadsForPackageVersion" value="100" />
```

The 125,000 is a value that Karan and I agreed upon based off of the number of downloads in the first 24 hours for the top 500 latest packages in the past 6 months. It is a protective measure we can remove later if we find it too cumbersome. I would like to start on the safe side for this feature and do small adjustments later as we build experience with the feature.

I am doing this feature in small PRs since it is a low priority and I can only work on it between other things.