### PR TITLE
Bug bash: fix transform issues

### DIFF
--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -129,11 +129,6 @@ namespace NuGetGallery
         public virtual async Task<ActionResult> TransformToOrganization(TransformAccountViewModel transformViewModel)
         {
             var accountToTransform = GetCurrentUser();
-            string errorReason;
-            if (!_userService.CanTransformUserToOrganization(accountToTransform, out errorReason))
-            {
-                return TransformToOrganizationFailed(errorReason);
-            }
 
             var adminUser = _userService.FindByUsername(transformViewModel.AdminUsername);
             if (adminUser == null)
@@ -143,12 +138,12 @@ namespace NuGetGallery
                 return View(transformViewModel);
             }
 
-            if (!adminUser.Confirmed)
+            string errorReason;
+            if (!_userService.CanTransformUserToOrganization(accountToTransform, adminUser, out errorReason))
             {
-                ModelState.AddModelError("AdminUsername", Strings.TransformAccount_AdminAccountNotConfirmed);
-                return View(transformViewModel);
+                return TransformToOrganizationFailed(errorReason);
             }
-            
+
             await _userService.RequestTransformToOrganizationAccount(accountToTransform, adminUser);
 
             // sign out pending organization and prompt for admin sign in

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -115,8 +115,8 @@ namespace NuGetGallery
             var transformRequest = accountToTransform.OrganizationMigrationRequest;
             if (transformRequest != null)
             {
-                TempData["Message"] = String.Format(CultureInfo.CurrentCulture, Strings.TransformAccount_RequestExists,
-                    transformRequest.RequestDate.ToNuGetShortDateString(), transformRequest.AdminUser.Username);
+                TempData["Message"] = String.Format(CultureInfo.CurrentCulture,
+                    Strings.TransformAccount_RequestExists, transformRequest.AdminUser.Username);
             }
 
             return View(new TransformAccountViewModel());
@@ -161,10 +161,6 @@ namespace NuGetGallery
         public virtual async Task<ActionResult> ConfirmTransformToOrganization(string accountNameToTransform, string token)
         {
             var adminUser = GetCurrentUser();
-            if (!adminUser.Confirmed)
-            {
-                return TransformToOrganizationFailed(Strings.TransformAccount_NotConfirmed);
-            }
 
             string errorReason;
             var accountToTransform = _userService.FindByUsername(accountNameToTransform);
@@ -175,15 +171,14 @@ namespace NuGetGallery
                 return TransformToOrganizationFailed(errorReason);
             }
 
-            if (!_userService.CanTransformUserToOrganization(accountToTransform, out errorReason))
+            if (!_userService.CanTransformUserToOrganization(accountToTransform, adminUser, out errorReason))
             {
                 return TransformToOrganizationFailed(errorReason);
             }
 
             if (!await _userService.TransformUserToOrganization(accountToTransform, adminUser, token))
             {
-                errorReason = String.Format(CultureInfo.CurrentCulture,
-                    Strings.TransformAccount_Failed, accountNameToTransform);
+                errorReason = Strings.TransformAccount_Failed;
                 return TransformToOrganizationFailed(errorReason);
             }
 

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -106,8 +106,7 @@ namespace NuGetGallery
         public virtual ActionResult TransformToOrganization()
         {
             var accountToTransform = GetCurrentUser();
-            string errorReason;
-            if (!_userService.CanTransformUserToOrganization(accountToTransform, out errorReason))
+            if (!_userService.CanTransformUserToOrganization(accountToTransform, out var errorReason))
             {
                 return TransformToOrganizationFailed(errorReason);
             }
@@ -137,9 +136,8 @@ namespace NuGetGallery
                     Strings.TransformAccount_AdminAccountDoesNotExist, transformViewModel.AdminUsername));
                 return View(transformViewModel);
             }
-
-            string errorReason;
-            if (!_userService.CanTransformUserToOrganization(accountToTransform, adminUser, out errorReason))
+            
+            if (!_userService.CanTransformUserToOrganization(accountToTransform, adminUser, out var errorReason))
             {
                 return TransformToOrganizationFailed(errorReason);
             }

