### PR TITLE
Cache admins and collaborators for permissions

### DIFF
--- a/src/NuGetGallery/Helpers/PermissionsHelpers.cs
+++ b/src/NuGetGallery/Helpers/PermissionsHelpers.cs
@@ -114,20 +114,19 @@ namespace NuGetGallery
                 return true;
             }
 
-            var matchingMembers = entityOwners
-                .OfType<Organization>()
-                .SelectMany(o => o.Members)
-                .Where(m => isUserMatch(m.Member))
-                .ToList();
+            var entityOrganizationOwners = entityOwners
+                .OfType<Organization>();
 
+            // use cached Administrators collection to avoid querying members directly
             if (WouldSatisfy(PermissionsRequirement.OrganizationAdmin, permissionsRequirement) &&
-                matchingMembers.Any(m => m.IsAdmin))
+                entityOrganizationOwners.Any(o => o.Administrators.Any(m => isUserMatch(m))))
             {
                 return true;
             }
 
+            // use cached Collaborators collection to avoid querying members directly
             if (WouldSatisfy(PermissionsRequirement.OrganizationCollaborator, permissionsRequirement) &&
-                matchingMembers.Any(m => !m.IsAdmin))
+                entityOrganizationOwners.Any(o => o.Collaborators.Any(m => isUserMatch(m))))
             {
                 return true;
             }

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -134,7 +134,7 @@ namespace NuGetGallery
             }
 
             // block removal of last admin
-            if (membership.IsAdmin && organization.Members.Count(m => m.IsAdmin) == 1)
+            if (membership.IsAdmin && organization.Administrators.Count() == 1)
             {
                 throw new EntityException(string.Format(CultureInfo.CurrentCulture,
                     Strings.UpdateOrDeleteMember_CannotRemoveLastAdmin, memberName));

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -109,7 +109,7 @@ namespace NuGetGallery
             if (membership.IsAdmin != isAdmin)
             {
                 // block removal of last admin
-                if (membership.IsAdmin && organization.Members.Count(m => m.IsAdmin) == 1)
+                if (membership.IsAdmin && organization.Administrators.Count() == 1)
                 {
                     throw new EntityException(string.Format(CultureInfo.CurrentCulture,
                         Strings.UpdateOrDeleteMember_CannotRemoveLastAdmin, memberName));


### PR DESCRIPTION
Issue #5461, optimization 2.

Caches and separates admin/collaborators lookups for current user during permissions checks so duplicate checks don't hit the DB.

Originally saw response go from 37.8s -> 35.1s, but now seeing it go from 59.1s -> 42.5s