### PR TITLE
Hotfix early validation message sending

### DIFF
--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -48,8 +48,6 @@ namespace NuGetGallery
                 user,
                 isVerified: shouldMarkIdVerified);
 
-            await _validationService.StartValidationAsync(package);
-
             if (shouldMarkIdVerified)
             {
                 // Add all relevant package registrations to the applicable namespaces
@@ -66,6 +64,8 @@ namespace NuGetGallery
 
         public async Task<PackageCommitResult> CommitPackageAsync(Package package, Stream packageFile)
         {
+            await _validationService.StartValidationAsync(package);
+
             if (package.PackageStatusKey != PackageStatus.Available
                 && package.PackageStatusKey != PackageStatus.Validating)
             {

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -74,27 +74,6 @@ namespace NuGetGallery
         public class TheGeneratePackageAsyncMethod
         {
             [Fact]
-            public async Task WillStartAsynchronousValidation()
-            {
-                var validationService = new Mock<IValidationService>();
-
-                var id = "Microsoft.Aspnet.Mvc";
-                var packageUploadService = CreateService(validationService: validationService);
-                var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: id);
-                var currentUser = new User();
-
-                var package = await packageUploadService.GeneratePackageAsync(
-                    id,
-                    nugetPackage.Object,
-                    new PackageStreamMetadata(),
-                    currentUser);
-
-                validationService.Verify(
-                    x => x.StartValidationAsync(package),
-                    Times.Once);
-            }
-
-            [Fact]
             public async Task WillCallCreatePackageAsyncCorrectly()
             {
                 var packageService = new Mock<IPackageService>();
@@ -198,6 +177,18 @@ namespace NuGetGallery
                     x => x.SaveChangesAsync(),
                     Times.Once);
                 Assert.Equal(PackageCommitResult.Success, result);
+            }
+
+            [Fact]
+            public async Task WillStartAsynchronousValidation()
+            {
+                _package.PackageStatusKey = PackageStatus.Available;
+
+                var result = await _target.CommitPackageAsync(_package, _packageFile);
+
+                _validationService.Verify(
+                    x => x.StartValidationAsync(_package),
+                    Times.Once);
             }
 
             [Theory]

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -169,7 +169,7 @@ namespace NuGetGallery
             [MemberData(nameof(SupportedPackageStatuses))]
             public async Task CommitsAfterSavingSupportedPackageStatuses(PackageStatus packageStatus)
             {
-                _package.PackageStatusKey = PackageStatus.Available;
+                _package.PackageStatusKey = PackageStatus.FailedValidation;
 
                 _validationService
                     .Setup(vs => vs.StartValidationAsync(_package))


### PR DESCRIPTION
Moved the validation message enqueuing to the `CommitPackageAsync` method of the `PackageUploadService` to prevent sending said message before package metadata is validated.

Partially addresses https://github.com/NuGet/Engineering/issues/1023.