### PR TITLE
Add overload to CopyFileAsync which supports a source URI

### DIFF
--- a/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 
@@ -16,6 +19,27 @@ namespace NuGetGallery
         {
             _storageConnectionString = storageConnectionString;
             _readAccessGeoRedundant = readAccessGeoRedundant;
+        }
+
+        public ISimpleCloudBlob GetBlobFromUri(Uri uri)
+        {
+            // For Azure blobs, the query string is assumed to be the SAS token.
+            ISimpleCloudBlob blob;
+            if (!string.IsNullOrEmpty(uri.Query))
+            {
+                var uriBuilder = new UriBuilder(uri);
+                uriBuilder.Query = string.Empty;
+
+                blob = new CloudBlobWrapper(new CloudBlockBlob(
+                    uriBuilder.Uri,
+                    new StorageCredentials(uri.Query)));
+            }
+            else
+            {
+                blob = new CloudBlobWrapper(new CloudBlockBlob(uri));
+            }
+
+            return blob;
         }
 
         public ICloudBlobContainer GetContainerReference(string containerAddress)

--- a/src/NuGetGallery.Core/Services/ICloudBlobClient.cs
+++ b/src/NuGetGallery.Core/Services/ICloudBlobClient.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+
 namespace NuGetGallery
 {
     public interface ICloudBlobClient
     {
         ICloudBlobContainer GetContainerReference(string containerAddress);
+
+        ISimpleCloudBlob GetBlobFromUri(Uri uri);
     }
 }

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -37,6 +37,28 @@ namespace NuGetGallery
         Task SaveFileAsync(string folderName, string fileName, Stream packageFile, bool overwrite = true);
 
         /// <summary>
+        /// Copies the source URI to the destination file. If the destination already exists and the content
+        /// is different, an exception should be thrown. If the file already exists, the implementation can choose to
+        /// no-op if the content is the same instead of throwing an exception. This method should throw if the source
+        /// file does not exist.
+        /// </summary>
+        /// <param name="srcUri">The URI of the source file.</param>
+        /// <param name="destFolderName">The destination folder.</param>
+        /// <param name="destFileName">The destination file name or relative file path.</param>
+        /// <param name="destAccessCondition">
+        /// The access condition used to determine whether the destination is in the expected state.
+        /// </param>
+        /// <returns>
+        /// The etag of the source file. This can be used if the destination file is later intended to replace
+        /// the source file in conjunction with <paramref name="destAccessCondition"/>.
+        /// </returns>
+        Task CopyFileAsync(
+            Uri srcUri,
+            string destFolderName,
+            string destFileName,
+            IAccessCondition destAccessCondition);
+
+        /// <summary>
         /// Copies the source file to the destination file. If the destination already exists and the content
         /// is different, an exception should be thrown. If the file already exists, the implementation can choose to
         /// no-op if the content is the same instead of throwing an exception. This method should throw if the source

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -169,6 +169,13 @@ namespace NuGetGallery
             return Task.FromResult(0);
         }
 
