### PR TITLE
Add GetPriviledgedFileUriAsync to create SAS enabled URLs

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Services\CorePackageFileService.cs" />
     <Compile Include="Services\CorePackageService.cs" />
     <Compile Include="Services\CryptographyService.cs" />
+    <Compile Include="Services\FileUriPermissions.cs" />
     <Compile Include="Services\IAccessCondition.cs" />
     <Compile Include="Services\ICloudBlobClient.cs" />
     <Compile Include="Services\ICloudBlobContainer.cs" />

--- a/src/NuGetGallery.Core/Services/CloudBlobWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobWrapper.cs
@@ -130,15 +130,15 @@ namespace NuGetGallery
                 state: null);
         }
 
-        public string GetSharedReadSignature(DateTimeOffset? endOfAccess)
+        public string GetSharedAccessSignature(SharedAccessBlobPermissions permissions, DateTimeOffset? endOfAccess)
         {
             var accessPolicy = new SharedAccessBlobPolicy
             {
                 SharedAccessExpiryTime = endOfAccess,
-                Permissions = SharedAccessBlobPermissions.Read
+                Permissions = permissions,
             };
 
-            var signature = this._blob.GetSharedAccessSignature(accessPolicy);
+            var signature = _blob.GetSharedAccessSignature(accessPolicy);
 
             return signature;
         }

--- a/src/NuGetGallery.Core/Services/FileUriPermissions.cs
+++ b/src/NuGetGallery.Core/Services/FileUriPermissions.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// A copy of <see cref="Microsoft.WindowsAzure.Storage.Blob.SharedAccessBlobPermissions"/> so that the caller
+    /// does not need a direct dependency on the WindowsAzure.Storage package.
+    /// </summary>
+    [Flags]
+    public enum FileUriPermissions
+    {
+        [Obsolete]
+        None = 0,
+
+        Read = 1,
+
+        Write = 2,
+
+        Delete = 4,
+
+        [Obsolete]
+        List = 8,
+
+        [Obsolete]
+        Add = 16,
+
+        Create = 32,
+    }
+}

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -34,6 +34,22 @@ namespace NuGetGallery
         /// <returns>Time limited URI (if requested and implementation supports it) for the specified file.</returns>
         Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess);
 
+        /// <summary>
+        /// Generates a storage file URI giving certain permissions for the specific file. For example, this method can
+        /// be used to generate a URI that allows the caller to either delete (via
+        /// <see cref="FileUriPermissions.Delete"/>) or read (via <see cref="FileUriPermissions.Read"/>) the file.
+        /// </summary>
+        /// <param name="folderName">The folder name containing the file.</param>
+        /// <param name="fileName">The file name.</param>
+        /// <param name="permissions">The permissions to give to the privileged URI.</param>
+        /// <param name="endOfAccess">The time when the access ends.</param>
+        /// <returns>The URI with privileged access.</returns>
+        Task<Uri> GetPriviledgedFileUriAsync(
+            string folderName,
+            string fileName,
+            FileUriPermissions permissions,
+            DateTimeOffset endOfAccess);
+
         Task SaveFileAsync(string folderName, string fileName, Stream packageFile, bool overwrite = true);
 
         /// <summary>

--- a/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
@@ -31,16 +31,17 @@ namespace NuGetGallery
         Task StartCopyAsync(ISimpleCloudBlob source, AccessCondition sourceAccessCondition, AccessCondition destAccessCondition);
 
         /// <summary>
-        /// Generates the shared read signature that if appended to the blob URI
-        /// would allow reading the contents of the blob using the produced URI 
-        /// only (without storage account credentials).
+        /// Generates the shared access signature that if appended to the blob URI
+        /// would allow actions matching the provided <paramref name="permissions"/> without having access to the
+        /// access keys of the storage account.
         /// </summary>
+        /// <param name="permissions">The permissions to include in the SAS token.</param>
         /// <param name="endOfAccess">
         /// "End of access" timestamp. After the specified timestamp, 
         /// the returned signature becomes invalid if implementation supports it.
         /// Null for no time limit.
         /// </param>
         /// <returns>Shared access signature in form of URI query portion.</returns>
-        string GetSharedReadSignature(DateTimeOffset? endOfAccess);
+        string GetSharedAccessSignature(SharedAccessBlobPermissions permissions, DateTimeOffset? endOfAccess);
     }
 }

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Web.Hosting;
 using System.Web.Mvc;
@@ -234,6 +233,12 @@ namespace NuGetGallery
             // produces the
             // file:///c:/Afoo%20bar%2525.baz
             // which is not particularly correct, so we'd need to work around that to have a correct implementation
+            throw new NotImplementedException();
+        }
+
+        public Task<Uri> GetPriviledgedFileUriAsync(string folderName, string fileName, FileUriPermissions permissions, DateTimeOffset endOfAccess)
+        {
+            /// Not implemented for the same reason as <see cref="GetFileReadUriAsync(string, string, DateTimeOffset?)"/>.
             throw new NotImplementedException();
         }
 

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Packaging\NupkgRewriterFacts.cs" />
     <Compile Include="SemVerLevelKeyFacts.cs" />
     <Compile Include="Services\AccessConditionWrapperFacts.cs" />
+    <Compile Include="Services\FileUriPermissionsFacts.cs" />
     <Compile Include="TestUtils\BlobStorageCollection.cs" />
     <Compile Include="TestUtils\BlobStorageFact.cs" />
     <Compile Include="TestUtils\BlobStorageFixture.cs" />

--- a/tests/NuGetGallery.Core.Facts/Services/FileUriPermissionsFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/FileUriPermissionsFacts.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Xunit;
+
+namespace NuGetGallery.Services
+{
+    public class FileUriPermissionsFacts
+    {
+        [Fact]
+        public void MatchesWindowAzureStorageEnumNames()
+        {
+            var expectedPairs = GetPairs<SharedAccessBlobPermissions>();
+            var actualPairs = GetPairs<FileUriPermissions>();
+
+            Assert.Equal(expectedPairs, actualPairs);
+        }
+
+        private static List<KeyValuePair<string, int>> GetPairs<T>() where T : struct
+        {
+            return Enum
+                .GetValues(typeof(T))
+                .Cast<T>()
+                .ToDictionary(x => x.ToString(), x => (int)(object)x)
+                .OrderBy(x => x.Value)
+                .ToList();
+        }
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1207.

Currently we only have `GetFileReadUriAsync` which allows downloading but nothing else. I am adding `GetPriviledgedFileUriAsync` which accepts arbitrary permissions. 

 I am adding this method so that `IProcessor` running in the orchestrator processor can use this URL to both read and delete (for clean up) a temporary .nupkg, a la `FileUriPermissions.Read | FileUriPermissions.Delete`.