### PR TITLE
[Organizations] Give organization collaborators the same permissions on packages as administrators

### DIFF
--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -364,10 +364,10 @@ namespace NuGetGallery
         [UIAuthorize]
         public virtual ActionResult ApiKeys()
         {
-            var user = GetCurrentUser();
+            var currentUser = GetCurrentUser();
 
             // Get API keys
-            if (!GetCredentialGroups(user).TryGetValue(CredentialKind.Token, out List<CredentialViewModel> credentials))
+            if (!GetCredentialGroups(currentUser).TryGetValue(CredentialKind.Token, out List<CredentialViewModel> credentials))
             {
                 credentials = new List<CredentialViewModel>();
             }
@@ -377,30 +377,32 @@ namespace NuGetGallery
                 .ToList();
 
             // Get package owners (user's self or organizations)
-            var owners = user.Organizations
-                .Select(o => CreateApiKeyOwnerViewModel(
-                    o.Organization,
-                    // todo: move logic for canPushNew to PermissionsService
-                    canPushNew: o.IsAdmin)
-                    ).ToList();
-            owners.Insert(0, CreateApiKeyOwnerViewModel(user, canPushNew: true));
+            var owners = new List<ApiKeyOwnerViewModel>
+            {
+                CreateApiKeyOwnerViewModel(currentUser, currentUser)
+            };
+
+            owners.AddRange(currentUser.Organizations
+                .Select(o => CreateApiKeyOwnerViewModel(currentUser, o.Organization)));
 
             var model = new ApiKeyListViewModel
             {
                 ApiKeys = apiKeys,
                 ExpirationInDaysForApiKeyV1 = _config.ExpirationInDaysForApiKeyV1,
-                PackageOwners = owners,
+                PackageOwners = owners.Where(o => o.CanPushNew || o.CanPushExisting || o.CanUnlist).ToList(),
             };
 
             return View("ApiKeys", model);
         }
 
-        private ApiKeyOwnerViewModel CreateApiKeyOwnerViewModel(User user, bool canPushNew)
+        private ApiKeyOwnerViewModel CreateApiKeyOwnerViewModel(User currentUser, User account)
         {
             return new ApiKeyOwnerViewModel(
-                user.Username,
-                canPushNew,
-                packageIds: _packageService.FindPackageRegistrationsByOwner(user)
+                account.Username,
+                ActionsRequiringPermissions.UploadNewPackageId.IsAllowedOnBehalfOfAccount(currentUser, account),
+                ActionsRequiringPermissions.UploadNewPackageVersion.IsAllowedOnBehalfOfAccount(currentUser, account),
+                ActionsRequiringPermissions.UnlistOrRelistPackage.IsAllowedOnBehalfOfAccount(currentUser, account),
+                packageIds: _packageService.FindPackageRegistrationsByOwner(account)
                                 .Select(p => p.Id)
                                 .OrderBy(i => i)
                                 .ToList());

--- a/src/NuGetGallery/Services/ActionRequiringEntityPermissions.cs
+++ b/src/NuGetGallery/Services/ActionRequiringEntityPermissions.cs
@@ -21,9 +21,19 @@ namespace NuGetGallery
             AccountOnBehalfOfPermissionsRequirement = accountOnBehalfOfPermissionsRequirement;
         }
 
