### PR TITLE
Create derived UserAccountViewModel for User (non-Organization) accounts

### DIFF
--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -348,7 +348,7 @@ namespace NuGetGallery
         [Authorize]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public virtual async Task<ActionResult> ChangeEmailSubscription(AccountViewModel model)
+        public virtual async Task<ActionResult> ChangeEmailSubscription(UserAccountViewModel model)
         {
             var user = GetCurrentUser();
 
@@ -605,7 +605,7 @@ namespace NuGetGallery
         [HttpPost]
         [Authorize]
         [ValidateAntiForgeryToken]
-        public virtual async Task<ActionResult> ChangeEmail(AccountViewModel model)
+        public virtual async Task<ActionResult> ChangeEmail(UserAccountViewModel model)
         {
             if (!ModelState.IsValidField("ChangeEmail.NewEmail"))
             {
@@ -634,7 +634,7 @@ namespace NuGetGallery
             if (string.Equals(model.ChangeEmail.NewEmail, user.LastSavedEmailAddress, StringComparison.OrdinalIgnoreCase))
             {
                 // email address unchanged - accept
-                return RedirectToAction("Account");
+                return RedirectToAction(actionName: "Account", controllerName: "Users");
             }
 
             try
@@ -659,26 +659,26 @@ namespace NuGetGallery
                 TempData["Message"] = Strings.EmailUpdated;
             }
 
-            return RedirectToAction("Account");
+            return RedirectToAction(actionName: "Account", controllerName: "Users");
         }
 
         [HttpPost]
         [Authorize]
         [ValidateAntiForgeryToken]
-        public virtual async Task<ActionResult> CancelChangeEmail(AccountViewModel model)
+        public virtual async Task<ActionResult> CancelChangeEmail(UserAccountViewModel model)
         {
             var user = GetCurrentUser();
 
             if (string.IsNullOrWhiteSpace(user.UnconfirmedEmailAddress))
             {
-                return RedirectToAction("Account");
+                return RedirectToAction(actionName: "Account", controllerName: "Users");
             }
 
             await _userService.CancelChangeEmailAddress(user);
 
             TempData["Message"] = Strings.CancelEmailAddress;
 
-            return RedirectToAction("Account");
+            return RedirectToAction(actionName: "Account", controllerName: "Users");
         }
 
 
@@ -1086,7 +1086,7 @@ namespace NuGetGallery
                 relativeUrl: false);
             _messageService.SendPasswordResetInstructions(user, resetPasswordUrl, forgotPassword);
 
-            return RedirectToAction("PasswordSent");
+            return RedirectToAction(actionName: "PasswordSent", controllerName: "Users");
         }
     }
 }

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -22,21 +22,6 @@ namespace NuGetGallery
     public partial class UsersController
         : AppController
     {
-        public static class Actions
-        {
-            public const string Account = "Account";
-            public const string ConfirmationRequired = "ConfirmationRequired";
-            public const string ConfirmTransform = "ConfirmTransform";
-            public const string DeleteAccount = "DeleteAccount";
-            public const string DeleteUserAccountStatus = "DeleteUserAccountStatus";
-            public const string DeleteRequest = "DeleteRequest";
-            public const string DeleteUserAccount = "DeleteUserAccount";
-            public const string PasswordChanged = "PasswordChanged";
-            public const string PasswordSent = "PasswordSent";
-            public const string Transform = "Transform";
-            public const string TransformFailed = "TransformFailed";
-        }
-
         private readonly ICuratedFeedService _curatedFeedService;
         private readonly IUserService _userService;
         private readonly IMessageService _messageService;
@@ -82,7 +67,7 @@ namespace NuGetGallery
 
         [Authorize]
         [HttpPost]
-        [ActionName(Actions.ConfirmationRequired)]
+        [ActionName("ConfirmationRequired")]
         [ValidateAntiForgeryToken]
         public virtual ActionResult ConfirmationRequiredPost()
         {
@@ -117,7 +102,7 @@ namespace NuGetGallery
 
         [HttpGet]
         [Authorize]
-        [ActionName(Actions.Transform)]
+        [ActionName("Transform")]
         public virtual ActionResult TransformToOrganization()
         {
             var accountToTransform = GetCurrentUser();
@@ -139,7 +124,7 @@ namespace NuGetGallery
         [HttpPost]
         [Authorize]
         [ValidateAntiForgeryToken]
-        [ActionName(Actions.Transform)]
+        [ActionName("Transform")]
         public virtual async Task<ActionResult> TransformToOrganization(TransformAccountViewModel transformViewModel)
         {
             var accountToTransform = GetCurrentUser();
@@ -170,7 +155,7 @@ namespace NuGetGallery
 
         [HttpGet]
         [Authorize]
-        [ActionName(Actions.ConfirmTransform)]
+        [ActionName("ConfirmTransform")]
         public virtual async Task<ActionResult> ConfirmTransformToOrganization(string accountNameToTransform, string token)
         {
             var adminUser = GetCurrentUser();
@@ -199,7 +184,7 @@ namespace NuGetGallery
                 Strings.TransformAccount_Success, accountNameToTransform);
 
             // todo: redirect to ManageOrganization (future work)
-            return RedirectToAction(Actions.Account);
+            return RedirectToAction("Account");
         }
 
         private ActionResult TransformToOrganizationFailed(string errorMessage)
@@ -235,7 +220,7 @@ namespace NuGetGallery
                 HasPendingRequests = hasPendingRequest
             };
 
-            return View(Actions.DeleteAccount, model);
+            return View("DeleteAccount", model);
         }
 
         [HttpPost]
@@ -260,11 +245,11 @@ namespace NuGetGallery
             if (!isSupportRequestCreated)
             {
                 TempData["RequestFailedMessage"] = Strings.AccountDelete_CreateSupportRequestFails;
-                return RedirectToAction(Actions.DeleteRequest);
+                return RedirectToAction("DeleteRequest");
             }
             _messageService.SendAccountDeleteNotice(user.ToMailAddress(), user.Username);
 
-            return RedirectToAction(Actions.DeleteRequest);
+            return RedirectToAction("DeleteRequest");
         }
 
         [HttpGet]
