### PR TITLE
Delete API keys scoped to a user when that user is deleted

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -154,6 +154,11 @@ namespace NuGetGallery
                 .As<IEntityRepository<Credential>>()
                 .InstancePerLifetimeScope();
 
+            builder.RegisterType<EntityRepository<Scope>>()
+                .AsSelf()
+                .As<IEntityRepository<Scope>>()
+                .InstancePerLifetimeScope();
+
             builder.RegisterType<EntityRepository<PackageOwnerRequest>>()
                 .AsSelf()
                 .As<IEntityRepository<PackageOwnerRequest>>()

--- a/src/NuGetGallery/Services/DeleteAccountService.cs
+++ b/src/NuGetGallery/Services/DeleteAccountService.cs
@@ -154,14 +154,6 @@ namespace NuGetGallery
                 .ToArray();
 
             var credentials = userScopes.Select(s => s.Credential).Distinct().ToArray();
-
-            foreach (var userScope in userScopes)
-            {
-                _scopeRepository.DeleteOnCommit(userScope);
-            }
-
-            await _scopeRepository.CommitChangesAsync();
-
             foreach (var credential in credentials)
             {
                 await _authService.RemoveCredential(credential.User, credential);

--- a/src/NuGetGallery/Services/DeleteAccountService.cs
+++ b/src/NuGetGallery/Services/DeleteAccountService.cs
@@ -24,11 +24,13 @@ namespace NuGetGallery
         private readonly ISecurityPolicyService _securityPolicyService;
         private readonly AuthenticationService _authService;
         private readonly IEntityRepository<User> _userRepository;
+        private readonly IEntityRepository<Scope> _scopeRepository;
         private readonly ISupportRequestService _supportRequestService;
         private readonly IAuditingService _auditingService;
 
         public DeleteAccountService(IEntityRepository<AccountDelete> accountDeleteRepository,
                                     IEntityRepository<User> userRepository,
+                                    IEntityRepository<Scope> scopeRepository,
                                     IEntitiesContext entitiesContext,
                                     IPackageService packageService,
                                     IPackageOwnershipManagementService packageOwnershipManagementService,
@@ -41,6 +43,7 @@ namespace NuGetGallery
         {
             _accountDeleteRepository = accountDeleteRepository ?? throw new ArgumentNullException(nameof(accountDeleteRepository));
             _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+            _scopeRepository = scopeRepository ?? throw new ArgumentNullException(nameof(scopeRepository));
             _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
             _packageOwnershipManagementService = packageOwnershipManagementService ?? throw new ArgumentNullException(nameof(packageOwnershipManagementService));
@@ -138,17 +141,36 @@ namespace NuGetGallery
 
         private async Task RemoveUserCredentials(User user)
         {
-            var copyOfUserCred = user.Credentials.ToArray();
-            foreach (var uc in copyOfUserCred)
+            // Remove any credential owned by this user.
+            foreach (var uc in user.Credentials.ToArray())
             {
                 await _authService.RemoveCredential(user, uc);
+            }
+
+            // Remove any credential scoped to this user.
+            var userScopes = _scopeRepository
+                .GetAll()
+                .Where(s => s.OwnerKey == user.Key)
+                .ToArray();
+
+            var credentials = userScopes.Select(s => s.Credential).Distinct().ToArray();
+
+            foreach (var userScope in userScopes)
+            {
+                _scopeRepository.DeleteOnCommit(userScope);
+            }
+
+            await _scopeRepository.CommitChangesAsync();
+
+            foreach (var credential in credentials)
+            {
+                await _authService.RemoveCredential(credential.User, credential);
             }
         }
 
         private async Task RemoveSecurityPolicies(User user)
         {
-            var copyOfUserPolicies = user.SecurityPolicies.ToArray();
-            foreach (var usp in copyOfUserPolicies)
+            foreach (var usp in user.SecurityPolicies.ToArray())
             {
                 await _securityPolicyService.UnsubscribeAsync(user, usp.Subscription);
             }
@@ -156,8 +178,7 @@ namespace NuGetGallery
 
         private async Task RemoveReservedNamespaces(User user)
         {
-            var copyOfUserNS = user.ReservedNamespaces.ToArray();
-            foreach (var rn in copyOfUserNS)
+            foreach (var rn in user.ReservedNamespaces.ToArray())
             {
                 await _reservedNamespaceService.DeleteOwnerFromReservedNamespaceAsync(rn.Value, user.Username, commitAsTransaction:false);
             }

--- a/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
@@ -374,7 +374,6 @@ namespace NuGetGallery.Services
             private UserSecurityPolicy _securityPolicy = new UserSecurityPolicy("PolicyName", SubscriptionName);
             private PackageRegistration _userPackagesRegistration = null;
             private ICollection<Package> _userPackages;
-            private bool _hasDeletedOwnerScope = false;
             private bool _hasDeletedCredentialWithOwnerScope = false;
             
             public List<AccountDelete> DeletedAccounts = new List<AccountDelete>();
@@ -382,7 +381,7 @@ namespace NuGetGallery.Services
             public List<Issue> SupportRequests = new List<Issue>();
             public List<PackageOwnerRequest> PackageOwnerRequests = new List<PackageOwnerRequest>();
             public FakeAuditingService AuditService = new FakeAuditingService();
-            public bool HasDeletedOwnerScope => _hasDeletedOwnerScope && _hasDeletedCredentialWithOwnerScope;
+            public bool HasDeletedOwnerScope => _hasDeletedCredentialWithOwnerScope;
 
             public DeleteAccountTestService(User user)
             {
@@ -553,13 +552,7 @@ namespace NuGetGallery.Services
                     .Returns(Task.CompletedTask);
                 scopeRepository
                     .Setup(m => m.DeleteOnCommit(It.IsAny<Scope>()))
-                    .Callback<Scope>(s =>
-                    {
-                        if (s == scope)
-                        {
-                            _hasDeletedOwnerScope = true;
-                        }
-                    });
+                    .Throws(new Exception("Scopes should be deleted by the AuthenticationService!"));
 
                 return scopeRepository;
             }


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5924

We must delete these API keys because
- they are no longer valid when the owner that they are scoped to is deleted
- there is a DB constraint that the user in the owner scope exists