### PR TITLE
[Organizations] Notifications for transforming an account into an organization

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1071,6 +1071,7 @@
     <Compile Include="Telemetry\UserPackageDeleteEvent.cs" />
     <Compile Include="Telemetry\UserPackageDeleteOutcome.cs" />
     <Compile Include="ViewModels\GalleryHomeViewModel.cs" />
+    <Compile Include="ViewModels\HandleOrganizationMembershipRequestModel.cs" />
     <Compile Include="WebRole.cs" />
     <Content Include="bin\NuGetGallery.dll.config">
       <SubType>Designer</SubType>
@@ -2054,6 +2055,7 @@
     <Content Include="Views\Pages\_TransformOrLink.cshtml" />
     <Content Include="Views\Organizations\_OrganizationAccountManageMembers.cshtml" />
     <Content Include="Views\Shared\_AutocompleteTemplate.cshtml" />
+    <Content Include="Views\Organizations\HandleOrganizationMembershipRequest.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="Properties\CodeAnalysisDictionary.xml" />

--- a/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
@@ -103,7 +103,7 @@
 
                 // Send the request.
                 $.ajax({
-                    url: self.OrganizationViewModel.UpdateMemberUrl,
+                    url: self.Pending ? self.OrganizationViewModel.AddMemberUrl : self.OrganizationViewModel.UpdateMemberUrl,
                     type: 'POST',
                     dataType: 'json',
                     data: data,
@@ -180,6 +180,20 @@
 
             this.AddMemberRole = ko.observable(this.RoleNames()[1]);
             this.AddMember = function () {
+                // Check if the member already exists.
+                var memberExists = false;
+                self.Members().forEach(function (member) {
+                    if (member.Username.toLocaleLowerCase() === self.NewMemberUsername().toLocaleLowerCase()) {
+                        memberExists = true;
+                    }
+                });
+
+                if (memberExists) {
+                    var error = "'" + self.NewMemberUsername() + "' is already a member or pending member.";
+                    self.Error(error);
+                    return;
+                }
+
                 // Build the request.
                 var data = {
                     accountName: self.AccountName,

--- a/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
@@ -55,6 +55,7 @@
             this.IsCurrentUser = member.IsCurrentUser;
             this.ProfileUrl = parent.ProfileUrlTemplate.replace('{username}', this.Username);
             this.GravatarUrl = member.GravatarUrl;
+            this.Pending = member.Pending;
 
             this.DeleteMember = function () {
                 if (!window.nuget.confirmEvent("Are you sure you want to delete member '" + self.Username + "'?")) {
@@ -70,7 +71,7 @@
 
                 // Send the request.
                 $.ajax({
-                    url: self.OrganizationViewModel.DeleteMemberUrl,
+                    url: self.Pending ? self.OrganizationViewModel.CancelMemberRequestUrl : self.OrganizationViewModel.DeleteMemberUrl,
                     type: 'POST',
                     dataType: 'json',
                     data: data,
@@ -130,6 +131,7 @@
 
             this.AccountName = initialData.AccountName;
             this.AddMemberUrl = initialData.AddMemberUrl;
+            this.CancelMemberRequestUrl = initialData.CancelMemberRequestUrl;
             this.UpdateMemberUrl = initialData.UpdateMemberUrl;
             this.DeleteMemberUrl = initialData.DeleteMemberUrl;
             this.ProfileUrlTemplate = initialData.ProfileUrlTemplate;

--- a/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
+++ b/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
@@ -83,7 +83,7 @@ namespace NuGetGallery
         /// <summary>
         /// The action of handling package ownership requests for a user to become an owner of a package.
         /// </summary>
-        public static ActionRequiringAccountPermissions HandlePackageOwnershipRequest = 
+        public static ActionRequiringAccountPermissions HandlePackageOwnershipRequest =
             new ActionRequiringAccountPermissions(
                 accountPermissionsRequirement: RequireOwnerOrOrganizationAdmin);
 

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -27,5 +27,14 @@ namespace NuGetGallery
         void SendPackageUploadedNotice(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl);
         void SendAccountDeleteNotice(MailAddress mailAddress, string userName);
         void SendPackageDeletedNotice(Package package, string packageUrl, string packageSupportUrl);
+        void SendOrganizationTransformRequest(User accountToTransform, User adminUser, string profileUrl, string confirmationUrl, string rejectionUrl);
+        void SendOrganizationTransformRequestAcceptedNotice(User accountToTransform, User adminUser);
+        void SendOrganizationTransformRequestRejectedNotice(User accountToTransform, User adminUser);
+        void SendOrganizationTransformRequestCancelledNotice(User accountToTransform, User adminUser);
+        void SendOrganizationMembershipRequest(Organization organization, User newUser, User adminUser, bool isAdmin, string profileUrl, string confirmationUrl, string rejectionUrl);
+        void SendOrganizationMembershipRequestRejectedNotice(Organization organization, User pendingUser);
+        void SendOrganizationMembershipRequestCancelledNotice(Organization organization, User pendingUser);
+        void SendOrganizationMemberUpdatedNotice(Organization organization, Membership membership);
+        void SendOrganizationMemberRemovedNotice(Organization organization, User removedUser);
     }
 }

--- a/src/NuGetGallery/Services/IUserService.cs
+++ b/src/NuGetGallery/Services/IUserService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,11 +9,17 @@ namespace NuGetGallery
 {
     public interface IUserService
     {
-        Task<Membership> AddMemberAsync(Organization organization, string memberName, bool isAdmin);
+        Task<MembershipRequest> AddMembershipRequestAsync(Organization organization, string memberName, bool isAdmin);
+
+        Task RejectMembershipRequestAsync(Organization organization, string memberName, string confirmationToken);
+
+        Task<User> CancelMembershipRequestAsync(Organization organization, string memberName);
+
+        Task<Membership> AddMemberAsync(Organization organization, string memberName, string confirmationToken);
 
         Task<Membership> UpdateMemberAsync(Organization organization, string memberName, bool isAdmin);
 
-        Task DeleteMemberAsync(Organization organization, string memberName);
+        Task<User> DeleteMemberAsync(Organization organization, string memberName);
 
         Task ChangeEmailSubscriptionAsync(User user, bool emailAllowed, bool notifyPackagePushed);
 
@@ -41,5 +48,7 @@ namespace NuGetGallery
         Task RequestTransformToOrganizationAccount(User accountToTransform, User adminUser);
         
         Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token);
+
+        Task<bool> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token);
     }
 }

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -681,6 +681,266 @@ The {0} Team";
             }
         }
 
+        public void SendOrganizationTransformRequest(User accountToTransform, User adminUser, string profileUrl, string confirmationUrl, string rejectionUrl)
+        {
+            if (!adminUser.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.
+
+User profile on NuGet.org: [{profileUrl}]({profileUrl})
+
+To accept this request and become an admin of '{accountToTransform.Username}' and gain the ability to manage the account's packages, click the following URL:
+
+[{confirmationUrl}]({confirmationUrl})
+
+If you do not want to become an admin of '{accountToTransform.Username}', click the following URL:
+
+[{rejectionUrl}]({rejectionUrl})
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(accountToTransform.ToMailAddress());
+
+                mailMessage.To.Add(adminUser.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationTransformRequestAcceptedNotice(User accountToTransform, User adminUser)
+        {
+            if (!accountToTransform.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(adminUser.ToMailAddress());
+
+                mailMessage.To.Add(accountToTransform.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationTransformRequestRejectedNotice(User accountToTransform, User adminUser)
+        {
+            if (!accountToTransform.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(adminUser.ToMailAddress());
+
+                mailMessage.To.Add(accountToTransform.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationTransformRequestCancelledNotice(User accountToTransform, User adminUser)
+        {
+            if (!adminUser.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(accountToTransform.ToMailAddress());
+
+                mailMessage.To.Add(adminUser.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationMembershipRequest(Organization organization, User newUser, User adminUser, bool isAdmin, string profileUrl, string confirmationUrl, string rejectionUrl)
+        {
+            if (!newUser.EmailAllowed)
+            {
+                return;
+            }
+
+            var membershipLevel = isAdmin ? "an admin" : "a collaborator";
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{adminUser.Username}' would like you to become {membershipLevel} of their organization, '{organization.Username}'.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{adminUser.Username}' would like you to become {membershipLevel} of their organization, '{organization.Username}'.
+
+Organization profile on NuGet.org: [{profileUrl}]({profileUrl})
+
+To accept this request and become {membershipLevel} of '{organization.Username}' and gain the ability to manage the organization's packages, click the following URL:
+
+[{confirmationUrl}]({confirmationUrl})
+
+If you do not want to become {membershipLevel} of '{organization.Username}', click the following URL:
+
+[{rejectionUrl}]({rejectionUrl})
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(organization.ToMailAddress());
+                mailMessage.ReplyToList.Add(adminUser.ToMailAddress());
+
+                mailMessage.To.Add(newUser.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationMembershipRequestRejectedNotice(Organization organization, User pendingUser)
+        {
+            if (!organization.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{pendingUser.Username}' has rejected your request for them to become a member of your organization.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{pendingUser.Username}' has rejected your request for them to become a member of your organization.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(pendingUser.ToMailAddress());
+
+                mailMessage.To.Add(organization.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationMembershipRequestCancelledNotice(Organization organization, User pendingUser)
+        {
+            if (!pendingUser.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The request for you to become a member of '{organization.Username}' has been cancelled.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The request for you to become a member of '{organization.Username}' has been cancelled.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(organization.ToMailAddress());
+
+                mailMessage.To.Add(pendingUser.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationMemberUpdatedNotice(Organization organization, Membership membership)
+        {
+            if (!organization.EmailAllowed)
+            {
+                return;
+            }
+
+            var membershipLevel = membership.IsAdmin ? "an admin" : "a collaborator";
+            var member = membership.Member;
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{member.Username}' is now {membershipLevel} of organization '{organization.Username}'.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{member.Username}' is now {membershipLevel} of organization '{organization.Username}'.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(member.ToMailAddress());
+
+                mailMessage.To.Add(organization.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationMemberRemovedNotice(Organization organization, User removedUser)
+        {
+            if (!organization.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{removedUser.Username}' is no longer a member of organization '{organization.Username}'.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{removedUser.Username}' is no longer a member of organization '{organization.Username}'.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(removedUser.ToMailAddress());
+
+                mailMessage.To.Add(organization.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
         protected override void SendMessage(MailMessage mailMessage, bool copySender)
         {
             try

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -143,6 +143,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There is no request for user &apos;{0}&apos; for join this organization with that token..
+        /// </summary>
+        public static string AddMember_MissingRequest {
+            get {
+                return ResourceManager.GetString("AddMember_MissingRequest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User &apos;{0}&apos; has not linked their account to an AAD credential matching this organization..
         /// </summary>
         public static string AddMember_UserDoesNotMeetOrganizationPolicy {
@@ -452,6 +461,24 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The pending organization member was deleted..
+        /// </summary>
+        public static string CancelMemberRequest_Success {
+            get {
+                return ResourceManager.GetString("CancelMemberRequest_Success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There is no request for user &apos;{0}&apos; to join this organization.
+        /// </summary>
+        public static string CancelMembershipRequest_MissingRequest {
+            get {
+                return ResourceManager.GetString("CancelMembershipRequest_MissingRequest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enqueuing unavailable: the gallery is currently in read only mode, with limited service. Please try again later..
         /// </summary>
         public static string CannotEnqueueDueToReadOnly {
@@ -632,7 +659,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Organization member was deleted..
+        ///   Looks up a localized string similar to The organization member was deleted..
         /// </summary>
         public static string DeleteMember_Success {
             get {
@@ -1247,6 +1274,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &gt;&gt;&gt;&gt;&gt;&gt;&gt; emails for transforming into org and changing org members.
+        /// </summary>
+        public static string RejectMembershipRequest_NotFound {
+            get {
+                return ResourceManager.GetString("RejectMembershipRequest_NotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The user &apos;{0}&apos; does not have permission to remove the owner &apos;{1}&apos;..
         /// </summary>
         public static string RemoveOwner_NotAllowed {
@@ -1620,6 +1656,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The transform request you are attempting to reject was not found..
+        /// </summary>
+        public static string TransformAccount_FailedMissingRequestToReject {
+            get {
+                return ResourceManager.GetString("TransformAccount_FailedMissingRequestToReject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Account &apos;{0}&apos; does not support organizations..
         /// </summary>
         public static string TransformAccount_FailedReasonNotInDomainWhitelist {
@@ -1634,6 +1679,15 @@ namespace NuGetGallery {
         public static string TransformAccount_OrganizationAccountDoesNotExist {
             get {
                 return ResourceManager.GetString("TransformAccount_OrganizationAccountDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The transform request for you to become an admin of &apos;{0}&apos; has been successfully rejected..
+        /// </summary>
+        public static string TransformAccount_Rejected {
+            get {
+                return ResourceManager.GetString("TransformAccount_Rejected", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -781,7 +781,7 @@ If you wish to update the linked Microsoft account you can do so from the accoun
     <value>Organization member '{0}' was not found.</value>
   </data>
   <data name="DeleteMember_Success" xml:space="preserve">
-    <value>Organization member was deleted.</value>
+    <value>The organization member was deleted.</value>
   </data>
   <data name="OrganizationMemberNameIsRequired" xml:space="preserve">
     <value>Member name is required.</value>
@@ -806,5 +806,24 @@ If you wish to update the linked Microsoft account you can do so from the accoun
   </data>
   <data name="DeleteMember_CannotRemoveLastAdmin" xml:space="preserve">
     <value>You can't leave the organization. In order to leave the organization, another collaborator must be assigned as an administrator.</value>
+  </data>
+  <data name="TransformAccount_Rejected" xml:space="preserve">
+    <value>The transform request for you to become an admin of '{0}' has been successfully rejected.</value>
+  </data>
+  <data name="TransformAccount_FailedMissingRequestToReject" xml:space="preserve">
+    <value>The transform request you are attempting to reject was not found.</value>
+  </data>
+  <data name="AddMember_MissingRequest" xml:space="preserve">
+    <value>There is no request for user '{0}' for join this organization with that token.</value>
+  </data>
+  <data name="CancelMembershipRequest_MissingRequest" xml:space="preserve">
+    <value>There is no request for user '{0}' to join this organization</value>
+  </data>
+  <data name="CancelMemberRequest_Success" xml:space="preserve">
+    <value>The pending organization member was deleted.</value>
+  </data>
+  <data name="RejectMembershipRequest_NotFound" xml:space="preserve">
+    <value>There is no request for user '{0}' for join this organization with that token.</value>
+>>>>>>> emails for transforming into org and changing org members
   </data>
 </root>

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -788,6 +788,41 @@ namespace NuGetGallery
                 });
         }
 
+        public static string AcceptOrganizationMembershipRequest(this UrlHelper url, MembershipRequest request, bool relativeUrl = true)
+        {
+            return url.HandleOrganizationMembershipRequest("ConfirmMemberRequest", request, relativeUrl);
+        }
+
+        public static string RejectOrganizationMembershipRequest(this UrlHelper url, MembershipRequest request, bool relativeUrl = true)
+        {
+            return url.HandleOrganizationMembershipRequest("RejectMemberRequest", request, relativeUrl);
+        }
+
+        private static string HandleOrganizationMembershipRequest(this UrlHelper url,  string routeName, MembershipRequest request, bool relativeUrl = true)
+        {
+            return GetActionLink(url,
+                routeName,
+                "Organizations",
+                relativeUrl,
+                routeValues: new RouteValueDictionary
+                {
+                    { "accountName", request.Organization.Username },
+                    { "confirmationToken", request.ConfirmationToken }
+                });
+        }
+
+        public static string CancelOrganizationMembershipRequest(this UrlHelper url, string accountName, bool relativeUrl = true)
+        {
+            return GetActionLink(url,
+                "CancelMemberRequest",
+                "Organizations",
+                relativeUrl,
+                routeValues: new RouteValueDictionary
+                {
+                    { "accountName", accountName }
+                });
+        }
+
         public static string UpdateOrganizationMember(this UrlHelper url, string accountName, bool relativeUrl = true)
         {
             return GetActionLink(url,
@@ -1079,9 +1114,20 @@ namespace NuGetGallery
 
         public static string ConfirmTransformAccount(this UrlHelper url, User accountToTransform, bool relativeUrl = true)
         {
-            return GetRouteLink(
+            return url.HandleTransformAccount(RouteName.TransformToOrganizationConfirmation, accountToTransform, relativeUrl);
+        }
+
+        public static string RejectTransformAccount(this UrlHelper url, User accountToTransform, bool relativeUrl = true)
+        {
+            return url.HandleTransformAccount("RejectTransform", accountToTransform, relativeUrl);
+        }
+
+        private static string HandleTransformAccount(this UrlHelper url, string routeName, User accountToTransform, bool relativeUrl = true)
+        {
+            return GetActionLink(
                 url,
-                RouteName.TransformToOrganizationConfirmation,
+                routeName,
+                "Users",
                 relativeUrl,
                 routeValues: new RouteValueDictionary
                 {

--- a/src/NuGetGallery/ViewModels/HandleOrganizationMembershipRequestModel.cs
+++ b/src/NuGetGallery/ViewModels/HandleOrganizationMembershipRequestModel.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public class HandleOrganizationMembershipRequestModel
+    {
+        /// <summary>
+        /// If true, this is an attempt to confirm a request.
+        /// If false, this is an attempt to reject a request.
+        /// </summary>
+        public bool Confirm { get; }
+        public string OrganizationName { get; }
+        public bool Successful { get; }
+        public string FailureReason { get; }
+
+        public HandleOrganizationMembershipRequestModel(bool confirm, Organization organization)
+        {
+            Confirm = confirm;
+            OrganizationName = organization.Username;
+            Successful = true;
+        }
+
+        public HandleOrganizationMembershipRequestModel(bool confirm, Organization organization, string failureReason)
+            : this(confirm, organization)
+        {
+            Successful = false;
+            FailureReason = failureReason;
+        }
+    }
+}

--- a/src/NuGetGallery/ViewModels/OrganizationMemberViewModel.cs
+++ b/src/NuGetGallery/ViewModels/OrganizationMemberViewModel.cs
@@ -15,6 +15,27 @@ namespace NuGetGallery
             Username = member.Username;
             EmailAddress = member.EmailAddress;
             IsAdmin = membership.IsAdmin;
+            Pending = false;
+            GravatarUrl = GravatarHelper.Url(EmailAddress, Constants.GravatarElementSize);
+        }
+
+        public OrganizationMemberViewModel(MembershipRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var member = request.NewMember;
+            if (member == null)
+            {
+                throw new ArgumentNullException(nameof(request.NewMember));
+            }
+
+            Username = member.Username;
+            EmailAddress = member.EmailAddress;
+            IsAdmin = request.IsAdmin;
+            Pending = true;
             GravatarUrl = GravatarHelper.Url(EmailAddress, Constants.GravatarElementSize);
         }
 
@@ -23,6 +44,8 @@ namespace NuGetGallery
         public string EmailAddress { get; }
 
         public bool IsAdmin { get; }
+
+        public bool Pending { get; }
 
         public string GravatarUrl { get; }
     }

--- a/src/NuGetGallery/Views/Organizations/HandleOrganizationMembershipRequest.cshtml
+++ b/src/NuGetGallery/Views/Organizations/HandleOrganizationMembershipRequest.cshtml
@@ -1,0 +1,74 @@
+﻿@model HandleOrganizationMembershipRequestModel
+@{
+    ViewBag.Title = "Manage Organization";
+    Layout = "~/Views/Shared/Gallery/Layout.cshtml";
+}
+
+<section role="main" class="container main-container page-manage-owners">
+    <div class="col-xs-12">
+        <h1 class="text-center">
+            @if (Model.Confirm)
+            {
+                if (Model.Successful)
+                {
+                    @:Membership Confirmed
+                }
+                else
+                {
+                    @:Membership Confirmation Failed
+                }
+            }
+            else
+            {
+                if (Model.Successful)
+                {
+                    @:Membership Rejected
+                }
+                else
+                {
+                    @:Membership Rejection Failed
+                }
+            }
+        </h1>
+    </div>
+    <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
+        @if (Model.Confirm)
+        {
+            if (Model.Successful)
+            {
+                <p class="text-center">
+                    You are now a member of the
+                    '<strong><a href="@Url.User(@Model.OrganizationName)" title="The @Model.OrganizationName organization">@Model.OrganizationName</a></strong>' organization!
+                </p>
+            }
+            else
+            {
+                <p class="text-center">
+                    We were not able to add you as a member of the @(Model.OrganizationName).
+                </p>
+                <p class="text-center">
+                    @Model.FailureReason
+                </p>
+            }
+        }
+        else
+        {
+            if (Model.Successful)
+            {
+                <p class="text-center">
+                    You have successfully rejected your membership request for the
+                    '<strong><a href="@Url.User(@Model.OrganizationName)" title="The @Model.OrganizationName organization">@Model.OrganizationName</a></strong>' organization!
+                </p>
+            }
+            else
+            {
+                <p class="text-center">
+                    We were not able to reject your membership request for the @(Model.OrganizationName).
+                </p>
+                <p class="text-center">
+                    @Model.FailureReason
+                </p>
+            }
+        }
+    </div>
+</section>

--- a/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
+++ b/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
@@ -50,6 +50,7 @@
                 GravatarUrl = m.GravatarUrl
             }),
             AddMemberUrl = Url.AddOrganizationMember(Model.AccountName),
+            CancelMemberRequestUrl = Url.CancelOrganizationMembershipRequest(Model.AccountName),
             UpdateMemberUrl = Url.UpdateOrganizationMember(Model.AccountName),
             DeleteMemberUrl = Url.DeleteOrganizationMember(Model.AccountName),
             ProfileUrlTemplate = Url.UserTemplate().LinkTemplate

--- a/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
+++ b/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
@@ -47,6 +47,7 @@
                 EmailAddress = m.EmailAddress,
                 IsAdmin = m.IsAdmin,
                 IsCurrentUser = m.Username.Equals(CurrentUser.Username, StringComparison.OrdinalIgnoreCase),
+                Pending = m.Pending,
                 GravatarUrl = m.GravatarUrl
             }),
             AddMemberUrl = Url.AddOrganizationMember(Model.AccountName),

--- a/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
+++ b/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
@@ -55,6 +55,9 @@
                             <!-- ko if: IsCurrentUser -->
                             <i>(that's you)</i>
                             <!-- /ko -->
+                            <!-- ko if: Pending -->
+                            <i>(pending)</i>
+                            <!-- /ko -->
                             <div data-bind="text: EmailAddress"></div>
                         </td>
                         <td class="align-middle member-username">

--- a/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
@@ -105,9 +105,10 @@ namespace NuGetGallery.Controllers
                 new ControllerActionRuleException(typeof(AccountsController<,>), nameof(UsersController.Confirm)),
                 new ControllerActionRuleException(typeof(AccountsController<,>), nameof(UsersController.ConfirmationRequired)),
                 new ControllerActionRuleException(typeof(AccountsController<,>), nameof(UsersController.ConfirmationRequiredPost)),
+                new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.Thanks)),
                 new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.TransformToOrganization)),
                 new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.ConfirmTransformToOrganization)),
-                new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.Thanks)),
+                new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.RejectTransformToOrganization)),
             };
 
             // Act

--- a/tests/NuGetGallery.Facts/Framework/Fakes.cs
+++ b/tests/NuGetGallery.Facts/Framework/Fakes.cs
@@ -63,7 +63,8 @@ namespace NuGetGallery.Framework
                 Credentials = new List<Credential>
                 {
                     credentialBuilder.CreatePasswordCredential(Password)
-                }
+                },
+                MemberRequests = new List<MembershipRequest>()
             };
             
             CreateOrganizationUsers(ref key, credentialBuilder, "", out var organization, out var organizationAdmin, out var organizationCollaborator);
@@ -269,7 +270,8 @@ namespace NuGetGallery.Framework
                 Credentials = new List<Credential>
                 {
                     credentialBuilder.CreatePasswordCredential(Password)
-                }
+                },
+                MemberRequests = new List<MembershipRequest>()
             };
 
             admin = new User("testOrganizationAdmin" + suffix)

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -1310,6 +1310,417 @@ namespace NuGetGallery
             }
         }
 
+        public class TheSendOrganizationTransformRequestMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = true };
+                var profileUrl = "www.profile.com";
+                var confirmationUrl = "www.confirm.com";
+                var rejectionUrl = "www.rejection.com";
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequest(accountToTransform, adminUser, profileUrl, confirmationUrl, rejectionUrl);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(adminUser.EmailAddress, message.To[0].Address);
+                Assert.Equal(accountToTransform.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.", message.Subject);
+                Assert.Contains($"The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.", message.Body);
+                Assert.Contains($"[{profileUrl}]({profileUrl})", message.Body);
+                Assert.Contains($"[{confirmationUrl}]({confirmationUrl})", message.Body);
+                Assert.Contains($"[{rejectionUrl}]({rejectionUrl})", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = false };
+                var profileUrl = "www.profile.com";
+                var confirmationUrl = "www.confirm.com";
+                var rejectionUrl = "www.rejection.com";
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequest(accountToTransform, adminUser, profileUrl, confirmationUrl, rejectionUrl);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationTransformRequestAcceptedNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = true };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestAcceptedNotice(accountToTransform, adminUser);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(accountToTransform.EmailAddress, message.To[0].Address);
+                Assert.Equal(adminUser.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.", message.Subject);
+                Assert.Contains($"The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = false };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestAcceptedNotice(accountToTransform, adminUser);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationTransformRequestRejectedNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = true };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestRejectedNotice(accountToTransform, adminUser);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(accountToTransform.EmailAddress, message.To[0].Address);
+                Assert.Equal(adminUser.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.", message.Subject);
+                Assert.Contains($"The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = false };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestRejectedNotice(accountToTransform, adminUser);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationTransformRequestCancelledNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = true };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestCancelledNotice(accountToTransform, adminUser);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(adminUser.EmailAddress, message.To[0].Address);
+                Assert.Equal(accountToTransform.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.", message.Subject);
+                Assert.Contains($"The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = false };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestCancelledNotice(accountToTransform, adminUser);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationMembershipRequestMethod
+            : TestContainer
+        {
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void WillSendEmailIfEmailAllowed(bool isAdmin)
+            {
+                // Arrange
+                var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com" };
+                var adminUser = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var newUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = true };
+                var profileUrl = "www.profile.com";
+                var confirmationUrl = "www.confirm.com";
+                var rejectionUrl = "www.rejection.com";
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMembershipRequest(organization, newUser, adminUser, isAdmin, profileUrl, confirmationUrl, rejectionUrl);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(newUser.EmailAddress, message.To[0].Address);
+                Assert.Equal(organization.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(adminUser.EmailAddress, message.ReplyToList[1].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                var membershipLevel = isAdmin ? "an admin" : "a collaborator";
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{adminUser.Username}' would like you to become {membershipLevel} of their organization, '{organization.Username}'.", message.Subject);
+                Assert.Contains($"The user '{adminUser.Username}' would like you to become {membershipLevel} of their organization, '{organization.Username}'.", message.Body);
+                Assert.Contains($"[{profileUrl}]({profileUrl})", message.Body);
+                Assert.Contains($"[{confirmationUrl}]({confirmationUrl})", message.Body);
+                Assert.Contains($"[{rejectionUrl}]({rejectionUrl})", message.Body);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void WillNotSendEmailIfEmailNotAllowed(bool isAdmin)
+            {
+                // Arrange
+                var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com" };
+                var adminUser = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var newUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = false };
+                var profileUrl = "www.profile.com";
+                var confirmationUrl = "www.confirm.com";
+                var rejectionUrl = "www.rejection.com";
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMembershipRequest(organization, newUser, adminUser, isAdmin, profileUrl, confirmationUrl, rejectionUrl);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationMembershipRequestRejectedNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = true };
+                var pendingUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMembershipRequestRejectedNotice(organization, pendingUser);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(organization.EmailAddress, message.To[0].Address);
+                Assert.Equal(pendingUser.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{pendingUser.Username}' has rejected your request for them to become a member of your organization.", message.Subject);
+                Assert.Contains($"The user '{pendingUser.Username}' has rejected your request for them to become a member of your organization.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = false };
+                var pendingUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMembershipRequestRejectedNotice(organization, pendingUser);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationMembershipRequestCancelledNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com" };
+                var pendingUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = true };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMembershipRequestCancelledNotice(organization, pendingUser);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(pendingUser.EmailAddress, message.To[0].Address);
+                Assert.Equal(organization.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The request for you to become a member of '{organization.Username}' has been cancelled.", message.Subject);
+                Assert.Contains($"The request for you to become a member of '{organization.Username}' has been cancelled.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new Organization("transformers") { EmailAddress = "transformers@transformers.com" };
+                var pendingUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = false };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMembershipRequestCancelledNotice(accountToTransform, pendingUser);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationMemberUpdatedNoticeMethod
+            : TestContainer
+        {
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void WillSendEmailIfEmailAllowed(bool isAdmin)
+            {
+                // Arrange
+                var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = true };
+                var member = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+                var membership = new Membership { Organization = organization, Member = member, IsAdmin = isAdmin };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMemberUpdatedNotice(organization, membership);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(organization.EmailAddress, message.To[0].Address);
+                Assert.Equal(member.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                var membershipLevel = isAdmin ? "an admin" : "a collaborator";
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{member.Username}' is now {membershipLevel} of organization '{organization.Username}'.", message.Subject);
+                Assert.Contains($"The user '{member.Username}' is now {membershipLevel} of organization '{organization.Username}'.", message.Body);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void WillNotSendEmailIfEmailNotAllowed(bool isAdmin)
+            {
+                // Arrange
+                var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = false };
+                var member = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+                var membership = new Membership { Organization = organization, Member = member, IsAdmin = isAdmin };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMemberUpdatedNotice(organization, membership);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationMemberRemovedNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = true };
+                var removedUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMemberRemovedNotice(organization, removedUser);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(organization.EmailAddress, message.To[0].Address);
+                Assert.Equal(removedUser.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{removedUser.Username}' is no longer a member of organization '{organization.Username}'.", message.Subject);
+                Assert.Contains($"The user '{removedUser.Username}' is no longer a member of organization '{organization.Username}'.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = false };
+                var member = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationMemberRemovedNotice(organization, member);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
         public class TestableMessageService 
             : MessageService
         {


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5263

This PR adds email notifications for
1 - Asking a user to become the admin of your transformed account
2 - Rejecting a request to become the admin of a transformed account
3 - Cancelling a request for a user to become the admin of your transformed account
4 - Asking a user to join your organization
5 - Accepting a request to join an organization
6 - Rejecting a request to join an organization
7 - Cancelling a request for a user to join your organization
8 - Removing a member from your organization
9 - Updating a member of your organization (changing admin to collaborator and vice-versa)

As a result, like packages, users are no longer automatically added to organizations when an admin adds them--they must accept the request. The UI has been updated to support this, and shows "(pending)" for users that are pending.

NOTE: more than half of this PR is unit tests