### PR TITLE
[Organizations] Fix Manage Package Owners issues

### DIFF
--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -10,7 +10,6 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using NuGetGallery.Authentication;
-using NuGetGallery.Filters;
 using NuGetGallery.Infrastructure.Authentication;
 
 namespace NuGetGallery

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1843,7 +1843,7 @@ namespace NuGetGallery
             return !String.Equals(posted.Replace("\r", ""), package.Replace("\r", ""), StringComparison.Ordinal);
         }
 
-        private HttpStatusCodeResult HttpForbidden()
+        private static HttpStatusCodeResult HttpForbidden()
         {
             return new HttpStatusCodeResult(HttpStatusCode.Forbidden, Strings.Unauthorized);
         }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -987,7 +987,7 @@ namespace NuGetGallery
 
             if (ActionsRequiringPermissions.ManagePackageOwnership.CheckPermissionsOnBehalfOfAnyAccount(GetCurrentUser(), package) != PermissionsCheckResult.Allowed)
             {
-                return new HttpStatusCodeResult(401, "Unauthorized");
+                return HttpForbidden();
             }
 
             var model = new ManagePackageOwnersViewModel(package, GetCurrentUser());
@@ -1007,7 +1007,7 @@ namespace NuGetGallery
             }
             if (ActionsRequiringPermissions.UnlistOrRelistPackage.CheckPermissionsOnBehalfOfAnyAccount(GetCurrentUser(), package) != PermissionsCheckResult.Allowed)
             {
-                return new HttpStatusCodeResult(401, "Unauthorized");
+                return HttpForbidden();
             }
 
             var model = new DeletePackageViewModel(package, GetCurrentUser(), ReportMyPackageReasons);
@@ -1462,7 +1462,7 @@ namespace NuGetGallery
 
             if (ActionsRequiringPermissions.EditPackage.CheckPermissionsOnBehalfOfAnyAccount(GetCurrentUser(), package) != PermissionsCheckResult.Allowed)
             {
-                return new HttpStatusCodeResult(401, "Unauthorized");
+                return HttpForbidden();
             }
 
             if (package.PackageRegistration.IsLocked)
@@ -1786,7 +1786,7 @@ namespace NuGetGallery
             }
             if (ActionsRequiringPermissions.EditPackage.CheckPermissionsOnBehalfOfAnyAccount(GetCurrentUser(), package) != PermissionsCheckResult.Allowed)
             {
-                return new HttpStatusCodeResult(401, "Unauthorized");
+                return HttpForbidden();
             }
 
             await _packageService.SetLicenseReportVisibilityAsync(package, visible);
@@ -1841,6 +1841,11 @@ namespace NuGetGallery
             // Compare non-empty strings
             // Ignore those pesky '\r' characters which screw up comparisons.
             return !String.Equals(posted.Replace("\r", ""), package.Replace("\r", ""), StringComparison.Ordinal);
+        }
+
+        private HttpStatusCodeResult HttpForbidden()
+        {
+            return new HttpStatusCodeResult(HttpStatusCode.Forbidden, Strings.Unauthorized);
         }
     }
 }

--- a/src/NuGetGallery/Extensions/OrganizationExtensions.cs
+++ b/src/NuGetGallery/Extensions/OrganizationExtensions.cs
@@ -8,6 +8,11 @@ namespace NuGetGallery
 {
     public static class OrganizationExtensions
     {
+        public static Membership GetMembershipOfUser(this Organization organization, User member)
+        {
+            return organization.Members.FirstOrDefault(m => m.Member.MatchesUser(member));
+        }
+
         /// <summary>
         /// Returns all the user accounts that are members of an organization.
         /// If the organization has nested organizations their members will be returned as well.

--- a/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
@@ -32,7 +32,7 @@ namespace NuGetGallery
             ProfileUrl = url.User(user, relativeUrl: false);
             ImageUrl = GravatarHelper.Url(user.EmailAddress, size: Constants.GravatarImageSize);
             GrantsCurrentUserAccess = ActionsRequiringPermissions.ManagePackageOwnership.CheckPermissions(currentUser, user, packageRegistration) == PermissionsCheckResult.Allowed;
-            IsCurrentUserAdminOfOrganization = user is Organization org && org.Members.Where(m => m.Member.MatchesUser(currentUser) && m.IsAdmin).Any();
+            IsCurrentUserAdminOfOrganization = (user as Organization)?.GetMembershipOfUser(currentUser)?.IsAdmin ?? false;
             Pending = isPending;
             IsNamespaceOwner = isNamespaceOwner;
         }

--- a/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
@@ -32,7 +32,7 @@ namespace NuGetGallery
             ProfileUrl = url.User(user, relativeUrl: false);
             ImageUrl = GravatarHelper.Url(user.EmailAddress, size: Constants.GravatarImageSize);
             GrantsCurrentUserAccess = ActionsRequiringPermissions.ManagePackageOwnership.CheckPermissions(currentUser, user, packageRegistration) == PermissionsCheckResult.Allowed;
-            IsCurrentUserAdminOfOrganization = user is Organization && (user as Organization).Members.Where(m => m.IsAdmin).Any();
+            IsCurrentUserAdminOfOrganization = user is Organization org && org.Members.Where(m => m.Member.MatchesUser(currentUser) && m.IsAdmin).Any();
             Pending = isPending;
             IsNamespaceOwner = isNamespaceOwner;
         }

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1603,13 +1603,13 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(NotOwner_Data))]
-            public void Returns401IfNotOwner(User currentUser, User owner)
+            public void Returns403IfNotOwner(User currentUser, User owner)
             {
                 var result = GetDeleteResult(currentUser, owner, out var controller);
                 
                 Assert.IsType<HttpStatusCodeResult>(result);
                 var httpStatusCodeResult = result as HttpStatusCodeResult;
-                Assert.Equal(401, httpStatusCodeResult.StatusCode);
+                Assert.Equal((int)HttpStatusCode.Forbidden, httpStatusCodeResult.StatusCode);
             }
 
             public static IEnumerable<object[]> Owner_Data
