### PR TITLE
Permissions tests for DisplayPackage

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -433,7 +433,7 @@ namespace NuGetGallery
             var model = new DisplayPackageViewModel(package, packageHistory);
 
             var isReadMePending = false;
-            if (PermissionsService.IsActionAllowed(package, User, PackageActions.Edit))
+            if (PermissionsService.IsActionAllowed(package, User, PackageActions.DisplayPrivatePackage))
             {
                 // Tell logged-in package owners not to cache the package page,
                 // so they won't be confused about the state of pending edits.

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -474,28 +474,28 @@ namespace NuGetGallery
             [MemberData(nameof(EditedPackageOwners))]
             public Task GivenAnOwnedValidPackageWithNoEditsItDisplaysCurrentMetadata(User currentUser, User owner)
             {
-                return CheckValidPackageWithEdits(currentUser, owner, false, false);
+                return CheckValidPackageWithEdits(currentUser, owner, isEdited: false, seeEdit: false);
             }
 
             [Theory]
             [MemberData(nameof(EditedPackageOwners))]
             public Task GivenAnOwnedValidPackageWithEditsItDisplaysEditedMetadata(User currentUser, User owner)
             {
-                return CheckValidPackageWithEdits(currentUser, owner, true, true);
+                return CheckValidPackageWithEdits(currentUser, owner, isEdited: true, seeEdit: true);
             }
 
             [Theory]
             [MemberData(nameof(EditedPackageNonOwners))]
             public Task GivenAnUnownedValidPackageWithNoEditsItDisplaysCurrentMetadata(User currentUser, User owner)
             {
-                return CheckValidPackageWithEdits(currentUser, owner, false, false);
+                return CheckValidPackageWithEdits(currentUser, owner, isEdited: false, seeEdit: false);
             }
 
             [Theory]
             [MemberData(nameof(EditedPackageNonOwners))]
             public Task GivenAnUnownedValidPackageWithEditsItDisplaysEditedMetadata(User currentUser, User owner)
             {
-                return CheckValidPackageWithEdits(currentUser, owner, true, false);
+                return CheckValidPackageWithEdits(currentUser, owner, isEdited: true, seeEdit: false);
             }
 
             private async Task CheckValidPackageWithEdits(User currentUser, User owner, bool isEdited, bool seeEdit)

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -239,43 +239,6 @@ namespace NuGetGallery
                 ResultAssert.IsNotFound(result);
             }
 
-            [Fact]
-            public async Task GivenAValidPackageThatTheCurrentUserDoesNotOwnItDisplaysCurrentMetadata()
-            {
-                // Arrange
-                var packageService = new Mock<IPackageService>();
-                var indexingService = new Mock<IIndexingService>();
-                var controller = CreateController(
-                    GetConfigurationService(),
-                    packageService: packageService,
-                    indexingService: indexingService);
-                controller.SetCurrentUser(TestUtility.FakeUser);
-
-                packageService.Setup(p => p.FindPackageByIdAndVersion("Foo", "1.1.1", SemVerLevelKey.SemVer2, true))
-                              .Returns(new Package()
-                              {
-                                  PackageRegistration = new PackageRegistration()
-                                  {
-                                      Id = "Foo",
-                                      Owners = new List<User>()
-                                  },
-                                  Version = "01.1.01",
-                                  NormalizedVersion = "1.1.1",
-                                  Title = "A test package!"
-                              });
-
-                indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
-
-                // Act
-                var result = await controller.DisplayPackage("Foo", "1.1.1");
-
-                // Assert
-                var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
-                Assert.Equal("Foo", model.Id);
-                Assert.Equal("1.1.1", model.Version);
-                Assert.Equal("A test package!", model.Title);
-            }
-
             public static IEnumerable<PackageStatus> ValidatingPackageStatuses = 
                 new[] { PackageStatus.Validating , PackageStatus.FailedValidation};
 