+        public bool IsAllowedOnBehalfOfAccount(User currentUser, User account)
+        {
+            return PermissionsHelpers.IsRequirementSatisfied(AccountOnBehalfOfPermissionsRequirement, currentUser, account);
+        }
+
+        public bool IsAllowedOnBehalfOfAccount(IPrincipal currentPrincipal, User account)
+        {
+            return PermissionsHelpers.IsRequirementSatisfied(AccountOnBehalfOfPermissionsRequirement, currentPrincipal, account);
+        }
+
         public PermissionsCheckResult CheckPermissions(User currentUser, User account, TEntity entity)
         {
-            if (!PermissionsHelpers.IsRequirementSatisfied(AccountOnBehalfOfPermissionsRequirement, currentUser, account))
+            if (!IsAllowedOnBehalfOfAccount(currentUser, account))
             {
                 return PermissionsCheckResult.AccountFailure;
             }
@@ -33,7 +43,7 @@ namespace NuGetGallery
 
         public PermissionsCheckResult CheckPermissions(IPrincipal currentPrincipal, User account, TEntity entity)
         {
-            if (!PermissionsHelpers.IsRequirementSatisfied(AccountOnBehalfOfPermissionsRequirement, currentPrincipal, account))
+            if (!IsAllowedOnBehalfOfAccount(currentPrincipal, account))
             {
                 return PermissionsCheckResult.AccountFailure;
             }

--- a/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
+++ b/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
@@ -29,7 +29,7 @@ namespace NuGetGallery
         /// </summary>
         public static ActionRequiringReservedNamespacePermissions UploadNewPackageId =
             new ActionRequiringReservedNamespacePermissions(
-                accountOnBehalfOfPermissionsRequirement: RequireOwnerOrOrganizationAdmin,
+                accountOnBehalfOfPermissionsRequirement: RequireOwnerOrOrganizationMember,
                 reservedNamespacePermissionsRequirement: PermissionsRequirement.Owner);
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace NuGetGallery
         /// </summary>
         public static ActionRequiringPackagePermissions UnlistOrRelistPackage =
             new ActionRequiringPackagePermissions(
-                RequireOwnerOrOrganizationMember,
+                accountOnBehalfOfPermissionsRequirement: RequireOwnerOrOrganizationMember,
                 packageRegistrationPermissionsRequirement: RequireOwnerOrSiteAdmin);
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace NuGetGallery
         /// </summary>
         public static ActionRequiringPackagePermissions ReportPackageAsOwner =
             new ActionRequiringPackagePermissions(
-                accountOnBehalfOfPermissionsRequirement: RequireOwnerOrOrganizationAdmin,
+                accountOnBehalfOfPermissionsRequirement: RequireOwnerOrOrganizationMember,
                 packageRegistrationPermissionsRequirement: PermissionsRequirement.Owner);
 
         /// <summary>

--- a/src/NuGetGallery/Services/IActionRequiringEntityPermissions.cs
+++ b/src/NuGetGallery/Services/IActionRequiringEntityPermissions.cs
@@ -2,13 +2,24 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Principal;
 
 namespace NuGetGallery
 {
     public interface IActionRequiringEntityPermissions<TEntity>
     {
+        /// <summary>
+        /// Determines whether <paramref name="currentUser"/> can perform this action on an arbitrary <see cref="TEntity"/> on behalf of <paramref name="account"/>.
+        /// </summary>
+        /// <returns>True if and only if <paramref name="currentUser"/> can perform this action on an arbitrary <see cref="TEntity"/> on behalf of <paramref name="account"/>.</returns>
+        bool IsAllowedOnBehalfOfAccount(User currentUser, User account);
+
+        /// <summary>
+        /// Determines whether <paramref name="currentPrincipal"/> can perform this action on an arbitrary <see cref="TEntity"/> on behalf of <paramref name="account"/>.
+        /// </summary>
+        /// <returns>True if and only if <paramref name="currentPrincipal"/> can perform this action on an arbitrary <see cref="TEntity"/> on behalf of <paramref name="account"/>.</returns>
+        bool IsAllowedOnBehalfOfAccount(IPrincipal currentPrincipal, User account);
+
         /// <summary>
         /// Determines whether <paramref name="currentUser"/> can perform this action on <paramref name="entity"/> on behalf of <paramref name="account"/>.
         /// </summary>
@@ -26,9 +37,9 @@ namespace NuGetGallery
         PermissionsCheckResult CheckPermissions(IPrincipal currentPrincipal, User account, TEntity entity);
 
         /// <summary>
-        /// Determines whether <paramref name="currentPrincipal"/> can perform this action on <paramref name="entity"/> on behalf of any <see cref="User"/>.
+        /// Determines whether <paramref name="currentUser"/> can perform this action on <paramref name="entity"/> on behalf of any <see cref="User"/>.
         /// </summary>
-        /// <returns>True if and only if <paramref name="currentPrincipal"/> can perform this action on <paramref name="entity"/> on behalf of any <see cref="User"/>.</returns>
+        /// <returns>True if and only if <paramref name="currentUser"/> can perform this action on <paramref name="entity"/> on behalf of any <see cref="User"/>.</returns>
         PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, TEntity entity);
 
         /// <summary>

--- a/src/NuGetGallery/ViewModels/ApiKeyOwnerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ApiKeyOwnerViewModel.cs
@@ -7,15 +7,19 @@ namespace NuGetGallery
 {
     public class ApiKeyOwnerViewModel
     {
-        public ApiKeyOwnerViewModel(string owner, bool canPushNew, IList<string> packageIds)
+        public ApiKeyOwnerViewModel(string owner, bool canPushNew, bool canPushExisting, bool canUnlist, IList<string> packageIds)
         {
             Owner = owner;
             CanPushNew = canPushNew;
+            CanPushExisting = canPushExisting;
+            CanUnlist = canUnlist;
             PackageIds = packageIds;
         }
         
         public string Owner { get; }
         public bool CanPushNew { get; }
+        public bool CanPushExisting { get; }
+        public bool CanUnlist { get; }
         public IList<string> PackageIds { get; }
     }
 }

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -299,7 +299,7 @@
                     <li>
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox" data-bind="checked: PushEnabled" />
+                                <input type="checkbox" data-bind="checked: PushEnabled, enable: PushAnyEnabled" />
                                 Push
                             </label>
                         </div>
@@ -320,7 +320,7 @@
                                 <div class="radio">
                                     <div class="label-sibling">
                                         <input name="PushScope" type="radio" value="@NuGetScopes.PackagePushVersion"
-                                               data-bind="checked: PushScope, enable: PushEnabled,
+                                               data-bind="checked: PushScope, enable: PushExistingEnabled,
                                                           attr: { id: PackagePushVersionId }" />
                                     </div>
                                     <label data-bind="attr: { for: PackagePushVersionId }">
@@ -334,7 +334,7 @@
                         <div class="checkbox">
                             <label>
                                 <input type="checkbox" value="@NuGetScopes.PackageUnlist"
-                                       data-bind="checked: UnlistScope" />
+                                       data-bind="checked: UnlistScopeChecked, enable: UnlistEnabled" />
                                 @NuGetScopes.Describe(NuGetScopes.PackageUnlist)
                             </label>
                         </div>
@@ -463,6 +463,8 @@
                          ApiKeys = Model.ApiKeys,
                          PackageOwners = Model.PackageOwners,
                          PackagePushScope = NuGetScopes.PackagePush,
+                         PackagePushVersionScope = NuGetScopes.PackagePushVersion,
+                         PackageUnlistScope = NuGetScopes.PackageUnlist,
                          RemoveUrl = Url.RemoveCredential(),
                          RegenerateUrl = Url.RegenerateCredential(),
                          EditUrl = Url.EditCredential(),

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -2520,12 +2520,6 @@ namespace NuGetGallery
                         TestUtility.FakeAdminUser,
                         Owner
                     };
-
-                    yield return new object[]
-                    {
-                        TestUtility.FakeOrganizationCollaborator,
-                        TestUtility.FakeOrganization
-                    };
                 }
             }
 
