### PR TITLE
Improve query performance for Manage Packages

### DIFF
--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -378,7 +378,7 @@ namespace NuGetGallery
             var orgSent = currentUser.Organizations
                 .Where(m => ActionsRequiringPermissions.HandlePackageOwnershipRequest.CheckPermissions(currentUser, m.Organization) == PermissionsCheckResult.Allowed)
                 .SelectMany(m => _packageOwnerRequestService.GetPackageOwnershipRequests(requestingOwner: m.Organization));
-            var sent = userReceived.Union(orgReceived);
+            var sent = userSent.Union(orgSent);
 
             var ownerRequests = new OwnerRequestsViewModel(received, sent, currentUser, _packageService);
 

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -366,13 +366,19 @@ namespace NuGetGallery
                 .Select(p => new ListPackageItemViewModel(p, currentUser)).OrderBy(p => p.Id)
                 .ToList();
 
+            // find all received ownership requests
             var userReceived = _packageOwnerRequestService.GetPackageOwnershipRequests(newOwner: currentUser);
             var orgReceived = currentUser.Organizations
                 .Where(m => ActionsRequiringPermissions.HandlePackageOwnershipRequest.CheckPermissions(currentUser, m.Organization) == PermissionsCheckResult.Allowed)
                 .SelectMany(m => _packageOwnerRequestService.GetPackageOwnershipRequests(newOwner: m.Organization));
             var received = userReceived.Union(orgReceived);
-            
-            var sent = packages.SelectMany(p => _packageOwnerRequestService.GetPackageOwnershipRequests(package: p.PackageRegistration));
+
+            // find all sent ownership requests
+            var userSent = _packageOwnerRequestService.GetPackageOwnershipRequests(requestingOwner: currentUser);
+            var orgSent = currentUser.Organizations
+                .Where(m => ActionsRequiringPermissions.HandlePackageOwnershipRequest.CheckPermissions(currentUser, m.Organization) == PermissionsCheckResult.Allowed)
+                .SelectMany(m => _packageOwnerRequestService.GetPackageOwnershipRequests(requestingOwner: m.Organization));
+            var sent = userReceived.Union(orgReceived);
 
             var ownerRequests = new OwnerRequestsViewModel(received, sent, currentUser, _packageService);
 

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -258,10 +258,11 @@ namespace NuGetGallery
             // where sometimes packages no rows with IsLatest set. In this case, we'll just select the last inserted
             // row (descending [Key]) as opposed to reading all rows into memory and sorting on NuGetVersion.
             return packages
-                .OrderBy(p => p.IsLatestStableSemVer2)
-                .ThenBy(p => p.IsLatestStable)
-                .ThenBy(p => p.IsLatestSemVer2)
-                .ThenBy(p => p.IsLatest)
+                // order booleans desc so that true (1) comes first
+                .OrderByDescending(p => p.IsLatestStableSemVer2)
+                .ThenByDescending(p => p.IsLatestStable)
+                .ThenByDescending(p => p.IsLatestSemVer2)
+                .ThenByDescending(p => p.IsLatest)
                 .ThenByDescending(p => p.Key)
                 .GroupBy(p => p.PackageRegistrationKey)
                 .Select(g => g.FirstOrDefault())
