### PR TITLE
Refresh content on app start

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -272,14 +272,6 @@ namespace NuGetGallery
                 .As<ICertificateService>()
                 .InstancePerLifetimeScope();
 
-            if (configuration.Current.IsHosted)
-            {
-                HostingEnvironment.QueueBackgroundWorkItem(async cancellationToken => await DependencyResolver
-                    .Current
-                    .GetService<IContentObjectService>()
-                    .Refresh());
-            }
-
             Func<MailSender> mailSenderFactory = () =>
                 {
                     var settings = configuration;

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -64,7 +64,7 @@ namespace NuGetGallery
             // Configure machine key for session persistence across slots
             SessionPersistence.Setup(config);
 
-            // Refresh the content
+            // Refresh the content for the ContentObjectService to guarantee it has loaded the latest configuration on startup.
             if (config.Current.IsHosted)
             {
                 var contentObjectService = dependencyResolver.GetService<IContentObjectService>();

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Web;
+using System.Web.Hosting;
 using System.Web.Http;
 using System.Web.Mvc;
 using Elmah;
@@ -62,6 +63,13 @@ namespace NuGetGallery
 
             // Configure machine key for session persistence across slots
             SessionPersistence.Setup(config);
+
+            // Refresh the content
+            if (config.Current.IsHosted)
+            {
+                var contentObjectService = dependencyResolver.GetService<IContentObjectService>();
+                HostingEnvironment.QueueBackgroundWorkItem(async cancellationToken => await contentObjectService.Refresh());
+            }
 
             // Setup telemetry
             var instrumentationKey = config.Current.AppInsightsInstrumentationKey;


### PR DESCRIPTION
There was a bug which would prevent content refresh on app start due to `NullReferenceException`, `DependencyResolver` cannot resolve a dependency in the `Autofac` builder, the resolver is set after the `load` method. Moving the code to OwinStartup fixes this issue.