### PR TITLE
ManagePackages: hide filter if not in organization

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -72,6 +72,10 @@
             this.PackageIconUrlFallback = initialData.PackageIconUrlFallback;
 
             this.OwnerFilter = ko.observable();
+            // More filter entries than 'All' and current user
+            if (this.Owners.length > 2) {
+                $("#ownerFilter").removeClass("hidden");
+            }
             
             this.ListedPackages = new PackagesListViewModel(this, "published", initialData.ListedPackages);
             this.UnlistedPackages = new PackagesListViewModel(this, "unlisted", initialData.UnlistedPackages);

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -31,7 +31,7 @@
         <div class="col-xs-12">
                 <h1>My Packages</h1>
                 <div class="col-xs-3 text-right form-group pull-right">
-                    <select id="ownerFilter" class="form-control pull-right"
+                    <select id="ownerFilter" class="form-control pull-right hidden"
                             data-bind="options: Owners, value: OwnerFilter, optionsText: 'Username'"></select>
                 </div>
             @Section("listed", "Published",


### PR DESCRIPTION
Fixes #5133, originally intended for PR #5060 