### PR TITLE
Add API to check for AAD credential

### DIFF
--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -26,7 +26,18 @@ namespace NuGetGallery
             public const string VerifyV1 = Prefix + "verify.v1";
         }
 
-        public const string ExternalPrefix = "external.";
+        public static class External
+        {
+            public const string Prefix = "external.";
+            public const string Microsoft = Prefix + ExternalProviders.Microsoft;
+            public const string AzureActiveDirectory = Prefix + ExternalProviders.AzureActiveDirectory;
+        }
+
+        public static class ExternalProviders
+        {
+            public const string Microsoft = "MicrosoftAccount";
+            public const string AzureActiveDirectory = "AzureActiveDirectory";
+        }
 
         public static bool IsPassword(string type)
         {
@@ -46,6 +57,14 @@ namespace NuGetGallery
         public static bool IsPackageVerificationApiKey(string type)
         {
             return type.Equals(ApiKey.VerifyV1, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Determine if credential is linked to an external AAD account.
+        /// </summary>
+        public static bool IsAzureActiveDirectoryCredential(this Credential credential)
+        {
+            return credential.Type.Equals(External.AzureActiveDirectory, StringComparison.OrdinalIgnoreCase);
         }
         
         internal static IReadOnlyList<string> SupportedCredentialTypes = new List<string> { Password.Sha1, Password.Pbkdf2, Password.V3, ApiKey.V1, ApiKey.V2, ApiKey.V4 };
@@ -70,7 +89,7 @@ namespace NuGetGallery
         public static bool IsViewSupportedCredential(this Credential credential)
         {
             return SupportedCredentialTypes.Any(credType => string.Compare(credential.Type, credType, StringComparison.OrdinalIgnoreCase) == 0)
-                    || credential.Type.StartsWith(ExternalPrefix, StringComparison.OrdinalIgnoreCase);
+                    || credential.Type.StartsWith(External.Prefix, StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool IsScopedApiKey(this Credential credential)

--- a/src/NuGetGallery/Authentication/Providers/AzureActiveDirectory/AzureActiveDirectoryAuthenticator.cs
+++ b/src/NuGetGallery/Authentication/Providers/AzureActiveDirectory/AzureActiveDirectoryAuthenticator.cs
@@ -13,8 +13,6 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectory
 {
     public class AzureActiveDirectoryAuthenticator : Authenticator<AzureActiveDirectoryAuthenticatorConfiguration>
     {
-        public static readonly string DefaultAuthenticationType = "AzureActiveDirectory";
-
         protected override void AttachToOwinApp(IGalleryConfigurationService config, IAppBuilder app)
         {
             // Fetch site root from configuration

--- a/src/NuGetGallery/Authentication/Providers/AzureActiveDirectory/AzureActiveDirectoryAuthenticatorConfiguration.cs
+++ b/src/NuGetGallery/Authentication/Providers/AzureActiveDirectory/AzureActiveDirectoryAuthenticatorConfiguration.cs
@@ -18,7 +18,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectory
 
         public AzureActiveDirectoryAuthenticatorConfiguration()
         {
-            AuthenticationType = AzureActiveDirectoryAuthenticator.DefaultAuthenticationType;
+            AuthenticationType = CredentialTypes.ExternalProviders.AzureActiveDirectory;
         }
 
         public override void ApplyToOwinSecurityOptions(AuthenticationOptions options)

--- a/src/NuGetGallery/Authentication/Providers/MicrosoftAccount/MicrosoftAccountAuthenticator.cs
+++ b/src/NuGetGallery/Authentication/Providers/MicrosoftAccount/MicrosoftAccountAuthenticator.cs
@@ -10,8 +10,6 @@ namespace NuGetGallery.Authentication.Providers.MicrosoftAccount
 {
     public class MicrosoftAccountAuthenticator : Authenticator<MicrosoftAccountAuthenticatorConfiguration>
     {
-        public static readonly string DefaultAuthenticationType = "MicrosoftAccount";
-
         protected override void AttachToOwinApp(IGalleryConfigurationService config, IAppBuilder app)
         {
             var options = new MicrosoftAccountAuthenticationOptions();

--- a/src/NuGetGallery/Authentication/Providers/MicrosoftAccount/MicrosoftAccountAuthenticatorConfiguration.cs
+++ b/src/NuGetGallery/Authentication/Providers/MicrosoftAccount/MicrosoftAccountAuthenticatorConfiguration.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
-using System.Collections.Generic;
 using System.Configuration;
 using System.Globalization;
-using System.Linq;
-using System.Text;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.MicrosoftAccount;
 
@@ -18,7 +16,7 @@ namespace NuGetGallery.Authentication.Providers.MicrosoftAccount
 
         public MicrosoftAccountAuthenticatorConfiguration()
         {
-            AuthenticationType = MicrosoftAccountAuthenticator.DefaultAuthenticationType;
+            AuthenticationType = CredentialTypes.ExternalProviders.Microsoft;
         }
 
         public override void ApplyToOwinSecurityOptions(AuthenticationOptions options)

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -185,7 +185,7 @@ namespace NuGetGallery
                 var providers = enforcedProviders.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
 
                 if (!providers.Any(p => string.Equals(p, authenticatedUser.CredentialUsed.Type, StringComparison.OrdinalIgnoreCase))
-                    && !providers.Any(p => string.Equals(CredentialTypes.ExternalPrefix + p, authenticatedUser.CredentialUsed.Type, StringComparison.OrdinalIgnoreCase)))
+                    && !providers.Any(p => string.Equals(CredentialTypes.External.Prefix + p, authenticatedUser.CredentialUsed.Type, StringComparison.OrdinalIgnoreCase)))
                 {
                     // Challenge authentication using the first required authentication provider
                     challenge = _authService.Challenge(

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -964,7 +964,7 @@ namespace NuGetGallery
         {
             return user.Credentials.Count(c =>
                 c.Type.StartsWith(CredentialTypes.Password.Prefix, StringComparison.OrdinalIgnoreCase) ||
-                c.Type.StartsWith(CredentialTypes.ExternalPrefix, StringComparison.OrdinalIgnoreCase));
+                c.Type.StartsWith(CredentialTypes.External.Prefix, StringComparison.OrdinalIgnoreCase));
         }
 
         private ActionResult SendPasswordResetEmail(User user, bool forgotPassword)

--- a/src/NuGetGallery/Infrastructure/Authentication/CredentialBuilder.cs
+++ b/src/NuGetGallery/Infrastructure/Authentication/CredentialBuilder.cs
@@ -65,10 +65,15 @@ namespace NuGetGallery.Infrastructure.Authentication
 
         public Credential CreateExternalCredential(string issuer, string value, string identity)
         {
-            return new Credential(CredentialTypes.ExternalPrefix + issuer, value)
+            return new Credential(CredentialTypes.External.Prefix + issuer, value)
             {
                 Identity = identity
             };
+        }
+
+        internal Credential CreateMicrosoftCredential(string value, string identity)
+        {
+            return CreateExternalCredential(CredentialTypes.ExternalProviders.Microsoft, value, identity);
         }
 
         private static string CreateKeyString()

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -524,7 +524,7 @@ namespace NuGetGallery.Authentication
             public async Task GivenMatchingCredential_ItWritesCredentialLastUsed()
             {
                 // Arrange
-                var cred = _fakes.User.Credentials.Single(c => c.Type.Contains(CredentialTypes.ExternalPrefix));
+                var cred = _fakes.User.Credentials.Single(c => c.Type.Contains(CredentialTypes.External.Prefix));
 
                 var referenceTime = DateTime.UtcNow;
                 _dateTimeProviderMock.SetupGet(x => x.UtcNow).Returns(referenceTime);
@@ -1422,7 +1422,7 @@ namespace NuGetGallery.Authentication
             public void GivenAnExternalCredential_ItDescribesItCorrectly(bool hasExpired)
             {
                 // Arrange
-                var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "abc123", "Test User");
+                var cred = new CredentialBuilder().CreateMicrosoftCredential("abc123", "Test User");
                 cred.Expires = hasExpired ? DateTime.UtcNow - TimeSpan.FromDays(1) : DateTime.UtcNow + TimeSpan.FromDays(1);
 
                 var msftAuther = new MicrosoftAccountAuthenticator();
@@ -1650,11 +1650,12 @@ namespace NuGetGallery.Authentication
             public async Task GivenMatchingIssuer_ItReturnsTheAutherWithThatName()
             {
                 // Arrange
+                var issuer = CredentialTypes.ExternalProviders.Microsoft;
                 var authThunk = new AuthenticateThunk()
                 {
                     ShimIdentity = new ClaimsIdentity(new[] {
-                        new Claim(ClaimTypes.NameIdentifier, "blarg", null, "MicrosoftAccount"),
-                        new Claim(ClaimTypes.Name, "bloog", null, "MicrosoftAccount")
+                        new Claim(ClaimTypes.NameIdentifier, "blarg", null, issuer),
+                        new Claim(ClaimTypes.Name, "bloog", null, issuer)
                     })
                 };
                 var authService = Get<AuthenticationService>();
@@ -1666,18 +1667,19 @@ namespace NuGetGallery.Authentication
 
                 // Assert
                 Assert.Same(authThunk.ShimIdentity, result.ExternalIdentity);
-                Assert.Same(authService.Authenticators["MicrosoftAccount"], result.Authenticator);
+                Assert.Same(authService.Authenticators[issuer], result.Authenticator);
             }
 
             [Fact]
             public async Task GivenAnIdentity_ItCreatesAnExternalCredential()
             {
                 // Arrange
+                var issuer = CredentialTypes.ExternalProviders.Microsoft;
                 var authThunk = new AuthenticateThunk()
                 {
                     ShimIdentity = new ClaimsIdentity(new[] {
-                        new Claim(ClaimTypes.NameIdentifier, "blarg", null, "MicrosoftAccount"),
-                        new Claim(ClaimTypes.Name, "bloog", null, "MicrosoftAccount")
+                        new Claim(ClaimTypes.NameIdentifier, "blarg", null, issuer),
+                        new Claim(ClaimTypes.Name, "bloog", null, issuer)
                     })
                 };
                 var authService = Get<AuthenticationService>();
@@ -1689,7 +1691,7 @@ namespace NuGetGallery.Authentication
 
                 // Assert
                 Assert.NotNull(result.Credential);
-                Assert.Equal("external.MicrosoftAccount", result.Credential.Type);
+                Assert.Equal(CredentialTypes.External.Microsoft, result.Credential.Type);
                 Assert.Equal("blarg", result.Credential.Value);
                 Assert.Equal("bloog", result.Credential.Identity);
             }

--- a/tests/NuGetGallery.Facts/Authentication/TestCredentialHelper.cs
+++ b/tests/NuGetGallery.Facts/Authentication/TestCredentialHelper.cs
@@ -65,7 +65,7 @@ namespace NuGetGallery.Authentication
 
         public static Credential CreateExternalCredential(string value)
         {
-            return new Credential { Type = CredentialTypes.ExternalPrefix + "MicrosoftAccount", Value = value };
+            return new Credential { Type = CredentialTypes.External.Microsoft, Value = value };
         }
 
         internal static Credential CreateApiKey(string type, string apiKey, TimeSpan? expiration)

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -65,7 +65,7 @@ namespace NuGetGallery
                     "test",
                     credentialBuilder.CreatePasswordCredential("hunter2"),
                     TestCredentialHelper.CreateV1ApiKey(Guid.NewGuid(), Fakes.ExpirationForApiKeyV1),
-                    credentialBuilder.CreateExternalCredential("MicrosoftAccount", "blarg", "Bloog"));
+                    credentialBuilder.CreateMicrosoftCredential("blarg", "Bloog"));
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
@@ -99,7 +99,7 @@ namespace NuGetGallery
                     TestCredentialHelper.CreateSha1Password("sha1"),
                     TestCredentialHelper.CreateV1ApiKey(Guid.NewGuid(), Fakes.ExpirationForApiKeyV1),
                     TestCredentialHelper.CreateV2ApiKey(Guid.NewGuid(), Fakes.ExpirationForApiKeyV1),
-                    credentialBuilder.CreateExternalCredential("MicrosoftAccount", "blarg", "Bloog"),
+                    credentialBuilder.CreateMicrosoftCredential("blarg", "Bloog"),
                     new Credential() { Type = "unsupported" }
                 };
 
@@ -1323,8 +1323,7 @@ namespace NuGetGallery
                 var user = new User("foo");
                 var cred = new CredentialBuilder().CreatePasswordCredential("old");
                 user.Credentials.Add(cred);
-                user.Credentials.Add(new CredentialBuilder()
-                    .CreateExternalCredential("MicrosoftAccount", "blorg", "bloog"));
+                user.Credentials.Add(new CredentialBuilder().CreateMicrosoftCredential("blorg", "bloog"));
 
                 GetMock<AuthenticationService>()
                     .Setup(a => a.RemoveCredential(user, cred))
@@ -1334,7 +1333,7 @@ namespace NuGetGallery
                     .Setup(m => 
                                 m.SendCredentialRemovedNotice(
                                     user,
-                                    It.Is<CredentialViewModel>(c => c.Type == CredentialTypes.ExternalPrefix + "MicrosoftAccount")))
+                                    It.Is<CredentialViewModel>(c => c.Type == CredentialTypes.External.Microsoft)))
                     .Verifiable();
 
                 var controller = GetController<UsersController>();
@@ -1470,7 +1469,7 @@ namespace NuGetGallery
                 // Arrange
                 var fakes = Get<Fakes>();
                 var user = fakes.CreateUser("test",
-                    new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "blorg", "bloog"));
+                    new CredentialBuilder().CreateMicrosoftCredential("blorg", "bloog"));
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
@@ -1492,7 +1491,7 @@ namespace NuGetGallery
                 var cred = credentialBuilder.CreatePasswordCredential("password");
                 var user = fakes.CreateUser("test",
                     cred,
-                    credentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "bloog"));
+                    credentialBuilder.CreateMicrosoftCredential("blorg", "bloog"));
 
                 GetMock<AuthenticationService>()
                     .Setup(a => a.RemoveCredential(user, cred))
@@ -1524,7 +1523,7 @@ namespace NuGetGallery
             {
                 // Arrange
                 var fakes = Get<Fakes>();
-                var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "blorg", "bloog");
+                var cred = new CredentialBuilder().CreateMicrosoftCredential("blorg", "bloog");
                 var user = fakes.CreateUser("test", cred);
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
@@ -1552,7 +1551,7 @@ namespace NuGetGallery
 
                 // Act
                 var result = await controller.RemoveCredential(
-                    credentialType: CredentialTypes.ExternalPrefix + "MicrosoftAccount",
+                    credentialType: CredentialTypes.External.Microsoft,
                     credentialKey: null);
 
                 // Assert
@@ -1594,7 +1593,7 @@ namespace NuGetGallery
                 // Arrange
                 var credentialBuilder = new CredentialBuilder();
                 var fakes = Get<Fakes>();
-                var cred = credentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "bloog");
+                var cred = credentialBuilder.CreateMicrosoftCredential("blorg", "bloog");
                 var user = fakes.CreateUser("test",
                     cred,
                     credentialBuilder.CreatePasswordCredential("password"));
@@ -1607,7 +1606,7 @@ namespace NuGetGallery
                     .Setup(m => 
                                 m.SendCredentialRemovedNotice(
                                     user,
-                                    It.Is<CredentialViewModel>(c => c.Type == CredentialTypes.ExternalPrefix + "MicrosoftAccount")))
+                                    It.Is<CredentialViewModel>(c => c.Type == CredentialTypes.External.Microsoft)))
                     .Verifiable();
 
                 var controller = GetController<UsersController>();