@@ -383,6 +346,7 @@ namespace NuGetGallery
                     packageService: packageService,
                     httpContext: httpContext);
                 controller.SetCurrentUser(currentUser);
+
                 httpContext.Setup(c => c.Response.Cache).Returns(httpCachePolicy.Object);
 
                 var package = new Package
@@ -426,6 +390,7 @@ namespace NuGetGallery
                     packageService: packageService,
                     editPackageService: editPackageService,
                     httpContext: httpContext);
+
                 controller.SetCurrentUser(TestUtility.FakeUser);
                 httpContext.Setup(c => c.Response.Cache).Returns(httpCachePolicy.Object);
 
@@ -547,12 +512,7 @@ namespace NuGetGallery
                     editPackageService: editPackageService,
                     indexingService: indexingService,
                     httpContext: httpContext);
-
-                if (currentUser != null)
-                {
-                    controller.SetCurrentUser(currentUser);
-                }
-
+                controller.SetCurrentUser(currentUser);
                 httpContext.Setup(c => c.Response.Cache).Returns(httpCachePolicy.Object);
                 var uneditedTitle = "A test package!";
                 var package = new Package()

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -306,7 +306,7 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(GivenAValidatingPackage_Data))]
-            public async Task GivenAValidatingPackageWhileLoggedOutDoesNotOwnThenHideIt(PackageStatus packageStatus)
+            public async Task GivenAValidatingPackageWhileLoggedOutThenHideIt(PackageStatus packageStatus)
             {
                 // Arrange & Act
                 var result = await GetActionResultForPackageStatusAsync(

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -62,8 +62,8 @@ namespace NuGetGallery
             {
                 uploadFileService = new Mock<IUploadFileService>();
                 uploadFileService.Setup(x => x.DeleteUploadFileAsync(It.IsAny<int>())).Returns(Task.FromResult(0));
-                uploadFileService.Setup(x => x.GetUploadFileAsync(42)).Returns(Task.FromResult<Stream>(null));
-                uploadFileService.Setup(x => x.SaveUploadFileAsync(42, It.IsAny<Stream>())).Returns(Task.FromResult(0));
+                uploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(null));
+                uploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
             }
             userService = userService ?? new Mock<IUserService>();
             messageService = messageService ?? new Mock<IMessageService>();
@@ -276,29 +276,94 @@ namespace NuGetGallery
                 Assert.Equal("A test package!", model.Title);
             }
 
+            public static IEnumerable<PackageStatus> ValidatingPackageStatuses = 
+                new[] { PackageStatus.Validating , PackageStatus.FailedValidation};
+
+            public static IEnumerable<object[]> GivenAValidatingPackage_Data => ValidatingPackageStatuses.Select(s => new object[] { s });
+
             [Theory]
-            [InlineData(PackageStatus.Validating)]
-            [InlineData(PackageStatus.FailedValidation)]
+            [MemberData(nameof(GivenAValidatingPackage_Data))]
             public async Task GivenAValidatingPackageThatTheCurrentUserOwnsThenShowIt(PackageStatus packageStatus)
             {
                 // Arrange & Act
                 var result = await GetActionResultForPackageStatusAsync(
                     packageStatus,
-                    p => p.PackageRegistration.Owners.Add(TestUtility.FakeUser));
+                    TestUtility.FakeUser,
+                    TestUtility.FakeUser);
 
                 // Assert
                 Assert.IsType<ViewResult>(result);
             }
 
             [Theory]
