### PR TITLE
Allow organization admins to remove their organization's ownership of a package in a reserved namespace

### DIFF
--- a/src/NuGetGallery/Services/ActionRequiringReservedNamespacePermissions.cs
+++ b/src/NuGetGallery/Services/ActionRequiringReservedNamespacePermissions.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
     /// E.g. "JQuery.Extensions.MyCoolExtension" matches both "JQuery.*" and "JQuery.Extensions.*".
     /// </remarks>
     public class ActionRequiringReservedNamespacePermissions
-        : ActionRequiringEntityPermissions<IReadOnlyCollection<ReservedNamespace>>, IActionRequiringEntityPermissions<ActionOnNewPackageContext>
+        : ActionRequiringEntityPermissions<IReadOnlyCollection<ReservedNamespace>>, IActionRequiringEntityPermissions<ActionOnNewPackageContext>, IActionRequiringEntityPermissions<ReservedNamespace>
     {
         public PermissionsRequirement ReservedNamespacePermissionsRequirement { get; }
 
@@ -32,9 +32,19 @@ namespace NuGetGallery
             return CheckPermissions(currentUser, account, GetReservedNamespaces(newPackageContext));
         }
 
+        public PermissionsCheckResult CheckPermissions(User currentUser, User account, ReservedNamespace reservedNamespace)
+        {
+            return CheckPermissions(currentUser, account, GetReservedNamespaces(reservedNamespace));
+        }
+
         public PermissionsCheckResult CheckPermissions(IPrincipal currentPrincipal, User account, ActionOnNewPackageContext newPackageContext)
         {
             return CheckPermissions(currentPrincipal, account, GetReservedNamespaces(newPackageContext));
+        }
+
+        public PermissionsCheckResult CheckPermissions(IPrincipal currentPrincipal, User account, ReservedNamespace reservedNamespace)
+        {
+            return CheckPermissions(currentPrincipal, account, GetReservedNamespaces(reservedNamespace));
         }
 
         protected override PermissionsCheckResult CheckPermissionsForEntity(User account, IReadOnlyCollection<ReservedNamespace> reservedNamespaces)
@@ -54,9 +64,19 @@ namespace NuGetGallery
             return CheckPermissionsOnBehalfOfAnyAccount(currentUser, GetReservedNamespaces(newPackageContext));
         }
 
+        public PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, ReservedNamespace reservedNamespace)
+        {
+            return CheckPermissionsOnBehalfOfAnyAccount(currentUser, GetReservedNamespaces(reservedNamespace));
+        }
+
         public PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, ActionOnNewPackageContext newPackageContext, out IEnumerable<User> accountsAllowedOnBehalfOf)
         {
             return CheckPermissionsOnBehalfOfAnyAccount(currentUser, GetReservedNamespaces(newPackageContext), out accountsAllowedOnBehalfOf);
+        }
+
+        public PermissionsCheckResult CheckPermissionsOnBehalfOfAnyAccount(User currentUser, ReservedNamespace reservedNamespace, out IEnumerable<User> accountsAllowedOnBehalfOf)
+        {
+            return CheckPermissionsOnBehalfOfAnyAccount(currentUser, GetReservedNamespaces(reservedNamespace), out accountsAllowedOnBehalfOf);
         }
 
         protected override IEnumerable<User> GetOwners(IReadOnlyCollection<ReservedNamespace> reservedNamespaces)
@@ -67,6 +87,11 @@ namespace NuGetGallery
         private IReadOnlyCollection<ReservedNamespace> GetReservedNamespaces(ActionOnNewPackageContext newPackageContext)
         {
             return newPackageContext.ReservedNamespaceService.GetReservedNamespacesForId(newPackageContext.PackageId);
+        }
+
+        private IReadOnlyCollection<ReservedNamespace> GetReservedNamespaces(ReservedNamespace reservedNamespace)
+        {
+            return new[] { reservedNamespace };
         }
     }
 }

--- a/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
+++ b/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
@@ -128,5 +128,21 @@ namespace NuGetGallery
              new ActionRequiringPackagePermissions(
                 accountOnBehalfOfPermissionsRequirement: RequireOwnerOrOrganizationAdmin,
                 packageRegistrationPermissionsRequirement: RequireOwnerOrOrganizationAdmin);
