### PR TITLE
Quick hotfix to removing package owners from the manage package owners page

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
@@ -64,7 +64,12 @@
                         && namespaceOwnerCount >= 2));
         },
         
-        IsOnlyUserGrantingAccessToCurrentUser: function () {
+        IsOnlyUserGrantingAccessToCurrentUser: function (item) {
+            if (!item.grantsCurrentUserAccess) {
+                // If the user we are trying to remove is not granting the current user access, they cannot be the only user granting access to the current user.
+                return false;
+            }
+
             if (isUserAnAdmin.toLocaleLowerCase() === "True".toLocaleLowerCase()) {
                 // If user is an admin, removing any user will not remove their ability to manage package owners.
                 return false;
@@ -165,7 +170,7 @@
         },
 
         removeOwner: function (item) {
-            var isOnlyUserGrantingAccessToCurrentUser = viewModel.IsOnlyUserGrantingAccessToCurrentUser();
+            var isOnlyUserGrantingAccessToCurrentUser = viewModel.IsOnlyUserGrantingAccessToCurrentUser(item);
             var isOnlyUserGrantingAccessToCurrentUserMessage = isOnlyUserGrantingAccessToCurrentUser ? strings_RemovingOwnership : "";
 
             if (item.isCurrentUserMemberOfOrganization) {


### PR DESCRIPTION
(This is a bug in master that's on dev but not yet deployed to int or prod.)

We want to redirect you back to the package details page after removing a package owner if you removed the last owner that granted you ownership of the package.

Currently, it will always redirect you back after removing any package owner, regardless of whether or not you are still an owner. This fixes this behavior.