### PR TITLE
Add GenerateEmptyCondition and fix AccessConditionWrapper bug

### DIFF
--- a/src/NuGetGallery.Core/Services/AccessConditionWrapper.cs
+++ b/src/NuGetGallery.Core/Services/AccessConditionWrapper.cs
@@ -10,12 +10,19 @@ namespace NuGetGallery
         private AccessConditionWrapper(string ifNoneMatchETag, string ifMatchETag)
         {
             IfNoneMatchETag = ifNoneMatchETag;
-            IfMatchETag = IfMatchETag;
+            IfMatchETag = ifMatchETag;
         }
 
         public string IfNoneMatchETag { get; }
 
         public string IfMatchETag { get; }
+
+        public static IAccessCondition GenerateEmptyCondition()
+        {
+            return new AccessConditionWrapper(
+                ifNoneMatchETag: null,
+                ifMatchETag: null);
+        }
 
         public static IAccessCondition GenerateIfMatchCondition(string etag)
         {

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Packaging\NupkgRewriterFacts.cs" />
     <Compile Include="SemVerLevelKeyFacts.cs" />
+    <Compile Include="Services\AccessConditionWrapperFacts.cs" />
     <Compile Include="Services\CloudBlobCoreFileStorageServiceFacts.cs" />
     <Compile Include="Services\CorePackageFileServiceFacts.cs" />
     <Compile Include="Services\CorePackageServiceFacts.cs" />

--- a/tests/NuGetGallery.Core.Facts/Services/AccessConditionWrapperFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/AccessConditionWrapperFacts.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.Services
+{
+    public class AccessConditionWrapperFacts
+    {
+        [Theory]
+        [InlineData("*")]
+        [InlineData("\"some-etag\"")]
+        [InlineData("no quotes")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void GenerateIfMatchCondition(string etag)
+        {
+            var actual = AccessConditionWrapper.GenerateIfMatchCondition(etag);
+
+            Assert.Equal(etag, actual.IfMatchETag);
+            Assert.Null(actual.IfNoneMatchETag);
+        }
+
+        [Fact]
+        public void GenerateIfNotExistsCondition()
+        {
+            var actual = AccessConditionWrapper.GenerateIfNotExistsCondition();
+
+            Assert.Null(actual.IfMatchETag);
+            Assert.Equal("*", actual.IfNoneMatchETag);
+        }
+
+        [Fact]
+        public void GenerateEmptyCondition()
+        {
+            var actual = AccessConditionWrapper.GenerateEmptyCondition();
+
+            Assert.Null(actual.IfMatchETag);
+            Assert.Null(actual.IfNoneMatchETag);
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -861,7 +861,7 @@ namespace NuGetGallery
                 _destBlobMock.Verify(
                     x => x.StartCopyAsync(It.IsAny<ISimpleCloudBlob>(), It.IsAny<AccessCondition>(), It.IsAny<AccessCondition>()),
                     Times.Once);
-                Assert.NotEqual("etag!", destAccessCondition.IfMatchETag);
+                Assert.Equal("etag!", destAccessCondition.IfMatchETag);
                 Assert.Null(destAccessCondition.IfNoneMatchETag);
             }
 


### PR DESCRIPTION
Note to self, add unit tests even on wrapper classes...

Progress on https://github.com/NuGet/Engineering/issues/1190.