### PR TITLE
Fix API expiry notification email to use the correct URL

### DIFF
--- a/src/NuGetGallery/Filters/ApiAuthorizeAttribute.cs
+++ b/src/NuGetGallery/Filters/ApiAuthorizeAttribute.cs
@@ -29,8 +29,7 @@ namespace NuGetGallery.Filters
 
                 if (apiKeyCredential != null && apiKeyCredential.Expires.HasValue)
                 {
-                    var accountUrl = controller.NuGetContext.Config.GetSiteRoot(
-                        controller.NuGetContext.Config.Current.RequireSSL).TrimEnd('/') + "/account";
+                    var accountUrl = controller.Url.ManageMyApiKeys(false);
 
                     var expirationPeriod = apiKeyCredential.Expires.Value - DateTime.UtcNow;
                     if (apiKeyCredential.HasExpired)


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/4900

When UI redesign happened, we started sending the wrong address because we changed the URL that the API keys could be set from.

By using the `UrlHelper` extension for navigating to the API keys page we should guarantee that the address is always correct.