### PR TITLE
[Organization] Update existing email notifications for organizations

### DIFF
--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -299,7 +299,7 @@ namespace NuGetGallery
             if (NuGetContext.Config.Current.ConfirmEmailAddresses && !string.IsNullOrEmpty(user.User.UnconfirmedEmailAddress))
             {
                 _messageService.SendNewAccountEmail(
-                    new MailAddress(user.User.UnconfirmedEmailAddress, user.User.Username),
+                    user.User,
                     Url.ConfirmEmail(
                         user.User.Username,
                         user.User.EmailConfirmationToken,

--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -148,10 +148,21 @@ namespace NuGetGallery
                     ownerRequest.ConfirmationCode,
                     relativeUrl: false);
 
+                var cancellationUrl = Url.CancelPendingOwnershipRequest(
+                    model.Package.Id,
+                    model.CurrentUser.Username,
+                    model.User.Username,
+                    relativeUrl: false);
+
                 var packageUrl = Url.Package(model.Package.Id, version: null, relativeUrl: false);
 
                 _messageService.SendPackageOwnerRequest(model.CurrentUser, model.User, model.Package, packageUrl,
                     confirmationUrl, rejectionUrl, encodedMessage, policyMessage: string.Empty);
+
+                foreach (var owner in model.Package.Owners)
+                {
+                    _messageService.SendPackageOwnerRequestInitiatedNotice(model.CurrentUser, owner, model.User, model.Package, cancellationUrl);
+                }
 
                 return Json(new
                 {

--- a/src/NuGetGallery/Controllers/OrganizationsController.cs
+++ b/src/NuGetGallery/Controllers/OrganizationsController.cs
@@ -43,7 +43,7 @@ namespace NuGetGallery
         protected override void SendEmailChangedConfirmationNotice(User account)
         {
             var confirmationUrl = Url.ConfirmOrganizationEmail(account.Username, account.EmailConfirmationToken, relativeUrl: false);
-            MessageService.SendEmailChangeConfirmationNotice(new MailAddress(account.UnconfirmedEmailAddress, account.Username), confirmationUrl);
+            MessageService.SendEmailChangeConfirmationNotice(account, confirmationUrl);
         }
 
         [HttpGet]

--- a/src/NuGetGallery/Controllers/OrganizationsController.cs
+++ b/src/NuGetGallery/Controllers/OrganizationsController.cs
@@ -37,7 +37,7 @@ namespace NuGetGallery
         {
             var confirmationUrl = Url.ConfirmOrganizationEmail(account.Username, account.EmailConfirmationToken, relativeUrl: false);
 
-            MessageService.SendNewAccountEmail(new MailAddress(account.UnconfirmedEmailAddress, account.Username), confirmationUrl);
+            MessageService.SendNewAccountEmail(account, confirmationUrl);
         }
 
         protected override void SendEmailChangedConfirmationNotice(User account)

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -69,7 +69,7 @@ namespace NuGetGallery
         protected override void SendEmailChangedConfirmationNotice(User account)
         {
             var confirmationUrl = Url.ConfirmEmail(account.Username, account.EmailConfirmationToken, relativeUrl: false);
-            MessageService.SendEmailChangeConfirmationNotice(new MailAddress(account.UnconfirmedEmailAddress, account.Username), confirmationUrl);
+            MessageService.SendEmailChangeConfirmationNotice(account, confirmationUrl);
         }
 
         protected override User GetAccount(string accountName)

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -63,7 +63,7 @@ namespace NuGetGallery
         {
             var confirmationUrl = Url.ConfirmEmail(account.Username, account.EmailConfirmationToken, relativeUrl: false);
 
-            MessageService.SendNewAccountEmail(new MailAddress(account.UnconfirmedEmailAddress, account.Username), confirmationUrl);
+            MessageService.SendNewAccountEmail(account, confirmationUrl);
         }
 
         protected override void SendEmailChangedConfirmationNotice(User account)

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery
         void ReportAbuse(ReportPackageRequest report);
         void ReportMyPackage(ReportPackageRequest report);
         void SendNewAccountEmail(MailAddress toAddress, string confirmationUrl);
-        void SendEmailChangeConfirmationNotice(MailAddress newEmailAddress, string confirmationUrl);
+        void SendEmailChangeConfirmationNotice(User user, string confirmationUrl);
         void SendPasswordResetInstructions(User user, string resetPasswordUrl, bool forgotPassword);
         void SendEmailChangeNoticeToPreviousEmailAddress(User user, string oldEmailAddress);
         void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string packageUrl, string confirmationUrl, string rejectionUrl, string message, string policyMessage);

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
         void SendContactOwnersMessage(MailAddress fromAddress, Package package, string packageUrl, string message, string emailSettingsUrl, bool copyFromAddress);
         void ReportAbuse(ReportPackageRequest report);
         void ReportMyPackage(ReportPackageRequest report);
-        void SendNewAccountEmail(MailAddress toAddress, string confirmationUrl);
+        void SendNewAccountEmail(User newUser, string confirmationUrl);
         void SendEmailChangeConfirmationNotice(User user, string confirmationUrl);
         void SendPasswordResetInstructions(User user, string resetPasswordUrl, bool forgotPassword);
         void SendEmailChangeNoticeToPreviousEmailAddress(User user, string oldEmailAddress);

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -17,12 +17,13 @@ namespace NuGetGallery
         void SendPasswordResetInstructions(User user, string resetPasswordUrl, bool forgotPassword);
         void SendEmailChangeNoticeToPreviousEmailAddress(User user, string oldEmailAddress);
         void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string packageUrl, string confirmationUrl, string rejectionUrl, string message, string policyMessage);
+        void SendPackageOwnerRequestInitiatedNotice(User requestingOwner, User receivingOwner, User newOwner, PackageRegistration package, string cancellationUrl);
         void SendPackageOwnerRequestRejectionNotice(User requestingOwner, User newOwner, PackageRegistration package);
         void SendPackageOwnerRequestCancellationNotice(User requestingOwner, User newOwner, PackageRegistration package);
         void SendPackageOwnerAddedNotice(User toUser, User newOwner, PackageRegistration package, string packageUrl, string policyMessage);
         void SendPackageOwnerRemovedNotice(User fromUser, User toUser, PackageRegistration package);
         void SendCredentialRemovedNotice(User user, CredentialViewModel removedCredentialViewModel);
-        void SendCredentialAddedNotice(User user, CredentialViewModel addedCrdentialViewModel);
+        void SendCredentialAddedNotice(User user, CredentialViewModel addedCredentialViewModel);
         void SendContactSupportEmail(ContactSupportRequest request);
         void SendPackageAddedNotice(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl);
         void SendPackageUploadedNotice(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl);

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -285,21 +285,22 @@ The {0} Team";
         {
             string body = @"Hi there,
 
-The email address associated with your {0} {1} was recently
-changed from _{2}_ to _{3}_.
+The email address associated with your {0} {1} was recently changed from _{2}_ to _{3}_.
 
 Thanks,
 The {0} Team";
+
+            var yourString = user is Organization ? "organization" : "account";
 
             body = String.Format(
                 CultureInfo.CurrentCulture,
                 body,
                 Config.GalleryOwner.DisplayName,
-                user is Organization ? "organization" : "account",
+                yourString,
                 oldEmailAddress,
                 user.EmailAddress);
 
-            string subject = String.Format(CultureInfo.CurrentCulture, "[{0}] Recent changes to your account.", Config.GalleryOwner.DisplayName);
+            string subject = String.Format(CultureInfo.CurrentCulture, "[{0}] Recent changes to your {1}.", Config.GalleryOwner.DisplayName, yourString);
             using (
                 var mailMessage = new MailMessage())
             {
@@ -484,7 +485,7 @@ The {3} Team";
                 return;
             }
 
-            var title = string.Format(CultureInfo.CurrentCulture, $"The user '{fromUser.Username}' has removed {(toUser is Organization ? "your organization" : "you")} as an owner of the package '{package.Id}'.");
+            var title = string.Format(CultureInfo.CurrentCulture, $"The user '{fromUser.Username}' removed {(toUser is Organization ? "your organization" : "you")} as an owner of the package '{package.Id}'.");
 
             var subject = $"[{Config.GalleryOwner.DisplayName}] {title}";
 

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -202,7 +202,7 @@ The {0} Team";
                 SendMessage(mailMessage);
             }
         }
-
+        
         public void SendSigninAssistanceEmail(MailAddress emailAddress, IEnumerable<Credential> credentials)
         {
             string body = @"Hi there,
@@ -244,29 +244,35 @@ The {0} Team";
             }
 
         }
