### PR TITLE
Add organization tenant policy

### DIFF
--- a/src/NuGetGallery.Core/Auditing/AuditedSecurityPolicyAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedSecurityPolicyAction.cs
@@ -6,6 +6,7 @@ namespace NuGetGallery.Auditing
     public enum AuditedSecurityPolicyAction
     {
         Create,
-        Verify
+        Verify,
+        JoinOrganization
     }
 }

--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -117,5 +117,10 @@ namespace NuGetGallery
         {
             return type?.Equals(ApiKey.VerifyV1, StringComparison.OrdinalIgnoreCase) ?? false;
         }
+
+        public static Credential GetOrganizationCredential(this ICollection<Credential> credentials)
+        {
+            return credentials.SingleOrDefault(c => IsAzureActiveDirectoryAccount(c.Type));
+        }
     }
 }

--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -118,7 +118,7 @@ namespace NuGetGallery
             return type?.Equals(ApiKey.VerifyV1, StringComparison.OrdinalIgnoreCase) ?? false;
         }
 
-        public static Credential GetOrganizationCredential(this ICollection<Credential> credentials)
+        public static Credential GetAzureActiveDirectoryCredential(this ICollection<Credential> credentials)
         {
             return credentials.SingleOrDefault(c => IsAzureActiveDirectoryAccount(c.Type));
         }

--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -300,7 +300,7 @@ namespace NuGetGallery
             routes.MapRoute(
                 RouteName.OrganizationAccount,
                 "organization/{accountName}/{action}",
-                new { controller = "Organizations", action = "Account" },
+                new { controller = "Organizations", action = "ManageOrganization" },
                 new RouteExtensions.ObfuscatedMetadata(1, Obfuscator.DefaultTelemetryUserName));
 
             routes.MapRoute(

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -261,7 +261,7 @@ namespace NuGetGallery
         [ActionName("VerifyPackageKey")]
         public async virtual Task<ActionResult> VerifyPackageKeyAsync(string id, string version)
         {
-            var policyResult = await SecurityPolicyService.EvaluateAsync(SecurityPolicyAction.PackageVerify, HttpContext);
+            var policyResult = await SecurityPolicyService.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackageVerify, HttpContext);
             if (!policyResult.Success)
             {
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, policyResult.ErrorMessage);
@@ -336,7 +336,7 @@ namespace NuGetGallery
 
         private async Task<ActionResult> CreatePackageInternal()
         {
-            var policyResult = await SecurityPolicyService.EvaluateAsync(SecurityPolicyAction.PackagePush, HttpContext);
+            var policyResult = await SecurityPolicyService.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, HttpContext);
             if (!policyResult.Success)
             {
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, policyResult.ErrorMessage);

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -119,7 +119,8 @@ namespace NuGetGallery
             
             if (!UserService.CanTransformUserToOrganization(accountToTransform, adminUser, out var errorReason))
             {
-                return TransformToOrganizationFailed(errorReason);
+                ModelState.AddModelError("AdminUsername", errorReason);
+                return View(transformViewModel);
             }
 
             await UserService.RequestTransformToOrganizationAccount(accountToTransform, adminUser);
@@ -163,7 +164,7 @@ namespace NuGetGallery
             TempData["Message"] = String.Format(CultureInfo.CurrentCulture,
                 Strings.TransformAccount_Success, accountNameToTransform);
 
-            return RedirectToRoute(RouteName.OrganizationAccount);
+            return Redirect(Url.ManageMyOrganization(accountNameToTransform));
         }
 
         private ActionResult TransformToOrganizationFailed(string errorMessage)

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -836,6 +836,7 @@
     <Compile Include="Migrations\201711021733062_ApiKeyOwnerScope.Designer.cs">
       <DependentUpon>201711021733062_ApiKeyOwnerScope.cs</DependentUpon>
     </Compile>
+    <Compile Include="Security\RequireOrganizationTenantPolicy.cs" />
     <Compile Include="Services\ActionOnNewPackageContext.cs" />
     <Compile Include="Services\ActionRequiringAccountPermissions.cs" />
     <Compile Include="Services\ActionRequiringEntityPermissions.cs" />

--- a/src/NuGetGallery/Security/ISecurityPolicyService.cs
+++ b/src/NuGetGallery/Security/ISecurityPolicyService.cs
@@ -56,6 +56,17 @@ namespace NuGetGallery.Security
         /// <returns>A task that represents the asynchronous operation.
         /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="SecurityPolicyResult" />
         /// instance.</returns>
-        Task<SecurityPolicyResult> EvaluateAsync(SecurityPolicyAction action, HttpContextBase httpContext);
+        Task<SecurityPolicyResult> EvaluateUserPoliciesAsync(SecurityPolicyAction action, HttpContextBase httpContext);
+
+        /// <summary>
+        /// Evaluate any organization security policies for the specified account.
+        /// </summary>
+        /// <param name="action">Security policy action.</param>
+        /// <param name="organization">Organization account.</param>
+        /// <param name="account">User account.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="SecurityPolicyResult" />
+        /// instance.</returns>
+        Task<SecurityPolicyResult> EvaluateOrganizationPoliciesAsync(SecurityPolicyAction action, Organization organization, User account);
     }
 }

