### PR TITLE
Add destination access condition parameter to CopyFileAsync

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="NuGetVersionExtensions.cs" />
     <Compile Include="SemVerLevelKey.cs" />
+    <Compile Include="Services\AccessConditionWrapper.cs" />
     <Compile Include="Services\CloudBlobClientWrapper.cs" />
     <Compile Include="Services\CloudBlobContainerWrapper.cs" />
     <Compile Include="Services\CloudBlobCoreFileStorageService.cs" />
@@ -241,6 +242,7 @@
     <Compile Include="Services\CorePackageFileService.cs" />
     <Compile Include="Services\CorePackageService.cs" />
     <Compile Include="Services\CryptographyService.cs" />
+    <Compile Include="Services\IAccessCondition.cs" />
     <Compile Include="Services\ICloudBlobClient.cs" />
     <Compile Include="Services\ICloudBlobContainer.cs" />
     <Compile Include="Services\ICoreMessageService.cs" />

--- a/src/NuGetGallery.Core/Services/AccessConditionWrapper.cs
+++ b/src/NuGetGallery.Core/Services/AccessConditionWrapper.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.WindowsAzure.Storage;
+
+namespace NuGetGallery
+{
+    public class AccessConditionWrapper : IAccessCondition
+    {
+        private AccessConditionWrapper(string ifNoneMatchETag, string ifMatchETag)
+        {
+            IfNoneMatchETag = ifNoneMatchETag;
+            IfMatchETag = IfMatchETag;
+        }
+
+        public string IfNoneMatchETag { get; }
+
+        public string IfMatchETag { get; }
+
+        public static IAccessCondition GenerateIfMatchCondition(string etag)
+        {
+            return new AccessConditionWrapper(
+                ifNoneMatchETag: null,
+                ifMatchETag: AccessCondition.GenerateIfMatchCondition(etag).IfMatchETag);
+        }
+
+        public static IAccessCondition GenerateIfNotExistsCondition()
+        {
+            return new AccessConditionWrapper(
+                ifNoneMatchETag: AccessCondition.GenerateIfNotExistsCondition().IfNoneMatchETag,
+                ifMatchETag: null);
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Services/IAccessCondition.cs
+++ b/src/NuGetGallery.Core/Services/IAccessCondition.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// A wrapper type around <see cref="Microsoft.WindowsAzure.Storage.AccessCondition"/>.
+    /// </summary>
+    public interface IAccessCondition
+    {
+        string IfNoneMatchETag { get; }
+        string IfMatchETag { get; }
+    }
+}

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -46,6 +46,18 @@ namespace NuGetGallery
         /// <param name="srcFileName">The source file name or relative file path.</param>
         /// <param name="destFolderName">The destination folder.</param>
         /// <param name="destFileName">The destination file name or relative file path.</param>
-        Task CopyFileAsync(string srcFolderName, string srcFileName, string destFolderName, string destFileName);
+        /// <param name="destAccessCondition">
+        /// The access condition used to determine whether the destination is in the expected state.
+        /// </param>
+        /// <returns>
+        /// The etag of the source file. This can be used if the destination file is later intended to replace
+        /// the source file in conjunction with <paramref name="destAccessCondition"/>.
+        /// </returns>
+        Task<string> CopyFileAsync(
+            string srcFolderName,
+            string srcFileName,
+            string destFolderName,
+            string destFileName,
+            IAccessCondition destAccessCondition);
     }
 }

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -169,7 +169,12 @@ namespace NuGetGallery
             return Task.FromResult(0);
         }
 
-        public Task CopyFileAsync(string srcFolderName, string srcFileName, string destFolderName, string destFileName)
+        public Task<string> CopyFileAsync(
+            string srcFolderName,
+            string srcFileName,
+            string destFolderName,
+            string destFileName,
+            IAccessCondition destAccessCondition)
         {
             if (srcFolderName == null)
             {
@@ -205,7 +210,7 @@ namespace NuGetGallery
                 throw new InvalidOperationException("Could not copy because destination file already exists", e);
             }
 
-            return Task.CompletedTask;
+            return Task.FromResult<string>(null);
         }
 
         public Task<bool> IsAvailableAsync()

--- a/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
@@ -333,7 +333,12 @@ namespace NuGetGallery
                     new MemoryStream(Encoding.ASCII.GetBytes(content)));
 
                 // Act
-                await _target.CopyFileAsync(_srcFolderName, _srcFileName, _destFolderName, _destFileName);
+                await _target.CopyFileAsync(
+                    _srcFolderName,
+                    _srcFileName,
+                    _destFolderName,
+                    _destFileName,
+                    destAccessCondition: null);
 
                 // Assert
                 using (var destStream = await _target.GetFileAsync(_destFolderName, _destFileName))
@@ -358,7 +363,12 @@ namespace NuGetGallery
                     new MemoryStream(Encoding.ASCII.GetBytes(content)));
 
                 await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => _target.CopyFileAsync(_srcFolderName, _srcFileName, _destFolderName, _destFileName));
+                    () => _target.CopyFileAsync(
+                        _srcFolderName,
+                        _srcFileName,
+                        _destFolderName,
+                        _destFileName,
+                        destAccessCondition: null));
             }
 
             [Fact]
@@ -377,7 +387,12 @@ namespace NuGetGallery
 
                 // Act & Assert
                 await Assert.ThrowsAsync<InvalidOperationException>(
-                    () => _target.CopyFileAsync(_srcFolderName, _srcFileName, _destFolderName, _destFileName));
+                    () => _target.CopyFileAsync(
+                        _srcFolderName,
+                        _srcFileName,
+                        _destFolderName,
+                        _destFileName,
+                        destAccessCondition: null));
             }
 
             public void Dispose()


### PR DESCRIPTION
This is used during revalidate to verify the destination package has not changed.

If a processor has mutated a package, the copy that replaces the destination package should fail if the destination has changed.

Progress on https://github.com/NuGet/Engineering/issues/1190