-            [InlineData(PackageStatus.Validating)]
-            [InlineData(PackageStatus.FailedValidation)]
+            [MemberData(nameof(GivenAValidatingPackage_Data))]
+            public async Task GivenAValidatingPackageAsAdminThenShowIt(PackageStatus packageStatus)
+            {
+                // Arrange & Act
+                var result = await GetActionResultForPackageStatusAsync(
+                    packageStatus,
+                    TestUtility.FakeAdminUser,
+                    new User { Key = 132114 });
+
+                // Assert
+                Assert.IsType<ViewResult>(result);
+            }
+
+            public static IEnumerable<object[]> GivenAValidatingPackageThatCurrentUsersOrganizationOwnsThenShowIt_Data
+            {
+                get
+                {
+                    foreach (var isAdmin in new[] { true, false })
+                    {
+                        foreach (var status in ValidatingPackageStatuses)
+                        {
+                            yield return new object[]
+                            {
+                                status,
+                                isAdmin
+                            };
+                        }
+                    }
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(GivenAValidatingPackageThatCurrentUsersOrganizationOwnsThenShowIt_Data))]
+            public async Task GivenAValidatingPackageThatCurrentUsersOrganizationOwnsThenShowIt(PackageStatus packageStatus, bool isAdmin)
+            {
+                // Arrange & Act
+                var result = await GetActionResultForPackageStatusAsync(
+                    packageStatus,
+                    isAdmin ? TestUtility.FakeOrganizationAdmin : TestUtility.FakeOrganizationCollaborator,
+                    TestUtility.FakeOrganization);
+
+                // Assert
+                Assert.IsType<ViewResult>(result);
+            }
+
+            [Theory]
+            [MemberData(nameof(GivenAValidatingPackage_Data))]
+            public async Task GivenAValidatingPackageWhileLoggedOutDoesNotOwnThenHideIt(PackageStatus packageStatus)
+            {
+                // Arrange & Act
+                var result = await GetActionResultForPackageStatusAsync(
+                    packageStatus,
+                    null,
+                    new User { Key = 132114 });
+
+                // Assert
+                ResultAssert.IsNotFound(result);
+            }
+
+            [Theory]
+            [MemberData(nameof(GivenAValidatingPackage_Data))]
             public async Task GivenAValidatingPackageThatTheCurrentUserDoesNotOwnThenHideIt(PackageStatus packageStatus)
             {
                 // Arrange & Act
                 var result = await GetActionResultForPackageStatusAsync(
                     packageStatus,
-                    p => p.PackageRegistration.Owners.Clear());
+                    TestUtility.FakeUser,
+                    new User { Key = 132114 });
 
                 // Assert
                 ResultAssert.IsNotFound(result);
@@ -306,7 +371,8 @@ namespace NuGetGallery
 
             private async Task<ActionResult> GetActionResultForPackageStatusAsync(
                 PackageStatus packageStatus,
-                Action<Package> mutatePackage)
+                User currentUser,
+                User owner)
             {
                 // Arrange
                 var packageService = new Mock<IPackageService>();
@@ -316,7 +382,7 @@ namespace NuGetGallery
                     GetConfigurationService(),
                     packageService: packageService,
                     httpContext: httpContext);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                controller.SetCurrentUser(currentUser);
                 httpContext.Setup(c => c.Response.Cache).Returns(httpCachePolicy.Object);
 
                 var package = new Package
@@ -324,14 +390,12 @@ namespace NuGetGallery
                     PackageRegistration = new PackageRegistration()
                     {
                         Id = "NuGet.Versioning",
-                        Owners = new List<User>(),
+                        Owners = new[] { owner }
                     },
                     Version = "3.4.0",
                     NormalizedVersion = "3.4.0",
                     PackageStatusKey = packageStatus,
                 };
