### PR TITLE
Error message for removal of last org admin

### DIFF
--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -111,8 +111,7 @@ namespace NuGetGallery
                 // block removal of last admin
                 if (membership.IsAdmin && organization.Administrators.Count() == 1)
                 {
-                    throw new EntityException(string.Format(CultureInfo.CurrentCulture,
-                        Strings.UpdateMember_CannotRemoveLastAdmin, memberName));
+                    throw new EntityException(Strings.UpdateMember_CannotRemoveLastAdmin);
                 }
 
                 membership.IsAdmin = isAdmin;
@@ -136,8 +135,7 @@ namespace NuGetGallery
             // block removal of last admin
             if (membership.IsAdmin && organization.Administrators.Count() == 1)
             {
-                throw new EntityException(string.Format(CultureInfo.CurrentCulture,
-                    Strings.DeleteMember_CannotRemoveLastAdmin, memberName));
+                throw new EntityException(Strings.DeleteMember_CannotRemoveLastAdmin);
             }
 
             organization.Members.Remove(membership);

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -112,7 +112,7 @@ namespace NuGetGallery
                 if (membership.IsAdmin && organization.Administrators.Count() == 1)
                 {
                     throw new EntityException(string.Format(CultureInfo.CurrentCulture,
-                        Strings.UpdateOrDeleteMember_CannotRemoveLastAdmin, memberName));
+                        Strings.UpdateMember_CannotRemoveLastAdmin, memberName));
                 }
 
                 membership.IsAdmin = isAdmin;
@@ -137,7 +137,7 @@ namespace NuGetGallery
             if (membership.IsAdmin && organization.Administrators.Count() == 1)
             {
                 throw new EntityException(string.Format(CultureInfo.CurrentCulture,
-                    Strings.UpdateOrDeleteMember_CannotRemoveLastAdmin, memberName));
+                    Strings.DeleteMember_CannotRemoveLastAdmin, memberName));
             }
 
             organization.Members.Remove(membership);

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -623,6 +623,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You can&apos;t leave the organization. In order to leave the organization, another collaborator must be assigned as an administrator..
+        /// </summary>
+        public static string DeleteMember_CannotRemoveLastAdmin {
+            get {
+                return ResourceManager.GetString("DeleteMember_CannotRemoveLastAdmin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Organization member was deleted..
         /// </summary>
         public static string DeleteMember_Success {
@@ -1701,11 +1710,11 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Organization member &apos;{0}&apos; is the last admin and cannot be changed..
+        ///   Looks up a localized string similar to You can&apos;t change your role to collaborator. In order to change, another collaborator must be assigned as an administrator..
         /// </summary>
-        public static string UpdateOrDeleteMember_CannotRemoveLastAdmin {
+        public static string UpdateMember_CannotRemoveLastAdmin {
             get {
-                return ResourceManager.GetString("UpdateOrDeleteMember_CannotRemoveLastAdmin", resourceCulture);
+                return ResourceManager.GetString("UpdateMember_CannotRemoveLastAdmin", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -786,8 +786,8 @@ If you wish to update the linked Microsoft account you can do so from the accoun
   <data name="DeleteMember_CannotDeleteLastAdmin" xml:space="preserve">
     <value>Organization member '{0}' is the last admin and cannot be deleted.</value>
   </data>
-  <data name="UpdateOrDeleteMember_CannotRemoveLastAdmin" xml:space="preserve">
-    <value>Organization member '{0}' is the last admin and cannot be changed.</value>
+  <data name="UpdateMember_CannotRemoveLastAdmin" xml:space="preserve">
+    <value>You can't change your role to collaborator. In order to change, another collaborator must be assigned as an administrator.</value>
   </data>
   <data name="UpdateOrDeleteMember_MemberNotFound" xml:space="preserve">
     <value>Organization member '{0}' was not found.</value>
@@ -815,5 +815,8 @@ If you wish to update the linked Microsoft account you can do so from the accoun
   </data>
   <data name="TransformAccount_AdminAccountDoesNotHaveTenant" xml:space="preserve">
     <value>Administrator account '{0}' is not linked to an AAD credential with an organization tenant.</value>
+  </data>
+  <data name="DeleteMember_CannotRemoveLastAdmin" xml:space="preserve">
+    <value>You can't leave the organization. In order to leave the organization, another collaborator must be assigned as an administrator.</value>
   </data>
 </root>

--- a/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
@@ -146,12 +146,16 @@ namespace NuGetGallery
                 var service = new TestableUserService();
 
                 // Act & Assert
-                await Assert.ThrowsAsync<EntityException>(async () =>
+                var exception = await Assert.ThrowsAsync<EntityException>(async () =>
                 {
                     await service.DeleteMemberAsync(fakes.Organization, fakes.OrganizationAdmin.Username);
                 });
 
                 service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
+
+                Assert.Equal(
+                    Strings.DeleteMember_CannotRemoveLastAdmin,
+                    exception.Message);
             }
 
             [Fact]
@@ -227,12 +231,15 @@ namespace NuGetGallery
                 var service = new TestableUserService();
 
                 // Act & Assert
-                await Assert.ThrowsAsync<EntityException>(async () =>
+                var exception = await Assert.ThrowsAsync<EntityException>(async () =>
                 {
                     await service.UpdateMemberAsync(fakes.Organization, fakes.OrganizationAdmin.Username, false);
                 });
 
                 service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
+                Assert.Equal(
+                    Strings.UpdateMember_CannotRemoveLastAdmin,
+                    exception.Message);
             }
 
             [Fact]


### PR DESCRIPTION
Issue #5463, messaging per @anangaur 

Scenario is current user (org admin) as only admin deleting their membership or changing self to collaborator... which we block.