### PR TITLE
Obfuscate new transform account route

### DIFF
--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -305,7 +305,8 @@ namespace NuGetGallery
             routes.MapRoute(
                 RouteName.TransformToOrganizationConfirmation,
                 "account/transform/confirm/{accountNameToTransform}/{token}",
-                new { controller = "Users", action = "ConfirmTransform" });
+                new { controller = "Users", action = "ConfirmTransform" },
+                new RouteExtensions.ObfuscatedMetadata(3, Obfuscator.DefaultTelemetryUserName));
 
             routes.MapRoute(
                 RouteName.ApiKeys,

--- a/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
@@ -76,7 +76,7 @@ namespace NuGetGallery.Telemetry
             foreach (var route in piiUrlRoutes)
             {
                 var expectedTrue = RouteExtensions.ObfuscatedRouteMap.ContainsKey(route);
-                Assert.True(expectedTrue, $"Route was not added to the obfuscated routeMap.");
+                Assert.True(expectedTrue, $"Route {route} was not added to the obfuscated routeMap.");
             }
         }
 


### PR DESCRIPTION
Fixing unit test failure. Obfuscation and test from PR #5236 didn't account for new route added in PR #5228.