@@ -1747,7 +1747,7 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(NotOwner_Data))]
-            public async Task Returns401IfNotOwner(User currentUser, User owner)
+            public async Task Returns403IfNotOwner(User currentUser, User owner)
             {
                 // Arrange
                 var package = new Package
@@ -1775,7 +1775,7 @@ namespace NuGetGallery
                 // Assert
                 Assert.IsType<HttpStatusCodeResult>(result);
                 var httpStatusCodeResult = result as HttpStatusCodeResult;
-                Assert.Equal(401, httpStatusCodeResult.StatusCode);
+                Assert.Equal((int)HttpStatusCode.Forbidden, httpStatusCodeResult.StatusCode);
             }
 
             public static IEnumerable<object[]> Owner_Data
@@ -2223,7 +2223,7 @@ namespace NuGetGallery
             
             [Theory]
             [MemberData(nameof(NotOwner_Data))]
-            public async Task Returns401IfNotOwner(User currentUser, User owner)
+            public async Task Returns403IfNotOwner(User currentUser, User owner)
             {
                 // Arrange
                 var package = new Package
@@ -2251,7 +2251,7 @@ namespace NuGetGallery
                 // Assert
                 Assert.IsType<HttpStatusCodeResult>(result);
                 var httpStatusCodeResult = result as HttpStatusCodeResult;
-                Assert.Equal(401, httpStatusCodeResult.StatusCode);
+                Assert.Equal((int)HttpStatusCode.Forbidden, httpStatusCodeResult.StatusCode);
             }
 
             [Theory]
@@ -2439,13 +2439,13 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(NotOwner_Data))]
-            public void Returns401IfNotOwner(User currentUser, User owner)
+            public void Returns403IfNotOwner(User currentUser, User owner)
             {
                 var result = GetManagePackageOwnersResult(currentUser, owner);
 
                 Assert.IsType<HttpStatusCodeResult>(result);
                 var httpStatusCodeResult = result as HttpStatusCodeResult;
-                Assert.Equal(401, httpStatusCodeResult.StatusCode);
+                Assert.Equal((int)HttpStatusCode.Forbidden, httpStatusCodeResult.StatusCode);
             }
 
             public static IEnumerable<object[]> Owner_Data
@@ -4950,7 +4950,7 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(NotOwner_Data))]
-            public async Task Returns401IfNotOwner(User currentUser, User owner, bool visible)
+            public async Task Returns403IfNotOwner(User currentUser, User owner, bool visible)
             {
                 // Arrange
                 var package = new Package
@@ -4978,7 +4978,7 @@ namespace NuGetGallery
                 // Assert
                 Assert.IsType<HttpStatusCodeResult>(result);
                 var httpStatusCodeResult = result as HttpStatusCodeResult;
-                Assert.Equal(401, httpStatusCodeResult.StatusCode);
+                Assert.Equal((int)HttpStatusCode.Forbidden, httpStatusCodeResult.StatusCode);
             }
 
             public static IEnumerable<object[]> Owner_Data


### PR DESCRIPTION
- https://github.com/NuGet/NuGetGallery/issues/5301

We have configured our MVC so that if a 401 is returned by an endpoint, the app will redirect you to the sign in page.

If you are signed in when this happens, the sign-in page will redirect you back to the page you were initially on that gave you the 401. This leads to an infinite redirect loop.

To fix this, we can return 403 instead. Edit already does this.

We should potentially monitor our other endpoints to see if this is possible elsewhere--any endpoint that returns 401 when the user is logged in will have this behavior.

- https://github.com/NuGet/NuGetGallery/issues/5318

Simple fix that I added unit tests to.