@@ -287,7 +272,7 @@ namespace NuGetGallery
                 User = user,
                 AccountName = user.Username,
             };
-            return View(Actions.DeleteUserAccount, model);
+            return View("DeleteUserAccount", model);
         }
 
         [HttpDelete]
@@ -299,7 +284,7 @@ namespace NuGetGallery
             var user = _userService.FindByUsername(model.AccountName);
             if (user == null || user.IsDeleted)
             {
-                return View(Actions.DeleteUserAccountStatus, new DeleteUserAccountStatus()
+                return View("DeleteUserAccountStatus", new DeleteUserAccountStatus()
                 {
                     AccountName = model.AccountName,
                     Description = $"Account {model.AccountName} not found.",
@@ -310,7 +295,7 @@ namespace NuGetGallery
             {
                 var admin = GetCurrentUser();
                 var status = await _deleteAccountService.DeleteGalleryUserAccountAsync(user, admin, model.Signature, model.ShouldUnlist, commitAsTransaction: true);
-                return View(Actions.DeleteUserAccountStatus, status);
+                return View("DeleteUserAccountStatus", status);
             }
         }
 
@@ -374,7 +359,7 @@ namespace NuGetGallery
 
             TempData["Message"] = Strings.EmailPreferencesUpdated;
 
-            return RedirectToAction(Actions.Account);
+            return RedirectToAction("Account");
         }
 
         [HttpGet]
@@ -542,7 +527,7 @@ namespace NuGetGallery
                 _messageService.SendCredentialAddedNotice(credential.User, _authService.DescribeCredential(credential));
             }
 
-            return RedirectToAction(Actions.PasswordChanged);
+            return RedirectToAction("PasswordChanged");
         }
 
         [Authorize]
@@ -649,7 +634,7 @@ namespace NuGetGallery
             if (string.Equals(model.ChangeEmail.NewEmail, user.LastSavedEmailAddress, StringComparison.OrdinalIgnoreCase))
             {
                 // email address unchanged - accept
-                return RedirectToAction(Actions.Account);
+                return RedirectToAction("Account");
             }
 
             try
@@ -674,7 +659,7 @@ namespace NuGetGallery
                 TempData["Message"] = Strings.EmailUpdated;
             }
 
-            return RedirectToAction(Actions.Account);
+            return RedirectToAction("Account");
         }
 
         [HttpPost]
@@ -686,14 +671,14 @@ namespace NuGetGallery
 
             if (string.IsNullOrWhiteSpace(user.UnconfirmedEmailAddress))
             {
-                return RedirectToAction(Actions.Account);
+                return RedirectToAction("Account");
             }
 
             await _userService.CancelChangeEmailAddress(user);
 
             TempData["Message"] = Strings.CancelEmailAddress;
 
-            return RedirectToAction(Actions.Account);
+            return RedirectToAction("Account");
         }
 
 
@@ -744,7 +729,7 @@ namespace NuGetGallery
                 }
 
                 TempData["Message"] = Strings.PasswordChanged;
-                return RedirectToAction(Actions.Account);
+                return RedirectToAction("Account");
             }
         }
 
@@ -1002,7 +987,7 @@ namespace NuGetGallery
             {
                 TempData["Message"] = Strings.CredentialNotFound;
 
-                return RedirectToAction(Actions.Account);
+                return RedirectToAction("Account");
             }
 
             // Count credentials and make sure the user can always login
@@ -1020,7 +1005,7 @@ namespace NuGetGallery
                 TempData["Message"] = message;
             }
 
-            return RedirectToAction(Actions.Account);
+            return RedirectToAction("Account");
         }
 
         private ActionResult AccountView<TAccountViewModel>(TAccountViewModel model = null)
@@ -1057,7 +1042,7 @@ namespace NuGetGallery
             // update model for user accounts
             UpdateUserAccountModel(account, userModel);
            
-            return View(Actions.Account, model);
+            return View("Account", model);
         }
 
         private void UpdateUserAccountModel(User account, UserAccountViewModel model)
@@ -1101,7 +1086,7 @@ namespace NuGetGallery
                 relativeUrl: false);
             _messageService.SendPasswordResetInstructions(user, resetPasswordUrl, forgotPassword);
 
