### PR TITLE
Reject duplicate metadata elements during upload

### DIFF
--- a/src/NuGetGallery.Core/CoreStrings.Designer.cs
+++ b/src/NuGetGallery.Core/CoreStrings.Designer.cs
@@ -124,6 +124,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package manifest contains duplicate metadata elements: &apos;{0}&apos;.
+        /// </summary>
+        public static string Manifest_DuplicateMetadataElements {
+            get {
+                return ResourceManager.GetString("Manifest_DuplicateMetadataElements", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package manifest contains an ID that is too long. Package IDs can be no longer than 100 characters..
         /// </summary>
         public static string Manifest_IdTooLong {

--- a/src/NuGetGallery.Core/CoreStrings.resx
+++ b/src/NuGetGallery.Core/CoreStrings.resx
@@ -189,4 +189,8 @@
   <data name="PackageIsMissingRequiredData" xml:space="preserve">
     <value>The package is missing required data.</value>
   </data>
+  <data name="Manifest_DuplicateMetadataElements" xml:space="preserve">
+    <value>The package manifest contains duplicate metadata elements: '{0}'</value>
+    <comment>{0} is a comma-delimited list of duplicate metadata element names.</comment>
+  </data>
 </root>

--- a/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
@@ -2,10 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
@@ -55,7 +53,80 @@ namespace NuGetGallery.Packaging
         }
 
         [Fact]
-        public static void DoesNotThrowInvalidDepencencyVersionRangeDetectedAndParsingIsNotStrict()
+        public static void ThrowsPackagingExceptionWhenEmptyAndNonEmptyDuplicateMetadataElementsDetected()
+        {
+            // Arrange
+            var packageStream = CreateTestPackageStreamWithDuplicateEmptyAndNonEmptyMetadataElements();
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act & Assert
+            var ex = Assert.Throws<PackagingException>(() => PackageMetadata.FromNuspecReader(
+                nuspec,
+                strict: true));
+            Assert.Equal(
+                "The package manifest contains duplicate metadata elements: 'title', 'authors', 'owners', 'description', 'language', 'foo', 'releaseNotes'",
+                ex.Message);
+        }
+
+        [Fact]
+        public static void ThrowsForEmptyAndNonEmptyDuplicatesWhenDuplicateMetadataElementsDetectedAndParsingIsNotStrict()
+        {
+            // Arrange
+            var packageStream = CreateTestPackageStreamWithDuplicateEmptyAndNonEmptyMetadataElements();
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => PackageMetadata.FromNuspecReader(
+                nuspec,
+                strict: false));
+            Assert.Equal(
+                "An item with the same key has already been added.",
+                ex.Message);
+        }
+
+        [Fact]
+        public static void ThrowsPackagingExceptionWhenEmptyDuplicateMetadataElementsDetected()
+        {
+            // Arrange
+            var packageStream = CreateTestPackageStreamWithDuplicateEmptyMetadataElements();
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act & Assert
+            var ex = Assert.Throws<PackagingException>(() => PackageMetadata.FromNuspecReader(
+                nuspec,
+                strict: true));
+            Assert.Equal(
+                "The package manifest contains duplicate metadata elements: 'title', 'authors', 'description', 'releaseNotes'",
+                ex.Message);
+        }
+
+        [Fact]
+        public static void ThrowsForEmptyDuplicatesWhenDuplicateMetadataElementsDetectedAndParsingIsNotStrict()
+        {
+            // Arrange
+            var packageStream = CreateTestPackageStreamWithDuplicateEmptyMetadataElements();
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act
+            var packageMetadata = PackageMetadata.FromNuspecReader(
+                nuspec,
+                strict: false);
+
+            // Assert
+            Assert.Equal("TestPackage", packageMetadata.Id);
+            Assert.Equal(NuGetVersion.Parse("0.0.0.1"), packageMetadata.Version);
+            Assert.Equal("Package A", packageMetadata.Title);
+            Assert.Equal(new[] { "authora", "authorb" }, packageMetadata.Authors);
+            Assert.Equal("package A description.", packageMetadata.Description);
+            Assert.Null(packageMetadata.ReleaseNotes);
+        }
+
+        [Fact]
+        public static void DoesNotThrowWhenInvalidDependencyVersionRangeDetectedAndParsingIsNotStrict()
         {
             var packageStream = CreateTestPackageStreamWithInvalidDependencyVersion();
             var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
@@ -86,19 +157,13 @@ namespace NuGetGallery.Packaging
 
         private static Stream CreateTestPackageStream()
         {
-            var packageStream = new MemoryStream();
-            using (var packageArchive = new ZipArchive(packageStream, ZipArchiveMode.Create, true))
-            {
-                var nuspecEntry = packageArchive.CreateEntry("TestPackage.nuspec", CompressionLevel.Fastest);
-                using (var streamWriter = new StreamWriter(nuspecEntry.Open()))
-                {
-                    streamWriter.WriteLine(@"<?xml version=""1.0""?>
+            return CreateTestPackageStream(@"<?xml version=""1.0""?>
                     <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
                       <metadata>
                         <id>TestPackage</id>
                         <version>0.0.0.1</version>
                         <title>Package A</title>
-                        <authors>ownera, ownerb</authors>
+                        <authors>authora, authorb</authors>
                         <owners>ownera, ownerb</owners>
                         <requireLicenseAcceptance>false</requireLicenseAcceptance>
                         <description>package A description.</description>
@@ -109,30 +174,17 @@ namespace NuGetGallery.Packaging
                         <dependencies />
                       </metadata>
                     </package>");
-                }
-
-                packageArchive.CreateEntry("content\\HelloWorld.cs", CompressionLevel.Fastest);
-            }
-
-            packageStream.Position = 0;
-
-            return packageStream;
         }
+
         private static Stream CreateTestPackageStreamWithInvalidDependencyVersion()
         {
-            var packageStream = new MemoryStream();
-            using (var packageArchive = new ZipArchive(packageStream, ZipArchiveMode.Create, true))
-            {
-                var nuspecEntry = packageArchive.CreateEntry("TestPackage.nuspec", CompressionLevel.Fastest);
-                using (var streamWriter = new StreamWriter(nuspecEntry.Open()))
-                {
-                    streamWriter.WriteLine(@"<?xml version=""1.0""?>
+            return CreateTestPackageStream(@"<?xml version=""1.0""?>
                     <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
                       <metadata>
                         <id>TestPackage</id>
                         <version>0.0.0.1</version>
                         <title>Package A</title>
-                        <authors>ownera, ownerb</authors>
+                        <authors>authora, authorb</authors>
                         <owners>ownera, ownerb</owners>
                         <requireLicenseAcceptance>false</requireLicenseAcceptance>
                         <description>package A description.</description>
@@ -145,6 +197,70 @@ namespace NuGetGallery.Packaging
                         </dependencies>
                       </metadata>
                     </package>");
+        }
+
+        private static Stream CreateTestPackageStreamWithDuplicateEmptyMetadataElements()
+        {
+            return CreateTestPackageStream(@"<?xml version=""1.0""?>
+                    <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                      <metadata>
+                        <id>TestPackage</id>
+                        <version>0.0.0.1</version>
+                        <title>Package A</title>
+                        <title />
+                        <authors>authora, authorb</authors>
+                        <authors></authors>
+                        <description>
+
+                        </description>
+                        <description>package A description.</description>
+                        <releaseNotes></releaseNotes>
+                        <releaseNotes></releaseNotes>
+                        <language>en-US</language>
+                      </metadata>
+                    </package>");
+        }
+
+        private static Stream CreateTestPackageStreamWithDuplicateEmptyAndNonEmptyMetadataElements()
+        {
+            return CreateTestPackageStream(@"<?xml version=""1.0""?>
+                    <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                      <metadata>
+                        <id>TestPackage</id>
+                        <version>0.0.0.1</version>
+                        <title>Package A</title>
+                        <title />
+                        <authors>ownera, ownerb</authors>
+                        <authors></authors>
+                        <owners>ownera, ownerb</owners>
+                        <owners>ownerc, ownerd</owners>
+                        <description>
+
+                        </description>
+                        <description>package A description.</description>
+                        <language>en-US</language>
+                        <language>
+
+                        de-DE                        
+
+                        </language>
+                        <foo>1</foo>
+                        <foo>2</foo>
+                        <releaseNotes></releaseNotes>
+                        <releaseNotes></releaseNotes>
+                      </metadata>
+                    </package>");
+        }
+
+        private static Stream CreateTestPackageStream(string nuspec)
+        {
+            var packageStream = new MemoryStream();
+            using (var packageArchive = new ZipArchive(packageStream, ZipArchiveMode.Create, true))
+            {
+                var nuspecEntry = packageArchive.CreateEntry("TestPackage.nuspec", CompressionLevel.Fastest);
+                using (var streamWriter = new StreamWriter(nuspecEntry.Open()))
+                {
+                    streamWriter.WriteLine(nuspec);
                 }
 
                 packageArchive.CreateEntry("content\\HelloWorld.cs", CompressionLevel.Fastest);


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/5119.

There will be another PR to make `catalog2lucene` resilient to such catalog leaves.