### PR TITLE
[Organizations] Use a configurable list to determine what users should be asked to transform to an organization with a deprecated password

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -358,7 +358,7 @@ img.reserved-indicator-icon {
   vertical-align: top;
 }
 .modal-container .modal-box .modal-body .action-node {
-  padding: 9% 6%;
+  padding: 0 6%;
   text-align: center;
 }
 .modal-container .modal-box .modal-body .action-button {
@@ -366,7 +366,7 @@ img.reserved-indicator-icon {
   line-height: 2em;
 }
 .modal-container .modal-box .modal-body .transform-text {
-  padding: 0 15px;
+  padding: 40px 15px;
   margin: 0;
 }
 #edit-metadata-form-container .loading:after {

--- a/src/Bootstrap/less/theme/modals.less
+++ b/src/Bootstrap/less/theme/modals.less
@@ -50,7 +50,7 @@
       }
 
       .action-node {
-        padding: 9% 6%;
+        padding: 0% 6%;
         text-align: center;
       }
 
@@ -60,7 +60,7 @@
       }
 
       .transform-text {
-        padding: 0px 15px;
+        padding: 40px 15px;
         margin: 0px;
       }
     }

--- a/src/NuGetGallery/App_Data/Files/Content/Login-Discontinuation-Configuration.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Login-Discontinuation-Configuration.json
@@ -7,5 +7,8 @@
   ],
   "ExceptionsForEmailAddresses": [
     "exception@cannotUsePassword.com"
+  ],
+  "ForceTransformationToOrganizationForEmailAddresses": [
+    "organization@cannotUsePassword.com"
   ]
 }

--- a/src/NuGetGallery/Controllers/PagesController.cs
+++ b/src/NuGetGallery/Controllers/PagesController.cs
@@ -19,15 +19,18 @@ namespace NuGetGallery
         : AppController
     {
         private readonly IContentService _contentService;
+        private readonly IContentObjectService _contentObjectService;
         private readonly IMessageService _messageService;
         private readonly ISupportRequestService _supportRequestService;
 
         protected PagesController() { }
         public PagesController(IContentService contentService,
+            IContentObjectService contentObjectService,
             IMessageService messageService,
             ISupportRequestService supportRequestService)
         {
             _contentService = contentService;
+            _contentObjectService = contentObjectService;
             _messageService = messageService;
             _supportRequestService = supportRequestService;
         }
@@ -102,8 +105,10 @@ namespace NuGetGallery
         public virtual ActionResult Home()
         {
             var identity = OwinContext.Authentication?.User?.Identity as ClaimsIdentity;
-            var showTransformModal = ClaimsExtensions.HasDiscontinuedLoginCLaims(identity);
-            return View(new GalleryHomeViewModel(showTransformModal));
+            var showTransformModal = ClaimsExtensions.HasDiscontinuedLoginClaims(identity);
+            var shouldTransform = _contentObjectService.LoginDiscontinuationConfiguration
+                .ShouldUserTransformIntoOrganization(GetCurrentUser());
+            return View(new GalleryHomeViewModel(showTransformModal, shouldTransform));
         }
 
         [HttpGet]

--- a/src/NuGetGallery/Controllers/PagesController.cs
+++ b/src/NuGetGallery/Controllers/PagesController.cs
@@ -106,9 +106,9 @@ namespace NuGetGallery
         {
             var identity = OwinContext.Authentication?.User?.Identity as ClaimsIdentity;
             var showTransformModal = ClaimsExtensions.HasDiscontinuedLoginClaims(identity);
-            var shouldTransform = _contentObjectService.LoginDiscontinuationConfiguration
+            var transformIntoOrganization = _contentObjectService.LoginDiscontinuationConfiguration
                 .ShouldUserTransformIntoOrganization(GetCurrentUser());
-            return View(new GalleryHomeViewModel(showTransformModal, shouldTransform));
+            return View(new GalleryHomeViewModel(showTransformModal, transformIntoOrganization));
         }
 
         [HttpGet]

--- a/src/NuGetGallery/Extensions/ClaimsExtensions.cs
+++ b/src/NuGetGallery/Extensions/ClaimsExtensions.cs
@@ -33,7 +33,7 @@ namespace NuGetGallery
             return new IdentityInformation(identifierClaim.Value, nameClaim.Value, emailClaim?.Value, authType, tenantId: null);
         }
 
