### PR TITLE
[Validation] Display notice if package validation exceeds expectation

### DIFF
--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -68,6 +68,8 @@ namespace NuGetGallery.Configuration
 
         public TimeSpan AsynchronousPackageValidationDelay { get; set; }
 
+        public TimeSpan ValidationExpectedTime { get; set; }
+
         public bool DeprecateNuGetPasswordLogins { get; set; }
 
         /// <summary>
@@ -254,6 +256,11 @@ namespace NuGetGallery.Configuration
         /// Gets/sets a bool that indicates if the OData requests will be filtered.
         /// </summary>
         public bool IsODataFilterEnabled { get; set; }
+
+        /// <summary>
+        /// Gets/sets a string that is a link to an external status page
+        /// </summary>
+        public string ExternalStatusUrl { get; set; }
 
         /// <summary>
         /// Gets/sets a string that is a link to an external about page

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -96,6 +96,11 @@ namespace NuGetGallery.Configuration
         TimeSpan AsynchronousPackageValidationDelay { get; set; }
 
         /// <summary>
+        /// The upper bound for package validations. A notice will be displayed if a package's validation exceeds this value.
+        /// </summary>
+        TimeSpan ValidationExpectedTime { get; set; }
+
+        /// <summary>
         /// Gets a boolean indicating whether NuGet password logins are deprecated.
         /// </summary>
         bool DeprecateNuGetPasswordLogins { get; set; }
@@ -253,6 +258,11 @@ namespace NuGetGallery.Configuration
         /// Gets/sets a bool that indicates if the OData requests will be filtered.
         /// </summary>
         bool IsODataFilterEnabled { get; set; }
+
+        /// <summary>
+        /// Gets/sets a string that is a link to the status page
+        /// </summary>
+        string ExternalStatusUrl { get; set; }
 
         /// <summary>
         /// Gets/sets a string that is a link to an external about page

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -461,6 +461,7 @@ namespace NuGetGallery
 
             var model = new DisplayPackageViewModel(package, currentUser, packageHistory);
 
+            model.ValidatingTooLong = _validationService.IsValidatingTooLong(package);
             model.ValidationIssues = _validationService.GetLatestValidationIssues(package);
 
             model.ReadMeHtml = await _readMeService.GetReadMeHtmlAsync(package);

--- a/src/NuGetGallery/Services/IValidationService.cs
+++ b/src/NuGetGallery/Services/IValidationService.cs
@@ -27,6 +27,13 @@ namespace NuGetGallery
         Task RevalidateAsync(Package package);
 
         /// <summary>
+        /// Whether the package's validation time exceeds the expected validation time.
+        /// </summary>
+        /// <param name="package">The package whose validation time should be inspected.</param>
+        /// <returns>Whether the package's validation time exceeds the expected validation time.</returns>
+        bool IsValidatingTooLong(Package package);
+
+        /// <summary>
         /// Get the package's validation issues from the latest validation.
         /// </summary>
         /// <param name="package">The package whose validation issues should be fetched.</param>

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -53,6 +53,7 @@ namespace NuGetGallery
             DownloadsPerDayLabel = DownloadsPerDay < 1 ? "<1" : DownloadsPerDay.ToNuGetNumberString();
         }
 
+        public bool ValidatingTooLong { get; set; }
         public IReadOnlyList<ValidationIssue> ValidationIssues { get; set; }
         public DependencySetsViewModel Dependencies { get; set; }
         public IEnumerable<DisplayPackageViewModel> PackageVersions { get; set; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -153,6 +153,15 @@
                         validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
                     </text>
                 )
+
+                if (Model.ValidatingTooLong)
+                {
+                    @ViewHelpers.AlertWarning(
+                        @<text>
+                            <strong>Package validation is taking longer than expected.</strong> This is not normal, but we are on it!
+                        </text>
+                    )
+                }
             }
 
             @if (Model.FailedValidation)

--- a/src/NuGetGallery/Views/Shared/Gallery/Footer.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Footer.cshtml
@@ -8,7 +8,7 @@
                 </p>
             </div>
             <div class="col-sm-4">
-                <span class="footer-heading"><a href="https://status.nuget.org/">Status</a></span>
+                <span class="footer-heading"><a href="@this.Config.Current.ExternalStatusUrl">Status</a></span>
                 <p>
                     Find out the service status of NuGet.org and its related services.
                 </p>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -41,6 +41,7 @@
     <add key="Gallery.AsynchronousPackageValidationEnabled" value="false" />
     <add key="Gallery.BlockingAsynchronousPackageValidationEnabled" value="false" />
     <add key="Gallery.AsynchronousPackageValidationDelay" value="00:00:05" />
+    <add key="Gallery.ValidationExpectedTime" value="00:50:00" />
     <add key="Gallery.DeprecateNuGetPasswordLogins" value="false" />
 
     <add key="AzureServiceBus.Validation.ConnectionString" value="" />
@@ -142,6 +143,7 @@
     <add key="Gallery.CollectPerfLogs" value="false" />
     <add key="Gallery.IsODataFilterEnabled" value="false" />
 
+    <add key="Gallery.ExternalStatusUrl" value="https://status.nuget.org/" />
     <add key="Gallery.ExternalAboutUrl" value="" />
     <add key="Gallery.ExternalPrivacyPolicyUrl" value="" />
     <add key="Gallery.ExternalTermsOfUseUrl" value="" />


### PR DESCRIPTION
Displays a notice on the Display Package page if the validation is taking longer than expected.

![validationtoolong](https://user-images.githubusercontent.com/737941/37376305-d56e0390-26e0-11e8-9b39-c68b75f64cdb.png)

Progress on https://github.com/NuGet/Engineering/issues/1144