--- a/src/NuGetGallery/Security/IUserSecurityPolicySubscription.cs
+++ b/src/NuGetGallery/Security/IUserSecurityPolicySubscription.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace NuGetGallery.Security

--- a/src/NuGetGallery/Security/RequireOrganizationTenantPolicy.cs
+++ b/src/NuGetGallery/Security/RequireOrganizationTenantPolicy.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace NuGetGallery.Security
+{
+    public class RequireOrganizationTenantPolicy : UserSecurityPolicyHandler, IUserSecurityPolicySubscription
+    {
+        public const string _SubscriptionName = "AzureActiveDirectoryTenant";
+        public const string PolicyName = nameof(RequireOrganizationTenantPolicy);
+
+        public string SubscriptionName => _SubscriptionName;
+
+        public IEnumerable<UserSecurityPolicy> Policies { get; set; }
+
+        public class State
+        {
+            [JsonProperty("o")]
+            public int OrganizationKey { get; set; }
+
+            [JsonProperty("t")]
+            public string Tenant { get; set; }
+        }
+
+        public RequireOrganizationTenantPolicy()
+            : base(PolicyName, SecurityPolicyAction.JoinOrganization)
+        {
+        }
+
+        private RequireOrganizationTenantPolicy(IEnumerable<UserSecurityPolicy> policies)
+            : base(PolicyName, SecurityPolicyAction.JoinOrganization)
+        {
+            Policies = policies;
+        }
+
+        public static IUserSecurityPolicySubscription Create(int organizationKey, string tenantId)
+        {
+            var value = JsonConvert.SerializeObject(new State()
+            {
+                OrganizationKey = organizationKey,
+                Tenant = tenantId
+            });
+
+            return new RequireOrganizationTenantPolicy(new []
+            {
+                new UserSecurityPolicy(PolicyName, PolicyName, value)
+            });
+        }
+
+        private static State GetPolicyState(UserSecurityPolicyEvaluationContext context)
+        {
+            return context.Policies
+                .Select(p => JsonConvert.DeserializeObject<State>(p.Value))
+                .FirstOrDefault();
+        }
+
+        public Task OnSubscribeAsync(UserSecurityPolicySubscriptionContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task OnUnsubscribeAsync(UserSecurityPolicySubscriptionContext context)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override SecurityPolicyResult Evaluate(UserSecurityPolicyEvaluationContext context)
+        {
+            context = context ?? throw new ArgumentNullException(nameof(context));
+
+            var state = GetPolicyState(context);
+            var targetAccount = context.TargetAccount;
+            var targetCredential = targetAccount.Credentials.GetOrganizationCredential();
+
+            if (targetCredential == null
+                || !targetCredential.TenantId.Equals(state.Tenant, StringComparison.OrdinalIgnoreCase))
+            {
+                return SecurityPolicyResult.CreateErrorResult(string.Format(CultureInfo.CurrentCulture,
+                        Strings.AddMember_UserDoesNotMeetOrganizationPolicy, targetAccount.Username));
+            }
+
+            return SecurityPolicyResult.SuccessResult;
+        }
+    }
+}

--- a/src/NuGetGallery/Security/RequireOrganizationTenantPolicy.cs
+++ b/src/NuGetGallery/Security/RequireOrganizationTenantPolicy.cs
@@ -21,9 +21,6 @@ namespace NuGetGallery.Security
 
         public class State
         {
-            [JsonProperty("o")]
-            public int OrganizationKey { get; set; }
-
             [JsonProperty("t")]
             public string Tenant { get; set; }
         }
@@ -39,11 +36,10 @@ namespace NuGetGallery.Security
             Policies = policies;
         }
 
-        public static IUserSecurityPolicySubscription Create(int organizationKey, string tenantId)
+        public static IUserSecurityPolicySubscription Create(string tenantId)
         {
             var value = JsonConvert.SerializeObject(new State()
             {
-                OrganizationKey = organizationKey,
                 Tenant = tenantId
             });
 
@@ -76,7 +72,7 @@ namespace NuGetGallery.Security
 
             var state = GetPolicyState(context);
             var targetAccount = context.TargetAccount;
-            var targetCredential = targetAccount.Credentials.GetOrganizationCredential();
+            var targetCredential = targetAccount.Credentials.GetAzureActiveDirectoryCredential();
 
             if (targetCredential == null
                 || !targetCredential.TenantId.Equals(state.Tenant, StringComparison.OrdinalIgnoreCase))

--- a/src/NuGetGallery/Security/SecurityPolicyAction.cs
+++ b/src/NuGetGallery/Security/SecurityPolicyAction.cs
@@ -7,6 +7,7 @@ namespace NuGetGallery.Security
     {
         PackagePush,
         PackageVerify,
-        ManagePackageOwners
+        ManagePackageOwners,
+        JoinOrganization
     }
 }

