### PR TITLE
Change Permissions Service 2.0 GetAccountsAllowedOnBehalfOf API

### DIFF
--- a/src/NuGetGallery/Services/ActionRequiringPackagePermissions.cs
+++ b/src/NuGetGallery/Services/ActionRequiringPackagePermissions.cs
@@ -38,9 +38,14 @@ namespace NuGetGallery
             return PermissionsHelpers.IsRequirementSatisfied(PackageRegistrationPermissionsRequirement, account, packageRegistration) ? PermissionsCheckResult.Allowed : PermissionsCheckResult.PackageRegistrationFailure;
         }
 
-        public bool TryGetAccountsAllowedOnBehalfOf(User currentUser, Package package, out IEnumerable<User> accountsAllowedOnBehalfOf)
+        public PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, Package package)
         {
-            return TryGetAccountsAllowedOnBehalfOf(currentUser, GetPackageRegistration(package), out accountsAllowedOnBehalfOf);
+            return CheckPermissionsOnBehalfOfAnyAccount(currentUser, GetPackageRegistration(package));
+        }
+
+        public PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, Package package, out IEnumerable<User> accountsAllowedOnBehalfOf)
+        {
+            return CheckPermissionsOnBehalfOfAnyAccount(currentUser, GetPackageRegistration(package), out accountsAllowedOnBehalfOf);
         }
 
         protected override IEnumerable<User> GetOwners(PackageRegistration packageRegistration)

--- a/src/NuGetGallery/Services/ActionRequiringReservedNamespacePermissions.cs
+++ b/src/NuGetGallery/Services/ActionRequiringReservedNamespacePermissions.cs
@@ -49,9 +49,14 @@ namespace NuGetGallery
                 PermissionsCheckResult.Allowed : PermissionsCheckResult.ReservedNamespaceFailure;
         }
 
-        public bool TryGetAccountsAllowedOnBehalfOf(User currentUser, ActionOnNewPackageContext newPackageContext, out IEnumerable<User> accountsAllowedOnBehalfOf)
+        public PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, ActionOnNewPackageContext newPackageContext)
         {
-            return TryGetAccountsAllowedOnBehalfOf(currentUser, GetReservedNamespaces(newPackageContext), out accountsAllowedOnBehalfOf);
+            return CheckPermissionsOnBehalfOfAnyAccount(currentUser, GetReservedNamespaces(newPackageContext));
+        }
+
+        public PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, ActionOnNewPackageContext newPackageContext, out IEnumerable<User> accountsAllowedOnBehalfOf)
+        {
+            return CheckPermissionsOnBehalfOfAnyAccount(currentUser, GetReservedNamespaces(newPackageContext), out accountsAllowedOnBehalfOf);
         }
 
         protected override IEnumerable<User> GetOwners(IReadOnlyCollection<ReservedNamespace> reservedNamespaces)

--- a/src/NuGetGallery/Services/IActionRequiringEntityPermissions.cs
+++ b/src/NuGetGallery/Services/IActionRequiringEntityPermissions.cs
@@ -28,8 +28,14 @@ namespace NuGetGallery
         /// <summary>
         /// Determines whether <paramref name="currentPrincipal"/> can perform this action on <paramref name="entity"/> on behalf of any <see cref="User"/>.
         /// </summary>
+        /// <returns>True if and only if <paramref name="currentPrincipal"/> can perform this action on <paramref name="entity"/> on behalf of any <see cref="User"/>.</returns>
+        PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, TEntity entity);
+
+        /// <summary>
+        /// Determines whether <paramref name="currentPrincipal"/> can perform this action on <paramref name="entity"/> on behalf of any <see cref="User"/>.
+        /// </summary>
         /// <param name="accountsAllowedOnBehalfOf">A <see cref="IEnumerable{User}"/> containing all accounts that <paramref name="currentUser"/> can perform this action on <paramref name="entity"/> on behalf of.</param>
         /// <returns>True if and only if <paramref name="currentPrincipal"/> can perform this action on <paramref name="entity"/> on behalf of any <see cref="User"/>.</returns>
-        bool TryGetAccountsAllowedOnBehalfOf(User currentUser, TEntity entity, out IEnumerable<User> accountsAllowedOnBehalfOf);
+        PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, TEntity entity, out IEnumerable<User> accountsAllowedOnBehalfOf);
     }
 }

--- a/src/NuGetGallery/Services/PermissionsCheckResult.cs
+++ b/src/NuGetGallery/Services/PermissionsCheckResult.cs
@@ -14,6 +14,11 @@ namespace NuGetGallery
         Allowed = default(int),
 
         /// <summary>
+        /// The permissions check failed for an unknown reason.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
         /// The current user does not have permissions to perform the action on the <see cref="User"/>.
         /// </summary>
         AccountFailure,

--- a/tests/NuGetGallery.Facts/Services/ActionRequiringEntityPermissionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ActionRequiringEntityPermissionsFacts.cs
@@ -43,7 +43,7 @@ namespace NuGetGallery
             }
         }
 
-        public class TheIsAllowedMethod
+        public class TheCheckPermissionsMethod
         {
             [Fact]
             public void ReturnsAccountPermissionsFailureWhenAccountCheckFails()
@@ -67,14 +67,15 @@ namespace NuGetGallery
             }
         }
 
