### PR TITLE
Added LDAP support

### DIFF
--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -9,6 +9,12 @@ namespace NuGetGallery
 {
     public static class CredentialTypes
     {
+        public static class Ldap
+        {
+            public const string Prefix = "ldap.";
+            public const string User = Prefix + "user";
+        }
+
         public static class Password
         {
             public const string Prefix = "password.";
@@ -32,6 +38,11 @@ namespace NuGetGallery
             public const string Prefix = "external.";
             public const string MicrosoftAccount = Prefix + "MicrosoftAccount";
             public const string AzureActiveDirectoryAccount = Prefix + "AzureActiveDirectory";
+        }
+
+        public static bool IsLdap(this Credential c)
+        {
+            return c?.Type?.StartsWith(Ldap.Prefix, StringComparison.OrdinalIgnoreCase) ?? false;
         }
 
         public static bool IsPassword(this Credential c)
@@ -59,6 +70,7 @@ namespace NuGetGallery
             Password.Sha1,
             Password.Pbkdf2,
             Password.V3,
+            Ldap.User,
             ApiKey.V1,
             ApiKey.V2,
             ApiKey.V3,

--- a/src/NuGetGallery/Authentication/AuthenticationTypes.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationTypes.cs
@@ -7,6 +7,7 @@ namespace NuGetGallery.Authentication
     {
         public static readonly string External = "External";
         public static readonly string LocalUser = "LocalUser";
+        public static readonly string Ldap = "Ldap";
         public static readonly string ApiKey = "ApiKey";
     }
 }

--- a/src/NuGetGallery/Authentication/Providers/LdapUser/LdapUserAuthenticator.cs
+++ b/src/NuGetGallery/Authentication/Providers/LdapUser/LdapUserAuthenticator.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Cookies;
+using NuGetGallery.Configuration;
+using Owin;
+
+namespace NuGetGallery.Authentication.Providers.LdapUser
+{
+    public class LdapUserAuthenticator : Authenticator<LdapUserAuthenticatorConfiguration>
+    {
+        protected override void AttachToOwinApp(IGalleryConfigurationService config, IAppBuilder app)
+        {
+            var cookieSecurity = config.Current.RequireSSL ?
+                CookieSecureOption.Always :
+                CookieSecureOption.Never;
+
+            var options = new CookieAuthenticationOptions
+            {
+                AuthenticationType = AuthenticationTypes.Ldap,
+                AuthenticationMode = AuthenticationMode.Active,
+                CookieHttpOnly = true,
+                CookieSecure = cookieSecurity,
+                LoginPath = new PathString("/users/account/LogOn"),
+                ExpireTimeSpan = TimeSpan.FromHours(6),
+                SlidingExpiration = true
+            };
+
+            BaseConfig.ApplyToOwinSecurityOptions(options);
+            app.UseCookieAuthentication(options);
+            app.SetDefaultSignInAsAuthenticationType(AuthenticationTypes.Ldap);
+        }
+
+        protected internal override AuthenticatorConfiguration CreateConfigObject()
+        {
+            return new AuthenticatorConfiguration
+            {
+                AuthenticationType = AuthenticationTypes.Ldap,
+                Enabled = false
+            };
+        }
+    }
+}

--- a/src/NuGetGallery/Authentication/Providers/LdapUser/LdapUserAuthenticatorConfiguration.cs
+++ b/src/NuGetGallery/Authentication/Providers/LdapUser/LdapUserAuthenticatorConfiguration.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Authentication.Providers.LdapUser
+{
+    public class LdapUserAuthenticatorConfiguration : AuthenticatorConfiguration
+    {
+        public string Host { get; set; }
+        public string Port { get; set; }
+        public string ServiceAccountUserName { get; set; }
+        public string ServiceAccountPassword { get; set; }
+        public string UserBase { get; set; }
+        public string ObjectFilter { get; set; }
+        public string NameAttribute { get; set; }
+        public string GroupAttribute { get; set; }
+        public string AllowedGroup { get; set; }
+
+        public static readonly string DefaultAuthenticationType = "LdapUser";
+
+        public LdapUserAuthenticatorConfiguration()
+        {
+            AuthenticationType = DefaultAuthenticationType;
+        }
+    }
+}

--- a/src/NuGetGallery/Infrastructure/Authentication/CredentialBuilder.cs
+++ b/src/NuGetGallery/Infrastructure/Authentication/CredentialBuilder.cs
@@ -11,6 +11,13 @@ namespace NuGetGallery.Infrastructure.Authentication
     {
         public const string LatestPasswordType = CredentialTypes.Password.V3;
 
+        public Credential CreateLdapCredential(string username)
+        {
+            return new Credential(
+                CredentialTypes.Ldap.User,
+                username);
+        }
+
         public Credential CreatePasswordCredential(string plaintextPassword)
         {
             return new Credential(

--- a/src/NuGetGallery/Infrastructure/Authentication/CredentialValidator.cs
+++ b/src/NuGetGallery/Infrastructure/Authentication/CredentialValidator.cs
@@ -12,6 +12,7 @@ namespace NuGetGallery.Infrastructure.Authentication
     public class CredentialValidator : ICredentialValidator
     {
         public static readonly Dictionary<string, Func<string, Credential, bool>> Validators = new Dictionary<string, Func<string, Credential, bool>>(StringComparer.OrdinalIgnoreCase) {
+            { CredentialTypes.Ldap.User, (password, cred) => LdapValidator.ValidateUser(username: cred.Value, password: password) },
             { CredentialTypes.Password.V3, (password, cred) => V3Hasher.VerifyHash(hashedData: cred.Value, providedInput: password) },
             { CredentialTypes.Password.Pbkdf2, (password, cred) => Crypto.VerifyHashedPassword(hashedPassword: cred.Value, password: password) },
             { CredentialTypes.Password.Sha1, (password, cred) => LegacyHasher.VerifyHash(cred.Value, password, Constants.Sha1HashAlgorithmId) }

--- a/src/NuGetGallery/Infrastructure/Authentication/ICredentialBuilder.cs
+++ b/src/NuGetGallery/Infrastructure/Authentication/ICredentialBuilder.cs
@@ -7,6 +7,8 @@ namespace NuGetGallery.Infrastructure.Authentication
 {
     public interface ICredentialBuilder
     {
+        Credential CreateLdapCredential(string username);
+
         Credential CreatePasswordCredential(string plaintextPassword);
 
         Credential CreateApiKey(TimeSpan? expiration, out string plaintextApiKey);

--- a/src/NuGetGallery/Infrastructure/Authentication/LdapValidator.cs
+++ b/src/NuGetGallery/Infrastructure/Authentication/LdapValidator.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetGallery.Authentication.Providers.LdapUser;
+using NuGetGallery.Configuration;
+using System;
+using System.DirectoryServices;
+using System.Linq;
+using System.Web.Mvc;
+
+namespace NuGetGallery.Infrastructure.Authentication
+{
+    public static class LdapValidator
+    {
+        static LdapValidator()
+        {
+            var configuration = DependencyResolver.Current.GetService<ConfigurationService>();
+            BaseConfig = configuration.ResolveConfigObject(new LdapUserAuthenticatorConfiguration(), "Auth.LdapUser.").Result;
+        }
+
+        public static LdapUserAuthenticatorConfiguration BaseConfig { get; }
+
+        /// <summary>
+        /// Returns a <see cref="bool"/> indicating the result of a hash comparison.
+        /// </summary>
+        /// <param name="username">The user name.</param>
+        /// <param name="password">The hashed password supplied for comparison.</param>
+        /// <returns>A <see cref="bool"/> indicating the result of a hash comparison.</returns>
+        public static bool ValidateUser(string username, string password)
+        {
+            try
+            {
+                var servicePath = "LDAP://" + BaseConfig.Host + ":" + BaseConfig.Port + "/" + BaseConfig.UserBase;
+                DirectoryEntry ldapConnection;
+                if (string.IsNullOrEmpty(BaseConfig.ServiceAccountUserName) || string.IsNullOrEmpty(BaseConfig.ServiceAccountPassword))
+                    ldapConnection = new DirectoryEntry(servicePath);
+                else
+                    ldapConnection = new DirectoryEntry(servicePath, BaseConfig.ServiceAccountUserName, BaseConfig.ServiceAccountPassword);
+
+                var search = new DirectorySearcher(ldapConnection)
+                {
+                    Filter = $"(&{BaseConfig.ObjectFilter}({BaseConfig.NameAttribute}={username}))"
+                };
+                search.PropertiesToLoad.AddRange(new[] { BaseConfig.NameAttribute, BaseConfig.GroupAttribute });
+
+                // This CAN return null if nothing was found:
+                var result = search.FindOne();
+                if (result == null)
+                    return false;
+
+                var usernameLdap = result.Properties[BaseConfig.NameAttribute][0].ToString();
+                // Check username:
+                if (string.Compare(usernameLdap, username, StringComparison.CurrentCultureIgnoreCase) != 0)
+                    return false;
+
+                // Check password:
+                var validatedUser = ValidateDirectoryUser(result.Path, usernameLdap, password);
+                if (validatedUser == null)
+                    return false;
+
+                // Check if is in allowed group:
+                if (validatedUser.Properties[BaseConfig.GroupAttribute].OfType<string>().All(group => string.Compare(group, BaseConfig.AllowedGroup, StringComparison.CurrentCultureIgnoreCase) != 0))
+                    return false;
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static DirectoryEntry ValidateDirectoryUser(string path, string userName, string userPassword)
+        {
+            try
+            {
+                var validatedUser = new DirectoryEntry(path, userName, userPassword);
+                if (validatedUser.NativeObject != null)
+                    return validatedUser;
+            }
+            catch (DirectoryServicesCOMException)
+            {
+            }
+            return null;
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -499,6 +499,7 @@
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.DirectoryServices" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -732,11 +733,13 @@
     <Compile Include="Authentication\PasswordResetResult.cs" />
     <Compile Include="Authentication\Providers\AuthenticationPolicy.cs" />
     <Compile Include="Authentication\Providers\AuthenticatorT.cs" />
+    <Compile Include="Authentication\Providers\LdapUser\LdapUserAuthenticatorConfiguration.cs" />
     <Compile Include="Authentication\Providers\IdentityInformation.cs" />
     <Compile Include="Authentication\Providers\AzureActiveDirectoryV2\AzureActiveDirectoryV2Authenticator.cs" />
     <Compile Include="Authentication\Providers\AzureActiveDirectoryV2\AzureActiveDirectoryV2AuthenticatorConfiguration.cs" />
     <Compile Include="Authentication\Providers\AzureActiveDirectory\AzureActiveDirectoryAuthenticator.cs" />
     <Compile Include="Authentication\Providers\AzureActiveDirectory\AzureActiveDirectoryAuthenticatorConfiguration.cs" />
+    <Compile Include="Authentication\Providers\LdapUser\LdapUserAuthenticator.cs" />
     <Compile Include="Extensions\ClaimsExtensions.cs" />
     <Compile Include="Configuration\IGalleryConfigurationService.cs" />
     <Compile Include="Configuration\IPackageDeleteConfiguration.cs" />
@@ -805,6 +808,7 @@
     <Compile Include="Infrastructure\Authentication\ApiKeyV3.cs" />
     <Compile Include="Infrastructure\Authentication\ApiKeyV4.cs" />
     <Compile Include="Infrastructure\Authentication\Base32Encoder.cs" />
+    <Compile Include="Infrastructure\Authentication\LdapValidator.cs" />
     <Compile Include="Migrations\201711082145351_AddAccountDelete.cs" />
     <Compile Include="Migrations\201711082145351_AddAccountDelete.Designer.cs">
       <DependentUpon>201711082145351_AddAccountDelete.cs</DependentUpon>

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -668,6 +668,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to LDAP.
+        /// </summary>
+        public static string CredentialType_Ldap {
+            get {
+                return ResourceManager.GetString("CredentialType_Ldap", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Password.
         /// </summary>
         public static string CredentialType_Password {
@@ -919,6 +928,15 @@ namespace NuGetGallery {
         public static string JobLogBlobNameInvalid {
             get {
                 return ResourceManager.GetString("JobLogBlobNameInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The user &apos;{0}&apos; was not validated through LDAP. Please check the LDAP username and password..
+        /// </summary>
+        public static string LdapUserInvalid {
+            get {
+                return ResourceManager.GetString("LdapUserInvalid", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -126,6 +126,9 @@
   <data name="UsernameAndPasswordNotFound" xml:space="preserve">
     <value>A unique user with that username or email address and password does not exist. Try logging on with your username if you were using an email address to log on.</value>
   </data>
+  <data name="LdapUserInvalid" xml:space="preserve">
+    <value>The user '{0}' was not validated through LDAP. Please check the LDAP username and password.</value>
+  </data>
   <data name="PackageIdNotAvailable" xml:space="preserve">
     <value>The package ID '{0}' is not available.</value>
   </data>
@@ -215,6 +218,9 @@
   </data>
   <data name="CredentialType_Password" xml:space="preserve">
     <value>Password</value>
+  </data>
+  <data name="CredentialType_Ldap" xml:space="preserve">
+    <value>LDAP</value>
   </data>
   <data name="ApiKeyGenerated" xml:space="preserve">
     <value>A new API key has been generated. Check below and make sure to copy the value, as now is the only time it will be visible.</value>

--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -12,6 +12,7 @@ namespace NuGetGallery
     public class LogOnViewModel
     {
         public AssociateExternalAccountViewModel External { get; set; }
+        public bool UseLdap { get; set; }
         public SignInViewModel SignIn { get; set; }
         public RegisterViewModel Register { get; set; }
         public IList<AuthenticationProviderViewModel> Providers { get; set; }

--- a/src/NuGetGallery/Views/Authentication/_Register.cshtml
+++ b/src/NuGetGallery/Views/Authentication/_Register.cshtml
@@ -7,6 +7,7 @@
     @Html.AntiForgeryToken()
     @Html.Hidden("ReturnUrl", returnUrl)
     @Html.Hidden("LinkingAccount", Model.External != null)
+    @Html.HiddenFor(m => m.UseLdap)
 
     if (Model.External != null)
     {

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -92,6 +92,18 @@
     <add key="Auth.MicrosoftAccount.ClientId" value="" />
     <add key="Auth.MicrosoftAccount.ClientSecret" value="" />
 
+    <add key="Auth.LdapUser.Enabled" value="false" />
+    <add key="Auth.LdapUser.Host" value="" />
+    <add key="Auth.LdapUser.Port" value="" />
+    <!-- Leave username and password empty to use user login credentials -->
+    <add key="Auth.LdapUser.ServiceAccountUserName" value="" />
+    <add key="Auth.LdapUser.ServiceAccountPassword" value="" />
+    <add key="Auth.LdapUser.UserBase" value="" />
+    <add key="Auth.LdapUser.ObjectFilter" value="(objectCategory=Person)" />
+    <add key="Auth.LdapUser.NameAttribute" value="SAMAccountName" />
+    <add key="Auth.LdapUser.GroupAttribute" value="memberOf" />
+    <add key="Auth.LdapUser.AllowedGroup" value="" />
+
     <add key="Auth.AzureActiveDirectoryV2.Enabled" value="false" />
     <add key="Auth.AzureActiveDirectoryV2.ClientId" value="" />
     <add key="Auth.AzureActiveDirectoryV2.ClientSecret" value="" />


### PR DESCRIPTION
Fixes #554, #5288

Since I also needed it, I added support for LDAP / Windows Active Directory. I was only able to test it within our company with our companies AD. To use it, you have to configure the `Auth.LdapUser` block in the `Web.config` file.

When `Auth.LdapUser.Enabled`, the register form is used to check the given credentials (username and password) and if the credentials are valid, it creates a new account with the username as `ldap.user` credentials instead of saving the password with `password.v3` credentials. No password credentials will be created for this account. If you want to use `LdapUser` with the current password as `LocalUser` fallback, you can just add the credentials to the account in `AuthenticationService.cs` right after the `CreateIdentity` was called (around line 252). This may be something to make configurable.

If you only want to support LDAP without regular passwords (i.e. when you are setting up a new server), I advise you to set `Auth.LocalUser.Enabled` in `Web.config` to `false`. They can coexist, since they both have an own cookie, but in most cases, you really only want to have either LDAP or local users.

Right now, there is no migration path to change existing user credentials from `password.v3` to `ldap.user`. In case the NuGet username already matches the LDAP username, the easiest way would be to update the `dbo.Credentials` entries for `password.v3` and set `Type`= `ldap.user` and `Value` = `(SELECT [Username] FROM [Users] WHERE [Key] = [UserKey])`.

**Tests are currently missing. I didn't want to put in the effort in case that it won't be merged. So I will add them, in case that there are no points speaking against merging.**