+        public Task CopyFileAsync(Uri srcUri, string destFolderName, string destFileName, IAccessCondition destAccessCondition)
+        {
+            // We could theoretically support this by downloading the source URI to the destination path. This is not
+            // needed today so this method will remain unimplemented until it is needed.
+            throw new NotImplementedException();
+        }
+
         public Task<string> CopyFileAsync(
             string srcFolderName,
             string srcFileName,

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Packaging\NupkgRewriterFacts.cs" />
     <Compile Include="SemVerLevelKeyFacts.cs" />
     <Compile Include="Services\AccessConditionWrapperFacts.cs" />
+    <Compile Include="Services\CloudBlobClientWrapperFacts.cs" />
     <Compile Include="Services\CloudBlobCoreFileStorageServiceFacts.cs" />
     <Compile Include="Services\CorePackageFileServiceFacts.cs" />
     <Compile Include="Services\CorePackageServiceFacts.cs" />

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobClientWrapperFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobClientWrapperFacts.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Xunit;
+
+namespace NuGetGallery.Services
+{
+    public class CloudBlobClientWrapperFacts
+    {
+        public class GetBlobFromUri
+        {
+            [Fact]
+            public void UsesQueryStringAsSasToken()
+            {
+                var blobUrl = "https://example.blob.core.windows.net/packages/nuget.versioning.4.6.0.nupkg";
+                var sasToken = "?st=2018-03-12T14%3A55%3A00Z&se=2018-03-13T14%3A55%3A00Z&sp=r&sv=2017-04-17&sr=c&sig=dCXxOlBp6dQHqxTeCRABpr1lfpt40QUaHsAQqs9zHds%3D";
+                var uri = new Uri(blobUrl + sasToken);
+                var target = new CloudBlobClientWrapper("UseDevelopmentStorage=true", readAccessGeoRedundant: false);
+
+                var blob = target.GetBlobFromUri(uri);
+
+                var innerBlob = Assert.IsType<CloudBlockBlob>(blob
+                    .GetType()
+                    .GetField("_blob", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .GetValue(blob));
+                Assert.Equal(AuthenticationScheme.SharedKey, innerBlob.ServiceClient.AuthenticationScheme);
+                Assert.False(innerBlob.ServiceClient.Credentials.IsAnonymous);
+                Assert.True(innerBlob.ServiceClient.Credentials.IsSAS);
+                Assert.False(innerBlob.ServiceClient.Credentials.IsSharedKey);
+                Assert.Equal(sasToken, innerBlob.ServiceClient.Credentials.SASToken);
+                Assert.Equal(blobUrl, innerBlob.Uri.AbsoluteUri);
+            }
+
+            [Fact]
+            public void UsesAnonymousAuthWhenThereIsNotQueryString()
+            {
+                var blobUrl = "https://example.blob.core.windows.net/packages/nuget.versioning.4.6.0.nupkg";
+                var uri = new Uri(blobUrl);
+                var target = new CloudBlobClientWrapper("UseDevelopmentStorage=true", readAccessGeoRedundant: false);
+
+                var blob = target.GetBlobFromUri(uri);
+
+                var innerBlob = Assert.IsType<CloudBlockBlob>(blob
+                    .GetType()
+                    .GetField("_blob", BindingFlags.NonPublic | BindingFlags.Instance)
+                    .GetValue(blob));
+                Assert.Equal(AuthenticationScheme.SharedKey, innerBlob.ServiceClient.AuthenticationScheme);
+                Assert.True(innerBlob.ServiceClient.Credentials.IsAnonymous);
+                Assert.False(innerBlob.ServiceClient.Credentials.IsSAS);
+                Assert.False(innerBlob.ServiceClient.Credentials.IsSharedKey);
+                Assert.Equal(blobUrl, innerBlob.Uri.AbsoluteUri);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -631,6 +631,7 @@ namespace NuGetGallery
             private string _srcFolderName;
             private string _srcFileName;
             private string _srcETag;
+            private Uri _srcUri;
             private BlobProperties _srcProperties;
             private string _destFolderName;
             private string _destFileName;
@@ -649,6 +650,7 @@ namespace NuGetGallery
                 _srcFolderName = "validation";
                 _srcFileName = "4b6f16cc-7acd-45eb-ac21-33f0d927ec14/nuget.versioning.4.5.0.nupkg";
                 _srcETag = "\"src-etag\"";
+                _srcUri = new Uri("https://example/nuget.versioning.4.5.0.nupkg");
                 _srcProperties = new BlobProperties();
                 _destFolderName = "packages";
                 _destFileName = "nuget.versioning.4.5.0.nupkg";
@@ -694,6 +696,41 @@ namespace NuGetGallery
                     .Returns(() => _destCopyState);
 
                 _target = CreateService(fakeBlobClient: _blobClient);
+            }
+
+            [Fact]
+            public async Task WillCopyBlobFromSourceUri()
+            {
+                // Arrange
+                _blobClient
+                    .Setup(x => x.GetBlobFromUri(It.IsAny<Uri>()))
+                    .Returns(_srcBlobMock.Object);
+
+                _destBlobMock
+                    .Setup(x => x.StartCopyAsync(It.IsAny<ISimpleCloudBlob>(), It.IsAny<AccessCondition>(), It.IsAny<AccessCondition>()))
+                    .Returns(Task.FromResult(0))
+                    .Callback<ISimpleCloudBlob, AccessCondition, AccessCondition>((_, __, ___) =>
+                    {
+                        SetDestCopyStatus(CopyStatus.Success);
+                    });
+
+                // Act
+                await _target.CopyFileAsync(
+                    _srcUri,
+                    _destFolderName,
+                    _destFileName,
+                    AccessConditionWrapper.GenerateIfNotExistsCondition());
+
+                // Assert
+                _destBlobMock.Verify(
+                    x => x.StartCopyAsync(_srcBlobMock.Object, It.IsAny<AccessCondition>(), It.IsAny<AccessCondition>()),
+                    Times.Once);
+                _destBlobMock.Verify(
+                    x => x.StartCopyAsync(It.IsAny<ISimpleCloudBlob>(), It.IsAny<AccessCondition>(), It.IsAny<AccessCondition>()),
+                    Times.Once);
+                _blobClient.Verify(
+                    x => x.GetBlobFromUri(_srcUri),
+                    Times.Once);
             }
 
             [Fact]


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1190

This is needed because `IProcessor` returns a `NupkgUrl`. Per Blob Storage's implementation of server-side copy, this URL must point to an Blob Storage location and must either be a public blob or authenticated with a SAS token:
https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob#request-headers

I could have chosen to make `IProcessor` return a container name and file name, but I think this is the wrong abstraction as it forces `IProcessor` nupkgs to be in the same region and account as the destination.