-        public class TheTryGetAccountsAllowedOnBehalfOfMethod
+        public class TheCheckPermissionsOnBehalfOfAnyAccountMethod
         {
             [Fact]
             public void SuccessWithNullAccount()
             {
                 var action = new TestableActionRequiringEntityPermissions(PermissionsRequirement.None, (account, entity) => PermissionsCheckResult.Allowed);
 
-                Assert.True(action.TryGetAccountsAllowedOnBehalfOf(null, null, out var accountsAllowedOnBehalfOf));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(null, null));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(null, null, out var accountsAllowedOnBehalfOf));
                 Assert.True(accountsAllowedOnBehalfOf.SequenceEqual(new User[] { null }));
             }
 
@@ -83,7 +84,8 @@ namespace NuGetGallery
             {
                 var action = new TestableActionRequiringEntityPermissions(PermissionsRequirement.Unsatisfiable, (a, e) => PermissionsCheckResult.Allowed);
 
-                Assert.False(action.TryGetAccountsAllowedOnBehalfOf(null, null, out var accountsAllowedOnBehalfOf));
+                Assert.Equal(PermissionsCheckResult.AccountFailure, action.CheckPermissionsOnBehalfOfAnyAccount(null, null));
+                Assert.Equal(PermissionsCheckResult.AccountFailure, action.CheckPermissionsOnBehalfOfAnyAccount(null, null, out var accountsAllowedOnBehalfOf));
                 Assert.Empty(accountsAllowedOnBehalfOf);
             }
 
@@ -94,18 +96,21 @@ namespace NuGetGallery
 
                 var action = new TestableActionRequiringEntityPermissions(PermissionsRequirement.None, (a, e) => PermissionsCheckResult.Allowed);
 
-                Assert.True(action.TryGetAccountsAllowedOnBehalfOf(user, null, out var accountsAllowedOnBehalfOf));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(user, null));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(user, null, out var accountsAllowedOnBehalfOf));
                 Assert.True(accountsAllowedOnBehalfOf.SequenceEqual(new[] { user }));
             }
 
             [Fact]
             public void FailureWithNullEntity()
             {
+                var failureResult = (PermissionsCheckResult)99;
                 var user = new User { Key = 1 };
 
                 var action = new TestableActionRequiringEntityPermissions(PermissionsRequirement.None, (a, e) => (PermissionsCheckResult)99);
 
-                Assert.False(action.TryGetAccountsAllowedOnBehalfOf(user, null, out var accountsAllowedOnBehalfOf));
+                Assert.Equal(failureResult, action.CheckPermissionsOnBehalfOfAnyAccount(user, null));
+                Assert.Equal(failureResult, action.CheckPermissionsOnBehalfOfAnyAccount(user, null, out var accountsAllowedOnBehalfOf));
                 Assert.Empty(accountsAllowedOnBehalfOf);
             }
 
@@ -116,7 +121,8 @@ namespace NuGetGallery
 
                 var action = new TestableActionRequiringEntityPermissions(PermissionsRequirement.None, (a, e) => PermissionsCheckResult.Allowed);
 
-                Assert.True(action.TryGetAccountsAllowedOnBehalfOf(user, null, out var accountsAllowedOnBehalfOf));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(user, null));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(user, null, out var accountsAllowedOnBehalfOf));
                 Assert.True(accountsAllowedOnBehalfOf.SequenceEqual(new[] { user, organization }));
             }
 
@@ -127,7 +133,8 @@ namespace NuGetGallery
 
                 var action = new TestableActionRequiringEntityPermissions(PermissionsRequirement.None, (a, e) => PermissionsCheckResult.Allowed);
 
-                Assert.True(action.TryGetAccountsAllowedOnBehalfOf(null, entity, out var accountsAllowedOnBehalfOf));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(null, entity));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(null, entity, out var accountsAllowedOnBehalfOf));
                 Assert.True(accountsAllowedOnBehalfOf.SequenceEqual(new[] { null, entityOwner }));
             }
 
@@ -139,7 +146,8 @@ namespace NuGetGallery
 
                 var action = new TestableActionRequiringEntityPermissions(PermissionsRequirement.None, (a, e) => PermissionsCheckResult.Allowed);
 
-                Assert.True(action.TryGetAccountsAllowedOnBehalfOf(user, entity, out var accountsAllowedOnBehalfOf));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(user, entity));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(user, entity, out var accountsAllowedOnBehalfOf));
                 Assert.True(accountsAllowedOnBehalfOf.SequenceEqual(new[] { user, entityOwner, organization }));
             }
 
@@ -166,7 +174,8 @@ namespace NuGetGallery
                 var action = new TestableActionRequiringEntityPermissions(PermissionsRequirement.None, 
                     (a, e) => expectedAccountsList.Any(u => u.MatchesUser(a)) ? PermissionsCheckResult.Allowed : (PermissionsCheckResult)99);
 
-                Assert.True(action.TryGetAccountsAllowedOnBehalfOf(user, entity, out var accountsAllowedOnBehalfOf));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(user, entity));
+                Assert.Equal(PermissionsCheckResult.Allowed, action.CheckPermissionsOnBehalfOfAnyAccount(user, entity, out var accountsAllowedOnBehalfOf));
                 Assert.True(accountsAllowedOnBehalfOf.SequenceEqual(expectedAccountsList));
             }
 


### PR DESCRIPTION
Per discussion with @chenriksson:

`TryGetAccountsIsAllowedOnBehalfOf` is now `CheckPermissionsOnBehalfOfAnyAccount` and returns `PermissionsCheckResult` instead of `bool` to mimic the existing `CheckPermissions` method. It also has an override without the `out` parameter for cases in which the `out` parameter is not desired.