-            return RedirectToAction(Actions.PasswordSent);
+            return RedirectToAction("PasswordSent");
         }
     }
 }

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -22,6 +22,21 @@ namespace NuGetGallery
     public partial class UsersController
         : AppController
     {
+        public static class Actions
+        {
+            public const string Account = "Account";
+            public const string ConfirmationRequired = "ConfirmationRequired";
+            public const string ConfirmTransform = "ConfirmTransform";
+            public const string DeleteAccount = "DeleteAccount";
+            public const string DeleteUserAccountStatus = "DeleteUserAccountStatus";
+            public const string DeleteRequest = "DeleteRequest";
+            public const string DeleteUserAccount = "DeleteUserAccount";
+            public const string PasswordChanged = "PasswordChanged";
+            public const string PasswordSent = "PasswordSent";
+            public const string Transform = "Transform";
+            public const string TransformFailed = "TransformFailed";
+        }
+
         private readonly ICuratedFeedService _curatedFeedService;
         private readonly IUserService _userService;
         private readonly IMessageService _messageService;
@@ -67,7 +82,7 @@ namespace NuGetGallery
 
         [Authorize]
         [HttpPost]
-        [ActionName("ConfirmationRequired")]
+        [ActionName(Actions.ConfirmationRequired)]
         [ValidateAntiForgeryToken]
         public virtual ActionResult ConfirmationRequiredPost()
         {
@@ -97,12 +112,12 @@ namespace NuGetGallery
         [Authorize]
         public virtual ActionResult Account()
         {
-            return AccountView(new AccountViewModel());
+            return AccountView<UserAccountViewModel>();
         }
 
         [HttpGet]
         [Authorize]
-        [ActionName("Transform")]
+        [ActionName(Actions.Transform)]
         public virtual ActionResult TransformToOrganization()
         {
             var accountToTransform = GetCurrentUser();
@@ -124,7 +139,7 @@ namespace NuGetGallery
         [HttpPost]
         [Authorize]
         [ValidateAntiForgeryToken]
-        [ActionName("Transform")]
+        [ActionName(Actions.Transform)]
         public virtual async Task<ActionResult> TransformToOrganization(TransformAccountViewModel transformViewModel)
         {
             var accountToTransform = GetCurrentUser();
@@ -155,7 +170,7 @@ namespace NuGetGallery
 
         [HttpGet]
         [Authorize]
-        [ActionName("ConfirmTransform")]
+        [ActionName(Actions.ConfirmTransform)]
         public virtual async Task<ActionResult> ConfirmTransformToOrganization(string accountNameToTransform, string token)
         {
             var adminUser = GetCurrentUser();
@@ -184,7 +199,7 @@ namespace NuGetGallery
                 Strings.TransformAccount_Success, accountNameToTransform);
 
             // todo: redirect to ManageOrganization (future work)
-            return RedirectToAction("Account");
+            return RedirectToAction(Actions.Account);
         }
 
         private ActionResult TransformToOrganizationFailed(string errorMessage)
@@ -208,7 +223,7 @@ namespace NuGetGallery
                  .Select(p => new ListPackageItemViewModel(p, user))
                  .ToList();
 
-            bool hasPendingRequest = _supportRequestService.GetIssues().Where((issue)=> (issue.UserKey.HasValue && issue.UserKey.Value == user.Key) && 
+            bool hasPendingRequest = _supportRequestService.GetIssues().Where((issue) => (issue.UserKey.HasValue && issue.UserKey.Value == user.Key) &&
                                                                                  string.Equals(issue.IssueTitle, Strings.AccountDelete_SupportRequestTitle) &&
                                                                                  issue.Key != IssueStatusKeys.Resolved).Any();
 
@@ -219,8 +234,8 @@ namespace NuGetGallery
                 AccountName = user.Username,
                 HasPendingRequests = hasPendingRequest
             };
-            
-            return View("DeleteAccount", model);
+
+            return View(Actions.DeleteAccount, model);
         }
 
         [HttpPost]
@@ -245,11 +260,11 @@ namespace NuGetGallery
             if (!isSupportRequestCreated)
             {
                 TempData["RequestFailedMessage"] = Strings.AccountDelete_CreateSupportRequestFails;
-                return RedirectToAction("DeleteRequest");
+                return RedirectToAction(Actions.DeleteRequest);
             }
             _messageService.SendAccountDeleteNotice(user.ToMailAddress(), user.Username);
-           
-            return RedirectToAction("DeleteRequest");
+
+            return RedirectToAction(Actions.DeleteRequest);
         }
 
         [HttpGet]
@@ -257,13 +272,13 @@ namespace NuGetGallery
         public virtual ActionResult Delete(string accountName)
         {
             var user = _userService.FindByUsername(accountName);
-            if(user == null || user.IsDeleted || (user is Organization))
+            if (user == null || user.IsDeleted || (user is Organization))
             {
                 return HttpNotFound("User not found.");
             }
 
             var listPackageItems = _packageService
-                 .FindPackagesByAnyMatchingOwner(user, includeUnlisted:true)
+                 .FindPackagesByAnyMatchingOwner(user, includeUnlisted: true)
                  .Select(p => new ListPackageItemViewModel(p, user))
                  .ToList();
             var model = new DeleteUserAccountViewModel
@@ -272,7 +287,7 @@ namespace NuGetGallery
                 User = user,
                 AccountName = user.Username,
             };
-            return View("DeleteUserAccount", model);
+            return View(Actions.DeleteUserAccount, model);
         }
 
         [HttpDelete]
@@ -284,7 +299,7 @@ namespace NuGetGallery
             var user = _userService.FindByUsername(model.AccountName);
             if (user == null || user.IsDeleted)
             {
-                return View("DeleteUserAccountStatus", new DeleteUserAccountStatus()
+                return View(Actions.DeleteUserAccountStatus, new DeleteUserAccountStatus()
                 {
                     AccountName = model.AccountName,
                     Description = $"Account {model.AccountName} not found.",
@@ -295,7 +310,7 @@ namespace NuGetGallery
             {
                 var admin = GetCurrentUser();
                 var status = await _deleteAccountService.DeleteGalleryUserAccountAsync(user, admin, model.Signature, model.ShouldUnlist, commitAsTransaction: true);
-                return View("DeleteUserAccountStatus", status);
+                return View(Actions.DeleteUserAccountStatus, status);
             }
         }
 
@@ -353,13 +368,13 @@ namespace NuGetGallery
             var user = GetCurrentUser();
 
             await _userService.ChangeEmailSubscriptionAsync(
-                user, 
-                model.ChangeNotifications.EmailAllowed, 
+                user,
+                model.ChangeNotifications.EmailAllowed,
                 model.ChangeNotifications.NotifyPackagePushed);
 
             TempData["Message"] = Strings.EmailPreferencesUpdated;
 
-            return RedirectToAction("Account");
+            return RedirectToAction(Actions.Account);
         }
 
         [HttpGet]
@@ -527,9 +542,7 @@ namespace NuGetGallery
                 _messageService.SendCredentialAddedNotice(credential.User, _authService.DescribeCredential(credential));
             }
 
-            return RedirectToAction(
-                actionName: "PasswordChanged",
-                controllerName: "Users");
+            return RedirectToAction(Actions.PasswordChanged);
         }
 
         [Authorize]
@@ -636,7 +649,7 @@ namespace NuGetGallery
             if (string.Equals(model.ChangeEmail.NewEmail, user.LastSavedEmailAddress, StringComparison.OrdinalIgnoreCase))
             {
                 // email address unchanged - accept
-                return RedirectToAction(actionName: "Account", controllerName: "Users");
+                return RedirectToAction(Actions.Account);
             }
 
             try
@@ -661,7 +674,7 @@ namespace NuGetGallery
                 TempData["Message"] = Strings.EmailUpdated;
             }
 
-            return RedirectToAction(actionName: "Account", controllerName: "Users");
+            return RedirectToAction(Actions.Account);
         }
 
         [HttpPost]
