### PR TITLE
Get the package hash from the stream when backing up

### DIFF
--- a/src/NuGetGallery.Core/Services/CorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageFileService.cs
@@ -159,10 +159,17 @@ namespace NuGetGallery
                 version = package.NormalizedVersion;
             }
 
+            // Hash the provided stream instead of using the hash on the package. This is to avoid a backup with the
+            // incorrect file name if the hash in the DB does not match the package (a potentially transient issue).
+            var hash = CryptographyService.GenerateHash(
+                packageFile,
+                hashAlgorithmId: CoreConstants.Sha512HashAlgorithmId);
+            packageFile.Position = 0;
+
             var fileName = BuildBackupFileName(
                 package.PackageRegistration.Id,
                 version,
-                package.Hash);
+                hash);
 
             // If the package already exists, don't even bother uploading it. The file name is based off of the hash so
             // we know the upload isn't necessary.

--- a/src/NuGetGallery.Core/Services/CryptographyService.cs
+++ b/src/NuGetGallery.Core/Services/CryptographyService.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
     {
         public static string GenerateHash(
             Stream input,
-            string hashAlgorithmId = CoreConstants.Sha512HashAlgorithmId)
+            string hashAlgorithmId)
         {
             input.Position = 0;
 

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -462,7 +462,9 @@ namespace NuGetGallery
                         var packageStreamMetadata = new PackageStreamMetadata
                         {
                             HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
-                            Hash = CryptographyService.GenerateHash(packageStream.AsSeekableStream()),
+                            Hash = CryptographyService.GenerateHash(
+                                packageStream.AsSeekableStream(),
+                                CoreConstants.Sha512HashAlgorithmId),
                             Size = packageStream.Length
                         };
 

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1488,7 +1488,9 @@ namespace NuGetGallery
                 var packageStreamMetadata = new PackageStreamMetadata
                 {
                     HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
-                    Hash = CryptographyService.GenerateHash(uploadFile.AsSeekableStream()),
+                    Hash = CryptographyService.GenerateHash(
+                        uploadFile.AsSeekableStream(),
+                        CoreConstants.Sha512HashAlgorithmId),
                     Size = uploadFile.Length,
                 };
 

--- a/src/NuGetGallery/Services/ReflowPackageService.cs
+++ b/src/NuGetGallery/Services/ReflowPackageService.cs
@@ -49,7 +49,9 @@ namespace NuGetGallery
                         var packageStreamMetadata = new PackageStreamMetadata
                         {
                             HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
-                            Hash = CryptographyService.GenerateHash(packageStream.AsSeekableStream()),
+                            Hash = CryptographyService.GenerateHash(
+                                packageStream.AsSeekableStream(),
+                                CoreConstants.Sha512HashAlgorithmId),
                             Size = packageStream.Length,
                         };
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1190.

Since we can now mutate packages via processors, it is possible for the hash in the DB to mismatch the hash of the actual package. Therefore, we should calculate the hash from the backed up stream.

I chose not to change the backup method to use `CopyFileAsync` (i.e. server-side copy) because this would have it's own race conditions and requires a `srcAccessCondition`. We have to download the package anyway to calculate the hash. We can revisit this later if we want to improve the performance.

Also, make the hash algorithm a required parameter to `CryptographyService.GenerateHash`. It's silly for the caller to not care about the hash algorithm, especially since you have to put the hash algorithm name in the database record anyway.