-
-        public void SendEmailChangeConfirmationNotice(MailAddress newEmailAddress, string confirmationUrl)
+        
+        public void SendEmailChangeConfirmationNotice(User user, string confirmationUrl)
         {
-            string body = @"You recently changed your {0} email address.
+            string body = @"You recently changed {0} {1} email address.
 
-To verify your new email address, please click the following link:
+To verify {0} new email address, please click the following link:
 
-[{1}]({2})
+[{2}]({3})
 
 Thanks,
 The {0} Team";
 
+            var yourString = user is Organization ? "your organization's" : "your account's";
+
             body = String.Format(
                 CultureInfo.CurrentCulture,
                 body,
+                yourString,
                 Config.GalleryOwner.DisplayName,
                 HttpUtility.UrlDecode(confirmationUrl).Replace("_", "\\_"),
                 confirmationUrl);
 
+            var newEmailAddress = new MailAddress(user.UnconfirmedEmailAddress, user.Username);
+
             using (var mailMessage = new MailMessage())
             {
                 mailMessage.Subject = String.Format(
-                    CultureInfo.CurrentCulture, "[{0}] Please verify your new email address.", Config.GalleryOwner.DisplayName);
+                    CultureInfo.CurrentCulture, "[{0}] Please verify {1} new email address.", 
+                    Config.GalleryOwner.DisplayName, yourString);
                 mailMessage.Body = body;
                 mailMessage.From = Config.GalleryNoReplyAddress;
 
@@ -279,8 +285,8 @@ The {0} Team";
         {
             string body = @"Hi there,
 
-The email address associated to your {0} account was recently
-changed from _{1}_ to _{2}_.
+The email address associated with your {0} {1} was recently
+changed from _{2}_ to _{3}_.
 
 Thanks,
 The {0} Team";
@@ -289,6 +295,7 @@ The {0} Team";
                 CultureInfo.CurrentCulture,
                 body,
                 Config.GalleryOwner.DisplayName,
+                user is Organization ? "organization" : "account",
                 oldEmailAddress,
                 user.EmailAddress);
 

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -382,7 +382,10 @@ The {Config.GalleryOwner.DisplayName} Team";
                 mailMessage.From = Config.GalleryNoReplyAddress;
                 mailMessage.ReplyToList.Add(fromUser.ToMailAddress());
 
-                AddAddressesForPackageOwnershipManagementToEmail(mailMessage, toUser);
+                if (!AddAddressesForPackageOwnershipManagementToEmail(mailMessage, toUser))
+                {
+                    return;
+                }
 
                 SendMessage(mailMessage);
             }