@@ -671,23 +684,23 @@ namespace NuGetGallery
         {
             var user = GetCurrentUser();
 
-            if(string.IsNullOrWhiteSpace(user.UnconfirmedEmailAddress))
+            if (string.IsNullOrWhiteSpace(user.UnconfirmedEmailAddress))
             {
-                return RedirectToAction(actionName: "Account", controllerName: "Users");
+                return RedirectToAction(Actions.Account);
             }
 
             await _userService.CancelChangeEmailAddress(user);
 
             TempData["Message"] = Strings.CancelEmailAddress;
 
-            return RedirectToAction(actionName: "Account", controllerName: "Users");
+            return RedirectToAction(Actions.Account);
         }
 
 
         [HttpPost]
         [Authorize]
         [ValidateAntiForgeryToken]
-        public virtual async Task<ActionResult> ChangePassword(AccountViewModel model)
+        public virtual async Task<ActionResult> ChangePassword(UserAccountViewModel model)
         {
             var user = GetCurrentUser();
 
@@ -731,7 +744,7 @@ namespace NuGetGallery
                 }
 
                 TempData["Message"] = Strings.PasswordChanged;
-                return RedirectToAction("Account");
+                return RedirectToAction(Actions.Account);
             }
         }
 
@@ -786,7 +799,7 @@ namespace NuGetGallery
                 Response.StatusCode = (int)HttpStatusCode.BadRequest;
                 return Json(Strings.Unsupported);
             }
-           
+
             var newCredentialViewModel = await GenerateApiKeyInternal(
                 cred.Description,
                 BuildScopes(cred.Scopes),
@@ -989,7 +1002,7 @@ namespace NuGetGallery
             {
                 TempData["Message"] = Strings.CredentialNotFound;
 
-                return RedirectToAction("Account");
+                return RedirectToAction(Actions.Account);
             }
 
             // Count credentials and make sure the user can always login
@@ -1007,37 +1020,57 @@ namespace NuGetGallery
                 TempData["Message"] = message;
             }
 
-            return RedirectToAction("Account");
+            return RedirectToAction(Actions.Account);
         }
 
-        private ActionResult AccountView(AccountViewModel model)
+        private ActionResult AccountView<TAccountViewModel>(TAccountViewModel model = null)
+            where TAccountViewModel : AccountViewModel
         {
-            var user = GetCurrentUser();
+            model = model ?? Activator.CreateInstance<TAccountViewModel>();
+            
+            // only users for now, but organizations are coming
+            var userModel = model as UserAccountViewModel;
+            if (userModel == null)
+            {
+                throw new ArgumentException("Invalid view model type.", nameof(model));
+            }
+
+            // update model for all accounts
+            var account = GetCurrentUser();
 
             model.CuratedFeeds = _curatedFeedService
-                .GetFeedsForManager(user.Key)
+                .GetFeedsForManager(account.Key)
                 .Select(f => f.Name)
                 .ToList();
-            model.CredentialGroups = GetCredentialGroups(user);
+
+            model.HasPassword = account.Credentials.Any(c => c.Type.StartsWith(CredentialTypes.Password.Prefix));
+            model.CurrentEmailAddress = account.UnconfirmedEmailAddress ?? account.EmailAddress;
+            model.HasConfirmedEmailAddress = !string.IsNullOrEmpty(account.EmailAddress);
+            model.HasUnconfirmedEmailAddress = !string.IsNullOrEmpty(account.UnconfirmedEmailAddress);
+
+            model.ChangeEmail = new ChangeEmailViewModel();
+
+            model.ChangeNotifications = model.ChangeNotifications ?? new ChangeNotificationsViewModel();
+            model.ChangeNotifications.EmailAllowed = account.EmailAllowed;
+            model.ChangeNotifications.NotifyPackagePushed = account.NotifyPackagePushed;
+
+            // update model for user accounts
+            UpdateUserAccountModel(account, userModel);
+           
+            return View(Actions.Account, model);
+        }
+
+        private void UpdateUserAccountModel(User account, UserAccountViewModel model)
+        {
+            model.CredentialGroups = GetCredentialGroups(account);
             model.SignInCredentialCount = model
                 .CredentialGroups
                 .Where(p => p.Key == CredentialKind.Password || p.Key == CredentialKind.External)
                 .Sum(p => p.Value.Count);
-
             model.ExpirationInDaysForApiKeyV1 = _config.ExpirationInDaysForApiKeyV1;
-            model.HasPassword = model.CredentialGroups.ContainsKey(CredentialKind.Password);
-            model.CurrentEmailAddress = user.UnconfirmedEmailAddress ?? user.EmailAddress;
-            model.HasConfirmedEmailAddress = !string.IsNullOrEmpty(user.EmailAddress);
-            model.HasUnconfirmedEmailAddress = !string.IsNullOrEmpty(user.UnconfirmedEmailAddress);
 
             model.ChangePassword = model.ChangePassword ?? new ChangePasswordViewModel();
             model.ChangePassword.EnablePasswordLogin = model.HasPassword;
-
-            model.ChangeNotifications = model.ChangeNotifications ?? new ChangeNotificationsViewModel();
-            model.ChangeNotifications.EmailAllowed = user.EmailAllowed;
-            model.ChangeNotifications.NotifyPackagePushed = user.NotifyPackagePushed;
-           
-            return View("Account", model);
         }
 
         private Dictionary<CredentialKind, List<CredentialViewModel>> GetCredentialGroups(User user)
@@ -1068,7 +1101,7 @@ namespace NuGetGallery
                 relativeUrl: false);
             _messageService.SendPasswordResetInstructions(user, resetPasswordUrl, forgotPassword);
 
-            return RedirectToAction(actionName: "PasswordSent", controllerName: "Users");
+            return RedirectToAction(Actions.PasswordSent);
         }
     }
 }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1623,6 +1623,11 @@
     <Compile Include="Areas\Admin\ViewModels\DeleteUserAccountViewModel.cs" />
     <Compile Include="ViewModels\ListOrganizationsItemViewModel.cs" />
     <Compile Include="ViewModels\ListOrganizationsViewModel.cs" />
