### PR TITLE
Add logic for respecting the package auto-delete configuration

### DIFF
--- a/src/NuGetGallery/Configuration/IPackageDeleteConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IPackageDeleteConfiguration.cs
@@ -27,7 +27,9 @@ namespace NuGetGallery.Configuration
         /// regardless of the number of downloads. Since the download counts for packages are not updated immediately,
         /// there is a window of time when a new package won't have any recorded downloads. Note that
         /// <see cref="AllowUsersToDeletePackages"/> and <see cref="MaximumDownloadsForPackageVersion"/> take
-        /// precedence over this option.
+        /// precedence over this option. The jobs that imply this value are the Stats.CreateAzureCdnWarehouseReports and
+        /// Stats.AggregateCdnDownloadsInGallery jobs. Note that this configuration value may be higher than the actual
+        /// update frequency. This is the more like the maximum expected update frequency.
         /// </summary>
         int? StatisticsUpdateFrequencyInHours { get; }
 

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1063,6 +1063,8 @@
     <Compile Include="Diagnostics\DiagnosticsServiceExtensions.cs" />
     <Compile Include="Diagnostics\DiagnosticsSourceExtensions.cs" />
     <Compile Include="Configuration\StorageType.cs" />
+    <Compile Include="Telemetry\UserPackageDeleteEvent.cs" />
+    <Compile Include="Telemetry\UserPackageDeleteOutcome.cs" />
     <Compile Include="ViewModels\GalleryHomeViewModel.cs" />
     <Compile Include="WebRole.cs" />
     <Content Include="bin\NuGetGallery.dll.config">

--- a/src/NuGetGallery/Services/IPackageDeleteService.cs
+++ b/src/NuGetGallery/Services/IPackageDeleteService.cs
@@ -8,7 +8,7 @@ namespace NuGetGallery
 {
     public interface IPackageDeleteService
     {
-        Task<bool> CanPackageBeDeletedByUserAsync(Package package);
+        Task<bool> CanPackageBeDeletedByUserAsync(Package package, ReportPackageReason? reportPackageReason, PackageDeleteDecision? packageDeleteDecision);
         Task SoftDeletePackagesAsync(IEnumerable<Package> packages, User deletedBy, string reason, string signature);
         Task HardDeletePackagesAsync(IEnumerable<Package> packages, User deletedBy, string reason, string signature, bool deleteEmptyPackageRegistration);
         Task ReflowHardDeletedPackageAsync(string id, string version);

--- a/src/NuGetGallery/Services/ITelemetryClient.cs
+++ b/src/NuGetGallery/Services/ITelemetryClient.cs
@@ -13,6 +13,8 @@ namespace NuGetGallery
     {
         void TrackEvent(string eventName, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null);
 
+        void TrackMetric(string metricName, double value, IDictionary<string, string> properties = null);
+
         void TrackException(Exception exception, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null);
     }
 }

--- a/src/NuGetGallery/Services/ITelemetryService.cs
+++ b/src/NuGetGallery/Services/ITelemetryService.cs
@@ -26,6 +26,16 @@ namespace NuGetGallery
         void TrackNewCredentialCreated(User user, Credential credential);
 
         /// <summary>
+        /// A telemetry event emitted when the service checks whether a user package delete is allowed.
+        /// </summary>
+        void TrackUserPackageDeleteChecked(UserPackageDeleteEvent details, UserPackageDeleteOutcome outcome);
+
+        /// <summary>
+        /// A telemetry event emitted when a user package delete is executed.
+        /// </summary>
+        void TrackUserPackageDeleteExecuted(int packageKey, string packageId, string packageVersion, ReportPackageReason reason, bool success);
+
+        /// <summary>
         /// Create a trace for an exception. These are informational for support requests.
         /// </summary>
         void TraceException(Exception exception);

--- a/src/NuGetGallery/Services/TelemetryClientWrapper.cs
+++ b/src/NuGetGallery/Services/TelemetryClientWrapper.cs
@@ -52,5 +52,17 @@ namespace NuGetGallery
                 // logging failed, don't allow exception to escape
             }
         }