@@ -2542,6 +2536,12 @@ namespace NuGetGallery
                     yield return new object[]
                     {
                         TestUtility.FakeOrganizationAdmin,
+                        TestUtility.FakeOrganization
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeOrganizationCollaborator,
                         TestUtility.FakeOrganization
                     };
                 }
@@ -2780,12 +2780,6 @@ namespace NuGetGallery
                         TestUtility.FakeAdminUser,
                         null
                     };
-
-                    yield return new object[]
-                    {
-                        TestUtility.FakeOrganizationCollaborator,
-                        TestUtility.FakeOrganization
-                    };
                 }
             }
 
@@ -2802,6 +2796,12 @@ namespace NuGetGallery
                     yield return new object[]
                     {
                         TestUtility.FakeOrganizationAdmin,
+                        TestUtility.FakeOrganization
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeOrganizationCollaborator,
                         TestUtility.FakeOrganization
                     };
                 }
@@ -3295,7 +3295,7 @@ namespace NuGetGallery
                     yield return MemberDataHelper.AsData(TestUtility.FakeUser, new[] { TestUtility.FakeUser });
                     yield return MemberDataHelper.AsData(TestUtility.FakeAdminUser, new[] { TestUtility.FakeAdminUser });
                     yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationAdmin, new[] { TestUtility.FakeOrganizationAdmin, TestUtility.FakeOrganization });