+
+        /// <summary>
+        /// The action of showing a package as verified by a reserved namespace.
+        /// </summary>
+        public static ActionRequiringReservedNamespacePermissions ShowPackageAsVerifiedByReservedNamespace =
+            new ActionRequiringReservedNamespacePermissions(
+                accountOnBehalfOfPermissionsRequirement: PermissionsRequirement.Owner,
+                reservedNamespacePermissionsRequirement: PermissionsRequirement.Owner);
+
+        /// <summary>
+        /// The action of removing a package from a reserved namespace.
+        /// </summary>
+        public static ActionRequiringReservedNamespacePermissions RemovePackageFromReservedNamespace =
+            new ActionRequiringReservedNamespacePermissions(
+                accountOnBehalfOfPermissionsRequirement: RequireOwnerOrSiteAdminOrOrganizationAdmin,
+                reservedNamespacePermissionsRequirement: RequireOwnerOrOrganizationAdmin);
     }
 }

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -68,7 +68,7 @@ namespace NuGetGallery
         /// <returns>Awaitable task.</returns>
         Task AddPackageOwnerAsync(PackageRegistration package, User newOwner);
 
-        Task RemovePackageOwnerAsync(PackageRegistration package, User user);
+        Task RemovePackageOwnerAsync(PackageRegistration package, User user, bool commitChanges = true);
 
         Task SetLicenseReportVisibilityAsync(Package package, bool visible, bool commitChanges = true);
 
@@ -76,7 +76,7 @@ namespace NuGetGallery
 
         Task IncrementDownloadCountAsync(string id, string version, bool commitChanges = true);
 
-        Task UpdatePackageVerifiedStatusAsync(IReadOnlyCollection<PackageRegistration> package, bool isVerified);
+        Task UpdatePackageVerifiedStatusAsync(IReadOnlyCollection<PackageRegistration> package, bool isVerified, bool commitChanges = true);
 
         /// <summary>
         /// For a package get the list of owners that are not organizations.

--- a/src/NuGetGallery/Services/IReservedNamespaceService.cs
+++ b/src/NuGetGallery/Services/IReservedNamespaceService.cs
@@ -57,9 +57,9 @@ namespace NuGetGallery
         /// Remove the specified package registration from the reserved namespace. It is the caller's reponsibility to
         /// commit the changes to the database.
         /// </summary>
-        /// <param name="prefix">The prefix value of the reserved namespace to modify</param>
+        /// <param name="reservedNamespace">The reserved namespace to modify</param>
         /// <param name="packageRegistration">The package registration entity to be removed.</param>
-        void RemovePackageRegistrationFromNamespace(string prefix, PackageRegistration packageRegistration);
+        void RemovePackageRegistrationFromNamespace(ReservedNamespace reservedNamespace, PackageRegistration packageRegistration);
 
         /// <summary>
         /// Retrieves the first reserved namespace which matches the given prefix.

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -361,11 +361,14 @@ namespace NuGetGallery
             }
         }
 
-        public async Task RemovePackageOwnerAsync(PackageRegistration package, User user)
+        public async Task RemovePackageOwnerAsync(PackageRegistration package, User user, bool commitChanges = true)
         {
             // To support the delete account scenario, the admin can delete the last owner of a package.
             package.Owners.Remove(user);
-            await _packageRepository.CommitChangesAsync();
+            if (commitChanges)
+            {
+                await _packageRepository.CommitChangesAsync();
+            }
         }
 
         public async Task MarkPackageListedAsync(Package package, bool commitChanges = true)
@@ -701,7 +704,7 @@ namespace NuGetGallery
             }
         }
 
