### PR TITLE
[Perf][ApiKeys]Fix hang due to resetFormValidation including all fields

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -210,8 +210,10 @@
 
     nuget.resetFormValidation = function (formElement) {
         var validator = $(formElement).validate();
-        $(formElement).find("*[name]").each(function () {
-            validator.successList.push(this);
+        $(formElement).find("*[name][data-val]").each(function () {
+            if (this.getAttribute("data-val").toLowerCase() === "true") {
+                validator.successList.push(this);
+            }
         });
         validator.showErrors();
         validator.resetForm();


### PR DESCRIPTION
Issue #4604 - Fixes client side hang during ApiKey creation callback due to resetFormValidation including all package checkboxes. Tested with test account on DEV, which had >8K package registrations.

Note, there are more perf issues on this page - may open separate issues when I have more time.