+    <Compile Include="ViewModels\ChangeEmailViewModel.cs" />
+    <Compile Include="ViewModels\ChangeNotificationsViewModel.cs" />
+    <Compile Include="ViewModels\ChangePasswordViewModel.cs" />
+    <Compile Include="ViewModels\CredentialKind.cs" />
+    <Compile Include="ViewModels\CredentialViewModel.cs" />
     <Compile Include="ViewModels\ListPackageOwnerViewModel.cs" />
     <Compile Include="ViewModels\PackageDeleteDecision.cs" />
     <Compile Include="ViewModels\DeleteAccountViewModel.cs" />
@@ -1646,6 +1651,7 @@
     <Compile Include="ViewModels\ThirdPartyPackageManagerViewModel.cs" />
     <Compile Include="ViewModels\TransformAccountFailedViewModel.cs" />
     <Compile Include="ViewModels\TransformAccountViewModel.cs" />
+    <Compile Include="ViewModels\UserAccountViewModel.cs" />
     <Compile Include="WebApi\PlainTextResult.cs" />
     <Compile Include="WebApi\QueryResult.cs" />
     <Compile Include="WebApi\QueryResultDefaults.cs" />

--- a/src/NuGetGallery/ViewModels/AccountViewModel.cs
+++ b/src/NuGetGallery/ViewModels/AccountViewModel.cs
@@ -1,114 +1,24 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Web.Mvc;
-using NuGetGallery.Authentication.Providers;
-using NuGetGallery.Infrastructure;
 
 namespace NuGetGallery
 {
-    public class AccountViewModel
+    public abstract class AccountViewModel
     {
-        public AccountViewModel()
-        {
-            CuratedFeeds = new List<string>();
-            ChangePassword = new ChangePasswordViewModel();
-            ChangeEmail = new ChangeEmailViewModel();
-            CredentialGroups = new Dictionary<CredentialKind, List<CredentialViewModel>>();
-            ChangeNotifications = new ChangeNotificationsViewModel();
-        }
-
         public IList<string> CuratedFeeds { get; set; }
-        public ChangePasswordViewModel ChangePassword { get; set; }
+
         public ChangeEmailViewModel ChangeEmail { get; set; }
+
         public ChangeNotificationsViewModel ChangeNotifications { get; set; }
-        public int ExpirationInDaysForApiKeyV1 { get; set; }
+
         public bool HasPassword { get; set; }
+
         public string CurrentEmailAddress { get; set; }
+
         public bool HasUnconfirmedEmailAddress { get; set; }
+
         public bool HasConfirmedEmailAddress { get; set; }
-        public IDictionary<CredentialKind, List<CredentialViewModel>> CredentialGroups { get; set; }
-        public int SignInCredentialCount { get; set; }
-    }
-
-    public class ChangeNotificationsViewModel
-    {
-        public bool EmailAllowed { get; set; }
-        public bool NotifyPackagePushed { get; set; }
-    }
-
-    public class ChangeEmailViewModel
-    {
-        [Required]
-        [StringLength(255)]
-        [Display(Name = "New Email Address")]
-        [RegularExpression(RegisterViewModel.EmailValidationRegex, ErrorMessage = RegisterViewModel.EmailValidationErrorMessage)]
-        public string NewEmail { get; set; }
-
-        [Required]
-        [DataType(DataType.Password)]
-        [Display(Name = "Password")]
-        [StringLength(64)]
-        [AllowHtml]
-        public string Password { get; set; }
-    }
-
-    public class ChangePasswordViewModel
-    {
-        [Required]
-        [Display(Name = "Enable Password Login")]
-        public bool EnablePasswordLogin { get; set; }
-
-        [Required]
-        [Display(Name = "Current Password")]
-        [AllowHtml]
-        public string OldPassword { get; set; }
-
-        [Required]
-        [Display(Name = "New Password")]
-        [PasswordValidation]
-        [AllowHtml]
-        public string NewPassword { get; set; }
-
-        [Required]
-        [Display(Name = "Verify Password")]
-        [PasswordValidation]
-        [AllowHtml]
-        public string VerifyPassword { get; set; }
-    }
-    
-    public class CredentialViewModel
-    {
-        public int Key { get; set; }
-        public string Type { get; set; }
-        public string TypeCaption { get; set; }
-        public string Identity { get; set; }
-        public DateTime Created { get; set; }
-        public DateTime? Expires { get; set; }
-        public CredentialKind Kind { get; set; }
-        public AuthenticatorUI AuthUI { get; set; }
-        public string Description { get; set; }
-        public List<ScopeViewModel> Scopes { get; set; }
-        public bool HasExpired { get; set; }
-        public string Value { get; set; }
-        public TimeSpan? ExpirationDuration { get; set; }
-
-        public bool IsNonScopedApiKey
-        {
-            get
-            {
-                return CredentialTypes.IsApiKey(Type) && !Scopes.AnySafe();
-            }
-        }
-    }
-
-    public enum CredentialKind
-    {
-        Password,
-        Token,
-        External
     }
 }

--- a/src/NuGetGallery/ViewModels/ChangeEmailViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ChangeEmailViewModel.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+using System.Web.Mvc;
+
+namespace NuGetGallery
+{
+    public class ChangeEmailViewModel
+    {
+        [Required]
+        [StringLength(255)]
+        [Display(Name = "New Email Address")]
+        [RegularExpression(RegisterViewModel.EmailValidationRegex, ErrorMessage = RegisterViewModel.EmailValidationErrorMessage)]
+        public string NewEmail { get; set; }
+
+        [Required]
+        [DataType(DataType.Password)]
+        [Display(Name = "Password")]
+        [StringLength(64)]
+        [AllowHtml]
+        public string Password { get; set; }
+    }
+}

--- a/src/NuGetGallery/ViewModels/ChangeNotificationsViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ChangeNotificationsViewModel.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public class ChangeNotificationsViewModel
+    {
+        public bool EmailAllowed { get; set; }
+
+        public bool NotifyPackagePushed { get; set; }
+    }
+}

