### PR TITLE
Organization bug bash: Manage Packages page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -922,6 +922,33 @@ img.reserved-indicator-icon {
 .page-manage-owners .current-owner .remove-owner-disabled .icon-link:hover span {
   text-decoration: none;
 }
+.page-manage-packages h1 {
+  margin-bottom: 0;
+}
+.page-manage-packages h2 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+.page-manage-packages .form-section-title {
+  margin-top: 40px;
+}
+@media (min-width: 768px) {
+  .page-manage-packages .form-section-title {
+    float: left;
+    text-align: right;
+  }
+}
+@media (min-width: 768px) {
+  .page-manage-packages .form-section-data {
+    float: right;
+    margin-top: 40px;
+    line-height: 3;
+    text-align: right;
+  }
+}
+.page-manage-packages .panel {
+  margin-top: 5px;
+}
 .page-delete-package h1 {
   margin-bottom: 0;
 }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -949,6 +949,10 @@ img.reserved-indicator-icon {
 .page-manage-packages .panel {
   margin-top: 5px;
 }
+.page-manage-packages .manage-package-listing .ms-Icon {
+  position: relative;
+  top: 2px;
+}
 .page-delete-package h1 {
   margin-bottom: 0;
 }

--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -1,6 +1,6 @@
 /*!
  * Bootstrap v3.3.7 (http://getbootstrap.com)
- * Copyright 2011-2017 Twitter, Inc.
+ * Copyright 2011-2018 Twitter, Inc.
  * Licensed under the MIT license
  */
 

--- a/src/Bootstrap/less/theme/all.less
+++ b/src/Bootstrap/less/theme/all.less
@@ -17,6 +17,7 @@
 @import "page-list-packages.less";
 @import "page-manage-curated-feed.less";
 @import "page-manage-owners.less";
+@import "page-manage-packages.less";
 @import "page-delete-package.less";
 @import "page-profile.less";
 @import "page-report-abuse.less";

--- a/src/Bootstrap/less/theme/page-manage-packages.less
+++ b/src/Bootstrap/less/theme/page-manage-packages.less
@@ -1,0 +1,34 @@
+.page-manage-packages {
+  @section-margin-top: 40px;
+
+  h1 {
+    margin-bottom: 0;
+  }
+
+  h2 {
+    margin-bottom: 10px;
+    margin-top: 0;
+  }
+
+  .form-section-title {
+    margin-top: @section-margin-top;
+
+    @media (min-width: @screen-sm-min) {
+      float: left;
+      text-align: right;
+    }
+  }
+
+  .form-section-data {
+    @media (min-width: @screen-sm-min) {
+      margin-top: @section-margin-top;
+      line-height: 3;
+      float: right;
+      text-align: right;
+    }
+  }
+
+  .panel {
+    margin-top: 5px;
+  }
+}

--- a/src/Bootstrap/less/theme/page-manage-packages.less
+++ b/src/Bootstrap/less/theme/page-manage-packages.less
@@ -31,4 +31,11 @@
   .panel {
     margin-top: 5px;
   }
+  
+  .manage-package-listing {
+    .ms-Icon {
+      position: relative;
+      top: 2px;
+    }
+  }
 }

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -408,10 +408,10 @@ namespace NuGetGallery
                 .Select(p => new ListPackageItemViewModel(p, currentUser)).OrderBy(p => p.Id)
                 .ToList();
 
-            var incoming = _packageOwnerRequestService.GetPackageOwnershipRequests(newOwner: currentUser);
-            var outgoing = _packageOwnerRequestService.GetPackageOwnershipRequests(requestingOwner: currentUser);
+            var received = _packageOwnerRequestService.GetPackageOwnershipRequests(newOwner: currentUser);
+            var sent = _packageOwnerRequestService.GetPackageOwnershipRequests(requestingOwner: currentUser);
 
-            var ownerRequests = new OwnerRequestsViewModel(incoming, outgoing, currentUser, _packageService);
+            var ownerRequests = new OwnerRequestsViewModel(received, sent, currentUser, _packageService);
             var reservedPrefixes = new ReservedNamespaceListViewModel(currentUser.ReservedNamespaces);
 
             var model = new ManagePackagesViewModel

--- a/src/NuGetGallery/Scripts/gallery/page-api-keys.js
+++ b/src/NuGetGallery/Scripts/gallery/page-api-keys.js
@@ -238,6 +238,13 @@
             this.TotalCount = ko.pureComputed(function () {
                 return this.PendingPackages().length;
             }, this);
+            this.SelectedCountLabel = ko.pureComputed(function () {
+                return ko.unwrap(SelectedCount).toLocaleString()
+                    + ' of '
+                    + ko.unwrap(TotalCount).toLocaleString()
+                    + ' package' + (TotalCount == 1 ? '' : 's')
+                    + ' selected';
+            }, this);
 
             // Apply the glob pattern to the package IDs
             this.ApplyPendingGlobPattern = function (newValue) {

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -1,6 +1,19 @@
 ﻿(function () {
     'use strict';
-    
+
+    function showInitialPackagesData(dataSelector, packagesList) {
+        var downloadsCount = 0;
+        $.each(packagesList, function () { downloadsCount += this.TotalDownloadCount });
+        $(dataSelector).text(formatPackagesData(packagesList.length, downloadsCount));
+    }
+
+    function formatPackagesData(packagesCount, downloadsCount) {
+        return packagesCount.toLocaleString()
+            + ' packages / '
+            + downloadsCount.toLocaleString()
+            + ' downloads';
+    }
+
     $(function () {
         function PackageListItemViewModel(packagesListViewModel, packageItem) {
             var self = this;
@@ -51,6 +64,11 @@
             });
             this.VisiblePackagesCount = ko.observable();
             this.VisibleDownloadCount = ko.observable();
+            this.VisiblePackagesHeading = ko.pureComputed(function () {
+                return formatPackagesData(
+                    ko.unwrap(self.VisiblePackagesCount()),
+                    ko.unwrap(self.VisibleDownloadCount()));
+            }, this);
 
             this.ManagePackagesViewModel.OwnerFilter.subscribe(function (newOwner) {
                 var packagesCount = 0;
@@ -83,6 +101,10 @@
             this.ListedPackages = new PackagesListViewModel(this, "published", initialData.ListedPackages);
             this.UnlistedPackages = new PackagesListViewModel(this, "unlisted", initialData.UnlistedPackages);
         }
+
+        // Immediately load initial expander data
+        showInitialPackagesData("#listed-data", initialData.ListedPackages);
+        showInitialPackagesData("#unlisted-data", initialData.UnlistedPackages);
 
         // Set up the data binding.
         var managePackagesViewModel = new ManagePackagesViewModel(initialData);

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -35,6 +35,10 @@
             this.CanManageOwners = packageItem.CanManageOwners;
             this.CanDelete = packageItem.CanDelete;
 
+            this.FormattedDownloadCount = ko.pureComputed(function () {
+                return ko.unwrap(this.DownloadCount).toLocaleString();
+            }, this);
+
             this.Visible = ko.observable(true);
 
             this.UpdateVisibility = function (ownerFilter) {

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -9,9 +9,10 @@
 
     function formatPackagesData(packagesCount, downloadsCount) {
         return packagesCount.toLocaleString()
-            + ' packages / '
+            + ' package' + (packagesCount == 1 ? '' : 's')
+            + ' / '
             + downloadsCount.toLocaleString()
-            + ' downloads';
+            + ' download' + (downloadsCount == 1 ? '' : 's');
     }
 
     $(function () {

--- a/src/NuGetGallery/ViewModels/OwnerRequestsViewModel.cs
+++ b/src/NuGetGallery/ViewModels/OwnerRequestsViewModel.cs
@@ -10,17 +10,21 @@ namespace NuGetGallery
         /// <summary>
         /// A model to show the requests for this user to become an owner of a package.
         /// </summary>
-        public OwnerRequestsListViewModel Incoming { get; }
+        public OwnerRequestsListViewModel Received { get; }
 
         /// <summary>
         /// A model to show the requests this user has sent to other users to become owners.
         /// </summary>
-        public OwnerRequestsListViewModel Outgoing { get; }
+        public OwnerRequestsListViewModel Sent { get; }
 
-        public OwnerRequestsViewModel(IEnumerable<PackageOwnerRequest> incoming, IEnumerable<PackageOwnerRequest> outgoing, User currentUser, IPackageService packageService)
+        public OwnerRequestsViewModel(
+            IEnumerable<PackageOwnerRequest> received,
+            IEnumerable<PackageOwnerRequest> sent,
+            User currentUser,
+            IPackageService packageService)
         {
-            Incoming = new OwnerRequestsListViewModel(incoming, nameof(Incoming), currentUser, packageService);
-            Outgoing = new OwnerRequestsListViewModel(outgoing, nameof(Outgoing), currentUser, packageService);
+            Received = new OwnerRequestsListViewModel(received, nameof(Received), currentUser, packageService);
+            Sent = new OwnerRequestsListViewModel(sent, nameof(Sent), currentUser, packageService);
         }
     }
 }

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -431,8 +431,8 @@
         <div class="row" data-bind="css: { disabled: !SelectPackagesEnabled() }">
             <div class="col-sm-12">
                 <p>
-                    <span data-bind="text: SelectedCount"></span> of <span data-bind="text: TotalCount"></span>
-                    <span data-bind="text: TotalCount > 1 ? 'packages' : 'package'"></span> selected
+                    <span data-bind="text: ko.unwrap(SelectedCount).toLocaleString()"></span> of <span data-bind="text: ko.unwrap(TotalCount).toLocaleString()"></span>
+                    <span data-bind="text: TotalCount == 1 ? 'package' : 'packages'"></span> selected
                 </p>
             </div>
         </div>

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -431,8 +431,7 @@
         <div class="row" data-bind="css: { disabled: !SelectPackagesEnabled() }">
             <div class="col-sm-12">
                 <p>
-                    <span data-bind="text: ko.unwrap(SelectedCount).toLocaleString()"></span> of <span data-bind="text: ko.unwrap(TotalCount).toLocaleString()"></span>
-                    <span data-bind="text: TotalCount == 1 ? 'package' : 'packages'"></span> selected
+                    <span data-bind="text: SelectedCountLabel"></span>
                 </p>
             </div>
         </div>

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -4,92 +4,82 @@
     ViewBag.Title = "Manage My Package";
     ViewBag.Tab = "Packages";
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
+
+    var publishedPackagesCount = Model.ListedPackages.Count();
+    var unlistedPackagesCount = Model.UnlistedPackages.Count();
+    var namespacesCount = Model.ReservedNamespaces.ReservedNamespaces.Count();
+    var ownerRequestsIncomingCount = Model.OwnerRequests.Incoming.RequestItems.Count();
+    var ownerRequestsOutgoingCount = Model.OwnerRequests.Outgoing.RequestItems.Count();
 }
 
-<section role="main" class="container main-container page-manage-packages page-package-details">
+<section role="main" class="container main-container page-account-settings">
     <div class="row">
-        <div class="col-xs-12">
-                <h1>My Packages</h1>
-                <div class="col-xs-3 text-right form-group pull-right">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
+            <div class="clearfix">
+                <div style="float: left">
+                    <h1 style="text-align: right">Manage Packages</h1>
+                </div>
+                <span class="form-section-data">
                     <select id="ownerFilter" class="form-control pull-right hidden"
                             data-bind="options: Owners, value: OwnerFilter, optionsText: 'Username'"></select>
-                </div>
-            @ViewHelpers.Section(this, "listed", "Published",
+                </span>
+            </div>
+
+            @ViewHelpers.Section(this, "listed", @<text>Published Packages</text>,
+                @<text>
+                    <span id="listed-data" data-bind="text: ListedPackages.VisiblePackagesHeading()"></span>
+                </text>,
                 @<text>
                     <div class="row user-package-list">
                         <div data-bind="template: { name: 'manage-packages', data: ListedPackages }"></div>
                     </div>
-                </text>)
+                </text>, expanded: false)
 
-            @ViewHelpers.Section(this, "unlisted", "Unlisted",
+            @ViewHelpers.Section(this, "unlisted", @<text>Unlisted Packages</text>,
+                @<text>
+                    <span id="unlisted-data" data-bind="text: UnlistedPackages.VisiblePackagesHeading()"></span>
+                </text>,
                 @<text>
                     <div class="row user-package-list">
                         <div data-bind="template: { name: 'manage-packages', data: UnlistedPackages }"></div>
                     </div>
-                </text>)
-        </div>
-    </div>
+                </text>, expanded: false)
 
-    @if (Model.ReservedNamespaces.ReservedNamespaces.Any())
-    {
-        <div class="row">
-            <div class="col-xs-12">
-                <h1>My Reserved Namespaces</h1>
-                @ViewHelpers.Section(this,
-                    "namespaces",
-                    "Namespaces",
+            @if (namespacesCount > 0)
+            {
+                @ViewHelpers.Section(this, "namespaces",
+                            @<text>Reserved Namespaces</text>,
+                        @<text>@Html.Raw(namespacesCount + " namespace" + (namespacesCount == 1 ? "" : "s"))</text>,
                     @<text>
                         @Html.Partial("_ReservedNamespacesList", Model.ReservedNamespaces)
-                    </text>)
-            </div>
-        </div>
-    }
+                    </text>, expanded: false)
+            }
 
-    @if (Model.OwnerRequests.Incoming.RequestItems.Any() || Model.OwnerRequests.Outgoing.RequestItems.Any())
-    {
-        <div class="row">
-            <div class="col-xs-12">
-                <h1>My Pending Ownership Requests</h1>
-                @if (Model.OwnerRequests.Incoming.RequestItems.Any())
-                {
-                    @ViewHelpers.Section(this,
-                        "requests-incoming",
-                        "Incoming",
-                        @<text>
-                            @Html.Partial("_OwnerRequestsList", Model.OwnerRequests.Incoming)
-                        </text>)
-                }
+            @if (Model.OwnerRequests.Incoming.RequestItems.Any())
+            {
+                @ViewHelpers.Section(this, "requests-incoming",
+                            @<text>Ownership Requests (Received)</text>,
+                            @<text>@Html.Raw(ownerRequestsIncomingCount + " request" + (ownerRequestsIncomingCount == 1 ? "" : "s"))</text>,
+                            @<text>
+                                @Html.Partial("_OwnerRequestsList", Model.OwnerRequests.Incoming)
+                            </text>, expanded: false)
+            }
 
-                @if (Model.OwnerRequests.Outgoing.RequestItems.Any())
-                {
-                    @ViewHelpers.Section(this,
-                        "requests-outgoing",
-                        "Outgoing",
-                        @<text>
-                            @Html.Partial("_OwnerRequestsList", Model.OwnerRequests.Outgoing)
-                        </text>)
-                }
-            </div>
+            @if (Model.OwnerRequests.Outgoing.RequestItems.Any())
+            {
+                @ViewHelpers.Section(this, "requests-outgoing",
+                            @<text>Ownership Requests (Sent)</text>,
+                            @<text>@Html.Raw(ownerRequestsOutgoingCount + " request" + (ownerRequestsOutgoingCount == 1 ? "" : "s"))</text>,
+                            @<text>
+                                @Html.Partial("_OwnerRequestsList", Model.OwnerRequests.Outgoing)
+                            </text>, expanded: false)
+            }
         </div>
-    }
 </section>
 
 <script type="text/html" id="manage-packages">
     <div class="col-md-12">
         <div class="panel-collapse collapse in" aria-expanded="true">
-            <p>
-                You have
-                <b>
-                    <span data-bind="text: VisiblePackagesCount"></span>
-                    <span data-bind="text: Type"></span>
-                    <span data-bind="text: VisiblePackagesCount() === 1 ? 'package' : 'packages'"></span>
-                </b>
-                with a total of
-                <b>
-                    <span data-bind="text: VisibleDownloadCount"></span>
-                    <span data-bind="text: VisibleDownloadCount() === 1 ? 'download' : 'downloads'"></span>
-                </b>
-            </p>
             <table class="table">
                 <thead>
                     <tr class="manage-package-headings">
@@ -105,7 +95,7 @@
                     <tr class="manage-package-listing" data-bind="visible: Visible">
                         <td class="align-middle hidden-xs">
                             <img class="package-icon img-responsive" aria-hidden="true" alt=""
-                                    data-bind="attr: { src: PackageIconUrl, onerror: PackageIconUrlFallback }" />
+                                 data-bind="attr: { src: PackageIconUrl, onerror: PackageIconUrlFallback }" />
                         </td>
                         <td class="align-middle package-id">
                             <a title="View Package" data-bind="attr: { href: PackageUrl }">
@@ -114,14 +104,12 @@
                         </td>
                         <td class="align-middle">
                             <span class="ms-noWrap" data-bind="foreach: Owners">
-                                <i class="ms-Icon ms-Icon--Group" aria-hidden="true" data-bind="visible: IsOrganization"></i>
-                                <a data-bind="attr: { href: ProfileUrl }">
-                                    <span data-bind="text: Username"></span>
-                                </a>
+                                <i class="ms-Icon ms-Icon--Group" aria-hidden="true" data-bind="visible: IsOrganization" style="vertical-align: -2px"></i>
+                                <a data-bind="attr: { href: ProfileUrl }"><span data-bind="text: Username"></span></a><!-- ko if: ($index() < ($parent.Owners.length - 1)) -->,&nbsp;<!-- /ko -->
                             </span>
                         </td>
                         <td class="align-middle text-nowrap">
-                            <span data-bind="text: DownloadCount"></span>
+                            <span data-bind="text: ko.unwrap(DownloadCount).toLocaleString()"></span>
                         </td>
                         <td class="align-middle text-nowrap">
                             <span data-bind="text: LatestVersion"></span>
@@ -211,6 +199,22 @@
                          DefaultPackageIconUrl = Url.Absolute("~/Content/gallery/img/default-package-icon.svg"),
                          PackageIconUrlFallback = Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")
                      }));
+        JSON.stringifyOnce = function (obj, replacer, space) {
+            var cache = [];
+            var json = JSON.stringify(obj, function (key, value) {
+                if (typeof value === 'object' && value !== null) {
+                    if (cache.indexOf(value) !== -1) {
+                        // circular reference found, discard key
+                        return;
+                    }
+                    // store value in our collection
+                    cache.push(value);
+                }
+                return replacer ? replacer(key, value) : value;
+            }, space);
+            cache = null;
+            return json;
+        };
     </script>
     @ViewHelpers.SectionsScript(this)
     @Scripts.Render("~/Scripts/gallery/page-manage-packages.min.js")

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -4,9 +4,7 @@
     ViewBag.Title = "Manage My Package";
     ViewBag.Tab = "Packages";
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
-
-    var publishedPackagesCount = Model.ListedPackages.Count();
-    var unlistedPackagesCount = Model.UnlistedPackages.Count();
+    
     var namespacesCount = Model.ReservedNamespaces.ReservedNamespaces.Count();
     var ownerRequestsIncomingCount = Model.OwnerRequests.Incoming.RequestItems.Count();
     var ownerRequestsOutgoingCount = Model.OwnerRequests.Outgoing.RequestItems.Count();
@@ -199,22 +197,6 @@
                          DefaultPackageIconUrl = Url.Absolute("~/Content/gallery/img/default-package-icon.svg"),
                          PackageIconUrlFallback = Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")
                      }));
