### PR TITLE
USSC gallery api/status should use secondary storage.

### DIFF
--- a/src/NuGetGallery.Core/Infrastructure/AzureEntityList.cs
+++ b/src/NuGetGallery.Core/Infrastructure/AzureEntityList.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using System.Web;
 using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using Microsoft.WindowsAzure.Storage.Table;
 
 namespace NuGetGallery.Infrastructure
@@ -23,9 +24,13 @@ namespace NuGetGallery.Infrastructure
 
         private CloudTable _tableRef;
 
-        public AzureEntityList(string connStr, string tableName)
+        public AzureEntityList(string connStr, string tableName, bool readAccessGeoRedundant)
         {
             var tableClient = CloudStorageAccount.Parse(connStr).CreateCloudTableClient();
+            if (readAccessGeoRedundant)
+            {
+                tableClient.DefaultRequestOptions.LocationMode = LocationMode.PrimaryThenSecondary;
+            }
             _tableRef = tableClient.GetTableReference(tableName);
 
             // Create the actual Azure Table, if it doesn't yet exist.

--- a/src/NuGetGallery.Core/Infrastructure/TableErrorLog.cs
+++ b/src/NuGetGallery.Core/Infrastructure/TableErrorLog.cs
@@ -144,10 +144,10 @@ namespace NuGetGallery.Infrastructure
             private readonly string _connectionString;
             private readonly AzureEntityList<ErrorEntity> _entityList;
 
-            public TableErrorLog(string connectionString)
+            public TableErrorLog(string connectionString, bool readAccessGeoRedundant)
             {
                 _connectionString = connectionString;
-                _entityList = new AzureEntityList<ErrorEntity>(connectionString, TableName);
+                _entityList = new AzureEntityList<ErrorEntity>(connectionString, TableName, readAccessGeoRedundant);
             }
 
             public override ErrorLogEntry GetError(string id)

--- a/src/NuGetGallery.Core/Services/CloudBlobContainerWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobContainerWrapper.cs
@@ -35,7 +35,12 @@ namespace NuGetGallery
 
         public Task<bool> ExistsAsync()
         {
-            return _blobContainer.ExistsAsync();
+            var o = new BlobRequestOptions()
+            {
+                LocationMode = Microsoft.WindowsAzure.Storage.RetryPolicies.LocationMode.SecondaryOnly
+            };
+
+            return _blobContainer.ExistsAsync(o, null);
         }
     }
 }

--- a/src/NuGetGallery.Core/Services/CloudBlobContainerWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobContainerWrapper.cs
@@ -35,12 +35,7 @@ namespace NuGetGallery
 
         public Task<bool> ExistsAsync()
         {
-            var o = new BlobRequestOptions()
-            {
-                LocationMode = Microsoft.WindowsAzure.Storage.RetryPolicies.LocationMode.SecondaryOnly
-            };
-
-            return _blobContainer.ExistsAsync(o, null);
+            return _blobContainer.ExistsAsync();
         }
     }
 }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -605,7 +605,7 @@ namespace NuGetGallery
                 .As<IStatisticsService>()
                 .SingleInstance();
 
-            builder.RegisterInstance(new TableErrorLog(configuration.Current.AzureStorage_Errors_ConnectionString))
+            builder.RegisterInstance(new TableErrorLog(configuration.Current.AzureStorage_Errors_ConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant))
                 .As<ErrorLog>()
                 .SingleInstance();
         }
@@ -624,7 +624,7 @@ namespace NuGetGallery
 
             var localIp = AuditActor.GetLocalIpAddressAsync().Result;
 
-            var service = new CloudAuditingService(instanceId, localIp, configuration.Current.AzureStorage_Auditing_ConnectionString, AuditActor.GetAspNetOnBehalfOfAsync);
+            var service = new CloudAuditingService(instanceId, localIp, configuration.Current.AzureStorage_Auditing_ConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant, AuditActor.GetAspNetOnBehalfOfAsync);
 
             builder.RegisterInstance(service)
                 .As<ICloudStorageStatusDependency>()


### PR DESCRIPTION
Configure the Azure services to use secondary storage if the primary is not available. For a set of resources this setting was already in place but not for all. One sample is audit storage (that is used for api/stats) .