### PR TITLE
Functional test for package locking

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/EnvironmentSettings.cs
@@ -29,6 +29,7 @@ namespace NuGetGallery.FunctionalTests
         private static string _testEmailServerHost;
         private static List<string> _trustedHttpsCertificates;
         private static bool? _defaultSecurityPoliciesEnforced;
+        private static bool? _testPackageLock;
 
         /// <summary>
         /// The environment against which the test has to be run. The value would be picked from env variable.
@@ -328,6 +329,28 @@ namespace NuGetGallery.FunctionalTests
                 }
 
                 return _defaultSecurityPoliciesEnforced.Value;
+            }
+        }
+
+        public static bool TestPackageLock
+        {
+            get
+            {
+                if (!_testPackageLock.HasValue)
+                {
+                    // Try to get the setting from EnvironmentVariable. If fail, fallback to false
+                    bool temp;
+                    if (bool.TryParse(Environment.GetEnvironmentVariable("TestPackageLock"), out temp))
+                    {
+                        _testPackageLock = temp;
+                    }
+                    else
+                    {
+                        _testPackageLock = false;
+                    }
+                }
+
+                return _testPackageLock.Value;
             }
         }
 

--- a/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
+++ b/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
@@ -90,6 +90,7 @@
     <Compile Include="XunitExtensions\PriorityAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="XunitExtensions\CategoryDiscoverer.cs" />
+    <Compile Include="XunitExtensions\PackageLockFactAttribute.cs" />
     <Compile Include="XunitExtensions\TestPriorityOrderer.cs" />
     <Compile Include="Helpers\UrlHelper.cs" />
   </ItemGroup>

--- a/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/DefaultSecurityPoliciesEnforcedFactAttribute.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/DefaultSecurityPoliciesEnforcedFactAttribute.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Xunit;
 
 namespace NuGetGallery.FunctionalTests.XunitExtensions

--- a/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/PackageLockFactAttribute.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/PackageLockFactAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.FunctionalTests.XunitExtensions
+{
+    public class PackageLockFactAttribute : FactAttribute
+    {
+        public PackageLockFactAttribute()
+        {
+            if (!EnvironmentSettings.TestPackageLock)
+            {
+                Skip = string.Format("Package locking shouldn't be tested");
+            }
+        }
+    }
+}


### PR DESCRIPTION
 The test requires a locked package to exist on the feed, hence it will be disabled by default.