--- a/src/NuGetGallery/ViewModels/ChangePasswordViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ChangePasswordViewModel.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+using System.Web.Mvc;
+using NuGetGallery.Infrastructure;
+
+namespace NuGetGallery
+{
+    public class ChangePasswordViewModel
+    {
+        [Required]
+        [Display(Name = "Enable Password Login")]
+        public bool EnablePasswordLogin { get; set; }
+
+        [Required]
+        [Display(Name = "Current Password")]
+        [AllowHtml]
+        public string OldPassword { get; set; }
+
+        [Required]
+        [Display(Name = "New Password")]
+        [PasswordValidation]
+        [AllowHtml]
+        public string NewPassword { get; set; }
+
+        [Required]
+        [Display(Name = "Verify Password")]
+        [PasswordValidation]
+        [AllowHtml]
+        public string VerifyPassword { get; set; }
+    }
+}

--- a/src/NuGetGallery/ViewModels/CredentialKind.cs
+++ b/src/NuGetGallery/ViewModels/CredentialKind.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public enum CredentialKind
+    {
+        Password,
+        Token,
+        External
+    }
+}

--- a/src/NuGetGallery/ViewModels/CredentialViewModel.cs
+++ b/src/NuGetGallery/ViewModels/CredentialViewModel.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGetGallery.Authentication.Providers;
+
+namespace NuGetGallery
+{
+    public class CredentialViewModel
+    {
+        public int Key { get; set; }
+        public string Type { get; set; }
+        public string TypeCaption { get; set; }
+        public string Identity { get; set; }
+        public DateTime Created { get; set; }
+        public DateTime? Expires { get; set; }
+        public CredentialKind Kind { get; set; }
+        public AuthenticatorUI AuthUI { get; set; }
+        public string Description { get; set; }
+        public List<ScopeViewModel> Scopes { get; set; }
+        public bool HasExpired { get; set; }
+        public string Value { get; set; }
+        public TimeSpan? ExpirationDuration { get; set; }
+
+        public bool IsNonScopedApiKey
+        {
+            get
+            {
+                return CredentialTypes.IsApiKey(Type) && !Scopes.AnySafe();
+            }
+        }
+    }
+}

--- a/src/NuGetGallery/ViewModels/UserAccountViewModel.cs
+++ b/src/NuGetGallery/ViewModels/UserAccountViewModel.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGetGallery
+{
+    public class UserAccountViewModel : AccountViewModel
+    {
+        public ChangePasswordViewModel ChangePassword { get; set; }
+
+        public int ExpirationInDaysForApiKeyV1 { get; set; }
+
+        public IDictionary<CredentialKind, List<CredentialViewModel>> CredentialGroups { get; set; }
+
+        public int SignInCredentialCount { get; set; }
+    }
+}

--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -1,4 +1,4 @@
-﻿@model AccountViewModel
+﻿@model UserAccountViewModel
 @{
     ViewBag.Title = "Account Settings";
     ViewBag.MdPageColumns = Constants.ColumnsFormMd;

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -51,7 +51,7 @@ namespace NuGetGallery
                     .Returns(new[] { new CuratedFeed { Name = "theCuratedFeed" } });
 
                 // act
-                var model = ResultAssert.IsView<UserAccountViewModel>(controller.Account(), viewName: "Account");
+                var model = ResultAssert.IsView<UserAccountViewModel>(controller.Account(), UsersController.Actions.Account);
 
                 // verify
                 Assert.Equal("theCuratedFeed", model.CuratedFeeds.First());
@@ -75,7 +75,7 @@ namespace NuGetGallery
                 var result = controller.Account();
 
                 // Assert
-                var model = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
+                var model = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
                 var descs = model
                     .CredentialGroups
                     .SelectMany(x => x.Value)
@@ -114,7 +114,7 @@ namespace NuGetGallery
                 var result = controller.Account();
 
                 // Assert
-                var model = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
+                var model = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
                 var descs = model
                     .CredentialGroups
                     .SelectMany(x => x.Value)
@@ -190,7 +190,7 @@ namespace NuGetGallery
                     }
                 });
 
-                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                 GetMock<IUserService>().Verify(u => u.ChangeEmailSubscriptionAsync(user, false, true));
             }
         }
@@ -1351,7 +1351,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
+                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
                 Assert.Same(inputModel, outputModel);
             }
 
@@ -1384,7 +1384,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
+                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
                 Assert.Same(inputModel, outputModel);
                 Assert.NotEqual(inputModel.ChangePassword.NewPassword, inputModel.ChangePassword.VerifyPassword);
 
@@ -1425,7 +1425,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
+                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
                 Assert.Same(inputModel, outputModel);
 
                 var errorMessages = controller
@@ -1471,7 +1471,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                 Assert.Equal(Strings.PasswordRemoved, controller.TempData["Message"]);
             }
 
@@ -1502,7 +1502,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                 Assert.Equal(Strings.PasswordChanged, controller.TempData["Message"]);
             }
 
@@ -1579,7 +1579,7 @@ namespace NuGetGallery
                 var result = await controller.RemovePassword();
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                 Assert.Equal(Strings.CannotRemoveOnlyLoginCredential, controller.TempData["Message"]);
                 Assert.Equal(1, user.Credentials.Count);
             }
@@ -1598,7 +1598,7 @@ namespace NuGetGallery
                 var result = await controller.RemovePassword();
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                 Assert.Equal(Strings.CredentialNotFound, controller.TempData["Message"]);
                 Assert.Equal(1, user.Credentials.Count);
             }
@@ -1631,7 +1631,7 @@ namespace NuGetGallery
                 var result = await controller.RemovePassword();
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                 GetMock<AuthenticationService>().VerifyAll();
                 GetMock<IMessageService>().VerifyAll();
             }
@@ -1655,7 +1655,7 @@ namespace NuGetGallery
                     credentialKey: null);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                 Assert.Equal(Strings.CannotRemoveOnlyLoginCredential, controller.TempData["Message"]);
                 Assert.Equal(1, user.Credentials.Count);
             }
@@ -1676,7 +1676,7 @@ namespace NuGetGallery
                     credentialKey: null);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                 Assert.Equal(Strings.CredentialNotFound, controller.TempData["Message"]);
 
                 Assert.Equal(1, user.Credentials.Count);