--- a/src/NuGetGallery/Security/UserSecurityPolicyEvaluationContext.cs
+++ b/src/NuGetGallery/Security/UserSecurityPolicyEvaluationContext.cs
@@ -12,20 +12,71 @@ namespace NuGetGallery.Security
     /// </summary>
     public class UserSecurityPolicyEvaluationContext
     {
+        private Lazy<HttpContextBase> _httpContext;
+        private User _sourceAccount;
+        private User _targetAccount;
+
         /// <summary>
         /// Current http context.
         /// </summary>
-        public HttpContextBase HttpContext { get; }
+        public HttpContextBase HttpContext
+        {
+            get
+            {
+                return _httpContext.Value;
+            }
+        }
+
+        /// <summary>
+        /// Account under policy evaluation.
+        /// </summary>
+        public User CurrentUser
+        {
+            get
+            {
+                return HttpContext.GetCurrentUser();
+            }
+        }
+
+        /// <summary>
+        /// Account under policy evaluation.
+        /// </summary>
+        public User SourceAccount
+        {
+            get
+            {
+                return _sourceAccount ?? CurrentUser;
+            }
+        }
+
+        /// <summary>
+        /// Account under policy evaluation.
+        /// </summary>
+        public User TargetAccount
+        {
+            get
+            {
+                return _targetAccount ?? CurrentUser;
+            }
+        }
 
         /// <summary>
         /// Security policy entity.
         /// </summary>
         public IEnumerable<UserSecurityPolicy> Policies { get; }
 
-        public UserSecurityPolicyEvaluationContext(HttpContextBase httpContext, IEnumerable<UserSecurityPolicy> policies)
+        public UserSecurityPolicyEvaluationContext(IEnumerable<UserSecurityPolicy> policies, HttpContextBase httpContext)
         {
-            HttpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
             Policies = policies ?? throw new ArgumentNullException(nameof(policies));
+
+            _httpContext = new Lazy<HttpContextBase>(() => httpContext ?? new HttpContextWrapper(System.Web.HttpContext.Current));
+        }
+
+        public UserSecurityPolicyEvaluationContext(IEnumerable<UserSecurityPolicy> policies, User sourceAccount, User targetAccount, HttpContextBase httpContext = null)
+            : this(policies, httpContext)
+        {
+            _sourceAccount = sourceAccount;
+            _targetAccount = targetAccount;
         }
     }
 }

--- a/src/NuGetGallery/Security/UserSecurityPolicyEvaluationContext.cs
+++ b/src/NuGetGallery/Security/UserSecurityPolicyEvaluationContext.cs
@@ -17,7 +17,8 @@ namespace NuGetGallery.Security
         private User _targetAccount;
 
         /// <summary>
-        /// Current http context.
+        /// Current http context. This has been required for some user security policies in order
+        /// to get the current user and/or current request details.
         /// </summary>
         public HttpContextBase HttpContext
         {
@@ -28,7 +29,7 @@ namespace NuGetGallery.Security
         }
 
         /// <summary>
-        /// Account under policy evaluation.
+        /// Current user.
         /// </summary>
         public User CurrentUser
         {
@@ -39,7 +40,7 @@ namespace NuGetGallery.Security
         }
 
         /// <summary>
-        /// Account under policy evaluation.
+        /// Account where the security policy came from.
         /// </summary>
         public User SourceAccount
         {
@@ -61,18 +62,31 @@ namespace NuGetGallery.Security
         }
 
         /// <summary>
-        /// Security policy entity.
+        /// Security policies to be evaluated.
         /// </summary>
         public IEnumerable<UserSecurityPolicy> Policies { get; }
 
-        public UserSecurityPolicyEvaluationContext(IEnumerable<UserSecurityPolicy> policies, HttpContextBase httpContext)
+        /// <summary>
+        /// Create a policy (user) context, which uses the httpContext.
+        /// </summary>
+        public UserSecurityPolicyEvaluationContext(
+            IEnumerable<UserSecurityPolicy> policies,
+            HttpContextBase httpContext)
         {
             Policies = policies ?? throw new ArgumentNullException(nameof(policies));
 
-            _httpContext = new Lazy<HttpContextBase>(() => httpContext ?? new HttpContextWrapper(System.Web.HttpContext.Current));
+            _httpContext = new Lazy<HttpContextBase>(() => httpContext
+                ?? new HttpContextWrapper(System.Web.HttpContext.Current));
         }
 
