### PR TITLE
Reject invalid boolean values and properties generated by feed2catalog

### DIFF
--- a/src/NuGetGallery.Core/CoreStrings.Designer.cs
+++ b/src/NuGetGallery.Core/CoreStrings.Designer.cs
@@ -142,6 +142,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package manifest contains an invalid boolean value for metadata element: &apos;{0}&apos;. The value should be &apos;true&apos; or &apos;false&apos;..
+        /// </summary>
+        public static string Manifest_InvalidBooleanMetadata {
+            get {
+                return ResourceManager.GetString("Manifest_InvalidBooleanMetadata", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package manifest contains an invalid Dependency: &apos;{0} {1}&apos;.
         /// </summary>
         public static string Manifest_InvalidDependency {
@@ -165,6 +174,15 @@ namespace NuGetGallery {
         public static string Manifest_InvalidId {
             get {
                 return ResourceManager.GetString("Manifest_InvalidId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package manifest contains invalid metadata elements: &apos;{0}&apos;.
+        /// </summary>
+        public static string Manifest_InvalidMetadataElements {
+            get {
+                return ResourceManager.GetString("Manifest_InvalidMetadataElements", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery.Core/CoreStrings.resx
+++ b/src/NuGetGallery.Core/CoreStrings.resx
@@ -193,4 +193,12 @@
     <value>The package manifest contains duplicate metadata elements: '{0}'</value>
     <comment>{0} is a comma-delimited list of duplicate metadata element names.</comment>
   </data>
+  <data name="Manifest_InvalidBooleanMetadata" xml:space="preserve">
+    <value>The package manifest contains an invalid boolean value for metadata element: '{0}'. The value should be 'true' or 'false'.</value>
+    <comment>{0} is the name of the invalid boolean metadata element.</comment>
+  </data>
+  <data name="Manifest_InvalidMetadataElements" xml:space="preserve">
+    <value>The package manifest contains invalid metadata elements: '{0}'</value>
+    <comment>{0} is a comma-delimited list of invalid metadata element names.</comment>
+  </data>
 </root>

--- a/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
@@ -13,9 +13,71 @@ namespace NuGetGallery.Packaging
 {
     public class PackageMetadataFacts
     {
-        [Fact]
-        public static void CanReadBasicMetadataProperties()
+        [Theory]
+        [InlineData("developmentDependency")]
+        [InlineData("requireLicenseAcceptance")]
+        [InlineData("serviceable")]
+        public void RejectsInvalidBooleanValue(string metadataName)
         {
+            // Arrange
+            var packageStream = CreateTestPackageStreamWithMetadataElementName(metadataName);
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act & Assert
+            var ex = Assert.Throws<PackagingException>(() => PackageMetadata.FromNuspecReader(nuspec, strict: false));
+            Assert.Equal($"The package manifest contains an invalid boolean value for metadata element: '{metadataName}'. The value should be 'true' or 'false'.", ex.Message);
+        }
+
+        [Theory]
+        [InlineData("created")]
+        [InlineData("dependencyGroups")]
+        [InlineData("isPrerelease")]
+        [InlineData("lastEdited")]
+        [InlineData("listed")]
+        [InlineData("packageEntries")]
+        [InlineData("packageHash")]
+        [InlineData("packageHashAlgorithm")]
+        [InlineData("packageSize")]
+        [InlineData("published")]
+        [InlineData("supportedFrameworks")]
+        [InlineData("verbatimVersion")]
+        public void RejectsRestrictedElementNames(string metadataName)
+        {
+            // Arrange
+            var packageStream = CreateTestPackageStreamWithMetadataElementName(metadataName);
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act & Assert
+            var ex = Assert.Throws<PackagingException>(() => PackageMetadata.FromNuspecReader(nuspec, strict: false));
+            Assert.Equal($"The package manifest contains invalid metadata elements: '{metadataName}'", ex.Message);
+        }
+
+        [Fact]
+        public void AllowsUnrestrictedButUnofficialElementNames()
+        {
+            // Arrange
+            var name = "foo";
+            var packageStream = CreateTestPackageStreamWithMetadataElementName(name);
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act
+            var packageMetadata = PackageMetadata.FromNuspecReader(
+                nuspec,
+                strict: true);
+
+            // Assert
+            Assert.Equal("TestPackage", packageMetadata.Id);
+            Assert.Equal(NuGetVersion.Parse("0.0.0.1"), packageMetadata.Version);
+            Assert.Equal("some value", packageMetadata.GetValueFromMetadata(name));
+        }
+
+        [Fact]
+        public void CanReadBasicMetadataProperties()
+        {
+            // Arrange
             var packageStream = CreateTestPackageStream();
             var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
             var nuspec = nupkg.GetNuspecReader();
@@ -39,8 +101,22 @@ namespace NuGetGallery.Packaging
             Assert.Equal("http://www.nuget.org/", packageMetadata.LicenseUrl.ToString());
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ThrowsWhenInvalidMinClientVersion(bool strict)
+        {
+            var packageStream = CreateTestPackageStreamWithInvalidMinClientVersion();
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() => PackageMetadata.FromNuspecReader(nuspec, strict));
+            Assert.Equal("'bad' is not a valid version string.\r\nParameter name: value", ex.Message);
+        }
+
         [Fact]
-        public static void ThrowsPackagingExceptionWhenInvalidDepencencyVersionRangeDetected()
+        public void ThrowsPackagingExceptionWhenInvalidDependencyVersionRangeDetected()
         {
             var packageStream = CreateTestPackageStreamWithInvalidDependencyVersion();
             var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
@@ -53,7 +129,7 @@ namespace NuGetGallery.Packaging
         }
 
         [Fact]
-        public static void ThrowsPackagingExceptionWhenEmptyAndNonEmptyDuplicateMetadataElementsDetected()
+        public void ThrowsPackagingExceptionWhenEmptyAndNonEmptyDuplicateMetadataElementsDetected()
         {
             // Arrange
             var packageStream = CreateTestPackageStreamWithDuplicateEmptyAndNonEmptyMetadataElements();
@@ -70,7 +146,7 @@ namespace NuGetGallery.Packaging
         }
 
         [Fact]
-        public static void ThrowsForEmptyAndNonEmptyDuplicatesWhenDuplicateMetadataElementsDetectedAndParsingIsNotStrict()
+        public void ThrowsForEmptyAndNonEmptyDuplicatesWhenDuplicateMetadataElementsDetectedAndParsingIsNotStrict()
         {
             // Arrange
             var packageStream = CreateTestPackageStreamWithDuplicateEmptyAndNonEmptyMetadataElements();
@@ -87,7 +163,7 @@ namespace NuGetGallery.Packaging
         }
 
         [Fact]
-        public static void ThrowsPackagingExceptionWhenEmptyDuplicateMetadataElementsDetected()
+        public void ThrowsPackagingExceptionWhenEmptyDuplicateMetadataElementsDetected()
         {
             // Arrange
             var packageStream = CreateTestPackageStreamWithDuplicateEmptyMetadataElements();
@@ -104,7 +180,7 @@ namespace NuGetGallery.Packaging
         }
 
         [Fact]
-        public static void ThrowsForEmptyDuplicatesWhenDuplicateMetadataElementsDetectedAndParsingIsNotStrict()
+        public void ThrowsForEmptyDuplicatesWhenDuplicateMetadataElementsDetectedAndParsingIsNotStrict()
         {
             // Arrange
             var packageStream = CreateTestPackageStreamWithDuplicateEmptyMetadataElements();
@@ -126,7 +202,7 @@ namespace NuGetGallery.Packaging
         }
 
         [Fact]
-        public static void DoesNotThrowWhenInvalidDependencyVersionRangeDetectedAndParsingIsNotStrict()
+        public void DoesNotThrowWhenInvalidDependencyVersionRangeDetectedAndParsingIsNotStrict()
         {
             var packageStream = CreateTestPackageStreamWithInvalidDependencyVersion();
             var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
@@ -172,6 +248,29 @@ namespace NuGetGallery.Packaging
                         <iconUrl>http://www.nuget.org/</iconUrl>
                         <licenseUrl>http://www.nuget.org/</licenseUrl>
                         <dependencies />
+                      </metadata>
+                    </package>");
+        }
+
+        private static Stream CreateTestPackageStreamWithMetadataElementName(string metadataName)
+        {
+            return CreateTestPackageStream($@"<?xml version=""1.0""?>
+                    <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                      <metadata>
+                        <id>TestPackage</id>
+                        <version>0.0.0.1</version>
+                        <{metadataName}>some value</{metadataName}>
+                      </metadata>
+                    </package>");
+        }
+
+        private static Stream CreateTestPackageStreamWithInvalidMinClientVersion()
+        {
+            return CreateTestPackageStream(@"<?xml version=""1.0""?>
+                    <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                      <metadata minClientVersion=""bad"">
+                        <id>TestPackage</id>
+                        <version>0.0.0.1</version>
                       </metadata>
                     </package>");
         }


### PR DESCRIPTION
Address on https://github.com/NuGet/Engineering/issues/1308.
Address on https://github.com/NuGet/Engineering/issues/1309.
Address on https://github.com/NuGet/Engineering/issues/1310.

In short, two validations on upload or revalidate are being added:

1. Reject metadata element names that collide with those generated by feed2catalog.
1. Reject non-boolean values for boolean metadata fields.

Instead of overhauling .nuspec/.nupkg validation in gallery with XSD or some other strict approach, I am taking a minimal-ish approach that is least likely to break existing package authors. The goal here is to reject .nuspec metadata child elements that break V3. See the aforementioned issues for what is breaking. I don't want to tackle the problem of rejecting anything but the most perfect .nuspecs 😄. That is work that should be done... but not without more thorough analysis of all .nuspec oddities out there. This broader item is tracked here: https://github.com/NuGet/NuGetGallery/issues/5718.

I am currently analyzing all .nuspecs on NuGet.org checking for these two new validation cases. My expectation is that none of the existing packages are on NuGet.org because they would have caused live site incidents. My analysis should be done within the next couple hours.

References:

- [Client .nuspec XSD used at `pack` time](https://github.com/NuGet/NuGet.Client/blob/deab84db30cbd8cc738cd46ad694aebdbb43a1cf/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd)
- [feed2catalog XSLT](https://github.com/NuGet/NuGet.Services.Metadata/blob/f7a42142d0674fb8a8bc09b4c48e51595e331796/src/Catalog/xslt/nuspec.xslt)
- [Catalog leaf JSON-LD frame](https://github.com/NuGet/NuGet.Services.Metadata/blob/f7a42142d0674fb8a8bc09b4c48e51595e331796/src/Catalog/context/PackageDetails.json)