-                    yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, new[] { TestUtility.FakeOrganizationCollaborator });
+                    yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, new[] { TestUtility.FakeOrganizationCollaborator, TestUtility.FakeOrganization });
                 }
             }
 
@@ -3341,7 +3341,7 @@ namespace NuGetGallery
                     yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationAdmin, TestUtility.FakeUser, new[] { TestUtility.FakeOrganizationAdmin });
                     yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationAdmin, TestUtility.FakeOrganization, new[] { TestUtility.FakeOrganization });
                     yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, TestUtility.FakeUser, new[] { TestUtility.FakeOrganizationCollaborator });
-                    yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, TestUtility.FakeOrganization, new[] { TestUtility.FakeOrganizationCollaborator });
+                    yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, TestUtility.FakeOrganization, new[] { TestUtility.FakeOrganization });
                 }
             }
 
@@ -4233,12 +4233,6 @@ namespace NuGetGallery
                     yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationAdmin, TestUtility.FakeUser, null, TestUtility.FakeOrganization);
                     yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationAdmin, TestUtility.FakeUser, TestUtility.FakeOrganization, TestUtility.FakeOrganization);
                     
-                    // Organization collaborator on behalf of its organization.
-                    yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, TestUtility.FakeOrganization, null, null);
-                    // Organization collaborator who owns the package/reserved namespace on behalf of its organization.
-                    yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, TestUtility.FakeOrganization, null, TestUtility.FakeOrganizationCollaborator);
-                    // Organization collaborator whose organization owns the reserved namespace on behalf of its organization.
-                    yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, TestUtility.FakeOrganization, null, TestUtility.FakeOrganization);
                     // Organization collaborator whose organization owns the package/reserved namespace on behalf of an unrelated user.
                     yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, TestUtility.FakeUser, TestUtility.FakeOrganization, null);
                     yield return MemberDataHelper.AsData(TestUtility.FakeOrganizationCollaborator, TestUtility.FakeUser, null, TestUtility.FakeOrganization);

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -486,6 +486,8 @@ namespace NuGetGallery
                 var firstPackageOwner = model.PackageOwners.First();
                 Assert.True(firstPackageOwner.Owner == currentUser.Username);
                 Assert.True(firstPackageOwner.CanPushNew);
+                Assert.True(firstPackageOwner.CanPushExisting);
+                Assert.True(firstPackageOwner.CanUnlist);
             }
             
             [Theory]
@@ -497,8 +499,11 @@ namespace NuGetGallery
                 var organization = TestUtility.FakeOrganization;
 
                 var model = GetModelForApiKeys(currentUser);
-                
-                Assert.Equal(1, model.PackageOwners.Count(o => o.Owner == organization.Username && o.CanPushNew == isAdmin));
+
+                var owner = model.PackageOwners.Single(o => o.Owner == organization.Username);
+                Assert.True(owner.CanPushNew);
+                Assert.True(owner.CanPushExisting);
+                Assert.True(owner.CanUnlist);
             }
 
             public static IEnumerable<object[]> OrganizationIsNotInPackageOwnersIfNotMember_Data


### PR DESCRIPTION
We decided that allowing collaborators not to push new IDs and contact support was a weird experience.

This PR includes making that permissions change and also updating the API keys page to use the permissions service correctly.

https://github.com/NuGet/NuGetGallery/issues/5731
https://github.com/nuget/nugetgallery/issues/5104