### PR TITLE
Add default regex match timeout (10s)

### DIFF
--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -45,6 +45,9 @@ namespace NuGetGallery
             ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
+            // Setting time out for all RegEx objects. Noted in remarks at https://msdn.microsoft.com/en-us/library/system.text.regularexpressions.regex.matchtimeout%28v=vs.110%29.aspx
+            AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", TimeSpan.FromSeconds(10));
+
             // Register IoC
             app.UseAutofacInjection(GlobalConfiguration.Configuration);
             var dependencyResolver = DependencyResolver.Current;


### PR DESCRIPTION
Add a domain variable that sets a default time out on RegEx matches. Found [here](https://msdn.microsoft.com/en-us/library/system.text.regularexpressions.regex.matchtimeout%28v=vs.110%29.aspx)

Regex match timeout defaults to Regex.InfiniteMatchTimeout if a timeout is not specified.
Example of nearly unbounded match is shown on the [Best Practices](https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices) page.

@blowdart Is this sufficient for protection from Regex match taking unbounded time?