### PR TITLE
Don't immediately commit readme changes during UI upload

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1249,7 +1249,12 @@ namespace NuGetGallery
             if (formData.Edit != null)
             {
                 // Update readme.md file, if modified.
-                var readmeChanged = await _readMeService.SaveReadMeMdIfChanged(package, formData.Edit, Request.ContentEncoding);
+                var readmeChanged = await _readMeService.SaveReadMeMdIfChanged(
+                    package,
+                    formData.Edit,
+                    Request.ContentEncoding,
+                    commitChanges: true);
+
                 if (readmeChanged)
                 {
                     _telemetryService.TrackPackageReadMeChangeEvent(package, formData.Edit.ReadMe.SourceType, formData.Edit.ReadMeState);
@@ -1574,7 +1579,11 @@ namespace NuGetGallery
 
                 if (formData.Edit != null)
                 {
-                    if (await _readMeService.SaveReadMeMdIfChanged(package, formData.Edit, Request.ContentEncoding))
+                    if (await _readMeService.SaveReadMeMdIfChanged(
+                        package,
+                        formData.Edit,
+                        Request.ContentEncoding,
+                        commitChanges: false))
                     {
                         _telemetryService.TrackPackageReadMeChangeEvent(package, formData.Edit.ReadMe.SourceType, formData.Edit.ReadMeState);
                     }

--- a/src/NuGetGallery/Services/IReadMeService.cs
+++ b/src/NuGetGallery/Services/IReadMeService.cs
@@ -41,7 +41,13 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="package">Package entity associated with the ReadMe.</param>
         /// <param name="edit">Package version edit readme request.</param>
+        /// <param name="encoding">The encoding used when reading the existing readme.</param>
+        /// <param name="commitChanges">Whether or not to commit the pending changes to the database.</param>
         /// <returns>True if the package readme changed, otherwise false.</returns>
-        Task<bool> SaveReadMeMdIfChanged(Package package, EditPackageVersionReadMeRequest edit, Encoding encoding);
+        Task<bool> SaveReadMeMdIfChanged(
+            Package package,
+            EditPackageVersionReadMeRequest edit,
+            Encoding encoding,
+            bool commitChanges);
     }
 }

--- a/src/NuGetGallery/Services/ReadMeService.cs
+++ b/src/NuGetGallery/Services/ReadMeService.cs
@@ -112,8 +112,14 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="package">Package entity associated with the ReadMe.</param>
         /// <param name="edit">Package version edit readme request.</param>
+        /// <param name="encoding">The encoding used when reading the existing readme.</param>
+        /// <param name="commitChanges">Whether or not to commit the pending changes to the database.</param>
         /// <returns>True if the package readme changed, otherwise false.</returns>
-        public async Task<bool> SaveReadMeMdIfChanged(Package package, EditPackageVersionReadMeRequest edit, Encoding encoding)
+        public async Task<bool> SaveReadMeMdIfChanged(
+            Package package,
+            EditPackageVersionReadMeRequest edit,
+            Encoding encoding,
+            bool commitChanges)
         {
             var activeReadMe = package.HasReadMe ?
                 NormalizeNewLines(await GetReadMeMdAsync(package)) :
@@ -131,7 +137,11 @@ namespace NuGetGallery
 
                 // Save entity to db.
                 package.HasReadMe = true;
-                await _entitiesContext.SaveChangesAsync();
+
+                if (commitChanges)
+                {
+                    await _entitiesContext.SaveChangesAsync();
+                }
             }
             else if (!hasReadMe && !string.IsNullOrEmpty(activeReadMe))
             {
@@ -140,7 +150,11 @@ namespace NuGetGallery
                 
                 // Save entity to db.
                 package.HasReadMe = false;
-                await _entitiesContext.SaveChangesAsync();
+
+                if (commitChanges)
+                {
+                    await _entitiesContext.SaveChangesAsync();
+                }
             }
             else
             {


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/5625.

28 packages were affected by this bug. The symptom was that validation failed due to broken .nupkg URL passed to the validator. This happened because I made a change to orchestrator to use the `Package.PackageStatusKey` to determine where the .nupkg should be (`packages` container vs. `validation` container). Because of this gallery bug, there was a short window of time that the package was in the `Available` state but the package was _not_ in the `packages` container.

All 28 packages were UI uploads and all has readmes added on upload.