@@ -1739,7 +1739,7 @@ namespace NuGetGallery
                     credentialKey: null);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                 GetMock<AuthenticationService>().VerifyAll();
                 GetMock<IMessageService>().VerifyAll();
             }
@@ -1769,7 +1769,7 @@ namespace NuGetGallery
                         credentialKey: creds[i].Key);
 
                     // Assert
-                    ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
+                    ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
                     Assert.Equal(Strings.CredentialRemoved, controller.TempData["Message"]);
                     Assert.Equal(creds.Length - i - 1, user.Credentials.Count);
                 }
@@ -2229,7 +2229,7 @@ namespace NuGetGallery
                     .Returns(userPackages);
 
                 // act
-                var model = ResultAssert.IsView<DeleteUserAccountViewModel>(controller.Delete(accountName: userName), viewName: "DeleteUserAccount");
+                var model = ResultAssert.IsView<DeleteUserAccountViewModel>(controller.Delete(accountName: userName), UsersController.Actions.DeleteUserAccount);
 
                 // Assert
                 Assert.Equal(userName, model.AccountName);

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -51,7 +51,7 @@ namespace NuGetGallery
                     .Returns(new[] { new CuratedFeed { Name = "theCuratedFeed" } });
 
                 // act
-                var model = ResultAssert.IsView<UserAccountViewModel>(controller.Account(), UsersController.Actions.Account);
+                var model = ResultAssert.IsView<UserAccountViewModel>(controller.Account(), viewName: "Account");
 
                 // verify
                 Assert.Equal("theCuratedFeed", model.CuratedFeeds.First());
@@ -75,7 +75,7 @@ namespace NuGetGallery
                 var result = controller.Account();
 
                 // Assert
-                var model = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
+                var model = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 var descs = model
                     .CredentialGroups
                     .SelectMany(x => x.Value)
@@ -114,7 +114,7 @@ namespace NuGetGallery
                 var result = controller.Account();
 
                 // Assert
-                var model = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
+                var model = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 var descs = model
                     .CredentialGroups
                     .SelectMany(x => x.Value)
@@ -190,7 +190,7 @@ namespace NuGetGallery
                     }
                 });
 
-                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                 GetMock<IUserService>().Verify(u => u.ChangeEmailSubscriptionAsync(user, false, true));
             }
         }
@@ -1351,7 +1351,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
+                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 Assert.Same(inputModel, outputModel);
             }
 
@@ -1384,7 +1384,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
+                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 Assert.Same(inputModel, outputModel);
                 Assert.NotEqual(inputModel.ChangePassword.NewPassword, inputModel.ChangePassword.VerifyPassword);
 
@@ -1425,7 +1425,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, UsersController.Actions.Account);
+                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 Assert.Same(inputModel, outputModel);
 
                 var errorMessages = controller
@@ -1471,7 +1471,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                 Assert.Equal(Strings.PasswordRemoved, controller.TempData["Message"]);
             }
 
@@ -1502,7 +1502,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                 Assert.Equal(Strings.PasswordChanged, controller.TempData["Message"]);
             }
 
@@ -1579,7 +1579,7 @@ namespace NuGetGallery
                 var result = await controller.RemovePassword();
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                 Assert.Equal(Strings.CannotRemoveOnlyLoginCredential, controller.TempData["Message"]);
                 Assert.Equal(1, user.Credentials.Count);
             }
@@ -1598,7 +1598,7 @@ namespace NuGetGallery
                 var result = await controller.RemovePassword();
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                 Assert.Equal(Strings.CredentialNotFound, controller.TempData["Message"]);
                 Assert.Equal(1, user.Credentials.Count);
             }
@@ -1631,7 +1631,7 @@ namespace NuGetGallery
                 var result = await controller.RemovePassword();
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                 GetMock<AuthenticationService>().VerifyAll();
                 GetMock<IMessageService>().VerifyAll();
             }
@@ -1655,7 +1655,7 @@ namespace NuGetGallery
                     credentialKey: null);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                 Assert.Equal(Strings.CannotRemoveOnlyLoginCredential, controller.TempData["Message"]);
                 Assert.Equal(1, user.Credentials.Count);
             }
@@ -1676,7 +1676,7 @@ namespace NuGetGallery
                     credentialKey: null);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                 Assert.Equal(Strings.CredentialNotFound, controller.TempData["Message"]);
 
                 Assert.Equal(1, user.Credentials.Count);
@@ -1739,7 +1739,7 @@ namespace NuGetGallery
                     credentialKey: null);
 
                 // Assert
-                ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                 GetMock<AuthenticationService>().VerifyAll();
                 GetMock<IMessageService>().VerifyAll();
             }
@@ -1769,7 +1769,7 @@ namespace NuGetGallery
                         credentialKey: creds[i].Key);
 
                     // Assert
-                    ResultAssert.IsRedirectToRoute(result, new { action = UsersController.Actions.Account });
+                    ResultAssert.IsRedirectToRoute(result, new { action = "Account" });
                     Assert.Equal(Strings.CredentialRemoved, controller.TempData["Message"]);
                     Assert.Equal(creds.Length - i - 1, user.Credentials.Count);
                 }
@@ -2229,7 +2229,7 @@ namespace NuGetGallery
                     .Returns(userPackages);
 
                 // act
-                var model = ResultAssert.IsView<DeleteUserAccountViewModel>(controller.Delete(accountName: userName), UsersController.Actions.DeleteUserAccount);
+                var model = ResultAssert.IsView<DeleteUserAccountViewModel>(controller.Delete(accountName: userName), viewName: "DeleteUserAccount");
 
                 // Assert
                 Assert.Equal(userName, model.AccountName);

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -51,7 +51,7 @@ namespace NuGetGallery
                     .Returns(new[] { new CuratedFeed { Name = "theCuratedFeed" } });
 
                 // act
-                var model = ResultAssert.IsView<AccountViewModel>(controller.Account(), viewName: "Account");
+                var model = ResultAssert.IsView<UserAccountViewModel>(controller.Account(), viewName: "Account");
 
                 // verify
                 Assert.Equal("theCuratedFeed", model.CuratedFeeds.First());
