### PR TITLE
Hotfix: Revert "Hotfix: Revert "Fix SemVerLevel propagation in Odata Next links. (#5582)" (#5623)"

### DIFF
--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -183,7 +183,7 @@ namespace NuGetGallery.Controllers
                         .ToV2FeedPackageQuery(GetSiteRoot(), _configurationService.Features.FriendlyLicenses, semVerLevelKey);
 
                     return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                       SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s));
+                       SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s, semVerLevelKey));
                 }
             }
             catch (Exception ex)
@@ -299,7 +299,8 @@ namespace NuGetGallery.Controllers
                             resultCount, 
                             new { searchTerm, targetFramework, includePrerelease }, 
                             o, 
-                            s);
+                            s,
+                            semVerLevelKey);
                     }
                     return null;
                 });

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -92,7 +92,7 @@ namespace NuGetGallery.Controllers
                                 semVerLevelKey);
 
                         return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                           SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, null, o, s));
+                           SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, null, o, s, semVerLevelKey));
                     }
                 }
             }
@@ -251,7 +251,7 @@ namespace NuGetGallery.Controllers
                             semVerLevelKey);
 
                     return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                       SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s));
+                       SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s, semVerLevelKey));
                 }
             }
             catch (Exception ex)
@@ -358,7 +358,7 @@ namespace NuGetGallery.Controllers
                     // Strip it of for backward compatibility.
                     if (o.Top == null || (resultCount.HasValue && o.Top.Value >= resultCount.Value))
                     {
-                        return SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { searchTerm, targetFramework, includePrerelease }, o, s);
+                        return SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { searchTerm, targetFramework, includePrerelease }, o, s, semVerLevelKey);
                     }
                     return null;
                 });

--- a/src/NuGetGallery/OData/SearchService/SearchAdaptor.cs
+++ b/src/NuGetGallery/OData/SearchService/SearchAdaptor.cs
@@ -291,7 +291,7 @@ namespace NuGetGallery.OData
             return true;
         }
         
-        public static Uri GetNextLink(Uri currentRequestUri, long? totalResultCount, object queryParameters, ODataQueryOptions options, ODataQuerySettings settings)
+        public static Uri GetNextLink(Uri currentRequestUri, long? totalResultCount, object queryParameters, ODataQueryOptions options, ODataQuerySettings settings, int? semVerLevelKey = null)
         {
             if (!totalResultCount.HasValue || totalResultCount.Value <= MaxPageSize || totalResultCount.Value == 0)
             {
@@ -372,6 +372,16 @@ namespace NuGetGallery.OData
                 queryBuilder.Append("$top=");
                 queryBuilder.Append(options.Top.RawValue);
                 queryBuilder.Append("&");
+            }
+
+            if (semVerLevelKey != null)
+            {
+                if(semVerLevelKey == SemVerLevelKey.SemVer2)
+                {
+                    queryBuilder.Append("semVerLevel=");
+                    queryBuilder.Append(SemVerLevelKey.SemVerLevel2);
+                    queryBuilder.Append("&");
+                }
             }
 
             var queryString = queryBuilder.ToString().TrimEnd('&');

--- a/tests/NuGetGallery.Facts/Services/SearchAdaptorFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SearchAdaptorFacts.cs
@@ -133,6 +133,23 @@ namespace NuGetGallery
                 // Assert
                 Assert.Equal(new Uri("https://localhost:8081/api/v2/Search()?searchTerm='foo'&$orderby=Id&$skip=200&$top=1000"), nextLink);
             }
+
+            [Fact]
+            public void GeneratesNextLinkForComplexUrlWithSemVerLevel2()
+            {
+                // Arrange
+                var requestUri = new Uri("https://localhost:8081/api/v2/Search()?searchTerm='foo'&$orderby=Id&$skip=100&$top=1000&semVerLevel=2.0.0");
+                var resultCount = 2000; // our result set contains 2000 elements
+
+                // Act
+                var nextLink = SearchAdaptor.GetNextLink(requestUri, resultCount, new { searchTerm = "foo" },
+                    GetODataQueryOptionsForTest(requestUri),
+                    GetODataQuerySettingsForTest(),
+                    SemVerLevelKey.SemVer2);
+
+                // Assert
+                Assert.Equal(new Uri("https://localhost:8081/api/v2/Search()?searchTerm='foo'&$orderby=Id&$skip=200&$top=1000&semVerLevel=2.0.0"), nextLink);
+            }
         }
     }
 }


### PR DESCRIPTION
This reverts commit 24256775e2c34c767f863bf3ff1036eccc7f9fa7.

We determined the issue with the commit was not actually caused by the commit but instead was an existing issue. As such, we are re-including it in the deployment.