+
+        public void TrackMetric(string metricName, double value, IDictionary<string, string> properties = null)
+        {
+            try
+            {
+                UnderlyingClient.TrackMetric(metricName, value, properties);
+            }
+            catch
+            {
+                // logging failed, don't allow exception to escape
+            }
+        }
     }
 }

--- a/src/NuGetGallery/Telemetry/AppInsightsHealthIndicatorLogger.cs
+++ b/src/NuGetGallery/Telemetry/AppInsightsHealthIndicatorLogger.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.ServiceModel;
 using Microsoft.ApplicationInsights;
 using NuGet.Services.Search.Client;
 

--- a/src/NuGetGallery/Telemetry/UserPackageDeleteEvent.cs
+++ b/src/NuGetGallery/Telemetry/UserPackageDeleteEvent.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery
+{
+    public class UserPackageDeleteEvent
+    {
+        public UserPackageDeleteEvent(
+            TimeSpan sinceCreated,
+            int packageKey,
+            string packageId,
+            string packageVersion,
+            int idDatabaseDownloads,
+            int idReportDownloads,
+            int versionDatabaseDownloads,
+            int versionReportDownloads,
+            ReportPackageReason? reportPackageReason,
+            PackageDeleteDecision? packageDeleteDecision)
+        {
+            SinceCreated = sinceCreated;
+            PackageKey = packageKey;
+            PackageId = packageId ?? throw new ArgumentNullException(nameof(packageId));
+            PackageVersion = packageVersion ?? throw new ArgumentNullException(nameof(packageVersion));
+            IdDatabaseDownloads = idDatabaseDownloads;
+            IdReportDownloads = idReportDownloads;
+            VersionDatabaseDownloads = versionDatabaseDownloads;
+            VersionReportDownloads = versionReportDownloads;
+            ReportPackageReason = reportPackageReason;
+            PackageDeleteDecision = packageDeleteDecision;
+        }
+
+        public TimeSpan SinceCreated { get; }
+        public int PackageKey { get; }
+        public string PackageId { get; }
+        public string PackageVersion { get; }
+        public int IdDatabaseDownloads { get; }
+        public int IdReportDownloads { get; }
+        public int VersionDatabaseDownloads { get; }
+        public int VersionReportDownloads { get; }
+        public ReportPackageReason? ReportPackageReason { get; }
+        public PackageDeleteDecision? PackageDeleteDecision { get; }
+    }
+}

--- a/src/NuGetGallery/Telemetry/UserPackageDeleteOutcome.cs
+++ b/src/NuGetGallery/Telemetry/UserPackageDeleteOutcome.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public enum UserPackageDeleteOutcome
+    {
+        Accepted,
+        AlreadyDeleted,
+        LockedRegistration,
+        TooManyIdDatabaseDownloads,
+        TooManyIdReportDownloads,
+        StaleStatistics,
+        TooManyVersionDatabaseDownloads,
+        TooManyVersionReportDownloads,
+        TooLate,
+    }
+}

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -2926,9 +2926,29 @@ namespace NuGetGallery
                 Assert.Equal("I like the cut of your jib. It&#39;s &lt;b&gt;bold&lt;/b&gt;.", reportRequest.Message);
             }
 
+            [Fact]
+            public async Task ChecksDeleteAllowedWithNoReasonOnGetEndpoint()
+            {
+                // Arrange
+                SetupTest(TestUtility.FakeUser, TestUtility.FakeUser);
+
+                // Act
+                var result = await _controller.ReportMyPackage(
+                    _package.PackageRegistration.Id,
+                    _package.Version);
+
+                // Assert
+                _packageDeleteService.Verify(
+                    x => x.CanPackageBeDeletedByUserAsync(
+                        It.IsAny<Package>(),
+                        null,
+                        null),
+                    Times.Once);
+            }
+
             [Theory]
             [MemberData(nameof(Owner_Data))]