@@ -273,7 +274,7 @@ namespace NuGetGallery
         private IEnumerable<Package> GetLatestPackageForEachRegistration(IReadOnlyCollection<Package> packages)
         {
             // This method uses First() and FirstOrDefault() instead of Single() or SingleOrDefault() to get the latest package, 
-            // in case there are multiple latest due .Thento concurrency issue
+            // in case there are multiple latest due to concurrency issue
             // see: https://github.com/NuGet/NuGetGallery/issues/2514
             foreach (var packagesByRegistration in packages.GroupBy(p => p.PackageRegistration.Id))
             {

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -230,12 +230,6 @@ namespace NuGetGallery
         /// <summary>
         /// Find packages by owner, including organization owners that the user belongs to.
         /// </summary>
-        /// <remarks>
-        /// When <paramref name="includeVersions"/> is false, only the latest package versions will be returned.
-        /// The IsLatest columns are used to determine the latest. We will not attempt to select all package rows
-        /// and order on NuGetVersion in memory due to the potential performance overhead of doing this. If no
-        /// IsLatest is set, the version pushed most recently (based on package key) will be selected.
-        /// </remarks>
         public IEnumerable<Package> FindPackagesByAnyMatchingOwner(
             User user,
             bool includeUnlisted,
@@ -261,8 +255,8 @@ namespace NuGetGallery
             }
 
             // Do a best effort of retrieving the latest version. Note that UpdateIsLatest has had concurrency issues
-            // where sometimes packages have multiple or no rows with IsLatest set. In this case, we'll just select
-            // the last inserted row as opposed to reading all rows into memory and sorting on NuGetVersion.
+            // where sometimes packages no rows with IsLatest set. In this case, we'll just select the last inserted
+            // row (descending [Key]) as opposed to reading all rows into memory and sorting on NuGetVersion.
             return packages
                 .OrderBy(p => p.IsLatestStableSemVer2)
                 .ThenBy(p => p.IsLatestStable)

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -258,14 +258,16 @@ namespace NuGetGallery
             // where sometimes packages no rows with IsLatest set. In this case, we'll just select the last inserted
             // row (descending [Key]) as opposed to reading all rows into memory and sorting on NuGetVersion.
             return packages
-                // order booleans desc so that true (1) comes first
-                .OrderByDescending(p => p.IsLatestStableSemVer2)
-                .ThenByDescending(p => p.IsLatestStable)
-                .ThenByDescending(p => p.IsLatestSemVer2)
-                .ThenByDescending(p => p.IsLatest)
-                .ThenByDescending(p => p.Key)
                 .GroupBy(p => p.PackageRegistrationKey)
-                .Select(g => g.FirstOrDefault())
+                .Select(g => g
+                    // order booleans desc so that true (1) comes first
+                    .OrderByDescending(p => p.IsLatestStableSemVer2)
+                    .ThenByDescending(p => p.IsLatestStable)
+                    .ThenByDescending(p => p.IsLatestSemVer2)
+                    .ThenByDescending(p => p.IsLatest)
+                    .ThenByDescending(p => p.Listed)
+                    .ThenByDescending(p => p.Key)
+                    .FirstOrDefault())
                 .Include(p => p.PackageRegistration)
                 .Include(p => p.PackageRegistration.Owners)
                 .ToList();

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -947,8 +947,19 @@ namespace NuGetGallery
               => base.ReturnsOnlyLatestStablePackageIfNoLatestStableSemVer2Exist(currentUser, packageOwner);
 
             [MemberData(nameof(TestData_RoleVariants))]
-            public override void ReturnsCorrectLatestVersionForMixedSemVer2AndNonSemVer2PackageVersions_IncludeUnlistedTrue(User currentUser, User packageOwner)
-              => base.ReturnsCorrectLatestVersionForMixedSemVer2AndNonSemVer2PackageVersions_IncludeUnlistedTrue(currentUser, packageOwner);
+            [Theory]
+            public virtual void ReturnsCorrectLatestVersionForMixedSemVer2AndNonSemVer2PackageVersions_IncludeUnlistedTrue(User currentUser, User packageOwner)
+            {
+                var context = GetMixedVersioningPackagesContext(currentUser, packageOwner);
+
+                var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: true).ToList();
+
+                var nugetCatalogReaderPackage = packages.Single(p => p.PackageRegistration.Id == "NuGet.CatalogReader");
+                Assert.Equal("1.5.12+git.78e44a8", NuGetVersionFormatter.ToFullStringOrFallback(nugetCatalogReaderPackage.Version, fallback: nugetCatalogReaderPackage.Version));
+
+                var sleetLibPackage = packages.Single(p => p.PackageRegistration.Id == "SleetLib");
+                Assert.Equal("2.2.24+git.f2a0cb6", NuGetVersionFormatter.ToFullStringOrFallback(sleetLibPackage.Version, fallback: sleetLibPackage.Version));
+            }
 
             [MemberData(nameof(TestData_RoleVariants))]
             public override void ReturnsFirstIfMultiplePackagesSetToLatest(User currentUser, User packageOwner)
@@ -1005,11 +1016,6 @@ namespace NuGetGallery
             [MemberData(nameof(TestData_RoleVariants))]
             public override void ReturnsOnlyLatestStablePackageIfNoLatestStableSemVer2Exist(User currentUser, User packageOwner)
               => base.ReturnsOnlyLatestStablePackageIfNoLatestStableSemVer2Exist(currentUser, packageOwner);
-
-            [Theory(Skip = "Disabled: FindPackagesByAnyMatchingOwner does not order by NuGetVersion for better performance")]
-            public override void ReturnsCorrectLatestVersionForMixedSemVer2AndNonSemVer2PackageVersions_IncludeUnlistedTrue(User currentUser, User packageOwner)
-            {
-            }
 
             [MemberData(nameof(TestData_RoleVariants))]
             public override void ReturnsFirstIfMultiplePackagesSetToLatest(User currentUser, User packageOwner)
@@ -1201,7 +1207,7 @@ namespace NuGetGallery
                 Assert.Contains(latestStablePackage, packages);
             }
 
