### PR TITLE
[Organizations] Minor bug fixes from dev

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-add-organization.js
+++ b/src/NuGetGallery/Scripts/gallery/page-add-organization.js
@@ -41,4 +41,9 @@
 
         _gravatar.attr("src", src);
     }
+
+    // Immediately fetch the image if the email box is filled in initially.
+    if (_emailBox.val()) {
+        UpdateGravatar();
+    }
 });

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -383,9 +383,7 @@ namespace NuGetGallery
             }
             
             var existingUserWithIdentity = EntitiesContext.Users
-                .FirstOrDefault(u => 
-                    u.Username.Equals(username, StringComparison.OrdinalIgnoreCase) || 
-                    string.Equals(u.EmailAddress, emailAddress, StringComparison.OrdinalIgnoreCase));
+                .FirstOrDefault(u => u.Username == username || u.EmailAddress == emailAddress);
             if (existingUserWithIdentity != null)
             {
                 if (existingUserWithIdentity.Username.Equals(username, StringComparison.OrdinalIgnoreCase))

--- a/src/NuGetGallery/Views/NuGetViewBase.cs
+++ b/src/NuGetGallery/Views/NuGetViewBase.cs
@@ -29,6 +29,8 @@ namespace NuGetGallery.Views
             get { return NuGetContext.CurrentUser; }
         }
 
+        public IContentObjectService ContentObjectService => DependencyResolver.Current.GetService<IContentObjectService>();
+
         public CookieConsentMessage CookieConsentMessage
         {
             get { return _cookieConsentMessage.Value; }
@@ -81,6 +83,8 @@ namespace NuGetGallery.Views
         {
             get { return NuGetContext.CurrentUser; }
         }
+
+        public IContentObjectService ContentObjectService => DependencyResolver.Current.GetService<IContentObjectService>();
 
         public CookieConsentMessage CookieConsentMessage
         {

--- a/src/NuGetGallery/Views/NuGetViewBase.cs
+++ b/src/NuGetGallery/Views/NuGetViewBase.cs
@@ -29,7 +29,7 @@ namespace NuGetGallery.Views
             get { return NuGetContext.CurrentUser; }
         }
 
-        public IContentObjectService ContentObjectService => DependencyResolver.Current.GetService<IContentObjectService>();
+        public Lazy<IContentObjectService> ContentObjectService => new Lazy<IContentObjectService>(() => DependencyResolver.Current.GetService<IContentObjectService>());
 
         public CookieConsentMessage CookieConsentMessage
         {
@@ -84,7 +84,7 @@ namespace NuGetGallery.Views
             get { return NuGetContext.CurrentUser; }
         }
 
-        public IContentObjectService ContentObjectService => DependencyResolver.Current.GetService<IContentObjectService>();
+        public Lazy<IContentObjectService> ContentObjectService => new Lazy<IContentObjectService>(() => DependencyResolver.Current.GetService<IContentObjectService>());
 
         public CookieConsentMessage CookieConsentMessage
         {

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -118,7 +118,8 @@
                                         <li role="presentation"><a href="@Url.AccountSettings()" role="menuitem">Account Settings</a></li>
                                         <li role="presentation"><a href="@Url.ManageMyApiKeys()" role="menuitem">API Keys</a></li>
                                         <li class="divider"></li>
-                                        @if (CurrentUser.Organizations.Any())
+                                        @if (CurrentUser.Organizations.Any() || 
+                                            ContentObjectService.LoginDiscontinuationConfiguration.AreOrganizationsSupportedForUser(CurrentUser))
                                         {
                                             <li role="presentation"><a href="@Url.ManageMyOrganizations()" role="menuitem">Manage Organizations</a></li>
                                         }

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -119,7 +119,7 @@
                                         <li role="presentation"><a href="@Url.ManageMyApiKeys()" role="menuitem">API Keys</a></li>
                                         <li class="divider"></li>
                                         @if (CurrentUser.Organizations.Any() || 
-                                            ContentObjectService.LoginDiscontinuationConfiguration.AreOrganizationsSupportedForUser(CurrentUser))
+                                            ContentObjectService.Value.LoginDiscontinuationConfiguration.AreOrganizationsSupportedForUser(CurrentUser))
                                         {
                                             <li role="presentation"><a href="@Url.ManageMyOrganizations()" role="menuitem">Manage Organizations</a></li>
                                         }


### PR DESCRIPTION
1 - Fetch the image immediately for the text box on the add page if the form is already filled (e.g. if form submission fails, show the image from the email already.
2 - Don't use `string.Equals` in EF queryables because it throws on Azure SQL lol.
3 - Show the `Manage Organizations` page for users who are allowed to create an org.