-        JSON.stringifyOnce = function (obj, replacer, space) {
-            var cache = [];
-            var json = JSON.stringify(obj, function (key, value) {
-                if (typeof value === 'object' && value !== null) {
-                    if (cache.indexOf(value) !== -1) {
-                        // circular reference found, discard key
-                        return;
-                    }
-                    // store value in our collection
-                    cache.push(value);
-                }
-                return replacer ? replacer(key, value) : value;
-            }, space);
-            cache = null;
-            return json;
-        };
     </script>
     @ViewHelpers.SectionsScript(this)
     @Scripts.Render("~/Scripts/gallery/page-manage-packages.min.js")

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -13,14 +13,15 @@
 <section role="main" class="container main-container page-manage-packages">
     <div class="row">
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
+            
             <div class="clearfix">
-                <div style="float: left">
-                    <h1 style="text-align: right">Manage Packages</h1>
+                <h1 class="pull-left">Manage Packages</h1>
+                <div class="text-center ms-font-xxl">
+                    <span class="form-section-data">
+                        <select id="ownerFilter" class="form-control pull-right hidden"
+                                data-bind="options: Owners, value: OwnerFilter, optionsText: 'Username'"></select>
+                    </span>
                 </div>
-                <span class="form-section-data">
-                    <select id="ownerFilter" class="form-control pull-right hidden"
-                            data-bind="options: Owners, value: OwnerFilter, optionsText: 'Username'"></select>
-                </span>
             </div>
 
             @ViewHelpers.Section(this, "listed", @<text>Published Packages</text>,
@@ -102,12 +103,12 @@
                         </td>
                         <td class="align-middle">
                             <span class="ms-noWrap" data-bind="foreach: Owners">
-                                <i class="ms-Icon ms-Icon--Group" aria-hidden="true" data-bind="visible: IsOrganization" style="vertical-align: -2px"></i>
+                                <i class="ms-Icon ms-Icon--Group" aria-hidden="true" data-bind="visible: IsOrganization"></i>
                                 <a data-bind="attr: { href: ProfileUrl }"><span data-bind="text: Username"></span></a><!-- ko if: ($index() < ($parent.Owners.length - 1)) -->,&nbsp;<!-- /ko -->
                             </span>
                         </td>
                         <td class="align-middle text-nowrap">
-                            <span data-bind="text: ko.unwrap(DownloadCount).toLocaleString()"></span>
+                            <span data-bind="text: FormattedDownloadCount"></span>
                         </td>
                         <td class="align-middle text-nowrap">
                             <span data-bind="text: LatestVersion"></span>

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -4,13 +4,13 @@
     ViewBag.Title = "Manage My Package";
     ViewBag.Tab = "Packages";
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
-    
+
     var namespacesCount = Model.ReservedNamespaces.ReservedNamespaces.Count();
-    var ownerRequestsIncomingCount = Model.OwnerRequests.Incoming.RequestItems.Count();
-    var ownerRequestsOutgoingCount = Model.OwnerRequests.Outgoing.RequestItems.Count();
+    var ownerRequestsReceivedCount = Model.OwnerRequests.Received.RequestItems.Count();
+    var ownerRequestsSentCount = Model.OwnerRequests.Sent.RequestItems.Count();
 }
 
