### PR TITLE
Fix GetCurrentUser for unauthenticated scenarios

### DIFF
--- a/src/NuGetGallery/ExtensionMethods.cs
+++ b/src/NuGetGallery/ExtensionMethods.cs
@@ -433,7 +433,8 @@ namespace NuGetGallery
         /// <returns>The current user</returns>
         public static User GetCurrentUser(this IOwinContext self)
         {
-            if (self.Request.User == null)
+            if (self.Request.User == null || 
+                (self.Request.User.Identity != null && !self.Request.User.Identity.IsAuthenticated))
             {
                 return null;
             }


### PR DESCRIPTION
`GetCurrentUser` had a bug where if `self.Request.User` was non-null (e.g. with a default `IPrincipal` that was unauthenticated) it would throw a 401 error. 