-            private FakeEntitiesContext GetMixedVersioningPackagesContext(User currentUser, User packageOwner)
+            protected FakeEntitiesContext GetMixedVersioningPackagesContext(User currentUser, User packageOwner)
             {
                 var context = GetFakeContext();
 
@@ -1247,20 +1253,6 @@ namespace NuGetGallery
                 }
 
                 return context;
-            }
-
-            [Theory]
-            public virtual void ReturnsCorrectLatestVersionForMixedSemVer2AndNonSemVer2PackageVersions_IncludeUnlistedTrue(User currentUser, User packageOwner)
-            {
-                var context = GetMixedVersioningPackagesContext(currentUser, packageOwner);
-
-                var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: true).ToList();
-
-                var nugetCatalogReaderPackage = packages.Single(p => p.PackageRegistration.Id == "NuGet.CatalogReader");
-                Assert.Equal("1.5.12+git.78e44a8", NuGetVersionFormatter.ToFullStringOrFallback(nugetCatalogReaderPackage.Version, fallback: nugetCatalogReaderPackage.Version));
-
-                var sleetLibPackage = packages.Single(p => p.PackageRegistration.Id == "SleetLib");
-                Assert.Equal("2.2.24+git.f2a0cb6", NuGetVersionFormatter.ToFullStringOrFallback(sleetLibPackage.Version, fallback: sleetLibPackage.Version));
             }
 
             [Theory]

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1293,7 +1293,7 @@ namespace NuGetGallery
                     Version = "1.0",
                     PackageRegistration = packageRegistration,
                     PackageRegistrationKey = 0,
-                   Listed = false,
+                    Listed = false,
                     IsLatest = false,
                     IsLatestStable = false
                 };

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1006,9 +1006,10 @@ namespace NuGetGallery
             public override void ReturnsOnlyLatestStablePackageIfNoLatestStableSemVer2Exist(User currentUser, User packageOwner)
               => base.ReturnsOnlyLatestStablePackageIfNoLatestStableSemVer2Exist(currentUser, packageOwner);
 
-            [MemberData(nameof(TestData_RoleVariants))]
+            [Theory(Skip = "Disabled: FindPackagesByAnyMatchingOwner does not order by NuGetVersion for better performance")]
             public override void ReturnsCorrectLatestVersionForMixedSemVer2AndNonSemVer2PackageVersions_IncludeUnlistedTrue(User currentUser, User packageOwner)
-              => base.ReturnsCorrectLatestVersionForMixedSemVer2AndNonSemVer2PackageVersions_IncludeUnlistedTrue(currentUser, packageOwner);
+            {
+            }
 
             [MemberData(nameof(TestData_RoleVariants))]
             public override void ReturnsFirstIfMultiplePackagesSetToLatest(User currentUser, User packageOwner)