-        public UserSecurityPolicyEvaluationContext(IEnumerable<UserSecurityPolicy> policies, User sourceAccount, User targetAccount, HttpContextBase httpContext = null)
+        /// <summary>
+        /// Create a policy (organization) context, which requires the source (organization) and target (member) accounts for context.
+        /// </summary>
+        public UserSecurityPolicyEvaluationContext(
+            IEnumerable<UserSecurityPolicy> policies,
+            User sourceAccount,
+            User targetAccount,
+            HttpContextBase httpContext = null)
             : this(policies, httpContext)
         {
             _sourceAccount = sourceAccount;

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -350,7 +350,7 @@ namespace NuGetGallery
             }
             else
             {
-                var tenantId = adminUser.Credentials.GetOrganizationCredential()?.TenantId;
+                var tenantId = adminUser.Credentials.GetAzureActiveDirectoryCredential()?.TenantId;
                 if (string.IsNullOrWhiteSpace(tenantId))
                 {
                     errorReason = String.Format(CultureInfo.CurrentCulture,
@@ -363,13 +363,13 @@ namespace NuGetGallery
 
         public async Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
         {
-            var tenantId = adminUser.Credentials.GetOrganizationCredential()?.TenantId;
+            var tenantId = adminUser.Credentials.GetAzureActiveDirectoryCredential()?.TenantId;
             if (string.IsNullOrWhiteSpace(tenantId))
             {
                 return false;
             }
 
-            var tenantPolicy = RequireOrganizationTenantPolicy.Create(accountToTransform.Key, tenantId);
+            var tenantPolicy = RequireOrganizationTenantPolicy.Create(tenantId);
             if (!await SecurityPolicyService.SubscribeAsync(accountToTransform, tenantPolicy))
             {
                 return false;

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -5,12 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Entity;
-using System.Data.SqlClient;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGetGallery.Auditing;
 using NuGetGallery.Configuration;
+using NuGetGallery.Security;
 using Crypto = NuGetGallery.CryptographyService;
 
 namespace NuGetGallery
@@ -18,10 +18,16 @@ namespace NuGetGallery
     public class UserService : IUserService
     {
         public IAppConfiguration Config { get; protected set; }
+
         public IEntityRepository<User> UserRepository { get; protected set; }
+
         public IEntityRepository<Credential> CredentialRepository { get; protected set; }
+
         public IAuditingService Auditing { get; protected set; }
+
         public IEntitiesContext EntitiesContext { get; protected set; }
+
+        public ISecurityPolicyService SecurityPolicyService { get; set; }
 
         protected UserService() { }
 
@@ -30,7 +36,8 @@ namespace NuGetGallery
             IEntityRepository<User> userRepository,
             IEntityRepository<Credential> credentialRepository,
             IAuditingService auditing,
-            IEntitiesContext entitiesContext)
+            IEntitiesContext entitiesContext,
+            ISecurityPolicyService securityPolicyService)
             : this()
         {
             Config = config;
@@ -38,6 +45,7 @@ namespace NuGetGallery
             CredentialRepository = credentialRepository;
             Auditing = auditing;
             EntitiesContext = entitiesContext;
+            SecurityPolicyService = securityPolicyService;
         }
 
         public async Task<Membership> AddMemberAsync(Organization organization, string memberName, bool isAdmin)
@@ -62,6 +70,14 @@ namespace NuGetGallery
             {
                 throw new EntityException(string.Format(CultureInfo.CurrentCulture,
                     Strings.AddMember_UserNotConfirmed, memberName));
+            }
+
+            // Ensure that the new member meets the AAD tenant policy for this organization.
+            var policyResult = await SecurityPolicyService.EvaluateOrganizationPoliciesAsync(
+                SecurityPolicyAction.JoinOrganization, organization, member);
+            if (policyResult != SecurityPolicyResult.SuccessResult)
+            {
+                throw new EntityException(policyResult.ErrorMessage);
             }
 
             membership = new Membership()
@@ -332,14 +348,33 @@ namespace NuGetGallery
                 errorReason = String.Format(CultureInfo.CurrentCulture,
                     Strings.TransformAccount_AdminAccountIsOrganization, adminUser.Username);
             }
+            else
+            {
+                var tenantId = adminUser.Credentials.GetOrganizationCredential()?.TenantId;
+                if (string.IsNullOrWhiteSpace(tenantId))
+                {
+                    errorReason = String.Format(CultureInfo.CurrentCulture,
+                        Strings.TransformAccount_AdminAccountDoesNotHaveTenant, adminUser.Username);
+                }
+            }
 
             return errorReason == null;
         }
 
         public async Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
         {
-            // todo: check for tenantId and add organization policy to enforce this (future work, with manage organization)
+            var tenantId = adminUser.Credentials.GetOrganizationCredential()?.TenantId;
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                return false;
+            }
 
+            var tenantPolicy = RequireOrganizationTenantPolicy.Create(accountToTransform.Key, tenantId);
+            if (!await SecurityPolicyService.SubscribeAsync(accountToTransform, tenantPolicy))
+            {
+                return false;
+            }
+            
             return await EntitiesContext.TransformUserToOrganization(accountToTransform, adminUser, token);
         }
     }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -143,6 +143,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to User &apos;{0}&apos; has not linked their account to an AAD credential matching this organization..
