### PR TITLE
Add telemetry for unlist, list, delete, reflow, and revalidate

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1052,7 +1052,8 @@ namespace NuGetGallery
             var reflowPackageService = new ReflowPackageService(
                 _entitiesContext,
                 (PackageService)_packageService,
-                _packageFileService);
+                _packageFileService,
+                _telemetryService);
 
             try
             {

--- a/src/NuGetGallery/Services/ITelemetryClient.cs
+++ b/src/NuGetGallery/Services/ITelemetryClient.cs
@@ -11,8 +11,6 @@ namespace NuGetGallery
     /// </summary>
     public interface ITelemetryClient
     {
-        void TrackEvent(string eventName, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null);
-
         void TrackMetric(string metricName, double value, IDictionary<string, string> properties = null);
 
         void TrackException(Exception exception, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null);

--- a/src/NuGetGallery/Services/ITelemetryService.cs
+++ b/src/NuGetGallery/Services/ITelemetryService.cs
@@ -13,6 +13,18 @@ namespace NuGetGallery
 
         void TrackPackagePushEvent(Package package, User user, IIdentity identity);
 
+        void TrackPackageUnlisted(Package package);
+
+        void TrackPackageListed(Package package);
+
+        void TrackPackageDelete(Package package, bool isHardDelete);
+
+        void TrackPackageReflow(Package package);
+
+        void TrackPackageHardDeleteReflow(string packageId, string packageVersion);
+
+        void TrackPackageRevalidate(Package package);
+
         void TrackPackageReadMeChangeEvent(Package package, string readMeSourceType, PackageEditReadMeState readMeState);
 
         void TrackCreatePackageVerificationKeyEvent(string packageId, string packageVersion, User user, IIdentity identity);

--- a/src/NuGetGallery/Services/TelemetryClientWrapper.cs
+++ b/src/NuGetGallery/Services/TelemetryClientWrapper.cs
@@ -29,18 +29,6 @@ namespace NuGetGallery
 
         internal TelemetryClient UnderlyingClient { get; }
 
-        public void TrackEvent(string eventName, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
-        {
-            try
-            {
-                UnderlyingClient.TrackEvent(eventName, properties, metrics);
-            }
-            catch
-            {
-                // logging failed, don't allow exception to escape
-            }
-        }
-
         public void TrackException(Exception exception, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
         {
             try

--- a/src/NuGetGallery/Services/ValidationService.cs
+++ b/src/NuGetGallery/Services/ValidationService.cs
@@ -16,15 +16,18 @@ namespace NuGetGallery
         private readonly IPackageService _packageService;
         private readonly IPackageValidationInitiator _initiator;
         private readonly IEntityRepository<PackageValidationSet> _validationSets;
+        private readonly ITelemetryService _telemetryService;
 
         public ValidationService(
             IPackageService packageService,
             IPackageValidationInitiator initiator,
-            IEntityRepository<PackageValidationSet> validationSets)
+            IEntityRepository<PackageValidationSet> validationSets,
+            ITelemetryService telemetryService)
         {
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
             _initiator = initiator ?? throw new ArgumentNullException(nameof(initiator));
             _validationSets = validationSets ?? throw new ArgumentNullException(nameof(validationSets));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
         }
 
         public async Task StartValidationAsync(Package package)
@@ -40,6 +43,8 @@ namespace NuGetGallery
         public async Task RevalidateAsync(Package package)
         {
             await _initiator.StartValidationAsync(package);
+
+            _telemetryService.TrackPackageRevalidate(package);
         }
 
         public IReadOnlyList<ValidationIssue> GetLatestValidationIssues(Package package)

--- a/tests/NuGetGallery.Facts/Services/ValidationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ValidationServiceFacts.cs
@@ -83,6 +83,16 @@ namespace NuGetGallery
                 /// <see cref="IPackageService"/> to do this.
                 Assert.Equal(PackageStatus.Available, _package.PackageStatusKey);
             }
+
+            [Fact]
+            public async Task EmitsTelemetry()
+            {
+                // Arrange & Act
+                await _target.RevalidateAsync(_package);
+
+                // Assert
+                _telemetryService.Verify(x => x.TrackPackageRevalidate(_package), Times.Once);
+            }
         }
 
         public class TheGetLatestValidationIssuesMethod : FactsBase
@@ -303,6 +313,7 @@ namespace NuGetGallery
             protected readonly Mock<IPackageService> _packageService;
             protected readonly Mock<IPackageValidationInitiator> _initiator;
             protected readonly Mock<IEntityRepository<PackageValidationSet>> _validationSets;
+            protected readonly Mock<ITelemetryService> _telemetryService;
             protected readonly Package _package;
             protected readonly ValidationService _target;
 
@@ -311,13 +322,15 @@ namespace NuGetGallery
                 _packageService = new Mock<IPackageService>();
                 _initiator = new Mock<IPackageValidationInitiator>();
                 _validationSets = new Mock<IEntityRepository<PackageValidationSet>>();
+                _telemetryService = new Mock<ITelemetryService>();
 
                 _package = new Package();
 
                 _target = new ValidationService(
                     _packageService.Object,
                     _initiator.Object,
-                    _validationSets.Object);
+                    _validationSets.Object,
+                    _telemetryService.Object);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
@@ -287,11 +287,14 @@ namespace NuGetGallery.TestUtils
                     packageRepository.Object);
             var auditingService = new TestAuditingService();
 
+            var telemetryService = new Mock<ITelemetryService>();
+
             var packageService = new Mock<PackageService>(
                 packageRegistrationRepository.Object,
                 packageRepository.Object,
                 packageNamingConflictValidator,
-                auditingService);
+                auditingService,
+                telemetryService.Object);
 
             packageService.CallBase = true;
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/5378.

I chose not to pass down `User` and `IIdentity` for now. I wanted to emit telemetry from the service layer and not the controller layer so that we would not need to duplicate emits in `ApiController` vs. `PackagesController` and we would not emit telemetry when the service call no-ops (e.g. unlisting an already unlisted package).