### PR TITLE
Displaying "package not indexed yet" alert only if package is available.

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -194,7 +194,7 @@
                 )
             }
 
-            @if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && !Model.Validating)
+            @if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
             {
                 @ViewHelpers.AlertWarning(
                     @<text>


### PR DESCRIPTION
Previous fix was too narrowly targeted at "not validating" state, while it should have been "only for available pacakges"

Addresses https://github.com/NuGet/Engineering/issues/1027