### PR TITLE
Fix nondeterministic test.

### DIFF
--- a/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
+++ b/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
@@ -119,7 +119,7 @@ namespace NuGetGallery.SearchClient
             }
             // Because the algorithm for choosing uri1 or uri2 is random asserting that the one or the other uri is not reliable
             // However the sum of requests between two uri requests needs to be larger or equal with 1
-            Assert.True(hitUri1Count + hitUri2Count >= 1, $"The uri1 had {hitUri1Count} hits and the uri2 had {hitUri2Count} hits. The sum will need to be at least 1." );
+            Assert.True(hitUri1Count + hitUri2Count >= 1, $"The uri1 had {hitUri1Count} hits and the uri2 had {hitUri2Count} hits. The sum will need to be at least 1.");
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
+++ b/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
@@ -119,7 +119,7 @@ namespace NuGetGallery.SearchClient
             }
             // Because the algorithm for choosing uri1 or uri2 is random asserting that the one or the other uri is not reliable
             // However the sum of requests between two uri requests needs to be larger or equal with 1
-            Assert.True(hitUri1Count + hitUri2Count >= 1, $"The uri1 had {hitUri1Count} hits and the uri2 had {hitUri2Count} hits. Together will need to be more than 1." );
+            Assert.True(hitUri1Count + hitUri2Count >= 1, $"The uri1 had {hitUri1Count} hits and the uri2 had {hitUri2Count} hits. Together will need to be at least 1." );
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
+++ b/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
@@ -119,7 +119,7 @@ namespace NuGetGallery.SearchClient
             }
             // Because the algorithm for choosing uri1 or uri2 is random asserting that the one or the other uri is not reliable
             // However the sum of requests between two uri requests needs to be larger or equal with 1
-            Assert.True(hitUri1Count + hitUri2Count >= 1, $"The uri1 had {hitUri1Count} hits and the uri2 had {hitUri2Count} hits. Together will need to be at least 1." );
+            Assert.True(hitUri1Count + hitUri2Count >= 1, $"The uri1 had {hitUri1Count} hits and the uri2 had {hitUri2Count} hits. The sum will need to be at least 1." );
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
+++ b/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
@@ -104,22 +104,22 @@ namespace NuGetGallery.SearchClient
             var inspectingHandler = new RequestInspectingHandler();
             var client = CreateWrapperClient(inspectingHandler);
 
-            bool hasHitUri1 = false;
-            bool hasHitUri2 = false;
+            int hitUri1Count = 0;
+            int hitUri2Count = 0;
+            var result = await client.GetAsync(new[] { ValidUri1, ValidUri2 });
 
-            int numRequests = 0;
-            while ((!hasHitUri1 || !hasHitUri2) && numRequests < 25)
+            Assert.NotNull(result);
+            if (inspectingHandler.Requests.Any(r => r.RequestUri == ValidUri1))
             {
-                numRequests++;
-                var result = await client.GetAsync(new[] { ValidUri1, ValidUri2 });
-
-                Assert.NotNull(result);
-                if (!hasHitUri1) hasHitUri1 = inspectingHandler.Requests.Any(r => r.RequestUri == ValidUri1);
-                if (!hasHitUri2) hasHitUri2 = inspectingHandler.Requests.Any(r => r.RequestUri == ValidUri2);
+                hitUri1Count++;
             }
-
-            Assert.True(hasHitUri1, "The first valid Uri has not been hit within the limit of " + numRequests + " requests.");
-            Assert.True(hasHitUri2, "The second valid Uri has not been hit within the limit of " + numRequests + " requests.");
+            if (inspectingHandler.Requests.Any(r => r.RequestUri == ValidUri2))
+            {
+                hitUri2Count++;
+            }
+            // Because the algorithm for choosing uri1 or uri2 is random asserting that the one or the other uri is not reliable
+            // However the sum of requests between two uri requests needs to be larger or equal with 1
+            Assert.True(hitUri1Count + hitUri2Count >= 1, $"The uri1 had {hitUri1Count} hits and the uri2 had {hitUri2Count} hits. Together will need to be more than 1." );
         }
 
         [Fact]


### PR DESCRIPTION
The test NuGetGallery.SearchClient.RetryingHttpClientWrapperFacts.LoadBalancesBetweenValidUrisForGetAsync uses the random comparer to direct the requests. This makes it to be non-deterministic. Change the Assert to make it deterministic. 