### PR TITLE
Certificates:  fix https://github.com/NuGet/NuGetGallery/issues/5882

### DIFF
--- a/src/NuGetGallery/ViewModels/ListPackageItemRequiredSignerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemRequiredSignerViewModel.cs
@@ -12,7 +12,8 @@ namespace NuGetGallery
     public sealed class ListPackageItemRequiredSignerViewModel : ListPackageItemViewModel
     {
         // username must be an empty string because <select /> option values are based on username
-        // and this "user" must be distinguishable from an account named "Any" and any other user;  null won't work.
+        // and this "user" must be distinguishable from an account named "Any" and any other user;
+        // null would be ideal, but null won't work as a <select /> option value.
         private static readonly SignerViewModel AnySigner = 
             new SignerViewModel(username: "", displayText: "Any");
 
@@ -133,7 +134,14 @@ namespace NuGetGallery
                     var ownersWithRequiredSignerControl = owners.Where(
                         owner => securityPolicyService.IsSubscribed(owner, ControlRequiredSignerPolicy.PolicyName));
 
-                    RequiredSignerMessage = GetRequiredSignerMessage(ownersWithRequiredSignerControl);
+                    if (owners.Count() == 1)
+                    {
+                        ShowTextBox = true;
+                    }
+                    else
+                    {
+                        RequiredSignerMessage = GetRequiredSignerMessage(ownersWithRequiredSignerControl);
+                    }
                 }
 
                 CanEditRequiredSigner &= wasMultiFactorAuthenticated;

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -440,7 +440,7 @@
                                 @VersionListDivider(rowCount, versionsExpanded)
                                 <tr>
                                     <td class="signature-info-cell">
-                                        @if (packageVersion.CanDisplayPrivateMetadata && !string.IsNullOrEmpty(packageVersion.SignatureInformation))
+                                        @if (!string.IsNullOrEmpty(packageVersion.SignatureInformation))
                                         {
                                             <i class="ms-Icon ms-Icon--Ribbon signature-info" title="@packageVersion.SignatureInformation"></i>
                                         }

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemRequiredSignerViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemRequiredSignerViewModelFacts.cs
@@ -302,7 +302,7 @@ namespace NuGetGallery.ViewModels
             Assert.Null(viewModel.RequiredSignerMessage);
             VerifySigners(package.PackageRegistration.Owners, viewModel.AllSigners, expectAnySigner: false);
             Assert.True(viewModel.ShowRequiredSigner);
-            Assert.False(viewModel.ShowTextBox);
+            Assert.True(viewModel.ShowTextBox);
             Assert.False(viewModel.CanEditRequiredSigner);
 
             _securityPolicyService.VerifyAll();


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/5882.

Should display text instead of a disabled dropdown when the current user lacks permission to set the signing owner on a package with one owner.