--- a/src/NuGetGallery/Services/IUserService.cs
+++ b/src/NuGetGallery/Services/IUserService.cs
@@ -29,7 +29,9 @@ namespace NuGetGallery
         Task<IDictionary<int, string>> GetEmailAddressesForUserKeysAsync(IReadOnlyCollection<int> distinctUserKeys);
 
         bool CanTransformUserToOrganization(User accountToTransform, out string errorReason);
-        
+
+        bool CanTransformUserToOrganization(User accountToTransform, User adminUser, out string errorReason);
+
         Task RequestTransformToOrganizationAccount(User accountToTransform, User adminUser);
         
         Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token);

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -201,8 +201,7 @@ namespace NuGetGallery
             }
             else if (accountToTransform.Organizations.Any() || accountToTransform.OrganizationRequests.Any())
             {
-                errorReason = String.Format(CultureInfo.CurrentCulture,
-                    Strings.TransformAccount_FailedReasonHasMemberships, accountToTransform.Username);
+                errorReason = Strings.TransformAccount_FailedReasonHasMemberships;
             }
             else if (enabledDomains == null ||
                 !enabledDomains.Contains(accountToTransform.ToMailAddress().Host, StringComparer.OrdinalIgnoreCase))
@@ -240,7 +239,7 @@ namespace NuGetGallery
             return errorReason == null;
         }
 
-            public async Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
+        public async Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
         {
             // todo: check for tenantId and add organization policy to enforce this (future work, with manage organization)
 

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -214,7 +214,33 @@ namespace NuGetGallery
             return errorReason == null;
         }
 