-        public virtual async Task UpdatePackageVerifiedStatusAsync(IReadOnlyCollection<PackageRegistration> packageRegistrationList, bool isVerified)
+        public virtual async Task UpdatePackageVerifiedStatusAsync(IReadOnlyCollection<PackageRegistration> packageRegistrationList, bool isVerified, bool commitChanges = true)
         {
             var packageRegistrationIdSet = new HashSet<string>(packageRegistrationList.Select(prl => prl.Id));
             var allPackageRegistrations = _packageRegistrationRepository.GetAll();
@@ -714,7 +717,10 @@ namespace NuGetGallery
                 packageRegistrationsToUpdate
                     .ForEach(pru => pru.IsVerified = isVerified);
 
-                await _packageRegistrationRepository.CommitChangesAsync();
+                if (commitChanges)
+                {
+                    await _packageRegistrationRepository.CommitChangesAsync();
+                }
             }
         }
 

--- a/src/NuGetGallery/Services/ReservedNamespaceService.cs
+++ b/src/NuGetGallery/Services/ReservedNamespaceService.cs
@@ -206,40 +206,43 @@ namespace NuGetGallery
 
         private async Task<List<PackageRegistration>> DeleteOwnerFromReservedNamespaceImplAsync(string prefix, string username, ReservedNamespace namespaceToModify)
         {
-                var userToRemove = UserService.FindByUsername(username)
-                    ?? throw new InvalidOperationException(string.Format(
-                        CultureInfo.CurrentCulture, Strings.ReservedNamespace_UserNotFound, username));
+            var userToRemove = UserService.FindByUsername(username)
+                ?? throw new InvalidOperationException(string.Format(
+                    CultureInfo.CurrentCulture, Strings.ReservedNamespace_UserNotFound, username));
 
-                if (!namespaceToModify.Owners.Contains(userToRemove))
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.ReservedNamespace_UserNotAnOwner, username));
-                }
+            if (!namespaceToModify.Owners.Contains(userToRemove))
+            {
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.ReservedNamespace_UserNotAnOwner, username));
+            }
 
-                var packagesOwnedByUserMatchingPrefix = namespaceToModify
-                        .PackageRegistrations
-                        .Where(pr => pr
-                            .Owners
-                            .Any(pro => pro.Username == userToRemove.Username))
-                        .ToList();
-
-                // Remove verified mark for package registrations if the user to be removed is the only prefix owner
-                // for the given package registration.
-                var packageRegistrationsToMarkUnverified = packagesOwnedByUserMatchingPrefix
-                    .Where(pr => pr.Owners.Intersect(namespaceToModify.Owners).Count() == 1)
+            var packagesOwnedByUserMatchingPrefix = namespaceToModify
+                    .PackageRegistrations
+                    .Where(pr => pr
+                        .Owners
+                        .Any(pro => pro.Username == userToRemove.Username))
                     .ToList();
 
-                if (packageRegistrationsToMarkUnverified.Any())
-                {
-                    packageRegistrationsToMarkUnverified
-                        .ForEach(pr => namespaceToModify.PackageRegistrations.Remove(pr));
+            namespaceToModify.Owners.Remove(userToRemove);
 
-                    await PackageService.UpdatePackageVerifiedStatusAsync(packageRegistrationsToMarkUnverified, isVerified: false);
-                }
+            // Remove verified mark for package registrations if the user to be removed is the only prefix owner
+            // for the given package registration.
+            var packageRegistrationsToMarkUnverified = packagesOwnedByUserMatchingPrefix
+                .Where(pr => !pr.Owners.Any(o => 
+                    ActionsRequiringPermissions.ShowPackageAsVerifiedByReservedNamespace.CheckPermissionsOnBehalfOfAnyAccount(
+                        o, new[] { namespaceToModify }) == PermissionsCheckResult.Allowed))
+                .ToList();
 
-                namespaceToModify.Owners.Remove(userToRemove);
-                await ReservedNamespaceRepository.CommitChangesAsync();
+            if (packageRegistrationsToMarkUnverified.Any())
+            {
+                packageRegistrationsToMarkUnverified
+                    .ForEach(pr => namespaceToModify.PackageRegistrations.Remove(pr));
 
-                return packageRegistrationsToMarkUnverified;
+                await PackageService.UpdatePackageVerifiedStatusAsync(packageRegistrationsToMarkUnverified, isVerified: false);
+            }
+            
+            await ReservedNamespaceRepository.CommitChangesAsync();
+
+            return packageRegistrationsToMarkUnverified;
         }
 
 
