### PR TITLE
[Organizations] Hide organization confirmation link when user is a collaborator

### DIFF
--- a/src/NuGetGallery/Views/Shared/_AccountConfirmationNotices.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountConfirmationNotices.cshtml
@@ -27,15 +27,17 @@
 
         @if (Model.HasConfirmedEmailAddress)
         {
+            var linkText = "new email address is verified.";
             <text>
                 We will continue sending notification emails to the old verified email address (@account.EmailAddress)
-                until the <a href="@ViewBag.ConfirmationLink">new email address is verified.</a>
+                until the @(ViewBag.ShowConfirmationLink ? Html.Raw("<a href=\"" + ViewBag.ConfirmationLink + "\">" + linkText + "</a>") : linkText)
             </text>
         }
         else
         {
+            var linkText = "email address has been verified.";
             <text>
-                We will only send notification emails after the <a href="@ViewBag.ConfirmationLink">email address has been verified.</a><br />
+                We will only send notification emails after the @(ViewBag.ShowConfirmationLink ? Html.Raw("<a href=\"" + ViewBag.ConfirmationLink + "\">" + linkText + "</a>") : linkText)<br />
             </text>
         }
     </text>)

--- a/src/NuGetGallery/Views/Shared/_AccountConfirmationNotices.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountConfirmationNotices.cshtml
@@ -7,12 +7,16 @@
         ViewBag.ConfirmationLink = Url.OrganizationConfirmationRequired(account.Username);
         ViewBag.UnconfirmedEmailMessage = "A new organization email address was recently registered: ";
         ViewBag.ConfirmNowLinkText = "confirm your organization account";
+        ViewBag.ShowConfirmationLink = (Model as OrganizationAccountViewModel).CanManage;
+        ViewBag.NonConfirmationText = "Your organization needs to be confirmed before you can upload any packages to it.";
     }
     else
     {
         ViewBag.ConfirmationLink = Url.ConfirmationRequired();
         ViewBag.UnconfirmedEmailMessage = "You recently registered a new email address: ";
         ViewBag.ConfirmNowLinkText = "confirm your account";
+        ViewBag.ShowConfirmationLink = true;
+        ViewBag.NonConfirmationText = "Your account needs to be confirmed before you can upload any packages.";
     }
 }
 
@@ -39,8 +43,14 @@
 
 @if (!account.Confirmed)
 {
-    @ViewHelpers.AlertInfo(
-    @<text>
-        Uploading packages requires that you <a href="@ViewBag.ConfirmationLink">@ViewBag.ConfirmNowLinkText</a>. Why not get that out of the way now?
-    </text>)
+    if (ViewBag.ShowConfirmationLink)
+    {
+        @ViewHelpers.AlertInfo(
+            @<text>Uploading packages requires that you <a href="@ViewBag.ConfirmationLink">@ViewBag.ConfirmNowLinkText</a>. Why not get that out of the way now?</text>)
+    }
+    else
+    {
+        @ViewHelpers.AlertInfo(
+            @<text>@ViewBag.NonConfirmationText</text>)
+    }
 }


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5654

New organization as collaborator:

![image](https://user-images.githubusercontent.com/18014088/37723111-d33793f6-2cea-11e8-99d1-2f90bb594fcc.png)

Existing organization as collaborator:

![image](https://user-images.githubusercontent.com/18014088/37723580-f97c2792-2ceb-11e8-9a0b-7c5b2ecf4942.png)