@@ -1632,7 +1631,7 @@ namespace NuGetGallery
                 var creds = new Credential[5];
                 for (int i = 0; i < creds.Length; i++)
                 {
-                    creds[i] = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "blorg", "bloog" + i);
+                    creds[i] = new CredentialBuilder().CreateMicrosoftCredential("blorg", "bloog" + i);
                     creds[i].Key = i + 1;
                 }
 

--- a/tests/NuGetGallery.Facts/Infrastructure/UserAuditRecordFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/UserAuditRecordFacts.cs
@@ -26,7 +26,7 @@ namespace NuGetGallery.Infrastructure
                     TestCredentialHelper.CreateV1ApiKey(Guid.NewGuid(), Fakes.ExpirationForApiKeyV1),
                     TestCredentialHelper.CreateV2ApiKey(Guid.NewGuid(), Fakes.ExpirationForApiKeyV1),
                     TestCredentialHelper.CreateV2VerificationApiKey(Guid.NewGuid()),
-                    credentialBuilder.CreateExternalCredential("MicrosoftAccount", "blarg", "Bloog"),
+                    credentialBuilder.CreateMicrosoftCredential("blarg", "Bloog"),
                     new Credential { Type = "unsupported" }
             };
 

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -596,7 +596,7 @@ namespace NuGetGallery
             public void UsesProviderNounToDescribeCredentialIfPresent()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
-                var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "abc123", "Test User");
+                var cred = new CredentialBuilder().CreateMicrosoftCredential("abc123", "Test User");
                 const string MicrosoftAccountCredentialName = "Microsoft account";
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
@@ -659,7 +659,7 @@ namespace NuGetGallery
             public void UsesProviderNounToDescribeCredentialIfPresent()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
-                var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "abc123", "Test User");
+                var cred = new CredentialBuilder().CreateMicrosoftCredential("abc123", "Test User");
                 const string MicrosoftAccountCredentialName = "Microsoft account";
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());


### PR DESCRIPTION
Need the `CredentialTypes.IsAzureActiveDirectoryCredential` API to enforce an organization policy of requiring that members have linked with AAD. Design review will be tomorrow.

Most of this PR is renaming, or refactoring to reuse the string consts in tests.