@@ -280,11 +283,11 @@ namespace NuGetGallery
         /// <param name="prefix">The prefix value of the reserved namespace to modify</param>
         /// <param name="packageRegistration">The package registration entity to be removed.</param>
         /// <returns>Awaitable task</returns>
-        public void RemovePackageRegistrationFromNamespace(string prefix, PackageRegistration packageRegistration)
+        public void RemovePackageRegistrationFromNamespace(ReservedNamespace reservedNamespace, PackageRegistration packageRegistration)
         {
-            if (string.IsNullOrWhiteSpace(prefix))
+            if (reservedNamespace == null)
             {
-                throw new ArgumentException(Strings.ReservedNamespace_InvalidNamespace);
+                throw new ArgumentNullException(nameof(reservedNamespace));
             }
 
             if (packageRegistration == null)
@@ -292,11 +295,7 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(packageRegistration));
             }
 
-            var namespaceToModify = FindReservedNamespaceForPrefix(prefix)
-                ?? throw new InvalidOperationException(string.Format(
-                    CultureInfo.CurrentCulture, Strings.ReservedNamespace_NamespaceNotFound, prefix));
-
-            namespaceToModify.PackageRegistrations.Remove(packageRegistration);
+            reservedNamespace.PackageRegistrations.Remove(packageRegistration);
         }
 
         public virtual ReservedNamespace FindReservedNamespaceForPrefix(string prefix)

--- a/tests/NuGetGallery.Facts/Services/PackageOwnershipManagementServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageOwnershipManagementServiceFacts.cs
@@ -35,17 +35,33 @@ namespace NuGetGallery
             if (useDefaultSetup)
             {
 
-                packageService.Setup(x => x.AddPackageOwnerAsync(It.IsAny<PackageRegistration>(), It.IsAny<User>())).Returns(Task.CompletedTask).Verifiable();
-                packageService.Setup(x => x.UpdatePackageVerifiedStatusAsync(It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>()))
-                    .Returns((IReadOnlyCollection<PackageRegistration> list, bool isVerified) =>
+                packageService
+                    .Setup(x => x.AddPackageOwnerAsync(It.IsAny<PackageRegistration>(), It.IsAny<User>()))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+                packageService
+                    .Setup(x => x.UpdatePackageVerifiedStatusAsync(It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Returns((IReadOnlyCollection<PackageRegistration> list, bool isVerified, bool commitChanges) =>
                     {
                         list.ToList().ForEach(item => item.IsVerified = isVerified);
                         return Task.CompletedTask;
-                    }).Verifiable();
-                packageService.Setup(x => x.RemovePackageOwnerAsync(It.IsAny<PackageRegistration>(), It.IsAny<User>())).Returns(Task.CompletedTask).Verifiable();
+                    })
+                    .Verifiable();
+                packageService
+                    .Setup(x => x.RemovePackageOwnerAsync(It.IsAny<PackageRegistration>(), It.IsAny<User>(), It.IsAny<bool>()))
+                    .Callback<PackageRegistration, User, bool>((pr, user, commitChanges) => pr.Owners.Remove(user))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
 
                 reservedNamespaceService.Setup(x => x.AddPackageRegistrationToNamespace(It.IsAny<string>(), It.IsAny<PackageRegistration>())).Verifiable();
-                reservedNamespaceService.Setup(x => x.RemovePackageRegistrationFromNamespace(It.IsAny<string>(), It.IsAny<PackageRegistration>())).Verifiable();
+                reservedNamespaceService
+                    .Setup(x => x.RemovePackageRegistrationFromNamespace(It.IsAny<ReservedNamespace>(), It.IsAny<PackageRegistration>()))
+                    .Callback<ReservedNamespace, PackageRegistration>((rn, pr) =>
+                    {
+                        rn.PackageRegistrations.Remove(pr);
+                        pr.ReservedNamespaces.Remove(rn);
+                    })
+                    .Verifiable();
 
                 packageOwnerRequestService.Setup(x => x.GetPackageOwnershipRequests(It.IsAny<PackageRegistration>(), It.IsAny<User>(), It.IsAny<User>())).Returns(new[] { new PackageOwnerRequest() }).Verifiable();
                 packageOwnerRequestService.Setup(x => x.DeletePackageOwnershipRequest(It.IsAny<PackageOwnerRequest>())).Returns(Task.CompletedTask).Verifiable();
@@ -129,7 +145,7 @@ namespace NuGetGallery
                 var service = CreateService(packageService: packageService, reservedNamespaceService: reservedNamespaceService, packageOwnerRequestService: packageOwnerRequestService);
                 await service.AddPackageOwnerAsync(package, pendingOwner);
 
-                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == true)));
+                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == true), true));
                 packageOwnerRequestService.Verify(x => x.GetPackageOwnershipRequests(It.IsAny<PackageRegistration>(), It.IsAny<User>(), It.IsAny<User>()));
                 packageOwnerRequestService.Verify(x => x.DeletePackageOwnershipRequest(It.IsAny<PackageOwnerRequest>()));
                 reservedNamespaceService.Verify(x => x.AddPackageRegistrationToNamespace(It.IsAny<string>(), It.IsAny<PackageRegistration>()), Times.Once);