-
-                mutatePackage(package);
 
                 packageService
                     .Setup(p => p.FindPackageByIdAndVersion(
@@ -393,57 +457,83 @@ namespace NuGetGallery
                 httpCachePolicy.VerifyAll();
             }
 
-            [Fact]
-            public async Task GivenAValidPackageThatTheCurrentUserOwnsWithNoEditsItDisplaysCurrentMetadata()
+            public static IEnumerable<object[]> EditedPackageOwners
             {
-                // Arrange
-                var packageService = new Mock<IPackageService>();
-                var indexingService = new Mock<IIndexingService>();
-                var editPackageService = new Mock<EditPackageService>();
-                var httpContext = new Mock<HttpContextBase>();
-                var httpCachePolicy = new Mock<HttpCachePolicyBase>();
-                var controller = CreateController(
-                    GetConfigurationService(),
-                    packageService: packageService,
-                    editPackageService: editPackageService,
-                    indexingService: indexingService,
-                    httpContext: httpContext);
-                controller.SetCurrentUser(TestUtility.FakeUser);
-                httpContext.Setup(c => c.Response.Cache).Returns(httpCachePolicy.Object);
-
-                var package = new Package()
+                get
                 {
-                    PackageRegistration = new PackageRegistration()
+                    yield return new object[]
                     {
-                        Id = "Foo",
-                        Owners = new List<User>() { TestUtility.FakeUser }
-                    },
-                    Version = "01.1.01",
-                    NormalizedVersion = "1.1.1",
-                    Title = "A test package!"
-                };
+                        TestUtility.FakeUser,
+                        TestUtility.FakeUser
+                    };
 
-                packageService
-                    .Setup(p => p.FindPackageByIdAndVersion("Foo", "1.1.1", SemVerLevelKey.SemVer2, true))
-                    .Returns(package);
-                editPackageService
-                    .Setup(e => e.GetPendingMetadata(package))
-                    .ReturnsNull();
+                    yield return new object[]
+                    {
+                        TestUtility.FakeAdminUser,
+                        new User { Key = 12414 }
+                    };
 
-                indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
+                    yield return new object[]
+                    {
+                        TestUtility.FakeOrganizationAdmin,
+                        TestUtility.FakeOrganization
+                    };
 
-                // Act
-                var result = await controller.DisplayPackage("Foo", "1.1.1");
-
-                // Assert
-                var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
-                Assert.Equal("Foo", model.Id);
-                Assert.Equal("1.1.1", model.Version);
-                Assert.Equal("A test package!", model.Title);
+                    yield return new object[]
+                    {
+                        TestUtility.FakeOrganizationCollaborator,
+                        TestUtility.FakeOrganization
+                    };
+                }
             }
 
-            [Fact]
-            public async Task GivenAValidPackageThatTheCurrentUserOwnsWithEditsItDisplaysEditedMetadata()
+            public static IEnumerable<object[]> EditedPackageNonOwners
+            {
+                get
+                {
+                    yield return new object[]
+                    {
+                        TestUtility.FakeUser,
+                        new User { Key = 12414 }
+                    };
+
+                    yield return new object[]
+                    {
+                        null,
+                        TestUtility.FakeUser
+                    };
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(EditedPackageOwners))]
+            public Task GivenAnOwnedValidPackageWithNoEditsItDisplaysCurrentMetadata(User currentUser, User owner)
+            {
+                return CheckValidPackageWithEdits(currentUser, owner, false, false);
+            }
+
+            [Theory]
+            [MemberData(nameof(EditedPackageOwners))]
+            public Task GivenAnOwnedValidPackageWithEditsItDisplaysEditedMetadata(User currentUser, User owner)
+            {
+                return CheckValidPackageWithEdits(currentUser, owner, true, true);
+            }
+
+            [Theory]
+            [MemberData(nameof(EditedPackageNonOwners))]
+            public Task GivenAnUnownedValidPackageWithNoEditsItDisplaysCurrentMetadata(User currentUser, User owner)
+            {
+                return CheckValidPackageWithEdits(currentUser, owner, false, false);
+            }
+
+            [Theory]
+            [MemberData(nameof(EditedPackageNonOwners))]
+            public Task GivenAnUnownedValidPackageWithEditsItDisplaysEditedMetadata(User currentUser, User owner)
+            {
+                return CheckValidPackageWithEdits(currentUser, owner, true, false);
+            }
+
+            private async Task CheckValidPackageWithEdits(User currentUser, User owner, bool isEdited, bool seeEdit)
             {
                 // Arrange
                 var packageService = new Mock<IPackageService>();
@@ -457,29 +547,35 @@ namespace NuGetGallery
                     editPackageService: editPackageService,
                     indexingService: indexingService,
                     httpContext: httpContext);
