### PR TITLE
Split up edit/verify views and make verify upload metadata read-only.

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1177,7 +1177,7 @@ namespace NuGetGallery
             // Create edit model from the latest pending edit.
             var pendingMetadata = _editPackageService.GetPendingMetadata(package);
 
-            model.Edit = new EditPackageVersionRequest(pendingMetadata);
+            model.Edit = new EditPackageVersionReadMeRequest(pendingMetadata);
 
             // Update edit model with the active or pending readme.md data.
             var isReadMePending = model.Edit.ReadMeState != PackageEditReadMeState.Unchanged;

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1177,7 +1177,7 @@ namespace NuGetGallery
             // Create edit model from the latest pending edit.
             var pendingMetadata = _editPackageService.GetPendingMetadata(package);
 
-            model.Edit = new EditPackageVersionRequest(package, pendingMetadata);
+            model.Edit = new EditPackageVersionRequest(pendingMetadata);
 
             // Update edit model with the active or pending readme.md data.
             var isReadMePending = model.Edit.ReadMeState != PackageEditReadMeState.Unchanged;
@@ -1231,9 +1231,8 @@ namespace NuGetGallery
                     await _entitiesContext.SaveChangesAsync();
 
                     // Add an auditing record for the package edit. HasReadMe flag is updated in DB by background job.
-                    var packageWithEditsApplied = formData.Edit.ApplyTo(package);
-                    packageWithEditsApplied.HasReadMe = hasReadMe;
-                    await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(packageWithEditsApplied, AuditedPackageAction.Edit));
+                    package.HasReadMe = hasReadMe;
+                    await _auditingService.SaveAuditRecordAsync(new PackageAuditRecord(package, AuditedPackageAction.Edit));
                 }
                 catch (EntityException ex)
                 {
@@ -1568,19 +1567,6 @@ namespace NuGetGallery
                         pendEdit = true;
                         _telemetryService.TrackPackageReadMeChangeEvent(package, formData.Edit.ReadMe.SourceType, formData.Edit.ReadMeState);
                     }
-                    
-                    pendEdit = pendEdit || formData.Edit.RequiresLicenseAcceptance != packageMetadata.RequireLicenseAcceptance;
-
-                    pendEdit = pendEdit || IsDifferent(formData.Edit.IconUrl, packageMetadata.IconUrl.ToEncodedUrlStringOrNull());
-                    pendEdit = pendEdit || IsDifferent(formData.Edit.ProjectUrl, packageMetadata.ProjectUrl.ToEncodedUrlStringOrNull());
-
-                    pendEdit = pendEdit || IsDifferent(formData.Edit.Authors, packageMetadata.Authors.Flatten());
-                    pendEdit = pendEdit || IsDifferent(formData.Edit.Copyright, packageMetadata.Copyright);
-                    pendEdit = pendEdit || IsDifferent(formData.Edit.Description, packageMetadata.Description);
-                    pendEdit = pendEdit || IsDifferent(formData.Edit.ReleaseNotes, packageMetadata.ReleaseNotes);
-                    pendEdit = pendEdit || IsDifferent(formData.Edit.Summary, packageMetadata.Summary);
-                    pendEdit = pendEdit || IsDifferent(formData.Edit.Tags, PackageHelper.ParseTags(packageMetadata.Tags));
-                    pendEdit = pendEdit || IsDifferent(formData.Edit.VersionTitle, packageMetadata.Title);
                 }
 
                 await _packageService.PublishPackageAsync(package, commitChanges: false);

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1961,6 +1961,8 @@
     <Content Include="Views\Users\_ReservedNamespacesList.cshtml" />
     <Content Include="Views\Users\DeleteAccount.cshtml" />
     <Content Include="Views\Authentication\SignInNuGetAccount.cshtml" />
+    <Content Include="Views\Packages\_VerifyForm.cshtml" />
+    <Content Include="Views\Packages\_VerifyMetadata.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="Properties\CodeAnalysisDictionary.xml" />

