### PR TITLE
[Organizations] Transform User to Organization Notifications

### DIFF
--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -135,6 +135,7 @@ namespace NuGetGallery
                 return View(transformViewModel);
             }
 
+            // Get the user from the previous organization migration request (if there was one) so we can notify them that their request has been cancelled.
             var existingTransformRequestUser = accountToTransform.OrganizationMigrationRequest?.AdminUser;
 
             await UserService.RequestTransformToOrganizationAccount(accountToTransform, adminUser);

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -221,7 +221,7 @@ namespace NuGetGallery
                 }
                 else
                 {
-                    message = Strings.TransformAccount_FailedMissingRequestToReject;
+                    message = Strings.TransformAccount_FailedMissingRequestToCancel;
                 }
             }
 

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -128,23 +128,35 @@ namespace NuGetGallery
                     Strings.TransformAccount_AdminAccountDoesNotExist, transformViewModel.AdminUsername));
                 return View(transformViewModel);
             }
-            
+
             if (!UserService.CanTransformUserToOrganization(accountToTransform, adminUser, out var errorReason))
             {
                 ModelState.AddModelError(string.Empty, errorReason);
                 return View(transformViewModel);
             }
 
+            var existingTransformRequestUser = accountToTransform.OrganizationMigrationRequest?.AdminUser;
+
             await UserService.RequestTransformToOrganizationAccount(accountToTransform, adminUser);
+
+            if (existingTransformRequestUser != null)
+            {
+                MessageService.SendOrganizationTransformRequestCancelledNotice(accountToTransform, existingTransformRequestUser);
+            }
+
+            var returnUrl = Url.ConfirmTransformAccount(accountToTransform);
+            var confirmUrl = Url.ConfirmTransformAccount(accountToTransform, relativeUrl: false);
+            var rejectUrl = Url.RejectTransformAccount(accountToTransform, relativeUrl: false);
+            MessageService.SendOrganizationTransformRequest(accountToTransform, adminUser, Url.User(accountToTransform, relativeUrl: false), confirmUrl, rejectUrl);
 
             // sign out pending organization and prompt for admin sign in
             OwinContext.Authentication.SignOut();
 
             TempData[Constants.ReturnUrlMessageViewDataKey] = String.Format(CultureInfo.CurrentCulture,
                 Strings.TransformAccount_SignInToConfirm, adminUser.Username, accountToTransform.Username);
-            var returnUrl = Url.ConfirmTransformAccount(accountToTransform);
             return Redirect(Url.LogOn(returnUrl));
         }
+
 
         [HttpGet]
         [UIAuthorize(allowDiscontinuedLogins: true)]
@@ -173,10 +185,46 @@ namespace NuGetGallery
                 return TransformToOrganizationFailed(errorReason);
             }
 
+            MessageService.SendOrganizationTransformRequestAcceptedNotice(accountToTransform, adminUser);
+
             TempData["Message"] = String.Format(CultureInfo.CurrentCulture,
                 Strings.TransformAccount_Success, accountNameToTransform);
 
             return Redirect(Url.ManageMyOrganization(accountNameToTransform));
+        }
+
+        [HttpGet]
+        [UIAuthorize(allowDiscontinuedLogins: true)]
+        [ActionName("RejectTransform")]
+        public virtual async Task<ActionResult> RejectTransformToOrganization(string accountNameToTransform, string token)
+        {
+            var adminUser = GetCurrentUser();
+
+            string message;
+            var accountToTransform = UserService.FindByUsername(accountNameToTransform);
+            if (accountToTransform == null)
+            {
+                message = String.Format(CultureInfo.CurrentCulture,
+                    Strings.TransformAccount_OrganizationAccountDoesNotExist, accountNameToTransform);
+            }
+            else
+            {
+                if (await UserService.RejectTransformUserToOrganizationRequest(accountToTransform, adminUser, token))
+                {
+                    MessageService.SendOrganizationTransformRequestRejectedNotice(accountToTransform, adminUser);
+
+                    message = String.Format(CultureInfo.CurrentCulture,
+                        Strings.TransformAccount_Rejected, accountNameToTransform);
+                }
+                else
+                {
+                    message = Strings.TransformAccount_FailedMissingRequestToReject;
+                }
+            }
+
+            TempData["Message"] = message;
+
+            return RedirectToAction(actionName: "Home", controllerName: "Pages");
         }
 
         private ActionResult TransformToOrganizationFailed(string errorMessage)