-                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                if (currentUser != null)
+                {
+                    controller.SetCurrentUser(currentUser);
+                }
+
                 httpContext.Setup(c => c.Response.Cache).Returns(httpCachePolicy.Object);
+                var uneditedTitle = "A test package!";
                 var package = new Package()
                 {
                     PackageRegistration = new PackageRegistration()
                     {
                         Id = "Foo",
-                        Owners = new List<User>() { TestUtility.FakeUser }
+                        Owners = new List<User>() { owner }
                     },
                     Version = "01.1.01",
                     NormalizedVersion = "1.1.1",
-                    Title = "A test package!"
+                    Title = uneditedTitle
                 };
 
                 packageService
                     .Setup(p => p.FindPackageByIdAndVersion("Foo", "1.1.1", SemVerLevelKey.SemVer2, true))
                     .Returns(package);
+
+                var editedTitle = "A modified package!";
+                var packageEdit = isEdited ? new PackageEdit { Title = editedTitle } : null;
                 editPackageService
                     .Setup(e => e.GetPendingMetadata(package))
-                    .Returns(new PackageEdit()
-                    {
-                        Title = "A modified package!"
-                    });
+                    .Returns(packageEdit);
 
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
 
@@ -490,7 +586,7 @@ namespace NuGetGallery
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Equal("Foo", model.Id);
                 Assert.Equal("1.1.1", model.Version);
-                Assert.Equal("A modified package!", model.Title);
+                Assert.Equal(seeEdit ? editedTitle : uneditedTitle, model.Title);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Framework/TestExtensionMethods.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestExtensionMethods.cs
@@ -57,6 +57,9 @@ namespace NuGetGallery
         {
             if (user == null)
             {
+                // Reset the current user
+                self.OwinContext.Request.User = null;
+                self.OwinContext.Environment.Remove(Constants.CurrentUserOwinEnvironmentKey);
                 return;
             }
 

--- a/tests/NuGetGallery.Facts/Framework/TestExtensionMethods.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestExtensionMethods.cs
@@ -34,8 +34,14 @@ namespace NuGetGallery
             }
             else
             {
-                identity = new ClaimsIdentity(
-                    new[] { new Claim(ClaimTypes.Name, string.IsNullOrEmpty(user.Username) ? "theUserName" : user.Username) });
+                if (string.IsNullOrEmpty(user.Username))
+                {
+                    user.Username = "theUsername";
+                }
+
+                identity = AuthenticationService.CreateIdentity(
+                    user,
+                    AuthenticationTypes.External);
             }
 
             var principal = new ClaimsPrincipal(identity);
@@ -49,6 +55,11 @@ namespace NuGetGallery
 
         public static void SetCurrentUser(this AppController self, User user, Credential credential = null)
         {
+            if (user == null)
+            {
+                return;
+            }
+
             SetOwinContextCurrentUser(self, user, credential);
             self.OwinContext.Environment[Constants.CurrentUserOwinEnvironmentKey] = user;
         }

--- a/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
@@ -6,16 +6,11 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Net.Mail;
 using System.Reflection;
-using System.Security.Principal;
 using System.Text;