--- a/src/NuGetGallery/RequestModels/EditPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageRequest.cs
@@ -10,7 +10,7 @@ namespace NuGetGallery
     {
         public SelectList VersionSelectList { get; set; }
 
-        public EditPackageVersionRequest Edit { get; set; }
+        public EditPackageVersionReadMeRequest Edit { get; set; }
 
         public string PackageId { get; set; }
         public string PackageTitle { get; set; }

--- a/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
@@ -3,14 +3,14 @@
 
 namespace NuGetGallery
 {
-    public class EditPackageVersionRequest
+    public class EditPackageVersionReadMeRequest
     {
-        public EditPackageVersionRequest()
+        public EditPackageVersionReadMeRequest()
         {
             ReadMe = new ReadMeRequest();
         }
 
-        public EditPackageVersionRequest(PackageEdit pendingMetadata)
+        public EditPackageVersionReadMeRequest(PackageEdit pendingMetadata)
         {
             var metadata = pendingMetadata ?? new PackageEdit();
 

--- a/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
+++ b/src/NuGetGallery/RequestModels/EditPackageVersionRequest.cs
@@ -1,156 +1,26 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.ComponentModel.DataAnnotations;
-using NuGetGallery.Packaging;
-
 namespace NuGetGallery
 {
     public class EditPackageVersionRequest
     {
-        public const string TitleStr = "Title";
-        public const string IconUrlStr = "Icon URL";
-        public const string DescriptionStr = "Description";
-        public const string SummaryStr = "Summary (shown in package search results)";
-        public const string ProjectUrlStr = "Project Home Page URL";
-        public const string AuthorsStr = "Authors (comma separated  - e.g. 'Anna, Bob, Carl')";
-        public const string CopyrightStr = "Copyright";
-        public const string TagsStr = "Tags (space separated - e.g. 'ASP.NET Templates MVC')";
-        public const string ReleaseNotesStr = "Release Notes (for this version)";
-        public const string RequiresLicenseAcceptanceStr = "Requires license acceptance";
-
         public EditPackageVersionRequest()
         {
-        }
-
-        public EditPackageVersionRequest(PackageMetadata packageMetadata)
-        {
-
-            Authors = packageMetadata.Authors.Flatten();
-            Copyright = packageMetadata.Copyright;
-            Description = packageMetadata.Description;
-            IconUrl = packageMetadata.IconUrl.ToEncodedUrlStringOrNull();
-            LicenseUrl = packageMetadata.LicenseUrl.ToEncodedUrlStringOrNull();
-            ProjectUrl = packageMetadata.ProjectUrl.ToEncodedUrlStringOrNull();
-            ReleaseNotes = packageMetadata.ReleaseNotes;
-            RequiresLicenseAcceptance = packageMetadata.RequireLicenseAcceptance;
-            Summary = packageMetadata.Summary;
-            Tags = PackageHelper.ParseTags(packageMetadata.Tags);
-            VersionTitle = packageMetadata.Title;
-
             ReadMe = new ReadMeRequest();
         }
 
-        public EditPackageVersionRequest(Package package, PackageEdit pendingMetadata)
+        public EditPackageVersionRequest(PackageEdit pendingMetadata)
         {
-            var metadata = pendingMetadata ?? new PackageEdit
-            {
-                Authors = package.FlattenedAuthors,
-                Copyright = package.Copyright,
-                Description = package.Description,
-                IconUrl = package.IconUrl,
-                LicenseUrl = package.LicenseUrl,
-                ProjectUrl = package.ProjectUrl,
-                ReleaseNotes = package.ReleaseNotes,
-                RequiresLicenseAcceptance = package.RequiresLicenseAcceptance,
-                Summary = package.Summary,
-                Tags = package.Tags,
-                Title = package.Title,
-            };
-            Authors = metadata.Authors;
-            Copyright = metadata.Copyright;
-            Description = metadata.Description;
-            IconUrl = metadata.IconUrl;
-            LicenseUrl = metadata.LicenseUrl;
-            ProjectUrl = metadata.ProjectUrl;
-            ReleaseNotes = metadata.ReleaseNotes;
-            RequiresLicenseAcceptance = metadata.RequiresLicenseAcceptance;
-            Summary = metadata.Summary;
-            Tags = metadata.Tags;
-            VersionTitle = metadata.Title;
+            var metadata = pendingMetadata ?? new PackageEdit();
+
             ReadMeState = metadata.ReadMeState;
 
             ReadMe = new ReadMeRequest();
         }
 
-        // We won't show this in the UI, and we won't actually honor edits to it at the moment, by our current policy.
-        public string LicenseUrl { get; set; }
-
-        [StringLength(256)]
-        [Display(Name = TitleStr)]
-        [DataType(DataType.Text)]
-        public string VersionTitle { get; set; } // not naming it Title in our model because that would clash with page Title in the property bag. Blech.
-
-        [StringLength(256)]
-        [Display(Name = IconUrlStr)]
-        [DataType(DataType.ImageUrl)]
-        [RegularExpression(Constants.UrlValidationRegEx, ErrorMessage = Constants.UrlValidationErrorMessage)]
-        public string IconUrl { get; set; }
-
-        [StringLength(1024)]
-        [DataType(DataType.MultilineText)]
-        [Display(Name = SummaryStr)]
-        public string Summary { get; set; }
-
-        [StringLength(4000)]
-        [DataType(DataType.MultilineText)]
-        [Display(Name = DescriptionStr)]
-        [Required]
-        public string Description { get; set; }
-
-        [StringLength(256)]
-        [Display(Name = ProjectUrlStr)]
-        [DataType(DataType.Text)]
-        [RegularExpression(Constants.UrlValidationRegEx, ErrorMessage = Constants.UrlValidationErrorMessage)]
-        public string ProjectUrl { get; set; }
-
-        [StringLength(512)]
-        [Display(Name = AuthorsStr)]
-        [DataType(DataType.Text)]
-        [Required]
-        public string Authors { get; set; }
-
-        [StringLength(512)]
-        [Display(Name = CopyrightStr)]
-        [DataType(DataType.Text)]
-        public string Copyright { get; set; }
-
-        [StringLength(1024)]
-        [DataType(DataType.Text)]
-        [Display(Name = TagsStr)]
-        public string Tags { get; set; }
-
-        [Display(Name = ReleaseNotesStr)]
-        [DataType(DataType.MultilineText)]
-        public string ReleaseNotes { get; set; }
-
-        [Display(Name = RequiresLicenseAcceptanceStr)]
-        public bool RequiresLicenseAcceptance { get; set; }
-
         public PackageEditReadMeState ReadMeState { get; set; }
 
         public ReadMeRequest ReadMe { get; set; }
-
-        /// <summary>
-        /// Applied the edit to a package
-        /// </summary>
-        /// <param name="package">Package to apply edits to</param>
-        /// <returns>Edited package</returns>
-        public Package ApplyTo(Package package)
-        {
-            package.FlattenedAuthors = Authors;
-            package.Copyright = Copyright;
-            package.Description = Description;
-            package.IconUrl = IconUrl;
-            package.LicenseUrl = LicenseUrl;
-            package.ProjectUrl = ProjectUrl;
-            package.ReleaseNotes = ReleaseNotes;
-            package.RequiresLicenseAcceptance = RequiresLicenseAcceptance;
-            package.Summary = Summary;
-            package.Tags = Tags;
-            package.Title = VersionTitle;
-
-            return package;
-        }
     }
 }

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -42,7 +42,7 @@ namespace NuGetGallery
 
             // Editable server-state
             Listed = true;
-            Edit = new EditPackageVersionRequest();
+            Edit = new EditPackageVersionReadMeRequest();
         }
 
         public string Id { get; set; }
@@ -62,7 +62,7 @@ namespace NuGetGallery
 
         // Editable server-state
         public bool Listed { get; set; }
-        public EditPackageVersionRequest Edit { get; set; }
+        public EditPackageVersionReadMeRequest Edit { get; set; }
 
         // Verifiable fields
         public string Authors { get; set; }

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -14,23 +14,35 @@ namespace NuGetGallery
 
         public VerifyPackageRequest(PackageMetadata packageMetadata)
         {
-            var dependencyGroups = packageMetadata.GetDependencyGroups();
-
             Id = packageMetadata.Id;
             Version = packageMetadata.Version.ToFullStringSafe();
             OriginalVersion = packageMetadata.Version.OriginalVersion;
             HasSemVer2Version = packageMetadata.Version.IsSemVer2;
-            HasSemVer2Dependency = dependencyGroups.Any(d => d.Packages.Any(
+            HasSemVer2Dependency = packageMetadata.GetDependencyGroups().Any(d => d.Packages.Any(
                                 p => (p.VersionRange.HasUpperBound && p.VersionRange.MaxVersion.IsSemVer2)
                                     || (p.VersionRange.HasLowerBound && p.VersionRange.MinVersion.IsSemVer2)));
-            LicenseUrl = packageMetadata.LicenseUrl.ToEncodedUrlStringOrNull();
-            Listed = true;
+            
+            // Verifiable fields
             Language = packageMetadata.Language;
             MinClientVersionDisplay = packageMetadata.MinClientVersion.ToFullStringSafe();
             FrameworkReferenceGroups = packageMetadata.GetFrameworkReferenceGroups();
             Dependencies = new DependencySetsViewModel(packageMetadata.GetDependencyGroups().AsPackageDependencyEnumerable());
             DevelopmentDependency = packageMetadata.GetValueFromMetadata("developmentDependency");
-            Edit = new EditPackageVersionRequest(packageMetadata);
+            Authors = packageMetadata.Authors.Flatten();
+            Copyright = packageMetadata.Copyright;
+            Description = packageMetadata.Description;
+            IconUrl = packageMetadata.IconUrl.ToEncodedUrlStringOrNull();
+            LicenseUrl = packageMetadata.LicenseUrl.ToEncodedUrlStringOrNull();
+            ProjectUrl = packageMetadata.ProjectUrl.ToEncodedUrlStringOrNull();
+            ReleaseNotes = packageMetadata.ReleaseNotes;
+            RequiresLicenseAcceptance = packageMetadata.RequireLicenseAcceptance;
+            Summary = packageMetadata.Summary;
+            Tags = PackageHelper.ParseTags(packageMetadata.Tags);
+            Title = packageMetadata.Title;
+
+            // Editable server-state
+            Listed = true;
+            Edit = new EditPackageVersionRequest();
         }
 
         public string Id { get; set; }
@@ -47,13 +59,27 @@ namespace NuGetGallery
         public bool IsSemVer2 => HasSemVer2Version || HasSemVer2Dependency;
         public bool HasSemVer2Version { get; set; }
         public bool HasSemVer2Dependency { get; set; }
-        public string LicenseUrl { get; set; }
+
+        // Editable server-state
         public bool Listed { get; set; }
         public EditPackageVersionRequest Edit { get; set; }
-        public string MinClientVersionDisplay { get; set; }
-        public string Language { get; set; }
-        public string DevelopmentDependency { get; set; }
+
+        // Verifiable fields
+        public string Authors { get; set; }
+        public string Copyright { get; set; }
+        public string Description { get; set; }
         public DependencySetsViewModel Dependencies { get; set; }
+        public string DevelopmentDependency { get; set; }
         public IReadOnlyCollection<FrameworkSpecificGroup> FrameworkReferenceGroups { get; set; }
+        public string IconUrl { get; set; }
+        public string Language { get; set; }
+        public string LicenseUrl { get; set; }
+        public string MinClientVersionDisplay { get; set; }
+        public string ProjectUrl { get; set; }
+        public string ReleaseNotes { get; set; }
+        public bool RequiresLicenseAcceptance { get; set; }
+        public string Summary { get; set; }
+        public string Tags { get; set; }
+        public string Title { get; set; }
     }
 }

--- a/src/NuGetGallery/Services/EditPackageService.cs
+++ b/src/NuGetGallery/Services/EditPackageService.cs
@@ -9,16 +9,12 @@ namespace NuGetGallery
     public class EditPackageService
     {
         public IEntitiesContext EntitiesContext { get; set; }
-        public IPackageNamingConflictValidator PackageNamingConflictValidator { get; set; }
 
         public EditPackageService() { }
 
-        public EditPackageService(
-            IEntitiesContext entitiesContext,
-            IPackageNamingConflictValidator packageNamingConflictValidator)
+        public EditPackageService(IEntitiesContext entitiesContext)
         {
             EntitiesContext = entitiesContext;
-            PackageNamingConflictValidator = packageNamingConflictValidator;
         }
 
         /// <summary>
@@ -34,29 +30,28 @@ namespace NuGetGallery
 
         public virtual void StartEditPackageRequest(Package p, EditPackageVersionRequest request, User editingUser)
         {
-            if (PackageNamingConflictValidator.TitleConflictsWithExistingRegistrationId(p.PackageRegistration.Id, request.VersionTitle))
+            var edit = new PackageEdit
             {
-                throw new EntityException(Strings.TitleMatchesExistingRegistration, request.VersionTitle);
-            }
-
-            PackageEdit edit = new PackageEdit
-            {
-                // Description
-                User = editingUser,
-                Authors = request.Authors,
-                Copyright = request.Copyright,
-                Description = request.Description,
-                IconUrl = request.IconUrl,
-                LicenseUrl = p.LicenseUrl, // Our current policy is not to allow editing the license URL, so just clone it from its previous value.
-                ProjectUrl = request.ProjectUrl,
-                ReleaseNotes = request.ReleaseNotes,
-                RequiresLicenseAcceptance = request.RequiresLicenseAcceptance,
-                Summary = request.Summary,
-                Tags = request.Tags,
-                Title = request.VersionTitle,
+                // No longer change these fields as they are no longer editable.
+                // To be removed in a next wave of package immutability implementation.
+                // (when no pending edits left to be processed in the db)
+                Authors = p.FlattenedAuthors,
+                Copyright = p.Copyright,
+                Description = p.Description,
+                IconUrl = p.IconUrl,
+                LicenseUrl = p.LicenseUrl,
+                ProjectUrl = p.ProjectUrl,
+                ReleaseNotes = p.ReleaseNotes,
+                RequiresLicenseAcceptance = p.RequiresLicenseAcceptance,
+                Summary = p.Summary,
+                Tags = p.Tags,
+                Title = p.Title,
+                
+                // Readme
                 ReadMeState = request.ReadMeState,
 
                 // Other
+                User = editingUser,
                 Package = p,
                 Timestamp = DateTime.UtcNow,
                 TriedCount = 0,

--- a/src/NuGetGallery/Services/EditPackageService.cs
+++ b/src/NuGetGallery/Services/EditPackageService.cs
@@ -20,39 +20,39 @@ namespace NuGetGallery
         /// <summary>
         /// Returns the newest, uncompleted metadata for a package (i.e. a pending edit)
         /// </summary>
-        public virtual PackageEdit GetPendingMetadata(Package p)
+        public virtual PackageEdit GetPendingMetadata(Package package)
         {
             return EntitiesContext.Set<PackageEdit>()
-                .Where(m => m.PackageKey == p.Key)
+                .Where(m => m.PackageKey == package.Key)
                 .OrderByDescending(m => m.Timestamp)
                 .FirstOrDefault();
         }
 
-        public virtual void StartEditPackageRequest(Package p, EditPackageVersionRequest request, User editingUser)
+        public virtual void StartEditPackageRequest(Package package, EditPackageVersionReadMeRequest request, User editingUser)
         {
             var edit = new PackageEdit
             {
                 // No longer change these fields as they are no longer editable.
                 // To be removed in a next wave of package immutability implementation.
                 // (when no pending edits left to be processed in the db)
-                Authors = p.FlattenedAuthors,
-                Copyright = p.Copyright,
-                Description = p.Description,
-                IconUrl = p.IconUrl,
-                LicenseUrl = p.LicenseUrl,
-                ProjectUrl = p.ProjectUrl,
-                ReleaseNotes = p.ReleaseNotes,
-                RequiresLicenseAcceptance = p.RequiresLicenseAcceptance,
-                Summary = p.Summary,
-                Tags = p.Tags,
-                Title = p.Title,
+                Authors = package.FlattenedAuthors,
+                Copyright = package.Copyright,
+                Description = package.Description,
+                IconUrl = package.IconUrl,
+                LicenseUrl = package.LicenseUrl,
+                ProjectUrl = package.ProjectUrl,
+                ReleaseNotes = package.ReleaseNotes,
+                RequiresLicenseAcceptance = package.RequiresLicenseAcceptance,
+                Summary = package.Summary,
+                Tags = package.Tags,
+                Title = package.Title,
                 
                 // Readme
                 ReadMeState = request.ReadMeState,
 
                 // Other
                 User = editingUser,
-                Package = p,
+                Package = package,
                 Timestamp = DateTime.UtcNow,
                 TriedCount = 0,
             };

--- a/src/NuGetGallery/Services/IReadMeService.cs
+++ b/src/NuGetGallery/Services/IReadMeService.cs
@@ -44,6 +44,6 @@ namespace NuGetGallery
         /// <param name="package">Package entity associated with the ReadMe.</param>
         /// <param name="edit">Package edit entity.</param>
         /// <returns>True if a ReadMe is pending, false otherwise.</returns>
-        Task<bool> SavePendingReadMeMdIfChanged(Package package, EditPackageVersionRequest edit, Encoding encoding);
+        Task<bool> SavePendingReadMeMdIfChanged(Package package, EditPackageVersionReadMeRequest edit, Encoding encoding);
     }
 }

--- a/src/NuGetGallery/Services/ReadMeService.cs
+++ b/src/NuGetGallery/Services/ReadMeService.cs
@@ -112,7 +112,7 @@ namespace NuGetGallery
         /// <param name="package">Package entity associated with the ReadMe.</param>
         /// <param name="edit">Package edit entity.</param>
         /// <returns>True if a ReadMe is pending, false otherwise.</returns>
-        public async Task<bool> SavePendingReadMeMdIfChanged(Package package, EditPackageVersionRequest edit, Encoding encoding)
+        public async Task<bool> SavePendingReadMeMdIfChanged(Package package, EditPackageVersionReadMeRequest edit, Encoding encoding)
         {
             var activeReadMe = package.HasReadMe ?
                 NormalizeNewLines(await GetReadMeMdAsync(package)) :

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -64,7 +64,7 @@
                 </div>
             }
 
-            @Html.Partial("_EditForm")
+            @Html.Partial("_VerifyForm")
         </div>
     </div>
 </section>

--- a/src/NuGetGallery/Views/Packages/_VerifyForm.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyForm.cshtml
@@ -1,0 +1,46 @@
+﻿<form id="verify-metadata-form">
+    @Html.AntiForgeryToken()
+
+    <div id="verify-collapser-container" class="hidden">
+        <h2>
+            <a href="#" role="button" data-toggle="collapse" data-target="#verify-package-form"
+               aria-expanded="true" aria-controls="verify-package-form" id="show-verify-package-form">
+                <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                <span>Verify</span>
+            </a>
+        </h2>
+    </div>
+
+    <div id="verify-package-container">
+    </div>
+
+    @Html.Partial("_VerifyMetadata")
+
+    <div id="readme-collapser-container" class="hidden">
+        <h2>
+            <a href="#" role="button" data-toggle="collapse" data-target="#readme-package-form"
+               aria-expanded="false" aria-controls="readme-package-form" id="show-readme-package-form">
+                <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                <span>Import Documentation</span>
+            </a>
+        </h2>
+    </div>
+
+    <div id="import-readme-container">
+    </div>
+    @Html.Partial("_ImportReadMe")
+
+    <div id="submit-collapser-container" class="hidden">
+        <h2>
+            <a href="#" role="button" data-toggle="collapse" data-target="#submit-package-form"
+               aria-expanded="true" aria-controls="submit-package-form" id="show-submit-package-form">
+                <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                <span>Submit</span>
+            </a>
+        </h2>
+    </div>
+
+    <div id="submit-package-container">
+    </div>
+    @Html.Partial("_SubmitPackage")
+</form>

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -45,44 +45,40 @@
     <div class="collapse in">
         <div data-bind="if: $data">
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <label for="Id" class="verify-package-field-heading">Package ID</label>
                     <p data-bind="text: $data.Id"></p>
                     <input data-bind="value: $data.Id" type="hidden" name="Id" class="form-control" />
                 </div>
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <label for="Version" class="verify-package-field-heading">Version</label>
                     <p data-bind="text: $data.Version"></p>
                     <input data-bind="value: $data.Version" type="hidden" name="Version" class="form-control" />
                     <input data-bind="value: $data.OriginalVersion" type="hidden" name="OriginalVersion" class="form-control" />
                 </div>
 
-                <div class="verify-package-field form-group readonly">
-                    <label for="MinClientVersionDisplay" class="verify-package-field-heading">Minimum NuGet Client Version</label>
+                <div class="verify-package-field">
+                    <label class="verify-package-field-heading">Minimum NuGet Client Version</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.MinClientVersionDisplay }}"></div>
-                    <input data-bind="value: $data.MinClientVersionDisplay" type="hidden" name="MinClientVersionDisplay" class="form-control" />
                 </div>
 
-                <div class="verify-package-field form-group readonly">
-                    <label for="LicenseUrl" class="verify-package-field-heading">License URL</label>
+                <div class="verify-package-field">
+                    <label class="verify-package-field-heading">License URL</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.LicenseUrl, Link: true }}"></div>
-                    <input data-bind="value: $data.LicenseUrl" type="hidden" name="LicenseUrl" class="form-control" />
                 </div>
 
-                <div class="verify-package-field form-group readonly">
-                    <label for="Language" class="verify-package-field-heading">Language</label>
+                <div class="verify-package-field">
+                    <label class="verify-package-field-heading">Language</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Language }}"></div>
-                    <input data-bind="value: $data.Language" type="hidden" name="Language" class="form-control" />
                 </div>
 