-            public async Task DoesNotCheckDeleteAllowedIfDeleteWasNotRequested(User currentUser, User owner)
+            public async Task ChecksDeleteAllowedEvenIfDeleteWasNotRequested(User currentUser, User owner)
             {
                 // Arrange
                 SetupTest(currentUser, owner);
@@ -2944,8 +2964,10 @@ namespace NuGetGallery
                 // Assert
                 _packageDeleteService.Verify(
                     x => x.CanPackageBeDeletedByUserAsync(
-                        It.IsAny<Package>()),
-                    Times.Never);
+                        It.IsAny<Package>(),
+                        _viewModel.Reason.Value,
+                        PackageDeleteDecision.ContactSupport),
+                    Times.Once);
                 _supportRequestService.Verify(
                     x => x.AddNewSupportRequestAsync(
                         string.Format(
@@ -2970,7 +2992,10 @@ namespace NuGetGallery
                 _viewModel.DeleteDecision = PackageDeleteDecision.DeletePackage;
                 _viewModel.DeleteConfirmation = true;
                 _packageDeleteService
-                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(
+                        It.IsAny<Package>(),
+                        It.IsAny<ReportPackageReason?>(),
+                        It.IsAny<PackageDeleteDecision?>()))
                     .ReturnsAsync(true);
 
                 // Act
@@ -3032,7 +3057,10 @@ namespace NuGetGallery
                 _viewModel.DeleteConfirmation = true;
                 _viewModel.CopySender = true;
                 _packageDeleteService
-                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(
+                        It.IsAny<Package>(),
+                        It.IsAny<ReportPackageReason?>(),
+                        It.IsAny<PackageDeleteDecision?>()))
                     .ReturnsAsync(true);
                 _packageDeleteService
                     .Setup(x => x.SoftDeletePackagesAsync(
@@ -3086,7 +3114,10 @@ namespace NuGetGallery
                 _viewModel.DeleteDecision = PackageDeleteDecision.ContactSupport;
                 _viewModel.Message = null;
                 _packageDeleteService
-                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(
+                        It.IsAny<Package>(),
+                        It.IsAny<ReportPackageReason?>(),
+                        It.IsAny<PackageDeleteDecision?>()))
                     .ReturnsAsync(true);
 
                 // Act
@@ -3114,7 +3145,10 @@ namespace NuGetGallery
                 _viewModel.DeleteDecision = PackageDeleteDecision.DeletePackage;
                 _viewModel.DeleteConfirmation = false;
                 _packageDeleteService
-                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(
+                        It.IsAny<Package>(),
+                        It.IsAny<ReportPackageReason?>(),
+                        It.IsAny<PackageDeleteDecision?>()))
                     .ReturnsAsync(true);
 
                 // Act
@@ -3168,7 +3202,10 @@ namespace NuGetGallery
                 _viewModel.DeleteDecision = null;
                 _viewModel.DeleteConfirmation = true;
                 _packageDeleteService
-                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(
+                        It.IsAny<Package>(),
+                        It.IsAny<ReportPackageReason?>(),
+                        It.IsAny<PackageDeleteDecision?>()))
                     .ReturnsAsync(true);
 
                 // Act
@@ -3198,7 +3235,10 @@ namespace NuGetGallery
                 _viewModel.Reason = reason;
                 _viewModel.DeleteDecision = null;
                 _packageDeleteService
-                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(
+                        It.IsAny<Package>(),
+                        It.IsAny<ReportPackageReason?>(),
+                        It.IsAny<PackageDeleteDecision?>()))
                     .ReturnsAsync(false);
 
                 // Act
@@ -3235,7 +3275,10 @@ namespace NuGetGallery
                 _viewModel.DeleteDecision = PackageDeleteDecision.DeletePackage;
                 _viewModel.DeleteConfirmation = true;
                 _packageDeleteService
-                    .Setup(x => x.CanPackageBeDeletedByUserAsync(It.IsAny<Package>()))
+                    .Setup(x => x.CanPackageBeDeletedByUserAsync(
+                        It.IsAny<Package>(),
+                        It.IsAny<ReportPackageReason?>(),
+                        It.IsAny<PackageDeleteDecision?>()))
                     .ReturnsAsync(false);
 
                 // Act


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/921.

Could I get some crazy nitpick 👀s on this PR? There is risk associated with this change as it allows users to delete their own packages in some cases.

I check both the DB and the statistics reports for download counts. This is to improve resiliency as separate jobs write these two artifacts.