### PR TITLE
[Hotfix]Overflow on Manage Package page

### DIFF
--- a/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesList.cshtml
@@ -2,7 +2,7 @@
 @{
     var packagesString = "package" + (Model.Packages.Count() != 1 ? "s" : "");
     
-    var numDownloads = Model.Packages.Sum(p => p.TotalDownloadCount);
+    var numDownloads = Model.Packages.Sum(p => (long)p.TotalDownloadCount);
     var downloadsString = "download" + (numDownloads != 1 ? "s" : "");
 }
 


### PR DESCRIPTION
Cast download count values as long before summing so we sum them into a long.

@joelverhagen @scottbommarito @skofman1 @chenriksson 