@@ -169,7 +185,7 @@ namespace NuGetGallery
                 await service.AddPackageOwnerAsync(package, pendingOwner);
 
                 reservedNamespaceService.Verify(x => x.AddPackageRegistrationToNamespace(It.IsAny<string>(), It.IsAny<PackageRegistration>()), Times.Never);
-                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>()), Times.Never);
+                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
             }
 
             [Fact]
@@ -249,7 +265,7 @@ namespace NuGetGallery
                 var service = CreateService(packageService: packageService);
                 await service.RemovePackageOwnerAsync(package, owner1, owner2);
 
-                packageService.Verify(x => x.RemovePackageOwnerAsync(package, owner2));
+                packageService.Verify(x => x.RemovePackageOwnerAsync(package, owner2, false));
             }
 
             [Fact]
@@ -288,8 +304,8 @@ namespace NuGetGallery
                 var service = CreateService(packageService: packageService, reservedNamespaceService: reservedNamespaceService, packageOwnerRequestService: packageOwnerRequestService);
                 await service.RemovePackageOwnerAsync(package, existingOwner1, existingOwner1);
 
-                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false)));
-                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(It.IsAny<string>(), It.IsAny<PackageRegistration>()), Times.Once);
+                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false), false));
+                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(It.IsAny<ReservedNamespace>(), It.IsAny<PackageRegistration>()), Times.Once);
                 Assert.False(package.IsVerified);
             }
 
@@ -312,8 +328,8 @@ namespace NuGetGallery
                 var service = CreateService(packageService: packageService, reservedNamespaceService: reservedNamespaceService, packageOwnerRequestService: packageOwnerRequestService);
                 await service.RemovePackageOwnerAsync(package, existingOwner2, existingOwner1);
 
-                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false)), Times.Never);
-                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(It.IsAny<string>(), It.IsAny<PackageRegistration>()), Times.Never);
+                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false), false), Times.Never);
+                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(It.IsAny<ReservedNamespace>(), It.IsAny<PackageRegistration>()), Times.Never);
                 Assert.True(package.IsVerified);
             }
 
@@ -336,8 +352,8 @@ namespace NuGetGallery
                 var service = CreateService(packageService: packageService, reservedNamespaceService: reservedNamespaceService, packageOwnerRequestService: packageOwnerRequestService);
                 await service.RemovePackageOwnerAsync(package, existingOwner1, existingOwner2);
 
-                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false)), Times.Never);
-                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(It.IsAny<string>(), It.IsAny<PackageRegistration>()), Times.Never);
+                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false), false), Times.Never);
+                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(It.IsAny<ReservedNamespace>(), It.IsAny<PackageRegistration>()), Times.Never);
                 Assert.True(package.IsVerified);
             }
 
@@ -367,8 +383,8 @@ namespace NuGetGallery
                 var service = CreateService(packageService: packageService, reservedNamespaceService: reservedNamespaceService, packageOwnerRequestService: packageOwnerRequestService);
                 await service.RemovePackageOwnerAsync(package, existingOwner1, existingOwner2);
 