-                <div class="verify-package-field form-group readonly">
-                    <label for="DevelopmentDependency" class="verify-package-field-heading">Development Dependency</label>
+                <div class="verify-package-field">
+                    <label class="verify-package-field-heading">Development Dependency</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.DevelopmentDependency }}"></div>
-                    <input data-bind="value: $data.DevelopmentDependency" type="hidden" name="DevelopmentDependency" class="form-control" />
                 </div>
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <div class="verify-package-field-heading">Dependencies</div>
                     <!-- ko if: $data.Dependencies && Object.keys($data.Dependencies.DependencySets).length > 0 -->
                     <div data-bind="template: {name: 'display-dependencysets', data: { DependencySets: Dependencies.DependencySets, OnlyHasAllFrameworks: Dependencies.OnlyHasAllFrameworks }}"></div>
@@ -92,67 +88,63 @@
                     <!-- /ko -->
                 </div>
 
-                <!--BEGIN EDITABLE FIELDS-->
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <label class="verify-package-field-heading">Title</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Title }}"></div>
                 </div>
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <label class="verify-package-field-heading">Description</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Description }}"></div>
                 </div>
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <div class="verify-package-field-heading"><label>Summary</label> (shown on package search page)</div>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Summary }}"></div>
                 </div>
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <div class="verify-package-field-heading"><label>Release Notes</label> (for this version)</div>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.ReleaseNotes }}"></div>
                 </div>
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <label class="verify-package-field-heading">Project URL</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.ProjectUrl }}"></div>
                 </div>
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <!-- Bind an on change event here to update the preview below-->
                     <label class="verify-package-field-heading">Icon URL</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.IconUrl }}"></div>
                 </div>
 