@@ -411,7 +414,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.From = Config.GalleryNoReplyAddress;
                 mailMessage.ReplyToList.Add(newOwner.ToMailAddress());
 
-                AddAddressesForPackageOwnershipManagementToEmail(mailMessage, requestingOwner);
+                if (!AddAddressesForPackageOwnershipManagementToEmail(mailMessage, requestingOwner))
+                {
+                    return;
+                }
+
                 SendMessage(mailMessage);
             }
         }
@@ -439,7 +446,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.From = Config.GalleryNoReplyAddress;
                 mailMessage.ReplyToList.Add(requestingOwner.ToMailAddress());
 
-                AddAddressesForPackageOwnershipManagementToEmail(mailMessage, newOwner);
+                if (!AddAddressesForPackageOwnershipManagementToEmail(mailMessage, newOwner))
+                {
+                    return;
+                }
+
                 SendMessage(mailMessage);
             }
         }
@@ -473,7 +484,10 @@ The {3} Team";
                 mailMessage.From = Config.GalleryNoReplyAddress;
                 mailMessage.ReplyToList.Add(Config.GalleryNoReplyAddress);
 
-                AddAddressesForPackageOwnershipManagementToEmail(mailMessage, toUser);
+                if (!AddAddressesForPackageOwnershipManagementToEmail(mailMessage, toUser))
+                {
+                    return;
+                }
                 SendMessage(mailMessage);
             }
         }
@@ -503,7 +517,11 @@ The {Config.GalleryOwner.DisplayName} Team";
                 mailMessage.From = Config.GalleryNoReplyAddress;
                 mailMessage.ReplyToList.Add(fromUser.ToMailAddress());
 
-                AddAddressesForPackageOwnershipManagementToEmail(mailMessage, toUser);
+                if (!AddAddressesForPackageOwnershipManagementToEmail(mailMessage, toUser))
+                {
+                    return;
+                }
+
                 SendMessage(mailMessage);
             }
         }

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -508,7 +508,7 @@ The {Config.GalleryOwner.DisplayName} Team";
             }
         }
 