-        public static bool HasDiscontinuedLoginCLaims(ClaimsIdentity identity)
+        public static bool HasDiscontinuedLoginClaims(ClaimsIdentity identity)
         {
             if (identity == null || !identity.IsAuthenticated)
             {

--- a/src/NuGetGallery/Filters/UiAuthorizeAttribute.cs
+++ b/src/NuGetGallery/Filters/UiAuthorizeAttribute.cs
@@ -21,7 +21,7 @@ namespace NuGetGallery.Filters
         {
             // If the user has a discontinued login claim, redirect them to the homepage
             var identity = filterContext.HttpContext.User.Identity as ClaimsIdentity;
-            if (!AllowDiscontinuedLogins && ClaimsExtensions.HasDiscontinuedLoginCLaims(identity))
+            if (!AllowDiscontinuedLogins && ClaimsExtensions.HasDiscontinuedLoginClaims(identity))
             {
                 filterContext.Result = new RedirectToRouteResult(
                     new RouteValueDictionary(

--- a/src/NuGetGallery/Services/ContentObjectService.cs
+++ b/src/NuGetGallery/Services/ContentObjectService.cs
@@ -18,9 +18,7 @@ namespace NuGetGallery
         {
             _contentService = contentService;
 
-            LoginDiscontinuationConfiguration = 
-                new LoginDiscontinuationConfiguration(
-                    Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>());
+            LoginDiscontinuationConfiguration = new LoginDiscontinuationConfiguration();
         }
 
         public ILoginDiscontinuationConfiguration LoginDiscontinuationConfiguration { get; set; }

--- a/src/NuGetGallery/Services/LoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery/Services/LoginDiscontinuationConfiguration.cs
@@ -11,10 +11,10 @@ namespace NuGetGallery
 {
     public class LoginDiscontinuationConfiguration : ILoginDiscontinuationConfiguration
     {
-        public HashSet<string> DiscontinuedForEmailAddresses { get; }
-        public HashSet<string> DiscontinuedForDomains { get; }
-        public HashSet<string> ExceptionsForEmailAddresses { get; }
-        public HashSet<string> ForceTransformationForEmailAddresses { get; }
+        internal HashSet<string> DiscontinuedForEmailAddresses { get; }
+        internal HashSet<string> DiscontinuedForDomains { get; }
+        internal HashSet<string> ExceptionsForEmailAddresses { get; }
+        internal HashSet<string> ForceTransformationToOrganizationForEmailAddresses { get; }
 
         public LoginDiscontinuationConfiguration()
             : this(Enumerable.Empty<string>(), 
@@ -29,12 +29,12 @@ namespace NuGetGallery
             IEnumerable<string> discontinuedForEmailAddresses,
             IEnumerable<string> discontinuedForDomains,
             IEnumerable<string> exceptionsForEmailAddresses,
-            IEnumerable<string> forceTransformationForEmailAddresses)
+            IEnumerable<string> forceTransformationToOrganizationForEmailAddresses)
         {
             DiscontinuedForEmailAddresses = new HashSet<string>(discontinuedForEmailAddresses);
             DiscontinuedForDomains = new HashSet<string>(discontinuedForDomains);
             ExceptionsForEmailAddresses = new HashSet<string>(exceptionsForEmailAddresses);
-            ForceTransformationForEmailAddresses = new HashSet<string>(forceTransformationForEmailAddresses);
+            ForceTransformationToOrganizationForEmailAddresses = new HashSet<string>(forceTransformationToOrganizationForEmailAddresses);
         }
 
         public bool IsLoginDiscontinued(AuthenticatedUser authUser)
@@ -72,7 +72,7 @@ namespace NuGetGallery
             }
 
             var email = user.ToMailAddress();
-            return ForceTransformationForEmailAddresses.Contains(email.Address);
+            return ForceTransformationToOrganizationForEmailAddresses.Contains(email.Address);
         }
     }
 

--- a/src/NuGetGallery/Services/LoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery/Services/LoginDiscontinuationConfiguration.cs
@@ -14,9 +14,13 @@ namespace NuGetGallery
         public HashSet<string> DiscontinuedForEmailAddresses { get; }
         public HashSet<string> DiscontinuedForDomains { get; }
         public HashSet<string> ExceptionsForEmailAddresses { get; }
+        public HashSet<string> ForceTransformationForEmailAddresses { get; }
 
         public LoginDiscontinuationConfiguration()
-            : this(Enumerable.Empty<string>(), Enumerable.Empty<string>(), Enumerable.Empty<string>())
+            : this(Enumerable.Empty<string>(), 
+                  Enumerable.Empty<string>(), 
+                  Enumerable.Empty<string>(), 
+                  Enumerable.Empty<string>())
         {
         }
 
@@ -24,15 +28,22 @@ namespace NuGetGallery
         public LoginDiscontinuationConfiguration(
             IEnumerable<string> discontinuedForEmailAddresses,
             IEnumerable<string> discontinuedForDomains,
-            IEnumerable<string> exceptionsForEmailAddresses)
+            IEnumerable<string> exceptionsForEmailAddresses,
+            IEnumerable<string> forceTransformationForEmailAddresses)
         {
             DiscontinuedForEmailAddresses = new HashSet<string>(discontinuedForEmailAddresses);
             DiscontinuedForDomains = new HashSet<string>(discontinuedForDomains);
             ExceptionsForEmailAddresses = new HashSet<string>(exceptionsForEmailAddresses);
+            ForceTransformationForEmailAddresses = new HashSet<string>(forceTransformationForEmailAddresses);
         }
 
         public bool IsLoginDiscontinued(AuthenticatedUser authUser)
         {
+            if (authUser == null || authUser.User == null)
+            {
+                return false;
+            }
+
             var email = authUser.User.ToMailAddress();
             return
                 authUser.CredentialUsed.IsPassword() &&
@@ -42,10 +53,26 @@ namespace NuGetGallery
 
         public bool AreOrganizationsSupportedForUser(User user)
         {
+            if (user == null)
+            {
+                return false;
+            }
+
             var email = user.ToMailAddress();
             return
                 DiscontinuedForDomains.Contains(email.Host, StringComparer.OrdinalIgnoreCase) ||
                 DiscontinuedForEmailAddresses.Contains(email.Address);
+        }
+
+        public bool ShouldUserTransformIntoOrganization(User user)
+        {
+            if (user == null)
+            {
+                return false;
+            }
+
+            var email = user.ToMailAddress();
+            return ForceTransformationForEmailAddresses.Contains(email.Address);
         }
     }
 
@@ -53,5 +80,6 @@ namespace NuGetGallery
     {
         bool IsLoginDiscontinued(AuthenticatedUser authUser);
         bool AreOrganizationsSupportedForUser(User user);
+        bool ShouldUserTransformIntoOrganization(User user);
     }
 }

--- a/src/NuGetGallery/ViewModels/GalleryHomeViewModel.cs
+++ b/src/NuGetGallery/ViewModels/GalleryHomeViewModel.cs
@@ -9,16 +9,16 @@ namespace NuGetGallery
     {
         public bool ShowTransformModal { get; set; }
 
-        public bool ShouldTransform { get; set; }
+        public bool TransformIntoOrganization { get; set; }
 
         public IList<AuthenticationProviderViewModel> Providers { get; set; }
 
-        public GalleryHomeViewModel() : this(showTransformModal: false, canTransform: false) { }
+        public GalleryHomeViewModel() : this(showTransformModal: false, transformIntoOrganization: false) { }
 
-        public GalleryHomeViewModel(bool showTransformModal, bool canTransform)
+        public GalleryHomeViewModel(bool showTransformModal, bool transformIntoOrganization)
         {
             ShowTransformModal = showTransformModal;
-            ShouldTransform = canTransform;
+            TransformIntoOrganization = transformIntoOrganization;
         }
     }
 }

--- a/src/NuGetGallery/ViewModels/GalleryHomeViewModel.cs
+++ b/src/NuGetGallery/ViewModels/GalleryHomeViewModel.cs
@@ -9,13 +9,16 @@ namespace NuGetGallery
     {
         public bool ShowTransformModal { get; set; }
 
+        public bool ShouldTransform { get; set; }
+
         public IList<AuthenticationProviderViewModel> Providers { get; set; }
 
-        public GalleryHomeViewModel() : this(showTransformModal: false) { }
+        public GalleryHomeViewModel() : this(showTransformModal: false, canTransform: false) { }
 
-        public GalleryHomeViewModel(bool showTransformModal)
+        public GalleryHomeViewModel(bool showTransformModal, bool canTransform)
         {
             ShowTransformModal = showTransformModal;
+            ShouldTransform = canTransform;
         }
     }
 }