--- a/src/NuGetGallery/RouteName.cs
+++ b/src/NuGetGallery/RouteName.cs
@@ -10,7 +10,7 @@ namespace NuGetGallery
         public const string AddOrganization = "AddOrganization";
         public const string ChangeOrganizationEmailSubscription = "ChangeOrganizationEmailSubscription";
         public const string TransformToOrganization = "TransformToOrganization";
-        public const string TransformToOrganizationConfirmation = "ConfirmTransformToOrganization";
+        public const string TransformToOrganizationConfirmation = "ConfirmTransform";
         public const string ApiKeys = "ApiKeys";
         public const string Profile = "Profile";
         public const string DisplayPackage = "package-route";

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -29,5 +29,9 @@ namespace NuGetGallery
         void SendAccountDeleteNotice(MailAddress mailAddress, string userName);
         void SendPackageDeletedNotice(Package package, string packageUrl, string packageSupportUrl);
         void SendSigninAssistanceEmail(MailAddress emailAddress, IEnumerable<Credential> credentials);
+        void SendOrganizationTransformRequest(User accountToTransform, User adminUser, string profileUrl, string confirmationUrl, string rejectionUrl);
+        void SendOrganizationTransformRequestAcceptedNotice(User accountToTransform, User adminUser);
+        void SendOrganizationTransformRequestRejectedNotice(User accountToTransform, User adminUser);
+        void SendOrganizationTransformRequestCancelledNotice(User accountToTransform, User adminUser);
     }
 }

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -30,6 +30,7 @@ namespace NuGetGallery
         void SendPackageDeletedNotice(Package package, string packageUrl, string packageSupportUrl);
         void SendSigninAssistanceEmail(MailAddress emailAddress, IEnumerable<Credential> credentials);
         void SendOrganizationTransformRequest(User accountToTransform, User adminUser, string profileUrl, string confirmationUrl, string rejectionUrl);
+        void SendOrganizationTransformInitiatedNotice(User accountToTransform, User adminUser, string cancellationUrl);
         void SendOrganizationTransformRequestAcceptedNotice(User accountToTransform, User adminUser);
         void SendOrganizationTransformRequestRejectedNotice(User accountToTransform, User adminUser);
         void SendOrganizationTransformRequestCancelledNotice(User accountToTransform, User adminUser);

--- a/src/NuGetGallery/Services/IUserService.cs
+++ b/src/NuGetGallery/Services/IUserService.cs
@@ -42,6 +42,8 @@ namespace NuGetGallery
         
         Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token);
 
+        Task<bool> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token);
+        
         Task<Organization> AddOrganizationAsync(string username, string emailAddress, User adminUser);
     }
 }

--- a/src/NuGetGallery/Services/IUserService.cs
+++ b/src/NuGetGallery/Services/IUserService.cs
@@ -43,7 +43,9 @@ namespace NuGetGallery
         Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token);
 
         Task<bool> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token);
-        
+
+        Task<bool> CancelTransformUserToOrganizationRequest(User accountToTransform, string token);
+
         Task<Organization> AddOrganizationAsync(string username, string emailAddress, User adminUser);
     }
 }

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -724,6 +724,120 @@ The {0} Team";
             }
         }
 