-                <div class="verify-package-field form-group readonly row">
+                <!-- ko if: $data.IconUrl -->
+                <div class="verify-package-field row">
                     <div class="verify-package-field-heading col-sm-12">Icon Preview</div>
                     <div id="icon-preview-container" class="col-sm-1">
-                        <!-- ko if: Edit.IconUrl -->
                         <img class="package-icon img-responsive" id="icon-preview" data-bind="attr: { src: $data.IconUrl }" /> <!-- probably need to check this for safety-->
-                        <!-- /ko -->
-                        <!-- ko ifnot: Edit.IconUrl -->
-                        <p><i>(none specified)</i></p>
-                        <!-- /ko -->
                     </div>
                 </div>
+                <!-- /ko -->
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <div class="verify-package-field-heading"><label>Authors</label></div>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Authors }}"></div>
                 </div>
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <label class="verify-package-field-heading">Copyright</label>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Copyright }}"></div>
                 </div>
 
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <div class="verify-package-field-heading"><label>Tags</label></div>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Tags }}"></div>
                 </div>
 
                 <!-- ko if: $data.LicenseUrl -->
-                <div class="verify-package-field form-group readonly">
+                <div class="verify-package-field">
                     <div class="verify-package-field-heading">Require License Acceptance</div>
                     <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.RequiresLicenseAcceptance }}"></div>
                 </div>