-        public async Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
+        public bool CanTransformUserToOrganization(User accountToTransform, User adminUser, out string errorReason)
+        {
+            if (!CanTransformUserToOrganization(accountToTransform, out errorReason))
+            {
+                return false;
+            }
+
+            if (adminUser.MatchesUser(accountToTransform))
+            {
+                errorReason = String.Format(CultureInfo.CurrentCulture,
+                    Strings.TransformAccount_AdminMustBeDifferentAccount, adminUser.Username);
+            }
+            else if (!adminUser.Confirmed)
+            {
+                errorReason = String.Format(CultureInfo.CurrentCulture,
+                    Strings.TransformAccount_AdminAccountNotConfirmed, adminUser.Username);
+            }
+            else if (adminUser is Organization)
+            {
+                errorReason = String.Format(CultureInfo.CurrentCulture,
+                    Strings.TransformAccount_AdminAccountIsOrganization, adminUser.Username);
+            }
+
+            return errorReason == null;
+        }
+
+            public async Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
         {
             // todo: check for tenantId and add organization policy to enforce this (future work, with manage organization)
 

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -192,16 +192,16 @@ namespace NuGetGallery
             if (!accountToTransform.Confirmed)
             {
                 errorReason = String.Format(CultureInfo.CurrentCulture,
-                    Strings.TransformAccount_FailedReasonNotConfirmedUser, accountToTransform.Username);
+                    Strings.TransformAccount_AccountNotConfirmed, accountToTransform.Username);
             }
             else if (accountToTransform is Organization)
             {
                 errorReason = String.Format(CultureInfo.CurrentCulture,
-                    Strings.TransformAccount_FailedReasonIsOrganization, accountToTransform.Username);
+                    Strings.TransformAccount_AccountIsAnOrganization, accountToTransform.Username);
             }
             else if (accountToTransform.Organizations.Any() || accountToTransform.OrganizationRequests.Any())
             {
-                errorReason = Strings.TransformAccount_FailedReasonHasMemberships;
+                errorReason = Strings.TransformAccount_AccountHasMemberships;
             }
             else if (enabledDomains == null ||
                 !enabledDomains.Contains(accountToTransform.ToMailAddress().Host, StringComparer.OrdinalIgnoreCase))

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1417,11 +1417,29 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Administrator account &apos;{0}&apos; must not be an organization..
+        /// </summary>
+        public static string TransformAccount_AdminAccountIsOrganization {
+            get {
+                return ResourceManager.GetString("TransformAccount_AdminAccountIsOrganization", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Administrator account &apos;{0}&apos; has not confirmed their email address..
         /// </summary>
         public static string TransformAccount_AdminAccountNotConfirmed {
             get {
                 return ResourceManager.GetString("TransformAccount_AdminAccountNotConfirmed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Administrator account &apos;{0}&apos; must be a different account than the one being transformed..
+        /// </summary>
+        public static string TransformAccount_AdminMustBeDifferentAccount {
+            get {
+                return ResourceManager.GetString("TransformAccount_AdminMustBeDifferentAccount", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1417,7 +1417,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Administrator account &apos;{0}&apos; must not be an organization..
+        ///   Looks up a localized string similar to Administrator account &apos;{0}&apos; cannot be an organization..
         /// </summary>
         public static string TransformAccount_AdminAccountIsOrganization {
             get {
@@ -1435,7 +1435,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Administrator account &apos;{0}&apos; must be a different account than the one being transformed..
+        ///   Looks up a localized string similar to Administrator account &apos;{0}&apos; cannot be the same account as the one being transformed..
         /// </summary>
         public static string TransformAccount_AdminMustBeDifferentAccount {
             get {
@@ -1444,7 +1444,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unexpected error when transforming account &apos;{0}&apos;. Contact support@nuget.org for more details..
+        ///   Looks up a localized string similar to An unexpected error occurred while transforming this account. Contact support  for assistance..
         /// </summary>
         public static string TransformAccount_Failed {
             get {
@@ -1453,7 +1453,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Account &apos;{0}&apos; should not belong to any organizations..
+        ///   Looks up a localized string similar to You are a member of one or more organizations. You must leave all organizations before transforming your account..
         /// </summary>
         public static string TransformAccount_FailedReasonHasMemberships {
             get {
@@ -1489,15 +1489,6 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You must confirm the email address for this account in order to complete this request..
-        /// </summary>
-        public static string TransformAccount_NotConfirmed {
-            get {
-                return ResourceManager.GetString("TransformAccount_NotConfirmed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Organization account &apos;{0}&apos; does not exist..
         /// </summary>
         public static string TransformAccount_OrganizationAccountDoesNotExist {
@@ -1507,7 +1498,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Another tranform request was created on {0} for administrator &apos;{1}&apos;. Note that a new request will overwrite this request..
+        ///   Looks up a localized string similar to A transform request, with account &apos;{0}&apos; as administrator, is in progress. A new request will override any existing request(s)..
         /// </summary>
         public static string TransformAccount_RequestExists {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1408,6 +1408,33 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You are a member of one or more organizations. You must leave all organizations before transforming your account..
+        /// </summary>
+        public static string TransformAccount_AccountHasMemberships {
+            get {
+                return ResourceManager.GetString("TransformAccount_AccountHasMemberships", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Account &apos;{0}&apos; is already an organization..
+        /// </summary>
+        public static string TransformAccount_AccountIsAnOrganization {
+            get {
+                return ResourceManager.GetString("TransformAccount_AccountIsAnOrganization", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Account &apos;{0}&apos; should be a confirmed user..
+        /// </summary>
+        public static string TransformAccount_AccountNotConfirmed {
+            get {
+                return ResourceManager.GetString("TransformAccount_AccountNotConfirmed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Administrator account &apos;{0}&apos; does not exist..
         /// </summary>
         public static string TransformAccount_AdminAccountDoesNotExist {
@@ -1449,33 +1476,6 @@ namespace NuGetGallery {
         public static string TransformAccount_Failed {
             get {
                 return ResourceManager.GetString("TransformAccount_Failed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to You are a member of one or more organizations. You must leave all organizations before transforming your account..
-        /// </summary>
-        public static string TransformAccount_FailedReasonHasMemberships {
-            get {
-                return ResourceManager.GetString("TransformAccount_FailedReasonHasMemberships", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Account &apos;{0}&apos; is already an organization..
-        /// </summary>
-        public static string TransformAccount_FailedReasonIsOrganization {
-            get {
-                return ResourceManager.GetString("TransformAccount_FailedReasonIsOrganization", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Account &apos;{0}&apos; should be a confirmed user..
-        /// </summary>
-        public static string TransformAccount_FailedReasonNotConfirmedUser {
-            get {
-                return ResourceManager.GetString("TransformAccount_FailedReasonNotConfirmedUser", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -703,11 +703,8 @@ For more information, please contact '{2}'.</value>
   <data name="VerifyPackage_UserNonExistent" xml:space="preserve">
     <value>The user '{0}' doesn't exist. You cannot upload a package as a user that doesn't exist.</value>
   </data>
-  <data name="TransformAccount_NotConfirmed" xml:space="preserve">
-    <value>You must confirm the email address for this account in order to complete this request.</value>
-  </data>
   <data name="TransformAccount_Failed" xml:space="preserve">
-    <value>Unexpected error when transforming account '{0}'. Contact support@nuget.org for more details.</value>
+    <value>An unexpected error occurred while transforming this account. Contact support  for assistance.</value>
   </data>
   <data name="TransformAccount_OrganizationAccountDoesNotExist" xml:space="preserve">
     <value>Organization account '{0}' does not exist.</value>
@@ -716,7 +713,7 @@ For more information, please contact '{2}'.</value>
     <value>Account '{0}' was successfully transformed into an organization.</value>
   </data>
   <data name="TransformAccount_FailedReasonHasMemberships" xml:space="preserve">
-    <value>Account '{0}' should not belong to any organizations.</value>
+    <value>You are a member of one or more organizations. You must leave all organizations before transforming your account.</value>
   </data>
   <data name="TransformAccount_FailedReasonNotConfirmedUser" xml:space="preserve">
     <value>Account '{0}' should be a confirmed user.</value>
@@ -734,15 +731,15 @@ For more information, please contact '{2}'.</value>
     <value>Administrator account '{0}' has not confirmed their email address.</value>
   </data>
   <data name="TransformAccount_RequestExists" xml:space="preserve">
-    <value>Another tranform request was created on {0} for administrator '{1}'. Note that a new request will overwrite this request.</value>
+    <value>A transform request, with account '{0}' as administrator, is in progress. A new request will override any existing request(s).</value>
   </data>
   <data name="TransformAccount_SignInToConfirm" xml:space="preserve">
     <value>Please sign in as administrator '{0}' to finish transforming account '{1}' into an organization.</value>
   </data>
   <data name="TransformAccount_AdminAccountIsOrganization" xml:space="preserve">
-    <value>Administrator account '{0}' must not be an organization.</value>
+    <value>Administrator account '{0}' cannot be an organization.</value>
   </data>
   <data name="TransformAccount_AdminMustBeDifferentAccount" xml:space="preserve">
-    <value>Administrator account '{0}' must be a different account than the one being transformed.</value>
+    <value>Administrator account '{0}' cannot be the same account as the one being transformed.</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -739,4 +739,10 @@ For more information, please contact '{2}'.</value>
   <data name="TransformAccount_SignInToConfirm" xml:space="preserve">
     <value>Please sign in as administrator '{0}' to finish transforming account '{1}' into an organization.</value>
   </data>
+  <data name="TransformAccount_AdminAccountIsOrganization" xml:space="preserve">
+    <value>Administrator account '{0}' must not be an organization.</value>
+  </data>
+  <data name="TransformAccount_AdminMustBeDifferentAccount" xml:space="preserve">
+    <value>Administrator account '{0}' must be a different account than the one being transformed.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -712,16 +712,16 @@ For more information, please contact '{2}'.</value>
   <data name="TransformAccount_Success" xml:space="preserve">
     <value>Account '{0}' was successfully transformed into an organization.</value>
   </data>
-  <data name="TransformAccount_FailedReasonHasMemberships" xml:space="preserve">
+  <data name="TransformAccount_AccountHasMemberships" xml:space="preserve">
     <value>You are a member of one or more organizations. You must leave all organizations before transforming your account.</value>
   </data>
-  <data name="TransformAccount_FailedReasonNotConfirmedUser" xml:space="preserve">
+  <data name="TransformAccount_AccountNotConfirmed" xml:space="preserve">
     <value>Account '{0}' should be a confirmed user.</value>
   </data>
   <data name="TransformAccount_FailedReasonNotInDomainWhitelist" xml:space="preserve">
     <value>Account '{0}' does not support organizations.</value>
   </data>
-  <data name="TransformAccount_FailedReasonIsOrganization" xml:space="preserve">
+  <data name="TransformAccount_AccountIsAnOrganization" xml:space="preserve">
     <value>Account '{0}' is already an organization.</value>
   </data>
   <data name="TransformAccount_AdminAccountDoesNotExist" xml:space="preserve">

--- a/src/NuGetGallery/Views/Authentication/SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/SignIn.cshtml
@@ -11,13 +11,18 @@
 }
 
 <section role="main" class="container main-container page-sign-in">
+    @if (!string.IsNullOrEmpty(returnUrlMessage))
+    {
+        <div class="row">
+            <div class="col-xs-12 text-center">
+                @ViewHelpers.AlertInfo(@<text>@returnUrlMessage</text>)
+            </div>
+        </div>
+    }
+
     <div class="row">
         <div class="col-xs-12 text-center">
             <h1>Sign in</h1>
-            @if (!string.IsNullOrEmpty(returnUrlMessage))
-            {
-                @ViewHelpers.AlertInfo(@<text>@returnUrlMessage</text>)
-            }
         </div>
     </div>
 

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -151,7 +151,7 @@
     <div class="alert-transient @(ViewBag.HasJumbotron == true ? "alert-transient-jumbotron" : string.Empty)">
         <div class="container">
             <div class="row">
-                <div class="@ViewHelpers.GetColumnClasses(ViewBag)" role="alert" aria-live="assertive">
+                <div class="col-sm-12" role="alert" aria-live="assertive">
                     @ViewHelpers.AlertInfo(@<text>@TempData["Message"]</text>)
                 </div>
             </div>

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -151,7 +151,7 @@
     <div class="alert-transient @(ViewBag.HasJumbotron == true ? "alert-transient-jumbotron" : string.Empty)">
         <div class="container">
             <div class="row">
-                <div class="col-sm-12" role="alert" aria-live="assertive">
+                <div class="@ViewHelpers.GetColumnClasses(ViewBag)" role="alert" aria-live="assertive">
                     @ViewHelpers.AlertInfo(@<text>@TempData["Message"]</text>)
                 </div>
             </div>

--- a/src/NuGetGallery/Views/Users/Transform.cshtml
+++ b/src/NuGetGallery/Views/Users/Transform.cshtml
@@ -3,6 +3,10 @@
     ViewBag.Title = "Transform Account";
     ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
+
+    var transformNote = "Note that administrators have full control over the organization, including the ability to add and remove other members.";
+    var transformToolTip = "Please enter a username for the organization administrator. " + transformNote;
+    var transformConfirmation = "You have added '{0}' as an administrator. " + transformNote;
 }
 
 <section role="main" class="container main-container page-account-settings">
@@ -23,24 +27,21 @@
                     @Html.Label("Organization")
                     <p>@CurrentUser.Username</p>
                 </div>
-                
+
                 <div class="row form-group col-md-9 col-md-pull-3">
                     @Html.Label("Email")
                     <p>@CurrentUser.EmailAddress</p>
                 </div>
 
-                @using (Html.BeginForm("Transform", "Users"))
+                @using (Html.BeginForm("Transform", "Users", FormMethod.Post, new { id = "transform"}))
                 {
                     @Html.AntiForgeryToken()
 
                     <div class="row form-group col-md-9 col-md-pull-3 @Html.HasErrorFor(m => m.AdminUsername)">
                         @Html.ShowLabelFor(m => m.AdminUsername)
-                        @ViewHelpers.AlertInfo(
-                            @<text>
-                                Please enter a username for an organization administrator. Note that administrators
-                                have full control over the organization, including the ability to add and remove other members.
-                            </text>)
-
+                        <a href="#" data-toggle="tooltip" title="@transformToolTip">
+                            <i class="ms-Icon ms-Icon--Info" aria-hidden="true" style="vertical-align: -2px"></i>
+                        </a>
                         @Html.ShowTextBoxFor(m => m.AdminUsername)
                         @Html.ShowValidationMessagesFor(m => m.AdminUsername)
                     </div>
@@ -61,3 +62,18 @@
         </div>
     </div>
 </section>
+
+@section bottomScripts {
+    <script type="text/javascript">
+        $(function ()
+        {
+           var confirmation = "@Html.Raw(transformConfirmation)";
+            $("#transform").submit(function (event) {
+                return window.nuget.confirmEvent(
+                    window.nuget.formatString(confirmation, $("#AdminUsername").val()),
+                    event);
+            })
+        });
+    </script>
+    @Scripts.Render("~/Scripts/gallery/site.min.js")
+}

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -2478,24 +2478,6 @@ namespace NuGetGallery
         public class TheConfirmTransformToOrganizationAction : TestContainer
         {
             [Fact]
-            public async Task WhenAdminIsNotConfirmed_ShowsError()
-            {
-                // Arrange
-                var controller = GetController<UsersController>();
-                var currentUser = new User() { UnconfirmedEmailAddress = "unconfirmed@example.com" };
-                controller.SetCurrentUser(currentUser);
-
-                // Act
-                var result = await controller.ConfirmTransformToOrganization("account", "token") as ViewResult;
-
-                // Assert
-                Assert.NotNull(result);
-
-                var model = result.Model as TransformAccountFailedViewModel;
-                Assert.Equal(Strings.TransformAccount_NotConfirmed, model.ErrorMessage);
-            }
-
-            [Fact]
             public async Task WhenAccountToTransformIsNotFound_ShowsError()
             {
                 // Arrange
@@ -2588,6 +2570,10 @@ namespace NuGetGallery
 
                 GetMock<IUserService>()
                     .Setup(u => u.CanTransformUserToOrganization(It.IsAny<User>(), out canTransformErrorReason))
+                    .Returns(string.IsNullOrEmpty(canTransformErrorReason));
+
+                GetMock<IUserService>()
+                    .Setup(u => u.CanTransformUserToOrganization(It.IsAny<User>(), It.IsAny<User>(), out canTransformErrorReason))
                     .Returns(string.IsNullOrEmpty(canTransformErrorReason));
 
                 GetMock<IUserService>()

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -2373,6 +2373,10 @@ namespace NuGetGallery
                     .Returns(string.IsNullOrEmpty(canTransformErrorReason));
 
                 GetMock<IUserService>()
+                    .Setup(u => u.CanTransformUserToOrganization(It.IsAny<User>(), It.IsAny<User>(), out canTransformErrorReason))
+                    .Returns(string.IsNullOrEmpty(canTransformErrorReason));
+
+                GetMock<IUserService>()
                     .Setup(s => s.RequestTransformToOrganizationAccount(It.IsAny<User>(), It.IsAny<User>()))
                     .Callback<User, User>((acct, admin) => {
                         acct.OrganizationMigrationRequest = new OrganizationMigrationRequest()

--- a/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -380,7 +379,7 @@ namespace NuGetGallery
                 // Assert
                 Assert.False(result);
                 Assert.Equal(errorReason, String.Format(CultureInfo.CurrentCulture,
-                    Strings.TransformAccount_FailedReasonNotConfirmedUser, unconfirmedUser.Username));
+                    Strings.TransformAccount_AccountNotConfirmed, unconfirmedUser.Username));
             }
 
             [Fact]
@@ -397,7 +396,7 @@ namespace NuGetGallery
                 // Assert
                 Assert.False(result);
                 Assert.Equal(errorReason, String.Format(CultureInfo.CurrentCulture,
-                    Strings.TransformAccount_FailedReasonIsOrganization, fakes.Organization.Username));
+                    Strings.TransformAccount_AccountIsAnOrganization, fakes.Organization.Username));
             }
 
             [Fact]
@@ -414,7 +413,7 @@ namespace NuGetGallery
                 // Assert
                 Assert.False(result);
                 Assert.Equal(errorReason, String.Format(CultureInfo.CurrentCulture,
-                    Strings.TransformAccount_FailedReasonHasMemberships, fakes.OrganizationCollaborator.Username));
+                    Strings.TransformAccount_AccountHasMemberships, fakes.OrganizationCollaborator.Username));
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
@@ -452,6 +452,64 @@ namespace NuGetGallery
             }
         }
 
+        public class TheCanTransformToOrganizationWithAdminMethod
+        {
+            [Fact]
+            public void WhenAdminMatchesAccountToTransform_ReturnsFalse()
+            {
+                // Arrange
+                var service = new TestableUserService();
+                service.MockConfig.SetupGet(c => c.OrganizationsEnabledForDomains).Returns(new[] { "example.com" });
+                var fakes = new Fakes();
+
+                // Act
+                string errorReason;
+                var result = service.CanTransformUserToOrganization(fakes.User, fakes.User, out errorReason);
+
+                // Assert
+                Assert.False(result);
+                Assert.Equal(errorReason, String.Format(CultureInfo.CurrentCulture,
+                    Strings.TransformAccount_AdminMustBeDifferentAccount, fakes.User.Username));
+            }
+
+            [Fact]
+            public void WhenAdminIsNotConfirmed_ReturnsFalse()
+            {
+                // Arrange
+                var service = new TestableUserService();
+                service.MockConfig.SetupGet(c => c.OrganizationsEnabledForDomains).Returns(new[] { "example.com" });
+                var fakes = new Fakes();
+                var unconfirmedUser = new User() { UnconfirmedEmailAddress = "unconfirmed@example.com" };
+
+                // Act
+                string errorReason;
+                var result = service.CanTransformUserToOrganization(fakes.User, unconfirmedUser, out errorReason);
+
+                // Assert
+                Assert.False(result);
+                Assert.Equal(errorReason, String.Format(CultureInfo.CurrentCulture,
+                    Strings.TransformAccount_AdminAccountNotConfirmed, unconfirmedUser.Username));
+            }
+
+            [Fact]
+            public void WhenAdminIsOrganization_ReturnsFalse()
+            {
+                // Arrange
+                var service = new TestableUserService();
+                service.MockConfig.SetupGet(c => c.OrganizationsEnabledForDomains).Returns(new[] { "example.com" });
+                var fakes = new Fakes();
+
+                // Act
+                string errorReason;
+                var result = service.CanTransformUserToOrganization(fakes.User, fakes.Organization, out errorReason);
+
+                // Assert
+                Assert.False(result);
+                Assert.Equal(errorReason, String.Format(CultureInfo.CurrentCulture,
+                    Strings.TransformAccount_AdminAccountIsOrganization, fakes.Organization.Username));
+            }
+        }
+
         public class TheRequestTransformToOrganizationAccountMethod
         {
             [Fact]


### PR DESCRIPTION
Fixes for the following:
- #5311: Transform should fail if admin is same as transformed account
- #5309: Transform should fail if admin is an organization
- #5317: Transform error not formatted correctly for unconfirmed admin

**Update 1/23**: Also incorporating feedback from @anangaur, including:
- #5308 and other transform error messages
- UI: Change admin info message to tooltip
- UI: Add transform confirmation
- UI: Formatting of sign-in returnUrl message