-                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false)), Times.Never);
-                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(existingNamespace2.Value, package), Times.Once);
+                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false), false), Times.Never);
+                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(existingNamespace2, package), Times.Once);
                 Assert.True(package.IsVerified);
             }
 
@@ -379,7 +395,7 @@ namespace NuGetGallery
                 var package = new PackageRegistration { Key = 2, Id = "Microsoft.Aspnet.Package1", IsVerified = true, Owners = new List<User> { existingOwner1 } };
                 var adminOwner = new User
                 {
-                    Key = 100,
+                    Key = 101,
                     Username = "aspnet",
                     Roles = new List<Role>
                     {
@@ -400,8 +416,8 @@ namespace NuGetGallery
                 var service = CreateService(packageService: packageService, reservedNamespaceService: reservedNamespaceService, packageOwnerRequestService: packageOwnerRequestService);
                 await service.RemovePackageOwnerAsync(package, adminOwner, existingOwner1);
 
-                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false)), Times.Once);
-                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(existingNamespace1.Value, package), Times.Once);
+                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false), false), Times.Once);
+                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(existingNamespace1, package), Times.Once);
                 Assert.False(package.IsVerified);
             }
 
@@ -445,8 +461,8 @@ namespace NuGetGallery
                 var service = CreateService(packageService: packageService, reservedNamespaceService: reservedNamespaceService, packageOwnerRequestService: packageOwnerRequestService);
                 await service.RemovePackageOwnerAsync(package, existingOwner1, existingOwner2);
 
-                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false)), Times.Never);
-                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(existingNamespace1.Value, package), Times.Never);
+                packageService.Verify(x => x.UpdatePackageVerifiedStatusAsync(It.Is<IReadOnlyCollection<PackageRegistration>>(pr => pr.First() == package), It.Is<bool>(b => b == false), false), Times.Never);
+                reservedNamespaceService.Verify(x => x.RemovePackageRegistrationFromNamespace(existingNamespace1, package), Times.Never);
                 Assert.True(package.IsVerified);
             }
         }

--- a/tests/NuGetGallery.Facts/Services/ReservedNamespaceServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReservedNamespaceServiceFacts.cs
@@ -201,7 +201,7 @@ namespace NuGetGallery.Services
                     .Verify(x => x.CommitChangesAsync());
                 service
                     .MockPackageService
-                    .Verify(p => p.UpdatePackageVerifiedStatusAsync(It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>()), Times.Never);
+                    .Verify(p => p.UpdatePackageVerifiedStatusAsync(It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
             }
 
             [Fact]
@@ -273,7 +273,8 @@ namespace NuGetGallery.Services
                             It.Is<IReadOnlyCollection<PackageRegistration>>(
                                 list => list.Count() == registrationsShouldUpdate.Count()
                                     && list.Any(pr => registrationsShouldUpdate.Any(ru => ru.Id == pr.Id))),
-                            false),
+                            false,
+                            true),
                         Times.Once);
 
                 msPrefix.PackageRegistrations.ToList().ForEach(rn => Assert.False(rn.IsVerified));
@@ -361,7 +362,7 @@ namespace NuGetGallery.Services
                 service
                     .MockPackageService
                     .Verify(p => p.UpdatePackageVerifiedStatusAsync(
-                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>()),
+                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), It.IsAny<bool>()),
                         Times.Never);
 
                 Assert.True(existingNamespace.Owners.Contains(owner));
@@ -414,7 +415,7 @@ namespace NuGetGallery.Services
                 service
                     .MockPackageService
                     .Verify(p => p.UpdatePackageVerifiedStatusAsync(
-                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>()),
+                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), true),
                         Times.Once);
 
                 Assert.True(existingNamespace.Owners.Contains(owner1));
@@ -463,7 +464,7 @@ namespace NuGetGallery.Services
                 service
                     .MockPackageService
                     .Verify(p => p.UpdatePackageVerifiedStatusAsync(
-                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>()),
+                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), true),
                         Times.Once);
 
                 Assert.True(existingNamespace.Owners.Contains(owner1));