@@ -170,7 +162,6 @@
                     </div>
                 </div>
                 <!-- /ko -->
-            @*</form>*@
         </div>
 
         <!-- ko if: $data.IsSemVer2 -->

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -1,0 +1,192 @@
+﻿<script type="text/html" id="validation-errors">
+    <div data-bind="foreach:$data" class="validation-error-message-list">
+        @ViewHelpers.AlertDanger(@<text><span data-bind="text:$data"></span></text>)
+    </div>
+</script>
+
+<script type="text/html" id="display-data-or-default">
+    <!-- ko if: DisplayText -->
+    <!-- ko if: $data.Link -->
+    <p><a data-bind="text: DisplayText, href: DisplayText"></a></p>
+    <!-- /ko-->
+    <!-- ko ifnot: $data.Link -->
+    <p data-bind="text: DisplayText"></p>
+    <!-- /ko -->
+    <!-- /ko -->
+    <!-- ko ifnot: DisplayText -->
+    <p><i>(none specified)</i></p>
+    <!-- /ko -->
+</script>
+
+<script type="text/html" id="display-dependencysets">
+    <div data-bind="foreach: {data: DependencySets, as: '_data'}" class="form-control-static">
+        <ul data-bind="foreach: {data: Object.keys(_data), as: '_propkey'}" class="input-group list-unstyled dependency-groups">
+            <li>
+                <h4>
+                    <span data-bind="text: _propkey"></span>
+                </h4>
+                <ul data-bind="foreach: _data[_propkey]" class="list-unstyled dependency-group">
+                    <li>
+                        <!-- ko if: $data -->
+                        <a class="dependency-id" data-bind="attr: { href: PackageUrl }, text: Id"></a>
+                        <span class="dependency-versionspec" data-bind="text: VersionSpec"></span>
+                        <!-- /ko -->
+                        <!-- ko ifnot: $data -->
+                        <span class="dependency-none">No Package Dependencies</span>
+                        <!-- /ko -->
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+</script>
+
+<script type="text/html" id="edit-metadata-template">
+    <div class="collapse in">
+        <div data-bind="if: $data">
+
+                <div class="verify-package-field form-group readonly">
+                    <label for="Id" class="verify-package-field-heading">Package ID</label>
+                    <p data-bind="text: $data.Id"></p>
+                    <input data-bind="value: $data.Id" type="hidden" name="Id" class="form-control" />
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <label for="Version" class="verify-package-field-heading">Version</label>
+                    <p data-bind="text: $data.Version"></p>
+                    <input data-bind="value: $data.Version" type="hidden" name="Version" class="form-control" />
+                    <input data-bind="value: $data.OriginalVersion" type="hidden" name="OriginalVersion" class="form-control" />
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <label for="MinClientVersionDisplay" class="verify-package-field-heading">Minimum NuGet Client Version</label>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.MinClientVersionDisplay }}"></div>
+                    <input data-bind="value: $data.MinClientVersionDisplay" type="hidden" name="MinClientVersionDisplay" class="form-control" />
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <label for="LicenseUrl" class="verify-package-field-heading">License URL</label>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.LicenseUrl, Link: true }}"></div>
+                    <input data-bind="value: $data.LicenseUrl" type="hidden" name="LicenseUrl" class="form-control" />
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <label for="Language" class="verify-package-field-heading">Language</label>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Language }}"></div>
+                    <input data-bind="value: $data.Language" type="hidden" name="Language" class="form-control" />
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <label for="DevelopmentDependency" class="verify-package-field-heading">Development Dependency</label>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.DevelopmentDependency }}"></div>
+                    <input data-bind="value: $data.DevelopmentDependency" type="hidden" name="DevelopmentDependency" class="form-control" />
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <div class="verify-package-field-heading">Dependencies</div>
+                    <!-- ko if: $data.Dependencies && Object.keys($data.Dependencies.DependencySets).length > 0 -->
+                    <div data-bind="template: {name: 'display-dependencysets', data: { DependencySets: Dependencies.DependencySets, OnlyHasAllFrameworks: Dependencies.OnlyHasAllFrameworks }}"></div>
+                    <!-- /ko -->
+                    <!-- ko ifnot: $data.Dependencies && Object.keys($data.Dependencies.DependencySets).length > 0  -->
+                    <p><i>(none specified)</i></p>
+                    <!-- /ko -->
+                </div>
+
+                <!--BEGIN EDITABLE FIELDS-->
+                <div class="verify-package-field form-group readonly">
+                    <label class="verify-package-field-heading">Title</label>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Title }}"></div>
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <label class="verify-package-field-heading">Description</label>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Description }}"></div>
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <div class="verify-package-field-heading"><label>Summary</label> (shown on package search page)</div>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Summary }}"></div>
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <div class="verify-package-field-heading"><label>Release Notes</label> (for this version)</div>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.ReleaseNotes }}"></div>
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <label class="verify-package-field-heading">Project URL</label>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.ProjectUrl }}"></div>
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <!-- Bind an on change event here to update the preview below-->
+                    <label class="verify-package-field-heading">Icon URL</label>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.IconUrl }}"></div>
+                </div>
+
+                <div class="verify-package-field form-group readonly row">
+                    <div class="verify-package-field-heading col-sm-12">Icon Preview</div>
+                    <div id="icon-preview-container" class="col-sm-1">
+                        <!-- ko if: Edit.IconUrl -->
+                        <img class="package-icon img-responsive" id="icon-preview" data-bind="attr: { src: $data.IconUrl }" /> <!-- probably need to check this for safety-->
+                        <!-- /ko -->
+                        <!-- ko ifnot: Edit.IconUrl -->
+                        <p><i>(none specified)</i></p>
+                        <!-- /ko -->
+                    </div>
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <div class="verify-package-field-heading"><label>Authors</label></div>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Authors }}"></div>
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <label class="verify-package-field-heading">Copyright</label>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Copyright }}"></div>
+                </div>
+
+                <div class="verify-package-field form-group readonly">
+                    <div class="verify-package-field-heading"><label>Tags</label></div>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.Tags }}"></div>
+                </div>
+
+                <!-- ko if: $data.LicenseUrl -->
+                <div class="verify-package-field form-group readonly">
+                    <div class="verify-package-field-heading">Require License Acceptance</div>
+                    <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.RequiresLicenseAcceptance }}"></div>
+                </div>
+                <!-- /ko -->
+
+                <!-- ko if: typeof($data.Listed) === 'boolean' -->
+                <div class="verify-package-field form-group editable">
+                    <div class="verify-package-field-heading">Package Visibility</div>
+                    <div class="checkbox">
+                        <label>
+                            <input data-bind="attr: { 'checked' : $data.Listed ? $data.Listed : null }"
+                                   type="checkbox" name="Listed" id="Listed" value="true" />
+                            List package in search results
+                        </label>
+                    </div>
+                </div>
+                <!-- /ko -->
+            @*</form>*@
+        </div>
+
+        <!-- ko if: $data.IsSemVer2 -->
+        @ViewHelpers.AlertWarning(@<text>
+            <!-- ko if: $data.HasSemVer2Version -->
+            This package has a SemVer 2.0.0 package version.<br />
+            <!-- /ko -->
+            <!-- ko if: !$data.HasSemVer2Version && $data.HasSemVer2Dependency -->
+            This package is considered a SemVer 2.0.0 package as it has a package dependency on SemVer 2.0.0 package(s).<br />
+            <!-- /ko -->
+            <em>
+                This package will only be available to download with SemVer 2.0.0 compatible NuGet clients, such as Visual
+                Studio 2017 (version 15.3) and above or NuGet client 4.3.0 and above.
+                <a href="https://go.microsoft.com/fwlink/?linkid=852248" alt="Read more">Read more</a><br />
+            </em>
+            </text>)
+        <!-- /ko -->
+    </div>
+</script>

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1636,7 +1636,7 @@ namespace NuGetGallery
 
                 var formData = new VerifyPackageRequest
                 {
-                    Edit = new EditPackageVersionRequest
+                    Edit = new EditPackageVersionReadMeRequest
                     {
                         ReadMe = new ReadMeRequest
                         {
@@ -1673,7 +1673,7 @@ namespace NuGetGallery
 
                 var formData = new VerifyPackageRequest
                 {
-                    Edit = new EditPackageVersionRequest()
+                    Edit = new EditPackageVersionReadMeRequest()
                 };
 
                 // Act.
@@ -3350,7 +3350,7 @@ namespace NuGetGallery
             {
                 get
                 {
-                    yield return new object[] { new EditPackageVersionRequest() {
+                    yield return new object[] { new EditPackageVersionReadMeRequest() {
                         ReadMe = new ReadMeRequest { SourceType = "Written", SourceText = "markdown" } }
                     };
                 }
@@ -3358,7 +3358,7 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData("WillApplyEdits_Data")]
-            public async Task WillApplyEdits(EditPackageVersionRequest edit)
+            public async Task WillApplyEdits(EditPackageVersionReadMeRequest edit)
             {
                 // Arrange
                 using (var fakeFileStream = new MemoryStream())
@@ -3408,7 +3408,7 @@ namespace NuGetGallery
         {
             get
             {
-                yield return new object[] { new EditPackageVersionRequest() {
+                yield return new object[] { new EditPackageVersionReadMeRequest() {
                     ReadMe = new ReadMeRequest { SourceType = "Written", SourceText = "markdown"} }
                 };
             }
@@ -3416,7 +3416,7 @@ namespace NuGetGallery
 
         [Theory]
         [MemberData(nameof(WillApplyReadMe_Data))]
-        public async Task WillApplyReadMeForWrittenReadMeData(EditPackageVersionRequest edit)
+        public async Task WillApplyReadMeForWrittenReadMeData(EditPackageVersionReadMeRequest edit)
         {
             // Arrange
             using (var fakeFileStream = new MemoryStream())

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -3350,16 +3350,6 @@ namespace NuGetGallery
             {
                 get
                 {
-                    yield return new object[] { new EditPackageVersionRequest() { RequiresLicenseAcceptance = true } };
-                    yield return new object[] { new EditPackageVersionRequest() { IconUrl = "https://iconnew" } };
-                    yield return new object[] { new EditPackageVersionRequest() { ProjectUrl = "https://projectnew" } };
-                    yield return new object[] { new EditPackageVersionRequest() { Authors = "author1new authors2new" } };
-                    yield return new object[] { new EditPackageVersionRequest() { Copyright = "copyright" } };
-                    yield return new object[] { new EditPackageVersionRequest() { Description = "new desc" } };
-                    yield return new object[] { new EditPackageVersionRequest() { ReleaseNotes = "notes123" } };
-                    yield return new object[] { new EditPackageVersionRequest() { Summary = "summary new" } };
-                    yield return new object[] { new EditPackageVersionRequest() { Tags = "tag1new tag2new" } };
-                    yield return new object[] { new EditPackageVersionRequest() { VersionTitle = "title" } };
                     yield return new object[] { new EditPackageVersionRequest() {
                         ReadMe = new ReadMeRequest { SourceType = "Written", SourceText = "markdown" } }
                     };
@@ -3418,16 +3408,6 @@ namespace NuGetGallery
         {
             get
             {
-                yield return new object[] { new EditPackageVersionRequest() { RequiresLicenseAcceptance = true } };
-                yield return new object[] { new EditPackageVersionRequest() { IconUrl = "https://iconnew" } };
-                yield return new object[] { new EditPackageVersionRequest() { ProjectUrl = "https://projectnew" } };
-                yield return new object[] { new EditPackageVersionRequest() { Authors = "author1new authors2new" } };
-                yield return new object[] { new EditPackageVersionRequest() { Copyright = "copyright" } };
-                yield return new object[] { new EditPackageVersionRequest() { Description = "new desc" } };
-                yield return new object[] { new EditPackageVersionRequest() { ReleaseNotes = "notes123" } };
-                yield return new object[] { new EditPackageVersionRequest() { Summary = "summary new" } };
-                yield return new object[] { new EditPackageVersionRequest() { Tags = "tag1new tag2new" } };
-                yield return new object[] { new EditPackageVersionRequest() { VersionTitle = "title" } };
                 yield return new object[] { new EditPackageVersionRequest() {
                     ReadMe = new ReadMeRequest { SourceType = "Written", SourceText = "markdown"} }
                 };


### PR DESCRIPTION
PR into feature branch for pkg immutability.

This PR focuses on the verify-upload experience, which now only allows toggling Listed/Unlisted and modifying Readme/Documentation.

The verify form is now a separate view from the edit form as they provide both different views and experience.