### PR TITLE
Site admins should be able to modify organization membership

### DIFF
--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -258,14 +258,12 @@ namespace NuGetGallery
                 return new HttpStatusCodeResult(HttpStatusCode.Forbidden, Strings.Unauthorized);
             }
 
-            if (string.IsNullOrWhiteSpace(account.UnconfirmedEmailAddress))
+            if (!string.IsNullOrWhiteSpace(account.UnconfirmedEmailAddress))
             {
-                return RedirectToAction(AccountAction);
+                await UserService.CancelChangeEmailAddress(account);
+
+                TempData["Message"] = Messages.EmailUpdateCancelled;
             }
-
-            await UserService.CancelChangeEmailAddress(account);
-
-            TempData["Message"] = Messages.EmailUpdateCancelled;
 
             return RedirectToAction(AccountAction);
         }

--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Net;
-using System.Net.Mail;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using NuGetGallery.Authentication;
@@ -14,7 +13,7 @@ namespace NuGetGallery
 {
     public abstract class AccountsController<TUser, TAccountViewModel> : AppController
         where TUser : User
-        where TAccountViewModel : AccountViewModel
+        where TAccountViewModel : AccountViewModel<TUser>
     {
         public class ViewMessages
         {

--- a/src/NuGetGallery/Controllers/OrganizationsController.cs
+++ b/src/NuGetGallery/Controllers/OrganizationsController.cs
@@ -94,7 +94,7 @@ namespace NuGetGallery
             var account = GetAccount(accountName);
 
             if (account == null
-                || ActionsRequiringPermissions.ManageAccount.CheckPermissions(GetCurrentUser(), account)
+                || ActionsRequiringPermissions.ManageMembership.CheckPermissions(GetCurrentUser(), account)
                     != PermissionsCheckResult.Allowed)
             {
                 return Json(HttpStatusCode.Forbidden, Strings.Unauthorized);
@@ -193,7 +193,7 @@ namespace NuGetGallery
             var account = GetAccount(accountName);
 
             if (account == null
-                || ActionsRequiringPermissions.ManageAccount.CheckPermissions(GetCurrentUser(), account)
+                || ActionsRequiringPermissions.ManageMembership.CheckPermissions(GetCurrentUser(), account)
                     != PermissionsCheckResult.Allowed)
             {
                 return Json(HttpStatusCode.Forbidden, Strings.Unauthorized);
@@ -219,7 +219,7 @@ namespace NuGetGallery
             var account = GetAccount(accountName);
 
             if (account == null
-                || ActionsRequiringPermissions.ManageAccount.CheckPermissions(GetCurrentUser(), account)
+                || ActionsRequiringPermissions.ManageMembership.CheckPermissions(GetCurrentUser(), account)
                     != PermissionsCheckResult.Allowed)
             {
                 return Json(HttpStatusCode.Forbidden, Strings.Unauthorized);
@@ -254,7 +254,7 @@ namespace NuGetGallery
 
             if (account == null || 
                 (currentUser.Username != memberName && 
-                ActionsRequiringPermissions.ManageAccount.CheckPermissions(currentUser, account)
+                ActionsRequiringPermissions.ManageMembership.CheckPermissions(currentUser, account)
                     != PermissionsCheckResult.Allowed))
             {
                 return Json(HttpStatusCode.Forbidden, Strings.Unauthorized);
@@ -286,6 +286,10 @@ namespace NuGetGallery
                 .Concat(account.MemberRequests.Select(m => new OrganizationMemberViewModel(m)));
 
             model.RequiresTenant = account.IsRestrictedToOrganizationTenantPolicy();
+
+            model.CanManageMemberships = 
+                ActionsRequiringPermissions.ManageMembership.CheckPermissions(GetCurrentUser(), account) == 
+                PermissionsCheckResult.Allowed;
         }
     }
 }

--- a/src/NuGetGallery/Extensions/OrganizationExtensions.cs
+++ b/src/NuGetGallery/Extensions/OrganizationExtensions.cs
@@ -10,7 +10,7 @@ namespace NuGetGallery
     {
         public static Membership GetMembershipOfUser(this Organization organization, User member)
         {
-            return organization.Members.FirstOrDefault(m => m.Member.MatchesUser(member));
+            return organization?.Members?.FirstOrDefault(m => m.Member.MatchesUser(member));
         }
 
         /// <summary>

--- a/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
+++ b/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
@@ -10,10 +10,14 @@ namespace NuGetGallery
     {
         private const PermissionsRequirement RequireOwnerOrSiteAdmin = 
             PermissionsRequirement.Owner | PermissionsRequirement.SiteAdmin;
+        private const PermissionsRequirement RequireOwnerOrSiteAdminOrOrganizationAdmin =
+            PermissionsRequirement.Owner | PermissionsRequirement.SiteAdmin | PermissionsRequirement.OrganizationAdmin;
         private const PermissionsRequirement RequireOwnerOrOrganizationAdmin = 
             PermissionsRequirement.Owner | PermissionsRequirement.OrganizationAdmin;
-        private const PermissionsRequirement RequireOwnerOrOrganizationMember = 
+        private const PermissionsRequirement RequireOwnerOrOrganizationMember =
             PermissionsRequirement.Owner | PermissionsRequirement.OrganizationAdmin | PermissionsRequirement.OrganizationCollaborator;
+        private const PermissionsRequirement RequireOwnerOrSiteAdminOrOrganizationMember =
+            PermissionsRequirement.Owner | PermissionsRequirement.SiteAdmin | PermissionsRequirement.OrganizationAdmin | PermissionsRequirement.OrganizationCollaborator;
 
         /// <summary>
         /// The action of seeing private metadata about a package.
@@ -96,6 +100,13 @@ namespace NuGetGallery
                 accountPermissionsRequirement: RequireOwnerOrOrganizationAdmin);
 
         /// <summary>
+        /// The action of viewing (read-only) a user or organization account.
+        /// </summary>
+        public static ActionRequiringAccountPermissions ViewAccount =
+            new ActionRequiringAccountPermissions(
+                accountPermissionsRequirement: RequireOwnerOrSiteAdminOrOrganizationMember);
+
+        /// <summary>
         /// The action of managing a user or organization account. This includes confirming an account,
         /// changing the email address, changing email subscriptions, modifying sign-in credentials, etc.
         /// </summary>
@@ -104,10 +115,10 @@ namespace NuGetGallery
                 accountPermissionsRequirement: RequireOwnerOrOrganizationAdmin);
 
         /// <summary>
-        /// The action of viewing (read-only) a user or organization account.
+        /// The action of managing an organization's memberships.
         /// </summary>
-        public static ActionRequiringAccountPermissions ViewAccount =
+        public static ActionRequiringAccountPermissions ManageMembership =
             new ActionRequiringAccountPermissions(
-                accountPermissionsRequirement: RequireOwnerOrOrganizationMember);
+                accountPermissionsRequirement: RequireOwnerOrSiteAdminOrOrganizationAdmin);
     }
 }

--- a/src/NuGetGallery/ViewModels/AccountViewModel.cs
+++ b/src/NuGetGallery/ViewModels/AccountViewModel.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 
 namespace NuGetGallery
 {
-    public abstract class AccountViewModel
+    public abstract class AccountViewModel<T> where T : User
     {
-        public User Account { get; set; }
+        public T Account { get; set; }
 
         public bool IsOrganization
         {

--- a/src/NuGetGallery/ViewModels/AccountViewModel.cs
+++ b/src/NuGetGallery/ViewModels/AccountViewModel.cs
@@ -5,17 +5,18 @@ using System.Collections.Generic;
 
 namespace NuGetGallery
 {
-    public abstract class AccountViewModel<T> where T : User
+    public abstract class AccountViewModel<T> : AccountViewModel where T : User
     {
         public T Account { get; set; }
 
-        public bool IsOrganization
-        {
-            get
-            {
-                return Account is Organization;
-            }
-        }
+        public override User User => Account;
+    }
+
+    public abstract class AccountViewModel
+    {
+        public virtual User User { get; }
+
+        public bool IsOrganization => User is Organization;
 
         public string AccountName { get; set; }
 

--- a/src/NuGetGallery/ViewModels/OrganizationAccountViewModel.cs
+++ b/src/NuGetGallery/ViewModels/OrganizationAccountViewModel.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace NuGetGallery
 {
-    public class OrganizationAccountViewModel : AccountViewModel
+    public class OrganizationAccountViewModel : AccountViewModel<Organization>
     {
         public IEnumerable<OrganizationMemberViewModel> Members { get; set; }
 

--- a/src/NuGetGallery/ViewModels/OrganizationAccountViewModel.cs
+++ b/src/NuGetGallery/ViewModels/OrganizationAccountViewModel.cs
@@ -10,5 +10,7 @@ namespace NuGetGallery
         public IEnumerable<OrganizationMemberViewModel> Members { get; set; }
 
         public bool RequiresTenant { get; set; }
+
+        public bool CanManageMemberships { get; set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/UserAccountViewModel.cs
+++ b/src/NuGetGallery/ViewModels/UserAccountViewModel.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace NuGetGallery
 {
-    public class UserAccountViewModel : AccountViewModel
+    public class UserAccountViewModel : AccountViewModel<User>
     {
         public ChangePasswordViewModel ChangePassword { get; set; }
 

--- a/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
+++ b/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
@@ -19,8 +19,7 @@
         </div>
 
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
-            @if (!Model.CanManage || !Model.CanManageMemberships)
-            {
+            @{
                 string membershipString;
 
                 var membership = Model.Account.GetMembershipOfUser(CurrentUser);
@@ -35,12 +34,13 @@
                         "You are a collaborator of this organization.";
                 }
 
-                string permissionsString;
+                var permissionsString = "";
                 if (Model.CanManage)
                 {
-                    permissionsString = Model.CanManageMemberships ? 
-                        "" : // This should not be possible because of the if statement wrapping this code.
-                        "You must be an administrator to change its members.";
+                    if (!Model.CanManageMemberships)
+                    {
+                        permissionsString = "You must be an administrator to change its members.";
+                    }
                 }
                 else
                 {
@@ -49,7 +49,12 @@
                         "You must be an administrator to make changes to it.";
                 }
 
-                @ViewHelpers.AlertInfo(@<text>@membershipString @permissionsString</text>)
+                if (!string.IsNullOrEmpty(permissionsString))
+                {
+                    permissionsString = " " + permissionsString;
+                }
+
+                @ViewHelpers.AlertInfo(@<text>@membershipString@permissionsString</text>)
             }
 
             @Html.Partial("_AccountConfirmationNotices", Model)

--- a/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
+++ b/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
@@ -49,7 +49,7 @@
                         "You must be an administrator to make changes to it.";
                 }
 
-                @ViewHelpers.AlertInfo(@<text>@membershipString </text>)
+                @ViewHelpers.AlertInfo(@<text>@membershipString @permissionsString</text>)
             }
 
             @Html.Partial("_AccountConfirmationNotices", Model)

--- a/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
+++ b/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
@@ -19,28 +19,37 @@
         </div>
 
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
-            @{ 
-                var membership = (Model.Account as Organization).GetMembershipOfUser(CurrentUser);
+            @if (!Model.CanManage || !Model.CanManageMemberships)
+            {
+                string membershipString;
+
+                var membership = Model.Account.GetMembershipOfUser(CurrentUser);
                 if (membership == null)
                 {
-                    <p>You are not a member of this organization.</p>
+                    membershipString = "You are not a member of this organization.";
                 }
                 else
                 {
-                    if (membership.IsAdmin)
-                    {
-                        <p>You are an administrator of this organization.</p>
-                    }
-                    else
-                    {
-                        <p>You are a collaborator of this organization.</p>
-                    }
+                    membershipString = membership.IsAdmin ?
+                        "You are an administrator of this organization." :
+                        "You are a collaborator of this organization.";
                 }
-            }
 
-            @if (!Model.CanManage)
-            {
-                @ViewHelpers.AlertInfo(@<text>You must be an administrator of this organization to make changes to its email settings and profile picture.</text>)
+                string permissionsString;
+                if (Model.CanManage)
+                {
+                    permissionsString = Model.CanManageMemberships ? 
+                        "" : // This should not be possible because of the if statement wrapping this code.
+                        "You must be an administrator to change its members.";
+                }
+                else
+                {
+                    permissionsString = Model.CanManageMemberships ?
+                        "You must be an administrator to make changes to its email settings and profile picture." :
+                        "You must be an administrator to make changes to it.";
+                }
+
+                @ViewHelpers.AlertInfo(@<text>@membershipString </text>)
             }
 
             @Html.Partial("_AccountConfirmationNotices", Model)

--- a/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
+++ b/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
@@ -19,9 +19,28 @@
         </div>
 
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
+            @{ 
+                var membership = (Model.Account as Organization).GetMembershipOfUser(CurrentUser);
+                if (membership == null)
+                {
+                    <p>You are not a member of this organization.</p>
+                }
+                else
+                {
+                    if (membership.IsAdmin)
+                    {
+                        <p>You are an administrator of this organization.</p>
+                    }
+                    else
+                    {
+                        <p>You are a collaborator of this organization.</p>
+                    }
+                }
+            }
+
             @if (!Model.CanManage)
             {
-                @ViewHelpers.AlertInfo(@<text>You are a collaborator of this organization. Only administrators can make changes.</text>);
+                @ViewHelpers.AlertInfo(@<text>You must be an administrator of this organization to make changes to its email settings and profile picture.</text>)
             }
 
             @Html.Partial("_AccountConfirmationNotices", Model)

--- a/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
+++ b/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
@@ -32,7 +32,7 @@
                     @ViewHelpers.AlertInfo(@<text>Membership to this organization is restricted to users from the AAD tenant determined by its email address.</text>)
                 }
             </div>
-            @if (Model.CanManage)
+            @if (Model.CanManageMemberships)
             {
                 <div class="input-group col-xs-12">
                     <div class="row">
@@ -71,7 +71,7 @@
                         </div>
                     </div>
                     <div class="col-xs-3">
-                        @if (Model.CanManage)
+                        @if (Model.CanManageMemberships)
                         {
                             <select class="form-control" aria-label="Change member role"
                                     data-bind="value: SelectedRole, options: OrganizationViewModel.RoleNames, event: { change: ToggleIsAdmin }">
@@ -82,7 +82,7 @@
                             <span data-bind="text: SelectedRole()"></span>
                         }
                     </div>
-                    <!-- ko if: IsCurrentUser || @(Model.CanManage ? "true" : "false") -->
+                    <!-- ko if: IsCurrentUser || @(Model.CanManageMemberships ? "true" : "false") -->
                     <div class="col-xs-1 text-right member-column">
                         <div>
                             <span>

--- a/src/NuGetGallery/Views/Shared/_AccountConfirmationNotices.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountConfirmationNotices.cshtml
@@ -1,6 +1,6 @@
 ﻿@model AccountViewModel
 @{
-    var account = Model.Account;
+    var account = Model.User;
 
     if (Model.IsOrganization)
     {

--- a/src/NuGetGallery/Views/Shared/_AccountProfilePicture.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountProfilePicture.cshtml
@@ -24,7 +24,7 @@
 @ViewHelpers.Section(parent,
     "profile-picture",
     @<text>Profile Picture @(Model.HasUnconfirmedEmailAddress ? "(preview)" : string.Empty)</text>,
-    @<text>@ViewHelpers.GravatarImage(Model.CurrentEmailAddress, Model.Account.Username, Constants.GravatarElementSize)</text>,
+    @<text>@ViewHelpers.GravatarImage(Model.CurrentEmailAddress, Model.AccountName, Constants.GravatarElementSize)</text>,
     @<text>
         @if (Model.HasUnconfirmedEmailAddress)
         {

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -35,7 +35,7 @@
             <div class="profile-title">
                 <h1>
                     @Model.Username&nbsp;
-                    @if (Model.CanViewAccount)
+                    @if (Model.CanViewAccount && (Model.UserIsOrganization || CurrentUser.MatchesUser(Model.User)))
                     {
                         <a href="@(Model.UserIsOrganization ? Url.ManageMyOrganization(Model.Username) : Url.AccountSettings())" aria-label="Manage this account"><i class="ms-Icon ms-Icon--Edit ms-font-xl"></i></a>
                     }
@@ -48,7 +48,7 @@
                             <i class="ms-Icon ms-Icon--Group ms-font-xl" aria-hidden="true">&nbsp;</i>
                             <a href="@Url.ManageMyOrganization(Model.Username)" aria-label="Manage this organization"><span class="ms-font-xxl">@((Model.User as Organization).Administrators.Count())</span>&nbsp;Administrators&nbsp;</a><span aria-hidden="true" class="ms-font-xxl organization-subtitle-divider">|</span><a href="@Url.ManageMyOrganization(Model.Username)" aria-label="Manage this organization">&nbsp;<span class="ms-font-xxl">@((Model.User as Organization).Collaborators.Count())</span>&nbsp;Collaborators</a>
                         }
-                        else if (!Model.UserIsOrganization && Model.User.Organizations.Any())
+                        else if (CurrentUser.MatchesUser(Model.User) && Model.User.Organizations.Any())
                         {
                             <span>member of<a href="@Url.ManageMyOrganizations()" aria-label="Manage my organizations"><span class="ms-font-xxl">&nbsp;@(Model.User.Organizations.Count()) organizations</span></a></span>
                         }

--- a/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
 using System.Threading.Tasks;
@@ -17,13 +18,13 @@ namespace NuGetGallery
         where TAccountViewModel : AccountViewModel
         where TAccountsController : AccountsController<TUser, TAccountViewModel>
     {
+        protected const string AllowedCurrentUsersDataName = "AllowedCurrentUsers_Data";
+
         public abstract class AccountsControllerTestContainer : TestContainer
         {
             public Fakes Fakes = new Fakes();
 
             private const string AccountEnvironmentKey = "nuget.account";
-
-            protected abstract User GetCurrentUser(TAccountsController controller);
 
             public TAccountsController GetController()
             {
@@ -53,35 +54,35 @@ namespace NuGetGallery
 
         public abstract class TheAccountBaseAction : AccountsControllerTestContainer
         {
-            [Fact]
-            public void WillGetCuratedFeedsManagedByTheCurrentUser()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public void WillGetCuratedFeedsManagedByTheCurrentUser(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController<TAccountsController>();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 // Act
-                InvokeAccountInternal(controller);
+                InvokeAccountInternal(controller, getCurrentUser);
 
                 // Assert
                 GetMock<ICuratedFeedService>()
                     .Verify(query => query.GetFeedsForManager(account.Key));
             }
 
-            [Fact]
-            public void WillReturnTheAccountViewModelWithTheCuratedFeeds()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public void WillReturnTheAccountViewModelWithTheCuratedFeeds(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController<TAccountsController>();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(GetCurrentUser(controller));
                 GetMock<ICuratedFeedService>()
                     .Setup(stub => stub.GetFeedsForManager(account.Key))
                     .Returns(new[] { new CuratedFeed { Name = "theCuratedFeed" } });
 
                 // Act
-                var result = InvokeAccountInternal(controller);
+                var result = InvokeAccountInternal(controller, getCurrentUser);
 
                 // Assert
                 var model = ResultAssert.IsView<TAccountViewModel>(result, viewName: controller.AccountAction);
@@ -90,9 +91,10 @@ namespace NuGetGallery
 
             protected abstract ActionResult InvokeAccount(TAccountsController controller);
 
-            private ActionResult InvokeAccountInternal(TAccountsController controller)
+            private ActionResult InvokeAccountInternal(TAccountsController controller, Func<Fakes, User> getCurrentUser)
             {
                 var account = GetAccount(controller);
+                controller.SetCurrentUser(getCurrentUser(Fakes));
                 var userService = GetMock<IUserService>();
                 userService.Setup(u => u.FindByUsername(account.Username))
                     .Returns(account as User);
@@ -103,23 +105,25 @@ namespace NuGetGallery
 
         public abstract class TheCancelChangeEmailBaseAction : AccountsControllerTestContainer
         {
-            [Fact]
-            public virtual async Task WhenAlreadyConfirmed_RedirectsToAccount()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenAlreadyConfirmed_RedirectsToAccount(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeCancelChangeEmail(controller, account);
+                var result = await InvokeCancelChangeEmail(controller, account, getCurrentUser);
 
                 // Assert
                 GetMock<IUserService>().Verify(u => u.CancelChangeEmailAddress(It.IsAny<User>()), Times.Never);
                 ResultAssert.IsRedirectToRoute(result, new { action = controller.AccountAction });
             }
 
-            [Fact]
-            public virtual async Task WhenUnconfirmed_CancelsEmailChangeRequest()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenUnconfirmed_CancelsEmailChangeRequest(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
@@ -129,10 +133,10 @@ namespace NuGetGallery
                 account.EmailAddress = null;
 
                 // Act
-                var result = await InvokeCancelChangeEmail(controller, account);
+                var result = await InvokeCancelChangeEmail(controller, account, getCurrentUser);
 
                 // Assert
-                GetMock<IUserService>().Verify(u => u.CancelChangeEmailAddress(It.IsAny<User>()), Times.Once);
+                GetMock<IUserService>().Verify(u => u.CancelChangeEmailAddress(account), Times.Once);
                 ResultAssert.IsRedirectToRoute(result, new { action = controller.AccountAction });
                 Assert.Equal(controller.Messages.EmailUpdateCancelled, controller.TempData["Message"]);
             }
@@ -140,15 +144,16 @@ namespace NuGetGallery
             protected virtual Task<ActionResult> InvokeCancelChangeEmail(
                 TAccountsController controller,
                 TUser account,
+                Func<Fakes, User> getCurrentUser,
                 TAccountViewModel model = null)
             {
                 // Arrange
-                controller.SetCurrentUser(GetCurrentUser(controller));
+                controller.SetCurrentUser(getCurrentUser(Fakes));
 
                 var userService = GetMock<IUserService>();
                 userService.Setup(u => u.FindByUsername(account.Username))
                     .Returns(account as User);
-                userService.Setup(u => u.CancelChangeEmailAddress(It.IsAny<User>()))
+                userService.Setup(u => u.CancelChangeEmailAddress(account))
                     .Returns(Task.CompletedTask)
                     .Verifiable();
 
@@ -162,19 +167,19 @@ namespace NuGetGallery
 
         public abstract class TheChangeEmailBaseAction : AccountsControllerTestContainer
         {
-            [Fact]
-            public virtual async Task WhenServiceThrowsEntityException_ShowsModelStateError()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenServiceThrowsEntityException_ShowsModelStateError(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                var currentUser = GetCurrentUser(controller);
 
                 var model = CreateViewModel(account);
                 model.ChangeEmail.NewEmail = "account2@example.com";
 
                 // Act
-                var result = await InvokeChangeEmail(controller, account, model,
+                var result = await InvokeChangeEmail(controller, account, getCurrentUser, model,
                     exception: new EntityException("e.g., Another user already has that email"));
 
                 // Assert
@@ -183,8 +188,9 @@ namespace NuGetGallery
                 Assert.Equal("ChangeEmail.NewEmail", controller.ModelState.Keys.Single());
             }
 
-            [Fact]
-            public virtual async Task WhenNewEmailIsInvalid_DoesNotSaveChanges()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenNewEmailIsInvalid_DoesNotSaveChanges(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
@@ -194,15 +200,16 @@ namespace NuGetGallery
                 controller.ModelState.AddModelError("ChangeEmail.NewEmail", "Invalid format");
 
                 // Act
-                var result = await InvokeChangeEmail(controller, account, model);
+                var result = await InvokeChangeEmail(controller, account, getCurrentUser, model);
 
                 // Assert
                 GetMock<IUserService>().Verify(u => u.ChangeEmailAddress(It.IsAny<User>(), It.IsAny<string>()), Times.Never);
                 Assert.False(controller.ModelState.IsValid);
             }
 
-            [Fact]
-            public virtual async Task WhenNewEmailIsSame_RedirectsWithoutChange()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenNewEmailIsSame_RedirectsWithoutChange(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
@@ -211,15 +218,16 @@ namespace NuGetGallery
                 model.ChangeEmail.NewEmail = account.EmailAddress;
 
                 // Act
-                var result = await InvokeChangeEmail(controller, account, model);
+                var result = await InvokeChangeEmail(controller, account, getCurrentUser, model);
 
                 // Assert
                 GetMock<IUserService>().Verify(u => u.ChangeEmailAddress(It.IsAny<User>(), It.IsAny<string>()), Times.Never);
                 ResultAssert.IsRedirectToRoute(result, new { action = controller.AccountAction });
             }
 
-            [Fact]
-            public virtual async Task WhenNewEmailIsDifferentAndWasConfirmed_SavesChanges()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenNewEmailIsDifferentAndWasConfirmed_SavesChanges(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
@@ -228,7 +236,7 @@ namespace NuGetGallery
                 model.ChangeEmail.NewEmail = "account2@example.com";
 
                 // Act
-                var result = await InvokeChangeEmail(controller, account, model);
+                var result = await InvokeChangeEmail(controller, account, getCurrentUser, model);
 
                 // Assert
                 GetMock<IUserService>().Verify(u => u.ChangeEmailAddress(It.IsAny<User>(), It.IsAny<string>()), Times.Once);
@@ -239,8 +247,9 @@ namespace NuGetGallery
                     Times.Once);
             }
 
-            [Fact]
-            public virtual async Task WhenNewEmailIsDifferentAndWasUnconfirmed_SavesChanges()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenNewEmailIsDifferentAndWasUnconfirmed_SavesChanges(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
@@ -252,7 +261,7 @@ namespace NuGetGallery
                 account.EmailAddress = null;
 
                 // Act
-                var result = await InvokeChangeEmail(controller, account, model);
+                var result = await InvokeChangeEmail(controller, account, getCurrentUser, model);
 
                 // Assert
                 GetMock<IUserService>().Verify(u => u.ChangeEmailAddress(It.IsAny<User>(), It.IsAny<string>()), Times.Once);
@@ -274,11 +283,12 @@ namespace NuGetGallery
             protected virtual Task<ActionResult> InvokeChangeEmail(
                 TAccountsController controller,
                 TUser account,
+                Func<Fakes, User> getCurrentUser,
                 TAccountViewModel model = null,
                 EntityException exception = null)
             {
                 // Arrange
-                controller.SetCurrentUser(GetCurrentUser(controller));
+                controller.SetCurrentUser(getCurrentUser(Fakes));
 
                 var messageService = GetMock<IMessageService>();
                 messageService.Setup(m => m.SendEmailChangeConfirmationNotice(It.IsAny<User>(), It.IsAny<string>()))
@@ -314,33 +324,45 @@ namespace NuGetGallery
 
         public abstract class TheChangeEmailSubscriptionBaseAction : AccountsControllerTestContainer
         {
+            public static IEnumerable<object[]> UpdatesEmailPreferences_DefaultData
+            {
+                get
+                {
+                    foreach (var emailAllowed in new[] { false, true })
+                    {
+                        foreach (var notifyPackagePushed in new[] { false, true })
+                        {
+                            yield return MemberDataHelper.AsData(emailAllowed, notifyPackagePushed);
+                        }
+                    }
+                }
+            }
+
             [Theory]
-            [InlineData(true, true)]
-            [InlineData(true, false)]
-            [InlineData(false, true)]
-            [InlineData(false, false)]
-            public virtual async Task UpdatesEmailPreferences(bool emailAllowed, bool notifyPackagePushed)
+            [MemberData("UpdatesEmailPreferences_Data")]
+            public virtual async Task UpdatesEmailPreferences(Func<Fakes, User> getCurrentUser, bool emailAllowed, bool notifyPackagePushed)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeChangeEmailSubscription(controller, emailAllowed, notifyPackagePushed);
+                var result = await InvokeChangeEmailSubscription(controller, getCurrentUser, emailAllowed, notifyPackagePushed);
 
                 // Assert
                 ResultAssert.IsRedirectToRoute(result, new { action = controller.AccountAction });
                 GetMock<IUserService>().Verify(u => u.ChangeEmailSubscriptionAsync(account, emailAllowed, notifyPackagePushed));
             }
 
-            [Fact]
-            public virtual async Task DisplaysMessageOnUpdate()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task DisplaysMessageOnUpdate(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
 
                 // Act
-                var result = await InvokeChangeEmailSubscription(controller);
+                var result = await InvokeChangeEmailSubscription(controller, getCurrentUser);
 
                 // Assert
                 Assert.Equal(controller.Messages.EmailPreferencesUpdated, controller.TempData["Message"]);
@@ -348,11 +370,12 @@ namespace NuGetGallery
 
             protected virtual async Task<ActionResult> InvokeChangeEmailSubscription(
                 TAccountsController controller,
+                Func<Fakes, User> getCurrentUser,
                 bool emailAllowed = true,
                 bool notifyPackagePushed = true)
             {
                 // Arrange
-                controller.SetCurrentUser(GetCurrentUser(controller));
+                controller.SetCurrentUser(getCurrentUser(Fakes));
 
                 var account = GetAccount(controller);
                 account.Username = "aUsername";
@@ -381,16 +404,16 @@ namespace NuGetGallery
 
         public abstract class TheConfirmationRequiredBaseAction : AccountsControllerTestContainer
         {
-            [Fact]
-            public virtual void WhenAccountAlreadyConfirmed()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual void WhenAccountAlreadyConfirmed(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 // Act
-                var result = InvokeConfirmationRequired(controller, account);
+                var result = InvokeConfirmationRequired(controller, account, getCurrentUser);
 
                 // Assert
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
@@ -399,19 +422,19 @@ namespace NuGetGallery
                 Assert.Null(model.UnconfirmedEmailAddress);
             }
 
-            [Fact]
-            public virtual void WhenAccountIsNotConfirmed()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual void WhenAccountIsNotConfirmed(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 account.UnconfirmedEmailAddress = account.EmailAddress;
                 account.EmailAddress = null;
 
                 // Act
-                var result = InvokeConfirmationRequired(controller, account);
+                var result = InvokeConfirmationRequired(controller, account, getCurrentUser);
 
                 // Assert
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
@@ -422,9 +445,11 @@ namespace NuGetGallery
 
             protected virtual ActionResult InvokeConfirmationRequired(
                 TAccountsController controller,
-                TUser account)
+                TUser account,
+                Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
+                controller.SetCurrentUser(getCurrentUser(Fakes));
                 var userService = GetMock<IUserService>();
                 userService.Setup(u => u.FindByUsername(account.Username))
                     .Returns(account as User);
@@ -436,16 +461,16 @@ namespace NuGetGallery
 
         public abstract class TheConfirmationRequiredPostBaseAction : AccountsControllerTestContainer
         {
-            [Fact]
-            public virtual void WhenAlreadyConfirmed_DoesNotSendEmail()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual void WhenAlreadyConfirmed_DoesNotSendEmail(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 // Act
-                var result = InvokeConfirmationRequiredPost(controller, account);
+                var result = InvokeConfirmationRequiredPost(controller, account, getCurrentUser);
 
                 // Assert
                 var mailService = GetMock<IMessageService>();
@@ -455,13 +480,13 @@ namespace NuGetGallery
                 Assert.False(model.SentEmail);
             }
 
-            [Fact]
-            public virtual void WhenIsNotConfirmed_SendsEmail()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual void WhenIsNotConfirmed_SendsEmail(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 account.EmailConfirmationToken = "confirmation";
                 account.UnconfirmedEmailAddress = account.EmailAddress;
@@ -471,7 +496,7 @@ namespace NuGetGallery
                 var confirmationUrl = (account is Organization)
                     ? TestUtility.GallerySiteRootHttps + $"organization/{account.Username}/Confirm?token=confirmation"
                     : TestUtility.GallerySiteRootHttps + $"account/confirm/{account.Username}/confirmation";
-                var result = InvokeConfirmationRequiredPost(controller, account, confirmationUrl);
+                var result = InvokeConfirmationRequiredPost(controller, account, getCurrentUser, confirmationUrl);
 
                 // Assert
                 var mailService = GetMock<IMessageService>();
@@ -484,9 +509,11 @@ namespace NuGetGallery
             protected virtual ActionResult InvokeConfirmationRequiredPost(
                 TAccountsController controller,
                 TUser account,
+                Func<Fakes, User> getCurrentUser,
                 string confirmationUrl = null)
             {
                 // Arrange
+                controller.SetCurrentUser(getCurrentUser(Fakes));
                 var userService = GetMock<IUserService>();
                 userService.Setup(u => u.FindByUsername(account.Username))
                     .Returns(account as User);
@@ -504,36 +531,36 @@ namespace NuGetGallery
 
         public abstract class TheConfirmBaseAction : AccountsControllerTestContainer
         {
-            [Fact]
-            public virtual async Task ClearsReturnUrlFromViewData()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task ClearsReturnUrlFromViewData(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
                 var token = account.EmailConfirmationToken = "token";
-                controller.SetCurrentUser(GetCurrentUser(controller));
                 controller.ViewData[Constants.ReturnUrlViewDataKey] = "https://localhost/returnUrl";
 
                 Assert.NotNull(controller.ViewData[Constants.ReturnUrlViewDataKey]);
 
                 // Act
-                var result = await InvokeConfirm(controller, account, token);
+                var result = await InvokeConfirm(controller, account, getCurrentUser, token);
 
                 // Assert
                 Assert.Null(controller.ViewData[Constants.ReturnUrlViewDataKey]);
             }
 
-            [Fact]
-            public virtual async Task WhenAlreadyConfirmed_DoesNotConfirmEmailAddress()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenAlreadyConfirmed_DoesNotConfirmEmailAddress(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
                 var token = account.EmailConfirmationToken = "token";
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 // Act
-                var result = await InvokeConfirm(controller, account, token);
+                var result = await InvokeConfirm(controller, account, getCurrentUser, token);
 
                 // Assert
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
@@ -552,20 +579,20 @@ namespace NuGetGallery
                         Times.Never);
             }
 
-            [Fact]
-            public virtual async Task WhenIsNotConfirmedAndNoExistingEmail_ConfirmsEmailAddress()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenIsNotConfirmedAndNoExistingEmail_ConfirmsEmailAddress(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
                 var token = account.EmailConfirmationToken = "token";
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 account.UnconfirmedEmailAddress = "account2@example.com";
                 account.EmailAddress = null;
 
                 // Act
-                var result = await InvokeConfirm(controller, account, token);
+                var result = await InvokeConfirm(controller, account, getCurrentUser, token);
 
                 // Assert
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
@@ -584,19 +611,19 @@ namespace NuGetGallery
                         Times.Never);
             }
 
-            [Fact]
-            public virtual async Task WhenIsNotConfirmedAndHasExistingEmail_ConfirmsEmailAddress()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public virtual async Task WhenIsNotConfirmedAndHasExistingEmail_ConfirmsEmailAddress(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
                 var token = account.EmailConfirmationToken = "token";
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 account.UnconfirmedEmailAddress = "account2@example.com";
 
                 // Act
-                var result = await InvokeConfirm(controller, account, token);
+                var result = await InvokeConfirm(controller, account, getCurrentUser, token);
 
                 // Assert
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
@@ -615,38 +642,38 @@ namespace NuGetGallery
                         Times.Once);
             }
 
-            [Fact]
-            public async Task WhenIsNotConfirmedAndTokenDoesNotMatch_ShowsError()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public async Task WhenIsNotConfirmedAndTokenDoesNotMatch_ShowsError(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
                 account.EmailConfirmationToken = "token";
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 account.UnconfirmedEmailAddress = "account2@example.com";
 
                 // Act
-                var result = await InvokeConfirm(controller, account, "wrongToken");
+                var result = await InvokeConfirm(controller, account, getCurrentUser, "wrongToken");
 
                 // Assert
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
                 Assert.False(model.SuccessfulConfirmation);
             }
 
-            [Fact]
-            public async Task WhenIsNotConfirmedAndEntityExceptionThrown_ShowsErrorForDuplicateEmail()
+            [Theory]
+            [MemberData(AllowedCurrentUsersDataName)]
+            public async Task WhenIsNotConfirmedAndEntityExceptionThrown_ShowsErrorForDuplicateEmail(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
                 var token = account.EmailConfirmationToken = "token";
-                controller.SetCurrentUser(GetCurrentUser(controller));
 
                 account.UnconfirmedEmailAddress = "account2@example.com";
 
                 // Act
-                var result = await InvokeConfirm(controller, account, token,
+                var result = await InvokeConfirm(controller, account, getCurrentUser, token,
                     exception: new EntityException("msg"));
 
                 // Assert
@@ -658,10 +685,12 @@ namespace NuGetGallery
             protected virtual Task<ActionResult> InvokeConfirm(
                 TAccountsController controller,
                 TUser account,
+                Func<Fakes, User> getCurrentUser,
                 string token = "token",
                 EntityException exception = null)
             {
                 // Arrange
+                controller.SetCurrentUser(getCurrentUser(Fakes));
                 var userService = GetMock<IUserService>();
                 userService.Setup(u => u.FindByUsername(account.Username))
                     .Returns(account as User);

--- a/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Mail;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using Moq;
@@ -15,7 +14,7 @@ namespace NuGetGallery
 {
     public class AccountsControllerFacts<TAccountsController, TUser, TAccountViewModel>
         where TUser : User
-        where TAccountViewModel : AccountViewModel
+        where TAccountViewModel : AccountViewModel<TUser>
         where TAccountsController : AccountsController<TUser, TAccountViewModel>
     {
         protected const string AllowedCurrentUsersDataName = "AllowedCurrentUsers_Data";

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
-using System.Net.Mail;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using Moq;

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
 using System.Net.Mail;
@@ -16,6 +17,11 @@ namespace NuGetGallery
     public class OrganizationsControllerFacts
         : AccountsControllerFacts<OrganizationsController, Organization, OrganizationAccountViewModel>
     {
+        private static Func<Fakes, User> _getFakesUser = (Fakes fakes) => fakes.User;
+        private static Func<Fakes, User> _getFakesSiteAdmin = (Fakes fakes) => fakes.Admin;
+        private static Func<Fakes, User> _getFakesOrganizationAdmin = (Fakes fakes) => fakes.OrganizationAdmin;
+        private static Func<Fakes, User> _getFakesOrganizationCollaborator = (Fakes fakes) => fakes.OrganizationCollaborator;
+
         public class TheAccountAction : TheAccountBaseAction
         {
             protected override ActionResult InvokeAccount(OrganizationsController controller)
@@ -24,81 +30,78 @@ namespace NuGetGallery
                 return controller.ManageOrganization(accountName);
             }
 
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
             }
 
             // Note general account tests are in the base class. Organization-specific tests are below.
 
-            [Fact]
-            public void WhenCurrentUserIsCollaborator_ReturnsReadOnly()
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsPartialPermissions_Data
+            {
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin, false, true);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator, false, false);
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsPartialPermissions_Data))]
+            public void WithNonOrganizationAdmin_ReturnsPartialPermissions(Func<Fakes, User> getCurrentUser, bool canManage, bool canManageMemberships)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
+                controller.SetCurrentUser(getCurrentUser(Fakes));
 
                 // Act
                 var result = InvokeAccount(controller);
 
                 // Assert
                 var model = ResultAssert.IsView<OrganizationAccountViewModel>(result, "ManageOrganization");
-                Assert.False(model.CanManage);
-            }
-
-            [Fact]
-            public void WhenCurrentUserIsNotMember_ReturnsForbidden()
-            {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
-
-                // Act
-                var result = InvokeAccount(controller) as HttpStatusCodeResult;
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal((int)HttpStatusCode.Forbidden, result.StatusCode);
+                Assert.Equal(canManage, model.CanManage);
+                Assert.Equal(canManageMemberships, model.CanManageMemberships);
             }
         }
 
         public class TheCancelChangeEmailAction : TheCancelChangeEmailBaseAction
         {
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
 
             // Note general account tests are in the base class. Organization-specific tests are below.
 
-            [Fact]
-            public async Task WhenCurrentUserIsCollaborator_ReturnsForbidden()
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
             {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
-
-                // Act
-                var result = await InvokeCancelChangeEmail(controller, account) as HttpStatusCodeResult;
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal((int)HttpStatusCode.Forbidden, result.StatusCode);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
             }
 
-            [Fact]
-            public async Task WhenCurrentUserIsNotMember_ReturnsForbidden()
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public async Task WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
 
                 // Act
-                var result = await InvokeCancelChangeEmail(controller, account) as HttpStatusCodeResult;
+                var result = await InvokeCancelChangeEmail(controller, account, getCurrentUser) as HttpStatusCodeResult;
 
                 // Assert
                 Assert.NotNull(result);
@@ -108,39 +111,36 @@ namespace NuGetGallery
 
         public class TheChangeEmailAction : TheChangeEmailBaseAction
         {
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
 
             // Note general account tests are in the base class. Organization-specific tests are below.
 
-            [Fact]
-            public async Task WhenCurrentUserIsCollaborator_ReturnsForbidden()
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
             {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
-
-                // Act
-                var result = await InvokeChangeEmail(controller, account) as HttpStatusCodeResult;
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal((int)HttpStatusCode.Forbidden, result.StatusCode);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
             }
 
-            [Fact]
-            public async Task WhenCurrentUserIsNotMember_ReturnsForbidden()
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public async Task WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
 
                 // Act
-                var result = await InvokeChangeEmail(controller, account) as HttpStatusCodeResult;
+                var result = await InvokeChangeEmail(controller, account, getCurrentUser) as HttpStatusCodeResult;
 
                 // Assert
                 Assert.NotNull(result);
@@ -150,37 +150,37 @@ namespace NuGetGallery
 
         public class TheChangeEmailSubscriptionAction : TheChangeEmailSubscriptionBaseAction
         {
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
+
+            public static IEnumerable<object[]> UpdatesEmailPreferences_Data => MemberDataHelper.Combine(AllowedCurrentUsers_Data, UpdatesEmailPreferences_DefaultData);
 
             // Note general account tests are in the base class. Organization-specific tests are below.
 
-            [Fact]
-            public async Task WhenCurrentUserIsCollaborator_ReturnsForbidden()
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
             {
-                // Arrange
-                var controller = GetController();
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
-
-                // Act
-                var result = await InvokeChangeEmailSubscription(controller) as HttpStatusCodeResult;
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal((int)HttpStatusCode.Forbidden, result.StatusCode);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
             }
 
-            [Fact]
-            public async Task WhenCurrentUserIsNotMember_ReturnsForbidden()
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public async Task WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
-                controller.SetCurrentUser(Fakes.User);
 
                 // Act
-                var result = await InvokeChangeEmailSubscription(controller) as HttpStatusCodeResult;
+                var result = await InvokeChangeEmailSubscription(controller, getCurrentUser) as HttpStatusCodeResult;
 
                 // Assert
                 Assert.NotNull(result);
@@ -190,39 +190,36 @@ namespace NuGetGallery
 
         public class TheConfirmationRequiredAction : TheConfirmationRequiredBaseAction
         {
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
 
             // Note general account tests are in the base class. Organization-specific tests are below.
 
-            [Fact]
-            public void WhenUserIsCollaborator_ReturnsForbidden()
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
             {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
-
-                // Act
-                var result = InvokeConfirmationRequired(controller, account) as HttpStatusCodeResult;
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal((int)HttpStatusCode.Forbidden, result.StatusCode);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
             }
 
-            [Fact]
-            public void WhenUserIsNotMember_ReturnsForbidden()
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public void WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
 
                 // Act
-                var result = InvokeConfirmationRequired(controller, account) as HttpStatusCodeResult;
+                var result = InvokeConfirmationRequired(controller, account, getCurrentUser) as HttpStatusCodeResult;
 
                 // Assert
                 Assert.NotNull(result);
@@ -232,39 +229,36 @@ namespace NuGetGallery
 
         public class TheConfirmationRequiredPostAction : TheConfirmationRequiredPostBaseAction
         {
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
 
             // Note general account tests are in the base class. Organization-specific tests are below.
 
-            [Fact]
-            public void WhenUserIsCollaborator_ReturnsForbidden()
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
             {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
-
-                // Act
-                var result = InvokeConfirmationRequiredPost(controller, account) as HttpStatusCodeResult;
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal((int)HttpStatusCode.Forbidden, result.StatusCode);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
             }
 
-            [Fact]
-            public void WhenUserIsNotMember_ReturnsForbidden()
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public void WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
 
                 // Act
-                var result = InvokeConfirmationRequiredPost(controller, account) as HttpStatusCodeResult;
+                var result = InvokeConfirmationRequiredPost(controller, account, getCurrentUser) as HttpStatusCodeResult;
 
                 // Assert
                 Assert.NotNull(result);
@@ -274,40 +268,36 @@ namespace NuGetGallery
 
         public class TheConfirmAction : TheConfirmBaseAction
         {
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
 
             // Note general account tests are in the base class. Organization-specific tests are below.
 
-            [Fact]
-            public async Task WhenUserIsCollaborator_ReturnsNonSuccess()
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
             {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
-
-                // Act
-                var result = await InvokeConfirm(controller, account);
-
-                // Assert
-                var model = ResultAssert.IsView<ConfirmationViewModel>(result);
-                Assert.True(model.WrongUsername);
-                Assert.False(model.SuccessfulConfirmation);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
             }
 
-            [Fact]
-            public async Task WhenUserIsNotMember_ReturnsNonSuccess()
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public async Task WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
 
                 // Act
-                var result = await InvokeConfirm(controller, account);
+                var result = await InvokeConfirm(controller, account, getCurrentUser);
 
                 // Assert
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
@@ -400,21 +390,38 @@ namespace NuGetGallery
         {
             private const string defaultMemberName = "member";
 
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
 
-            [Fact]
-            public async Task WhenUserIsCollaborator_ReturnsNonSuccess()
+            public static IEnumerable<object[]> AllowedCurrentUsers_IsAdmin_Data => MemberDataHelper.Combine(
+                AllowedCurrentUsers_Data, 
+                new[] { MemberDataHelper.AsData(false), MemberDataHelper.AsData(true) });
+
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
+            {
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public async Task WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
 
                 // Act
-                var result = await InvokeAddMember(controller, account);
+                var result = await InvokeAddMember(controller, account, getCurrentUser);
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.Forbidden, controller.Response.StatusCode);
@@ -424,27 +431,9 @@ namespace NuGetGallery
                 GetMock<IUserService>().Verify(s => s.AddMembershipRequestAsync(It.IsAny<Organization>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
             }
 
-            [Fact]
-            public async Task WhenCurrentUserIsNotMember_ReturnsNonSuccess()
-            {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
-
-                // Act
-                var result = await InvokeAddMember(controller, account);
-
-                // Assert
-                Assert.Equal((int)HttpStatusCode.Forbidden, controller.Response.StatusCode);
-                Assert.IsType<JsonResult>(result);
-                Assert.Equal(Strings.Unauthorized, result.Data);
-
-                GetMock<IUserService>().Verify(s => s.AddMembershipRequestAsync(It.IsAny<Organization>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
-            }
-
-            [Fact]
-            public async Task WhenOrganizationIsNotConfirmed_ReturnsNonSuccess()
+            [Theory]
+            [MemberData(nameof(AllowedCurrentUsers_Data))]
+            public async Task WhenOrganizationIsNotConfirmed_ReturnsNonSuccess(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
@@ -452,7 +441,7 @@ namespace NuGetGallery
                 account.EmailAddress = null;
 
                 // Act
-                var result = await InvokeAddMember(controller, account);
+                var result = await InvokeAddMember(controller, account, getCurrentUser);
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
@@ -463,16 +452,15 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(true)]
-            [InlineData(false)]
-            public async Task WhenEntityException_ReturnsNonSuccess(bool isAdmin)
+            [MemberData(nameof(AllowedCurrentUsers_IsAdmin_Data))]
+            public async Task WhenEntityException_ReturnsNonSuccess(Func<Fakes, User> getCurrentUser, bool isAdmin)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeAddMember(controller, account, isAdmin: isAdmin,
+                var result = await InvokeAddMember(controller, account, getCurrentUser, isAdmin: isAdmin,
                     exception: new EntityException("error"));
 
                 // Assert
@@ -484,16 +472,15 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(true)]
-            [InlineData(false)]
-            public async Task WhenMembershipRequestCreated_ReturnsSuccess(bool isAdmin)
+            [MemberData(nameof(AllowedCurrentUsers_IsAdmin_Data))]
+            public async Task WhenMembershipRequestCreated_ReturnsSuccess(Func<Fakes, User> getCurrentUser, bool isAdmin)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeAddMember(controller, account, isAdmin: isAdmin);
+                var result = await InvokeAddMember(controller, account, getCurrentUser, isAdmin: isAdmin);
 
                 // Assert
                 Assert.Equal(0, controller.Response.StatusCode);
@@ -526,12 +513,13 @@ namespace NuGetGallery
             private Task<JsonResult> InvokeAddMember(
                 OrganizationsController controller,
                 Organization account,
+                Func<Fakes, User> getCurrentUser,
                 string memberName = defaultMemberName,
                 bool isAdmin = false,
                 EntityException exception = null)
             {
                 // Arrange
-                controller.SetCurrentUser(GetCurrentUser(controller));
+                controller.SetCurrentUser(getCurrentUser(Fakes));
 
                 var userService = GetMock<IUserService>();
                 userService.Setup(u => u.FindByUsername(account.Username))
@@ -561,11 +549,6 @@ namespace NuGetGallery
         public class TheConfirmMemberAction : AccountsControllerTestContainer
         {
             private const string defaultConfirmationToken = "token";
-
-            protected override User GetCurrentUser(OrganizationsController controller)
-            {
-                return controller.GetCurrentUser() ?? Fakes.User;
-            }
 
             [Theory]
             [InlineData(true)]
@@ -624,12 +607,12 @@ namespace NuGetGallery
                 var result = await InvokeConfirmMember(controller, account, isAdmin: isAdmin);
 
                 // Assert
-                ResultAssert.IsRedirectTo(result, 
+                ResultAssert.IsRedirectTo(result,
                     controller.Url.ManageMyOrganization(account.Username));
 
 
                 Assert.Equal(String.Format(CultureInfo.CurrentCulture,
-                    Strings.AddMember_Success, account.Username), 
+                    Strings.AddMember_Success, account.Username),
                     controller.TempData["Message"]);
 
                 GetMock<IUserService>().Verify(s => s.AddMemberAsync(account, Fakes.User.Username, defaultConfirmationToken), Times.Once);
@@ -647,7 +630,7 @@ namespace NuGetGallery
                 EntityException exception = null)
             {
                 // Arrange
-                controller.SetCurrentUser(GetCurrentUser(controller));
+                controller.SetCurrentUser(Fakes.User);
 
                 var currentUser = controller.GetCurrentUser();
 
@@ -681,11 +664,6 @@ namespace NuGetGallery
         public class TheRejectMemberAction : AccountsControllerTestContainer
         {
             private const string defaultConfirmationToken = "token";
-
-            protected override User GetCurrentUser(OrganizationsController controller)
-            {
-                return controller.GetCurrentUser() ?? Fakes.User;
-            }
 
             [Theory]
             [InlineData(true)]
@@ -762,7 +740,7 @@ namespace NuGetGallery
                 EntityException exception = null)
             {
                 // Arrange
-                controller.SetCurrentUser(GetCurrentUser(controller));
+                controller.SetCurrentUser(Fakes.User);
 
                 var currentUser = controller.GetCurrentUser();
 
@@ -797,21 +775,38 @@ namespace NuGetGallery
         {
             private const string defaultMemberName = "member";
 
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
 
-            [Fact]
-            public async Task WhenUserIsCollaborator_ReturnsNonSuccess()
+            public static IEnumerable<object[]> AllowedCurrentUsers_IsAdmin_Data => MemberDataHelper.Combine(
+                AllowedCurrentUsers_Data,
+                new[] { MemberDataHelper.AsData(false), MemberDataHelper.AsData(true) });
+
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
+            {
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public async Task WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
 
                 // Act
-                var result = await InvokeUpdateMember(controller, account);
+                var result = await InvokeUpdateMember(controller, account, getCurrentUser);
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.Forbidden, controller.Response.StatusCode);
@@ -821,27 +816,9 @@ namespace NuGetGallery
                 GetMock<IUserService>().Verify(s => s.UpdateMemberAsync(It.IsAny<Organization>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
             }
 
-            [Fact]
-            public async Task WhenUserIsNotMember_ReturnsNonSuccess()
-            {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
-
-                // Act
-                var result = await InvokeUpdateMember(controller, account);
-
-                // Assert
-                Assert.Equal((int)HttpStatusCode.Forbidden, controller.Response.StatusCode);
-                Assert.IsType<JsonResult>(result);
-                Assert.Equal(Strings.Unauthorized, result.Data);
-
-                GetMock<IUserService>().Verify(s => s.UpdateMemberAsync(It.IsAny<Organization>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
-            }
-
-            [Fact]
-            public async Task WhenOrganizationIsUnconfirmed_ReturnsNonSuccess()
+            [Theory]
+            [MemberData(nameof(AllowedCurrentUsers_Data))]
+            public async Task WhenOrganizationIsUnconfirmed_ReturnsNonSuccess(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
@@ -849,7 +826,7 @@ namespace NuGetGallery
                 account.EmailAddress = null;
 
                 // Act
-                var result = await InvokeUpdateMember(controller, account);
+                var result = await InvokeUpdateMember(controller, account, getCurrentUser);
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
@@ -860,16 +837,15 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(true)]
-            [InlineData(false)]
-            public async Task WhenEntityException_ReturnsNonSuccess(bool isAdmin)
+            [MemberData(nameof(AllowedCurrentUsers_IsAdmin_Data))]
+            public async Task WhenEntityException_ReturnsNonSuccess(Func<Fakes, User> getCurrentUser, bool isAdmin)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeUpdateMember(controller, account, isAdmin: isAdmin,
+                var result = await InvokeUpdateMember(controller, account, getCurrentUser, isAdmin: isAdmin,
                     exception: new EntityException("error"));
 
                 // Assert
@@ -881,16 +857,15 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(true)]
-            [InlineData(false)]
-            public async Task WhenMembershipCreated_ReturnsSuccess(bool isAdmin)
+            [MemberData(nameof(AllowedCurrentUsers_IsAdmin_Data))]
+            public async Task WhenMembershipCreated_ReturnsSuccess(Func<Fakes, User> getCurrentUser, bool isAdmin)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeUpdateMember(controller, account, isAdmin: isAdmin);
+                var result = await InvokeUpdateMember(controller, account, getCurrentUser, isAdmin: isAdmin);
 
                 // Assert
                 Assert.Equal(0, controller.Response.StatusCode);
@@ -910,12 +885,13 @@ namespace NuGetGallery
             private Task<JsonResult> InvokeUpdateMember(
                 OrganizationsController controller,
                 Organization account,
+                Func<Fakes, User> getCurrentUser,
                 string memberName = defaultMemberName,
                 bool isAdmin = false,
                 EntityException exception = null)
             {
                 // Arrange
-                controller.SetCurrentUser(GetCurrentUser(controller));
+                controller.SetCurrentUser(getCurrentUser(Fakes));
 
                 var userService = GetMock<IUserService>();
                 userService.Setup(u => u.FindByUsername(account.Username))
@@ -945,21 +921,34 @@ namespace NuGetGallery
         {
             private const string defaultMemberName = "member";
 
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
 
-            [Fact]
-            public async Task WhenUserIsCollaborator_ReturnsNonSuccess()
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
+            {
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public async Task WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
 
                 // Act
-                var result = await InvokeDeleteMember(controller, account);
+                var result = await InvokeDeleteMember(controller, account, getCurrentUser);
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.Forbidden, controller.Response.StatusCode);
@@ -970,28 +959,9 @@ namespace NuGetGallery
                 GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
-            [Fact]
-            public async Task WhenUserIsNotMember_ReturnsNonSuccess()
-            {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
-
-                // Act
-                var result = await InvokeDeleteMember(controller, account);
-
-                // Assert
-                Assert.Equal((int)HttpStatusCode.Forbidden, controller.Response.StatusCode);
-                Assert.IsType<JsonResult>(result);
-                Assert.Equal(Strings.Unauthorized, result.Data);
-
-                GetMock<IUserService>().Verify(s => s.DeleteMemberAsync(It.IsAny<Organization>(), It.IsAny<string>()), Times.Never);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
-            }
-
-            [Fact]
-            public async Task WhenOrganizationIsUnconfirmed_ReturnsNonSuccess()
+            [Theory]
+            [MemberData(nameof(AllowedCurrentUsers_Data))]
+            public async Task WhenOrganizationIsUnconfirmed_ReturnsNonSuccess(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
@@ -999,7 +969,7 @@ namespace NuGetGallery
                 account.EmailAddress = null;
 
                 // Act
-                var result = await InvokeDeleteMember(controller, account);
+                var result = await InvokeDeleteMember(controller, account, getCurrentUser);
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
@@ -1010,15 +980,16 @@ namespace NuGetGallery
                 GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
-            [Fact]
-            public async Task WhenEntityException_ReturnsNonSuccess()
+            [Theory]
+            [MemberData(nameof(AllowedCurrentUsers_Data))]
+            public async Task WhenEntityException_ReturnsNonSuccess(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeDeleteMember(controller, account, exception: new EntityException("error"));
+                var result = await InvokeDeleteMember(controller, account, getCurrentUser, exception: new EntityException("error"));
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
@@ -1029,15 +1000,16 @@ namespace NuGetGallery
                 GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
-            [Fact]
-            public async Task WhenDeletingAsAdmin_ReturnsSuccess()
+            [Theory]
+            [MemberData(nameof(AllowedCurrentUsers_Data))]
+            public async Task WhenDeletingAsAdmin_ReturnsSuccess(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeDeleteMember(controller, account);
+                var result = await InvokeDeleteMember(controller, account, getCurrentUser);
 
                 // Assert
                 Assert.Equal(0, controller.Response.StatusCode);
@@ -1056,16 +1028,17 @@ namespace NuGetGallery
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                var collaborator = Fakes.OrganizationCollaborator;
+                Func<Fakes, User> getCollaborator = (Fakes fakes) => fakes.OrganizationCollaborator;
+                var collaborator = getCollaborator(Fakes);
                 controller.SetCurrentUser(collaborator);
 
                 // Act
-                var result = await InvokeDeleteMember(controller, account, memberName: collaborator.Username);
+                var result = await InvokeDeleteMember(controller, account, getCollaborator, memberName: collaborator.Username);
 
                 // Assert
                 Assert.Equal(0, controller.Response.StatusCode);
                 Assert.IsType<JsonResult>(result);
-                Assert.Equal(Strings.DeleteMember_Success, ((JsonResult)result).Data);
+                Assert.Equal(Strings.DeleteMember_Success, (result).Data);
 
                 GetMock<IUserService>().Verify(s => s.DeleteMemberAsync(account, collaborator.Username), Times.Once);
             }
@@ -1073,11 +1046,12 @@ namespace NuGetGallery
             private Task<JsonResult> InvokeDeleteMember(
                 OrganizationsController controller,
                 Organization account,
+                Func<Fakes, User> getCurrentUser,
                 string memberName = defaultMemberName,
                 EntityException exception = null)
             {
                 // Arrange
-                controller.SetCurrentUser(GetCurrentUser(controller));
+                controller.SetCurrentUser(getCurrentUser(Fakes));
 
                 var userService = GetMock<IUserService>();
                 userService.Setup(u => u.FindByUsername(account.Username))
@@ -1101,21 +1075,34 @@ namespace NuGetGallery
         {
             private const string defaultMemberName = "member";
 
-            protected override User GetCurrentUser(OrganizationsController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return controller.GetCurrentUser() ?? Fakes.OrganizationAdmin;
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesSiteAdmin);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationAdmin);
+                }
             }
 
-            [Fact]
-            public async Task WhenUserIsCollaborator_ReturnsNonSuccess()
+            public static IEnumerable<object[]> WithNonOrganizationAdmin_ReturnsForbidden_Data
+            {
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                    yield return MemberDataHelper.AsData(_getFakesOrganizationCollaborator);
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
+            public async Task WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.OrganizationCollaborator);
 
                 // Act
-                var result = await InvokeCancelMemberRequestMember(controller, account);
+                var result = await InvokeCancelMemberRequestMember(controller, account, getCurrentUser);
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.Forbidden, controller.Response.StatusCode);
@@ -1126,35 +1113,16 @@ namespace NuGetGallery
                 GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestCancelledNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
-            [Fact]
-            public async Task WhenUserIsNotMember_ReturnsNonSuccess()
-            {
-                // Arrange
-                var controller = GetController();
-                var account = GetAccount(controller);
-                controller.SetCurrentUser(Fakes.User);
-
-                // Act
-                var result = await InvokeCancelMemberRequestMember(controller, account);
-
-                // Assert
-                Assert.Equal((int)HttpStatusCode.Forbidden, controller.Response.StatusCode);
-                Assert.IsType<JsonResult>(result);
-                Assert.Equal(Strings.Unauthorized, result.Data);
-
-                GetMock<IUserService>().Verify(s => s.CancelMembershipRequestAsync(It.IsAny<Organization>(), It.IsAny<string>()), Times.Never);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestCancelledNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
-            }
-
-            [Fact]
-            public async Task WhenEntityException_ReturnsNonSuccess()
+            [Theory]
+            [MemberData(nameof(AllowedCurrentUsers_Data))]
+            public async Task WhenEntityException_ReturnsNonSuccess(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeCancelMemberRequestMember(controller, account, exception: new EntityException("error"));
+                var result = await InvokeCancelMemberRequestMember(controller, account, getCurrentUser, exception: new EntityException("error"));
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
@@ -1165,15 +1133,16 @@ namespace NuGetGallery
                 GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestCancelledNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
-            [Fact]
-            public async Task WhenSuccess_ReturnsSuccess()
+            [Theory]
+            [MemberData(nameof(AllowedCurrentUsers_Data))]
+            public async Task WhenSuccess_ReturnsSuccess(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = await InvokeCancelMemberRequestMember(controller, account);
+                var result = await InvokeCancelMemberRequestMember(controller, account, getCurrentUser);
 
                 // Assert
                 Assert.Equal(0, controller.Response.StatusCode);
@@ -1187,11 +1156,12 @@ namespace NuGetGallery
             private Task<JsonResult> InvokeCancelMemberRequestMember(
                 OrganizationsController controller,
                 Organization account,
+                Func<Fakes, User> getCurrentUser,
                 string memberName = defaultMemberName,
                 EntityException exception = null)
             {
                 // Arrange
-                controller.SetCurrentUser(GetCurrentUser(controller));
+                controller.SetCurrentUser(getCurrentUser(Fakes));
 
                 var userService = GetMock<IUserService>();
                 userService.Setup(u => u.FindByUsername(account.Username))

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -24,17 +24,22 @@ namespace NuGetGallery
         : AccountsControllerFacts<UsersController, User, UserAccountViewModel>
     {
         public static readonly int CredentialKey = 123;
-        
+
+        private static Func<Fakes, User> _getFakesUser = (Fakes fakes) => fakes.User;
+
         public class TheAccountAction : TheAccountBaseAction
         {
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
+            {
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                }
+            }
+
             protected override ActionResult InvokeAccount(UsersController controller)
             {
                 return controller.Account();
-            }
-
-            protected override User GetCurrentUser(UsersController controller)
-            {
-                return GetAccount(controller);
             }
             
             [Fact]
@@ -42,8 +47,7 @@ namespace NuGetGallery
             {
                 // Arrange
                 var credentialBuilder = new CredentialBuilder();
-                var fakes = Get<Fakes>();
-                var user = fakes.CreateUser(
+                var user = Fakes.CreateUser(
                     "test",
                     credentialBuilder.CreatePasswordCredential("hunter2"),
                     TestCredentialHelper.CreateV1ApiKey(Guid.NewGuid(), Fakes.ExpirationForApiKeyV1),
@@ -71,7 +75,6 @@ namespace NuGetGallery
             {
                 // Arrange
                 var credentialBuilder = new CredentialBuilder();
-                var fakes = Get<Fakes>();
 
                 var credentials = new List<Credential>
                 {
@@ -84,7 +87,7 @@ namespace NuGetGallery
                     new Credential() { Type = "unsupported" }
                 };
 
-                var user = fakes.CreateUser("test", credentials.ToArray());
+                var user = Fakes.CreateUser("test", credentials.ToArray());
 
                 var controller = GetController<UsersController>();
                 controller.SetCurrentUser(user);
@@ -110,9 +113,12 @@ namespace NuGetGallery
 
         public class TheCancelChangeEmailAction : TheCancelChangeEmailBaseAction
         {
-            protected override User GetCurrentUser(UsersController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return GetAccount(controller);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                }
             }
 
             // Note general account tests are in the base class. User-specific tests are below.
@@ -120,9 +126,12 @@ namespace NuGetGallery
 
         public class TheChangeEmailAction : TheChangeEmailBaseAction
         {
-            protected override User GetCurrentUser(UsersController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return GetAccount(controller);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                }
             }
 
             // Note general account tests are in the base class. User-specific tests are below.
@@ -166,9 +175,12 @@ namespace NuGetGallery
 
         public class TheConfirmationRequiredAction : TheConfirmationRequiredBaseAction
         {
-            protected override User GetCurrentUser(UsersController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return GetAccount(controller);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                }
             }
 
             // Note general account tests are in the base class. User-specific tests are below.
@@ -176,9 +188,12 @@ namespace NuGetGallery
 
         public class TheConfirmationRequiredPostAction : TheConfirmationRequiredPostBaseAction
         {
-            protected override User GetCurrentUser(UsersController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return GetAccount(controller);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                }
             }
 
             // Note general account tests are in the base class. User-specific tests are below.
@@ -186,10 +201,15 @@ namespace NuGetGallery
 
         public class TheChangeEmailSubscriptionAction : TheChangeEmailSubscriptionBaseAction
         {
-            protected override User GetCurrentUser(UsersController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return GetAccount(controller);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                }
             }
+
+            public static IEnumerable<object[]> UpdatesEmailPreferences_Data => MemberDataHelper.Combine(AllowedCurrentUsers_Data, UpdatesEmailPreferences_DefaultData);
 
             // Note general account tests are in the base class. User-specific tests are below.
         }
@@ -448,9 +468,12 @@ namespace NuGetGallery
         
         public class TheConfirmAction : TheConfirmBaseAction
         {
-            protected override User GetCurrentUser(UsersController controller)
+            public static IEnumerable<object[]> AllowedCurrentUsers_Data
             {
-                return GetAccount(controller);
+                get
+                {
+                    yield return MemberDataHelper.AsData(_getFakesUser);
+                }
             }
 
             // Note general account tests are in the base class. User-specific tests are below.


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5557

Site admins can now see the `Manage Organization` page for any user on the site and make changes to its membership.

In terms of UI, the only change is text on the manage organizations page that explains the permissions the current user has.