### PR TITLE
Use System.Net.Http from net46

### DIFF
--- a/src/NuGetGallery/packages.config
+++ b/src/NuGetGallery/packages.config
@@ -123,7 +123,6 @@
   <package id="System.IO" version="4.1.0" targetFramework="net46" />
   <package id="System.Linq" version="4.1.0" targetFramework="net46" />
   <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net46" />
-  <package id="System.Net.Http" version="4.1.0" targetFramework="net46" />
   <package id="System.Net.Primitives" version="4.0.11" targetFramework="net46" />
   <package id="System.Reflection" version="4.1.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net46" />

--- a/tests/NuGetGallery.Facts/App.config
+++ b/tests/NuGetGallery.Facts/App.config
@@ -13,8 +13,8 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -95,10 +95,6 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Security.Cryptography.X509Certificates" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -266,10 +266,7 @@
     </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Net.Http.4.3.0-beta-24431-01\lib\net46\System.Net.Http.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>

--- a/tests/NuGetGallery.Facts/packages.config
+++ b/tests/NuGetGallery.Facts/packages.config
@@ -63,7 +63,6 @@
   <package id="System.Globalization" version="4.0.11" targetFramework="net46" />
   <package id="System.IO" version="4.1.0" targetFramework="net46" />
   <package id="System.Linq" version="4.1.0" targetFramework="net46" />
-  <package id="System.Net.Http" version="4.3.0-beta-24431-01" targetFramework="net46" />
   <package id="System.Net.Primitives" version="4.0.11" targetFramework="net46" />
   <package id="System.Reflection" version="4.1.0" targetFramework="net46" />
   <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net46" />


### PR DESCRIPTION
SDL: OSS reg automation can't locate this System.Net.Http beta version. Since these projects target net46, we should just use the version of System.Net.Http that is part of the framework.

Notes:
- NuGetGallery.Core still targets 4.5.2, so still needs the 4.1.0 reference
- NuGetGallery.Facts was updated to use the [beta version](https://github.com/NuGet/NuGetGallery/commit/c0fc2d6256a6b9abbf0a31d829f935cf3c0ee01f#diff-a193ba314cd03d77ec62c470e7006d83) in order to fix [MediaTypeHeaderValue errors](https://stackoverflow.com/questions/38355544/type-argument-system-net-http-headers-mediatypeheadervalue-violates-the-constr) from tests.