### PR TITLE
[BugBash] Fix login discontinuation modal sizing on small windows

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -294,7 +294,6 @@ img.reserved-indicator-icon {
 }
 .modal-container .modal-box {
   padding: 0;
-  margin-left: 37.5%;
   overflow: hidden;
   background-color: white;
   border-radius: 8px;

--- a/src/Bootstrap/less/theme/modals.less
+++ b/src/Bootstrap/less/theme/modals.less
@@ -14,7 +14,6 @@
     border-radius: 8px; 
     background-color: white; 
     overflow: hidden;
-    margin-left: 37.5%;
     padding: 0px;
 
     .modal-title {

--- a/src/NuGetGallery/Constants.cs
+++ b/src/NuGetGallery/Constants.cs
@@ -17,8 +17,6 @@ namespace NuGetGallery
         public const int ColumnsWideAuthenticationSm = 8;
         public const int ColumnsWideAuthenticationMd = 6;
         public const int ColumnsFormMd = 10;
-        public const int ColumnsModalSm = 3;
-        public const int ColumnsModalMd = 3;
 
         public const int VisibleVersions = 5;
 

--- a/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
+++ b/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
@@ -1,10 +1,4 @@
-﻿@{
-    ViewBag.Title = "TransformOrLinkPage";
-    ViewBag.SmPageColumns = Constants.ColumnsModalSm;
-    ViewBag.MdPageColumns = Constants.ColumnsModalMd;
-}
-
-<div class="@ViewHelpers.GetColumnClasses(ViewBag) modal-box">
+﻿<div class="modal-dialog modal-box">
     <div class="modal-title">
         <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
         <span class="title-text">Sign-in using NuGet.org is discontinued</span>


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5446

We were not using Bootstrap's built in sizing/centering. By using `modal-dialog`, Bootstrap takes care of it for us.

It's now slightly bigger in general (4 columns as opposed to 3) but it works on small screens.

Large/medium sized windows:
![image](https://user-images.githubusercontent.com/18014088/36321282-1ea623ea-12fe-11e8-9bdd-405151c29d4e.png)

Small windows:
![image](https://user-images.githubusercontent.com/18014088/36321309-3b8239c2-12fe-11e8-95c7-817970f4ff85.png)