### PR TITLE
Fix login page for local debugging.

### DIFF
--- a/src/NuGetGallery/Views/Authentication/SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/SignIn.cshtml
@@ -25,28 +25,31 @@
             <h1>Sign in</h1>
         </div>
     </div>
-
-    @foreach (var provider in Model.Providers)
+    @if (Model.Providers.Any())
     {
-        <div class="row">
-            <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
-                <a role="button" class="btn btn-default btn-block provider-button"
-                   href="@Url.Authenticate(provider.ProviderName, returnUrl)">
-                    @if (!string.IsNullOrEmpty(@provider.UI.IconImagePath))
-                    {
-                        <img height="24" width="24" alt="" aria-hidden="true"
-                             src="@Href(provider.UI.IconImagePath)"
-                             @(!string.IsNullOrEmpty(provider.UI.IconImageFallbackPath) ? (IHtmlString)ViewHelpers.ImageFallback(Url.Absolute(provider.UI.IconImageFallbackPath)) : new HtmlString(string.Empty)) />
-                    }
-                    @provider.UI.SignInMessage
-                </a>
+        foreach (var provider in Model.Providers)
+        {
+            <div class="row">
+                <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
+                    <a role="button" class="btn btn-default btn-block provider-button"
+                       href="@Url.Authenticate(provider.ProviderName, returnUrl)">
+                        @if (!string.IsNullOrEmpty(@provider.UI.IconImagePath))
+                        {
+                            <img height="24" width="24" alt="" aria-hidden="true"
+                                 src="@Href(provider.UI.IconImagePath)"
+                                 @(!string.IsNullOrEmpty(provider.UI.IconImageFallbackPath) ? (IHtmlString)ViewHelpers.ImageFallback(Url.Absolute(provider.UI.IconImageFallbackPath)) : new HtmlString(string.Empty)) />
+                        }
+                        @provider.UI.SignInMessage
+                    </a>
+                </div>
             </div>
-        </div>
-        <div class="row text-center create-provider-account">
-                <span>
-                    <a href="#" id="signin-assistance">Need assistance signing in?</a>
-                </span>
-        </div>
+            <div class="row text-center create-provider-account">
+                    <span>
+                        <a href="#" id="signin-assistance">Need assistance signing in?</a>
+                    </span>
+            </div>
+        }
+
         <div class="row nuget-signin">
             <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
                 <p class="text-center">
@@ -55,7 +58,16 @@
             </div>
         </div>
     }
+    else
+    {
+        <div class="row">
+            <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
+                @Html.Partial("_SignIn", Model)
+            </div>
+        </div>
+    }
 </section>
+
 
 <div style="display: none" id="signinAssistanceModal" class="modal fade modal-container" data-backdrop="static">
     @Html.Partial("_SigninAssistance")
@@ -64,8 +76,6 @@
 @section bottomScripts {
     <script type="text/javascript">
         var signinAssistanceUrl = "@Url.SigninAssistance()"
-
-        // Strings
         var strings_InvalidUsername = "@Html.Raw(Strings.SigninAssistance_InvalidUser)";
     </script>
     @ViewHelpers.SectionsScript(this)


### PR DESCRIPTION
Fixes:
- https://github.com/NuGet/NuGetGallery/issues/5606 - Show password login for local login.
- https://github.com/NuGet/NuGetGallery/issues/5040 - Simplify password login when no external providers present.

Now if there is no external provider configured, we will see password login on the first sign in page itself. 

Note: use `?w=1`(https://github.com/NuGet/NuGetGallery/pull/5613/files?w=1) to ignore whitespace changes