-        private void AddAddressesForPackageOwnershipManagementToEmail(MailMessage mailMessage, User user)
+        private bool AddAddressesForPackageOwnershipManagementToEmail(MailMessage mailMessage, User user)
         {
             if (user is Organization organization)
             {
@@ -516,14 +516,26 @@ The {Config.GalleryOwner.DisplayName} Team";
                     .Where(m => ActionsRequiringPermissions.HandlePackageOwnershipRequest.CheckPermissions(m.Member, m.Organization) == PermissionsCheckResult.Allowed)
                     .Select(m => m.Member);
 
+                bool hasRecipients = false;
+
                 foreach (var member in membersAllowedToAct)
                 {
+                    if (!member.EmailAllowed)
+                    {
+                        continue;
+                    }
+
                     mailMessage.To.Add(member.ToMailAddress());
+
+                    hasRecipients = true;
                 }
+
+                return hasRecipients;
             }
             else
             {
                 mailMessage.To.Add(user.ToMailAddress());
+                return true;
             }
         }
 

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -173,24 +173,19 @@ namespace NuGetGallery
             }
         }
 
-        public void SendNewAccountEmail(MailAddress toAddress, string confirmationUrl)
+        public void SendNewAccountEmail(User newUser, string confirmationUrl)
         {
-            string body = @"Thank you for registering with the {0}.
+            var isOrganization = newUser is Organization;
+
+            string body = $@"Thank you for {(isOrganization ? $"creating an organization on the" : $"registering with the")} {Config.GalleryOwner.DisplayName}.
 We can't wait to see what packages you'll upload.
 
 So we can be sure to contact you, please verify your email address and click the following link:
 
-[{1}]({2})
+[{HttpUtility.UrlDecode(confirmationUrl).Replace("_", "\\_")}]({confirmationUrl})
 
 Thanks,
-The {0} Team";
-
-            body = String.Format(
-                CultureInfo.CurrentCulture,
-                body,
-                Config.GalleryOwner.DisplayName,
-                HttpUtility.UrlDecode(confirmationUrl).Replace("_", "\\_"),
-                confirmationUrl);
+The {Config.GalleryOwner.DisplayName} Team";
 
             using (var mailMessage = new MailMessage())
             {
@@ -198,7 +193,7 @@ The {0} Team";
                 mailMessage.Body = body;
                 mailMessage.From = Config.GalleryNoReplyAddress;
 
-                mailMessage.To.Add(toAddress);
+                mailMessage.To.Add(newUser.ToMailAddress());
                 SendMessage(mailMessage);
             }
         }

--- a/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
@@ -449,7 +449,7 @@ namespace NuGetGallery
 
                 // Assert
                 var mailService = GetMock<IMessageService>();
-                mailService.Verify(m => m.SendNewAccountEmail(It.IsAny<MailAddress>(), It.IsAny<string>()), Times.Never);
+                mailService.Verify(m => m.SendNewAccountEmail(It.IsAny<User>(), It.IsAny<string>()), Times.Never);
 
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
                 Assert.False(model.SentEmail);
@@ -475,7 +475,7 @@ namespace NuGetGallery
 
                 // Assert
                 var mailService = GetMock<IMessageService>();
-                mailService.Verify(m => m.SendNewAccountEmail(It.IsAny<MailAddress>(), confirmationUrl), Times.Once);
+                mailService.Verify(m => m.SendNewAccountEmail(It.IsAny<User>(), confirmationUrl), Times.Once);
 
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
                 Assert.True(model.SentEmail);
@@ -493,12 +493,8 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Setup(m => m.SendNewAccountEmail(
-                        It.IsAny<MailAddress>(),
+                        account,
                         string.IsNullOrEmpty(confirmationUrl) ? It.IsAny<string>() : confirmationUrl))
-                    .Callback<MailAddress, string>((actualMailAddress, actualConfirmationUrl) =>
-                    {
-                        Assert.Equal(account.UnconfirmedEmailAddress, actualMailAddress.Address);
-                    })
                     .Verifiable();
 
                 // Act

--- a/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
@@ -235,7 +235,7 @@ namespace NuGetGallery
                 ResultAssert.IsRedirectToRoute(result, new { action = controller.AccountAction });
 
                 GetMock<IMessageService>()
-                    .Verify(m => m.SendEmailChangeConfirmationNotice(It.IsAny<MailAddress>(), It.IsAny<string>()),
+                    .Verify(m => m.SendEmailChangeConfirmationNotice(It.IsAny<User>(), It.IsAny<string>()),
                     Times.Once);
             }
 
@@ -259,7 +259,7 @@ namespace NuGetGallery
                 ResultAssert.IsRedirectToRoute(result, new { action = controller.AccountAction });
 
                 GetMock<IMessageService>()