@@ -75,7 +75,7 @@ namespace NuGetGallery
                 var result = controller.Account();
 
                 // Assert
-                var model = ResultAssert.IsView<AccountViewModel>(result, viewName: "Account");
+                var model = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 var descs = model
                     .CredentialGroups
                     .SelectMany(x => x.Value)
@@ -114,7 +114,7 @@ namespace NuGetGallery
                 var result = controller.Account();
 
                 // Assert
-                var model = ResultAssert.IsView<AccountViewModel>(result, viewName: "Account");
+                var model = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 var descs = model
                     .CredentialGroups
                     .SelectMany(x => x.Value)
@@ -181,9 +181,9 @@ namespace NuGetGallery
                     .Setup(u => u.ChangeEmailSubscriptionAsync(user, false, true))
                     .Returns(Task.CompletedTask);
 
-                var result = await controller.ChangeEmailSubscription(new AccountViewModel
+                var result = await controller.ChangeEmailSubscription(new UserAccountViewModel
                 {
-                    ChangeNotifications =
+                    ChangeNotifications = new ChangeNotificationsViewModel
                     {
                         EmailAllowed = false,
                         NotifyPackagePushed = true
@@ -1163,7 +1163,7 @@ namespace NuGetGallery
                 controller.SetCurrentUser(user);
 
                 var result = await controller.ChangeEmail(
-                    new AccountViewModel()
+                    new UserAccountViewModel()
                     {
                         ChangeEmail = new ChangeEmailViewModel
                         {
@@ -1199,7 +1199,7 @@ namespace NuGetGallery
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
-                var model = new AccountViewModel()
+                var model = new UserAccountViewModel()
                 {
                     ChangeEmail = new ChangeEmailViewModel
                     {
@@ -1235,7 +1235,7 @@ namespace NuGetGallery
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
-                var model = new AccountViewModel()
+                var model = new UserAccountViewModel()
                 {
                     ChangeEmail = new ChangeEmailViewModel
                     {
@@ -1272,7 +1272,7 @@ namespace NuGetGallery
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
-                var model = new AccountViewModel()
+                var model = new UserAccountViewModel()
                 {
                     ChangeEmail = new ChangeEmailViewModel
                     {
@@ -1309,7 +1309,7 @@ namespace NuGetGallery
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
-                var model = new AccountViewModel
+                var model = new UserAccountViewModel
                 {
                     ChangeEmail = new ChangeEmailViewModel
                     {
@@ -1321,7 +1321,7 @@ namespace NuGetGallery
                 var result = await controller.ChangeEmail(model);
 
                 Assert.IsType<ViewResult>(result);
-                Assert.IsType<AccountViewModel>(((ViewResult)result).Model);
+                Assert.IsType<UserAccountViewModel>(((ViewResult)result).Model);
             }
         }
 
@@ -1333,9 +1333,9 @@ namespace NuGetGallery
                 // Arrange
                 var controller = GetController<UsersController>();
                 controller.ModelState.AddModelError("ChangePassword.blarg", "test");
-                var inputModel = new AccountViewModel
+                var inputModel = new UserAccountViewModel
                 {
-                    ChangePassword =
+                    ChangePassword = new ChangePasswordViewModel
                     {
                         EnablePasswordLogin = true,
                     }
@@ -1351,7 +1351,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                var outputModel = ResultAssert.IsView<AccountViewModel>(result, viewName: "Account");
+                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 Assert.Same(inputModel, outputModel);
             }
 
@@ -1369,7 +1369,7 @@ namespace NuGetGallery
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
-                var inputModel = new AccountViewModel()
+                var inputModel = new UserAccountViewModel()
                 {
                     ChangePassword = new ChangePasswordViewModel()
                     {
@@ -1384,7 +1384,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                var outputModel = ResultAssert.IsView<AccountViewModel>(result, viewName: "Account");
+                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 Assert.Same(inputModel, outputModel);
                 Assert.NotEqual(inputModel.ChangePassword.NewPassword, inputModel.ChangePassword.VerifyPassword);
 
@@ -1410,7 +1410,7 @@ namespace NuGetGallery
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
 
-                var inputModel = new AccountViewModel()
+                var inputModel = new UserAccountViewModel()
                 {
                     ChangePassword = new ChangePasswordViewModel()
                     {
@@ -1425,7 +1425,7 @@ namespace NuGetGallery
                 var result = await controller.ChangePassword(inputModel);
 
                 // Assert
-                var outputModel = ResultAssert.IsView<AccountViewModel>(result, viewName: "Account");
+                var outputModel = ResultAssert.IsView<UserAccountViewModel>(result, viewName: "Account");
                 Assert.Same(inputModel, outputModel);
 
                 var errorMessages = controller
@@ -1459,7 +1459,7 @@ namespace NuGetGallery
 
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
-                var inputModel = new AccountViewModel()
+                var inputModel = new UserAccountViewModel()
                 {
                     ChangePassword = new ChangePasswordViewModel()
                     {
@@ -1487,7 +1487,7 @@ namespace NuGetGallery
                     .CompletesWith(true);
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
-                var inputModel = new AccountViewModel()
+                var inputModel = new UserAccountViewModel()
                 {
                     ChangePassword = new ChangePasswordViewModel()
                     {
@@ -1529,7 +1529,7 @@ namespace NuGetGallery
                 controller.SetCurrentUser(user);
 
                 // Act
-                await controller.ChangePassword(new AccountViewModel());
+                await controller.ChangePassword(new UserAccountViewModel());
 
                 // Assert
                 Assert.Equal(TestUtility.GallerySiteRootHttps + "account/setpassword/test/t0k3n", actualConfirmUrl);
@@ -1551,7 +1551,7 @@ namespace NuGetGallery
                 controller.SetCurrentUser(user);
 
                 // Act
-                await controller.ChangePassword(new AccountViewModel());
+                await controller.ChangePassword(new UserAccountViewModel());
 
                 // Assert
                 var errorMessages = controller


### PR DESCRIPTION
Preparation for #4990.

Refactoring to create base AccountViewModel, to be used by both UserAccountViewModel and OrganizationAccountViewModel (coming w/ Manage Organization).