-using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 using Moq;
-using NuGet;
-using NuGetGallery.Framework;
-using NuGetGallery.Configuration;
 
 namespace NuGetGallery
 {
@@ -27,10 +22,40 @@ namespace NuGetGallery
         public static readonly string GallerySiteRootHttps = $"https://{galleryHostName}/";
 
         public static readonly string FakeUserName = "theUsername";
-        public static readonly string FakeAdminName = "theAdmin";
+        public static readonly int FakeUserKey = 42;
+        public static readonly User FakeUser = new User() { Username = FakeUserName, Key = FakeUserKey };
 
-        public static readonly User FakeUser = new User() { Username = FakeUserName, Key = 42 };
-        public static readonly User FakeAdminUser = new User() { Username = FakeAdminName, Roles = new List<Role>() { new Role() { Name = Constants.AdminRoleName } } };
+        public static readonly string FakeAdminName = "theAdmin";
+        public static readonly int FakeAdminKey = 43;
+        public static readonly User FakeAdminUser = new User() { Username = FakeAdminName, Key = FakeAdminKey, Roles = new List<Role>() { new Role() { Name = Constants.AdminRoleName } } };
+
+        public static readonly string FakeOrganizationName = "theOrganization";
+        public static readonly int FakeOrganizationKey = 44;
+        public static readonly Organization FakeOrganization;
+
+        public static readonly string FakeOrganizationAdminName = "theOrganizationAdmin";
+        public static readonly int FakeOrganizationAdminKey = 45;
+        public static readonly User FakeOrganizationAdmin;
+
+        public static readonly string FakeOrganizationCollaboratorName = "theOrganizationCollaborator";
+        public static readonly int FakeOrganizationCollaboratorKey = 45;
+        public static readonly User FakeOrganizationCollaborator;
+
+        static TestUtility()
+        {
+            // Set up fake Organization users
+            FakeOrganization = new Organization { Username = FakeOrganizationName, Key = FakeOrganizationKey };
+            FakeOrganizationAdmin = new User { Username = FakeOrganizationAdminName, Key = FakeOrganizationAdminKey };
+            FakeOrganizationCollaborator = new User { Username = FakeOrganizationCollaboratorName, Key = FakeOrganizationCollaboratorKey };
+
+            var organizationAdminMembership = new Membership { IsAdmin = true, Member = FakeOrganizationAdmin, MemberKey = FakeOrganizationAdmin.Key, Organization = FakeOrganization, OrganizationKey = FakeOrganization.Key };
+            FakeOrganizationAdmin.Organizations = new[] { organizationAdminMembership };
+
+            var organizationCollaboratorMembership = new Membership { IsAdmin = false, Member = FakeOrganizationCollaborator, MemberKey = FakeOrganizationCollaborator.Key, Organization = FakeOrganization, OrganizationKey = FakeOrganization.Key };
+            FakeOrganizationCollaborator.Organizations = new[] { organizationCollaboratorMembership };
+
+            FakeOrganization.Members = new[] { organizationAdminMembership, organizationCollaboratorMembership };
+        }
 
         // We only need this method because testing URL generation is a pain.
         // Alternatively, we could write our own service for generating URLs.

--- a/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
@@ -27,7 +27,7 @@ namespace NuGetGallery
 
         public static readonly string FakeAdminName = "theAdmin";
         public static readonly int FakeAdminKey = 43;
-        public static readonly User FakeAdminUser = new User() { Username = FakeAdminName, Key = FakeAdminKey, Roles = new List<Role>() { new Role() { Name = Constants.AdminRoleName } } };
+        public static readonly User FakeAdminUser = new User() { Username = FakeAdminName, Key = FakeAdminKey, Roles = new[] { new Role { Name = Constants.AdminRoleName } } };
 
         public static readonly string FakeOrganizationName = "theOrganization";
         public static readonly int FakeOrganizationKey = 44;


### PR DESCRIPTION
This adds some permissions tests to `DisplayPackage`

More specifically, these test that
1 - Packages with pending edits show the pending edit only to users that own them.
2 - Packages in the validating/failed validation state only appear for users that own them.

Note that I caught a change in behavior from before--with the addition of the permissions service, admins could no longer see pending edits on package. This change returns that functionality (which will rewritten with the "Permissions Service 2.0" PR).