-                    .Verify(m => m.SendEmailChangeConfirmationNotice(It.IsAny<MailAddress>(), It.IsAny<string>()),
+                    .Verify(m => m.SendEmailChangeConfirmationNotice(It.IsAny<User>(), It.IsAny<string>()),
                     Times.Never);
             }
 
@@ -281,7 +281,7 @@ namespace NuGetGallery
                 controller.SetCurrentUser(GetCurrentUser(controller));
 
                 var messageService = GetMock<IMessageService>();
-                messageService.Setup(m => m.SendEmailChangeConfirmationNotice(It.IsAny<MailAddress>(), It.IsAny<string>()))
+                messageService.Setup(m => m.SendEmailChangeConfirmationNotice(It.IsAny<User>(), It.IsAny<string>()))
                     .Verifiable();
 
                 var userService = GetMock<IUserService>();

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -721,11 +721,10 @@ namespace NuGetGallery.Controllers
 
                 // Assert
                 GetMock<AuthenticationService>().VerifyAll();
-
-                var expectedAddress = new MailAddress(authUser.User.UnconfirmedEmailAddress, authUser.User.Username);
+                
                 GetMock<IMessageService>()
                     .Verify(x => x.SendNewAccountEmail(
-                        expectedAddress,
+                        authUser.User,
                         TestUtility.GallerySiteRootHttps + "account/confirm/" + authUser.User.Username + "/" + authUser.User.EmailConfirmationToken));
                 ResultAssert.IsSafeRedirectTo(result, "/theReturnUrl");
             }
@@ -771,7 +770,7 @@ namespace NuGetGallery.Controllers
                 // Assert
                 GetMock<IMessageService>()
                     .Verify(x => x.SendNewAccountEmail(
-                        It.IsAny<MailAddress>(),
+                        It.IsAny<User>(),
                         It.IsAny<string>()), Times.Never());
             }
 
@@ -858,11 +857,10 @@ namespace NuGetGallery.Controllers
 
                 // Assert
                 authenticationServiceMock.VerifyAll();
-
-                var expectedAddress = new MailAddress(authUser.User.UnconfirmedEmailAddress, authUser.User.Username);
+                
                 GetMock<IMessageService>()
                     .Verify(x => x.SendNewAccountEmail(
-                        expectedAddress,
+                        authUser.User,
                         TestUtility.GallerySiteRootHttps + "account/confirm/" + authUser.User.Username + "/" + authUser.User.EmailConfirmationToken));
 
                 ResultAssert.IsSafeRedirectTo(result, "/theReturnUrl");

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -397,6 +397,18 @@ namespace NuGetGallery.Controllers
                                     ""))
                                 .Verifiable();
 
+                            foreach (var owner in fakes.Package.Owners)
+                            {
+                                messageServiceMock
+                                    .Setup(m => m.SendPackageOwnerRequestInitiatedNotice(
+                                        currentUser,
+                                        owner,
+                                        userToAdd,
+                                        fakes.Package,
+                                        It.IsAny<string>()))
+                                    .Verifiable();
+                            }
+
                             JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, userToAdd.Username, "Hello World! Html Encoded <3");
                             dynamic data = result.Data;
                             PackageOwnersResultViewModel model = data.model;

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -378,7 +378,7 @@ namespace NuGetGallery
 
                 messageService.Verify(
                     x => x.SendNewAccountEmail(
-                        It.Is<MailAddress>(m => m.Address == OrgEmail && m.DisplayName == org.Username), 
+                        org, 
                         It.Is<string>(s => s.Contains(token))), 
                     Times.Once());
             }

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -440,7 +440,7 @@ namespace NuGetGallery
                 Assert.Equal(oldEmail, message.To[0].Address);
                 Assert.Equal(TestGalleryNoReplyAddress.Address, message.From.Address);
                 Assert.Equal("[Joe Shmoe] Recent changes to your account.", message.Subject);
-                Assert.Contains($"The email address associated with your {TestGalleryNoReplyAddress} account was recently changed from _{oldEmail}_ to _{user.EmailAddress}_.", message.Body);
+                Assert.Contains($"The email address associated with your Joe Shmoe account was recently changed from _{oldEmail}_ to _{user.EmailAddress}_.", message.Body);
             }
         }
 


### PR DESCRIPTION
1 - If the target of the email is an organization, updated any reference of `you` or `your account` with `your organization`
2 - If the target of a package ownership email is an organization, the email sends to the admins of the organization and not the organization DL (because org admins are the only users who can handle these requests)

Messaging pending review with @anangaur 