+        /// </summary>
+        public static string AddMember_UserDoesNotMeetOrganizationPolicy {
+            get {
+                return ResourceManager.GetString("AddMember_UserDoesNotMeetOrganizationPolicy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User &apos;{0}&apos; has not confirmed their email..
         /// </summary>
         public static string AddMember_UserNotConfirmed {
@@ -1571,6 +1580,15 @@ namespace NuGetGallery {
         public static string TransformAccount_AdminAccountDoesNotExist {
             get {
                 return ResourceManager.GetString("TransformAccount_AdminAccountDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Administrator account &apos;{0}&apos; is not linked to an AAD credential with an organization tenant..
+        /// </summary>
+        public static string TransformAccount_AdminAccountDoesNotHaveTenant {
+            get {
+                return ResourceManager.GetString("TransformAccount_AdminAccountDoesNotHaveTenant", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -810,4 +810,10 @@ If you wish to update the linked Microsoft account you can do so from the accoun
   <data name="ChangeCredential_SuccessDifferentEmail" xml:space="preserve">
     <value>Successfully linked the Microsoft account ({0}). Note that the email address associated with the new linked Microsoft account is different than the NuGet.org account email ({1}).</value>
   </data>
+  <data name="AddMember_UserDoesNotMeetOrganizationPolicy" xml:space="preserve">
+    <value>User '{0}' has not linked their account to an AAD credential matching this organization.</value>
+  </data>
+  <data name="TransformAccount_AdminAccountDoesNotHaveTenant" xml:space="preserve">
+    <value>Administrator account '{0}' is not linked to an AAD credential with an organization tenant.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Telemetry/Obfuscator.cs
+++ b/src/NuGetGallery/Telemetry/Obfuscator.cs
@@ -16,7 +16,7 @@ namespace NuGetGallery
 
         internal static readonly HashSet<string> ObfuscatedActions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "Organizations/Account",
+            "Organizations/ManageOrganization",
             "Organizations/ChangeEmailSubscription",
             "Packages/ConfirmPendingOwnershipRequest",
             "Packages/RejectPendingOwnershipRequest",

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -1063,10 +1063,9 @@ namespace NuGetGallery
 
         public static string ConfirmTransformAccount(this UrlHelper url, User accountToTransform, bool relativeUrl = true)
         {
-            return GetActionLink(
+            return GetRouteLink(
                 url,
-                "ConfirmTransform",
-                "Users",
+                RouteName.TransformToOrganizationConfirmation,
                 relativeUrl,
                 routeValues: new RouteValueDictionary
                 {

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -89,7 +89,7 @@ namespace NuGetGallery
             MockTelemetryService = new Mock<ITelemetryService>();
             TelemetryService = MockTelemetryService.Object;
 
-            MockSecurityPolicyService.Setup(s => s.EvaluateAsync(It.IsAny<SecurityPolicyAction>(), It.IsAny<HttpContextBase>()))
+            MockSecurityPolicyService.Setup(s => s.EvaluateUserPoliciesAsync(It.IsAny<SecurityPolicyAction>(), It.IsAny<HttpContextBase>()))
                 .Returns(Task.FromResult(SecurityPolicyResult.SuccessResult));
             
             MockReservedNamespaceService
@@ -174,7 +174,7 @@ namespace NuGetGallery
             {
                 // Arrange
                 var controller = new TestableApiController(GetConfigurationService());
-                controller.MockSecurityPolicyService.Setup(s => s.EvaluateAsync(It.IsAny<SecurityPolicyAction>(), It.IsAny<HttpContextBase>()))
+                controller.MockSecurityPolicyService.Setup(s => s.EvaluateUserPoliciesAsync(It.IsAny<SecurityPolicyAction>(), It.IsAny<HttpContextBase>()))
                     .Returns(Task.FromResult(SecurityPolicyResult.CreateErrorResult("A")));
 
                 // Act
@@ -1377,7 +1377,7 @@ namespace NuGetGallery
                 // Arrange
                 var errorResult = "A";
                 var controller = SetupController(credentialType, null, package: null);
-                controller.MockSecurityPolicyService.Setup(s => s.EvaluateAsync(It.IsAny<SecurityPolicyAction>(), It.IsAny<HttpContextBase>()))
+                controller.MockSecurityPolicyService.Setup(s => s.EvaluateUserPoliciesAsync(It.IsAny<SecurityPolicyAction>(), It.IsAny<HttpContextBase>()))
                     .Returns(Task.FromResult(SecurityPolicyResult.CreateErrorResult(errorResult)));
 
                 // Act

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -2296,9 +2296,8 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.NotNull(result);
-
-                var model = result.Model as TransformAccountFailedViewModel;
-                Assert.Equal("error", model.ErrorMessage);
+                Assert.Equal(1, controller.ModelState["AdminUsername"].Errors.Count);
+                Assert.Equal("error", controller.ModelState["AdminUsername"].Errors.First().ErrorMessage);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -445,6 +445,7 @@
     <Compile Include="HttpContextBaseExtensionsFacts.cs" />
     <Compile Include="Infrastructure\Authentication\Base32EncoderTests.cs" />
     <Compile Include="Security\RequireMinProtocolVersionForPushPolicyFacts.cs" />
+    <Compile Include="Security\RequireOrganizationTenantPolicyFacts.cs" />
     <Compile Include="Services\ActionRequiringEntityPermissionsFacts.cs" />
     <Compile Include="Services\DeleteAccountServiceFacts.cs" />
     <Compile Include="Services\JsonStatisticsServiceFacts.cs" />

--- a/tests/NuGetGallery.Facts/Security/RequireMinClientVersionForPushPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/RequireMinClientVersionForPushPolicyFacts.cs
@@ -130,7 +130,7 @@ namespace NuGetGallery.Security
             var policies = minClientVersions.Split(',').Select(
                 v => RequireMinClientVersionForPushPolicy.CreatePolicy("Subscription", new NuGetVersion(v))
             ).ToArray();
-            var context = new UserSecurityPolicyEvaluationContext(httpContext.Object, policies);
+            var context = new UserSecurityPolicyEvaluationContext(policies, httpContext.Object);
 
             return new RequireMinClientVersionForPushPolicy().Evaluate(context);
         }

--- a/tests/NuGetGallery.Facts/Security/RequireMinProtocolVersionForPushPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/RequireMinProtocolVersionForPushPolicyFacts.cs
@@ -127,7 +127,7 @@ namespace NuGetGallery.Security
             var policies = minProtocolVersions.Split(',').Select(
                 v => RequireMinProtocolVersionForPushPolicy.CreatePolicy("Subscription", new NuGetVersion(v))
             ).ToArray();
-            var context = new UserSecurityPolicyEvaluationContext(httpContext.Object, policies);
+            var context = new UserSecurityPolicyEvaluationContext(policies, httpContext.Object);
 
             return new RequireMinProtocolVersionForPushPolicy().Evaluate(context);
         }

--- a/tests/NuGetGallery.Facts/Security/RequireOrganizationTenantPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/RequireOrganizationTenantPolicyFacts.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetGallery.Framework;
+using NuGetGallery.Infrastructure.Authentication;
+using Xunit;
+
+namespace NuGetGallery.Security
+{
+    public class RequireOrganizationTenantPolicyFacts
+    {
+        public const string TenantId = "tenant";
+
+        public class TheEvaluateMethod
+        {
+            [Theory]
+            [InlineData(null)]
+            [InlineData("different-tenant")]
+            public void WhenNoMatchingTargetCredential_ReturnsError(string tenantId)
+            {
+                var result = Evaluate(null);
+
+                Assert.False(result.Success);
+                Assert.Equal(
+                    string.Format(Strings.AddMember_UserDoesNotMeetOrganizationPolicy, "testUser"),
+                    result.ErrorMessage);
+            }
+
+            [Fact]
+            public void WhenMatchingTargetCredential_ReturnsSuccess()
+            {
+                var result = Evaluate(TenantId);
+
+                Assert.True(result.Success);
+                Assert.Null(result.ErrorMessage);
+            }
+
+            private SecurityPolicyResult Evaluate(string userTenantId)
+            {
+                var credentialBuilder = new CredentialBuilder();
+                var fakes = new Fakes();
+
+                if (!string.IsNullOrEmpty(userTenantId))
+                {
+                    fakes.User.Credentials.Add(
+                        credentialBuilder.CreateExternalCredential(
+                        issuer: "AzureActiveDirectory",
+                        value: "value",
+                        identity: "identity",
+                        tenantId: userTenantId));
+                }
+
+                foreach (var policy in RequireOrganizationTenantPolicy.Create(fakes.Organization.Key, TenantId).Policies)
+                {
+                    fakes.Organization.SecurityPolicies.Add(policy);
+                }
+
+                var context = new UserSecurityPolicyEvaluationContext(
+                    fakes.Organization.SecurityPolicies,
+                    sourceAccount: fakes.Organization,
+                    targetAccount: fakes.User
+                    );
+
+                return new RequireOrganizationTenantPolicy().Evaluate(context);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Security/RequireOrganizationTenantPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/RequireOrganizationTenantPolicyFacts.cs
@@ -50,7 +50,7 @@ namespace NuGetGallery.Security
                         tenantId: userTenantId));
                 }
 
-                foreach (var policy in RequireOrganizationTenantPolicy.Create(fakes.Organization.Key, TenantId).Policies)
+                foreach (var policy in RequireOrganizationTenantPolicy.Create(TenantId).Policies)
                 {
                     fakes.Organization.SecurityPolicies.Add(policy);
                 }

--- a/tests/NuGetGallery.Facts/Security/RequirePackageVerifyScopePolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/RequirePackageVerifyScopePolicyFacts.cs
@@ -66,8 +66,9 @@ namespace NuGetGallery.Security
             var httpContext = new Mock<HttpContextBase>();
             httpContext.Setup(c => c.User).Returns(principal.Object);
             
-            var context = new UserSecurityPolicyEvaluationContext(httpContext.Object,
-                new UserSecurityPolicy[] { new UserSecurityPolicy("RequireApiKeyWithPackageVerifyScopePolicy", "Subscription") });
+            var context = new UserSecurityPolicyEvaluationContext(
+                new UserSecurityPolicy[] { new UserSecurityPolicy("RequireApiKeyWithPackageVerifyScopePolicy", "Subscription") },
+                httpContext.Object);
 
             return new RequirePackageVerifyScopePolicy().Evaluate(context);
         }

--- a/tests/NuGetGallery.Facts/Security/SecurityPolicyServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/SecurityPolicyServiceFacts.cs
@@ -55,17 +55,18 @@ namespace NuGetGallery.Security
 
             // Assert
             Assert.NotNull(handlers);
-            Assert.Equal(3, handlers.Count);
+            Assert.Equal(4, handlers.Count);
             Assert.Equal(typeof(RequireMinClientVersionForPushPolicy), handlers[0].GetType());
             Assert.Equal(typeof(RequirePackageVerifyScopePolicy), handlers[1].GetType());
             Assert.Equal(typeof(RequireMinProtocolVersionForPushPolicy), handlers[2].GetType());
+            Assert.Equal(typeof(RequireOrganizationTenantPolicy), handlers[3].GetType());
         }
 
         [Fact]
         public async Task EvaluateAsync_ThrowsArgumentNullIfHttpContextIsNull()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(() => new TestSecurityPolicyService()
-                .EvaluateAsync(SecurityPolicyAction.PackagePush, null));
+                .EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, null));
         }
 
         [Fact]
@@ -76,7 +77,7 @@ namespace NuGetGallery.Security
             var user = new User("testUser");
 
             // Act
-            var result = await service.EvaluateAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
+            var result = await service.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
 
             // Assert
             Assert.True(result.Success);
@@ -96,7 +97,7 @@ namespace NuGetGallery.Security
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
-            var result = await service.EvaluateAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
+            var result = await service.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
 
             // Assert
             Assert.True(result.Success);
@@ -117,7 +118,7 @@ namespace NuGetGallery.Security
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
-            var result = await service.EvaluateAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
+            var result = await service.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
 
             // Assert
             service.Mocks.VerifyPolicyEvaluation(expectedPolicy1: false, expectedPolicy2: null, actual: result);
@@ -136,7 +137,7 @@ namespace NuGetGallery.Security
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
-            var result = await service.EvaluateAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
+            var result = await service.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
 
             // Assert
             Assert.Equal(success, result.Success);
@@ -163,7 +164,7 @@ namespace NuGetGallery.Security
             user.SecurityPolicies = userSecurityPolicies;
 
             // Act
-            var result = await service.EvaluateAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
+            var result = await service.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
 
             // Assert
             Assert.True(result.Success);
@@ -185,7 +186,7 @@ namespace NuGetGallery.Security
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
-            var result = await service.EvaluateAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
+            var result = await service.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
 
             // Assert
             Assert.True(result.Success);
@@ -207,7 +208,7 @@ namespace NuGetGallery.Security
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
-            var result = await service.EvaluateAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
+            var result = await service.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
 
             // Assert
             Assert.Equal(false, result.Success);
@@ -237,7 +238,7 @@ namespace NuGetGallery.Security
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
-            var result = await service.EvaluateAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
+            var result = await service.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
 
             // Assert
             Assert.Equal(userPolicyMet, result.Success);

--- a/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
@@ -9,6 +9,7 @@ using Moq;
 using NuGetGallery.Auditing;
 using NuGetGallery.Framework;
 using NuGetGallery.Infrastructure.Authentication;
+using NuGetGallery.Security;
 using NuGetGallery.TestUtils;
 using Xunit;
 
@@ -18,71 +19,94 @@ namespace NuGetGallery
     {
         public class TheAddMemberAsyncMethod
         {
+            public Fakes Fakes { get; }
+
+            public TestableUserService UserService { get; }
+
+            public TheAddMemberAsyncMethod()
+            {
+                Fakes = new Fakes();
+                UserService = new TestableUserService();
+
+                UserService.MockUserRepository.Setup(r => r.GetAll())
+                    .Returns(new[] {
+                        Fakes.User,
+                        Fakes.Organization
+                    }.AsQueryable());
+            }
+
             [Fact]
             public async Task WhenOrganizationIsNull_ThrowsException()
             {
-                // Arrange
-                var service = new TestableUserService();
-
                 // Act & Assert
                 await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                 {
-                    await service.AddMemberAsync(null, "member", false);
+                    await UserService.AddMemberAsync(null, "member", false);
                 });
             }
 
             [Fact]
             public async Task WhenMemberExists_ThrowsEntityException()
             {
-                // Arrange
-                var fakes = new Fakes();
-                var service = new TestableUserService();
-
                 // Act & Assert
                 await Assert.ThrowsAsync<EntityException>(async () =>
                 {
-                    await service.AddMemberAsync(fakes.Organization, fakes.OrganizationCollaborator.Username, false);
+                    await UserService.AddMemberAsync(Fakes.Organization, Fakes.OrganizationCollaborator.Username, false);
                 });
 
-                service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
+                UserService.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
             }
 
             [Fact]
             public async Task WhenUserNotFound_ThrowsEntityException()
             {
+                // Act & Assert
+                await Assert.ThrowsAsync<EntityException>(async () =>
+                {
+                    await UserService.AddMemberAsync(Fakes.Organization, "notAUser", false);
+                });
+
+                UserService.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
+            }
+
+            [Fact]
+            public async Task WhenSecurityPolicyEvalutionFailure_ThrowsEntityException()
+            {
                 // Arrange
-                var fakes = new Fakes();
-                var service = new TestableUserService();
+                UserService.MockSecurityPolicyService
+                    .Setup(s => s.EvaluateOrganizationPoliciesAsync(SecurityPolicyAction.JoinOrganization, Fakes.Organization, Fakes.User))
+                    .Returns(Task.FromResult(SecurityPolicyResult.CreateErrorResult("error")));
 
                 // Act & Assert
                 await Assert.ThrowsAsync<EntityException>(async () =>
                 {
-                    await service.AddMemberAsync(fakes.Organization, "notAUser", false);
+                    await UserService.AddMemberAsync(Fakes.Organization, Fakes.User.Username, isAdmin: true);
                 });
 
-                service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
+                UserService.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
             }
 
             [Theory]
             [InlineData(true)]
             [InlineData(false)]
-            public async Task WhenUserFound_CreatesMembership(bool isAdmin)
+            public async Task WhenSecurityPolicyEvalutionSuccess_CreatesMembership(bool isAdmin)
             {
                 // Arrange
-                var fakes = new Fakes();
-                var service = new TestableUserService();
-                service.MockUserRepository.Setup(r => r.GetAll())
-                    .Returns(new[] {
-                        fakes.User,
-                        fakes.Organization
-                    }.AsQueryable());
+                UserService.MockSecurityPolicyService
+                    .Setup(s => s.EvaluateOrganizationPoliciesAsync(SecurityPolicyAction.JoinOrganization, Fakes.Organization, Fakes.User))
+                    .Returns(Task.FromResult(SecurityPolicyResult.SuccessResult));
 
                 // Act
-                var result = await service.AddMemberAsync(fakes.Organization, fakes.User.Username, isAdmin);
-                Assert.Equal(isAdmin, result.IsAdmin);
-                Assert.Equal(fakes.User, result.Member);
+                var result = await UserService.AddMemberAsync(
+                    Fakes.Organization,
+                    Fakes.User.Username,
+                    isAdmin);
 
-                service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+                // Assert
+                Assert.Equal(isAdmin, result.IsAdmin);
+                Assert.Equal(Fakes.User, result.Member);
+
+                UserService.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
             }
         }
 
@@ -851,7 +875,7 @@ namespace NuGetGallery
                 return admin;
             }
         }
-        
+
         public class TheTransformToOrganizationAccountMethod
         {
             [Theory]
@@ -859,24 +883,13 @@ namespace NuGetGallery
             [InlineData(-1)]
             public async Task WhenSqlResultIsZeroOrLess_ReturnsFalse(int affectedRecords)
             {
-                // Arrange
-                var service = new TestableUserService();
-                var account = new User("Account");
-                var admin = new User("Admin");
-                admin.Credentials.Add(
-                    new CredentialBuilder().CreateExternalCredential(
-                        issuer: "MicrosoftAccount",
-                        value: "abc123",
-                        identity: "Admin",
-                        tenantId: "zyx987"));
+                Assert.False(await InvokeTransformUserToOrganization(affectedRecords));
+            }
 
-                service.MockDatabase
-                    .Setup(db => db.ExecuteSqlResourceAsync(It.IsAny<string>(), It.IsAny<object[]>()))
-                    .Returns(Task.FromResult(affectedRecords));
-
-                // Act & Assert
-                var result = await service.TransformUserToOrganization(account, admin, "token");
-                Assert.False(result);
+            [Fact]
+            public async Task WhenAdminHasNoTenant_ReturnsFalse()
+            {
+                Assert.False(await InvokeTransformUserToOrganization(3, new User("adminWithNoTenant")));
             }
 
             [Theory]
@@ -884,23 +897,35 @@ namespace NuGetGallery
             [InlineData(3)]
             public async Task WhenSqlResultIsPositive_ReturnsTrue(int affectedRecords)
             {
+                Assert.True(await InvokeTransformUserToOrganization(affectedRecords));
+            }
+
+            private Task<bool> InvokeTransformUserToOrganization(int affectedRecords, User admin = null)
+            {
                 // Arrange
                 var service = new TestableUserService();
                 var account = new User("Account");
-                var admin = new User("Admin");
-                admin.Credentials.Add(
-                    new CredentialBuilder().CreateExternalCredential(
-                        issuer: "MicrosoftAccount",
-                        value: "abc123",
-                        identity: "Admin",
-                        tenantId: "zyx987"));
+                admin = admin ?? new User("Admin")
+                {
+                    Credentials = new Credential[] {
+                        new CredentialBuilder().CreateExternalCredential(
+                            issuer: "AzureActiveDirectory",
+                            value: "abc123",
+                            identity: "Admin",
+                            tenantId: "zyx987")
+                    }
+                };
 
                 service.MockDatabase
                     .Setup(db => db.ExecuteSqlResourceAsync(It.IsAny<string>(), It.IsAny<object[]>()))
                     .Returns(Task.FromResult(affectedRecords));
 
+                service.MockSecurityPolicyService
+                    .Setup(sp => sp.SubscribeAsync(It.IsAny<User>(), It.IsAny<IUserSecurityPolicySubscription>()))
+                    .Returns(Task.FromResult(true));
+
                 // Act
-                Assert.True(await service.TransformUserToOrganization(account, admin, "token"));
+                return service.TransformUserToOrganization(account, admin, "token");
             }
         }
     }

--- a/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
@@ -4,6 +4,7 @@ using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Configuration;
 using NuGetGallery.Framework;
+using NuGetGallery.Security;
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
@@ -133,6 +134,7 @@ namespace NuGetGallery.TestUtils
     public class TestableUserService : UserService
     {
         public Mock<IAppConfiguration> MockConfig { get; protected set; }
+        public Mock<ISecurityPolicyService> MockSecurityPolicyService { get; protected set; }
         public Mock<IEntityRepository<User>> MockUserRepository { get; protected set; }
         public Mock<IEntityRepository<Credential>> MockCredentialRepository { get; protected set; }
         public Mock<IEntitiesContext> MockEntitiesContext { get; protected set; }
@@ -141,6 +143,7 @@ namespace NuGetGallery.TestUtils
         public TestableUserService()
         {
             Config = (MockConfig = new Mock<IAppConfiguration>()).Object;
+            SecurityPolicyService = (MockSecurityPolicyService = new Mock<ISecurityPolicyService>()).Object;
             UserRepository = (MockUserRepository = new Mock<IEntityRepository<User>>()).Object;
             CredentialRepository = (MockCredentialRepository = new Mock<IEntityRepository<Credential>>()).Object;
             EntitiesContext = (MockEntitiesContext = new Mock<IEntitiesContext>()).Object;


### PR DESCRIPTION
Addresses issue #5261
- Create organization policy requiring AAD credential with matching tenant
- On transform: adds policy to organization, using tenant from initial admin's AAD credential
- On add member: evaluates organization policy for new member

Will also require a small shims change for the new security policy action... separate PR coming.