### PR TITLE
Only show "Owner" dropdown in upload flow for new packages

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -201,7 +201,7 @@ namespace NuGetGallery
                         accountsAllowedOnBehalfOf = new[] { currentUser };
                     }
 
-                    var verifyRequest = new VerifyPackageRequest(packageMetadata, accountsAllowedOnBehalfOf);
+                    var verifyRequest = new VerifyPackageRequest(packageMetadata, accountsAllowedOnBehalfOf, existingPackageRegistration);
 
                     model.InProgressUpload = verifyRequest;
                 }
@@ -238,6 +238,7 @@ namespace NuGetGallery
                 return Json(400, new[] { Strings.UploadFileMustBeNuGetPackage });
             }
 
+            PackageRegistration existingPackageRegistration;
             // If the current user cannot upload the package on behalf of any of the existing owners, show the current user as the only possible owner in the upload form.
             // If the current user doesn't have the rights to upload the package, the package upload will be rejected by submitting the form.
             // Related: https://github.com/NuGet/NuGetGallery/issues/5043
@@ -319,7 +320,7 @@ namespace NuGetGallery
                 }
 
                 var id = nuspec.GetId();
-                var existingPackageRegistration = _packageService.FindPackageRegistrationById(id);
+                existingPackageRegistration = _packageService.FindPackageRegistrationById(id);
                 // For a new package id verify if the user is allowed to use it.
                 if (existingPackageRegistration == null &&
                     ActionsRequiringPermissions.UploadNewPackageId.CheckPermissionsOnBehalfOfAnyAccount(
@@ -416,7 +417,7 @@ namespace NuGetGallery
                 }
             }
 
-            var model = new VerifyPackageRequest(packageMetadata, accountsAllowedOnBehalfOf);
+            var model = new VerifyPackageRequest(packageMetadata, accountsAllowedOnBehalfOf, existingPackageRegistration);
 
             return Json(model);
         }

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
     {
         public VerifyPackageRequest() { }
 
-        public VerifyPackageRequest(PackageMetadata packageMetadata, IEnumerable<User> possibleOwners)
+        public VerifyPackageRequest(PackageMetadata packageMetadata, IEnumerable<User> possibleOwners, PackageRegistration existingPackageRegistration)
         {
             Id = packageMetadata.Id;
             Version = packageMetadata.Version.ToFullStringSafe();
@@ -39,12 +39,16 @@ namespace NuGetGallery
             Summary = packageMetadata.Summary;
             Tags = PackageHelper.ParseTags(packageMetadata.Tags);
             Title = packageMetadata.Title;
+            IsNewId = existingPackageRegistration == null;
+            if (!IsNewId)
+            {
+                ExistingOwners = string.Join(", ", ParseUserList(existingPackageRegistration.Owners));
+            }
 
             // Editable server-state
             Listed = true;
             Edit = new EditPackageVersionReadMeRequest();
-
-            PossibleOwners = possibleOwners.Select(u => u.Username).ToList();
+            PossibleOwners = ParseUserList(possibleOwners);
         }
 
         public string Id { get; set; }
@@ -60,9 +64,21 @@ namespace NuGetGallery
         public string OriginalVersion { get; set; }
 
         /// <summary>
+        /// This is a new ID.
+        /// There are no existing packages with this ID.
+        /// </summary>
+        public bool IsNewId { get; set; }
+
+        /// <summary>
         /// The username of the <see cref="User"/> to upload the package as.
         /// </summary>
         public string Owner { get; set; }
+
+        /// <summary>
+        /// The <see cref="User"/>s that own the existing package registration that this package will be added to in a string.
+        /// E.g. "alice, bob, chad".
+        /// </summary>
+        public string ExistingOwners { get; set; }
 
         /// <summary>
         /// The usernames of the <see cref="User"/>s that the current user can upload the package as.
@@ -94,5 +110,10 @@ namespace NuGetGallery
         public string Summary { get; set; }
         public string Tags { get; set; }
         public string Title { get; set; }
+
+        private static IReadOnlyCollection<string> ParseUserList(IEnumerable<User> users)
+        {
+            return users.Select(u => u.Username).ToList();
+        }
     }
 }

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -60,14 +60,19 @@
 
                 <!-- ko if: $data.PossibleOwners -->
                 <div class="verify-package-field form-group editable">
-                    <label for="Owner" class="verify-package-field-heading">Owner</label>
-                    <!-- ko if: $data.PossibleOwners.length > 1 -->
+                    <label for="Owner" class="verify-package-field-heading" data-bind="text: $data.IsNewId ? 'Owner' : 'Owners'">Owner</label>
+                    <!-- ko if: $data.PossibleOwners.length > 1 && $data.IsNewId -->
                     <select aria-required="true" class="form-control" data-val="true" data-val-required="You must select an owner for your package!" name="Owner" data-bind="foreach: $data.PossibleOwners">
                         <option data-bind="value: $data, text: $data"></option>
                     </select>
                     <!-- /ko -->
-                    <!-- ko if: $data.PossibleOwners.length == 1 -->
+                    <!-- ko if: $data.PossibleOwners.length == 1 || !$data.IsNewId -->
+                    <!-- ko if: $data.IsNewId -->
                     <p data-bind="text: $data.PossibleOwners[0]"></p>
+                    <!-- /ko -->
+                    <!-- ko ifnot: $data.IsNewId -->
+                    <p data-bind="text: $data.ExistingOwners"></p>
+                    <!-- /ko -->
                     <input data-bind="value: $data.PossibleOwners[0]" type="hidden" name="Owner" class="form-control" />
                     <!-- /ko -->
                 </div>

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -60,7 +60,7 @@
 
                 <!-- ko if: $data.PossibleOwners -->
                 <div class="verify-package-field form-group editable">
-                    <label for="Owner" class="verify-package-field-heading" data-bind="text: $data.IsNewId ? 'Owner' : 'Owners'">Owner</label>
+                    <label for="Owner" class="verify-package-field-heading" data-bind="text: $data.IsNewId ? 'Owner' : 'Owners'"></label>
                     <!-- ko if: $data.PossibleOwners.length > 1 && $data.IsNewId -->
                     <select aria-required="true" class="form-control" data-val="true" data-val-required="You must select an owner for your package!" name="Owner" data-bind="foreach: $data.PossibleOwners">
                         <option data-bind="value: $data, text: $data"></option>


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5312

![image](https://user-images.githubusercontent.com/18014088/35406019-a1d87bf8-01bc-11e8-812c-4711e7c6c9cb.png)

(same behavior as before for new package IDs)
![image](https://user-images.githubusercontent.com/18014088/35406045-b7af9bfa-01bc-11e8-9b49-95d718e4663c.png)