### PR TITLE
Don't delete Web UI test results and only delete minimal functional test results

### DIFF
--- a/tests/Scripts/RunP0Tests.bat
+++ b/tests/Scripts/RunP0Tests.bat
@@ -16,14 +16,11 @@ set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 
 REM Clean previous test results
-if exist functionaltests.*.xml (
-    del functionaltests.*.xml
+if exist functionaltests.P0.xml (
+    del functionaltests.P0.xml
 )
 if exist NuGetGallery.P0.*.trx (
     del NuGetGallery.P0.*.trx
-)
-if exist TestResults (
-    rd TestResults /S /Q
 )
 
 REM Restore packages

--- a/tests/Scripts/RunP1Tests.bat
+++ b/tests/Scripts/RunP1Tests.bat
@@ -16,14 +16,11 @@ set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 
 REM Clean previous test results
-if exist functionaltests.*.xml (
-    del functionaltests.*.xml
+if exist functionaltests.P1.xml (
+    del functionaltests.P1.xml
 )
 if exist NuGetGallery.P1.*.trx (
     del NuGetGallery.P1.*.trx
-)
-if exist TestResults (
-    rd TestResults /S /Q
 )
 
 REM Restore packages

--- a/tests/Scripts/RunP2Tests.bat
+++ b/tests/Scripts/RunP2Tests.bat
@@ -16,14 +16,11 @@ set nuget="nuget.exe"
 set mstest="C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\mstest.exe"
 
 REM Clean previous test results
-if exist functionaltests.*.xml (
-    del functionaltests.*.xml
+if exist functionaltests.P2.xml (
+    del functionaltests.P2.xml
 )
 if exist NuGetGallery.P2.*.trx (
     del NuGetGallery.P2.*.trx
-)
-if exist TestResults (
-    rd TestResults /S /Q
 )
 
 REM Restore packages


### PR DESCRIPTION
Today, since we delete the Web UI test results, only the P2 Web UI results are available.

We can depend on the CI build configurations "Clean all build directories" setting to do the clean-up.