@@ -549,15 +550,12 @@ namespace NuGetGallery.Services
 
         public class TheRemovePackageRegistrationFromNamespaceMethod
         {
-            [Theory]
-            [InlineData(null)]
-            [InlineData("")]
-            [InlineData("  ")]
-            public void NullNamespaceThrowsException(string value)
+            [Fact]
+            public void NullNamespaceThrowsException()
             {
                 var service = new TestableReservedNamespaceService();
 
-                Assert.Throws<ArgumentException>(() => service.RemovePackageRegistrationFromNamespace(value, new PackageRegistration()));
+                Assert.Throws<ArgumentNullException>(() => service.RemovePackageRegistrationFromNamespace(null, new PackageRegistration()));
             }
 
             [Fact]
@@ -565,18 +563,7 @@ namespace NuGetGallery.Services
             {
                 var service = new TestableReservedNamespaceService();
 
-                Assert.Throws<ArgumentNullException>(() => service.RemovePackageRegistrationFromNamespace("Microsoft.", null));
-            }
-
-            [Fact]
-            public void NonExistentNamespaceThrowsException()
-            {
-                var testNamespaces = ReservedNamespaceServiceTestData.GetTestNamespaces();
-                var testPackageRegistrations = ReservedNamespaceServiceTestData.GetRegistrations();
-                var existingReg = testPackageRegistrations.First();
-                var service = new TestableReservedNamespaceService(reservedNamespaces: testNamespaces, packageRegistrations: testPackageRegistrations);
-
-                Assert.Throws<InvalidOperationException>(() => service.RemovePackageRegistrationFromNamespace("Non.Existent.Namespace.", existingReg));
+                Assert.Throws<ArgumentNullException>(() => service.RemovePackageRegistrationFromNamespace(new ReservedNamespace(), null));
             }
 
             [Fact]
@@ -589,7 +576,7 @@ namespace NuGetGallery.Services
                 existingNamespace.PackageRegistrations.Add(existingReg);
                 var service = new TestableReservedNamespaceService(reservedNamespaces: testNamespaces, packageRegistrations: testPackageRegistrations);
 
-                service.RemovePackageRegistrationFromNamespace(existingNamespace.Value, existingReg);
+                service.RemovePackageRegistrationFromNamespace(existingNamespace, existingReg);
 
                 Assert.False(existingNamespace.PackageRegistrations.Contains(existingReg));
             }
@@ -604,7 +591,7 @@ namespace NuGetGallery.Services
                 existingNamespace.PackageRegistrations.Add(existingReg);
                 var service = new TestableReservedNamespaceService(reservedNamespaces: testNamespaces, packageRegistrations: testPackageRegistrations);
 
-                service.RemovePackageRegistrationFromNamespace(existingNamespace.Value, existingReg);
+                service.RemovePackageRegistrationFromNamespace(existingNamespace, existingReg);
 
                 service
                     .MockReservedNamespaceRepository
@@ -694,7 +681,7 @@ namespace NuGetGallery.Services
                 service
                     .MockPackageService
                     .Verify(p => p.UpdatePackageVerifiedStatusAsync(
-                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>()),
+                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), true),
                         Times.Never);
 
                 Assert.False(existingNamespace.Owners.Contains(owner));
@@ -754,7 +741,7 @@ namespace NuGetGallery.Services
                 service
                     .MockPackageService
                     .Verify(p => p.UpdatePackageVerifiedStatusAsync(
-                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>()),
+                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), true),
                         Times.Once);
 
                 Assert.False(existingNamespace.Owners.Contains(owner1));
@@ -799,7 +786,7 @@ namespace NuGetGallery.Services
                 service
                     .MockPackageService
                     .Verify(p => p.UpdatePackageVerifiedStatusAsync(
-                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>()),
+                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), true),
                         Times.Once);
 
                 Assert.False(existingNamespace.Owners.Contains(owner1));


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5944

1 - Organization A owns package B that is in reserved namespace C
2 - User D that is admin of A removes A from ownership of B

Expected:
Organization A is no longer an owner of B and B loses its verification

Actual:
D gets an HTTP 500.
Organization A remains an owner of B.

This PR fixes that behavior.

Also made some general fixes to prevent issues like these in the future.
E.g. we now use `ActionsRequiringPermissions` to determine reserved namespace package verification.