--- a/src/NuGetGallery/Views/Pages/Home.cshtml
+++ b/src/NuGetGallery/Views/Pages/Home.cshtml
@@ -13,7 +13,7 @@
         window.showModal = true;
     </script>
     <div id="popUpModal" class="modal fade modal-container" data-backdrop="static">
-        @Html.Partial("_TransformOrLink")
+        @Html.Partial("_TransformOrLink", Model)
     </div>
 }
 

--- a/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
+++ b/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
@@ -14,7 +14,7 @@
                 NuGet.org authentication is deprecated
             </span>
         </div>
-        @if (Model.ShouldTransform)
+        @if (Model.TransformIntoOrganization)
         {
             <p class="transform-text">We have determined this is a team (DL) based account, so you must transform it to an organization on NuGet.org:</p>
             <div class="action-node">

--- a/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
+++ b/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
@@ -1,4 +1,6 @@
-﻿<div class="modal-dialog modal-box">
+﻿@model GalleryHomeViewModel
+
+<div class="modal-dialog modal-box">
     <div class="modal-title">
         <span class="title-text">Sign-in with Microsoft corporate account</span>
         <button type="button" class="dismiss-button" data-dismiss="modal" aria-label="Close">
@@ -12,23 +14,29 @@
                 NuGet.org authentication is deprecated
             </span>
         </div>
-        <div class="action-node">
-            <a role="button" 
-               class="btn btn-default btn-block action-button" 
-               href="@Url.AuthenticateExternal("/")">
-                <img height="24" width="24" alt="" aria-hidden="true"
-                     src="@Href("~/Content/gallery/img/microsoft-account.svg")"
-                     @(!string.IsNullOrEmpty("~/Content/gallery/img/microsoft-account-24x24.png") ? (IHtmlString)ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/microsoft-account-24x24.png")) : new HtmlString(string.Empty)) />
-                <span>Sign in with Microsoft</span>
-            </a>
-        </div>
-        <p class="transform-text">If this is a team (DL) based account, you must transform it to an organization on NuGet.org:</p>
-        <div class="action-node">
-            <a role="button"
-                class="btn btn-default btn-block action-button"
-                href="@Url.TransformAccount()">
-                <span>Transform to an Organization</span>
-            </a>
-        </div>
+        @if (Model.ShouldTransform)
+        {
+            <p class="transform-text">We have determined this is a team (DL) based account, so you must transform it to an organization on NuGet.org:</p>
+            <div class="action-node">
+                <a role="button"
+                    class="btn btn-default btn-block action-button"
+                    href="@Url.TransformAccount()">
+                    <span>Transform to an Organization</span>
+                </a>
+            </div>
+        }
+        else
+        {
+            <div class="action-node">
+                <a role="button" 
+                   class="btn btn-default btn-block action-button" 
+                   href="@Url.AuthenticateExternal("/")">
+                    <img height="24" width="24" alt="" aria-hidden="true"
+                         src="@Href("~/Content/gallery/img/microsoft-account.svg")"
+                         @(!string.IsNullOrEmpty("~/Content/gallery/img/microsoft-account-24x24.png") ? (IHtmlString)ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/microsoft-account-24x24.png")) : new HtmlString(string.Empty)) />
+                    <span>Sign in with Microsoft</span>
+                </a>
+            </div>
+        }
     </div>
 </div>

--- a/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
+++ b/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
@@ -27,6 +27,7 @@
         }
         else
         {
+            <p class="transform-text">We have determined this is an account owned by an individual, so you must link it to a Microsoft account:</p>
             <div class="action-node">
                 <a role="button" 
                    class="btn btn-default btn-block action-button" 

--- a/tests/NuGetGallery.Facts/Services/ContentObjectServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ContentObjectServiceFacts.cs
@@ -32,8 +32,9 @@ namespace NuGetGallery.Services
                 var emails = new[] { "discontinued@different.com" };
                 var domains = new[] { "example.com" };
                 var exceptions = new[] { "exception@example.com" };
+                var shouldTransforms = new[] { "transfomer@example.com" };
 
-                var config = new LoginDiscontinuationConfiguration(emails, domains, exceptions);
+                var config = new LoginDiscontinuationConfiguration(emails, domains, exceptions, shouldTransforms);
                 var configString = JsonConvert.SerializeObject(config);
 
                 GetMock<IContentService>()


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5584

Added a new field to the existing `LoginDiscontinuationConfiguration` for the accounts that should be asked to transform.

Individual account:
![image](https://user-images.githubusercontent.com/18014088/37182007-37bfca48-22e4-11e8-8522-4cbcdabc2be1.png)

Organization account:
![image](https://user-images.githubusercontent.com/18014088/37182035-4c279330-22e4-11e8-9727-a0f90aed3713.png)
