### PR TITLE
[MSA] Fix logins on staging slots

### DIFF
--- a/src/NuGetGallery/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
+++ b/src/NuGetGallery/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
@@ -46,7 +46,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
 
         private static string _callbackPath = "users/account/authenticate/return";
         private static HashSet<string> _errorMessageList = new HashSet<string> { "access_denied", "consent_required" };
-        private static HashSet<string> _stagingUrlDomainList;
+        private static HashSet<string> _alternateSiteRootList;
 
         /// <summary>
         /// The possible values returned by <see cref="V2Claims.ACR"/> claim, and also the possible token values to be sent
@@ -75,16 +75,16 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
                 siteRoot = siteRoot.Replace("http://", "https://");
             }
 
-            if (!string.IsNullOrWhiteSpace(config.Current.StagingDomainsList))
+            if (!string.IsNullOrWhiteSpace(config.Current.AlternateSiteRootList))
             {
-                var stagingDomains = config
+                var alternateSiteRootList = config
                     .Current
-                    .StagingDomainsList
+                    .AlternateSiteRootList
                     .Split(';')
                     .Select(d => d.Trim())
                     .ToArray();
 
-                _stagingUrlDomainList = new HashSet<string>(stagingDomains, StringComparer.OrdinalIgnoreCase);
+                _alternateSiteRootList = new HashSet<string>(alternateSiteRootList, StringComparer.OrdinalIgnoreCase);
             }
 
             // Configure OpenIdConnect
@@ -236,8 +236,8 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
                 notification.ProtocolMessage.AcrValues = ACR_VALUES.ANY;
             }
 
-            // Set the redirect_uri token for the staging environments
-            if (_stagingUrlDomainList != null && _stagingUrlDomainList.Contains(notification.Request.Uri.Host))
+            // Set the redirect_uri token for the alternate domains of same gallery instance
+            if (_alternateSiteRootList != null && _alternateSiteRootList.Contains(notification.Request.Uri.Host))
             {
                 notification.ProtocolMessage.RedirectUri = "https://" + notification.Request.Uri.Host + "/" + _callbackPath ;
             }

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -240,9 +240,9 @@ namespace NuGetGallery.Configuration
         public int WarnAboutExpirationInDaysForApiKeyV1 { get; set; }
 
         /// <summary>
-        /// Defines a semi-colon separated list of domains for the staging slot of the environment, used for MSA authentication by AADv2
+        /// Defines a semi-colon separated list of domains for the alternate site roots for gallery, used for MSA authentication by AADv2
         /// </summary>
-        public string StagingDomainsList { get; set; }
+        public string AlternateSiteRootList { get; set; }
 
         /// <summary>
         /// Configuration to enable manual setting of the machine key for session persistence across deployments/slots.

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -243,9 +243,9 @@ namespace NuGetGallery.Configuration
         int WarnAboutExpirationInDaysForApiKeyV1 { get; set; }
 
         /// <summary>
-        /// Defines a semi-colon separated list of domains for the staging slot of the environment, used for MSA authentication by AADv2
+        /// Defines a semi-colon separated list of domains for the alternate site root for gallery, used for MSA authentication by AADv2
         /// </summary>
-        string StagingDomainsList { get; set; }
+        string AlternateSiteRootList { get; set; }
 
         /// <summary>
         /// Configuration to enable manual setting of the machine key for session persistence across deployments/slots.

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -105,8 +105,8 @@
     <add key="Gallery.EnforcedAuthProviderForAdmin" value="" />
     <add key="Gallery.ExpirationInDaysForApiKeyV1" value="365" />
     <add key="Gallery.WarnAboutExpirationInDaysForApiKeyV1" value="10" />
-    <!-- Semi-colon separated list of domains for the staging slot of the environment, used for MSA authentication by AADv2-->
-    <add key="Gallery.StagingDomainsList" value="" />
+    <!-- Semi-colon separated list of domains for the alternate site root for gallery, used for MSA authentication by AADv2-->
+    <add key="Gallery.AlternateSiteRootList" value="" />
 
     <!-- *********************************************************** -->
     <!-- Cookie session persistence across deployment/slots settings -->


### PR DESCRIPTION
Part of the work for #5400 

MSA login won't work on staging slot, due to URL redirection issues with MSA auth. To solve this problem I created new DNS records pointing to the `Staging` slot for the environments. These are:
- https://stagingdev.nugettest.org => DEV staging environment
- https://stagingint.nugettest.org => INT staging environment
- https://stagingslot.nuget.org => PROD staging environment

This will also resolve the HTTPS certificate invalid issues on the staging slots. These URLs have also been configured for redirection in the MSA apps for authentication. With this change, we will have correct redirection and authentication on the staging slots of all the environments. ~~I have to yet create a prod staging dns record, the config changes will be sent out in deployment repository subsequently.~~ Config [PR](https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetDeployment/pullrequest/435?_a=overview)

I have validated this on dev and it works fine. I will look into adding actual functional tests for MSA login after this work.