-<section role="main" class="container main-container page-account-settings">
+<section role="main" class="container main-container page-manage-packages">
     <div class="row">
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <div class="clearfix">
@@ -53,23 +53,23 @@
                     </text>, expanded: false)
             }
 
-            @if (Model.OwnerRequests.Incoming.RequestItems.Any())
+            @if (Model.OwnerRequests.Received.RequestItems.Any())
             {
-                @ViewHelpers.Section(this, "requests-incoming",
+                @ViewHelpers.Section(this, "requests-received",
                             @<text>Ownership Requests (Received)</text>,
-                            @<text>@Html.Raw(ownerRequestsIncomingCount + " request" + (ownerRequestsIncomingCount == 1 ? "" : "s"))</text>,
+                            @<text>@Html.Raw(ownerRequestsReceivedCount + " request" + (ownerRequestsReceivedCount == 1 ? "" : "s"))</text>,
                             @<text>
-                                @Html.Partial("_OwnerRequestsList", Model.OwnerRequests.Incoming)
+                                @Html.Partial("_OwnerRequestsList", Model.OwnerRequests.Received)
                             </text>, expanded: false)
             }
 
-            @if (Model.OwnerRequests.Outgoing.RequestItems.Any())
+            @if (Model.OwnerRequests.Sent.RequestItems.Any())
             {
-                @ViewHelpers.Section(this, "requests-outgoing",
+                @ViewHelpers.Section(this, "requests-sent",
                             @<text>Ownership Requests (Sent)</text>,
-                            @<text>@Html.Raw(ownerRequestsOutgoingCount + " request" + (ownerRequestsOutgoingCount == 1 ? "" : "s"))</text>,
+                            @<text>@Html.Raw(ownerRequestsSentCount + " request" + (ownerRequestsSentCount == 1 ? "" : "s"))</text>,
                             @<text>
-                                @Html.Partial("_OwnerRequestsList", Model.OwnerRequests.Outgoing)
+                                @Html.Partial("_OwnerRequestsList", Model.OwnerRequests.Sent)
                             </text>, expanded: false)
             }
         </div>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -41,7 +41,7 @@
 
     <add key="Gallery.AsynchronousPackageValidationEnabled" value="false" />
     <add key="Gallery.BlockingAsynchronousPackageValidationEnabled" value="false" />
-    <add key="Gallery.OrganizationsEnabledForDomains" value="" />
+    <add key="Gallery.OrganizationsEnabledForDomains" value="microsoft.com;gmail.com" />
 
     <add key="AzureServiceBus.Validation.ConnectionString" value="" />
     <add key="AzureServiceBus.Validation.TopicName" value="" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -41,7 +41,7 @@
 
     <add key="Gallery.AsynchronousPackageValidationEnabled" value="false" />
     <add key="Gallery.BlockingAsynchronousPackageValidationEnabled" value="false" />
-    <add key="Gallery.OrganizationsEnabledForDomains" value="microsoft.com;gmail.com" />
+    <add key="Gallery.OrganizationsEnabledForDomains" value="" />
 
     <add key="AzureServiceBus.Validation.ConnectionString" value="" />
     <add key="AzureServiceBus.Validation.TopicName" value="" />


### PR DESCRIPTION
Fixes the following bug bash issues:
- #5299 comma separators for package and download counts
- #5304 flash of empty containers
- #5310 Layout issues (except binding filter to namespaces / requests will be separate PR)
- #5298 Org icon too high
- #5306 Owner link whitespace fix
- #5307 Visual separation between owners

Page Screenshot:

![image](https://user-images.githubusercontent.com/15364949/35303845-4789b3a8-0048-11e8-9f9f-0ffecd2c3217.png)

Package row w/ owners screenshot:

![image](https://user-images.githubusercontent.com/15364949/35303824-3078f3c2-0048-11e8-8df4-f6670d615de6.png)