+        public void SendOrganizationTransformRequest(User accountToTransform, User adminUser, string profileUrl, string confirmationUrl, string rejectionUrl)
+        {
+            if (!adminUser.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.
+
+User profile on NuGet.org: [{profileUrl}]({profileUrl})
+
+To accept this request and become an admin of '{accountToTransform.Username}' and gain the ability to manage the account's packages, click the following URL:
+
+[{confirmationUrl}]({confirmationUrl})
+
+If you do not want to become an admin of '{accountToTransform.Username}', click the following URL:
+
+[{rejectionUrl}]({rejectionUrl})
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(accountToTransform.ToMailAddress());
+
+                mailMessage.To.Add(adminUser.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationTransformRequestAcceptedNotice(User accountToTransform, User adminUser)
+        {
+            if (!accountToTransform.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(adminUser.ToMailAddress());
+
+                mailMessage.To.Add(accountToTransform.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationTransformRequestRejectedNotice(User accountToTransform, User adminUser)
+        {
+            if (!accountToTransform.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(adminUser.ToMailAddress());
+
+                mailMessage.To.Add(accountToTransform.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
+        public void SendOrganizationTransformRequestCancelledNotice(User accountToTransform, User adminUser)
+        {
+            if (!adminUser.EmailAllowed)
+            {
+                return;
+            }
+
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.";
+
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.
+
+Thanks,
+The {Config.GalleryOwner.DisplayName} Team");
+
+            using (var mailMessage = new MailMessage())
+            {
+                mailMessage.Subject = subject;
+                mailMessage.Body = body;
+                mailMessage.From = Config.GalleryNoReplyAddress;
+                mailMessage.ReplyToList.Add(accountToTransform.ToMailAddress());
+
+                mailMessage.To.Add(adminUser.ToMailAddress());
+                SendMessage(mailMessage);
+            }
+        }
+
         protected override void SendMessage(MailMessage mailMessage, bool copySender)
         {
             try

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -767,9 +767,9 @@ The {Config.GalleryOwner.DisplayName} Team");
                 return;
             }
 
-            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.";
+            string subject = $"[{Config.GalleryOwner.DisplayName}] The user '{adminUser.Username}' has accepted your request and your account, '{accountToTransform.Username}' has now been transformed into an organization.";
 
-            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{adminUser.Username}' has accepted your request and your account, '{accountToTransform.Username}' has now been transformed into an organization.
 
 Thanks,
 The {Config.GalleryOwner.DisplayName} Team");

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -479,5 +479,26 @@ namespace NuGetGallery
 
             return true;
         }
+
+        public async Task<bool> CancelTransformUserToOrganizationRequest(User accountToTransform, string token)
+        {
+            var transformRequest = accountToTransform.OrganizationMigrationRequest;
+
+            if (transformRequest == null)
+            {
+                return false;
+            }
+
+            if (transformRequest.ConfirmationToken != token)
+            {
+                return false;
+            }
+
+            accountToTransform.OrganizationMigrationRequest = null;
+
+            await UserRepository.CommitChangesAsync();
+
+            return true;
+        }
     }
 }

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -453,5 +453,31 @@ namespace NuGetGallery
         {
             return user.Credentials.GetAzureActiveDirectoryCredential()?.TenantId;
         }
+
+        public async Task<bool> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token)
+        {
+            var transformRequest = accountToTransform.OrganizationMigrationRequest;
+
+            if (transformRequest == null)
+            {
+                return false;
+            }
+
+            if (transformRequest.AdminUser == null || !transformRequest.AdminUser.MatchesUser(adminUser))
+            {
+                return false;
+            }
+
+            if (transformRequest.ConfirmationToken != token)
+            {
+                return false;
+            }
+
+            accountToTransform.OrganizationMigrationRequest = null;
+
+            await UserRepository.CommitChangesAsync();
+
+            return true;
+        }
     }
 }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1634,11 +1634,29 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The transform request you are attempting to reject was not found..
+        /// </summary>
+        public static string TransformAccount_FailedMissingRequestToReject {
+            get {
+                return ResourceManager.GetString("TransformAccount_FailedMissingRequestToReject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Organization account &apos;{0}&apos; does not exist..
         /// </summary>
         public static string TransformAccount_OrganizationAccountDoesNotExist {
             get {
                 return ResourceManager.GetString("TransformAccount_OrganizationAccountDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The transform request for you to become an admin of &apos;{0}&apos; has been successfully rejected..
+        /// </summary>
+        public static string TransformAccount_Rejected {
+            get {
+                return ResourceManager.GetString("TransformAccount_Rejected", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1652,15 +1652,6 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The transform request you are attempting to reject was not found..
-        /// </summary>
-        public static string TransformAccount_FailedMissingRequestToReject {
-            get {
-                return ResourceManager.GetString("TransformAccount_FailedMissingRequestToReject", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Organization account &apos;{0}&apos; does not exist..
         /// </summary>
         public static string TransformAccount_OrganizationAccountDoesNotExist {
@@ -1670,7 +1661,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The transform request for you to become an admin of &apos;{0}&apos; has been successfully rejected..
+        ///   Looks up a localized string similar to The transform request for you to become an admin of &apos;{0}&apos; has been successfully cancelled..
         /// </summary>
         public static string TransformAccount_Rejected {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1625,11 +1625,29 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The transform request for your account has been successfully cancelled..
+        /// </summary>
+        public static string TransformAccount_Cancelled {
+            get {
+                return ResourceManager.GetString("TransformAccount_Cancelled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An unexpected error occurred while transforming this account. Contact support for assistance..
         /// </summary>
         public static string TransformAccount_Failed {
             get {
                 return ResourceManager.GetString("TransformAccount_Failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The transform request you are attempting to cancel was not found..
+        /// </summary>
+        public static string TransformAccount_FailedMissingRequestToCancel {
+            get {
+                return ResourceManager.GetString("TransformAccount_FailedMissingRequestToCancel", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -806,4 +806,10 @@ If you wish to update the linked Microsoft account you can do so from the accoun
   <data name="SigninAssistance_InvalidUser" xml:space="preserve">
     <value>Please enter a valid username</value>
   </data>
+  <data name="TransformAccount_FailedMissingRequestToReject" xml:space="preserve">
+    <value>The transform request you are attempting to reject was not found.</value>
+  </data>
+  <data name="TransformAccount_Rejected" xml:space="preserve">
+    <value>The transform request for you to become an admin of '{0}' has been successfully rejected.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -812,4 +812,10 @@ If you wish to update the linked Microsoft account you can do so from the accoun
   <data name="TransformAccount_Rejected" xml:space="preserve">
     <value>The transform request for you to become an admin of '{0}' has been successfully rejected.</value>
   </data>
+  <data name="TransformAccount_FailedMissingRequestToCancel" xml:space="preserve">
+    <value>The transform request you are attempting to cancel was not found.</value>
+  </data>
+  <data name="TransformAccount_Cancelled" xml:space="preserve">
+    <value>The transform request for your account has been successfully cancelled.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -806,11 +806,8 @@ If you wish to update the linked Microsoft account you can do so from the accoun
   <data name="SigninAssistance_InvalidUser" xml:space="preserve">
     <value>Please enter a valid username</value>
   </data>
-  <data name="TransformAccount_FailedMissingRequestToReject" xml:space="preserve">
-    <value>The transform request you are attempting to reject was not found.</value>
-  </data>
   <data name="TransformAccount_Rejected" xml:space="preserve">
-    <value>The transform request for you to become an admin of '{0}' has been successfully rejected.</value>
+    <value>The transform request for you to become an admin of '{0}' has been successfully cancelled.</value>
   </data>
   <data name="TransformAccount_FailedMissingRequestToCancel" xml:space="preserve">
     <value>The transform request you are attempting to cancel was not found.</value>

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -1188,6 +1188,19 @@ namespace NuGetGallery
                 });
         }
 
+        public static string CancelTransformAccount(this UrlHelper url, User accountToTransform, bool relativeUrl = true)
+        {
+            return GetActionLink(
+                url,
+                "CancelTransform",
+                "Users",
+                relativeUrl,
+                routeValues: new RouteValueDictionary
+                {
+                    { "token", accountToTransform.OrganizationMigrationRequest.ConfirmationToken }
+                });
+        }
+
         private static UriBuilder GetCanonicalUrl(UrlHelper url)
         {
             var builder = new UriBuilder(url.RequestContext.HttpContext.Request.Url);

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -1166,9 +1166,20 @@ namespace NuGetGallery
 
         public static string ConfirmTransformAccount(this UrlHelper url, User accountToTransform, bool relativeUrl = true)
         {
-            return GetRouteLink(
+            return url.HandleTransformAccount(RouteName.TransformToOrganizationConfirmation, accountToTransform, relativeUrl);
+        }
+
+        public static string RejectTransformAccount(this UrlHelper url, User accountToTransform, bool relativeUrl = true)
+        {
+            return url.HandleTransformAccount("RejectTransform", accountToTransform, relativeUrl);
+        }
+
+        private static string HandleTransformAccount(this UrlHelper url, string routeName, User accountToTransform, bool relativeUrl = true)
+        {
+            return GetActionLink(
                 url,
-                RouteName.TransformToOrganizationConfirmation,
+                routeName,
+                "Users",
                 relativeUrl,
                 routeValues: new RouteValueDictionary
                 {

--- a/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
@@ -105,9 +105,10 @@ namespace NuGetGallery.Controllers
                 new ControllerActionRuleException(typeof(AccountsController<,>), nameof(UsersController.Confirm)),
                 new ControllerActionRuleException(typeof(AccountsController<,>), nameof(UsersController.ConfirmationRequired)),
                 new ControllerActionRuleException(typeof(AccountsController<,>), nameof(UsersController.ConfirmationRequiredPost)),
+                new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.Thanks)),
                 new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.TransformToOrganization)),
                 new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.ConfirmTransformToOrganization)),
-                new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.Thanks)),
+                new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.RejectTransformToOrganization)),
             };
 
             // Act

--- a/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ControllerTests.cs
@@ -109,6 +109,7 @@ namespace NuGetGallery.Controllers
                 new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.TransformToOrganization)),
                 new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.ConfirmTransformToOrganization)),
                 new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.RejectTransformToOrganization)),
+                new ControllerActionRuleException(typeof(UsersController), nameof(UsersController.CancelTransformToOrganization)),
             };
 
             // Act

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -2459,7 +2459,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.NotNull(result);
-                Assert.Equal(Strings.TransformAccount_FailedMissingRequestToReject, controller.TempData["Message"]);
+                Assert.Equal(Strings.TransformAccount_FailedMissingRequestToCancel, controller.TempData["Message"]);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -1381,8 +1381,8 @@ namespace NuGetGallery
                 Assert.Equal(accountToTransform.EmailAddress, message.To[0].Address);
                 Assert.Equal(adminUser.EmailAddress, message.ReplyToList[0].Address);
                 Assert.Equal(TestGalleryNoReplyAddress, message.From);
-                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.", message.Subject);
-                Assert.Contains($"The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.", message.Body);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{adminUser.Username}' has accepted your request and your account, '{accountToTransform.Username}' has now been transformed into an organization.", message.Subject);
+                Assert.Contains($"The user '{adminUser.Username}' has accepted your request and your account, '{accountToTransform.Username}' has now been transformed into an organization.", message.Body);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -1309,6 +1309,182 @@ namespace NuGetGallery
                     $"The package [{packageRegistration.Id} {nugetVersion.ToFullString()}]({packageUrl}) was just deleted from Joe Shmoe. If this was not intended, please [contact support]({supportUrl}).", message.Body);
             }
         }
+        public class TheSendOrganizationTransformRequestMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = true };
+                var profileUrl = "www.profile.com";
+                var confirmationUrl = "www.confirm.com";
+                var rejectionUrl = "www.rejection.com";
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequest(accountToTransform, adminUser, profileUrl, confirmationUrl, rejectionUrl);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(adminUser.EmailAddress, message.To[0].Address);
+                Assert.Equal(accountToTransform.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.", message.Subject);
+                Assert.Contains($"The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.", message.Body);
+                Assert.Contains($"[{profileUrl}]({profileUrl})", message.Body);
+                Assert.Contains($"[{confirmationUrl}]({confirmationUrl})", message.Body);
+                Assert.Contains($"[{rejectionUrl}]({rejectionUrl})", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = false };
+                var profileUrl = "www.profile.com";
+                var confirmationUrl = "www.confirm.com";
+                var rejectionUrl = "www.rejection.com";
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequest(accountToTransform, adminUser, profileUrl, confirmationUrl, rejectionUrl);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationTransformRequestAcceptedNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = true };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestAcceptedNotice(accountToTransform, adminUser);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(accountToTransform.EmailAddress, message.To[0].Address);
+                Assert.Equal(adminUser.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.", message.Subject);
+                Assert.Contains($"The user '{adminUser.Username}' has accepted your request for them to be the admin of your transformed account.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = false };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestAcceptedNotice(accountToTransform, adminUser);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationTransformRequestRejectedNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = true };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestRejectedNotice(accountToTransform, adminUser);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(accountToTransform.EmailAddress, message.To[0].Address);
+                Assert.Equal(adminUser.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.", message.Subject);
+                Assert.Contains($"The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = false };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestRejectedNotice(accountToTransform, adminUser);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationTransformRequestCancelledNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = true };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestCancelledNotice(accountToTransform, adminUser);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(adminUser.EmailAddress, message.To[0].Address);
+                Assert.Equal(accountToTransform.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.", message.Subject);
+                Assert.Contains($"The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com", EmailAllowed = false };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformRequestCancelledNotice(accountToTransform, adminUser);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
 
         public class TestableMessageService 
             : MessageService

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -1333,9 +1333,8 @@ namespace NuGetGallery
                 Assert.Equal(adminUser.EmailAddress, message.To[0].Address);
                 Assert.Equal(accountToTransform.EmailAddress, message.ReplyToList[0].Address);
                 Assert.Equal(TestGalleryNoReplyAddress, message.From);
-                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.", message.Subject);
-                Assert.Contains($"The user '{accountToTransform.Username}' is transforming into an organization and would like you to be its admin.", message.Body);
-                Assert.Contains($"[{profileUrl}]({profileUrl})", message.Body);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] Organization transformation for account '{accountToTransform.Username}'", message.Subject);
+                Assert.Contains($"We have received a request to transform account ['{accountToTransform.Username}']({profileUrl}) into an organization.", message.Body);
                 Assert.Contains($"[{confirmationUrl}]({confirmationUrl})", message.Body);
                 Assert.Contains($"[{rejectionUrl}]({rejectionUrl})", message.Body);
             }
@@ -1354,6 +1353,52 @@ namespace NuGetGallery
 
                 // Act
                 messageService.SendOrganizationTransformRequest(accountToTransform, adminUser, profileUrl, confirmationUrl, rejectionUrl);
+
+                // Assert
+                Assert.Empty(messageService.MockMailSender.Sent);
+            }
+        }
+
+        public class TheSendOrganizationTransformInitiatedNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void WillSendEmailIfEmailAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = true };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+                var cancelUrl = "www.cancel.com";
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformInitiatedNotice(accountToTransform, adminUser, cancelUrl);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(accountToTransform.EmailAddress, message.To[0].Address);
+                Assert.Equal(adminUser.EmailAddress, message.ReplyToList[0].Address);
+                Assert.Equal(TestGalleryOwner, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] Organization transformation for account '{accountToTransform.Username}'", message.Subject);
+                Assert.Contains($"We have received a request to transform account '{accountToTransform.Username}' into an organization with user '{adminUser.Username}' as its admin.", message.Body);
+                Assert.Contains($"[{cancelUrl}]({cancelUrl})", message.Body);
+                Assert.Contains($"If you did not request this change, please contact support by responding to this email.", message.Body);
+            }
+
+            [Fact]
+            public void WillNotSendEmailIfEmailNotAllowed()
+            {
+                // Arrange
+                var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = false };
+                var adminUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
+                var cancelUrl = "www.cancel.com";
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendOrganizationTransformInitiatedNotice(accountToTransform, adminUser, cancelUrl);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1380,9 +1425,9 @@ namespace NuGetGallery
 
                 Assert.Equal(accountToTransform.EmailAddress, message.To[0].Address);
                 Assert.Equal(adminUser.EmailAddress, message.ReplyToList[0].Address);
-                Assert.Equal(TestGalleryNoReplyAddress, message.From);
-                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{adminUser.Username}' has accepted your request and your account, '{accountToTransform.Username}' has now been transformed into an organization.", message.Subject);
-                Assert.Contains($"The user '{adminUser.Username}' has accepted your request and your account, '{accountToTransform.Username}' has now been transformed into an organization.", message.Body);
+                Assert.Equal(TestGalleryOwner, message.From);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] Account '{accountToTransform.Username}' has been transformed into an organization", message.Subject);
+                Assert.Contains($"Account '{accountToTransform.Username}' has been transformed into an organization with user '{adminUser.Username}' as its administrator. If you did not request this change, please contact support by responding to this email.", message.Body);
             }
 
             [Fact]
@@ -1423,8 +1468,8 @@ namespace NuGetGallery
                 Assert.Equal(accountToTransform.EmailAddress, message.To[0].Address);
                 Assert.Equal(adminUser.EmailAddress, message.ReplyToList[0].Address);
                 Assert.Equal(TestGalleryNoReplyAddress, message.From);
-                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.", message.Subject);
-                Assert.Contains($"The user '{adminUser.Username}' has rejected your request for them to be the admin of your transformed account.", message.Body);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] Transformation of account '{accountToTransform.Username}' has been cancelled", message.Subject);
+                Assert.Contains($"Transformation of account '{accountToTransform.Username}' has been cancelled by user '{adminUser.Username}'.", message.Body);
             }
 
             [Fact]
@@ -1465,8 +1510,8 @@ namespace NuGetGallery
                 Assert.Equal(adminUser.EmailAddress, message.To[0].Address);
                 Assert.Equal(accountToTransform.EmailAddress, message.ReplyToList[0].Address);
                 Assert.Equal(TestGalleryNoReplyAddress, message.From);
-                Assert.Equal($"[{TestGalleryOwner.DisplayName}] The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.", message.Subject);
-                Assert.Contains($"The user '{accountToTransform.Username}' has cancelled their request for you to be the admin of their transformed account.", message.Body);
+                Assert.Equal($"[{TestGalleryOwner.DisplayName}] Transformation of account '{accountToTransform.Username}' has been cancelled", message.Subject);
+                Assert.Contains($"Transformation of account '{accountToTransform.Username}' has been cancelled by user '{accountToTransform.Username}'.", message.Body);
             }
 
             [Fact]


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5263

This PR adds email notifications to transforming users into organizations.
1 - Asking a user to become the admin of your transformed account
2 - Accepting a request to become an admin of a transformed account
3 - Rejecting a request to become the admin of a transformed account
4 - Cancelling a request for a user to become the admin of your transformed account

It also adds the ability to reject and cancel organization migration requests, to make it consistent with how the package ownership requests work.

Email text looks like:

1:
![image](https://user-images.githubusercontent.com/18014088/36760105-7875dd42-1bce-11e8-98b2-a47098e0ad03.png)

2:
![image](https://user-images.githubusercontent.com/18014088/36760154-a1974026-1bce-11e8-9a8e-5d8ca4165ae5.png)

3:
![image](https://user-images.githubusercontent.com/18014088/36760219-c7988726-1bce-11e8-9054-0b7298ed75a5.png)

4:
![image](https://user-images.githubusercontent.com/18014088/36760176-ae011b3e-1bce-11e8-9e68-0e4fa6a37759.png)