@@ -1036,9 +1037,9 @@ namespace NuGetGallery
 
             protected static TestUserRoles CreateTestUserRoles()
             {
-                var organization = new Organization { Username = "organization" };
+                var organization = new Organization { Key = 0, Username = "organization" };
 
-                var admin = new User { Username = "admin" };
+                var admin = new User { Key = 1, Username = "admin" };
                 var adminMembership = new Membership
                 {
                     Organization = organization,
@@ -1048,7 +1049,7 @@ namespace NuGetGallery
                 organization.Members.Add(adminMembership);
                 admin.Organizations.Add(adminMembership);
 
-                var collaborator = new User { Username = "collaborator" };
+                var collaborator = new User { Key = 2, Username = "collaborator" };
                 var collaboratorMembership = new Membership
                 {
                     Organization = organization,
@@ -1125,10 +1126,24 @@ namespace NuGetGallery
             [Theory]
             public virtual void ReturnsAPackageForEachPackageRegistration(User currentUser, User packageOwner)
             {
-                var packageRegistrationA = new PackageRegistration { Id = "idA", Owners = { packageOwner } };
-                var packageRegistrationB = new PackageRegistration { Id = "idB", Owners = { packageOwner } };
-                var packageA = new Package { Version = "1.0", PackageRegistration = packageRegistrationA, Listed = true, IsLatestSemVer2 = true, IsLatestStableSemVer2 = true };
-                var packageB = new Package { Version = "1.0", PackageRegistration = packageRegistrationB, Listed = true, IsLatestSemVer2 = true, IsLatestStableSemVer2 = true };
+                var packageRegistrationA = new PackageRegistration { Key = 0, Id = "idA", Owners = { packageOwner } };
+                var packageRegistrationB = new PackageRegistration { Key = 1, Id = "idB", Owners = { packageOwner } };
+                var packageA = new Package {
+                    Version = "1.0",
+                    PackageRegistration = packageRegistrationA,
+                    PackageRegistrationKey = 0,
+                    Listed = true,
+                    IsLatestSemVer2 = true,
+                    IsLatestStableSemVer2 = true
+                };
+                var packageB = new Package {
+                    Version = "1.0",
+                    PackageRegistration = packageRegistrationB,
+                    PackageRegistrationKey = 1,
+                    Listed = true,
+                    IsLatestSemVer2 = true,
+                    IsLatestStableSemVer2 = true
+                };
                 packageRegistrationA.Packages.Add(packageA);
                 packageRegistrationB.Packages.Add(packageB);
 
@@ -1272,11 +1287,26 @@ namespace NuGetGallery
             [Theory]
             public virtual void ReturnsVersionsWhenIncludedVersionsIsTrue_IncludeUnlistedTrue(User currentUser, User packageOwner)
             {
-                var packageRegistration = new PackageRegistration { Id = "theId", Owners = { packageOwner } };
-                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = false, IsLatest = false, IsLatestStable = false };
+                var packageRegistration = new PackageRegistration { Key = 0, Id = "theId", Owners = { packageOwner } };
+
+                var package1 = new Package {
+                    Version = "1.0",
+                    PackageRegistration = packageRegistration,
+                    PackageRegistrationKey = 0,
+                   Listed = false,
+                    IsLatest = false,
+                    IsLatestStable = false
+                };
                 packageRegistration.Packages.Add(package1);
 
-                var package2 = new Package { Version = "2.0", PackageRegistration = packageRegistration, Listed = true, IsLatest = true, IsLatestStable = true };
+                var package2 = new Package {
+                    Version = "2.0",
+                    PackageRegistration = packageRegistration,
+                    PackageRegistrationKey = 0,
+                    Listed = true,
+                    IsLatest = true,
+                    IsLatestStable = true
+                };
                 packageRegistration.Packages.Add(package2);
 
                 var context = GetFakeContext();


### PR DESCRIPTION
First optimization for #5461, which covers 2 fixes:
1. Regression from d8371bd

In **UsersController**, fix sent to query off the request table instead of the large list of packages. Performance was hard to measure, as it was hanging due to the regression.

2. Optimize packages query to only sort in DB, based on IsLatest columns

In **PackageService**, modified the EF query to sort and select based on IsLatest state in DB. Previously we'd read all rows and sort in memory (on NuGetVersion as last resort) to handle cases where IsLatest wasn't set due to concurrency issues.

The second optimization helps mostly in scenarios with many versions, as opposed to many registrations. Results below:

**Scenario 1:  59K registrations, 59K versions (NuGetStagingTest on DEV)**

  - BEFORE: 48.54, 49.41, 60, 35.74, 49.13 => 45.71s

  - AFTER: 36.12, 49.95, 43.13, 40.32, 46.30 => 41.47 **(-9.28%)**

**Scenario 2: 100 registrations, 52K versions (DEV, various packages)**

  - BEFORE: 126, 144, 90, 108, 78 => 100.5s

  - AFTER: 2.71, 3.15, 2.28, 2.23, 2.26 => 2.37s **(-97.64%)**