### PR TITLE
Move CryptographyService to NuGetGallery.Core so it can be used in the hash checker

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -13,6 +13,8 @@ namespace NuGetGallery
 
         public const string NuGetPackageFileExtension = ".nupkg";
 
+        public const string Sha512HashAlgorithmId = "SHA512";
+
         public const string PackageContentType = "binary/octet-stream";
         public const string OctetStreamContentType = "application/octet-stream";
         public const string TextContentType = "text/plain";

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -240,6 +240,7 @@
     <Compile Include="Services\CoreMessageService.cs" />
     <Compile Include="Services\CorePackageFileService.cs" />
     <Compile Include="Services\CorePackageService.cs" />
+    <Compile Include="Services\CryptographyService.cs" />
     <Compile Include="Services\ICloudBlobClient.cs" />
     <Compile Include="Services\ICloudBlobContainer.cs" />
     <Compile Include="Services\ICoreMessageService.cs" />

--- a/src/NuGetGallery.Core/Services/CryptographyService.cs
+++ b/src/NuGetGallery.Core/Services/CryptographyService.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
     {
         public static string GenerateHash(
             Stream input,
-            string hashAlgorithmId = Constants.Sha512HashAlgorithmId)
+            string hashAlgorithmId = CoreConstants.Sha512HashAlgorithmId)
         {
             input.Position = 0;
 

--- a/src/NuGetGallery/Constants.cs
+++ b/src/NuGetGallery/Constants.cs
@@ -51,7 +51,6 @@ namespace NuGetGallery
         public const string RelevanceSortOrder = "relevance";
 
         public const string Sha1HashAlgorithmId = "SHA1";
-        public const string Sha512HashAlgorithmId = "SHA512";
         public const string PBKDF2HashAlgorithmId = "PBKDF2";
 
         public const string UploadFileNameTemplate = "{0}{1}";

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -461,7 +461,7 @@ namespace NuGetGallery
 
                         var packageStreamMetadata = new PackageStreamMetadata
                         {
-                            HashAlgorithm = Constants.Sha512HashAlgorithmId,
+                            HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
                             Hash = CryptographyService.GenerateHash(packageStream.AsSeekableStream()),
                             Size = packageStream.Length
                         };

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1561,7 +1561,7 @@ namespace NuGetGallery
 
                 var packageStreamMetadata = new PackageStreamMetadata
                 {
-                    HashAlgorithm = Constants.Sha512HashAlgorithmId,
+                    HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
                     Hash = CryptographyService.GenerateHash(uploadFile.AsSeekableStream()),
                     Size = uploadFile.Length,
                 };

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1864,7 +1864,6 @@
     <Compile Include="Configuration\AppConfiguration.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="App_Start\DefaultDependenciesModule.cs" />
-    <Compile Include="Infrastructure\Authentication\CryptographyService.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="Services\FormsAuthenticationService.cs" />
     <Compile Include="Configuration\IAppConfiguration.cs" />

--- a/src/NuGetGallery/Services/ReflowPackageService.cs
+++ b/src/NuGetGallery/Services/ReflowPackageService.cs
@@ -45,7 +45,7 @@ namespace NuGetGallery
                         // 2) Determine package metadata from binary
                         var packageStreamMetadata = new PackageStreamMetadata
                         {
-                            HashAlgorithm = Constants.Sha512HashAlgorithmId,
+                            HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
                             Hash = CryptographyService.GenerateHash(packageStream.AsSeekableStream()),
                             Size = packageStream.Length,
                         };

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -248,17 +248,17 @@ namespace NuGetGallery
                 var currentUser = new User();
 
                 var packageStream = nugetPackage.Object.GetStream().AsSeekableStream();
-                var expectedHash = CryptographyService.GenerateHash(packageStream, Constants.Sha512HashAlgorithmId);
+                var expectedHash = CryptographyService.GenerateHash(packageStream, CoreConstants.Sha512HashAlgorithmId);
                 var packageStreamMetadata = new PackageStreamMetadata
                 {
                     Hash = expectedHash,
-                    HashAlgorithm = Constants.Sha512HashAlgorithmId,
+                    HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
                     Size = packageStream.Length
                 };
                 var package = await service.CreatePackageAsync(nugetPackage.Object, packageStreamMetadata, currentUser, currentUser, isVerified: false);
 
                 Assert.Equal(expectedHash, package.Hash);
-                Assert.Equal(Constants.Sha512HashAlgorithmId, package.HashAlgorithm);
+                Assert.Equal(CoreConstants.Sha512HashAlgorithmId, package.HashAlgorithm);
             }
 
             [Fact]
@@ -309,11 +309,11 @@ namespace NuGetGallery
                 var currentUser = new User();
 
                 var packageStream = nugetPackage.Object.GetStream().AsSeekableStream();
-                var packageHash = CryptographyService.GenerateHash(packageStream, Constants.Sha512HashAlgorithmId);
+                var packageHash = CryptographyService.GenerateHash(packageStream, CoreConstants.Sha512HashAlgorithmId);
                 var packageStreamMetadata = new PackageStreamMetadata
                 {
                     Hash = packageHash,
-                    HashAlgorithm = Constants.Sha512HashAlgorithmId,
+                    HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
                     Size = 618
                 };
                 var package = await service.CreatePackageAsync(nugetPackage.Object, packageStreamMetadata, currentUser, currentUser, isVerified: false);


### PR DESCRIPTION
Per feedback from @cristinamanum.

Progress on https://github.com/NuGet/Engineering/issues/1168