### PR TITLE
Test fixes found w/ xunit analyzers

### DIFF
--- a/src/NuGetGallery/Infrastructure/PackageIndexEntity.cs
+++ b/src/NuGetGallery/Infrastructure/PackageIndexEntity.cs
@@ -188,6 +188,7 @@ namespace NuGetGallery
         {
             var split = term.Split(IdSeparators, StringSplitOptions.RemoveEmptyEntries);
             var tokenized = split.SelectMany(CamelCaseTokenize);
+
             return tokenized.Any() ? string.Join(" ", tokenized) : "";
         }
 
@@ -212,6 +213,7 @@ namespace NuGetGallery
                 yield break;
             }
 
+            int tokenCount = 0;
             int tokenEnd = term.Length;
             for (int i = term.Length - 1; i > 0; i--)
             {
@@ -225,12 +227,16 @@ namespace NuGetGallery
                     }
 
                     yield return term.Substring(i, tokenEnd - i);
+                    tokenCount++;
                     tokenEnd = i;
                 }
             }
 
-            // Finally return the term in entirety
-            yield return term;
+            // Finally return the term in entirety, if not already returned
+            if (tokenCount != 1)
+            {
+                yield return term;
+            }
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditingServiceTests.cs
@@ -67,7 +67,7 @@ namespace NuGetGallery.Auditing
                 Assert.Equal(CredentialTypes.Password.V3, affectedCredential["Type"].Value<string>());
                 Assert.Equal(JTokenType.Null, affectedCredential["Value"].Type);
                 Assert.Equal(JTokenType.Null, affectedCredential["Description"].Type);
-                Assert.Equal(0, affectedCredential["Scopes"].AsJEnumerable().Count());
+                Assert.Empty(affectedCredential["Scopes"].AsJEnumerable());
                 Assert.Equal(JTokenType.Null, affectedCredential["Identity"].Type);
                 Assert.Equal(DateTime.MinValue, affectedCredential["Created"].Value<DateTime>());
                 Assert.Equal(user.Credentials.First().Expires.Value, affectedCredential["Expires"].Value<DateTime>());

--- a/tests/NuGetGallery.Core.Facts/Auditing/CloudAuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/CloudAuditingServiceTests.cs
@@ -42,12 +42,12 @@ namespace NuGetGallery.Auditing
             var record = entry["Record"];
             var actor = entry["Actor"];
 
-            Assert.Equal<string>("-1", record["PackageRecord"]["UserKey"].ToString());
-            Assert.Equal<string>(string.Empty, record["PackageRecord"]["FlattenedAuthors"].ToString());
-            Assert.Equal<string>("ObfuscatedUserName", actor["UserName"].ToString());
-            Assert.Equal<string>("2.2.2.0", actor["MachineIP"].ToString());
-            Assert.Equal<string>("ObfuscatedUserName", actor["OnBehalfOf"]["UserName"].ToString());
-            Assert.Equal<string>("3.3.3.0", actor["OnBehalfOf"]["MachineIP"].ToString());
+            Assert.Equal("-1", record["PackageRecord"]["UserKey"].ToString());
+            Assert.Equal(string.Empty, record["PackageRecord"]["FlattenedAuthors"].ToString());
+            Assert.Equal("ObfuscatedUserName", actor["UserName"].ToString());
+            Assert.Equal("2.2.2.0", actor["MachineIP"].ToString());
+            Assert.Equal("ObfuscatedUserName", actor["OnBehalfOf"]["UserName"].ToString());
+            Assert.Equal("3.3.3.0", actor["OnBehalfOf"]["MachineIP"].ToString());
         }
 
         [Theory]

--- a/tests/NuGetGallery.Core.Facts/Auditing/CredentialAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/CredentialAuditRecordTests.cs
@@ -85,7 +85,7 @@ namespace NuGetGallery.Auditing
             Assert.Equal("b", record.Identity);
             Assert.Equal(1, record.Key);
             Assert.Equal(lastUsed, record.LastUsed);
-            Assert.Equal(1, record.Scopes.Count);
+            Assert.Single(record.Scopes);
             var scope = record.Scopes[0];
             Assert.Equal("c", scope.Subject);
             Assert.Equal("d", scope.AllowedAction);

--- a/tests/NuGetGallery.Core.Facts/Auditing/FileSystemAuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/FileSystemAuditingServiceTests.cs
@@ -66,7 +66,7 @@ namespace NuGetGallery.Auditing
                 var actualFilePath = files.Single();
                 var expectedFilePathPattern = new Regex(@"package\\b\\1.0.0\\[0-9a-f]{32}-create.audit.v1.json$");
 
-                Assert.True(expectedFilePathPattern.IsMatch(actualFilePath));
+                Assert.Matches(expectedFilePathPattern, actualFilePath);
             }
         }
 

--- a/tests/NuGetGallery.Core.Facts/Auditing/ObfuscatorJsonConverterTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/ObfuscatorJsonConverterTests.cs
@@ -64,19 +64,19 @@ namespace NuGetGallery.Auditing
             var result = JObject.Parse(resultString);
 
             // Assert
-            Assert.Equal<string>("ObfuscatedUserName", result["UserName"].ToString());
-            Assert.Equal<string>("1.1.1.0", result["IP"].ToString());
-            Assert.Equal<string>(string.Empty, result["Authors"].ToString());
-            Assert.Equal<string>("-1", result["UserKey"].ToString());
-            Assert.Equal<string>("abc", result["SupportedTypeRandom"].ToString());
-            Assert.Equal<string>("2.5", Convert.ToString(result["NotSupportedTypeRandom"], CultureInfo.InvariantCulture));
+            Assert.Equal("ObfuscatedUserName", result["UserName"].ToString());
+            Assert.Equal("1.1.1.0", result["IP"].ToString());
+            Assert.Equal(string.Empty, result["Authors"].ToString());
+            Assert.Equal("-1", result["UserKey"].ToString());
+            Assert.Equal("abc", result["SupportedTypeRandom"].ToString());
+            Assert.Equal("2.5", Convert.ToString(result["NotSupportedTypeRandom"], CultureInfo.InvariantCulture));
 
-            Assert.Equal<string>("ObfuscatedUserName", result["OtherData"]["UserName"].ToString());
-            Assert.Equal<string>("1.1.1.0", result["OtherData"]["IP"].ToString());
-            Assert.Equal<string>(string.Empty, result["OtherData"]["Authors"].ToString());
-            Assert.Equal<string>("-1", result["OtherData"]["UserKey"].ToString());
-            Assert.Equal<string>("abc", result["SupportedTypeRandom"].ToString());
-            Assert.Equal<string>("2.5", Convert.ToString(result["OtherData"]["NotSupportedTypeRandom"], CultureInfo.InvariantCulture));
+            Assert.Equal("ObfuscatedUserName", result["OtherData"]["UserName"].ToString());
+            Assert.Equal("1.1.1.0", result["OtherData"]["IP"].ToString());
+            Assert.Equal(string.Empty, result["OtherData"]["Authors"].ToString());
+            Assert.Equal("-1", result["OtherData"]["UserKey"].ToString());
+            Assert.Equal("abc", result["SupportedTypeRandom"].ToString());
+            Assert.Equal("2.5", Convert.ToString(result["OtherData"]["NotSupportedTypeRandom"], CultureInfo.InvariantCulture));
         }
 
         public class Data

--- a/tests/NuGetGallery.Core.Facts/Auditing/PackageRegistrationAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/PackageRegistrationAuditRecordTests.cs
@@ -64,7 +64,7 @@ namespace NuGetGallery.Auditing
             Assert.Equal(test.PackageRegistration.Id, record.RegistrationRecord.Id);
         }
 
-        public static IEnumerable<RequiredSignerTest[]> RequiredSignerTests
+        public static IEnumerable<object[]> RequiredSignerTests
         {
             get
             {

--- a/tests/NuGetGallery.Core.Facts/Auditing/UserAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/UserAuditRecordTests.cs
@@ -36,12 +36,12 @@ namespace NuGetGallery.Auditing
             Assert.Equal("a", record.Username);
             Assert.Equal("b", record.EmailAddress);
             Assert.Equal("c", record.UnconfirmedEmailAddress);
-            Assert.Equal(1, record.Roles.Length);
+            Assert.Single(record.Roles);
             Assert.Equal("d", record.Roles[0]);
-            Assert.Equal(1, record.Credentials.Length);
+            Assert.Single(record.Credentials);
             Assert.Equal(CredentialTypes.Password.V3, record.Credentials[0].Type);
             Assert.Null(record.Credentials[0].Value);
-            Assert.Equal(1, record.AffectedCredential.Length);
+            Assert.Single(record.AffectedCredential);
             Assert.Equal("h", record.AffectedCredential[0].Type);
             Assert.Null(record.AffectedCredential[0].Value);
         }
@@ -86,13 +86,13 @@ namespace NuGetGallery.Auditing
             Assert.Equal("a", record.Username);
             Assert.Equal("b", record.EmailAddress);
             Assert.Equal("c", record.UnconfirmedEmailAddress);
-            Assert.Equal(1, record.Roles.Length);
+            Assert.Single(record.Roles);
             Assert.Equal("d", record.Roles[0]);
-            Assert.Equal(1, record.Credentials.Length);
+            Assert.Single(record.Credentials);
             Assert.Equal(CredentialTypes.Password.V3, record.Credentials[0].Type);
             Assert.Null(record.Credentials[0].Value);
-            Assert.Equal(0, record.AffectedCredential.Length);
-            Assert.Equal(1, record.AffectedPolicies.Length);
+            Assert.Empty(record.AffectedCredential);
+            Assert.Single(record.AffectedPolicies);
             Assert.Equal("A", record.AffectedPolicies[0].Name);
             Assert.Equal("B", record.AffectedPolicies[0].Subscription);
             Assert.Equal("C", record.AffectedPolicies[0].Value);

--- a/tests/NuGetGallery.Core.Facts/Auditing/UserSecurityPolicyAuditRecordFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/UserSecurityPolicyAuditRecordFacts.cs
@@ -60,7 +60,7 @@ namespace NuGetGallery.Auditing
             Assert.Equal("D", record.Username);
             Assert.False(record.Success);
             Assert.Equal("E", record.ErrorMessage);
-            Assert.Equal(1, record.AffectedPolicies.Length);
+            Assert.Single(record.AffectedPolicies);
             Assert.Equal("A", record.AffectedPolicies[0].Name);
             Assert.Equal("B", record.AffectedPolicies[0].Subscription);
             Assert.Equal("C", record.AffectedPolicies[0].Value);
@@ -77,7 +77,7 @@ namespace NuGetGallery.Auditing
             Assert.Equal("D", record.Username);
             Assert.True(record.Success);
             Assert.Null(record.ErrorMessage);
-            Assert.Equal(1, record.AffectedPolicies.Length);
+            Assert.Single(record.AffectedPolicies);
             Assert.Equal("A", record.AffectedPolicies[0].Name);
             Assert.Equal("B", record.AffectedPolicies[0].Subscription);
             Assert.Equal("C", record.AffectedPolicies[0].Value);

--- a/tests/NuGetGallery.Core.Facts/Entities/PackageFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Entities/PackageFacts.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
             var attributes = typeof(Package).GetProperty("HasReadMeInternal").GetCustomAttributes(typeof(ColumnAttribute), true) as ColumnAttribute[];
 
             // Assert
-            Assert.Equal(1, attributes.Length);
+            Assert.Single(attributes);
             Assert.Equal("HasReadMe", attributes[0].Name);
         }
 

--- a/tests/NuGetGallery.Core.Facts/Entities/UserSecurityPolicyFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Entities/UserSecurityPolicyFacts.cs
@@ -23,7 +23,7 @@ namespace NuGetGallery
             Assert.Equal(policy.Value, copy.Value);
         }
 
-        public static IEnumerable<UserSecurityPolicy[]> EqualsReturnsTrue_Data
+        public static IEnumerable<object[]> EqualsReturnsTrue_Data
         {
             get
             {
@@ -46,7 +46,7 @@ namespace NuGetGallery
             Assert.True(first.Equals(second));
         }
 
-        public static IEnumerable<UserSecurityPolicy[]> EqualsReturnsFalse_Data
+        public static IEnumerable<object[]> EqualsReturnsFalse_Data
         {
             get
             {

--- a/tests/NuGetGallery.Core.Facts/Infrastructure/ElmahExceptionFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/ElmahExceptionFacts.cs
@@ -19,9 +19,9 @@ namespace NuGetGallery.Infrastructure
             var elmahException = new ElmahException(exception, serverVariables);
 
             // Assert
-            Assert.Equal(elmahException.ServerVariables["AUTH_USER"], "booUser");
-            Assert.Equal(elmahException.InnerException.Message, "Inner Boo");
-            Assert.Equal(elmahException.Message, "Boo");
+            Assert.Equal("booUser", elmahException.ServerVariables["AUTH_USER"]);
+            Assert.Equal("Inner Boo", elmahException.InnerException.Message);
+            Assert.Equal("Boo", elmahException.Message);
             Assert.Equal(elmahException.Message, exception.Message);
             Assert.Equal(elmahException.ToString(), exception.ToString());
             Assert.Equal(elmahException.InnerException.ToString(), exception.InnerException.ToString());
@@ -37,7 +37,7 @@ namespace NuGetGallery.Infrastructure
             var elmahException = new ElmahException(exception, null);
 
             // Assert
-            Assert.Equal(elmahException.ServerVariables.Keys.Count, 0);
+            Assert.Empty(elmahException.ServerVariables.Keys);
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
@@ -480,7 +480,7 @@ namespace NuGetGallery.Packaging
         {
             var nuspecStream = CreateNuspecStream(NuSpecDependencySetContainsEmptyTargetFramework);
             
-            Assert.Equal(GetErrors(nuspecStream).Length, 0);
+            Assert.Empty(GetErrors(nuspecStream));
         }
 
         [Fact]
@@ -504,7 +504,7 @@ namespace NuGetGallery.Packaging
         {
             var nuspecStream = CreateNuspecStream(NuSpecFrameworkAssemblyReferenceContainsEmptyTargetFramework);
             
-            Assert.Equal(GetErrors(nuspecStream).Length, 0);
+            Assert.Empty(GetErrors(nuspecStream));
         }
 
         [Theory]

--- a/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/NupkgRewriterFacts.cs
@@ -76,7 +76,7 @@ namespace NuGetGallery.Packaging
             using (var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
             {
                 var nuspec = nupkg.GetNuspecReader();
-                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == PackageMetadataStrings.LicenseUrl), false);
+                Assert.DoesNotContain(nuspec.GetMetadata(), kvp => kvp.Key == PackageMetadataStrings.LicenseUrl);
             }
 
             // Act
@@ -95,9 +95,9 @@ namespace NuGetGallery.Packaging
                 var nuspec = nupkg.GetNuspecReader();
                 Assert.Equal("TestPackage", nuspec.GetId());
                 Assert.Equal(NuGetVersion.Parse("0.0.0.1"), nuspec.GetVersion());
-                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == PackageMetadataStrings.LicenseUrl), true);
-                Assert.Equal(nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.LicenseUrl).Value, "http://myget.org");
-                Assert.Equal(nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.RequireLicenseAcceptance).Value, "true");
+                Assert.Contains(nuspec.GetMetadata(), kvp => kvp.Key == PackageMetadataStrings.LicenseUrl);
+                Assert.Equal("http://myget.org", nuspec.GetMetadata().First(kvp => kvp.Key == PackageMetadataStrings.LicenseUrl).Value);
+                Assert.Contains(nuspec.GetMetadata(), kvp => kvp.Key == PackageMetadataStrings.RequireLicenseAcceptance);
             }
         }
 
@@ -109,7 +109,7 @@ namespace NuGetGallery.Packaging
             using (var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
             {
                 var nuspec = nupkg.GetNuspecReader();
-                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == PackageMetadataStrings.Title), true);
+                Assert.Contains(nuspec.GetMetadata(), kvp => kvp.Key == PackageMetadataStrings.Title);
             }
 
             // Act
@@ -123,7 +123,7 @@ namespace NuGetGallery.Packaging
             using (var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false))
             {
                 var nuspec = nupkg.GetNuspecReader();
-                Assert.Equal(nuspec.GetMetadata().Any(kvp => kvp.Key == PackageMetadataStrings.Title), false);
+                Assert.DoesNotContain(nuspec.GetMetadata(), kvp => kvp.Key == PackageMetadataStrings.Title);
             }
         }
 

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -55,7 +55,7 @@ namespace NuGetGallery
 
                 var ex = Assert.Throws<ArgumentException>(() => service.SavePackageFileAsync(package, CreatePackageFileStream()).Wait());
 
-                Assert.True(ex.Message.StartsWith("The package is missing required data."));
+                Assert.StartsWith("The package is missing required data.", ex.Message);
                 Assert.Equal("package", ex.ParamName);
             }
 
@@ -68,7 +68,7 @@ namespace NuGetGallery
 
                 var ex = Assert.Throws<ArgumentException>(() => service.SavePackageFileAsync(package, CreatePackageFileStream()).Wait());
 
-                Assert.True(ex.Message.StartsWith("The package is missing required data."));
+                Assert.StartsWith("The package is missing required data.", ex.Message);
                 Assert.Equal("package", ex.ParamName);
             }
 
@@ -81,7 +81,7 @@ namespace NuGetGallery
 
                 var ex = Assert.Throws<ArgumentException>(() => service.SavePackageFileAsync(package, CreatePackageFileStream()).Wait());
 
-                Assert.True(ex.Message.StartsWith("The package is missing required data."));
+                Assert.StartsWith("The package is missing required data.", ex.Message);
                 Assert.Equal("package", ex.ParamName);
             }
 
@@ -529,7 +529,7 @@ namespace NuGetGallery
 
                 var ex = await Assert.ThrowsAsync<ArgumentException>(() => service.StorePackageFileInBackupLocationAsync(package, CreatePackageFileStream()));
 
-                Assert.True(ex.Message.StartsWith("The package is missing required data."));
+                Assert.StartsWith("The package is missing required data.", ex.Message);
                 Assert.Equal("package", ex.ParamName);
             }
 
@@ -542,7 +542,7 @@ namespace NuGetGallery
 
                 var ex = await Assert.ThrowsAsync<ArgumentException>(() => service.StorePackageFileInBackupLocationAsync(package, CreatePackageFileStream()));
 
-                Assert.True(ex.Message.StartsWith("The package is missing required data."));
+                Assert.StartsWith("The package is missing required data.", ex.Message);
                 Assert.Equal("package", ex.ParamName);
             }
 
@@ -555,7 +555,7 @@ namespace NuGetGallery
 
                 var ex = await Assert.ThrowsAsync<ArgumentException>(() => service.StorePackageFileInBackupLocationAsync(package, CreatePackageFileStream()));
 
-                Assert.True(ex.Message.StartsWith("The package is missing required data."));
+                Assert.StartsWith("The package is missing required data.", ex.Message);
                 Assert.Equal("package", ex.ParamName);
             }
 

--- a/tests/NuGetGallery.Facts/App_Start/StorageDependentFacts.cs
+++ b/tests/NuGetGallery.Facts/App_Start/StorageDependentFacts.cs
@@ -58,10 +58,10 @@ namespace NuGetGallery
             Assert.Contains(typeof(PackageFileService), implementationToInterface.Keys);
             Assert.Contains(typeof(UploadFileService), implementationToInterface.Keys);
             Assert.Equal(4, implementationToInterface.Count);
-            Assert.Equal(implementationToInterface[typeof(CertificateService)], typeof(ICertificateService));
-            Assert.Equal(implementationToInterface[typeof(ContentService)], typeof(IContentService));
-            Assert.Equal(implementationToInterface[typeof(PackageFileService)], typeof(IPackageFileService));
-            Assert.Equal(implementationToInterface[typeof(UploadFileService)], typeof(IUploadFileService));
+            Assert.Equal(typeof(ICertificateService), implementationToInterface[typeof(CertificateService)]);
+            Assert.Equal(typeof(IContentService), implementationToInterface[typeof(ContentService)]);
+            Assert.Equal(typeof(IPackageFileService), implementationToInterface[typeof(PackageFileService)]);
+            Assert.Equal(typeof(IUploadFileService), implementationToInterface[typeof(UploadFileService)]);
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/DeleteAccountControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/DeleteAccountControllerFacts.cs
@@ -34,7 +34,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
             // Assert
             var data = (List<DeleteAccountSearchResult>)((JsonResult)searchResult).Data;
-            Assert.Equal<int>(0, data.Count);
+            Assert.Empty(data);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
             // Assert
             var data = (List<DeleteAccountSearchResult>)((JsonResult)searchResult).Data;
-            Assert.Equal<int>(0, data.Count);
+            Assert.Empty(data);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
             // Assert
             var data = (List<DeleteAccountSearchResult>)((JsonResult)searchResult).Data;
-            Assert.Equal<int>(0, data.Count);
+            Assert.Empty(data);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
             // Assert
             var data = (List<DeleteAccountSearchResult>)((JsonResult)searchResult).Data;
-            Assert.Equal<int>(1, data.Count);
+            Assert.Single(data);
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/SecurityPolicyControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/SecurityPolicyControllerFacts.cs
@@ -50,7 +50,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             var model = ResultAssert.IsView<SecurityPolicyViewModel>(result);
             Assert.NotNull(model);
             Assert.NotNull(model.SubscriptionNames);
-            Assert.Equal(1, model.SubscriptionNames.Count());
+            Assert.Single(model.SubscriptionNames);
         }
 
         [Theory]
@@ -137,7 +137,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             var controller = new SecurityPolicyController(entitiesMock.Object, policyService);
             var subscription = policyService.Mocks.Subscription.Object;
 
-            Assert.False(users.Any(u => policyService.IsSubscribed(u, subscription)));
+            Assert.DoesNotContain(users, u => policyService.IsSubscribed(u, subscription));
 
             // Act.
             var model = new List<string>

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -101,7 +101,7 @@ namespace NuGetGallery.Authentication
                 // Assert
                 var expectedCred = user.Credentials.SingleOrDefault(
                     c => string.Equals(c.Type, CredentialBuilder.LatestPasswordType, StringComparison.OrdinalIgnoreCase));
-                Assert.Equal(result.Result, PasswordAuthenticationResult.AuthenticationResult.Success);
+                Assert.Equal(PasswordAuthenticationResult.AuthenticationResult.Success, result.Result);
                 Assert.Same(user, result.AuthenticatedUser.User);
                 Assert.Same(expectedCred, result.AuthenticatedUser.CredentialUsed);
             }

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticatorFacts.cs
@@ -101,14 +101,14 @@ namespace NuGetGallery.Authentication
             public void IgnoresAbstractAndNonAuthenticatorTypes()
             {
                 // Act
-                var authers = Authenticator.GetAllAvailable(new[] {
+                var authenticators = Authenticator.GetAllAvailable(new[] {
                     typeof(ATestAuthenticator),
                     typeof(Authenticator),
                     typeof(TheGetAllAvailableMethod)
                 }).ToArray();
 
-                Assert.Equal(1, authers.Length);
-                Assert.IsType<ATestAuthenticator>(authers[0]);
+                Assert.Single(authenticators);
+                Assert.IsType<ATestAuthenticator>(authenticators[0]);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
@@ -53,6 +53,7 @@ namespace NuGetGallery
 
         public abstract class TheAccountBaseAction : AccountsControllerTestContainer
         {
+
             [Theory]
             [MemberData(AllowedCurrentUsersDataName)]
             public void WillGetCuratedFeedsManagedByTheCurrentUser(Func<Fakes, User> getCurrentUser)

--- a/tests/NuGetGallery.Facts/Controllers/CuratedFeedsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/CuratedFeedsControllerFacts.cs
@@ -172,7 +172,7 @@ namespace NuGetGallery
                 var viewModel = (controller.CuratedFeed("aName") as ViewResult).Model as CuratedFeedViewModel;
 
                 Assert.NotNull(viewModel);
-                Assert.Equal(1, viewModel.ExcludedPackages.Count());
+                Assert.Single(viewModel.ExcludedPackages);
                 Assert.Equal("theExcludedId", viewModel.ExcludedPackages.First());
             }
         }
@@ -230,7 +230,7 @@ namespace NuGetGallery
                 Assert.IsType<ViewResult>(result);
                 Assert.IsType<PackageListViewModel>(((ViewResult)result).Model);
                 var model = (result as ViewResult).Model as PackageListViewModel;
-                Assert.Equal(1, model.Items.Count());
+                Assert.Single(model.Items);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Controllers/CuratedPackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/CuratedPackagesControllerFacts.cs
@@ -266,16 +266,14 @@ namespace NuGetGallery
                         Included = true,
                     });
 
-                Assert.False(controller.StubCuratedFeed.Packages.Any(
-                    cp => cp.Included == false));
+                Assert.DoesNotContain(controller.StubCuratedFeed.Packages, cp => !cp.Included);
 
                 var result = await controller.PatchCuratedPackage(
                     "aFeedName",
                     "anId",
                     new ModifyCuratedPackageRequest { Included = false }) as HttpStatusCodeResult;
 
-                Assert.True(controller.StubCuratedFeed.Packages.Any(
-                    cp => cp.Included == false));
+                Assert.Contains(controller.StubCuratedFeed.Packages, cp => !cp.Included);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -1269,8 +1269,8 @@ namespace NuGetGallery
                 // Assert
                 var model = ResultAssert.IsView<DeleteOrganizationViewModel>(result, "DeleteAccount");
                 Assert.Equal(testOrganization.Username, model.AccountName);
-                Assert.Equal(1, model.Packages.Count());
-                Assert.Equal(true, model.HasOrphanPackages);
+                Assert.Single(model.Packages);
+                Assert.True(model.HasOrphanPackages);
                 Assert.Equal(withAdditionalMembers, model.HasAdditionalMembers);
             }
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1254,7 +1254,7 @@ namespace NuGetGallery
                 Assert.Equal(packageId, model.PackageId);
                 Assert.Equal(packageVersion, model.PackageVersion);
                 Assert.Equal(projectUrl, model.ProjectUrl);
-                Assert.Equal(1, model.Owners.Count());
+                Assert.Single(model.Owners);
                 Assert.True(model.HasOwners);
             }
 
@@ -2086,10 +2086,8 @@ namespace NuGetGallery
                 packageFileService.Verify(s => s.DownloadReadMeMdFileAsync(It.IsAny<Package>()), Times.Never);
             }
 
-            [Theory]
-            [MemberData(nameof(Owner_Data))]
-            [MemberData(nameof(NotOwner_Data))]
-            public async Task WhenPackageIsNotFoundReturns404(User currentUser, User owner)
+            [Fact]
+            public async Task WhenPackageIsNotFoundReturns404()
             {
                 // Arrange
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -306,7 +306,7 @@ namespace NuGetGallery
                 var result = await controller.ForgotPassword(model) as ViewResult;
 
                 Assert.NotNull(result);
-                Assert.IsNotType(typeof(RedirectResult), result);
+                Assert.IsNotType<RedirectResult>(result);
                 Assert.Contains(Strings.CouldNotFindAnyoneWithThatUsernameOrEmail, result.ViewData.ModelState[string.Empty].Errors.Select(e => e.ErrorMessage));
             }
 
@@ -324,7 +324,7 @@ namespace NuGetGallery
                 var result = await controller.ForgotPassword(model) as ViewResult;
 
                 Assert.NotNull(result);
-                Assert.IsNotType(typeof(RedirectResult), result);
+                Assert.IsNotType<RedirectResult>(result);
                 Assert.Contains(Strings.UserIsNotYetConfirmed, result.ViewData.ModelState[string.Empty].Errors.Select(e => e.ErrorMessage));
             }
 
@@ -2120,7 +2120,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.Equal(userName, model.AccountName);
-                Assert.Equal(1, model.Packages.Count());
+                Assert.Single(model.Packages);
                 Assert.Equal(withPendingIssues, model.HasPendingRequests);
             }
         }
@@ -2180,8 +2180,8 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.Equal(testUser.Username, model.AccountName);
-                Assert.Equal(1, model.Packages.Count());
-                Assert.Equal(true, model.HasOrphanPackages);
+                Assert.Single(model.Packages);
+                Assert.True(model.HasOrphanPackages);
                 Assert.Equal(withPendingIssues, model.HasPendingRequests);
             }
         }
@@ -2384,7 +2384,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.NotNull(result);
-                Assert.Equal(1, controller.ModelState[string.Empty].Errors.Count);
+                Assert.Single(controller.ModelState[string.Empty].Errors);
                 Assert.Equal("error", controller.ModelState[string.Empty].Errors.First().ErrorMessage);
 
                 GetMock<IMessageService>()
@@ -2426,7 +2426,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.NotNull(result);
-                Assert.Equal(1, controller.ModelState[string.Empty].Errors.Count);
+                Assert.Single(controller.ModelState[string.Empty].Errors);
                 Assert.Equal(
                     String.Format(CultureInfo.CurrentCulture,
                         Strings.TransformAccount_AdminAccountDoesNotExist, "AdminThatDoesNotExist"),

--- a/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
+++ b/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
@@ -62,7 +62,7 @@ namespace NuGetGallery
                 var currentUser = mockOwinContext.Object.GetCurrentUser();
 
                 // Assert
-                Assert.Equal(null, currentUser);
+                Assert.Null(currentUser);
             }
 
             [Fact]
@@ -85,7 +85,7 @@ namespace NuGetGallery
                 var currentUser = mockOwinContext.Object.GetCurrentUser();
 
                 // Assert
-                Assert.Equal(null, currentUser);
+                Assert.Null(currentUser);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Extensions/PrincipalExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/PrincipalExtensionsFacts.cs
@@ -104,7 +104,7 @@ namespace NuGetGallery.Extensions
 
                 var scopes = identity.GetScopesFromClaim();
 
-                Assert.Equal(1, scopes.Count);
+                Assert.Single(scopes);
                 Assert.Equal("theId", scopes.First().Subject);
             }
 
@@ -116,7 +116,7 @@ namespace NuGetGallery.Extensions
                     AuthenticationTypes.ApiKey,
                     new Claim(NuGetClaims.ApiKey, string.Empty));
 
-                Assert.Equal(null, identity.GetScopesFromClaim());
+                Assert.Null(identity.GetScopesFromClaim());
             }
 
             [Theory]
@@ -131,7 +131,7 @@ namespace NuGetGallery.Extensions
                     new Claim(NuGetClaims.ApiKey, string.Empty),
                     new Claim(NuGetClaims.Scope, scopeClaim));
 
-                Assert.Equal(null, identity.GetScopesFromClaim());
+                Assert.Null(identity.GetScopesFromClaim());
             }
         }
 

--- a/tests/NuGetGallery.Facts/Filters/ApiAuthorizeAttributeFacts.cs
+++ b/tests/NuGetGallery.Facts/Filters/ApiAuthorizeAttributeFacts.cs
@@ -8,7 +8,6 @@ using System.Web;
 using System.Web.Mvc;
 using Moq;
 using NuGetGallery.Authentication;
-using NuGetGallery.Security;
 using Xunit;
 using AuthorizationContext = System.Web.Mvc.AuthorizationContext;
 using AuthenticationTypes = NuGetGallery.Authentication.AuthenticationTypes;

--- a/tests/NuGetGallery.Facts/Filters/ApiScopeRequiredAttributeFacts.cs
+++ b/tests/NuGetGallery.Facts/Filters/ApiScopeRequiredAttributeFacts.cs
@@ -26,7 +26,7 @@ namespace NuGetGallery.Filters
                 var resolvedAttribute = container.Resolve<ApiScopeRequiredAttribute>();
 
                 // Assert
-                Assert.Equal(1, resolvedAttribute.ScopeActions.Length);
+                Assert.Single(resolvedAttribute.ScopeActions);
                 Assert.Equal(NuGetScopes.PackagePush, resolvedAttribute.ScopeActions.First());
             }
         }

--- a/tests/NuGetGallery.Facts/Filters/UiAuthorizeAttributeFacts.cs
+++ b/tests/NuGetGallery.Facts/Filters/UiAuthorizeAttributeFacts.cs
@@ -111,7 +111,7 @@ namespace NuGetGallery.Filters
             {
                 var context = BuildAuthorizationContext(
                     BuildClaimsIdentity(
-                        AuthenticationTypes.LocalUser, 
+                        authType, 
                         authenticated: true, 
                         hasDiscontinuedLoginClaim: true).Object).Object;
                 var attribute = new UIAuthorizeAttribute();
@@ -122,8 +122,8 @@ namespace NuGetGallery.Filters
                 // Assert
                 var redirectResult = context.Result as RedirectToRouteResult;
                 Assert.NotNull(redirectResult);
-                Assert.True(redirectResult.RouteValues.Contains(new KeyValuePair<string, object>("controller", "Pages")));
-                Assert.True(redirectResult.RouteValues.Contains(new KeyValuePair<string, object>("action", "Home")));
+                Assert.Contains(new KeyValuePair<string, object>("controller", "Pages"), redirectResult.RouteValues);
+                Assert.Contains(new KeyValuePair<string, object>("action", "Home"), redirectResult.RouteValues);
             }
 
             private static Mock<ClaimsIdentity> BuildClaimsIdentity(string authType, bool authenticated, bool hasDiscontinuedLoginClaim)

--- a/tests/NuGetGallery.Facts/Infrastructure/CookieTempDataProviderFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/CookieTempDataProviderFacts.cs
@@ -111,7 +111,7 @@ namespace NuGetGallery.Infrastructure
                             { "key3", "dumb&dumber?:;,isit" }
                         });
 
-                Assert.Equal(1, cookies.Count);
+                Assert.Single(cookies);
                 Assert.True(cookies[0].HttpOnly);
                 Assert.True(cookies[0].Secure);
                 Assert.Equal(3, cookies[0].Values.Count);
@@ -131,7 +131,7 @@ namespace NuGetGallery.Infrastructure
 
                 provider.SaveTempData(controllerContext, new Dictionary<string, object>());
 
-                Assert.Equal(0, cookies.Count);
+                Assert.Empty(cookies);
             }
 
             [Fact]
@@ -153,7 +153,7 @@ namespace NuGetGallery.Infrastructure
 
                 // Validate
                 provider.SaveTempData(controllerContext, new Dictionary<string, object>());
-                Assert.Equal(1, cookies.Count);
+                Assert.Single(cookies);
                 Assert.True(cookies[0].HttpOnly);
                 Assert.True(cookies[0].Secure);
                 Assert.Equal("", cookies[0].Value);

--- a/tests/NuGetGallery.Facts/Infrastructure/PackageIndexEntityFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/PackageIndexEntityFacts.cs
@@ -43,20 +43,21 @@ namespace NuGetGallery.Infrastructure
             Assert.Equal(result, tokens);
         }
 
+        [Theory]
         [InlineData("Sys-netFX", "Sys netFX")]
         [InlineData("xUnit", "xUnit")]
         [InlineData("jQueryUI", "jQueryUI")]
-        [InlineData("jQuery-UI", "jQuery UI")]
-        [InlineData("NuGetPowerTools", "NuGet Power Tools")]
+        [InlineData("jQuery-UI", "jQuery")]
+        [InlineData("NuGetPowerTools", "Tools Power NuGet NuGetPowerTools")]
         [InlineData("microsoft-web-helpers", "microsoft web helpers" )]
-        [InlineData("EntityFramework.sample", "Entity Framework sample" )]
-        [InlineData("SignalR.MicroSliver", "SignalR Micro Sliver")]
-        [InlineData("ABCMicroFramework", "ABC Micro Framework")]
-        [InlineData("SignalR.Hosting.AspNet", "SignalR Hosting Asp Net")]
+        [InlineData("EntityFramework.sample", "Framework Entity EntityFramework sample" )]
+        [InlineData("SignalR.MicroSliver", "SignalR Sliver Micro MicroSliver")]
+        [InlineData("ABCMicroFramework", "Framework Micro ABC ABCMicroFramework")]
+        [InlineData("SignalR.Hosting.AspNet", "SignalR Hosting Net Asp AspNet")]
         public void CamelIdSplitter(string term, string tokens)
         {
             var result = PackageIndexEntity.CamelSplitId(term);
-            Assert.Equal(result, tokens);
+            Assert.Equal(tokens, result);
         }
     }
 }

--- a/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
+++ b/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
@@ -178,7 +178,7 @@ namespace NuGetGallery.SearchClient
                 }
             }, comparer).ToList();
 
-            Assert.True(orderList.Select(u => u.AbsoluteUri).Contains(dummyUrl));
+            Assert.Contains(dummyUrl, orderList.Select(u => u.AbsoluteUri));
         }
     }
 }

--- a/tests/NuGetGallery.Facts/SearchClient/WebApiCorrelationHandlerFacts.cs
+++ b/tests/NuGetGallery.Facts/SearchClient/WebApiCorrelationHandlerFacts.cs
@@ -55,7 +55,7 @@ namespace NuGetGallery.SearchClient
 
             // Assert
             Assert.NotNull(response);
-            Assert.Equal(response.StatusCode, HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.True(response.Headers.Contains(WebApiCorrelationHandler.CorrelationIdHttpHeaderName));
             Assert.Equal(correlationId.ToString(),
                 response.Headers.GetValues(WebApiCorrelationHandler.CorrelationIdHttpHeaderName).FirstOrDefault());
@@ -82,7 +82,7 @@ namespace NuGetGallery.SearchClient
 
             // Assert
             Assert.NotNull(response);
-            Assert.Equal(response.StatusCode, HttpStatusCode.OK);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.True(response.Headers.Contains(WebApiCorrelationHandler.CorrelationIdHttpHeaderName));
             Assert.Equal(correlationId.ToString(),
                 response.Headers.GetValues(WebApiCorrelationHandler.CorrelationIdHttpHeaderName).FirstOrDefault());

--- a/tests/NuGetGallery.Facts/Security/AutomaticallyOverwriteRequiredSignerPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/AutomaticallyOverwriteRequiredSignerPolicyFacts.cs
@@ -26,7 +26,7 @@ namespace NuGetGallery.Security
             Assert.Equal(nameof(AutomaticallyOverwriteRequiredSignerPolicy), policy.Name);
             Assert.Equal(nameof(AutomaticallyOverwriteRequiredSignerPolicy), policy.SubscriptionName);
             Assert.Equal(SecurityPolicyAction.AutomaticallyOverwriteRequiredSigner, policy.Action);
-            Assert.Equal(1, policy.Policies.Count());
+            Assert.Single(policy.Policies);
             Assert.Equal(nameof(AutomaticallyOverwriteRequiredSignerPolicy), policy.Policies.Single().Name);
             Assert.Equal(nameof(AutomaticallyOverwriteRequiredSignerPolicy), policy.Policies.Single().Subscription);
         }

--- a/tests/NuGetGallery.Facts/Security/ControlRequiredSignerPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/ControlRequiredSignerPolicyFacts.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery.Security
             Assert.Equal(nameof(ControlRequiredSignerPolicy), policy.Name);
             Assert.Equal(nameof(ControlRequiredSignerPolicy), policy.SubscriptionName);
             Assert.Equal(SecurityPolicyAction.ControlRequiredSigner, policy.Action);
-            Assert.Equal(1, policy.Policies.Count());
+            Assert.Single(policy.Policies);
             Assert.Equal(nameof(ControlRequiredSignerPolicy), policy.Policies.Single().Name);
             Assert.Equal(nameof(ControlRequiredSignerPolicy), policy.Policies.Single().Subscription);
         }

--- a/tests/NuGetGallery.Facts/Security/RequireOrganizationTenantPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/RequireOrganizationTenantPolicyFacts.cs
@@ -18,7 +18,7 @@ namespace NuGetGallery.Security
             [InlineData("different-tenant")]
             public void WhenNoMatchingTargetCredential_ReturnsError(string tenantId)
             {
-                var result = Evaluate(null);
+                var result = Evaluate(tenantId);
 
                 Assert.False(result.Success);
                 Assert.Equal(

--- a/tests/NuGetGallery.Facts/Security/SecurityPolicyServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/SecurityPolicyServiceFacts.cs
@@ -212,7 +212,7 @@ namespace NuGetGallery.Security
             var result = await service.EvaluateUserPoliciesAsync(SecurityPolicyAction.PackagePush, CreateHttpContext(user));
 
             // Assert
-            Assert.Equal(false, result.Success);
+            Assert.False(result.Success);
             
             // The error indicates which subscription failed
             Assert.Contains(policyData.DefaultSubscription.Object.SubscriptionName, result.ErrorMessage);

--- a/tests/NuGetGallery.Facts/Services/CertificateServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CertificateServiceFacts.cs
@@ -517,7 +517,7 @@ namespace NuGetGallery.Services
 
             var certificates = service.GetCertificates(_user);
 
-            Assert.Equal(1, certificates.Count());
+            Assert.Single(certificates);
             Assert.Same(_certificate, certificates.Single());
 
             VerifyMockExpectations();

--- a/tests/NuGetGallery.Facts/Services/CuratedFeedServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CuratedFeedServiceFacts.cs
@@ -110,8 +110,8 @@ namespace NuGetGallery.Services
 
                 var curatedPackage = svc.StubCuratedFeed.Packages.First();
                 Assert.Equal(1066, curatedPackage.PackageRegistrationKey);
-                Assert.Equal(false, curatedPackage.Included);
-                Assert.Equal(true, curatedPackage.AutomaticallyCurated);
+                Assert.False(curatedPackage.Included);
+                Assert.True(curatedPackage.AutomaticallyCurated);
                 Assert.Equal("theNotes", curatedPackage.Notes);
             }
 
@@ -145,8 +145,8 @@ namespace NuGetGallery.Services
                     "theNotes");
 
                 Assert.Equal(1066, curatedPackage.PackageRegistrationKey);
-                Assert.Equal(false, curatedPackage.Included);
-                Assert.Equal(true, curatedPackage.AutomaticallyCurated);
+                Assert.False(curatedPackage.Included);
+                Assert.True(curatedPackage.AutomaticallyCurated);
                 Assert.Equal("theNotes", curatedPackage.Notes);
             }
         }

--- a/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
@@ -80,7 +80,7 @@ namespace NuGetGallery.Services
                                                 signature: signature,
                                                 orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans);
                 string expected = $"The account:{testUser.Username} was already deleted. No action was performed.";
-                Assert.Equal<string>(expected, result.Description);
+                Assert.Equal(expected, result.Description);
             }
 
             /// <summary>
@@ -114,11 +114,11 @@ namespace NuGetGallery.Services
                 Assert.Empty(registration.Owners);
                 Assert.Empty(testUser.SecurityPolicies);
                 Assert.Empty(testUser.ReservedNamespaces);
-                Assert.Equal(false, registration.Packages.ElementAt(0).Listed);
+                Assert.False(registration.Packages.ElementAt(0).Listed);
                 Assert.Null(testUser.EmailAddress);
-                Assert.Equal(1, testableService.DeletedAccounts.Count());
+                Assert.Single(testableService.DeletedAccounts);
                 Assert.Equal(signature, testableService.DeletedAccounts.ElementAt(0).Signature);
-                Assert.Equal(1, testableService.SupportRequests.Count());
+                Assert.Single(testableService.SupportRequests);
                 Assert.Empty(testableService.PackageOwnerRequests);
                 Assert.True(testableService.HasDeletedOwnerScope);
                 Assert.Equal(1, testableService.AuditService.Records.Count());
@@ -136,7 +136,7 @@ namespace NuGetGallery.Services
                     }
                     else
                     {
-                        Assert.True(notDeletedMembers.Any(m => m.IsAdmin));
+                        Assert.Contains(notDeletedMembers, m => m.IsAdmin);
                     }
                 }
                 
@@ -162,7 +162,7 @@ namespace NuGetGallery.Services
                 //Assert
                 Assert.True(status.Success);
                 Assert.Null(testableService.User);
-                Assert.True(testableService.HasDeletedOwnerScope);
+                Assert.Single(testableService.AuditService.Records);
                 Assert.Equal(1, testableService.AuditService.Records.Count);
                 var deleteAccountAuditRecord = testableService.AuditService.Records[0] as DeleteAccountAuditRecord;
                 Assert.NotNull(deleteAccountAuditRecord);
@@ -212,14 +212,15 @@ namespace NuGetGallery.Services
                 // Assert
                 Assert.True(status.Success);
                 Assert.Null(organization.EmailAddress);
-                Assert.Equal(0, registration.Owners.Count());
-                Assert.Equal(0, organization.SecurityPolicies.Count());
-                Assert.Equal(0, organization.ReservedNamespaces.Count());
-                Assert.Equal(1, testableService.DeletedAccounts.Count());
-                Assert.Equal(1, testableService.SupportRequests.Count);
-                Assert.Equal(0, testableService.PackageOwnerRequests.Count);
-                Assert.Equal(1, testableService.AuditService.Records.Count);
+                Assert.Empty(registration.Owners);
+                Assert.Empty(organization.SecurityPolicies);
+                Assert.Empty(organization.ReservedNamespaces);
+                Assert.Single(testableService.DeletedAccounts);
+                Assert.Single(testableService.SupportRequests);
+                Assert.Empty(testableService.PackageOwnerRequests);
+                Assert.Single(testableService.AuditService.Records);
                 Assert.True(testableService.HasDeletedOwnerScope);
+                
                 var deleteRecord = testableService.AuditService.Records[0] as DeleteAccountAuditRecord;
                 Assert.True(deleteRecord != null);
             }
@@ -265,14 +266,15 @@ namespace NuGetGallery.Services
                 // Assert
                 Assert.True(status.Success);
                 Assert.Null(testableService.User);
-                Assert.Equal(0, registration.Owners.Count());
-                Assert.Equal(0, organization.SecurityPolicies.Count());
-                Assert.Equal(0, organization.ReservedNamespaces.Count());
-                Assert.Equal(0, testableService.DeletedAccounts.Count());
-                Assert.Equal(1, testableService.SupportRequests.Count);
-                Assert.Equal(0, testableService.PackageOwnerRequests.Count);
+                Assert.Empty(registration.Owners);
+                Assert.Empty(organization.SecurityPolicies);
+                Assert.Empty(organization.ReservedNamespaces);
+                Assert.Empty(testableService.DeletedAccounts);
+                Assert.Single(testableService.SupportRequests);
+                Assert.Empty(testableService.PackageOwnerRequests);
                 Assert.True(testableService.HasDeletedOwnerScope);
-                Assert.Equal(1, testableService.AuditService.Records.Count);
+                Assert.Single(testableService.AuditService.Records);
+                
                 var deleteRecord = testableService.AuditService.Records[0] as DeleteAccountAuditRecord;
                 Assert.True(deleteRecord != null);
             }

--- a/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
@@ -402,7 +402,7 @@ namespace NuGetGallery
                            typeof(V1FeedPackage)),
                            v1Service.Request)));
                     var badRequest = result as BadRequestErrorMessageResult;
-                    Assert.NotEqual(null, badRequest);
+                    Assert.NotNull(badRequest);
                 }
 
                 [Fact]
@@ -416,7 +416,7 @@ namespace NuGetGallery
                            typeof(V1FeedPackage)),
                            service.Request));
                     var badRequest = result as BadRequestErrorMessageResult;
-                    Assert.NotEqual(null, badRequest);
+                    Assert.NotNull(badRequest);
                 }
 
                 private TestableV1Feed GetService(string host, string arguments = "?$skip=10")
@@ -689,7 +689,7 @@ namespace NuGetGallery
                         .ToArray();
 
                     // Assert
-                    Assert.False(result.Any(p => p.Id == "Baz"));
+                    Assert.DoesNotContain(result, p => p.Id == "Baz");
                 }
             }
 
@@ -1316,7 +1316,7 @@ namespace NuGetGallery
                         .ToArray();
 
                     // Assert
-                    Assert.Equal(1, result.Length);
+                    Assert.Single(result);
                     Assert.Equal("Foo", result[0].Id);
                     Assert.Equal("1.2.0", result[0].Version);
                 }
@@ -1443,7 +1443,7 @@ namespace NuGetGallery
                         .ToArray();
 
                     // Assert
-                    Assert.Equal(0, result.Length);
+                    Assert.Empty(result);
                 }
 
                 [Fact]
@@ -1655,7 +1655,7 @@ namespace NuGetGallery
                            v2Service.Request),
                        "Pid", "Version", false, false));
                     var badRequest = result as BadRequestErrorMessageResult;
-                    Assert.NotEqual(null, badRequest);
+                    Assert.NotNull(badRequest);
                 }
 
                 [Fact]
@@ -1669,7 +1669,7 @@ namespace NuGetGallery
                            typeof(V2FeedPackage)),
                            v2Service.Request)));
                     var badRequest = result as BadRequestErrorMessageResult;
-                    Assert.NotEqual(null, badRequest);
+                    Assert.NotNull(badRequest);
                 }
 
                 [Fact]
@@ -1683,7 +1683,7 @@ namespace NuGetGallery
                            typeof(V2FeedPackage)),
                            v2Service.Request)));
                     var badRequest = result as BadRequestErrorMessageResult;
-                    Assert.NotEqual(null, badRequest);
+                    Assert.NotNull(badRequest);
                 }
 
                 private TestableV2Feed GetService(string host, string arguments = "?$skip=10")

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -231,7 +231,7 @@ namespace NuGetGallery
                 // assert
                 Assert.Equal(2, messages.Count);
                 Assert.Equal(package.PackageRegistration.Owners.Count, messages[0].To.Count);
-                Assert.Equal(1, messages[1].To.Count);
+                Assert.Single(messages[1].To);
                 Assert.Equal(ownerAddress, messages[0].To[0].Address);
                 Assert.Equal(ownerAddress2, messages[0].To[1].Address);
                 Assert.Equal(messages[1].ReplyToList.Single(), messages[1].To.First());
@@ -315,7 +315,7 @@ namespace NuGetGallery
 
                 // assert
                 Assert.Equal(ownerAddress, message.To[0].Address);
-                Assert.Equal(1, message.To.Count);
+                Assert.Single(message.To);
             }
 
             [Fact]
@@ -772,7 +772,7 @@ namespace NuGetGallery
                 {
                     Assert.Equal(toUser.EmailAddress, message.To[0].Address);
                 }
-                Assert.Equal(TestGalleryNoReplyAddress.Address, "noreply@example.com");
+                Assert.Equal("noreply@example.com", TestGalleryNoReplyAddress.Address);
                 Assert.Contains($"Package ownership update for '{package.Id}'", message.Subject);
                 Assert.Contains($"User '{newUser.Username}' is now an owner of the package ['{package.Id}']({packageUrl}).", message.Body);
             }
@@ -1079,7 +1079,7 @@ namespace NuGetGallery
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal("yung@example.com", message.To[0].Address);
-                Assert.Equal(1, message.To.Count);
+                Assert.Single(message.To);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
@@ -90,7 +90,7 @@ namespace NuGetGallery
 
                 var ex = Assert.Throws<ArgumentException>(() => service.CreateDownloadPackageActionResultAsync(new Uri("http://fake"), package).Wait());
 
-                Assert.True(ex.Message.StartsWith("The package is missing required data."));
+                Assert.StartsWith("The package is missing required data.", ex.Message);
                 Assert.Equal("package", ex.ParamName);
             }
 
@@ -103,7 +103,7 @@ namespace NuGetGallery
 
                 var ex = Assert.Throws<ArgumentException>(() => service.CreateDownloadPackageActionResultAsync(new Uri("http://fake"), package).Wait());
 
-                Assert.True(ex.Message.StartsWith("The package is missing required data."));
+                Assert.StartsWith("The package is missing required data.", ex.Message);
                 Assert.Equal("package", ex.ParamName);
             }
 
@@ -116,7 +116,7 @@ namespace NuGetGallery
 
                 var ex = Assert.Throws<ArgumentException>(() => service.CreateDownloadPackageActionResultAsync(new Uri("http://fake"), package).Wait());
 
-                Assert.True(ex.Message.StartsWith("The package is missing required data."));
+                Assert.StartsWith("The package is missing required data.", ex.Message);
                 Assert.Equal("package", ex.ParamName);
             }
 

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -269,7 +269,7 @@ namespace NuGetGallery
                 Assert.Equal("http://theiconurl/", package.IconUrl);
                 Assert.Equal("http://thelicenseurl/", package.LicenseUrl);
                 Assert.Equal("http://theprojecturl/", package.ProjectUrl);
-                Assert.Equal(true, package.RequiresLicenseAcceptance);
+                Assert.True(package.RequiresLicenseAcceptance);
                 Assert.Equal("theSummary", package.Summary);
                 Assert.Equal("theTags", package.Tags);
                 Assert.Equal("theTitle", package.Title);
@@ -358,19 +358,6 @@ namespace NuGetGallery
 
                 Assert.Equal(expectedHash, package.Hash);
                 Assert.Equal(CoreConstants.Sha512HashAlgorithmId, package.HashAlgorithm);
-            }
-
-            [Fact]
-            public async Task WillNotCreateThePackageInAnUnpublishedState()
-            {
-                var service = CreateService(setup:
-                        mockPackageService => { mockPackageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null); });
-                var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
-                var currentUser = new User();
-
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
-
-                Assert.NotNull(package.Published);
             }
 
             [Fact]
@@ -1183,7 +1170,7 @@ namespace NuGetGallery
                 context.Packages.Add(package);
 
                 var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: false);
-                Assert.Equal(1, packages.Count());
+                Assert.Single(packages);
             }
 
             [Theory]
@@ -1199,7 +1186,7 @@ namespace NuGetGallery
                 context.Packages.Add(package);
 
                 var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: false);
-                Assert.Equal(0, packages.Count());
+                Assert.Empty(packages);
             }
 
             [Theory]
@@ -1215,7 +1202,7 @@ namespace NuGetGallery
                 context.Packages.Add(package);
 
                 var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: true);
-                Assert.Equal(1, packages.Count());
+                Assert.Single(packages);
             }
 
             [Theory]
@@ -1274,7 +1261,7 @@ namespace NuGetGallery
                 context.Packages.Add(latestStablePackage);
 
                 var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: false).ToList();
-                Assert.Equal(1, packages.Count);
+                Assert.Single(packages);
                 Assert.Contains(latestStablePackage, packages);
             }
 
@@ -1294,7 +1281,7 @@ namespace NuGetGallery
                 context.Packages.Add(latestStablePackage);
 
                 var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: false).ToList();
-                Assert.Equal(1, packages.Count);
+                Assert.Single(packages);
                 Assert.Contains(latestStablePackage, packages);
             }
 
@@ -1377,7 +1364,7 @@ namespace NuGetGallery
                 context.Packages.Add(package1);
 
                 var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: false);
-                Assert.Equal(1, packages.Count());
+                Assert.Single(packages);
                 Assert.Contains(package2, packages);
             }
 
@@ -1435,7 +1422,7 @@ namespace NuGetGallery
                 context.Packages.Add(package2);
 
                 var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: false, includeVersions: true);
-                Assert.Equal(1, packages.Count());
+                Assert.Single(packages);
             }
         }
 
@@ -1721,7 +1708,7 @@ namespace NuGetGallery
 
                 await service.PublishPackageAsync("theId", "1.0.42");
 
-                Assert.NotNull(package.Published);
+                Assert.NotEqual(default(DateTime), package.Published);
                 packageRepository.Verify(x => x.CommitChangesAsync());
             }
 
@@ -1744,7 +1731,7 @@ namespace NuGetGallery
 
                 await service.PublishPackageAsync(package, commitChanges: false);
 
-                Assert.NotNull(package.Published);
+                Assert.NotEqual(default(DateTime), package.Published);
                 packageRepository.Verify(x => x.CommitChangesAsync(), Times.Never());
             }
 

--- a/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
@@ -311,7 +311,7 @@ namespace NuGetGallery
             public async Task WhenMaxLengthExceeded_ThrowsInvalidOperationException(string sourceType)
             {
                 // Arrange.
-                var request = ReadMeServiceFacts.GetReadMeRequest(ReadMeService.TypeWritten, LargeMarkdown);
+                var request = ReadMeServiceFacts.GetReadMeRequest(sourceType, LargeMarkdown);
 
                 // Act & Assert.
                 await Assert.ThrowsAsync<InvalidOperationException>(() => ReadMeService.GetReadMeMdAsync(request, Encoding.UTF8));
@@ -348,7 +348,7 @@ namespace NuGetGallery
             public async Task WhenInvalidUrl_ThrowsInvalidOperationException(string url)
             {
                 // Arrange.
-                var request = ReadMeServiceFacts.GetReadMeRequest(ReadMeService.TypeUrl, "markdown");
+                var request = ReadMeServiceFacts.GetReadMeRequest(ReadMeService.TypeUrl, "markdown", url: url);
 
                 // Act & Assert.
                 await Assert.ThrowsAsync<ArgumentException>(() => ReadMeService.GetReadMeMdAsync(request, Encoding.UTF8));

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -167,32 +167,32 @@ namespace NuGetGallery
 
 #pragma warning disable 0618
                 Assert.Equal(2, result.Authors.Count);
-                Assert.True(result.Authors.Any(a => a.Name == "authora"));
-                Assert.True(result.Authors.Any(a => a.Name == "authorb"));
+                Assert.Contains(result.Authors, a => a.Name == "authora");
+                Assert.Contains(result.Authors, a => a.Name == "authorb");
 #pragma warning restore 0618
                 Assert.Equal("authora, authorb", result.FlattenedAuthors);
 
-                Assert.Equal(false, result.RequiresLicenseAcceptance);
+                Assert.False(result.RequiresLicenseAcceptance);
                 Assert.Equal("package A description.", result.Description);
                 Assert.Equal("en-US", result.Language);
 
                 Assert.Equal("WebActivator:[1.1.0, ):net40|PackageC:[1.1.0, 2.0.1):net40|jQuery:[1.0.0, ):net451", result.FlattenedDependencies);
                 Assert.Equal(3, result.Dependencies.Count);
 
-                Assert.True(result.Dependencies.Any(d =>
+                Assert.Contains(result.Dependencies, d =>
                     d.Id == "WebActivator"
                     && d.VersionSpec == "[1.1.0, )"
-                    && d.TargetFramework == "net40"));
+                    && d.TargetFramework == "net40");
 
-                Assert.True(result.Dependencies.Any(d =>
+                Assert.Contains(result.Dependencies, d =>
                     d.Id == "PackageC"
                     && d.VersionSpec == "[1.1.0, 2.0.1)"
-                    && d.TargetFramework == "net40"));
+                    && d.TargetFramework == "net40");
 
-                Assert.True(result.Dependencies.Any(d =>
+                Assert.Contains(result.Dependencies, d =>
                     d.Id == "jQuery"
                     && d.VersionSpec == "[1.0.0, )"
-                    && d.TargetFramework == "net451"));
+                    && d.TargetFramework == "net451");
 
                 Assert.Equal(0, result.SupportedFrameworks.Count);
             }
@@ -317,20 +317,20 @@ namespace NuGetGallery
                 Assert.Equal("test", result.PackageRegistration.Id);
                 Assert.Equal("1.0.0", result.NormalizedVersion);
 
-                Assert.True(result.Dependencies.Any(d =>
+                Assert.Contains(result.Dependencies, d =>
                     d.Id == "WebActivator"
                     && d.VersionSpec == "(, )"
-                    && d.TargetFramework == "net40"));
+                    && d.TargetFramework == "net40");
 
-                Assert.True(result.Dependencies.Any(d =>
+                Assert.Contains(result.Dependencies, d =>
                     d.Id == "PackageC"
                     && d.VersionSpec == "[1.1.0, 2.0.1)"
-                    && d.TargetFramework == "net40"));
+                    && d.TargetFramework == "net40");
 
-                Assert.True(result.Dependencies.Any(d =>
+                Assert.Contains(result.Dependencies, d =>
                     d.Id == "jQuery"
                     && d.VersionSpec == "(, )"
-                    && d.TargetFramework == "net451"));
+                    && d.TargetFramework == "net451");
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/SupportRequestServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SupportRequestServiceFacts.cs
@@ -100,7 +100,7 @@ namespace NuGetGallery.Services
                 await supportRequestService.TryAddDeleteSupportRequestAsync(user);
 
                 // Assert
-                Assert.Equal(1, auditingService.Records.Count);
+                Assert.Single(auditingService.Records);
                 var deleteRecord = auditingService.Records[0] as DeleteAccountAuditRecord;
                 Assert.True(deleteRecord != null);
                 Assert.Equal(DeleteAccountAuditRecord.ActionStatus.Success, deleteRecord.Status);

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -546,7 +546,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<int>()),
                     Times.Once);
-                Assert.True(service.LastTraceMessage.Contains("InvalidOperationException"));
+                Assert.Contains("InvalidOperationException", service.LastTraceMessage);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
@@ -517,7 +517,8 @@ namespace NuGetGallery
                 Fakes.Organization.MemberRequests.Add(new MembershipRequest
                 {
                     NewMember = Fakes.User,
-                    ConfirmationToken = token
+                    ConfirmationToken = token,
+                    IsAdmin = isAdmin
                 });
 
                 Fakes.User.EmailAddress = string.Empty;
@@ -952,7 +953,7 @@ namespace NuGetGallery
                 var result = await service.UpdateMemberAsync(fakes.Organization, fakes.OrganizationAdmin.Username, false);
 
                 // Assert
-                Assert.Equal(false, result.IsAdmin);
+                Assert.False(result.IsAdmin);
                 Assert.Equal(fakes.OrganizationAdmin, result.Member);
 
                 service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
@@ -975,7 +976,7 @@ namespace NuGetGallery
                 var result = await service.UpdateMemberAsync(fakes.Organization, fakes.OrganizationCollaborator.Username, true);
 
                 // Assert
-                Assert.Equal(true, result.IsAdmin);
+                Assert.True(result.IsAdmin);
                 Assert.Equal(fakes.OrganizationCollaborator, result.Member);
 
                 service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
@@ -1349,33 +1350,33 @@ namespace NuGetGallery
                 
                 // Disable notifications
                 await service.ChangeEmailSubscriptionAsync(user, false, false);
-                Assert.Equal(false, user.EmailAllowed);
-                Assert.Equal(false, user.NotifyPackagePushed);
+                Assert.False(user.EmailAllowed);
+                Assert.False(user.NotifyPackagePushed);
                 
                 // Enable contact notifications
                 await service.ChangeEmailSubscriptionAsync(user, true, false);
-                Assert.Equal(true, user.EmailAllowed);
-                Assert.Equal(false, user.NotifyPackagePushed);
+                Assert.True(user.EmailAllowed);
+                Assert.False(user.NotifyPackagePushed);
 
                 // Disable notifications
                 await service.ChangeEmailSubscriptionAsync(user, false, false);
-                Assert.Equal(false, user.EmailAllowed);
-                Assert.Equal(false, user.NotifyPackagePushed);
+                Assert.False(user.EmailAllowed);
+                Assert.False(user.NotifyPackagePushed);
 
                 // Enable package pushed notifications
                 await service.ChangeEmailSubscriptionAsync(user, false, true);
-                Assert.Equal(false, user.EmailAllowed);
-                Assert.Equal(true, user.NotifyPackagePushed);
+                Assert.False(user.EmailAllowed);
+                Assert.True(user.NotifyPackagePushed);
 
                 // Disable notifications
                 await service.ChangeEmailSubscriptionAsync(user, false, false);
-                Assert.Equal(false, user.EmailAllowed);
-                Assert.Equal(false, user.NotifyPackagePushed);
+                Assert.False(user.EmailAllowed);
+                Assert.False(user.NotifyPackagePushed);
 
                 // Enable all notifications
                 await service.ChangeEmailSubscriptionAsync(user, true, true);
-                Assert.Equal(true, user.EmailAllowed);
-                Assert.Equal(true, user.NotifyPackagePushed);
+                Assert.True(user.EmailAllowed);
+                Assert.True(user.NotifyPackagePushed);
 
                 service.MockUserRepository
                        .Verify(r => r.CommitChangesAsync());
@@ -1935,9 +1936,7 @@ namespace NuGetGallery
 
                 // Both the organization and the admin must have a membership to each other.
                 Func<Membership, bool> hasMembership = m => m.Member.Username == AdminName && m.Organization.Username == OrgName && m.IsAdmin;
-                Assert.True(
-                    org.Members.Any(
-                        m => hasMembership(m) && m.Member.Organizations.Any(hasMembership)));
+                Assert.Contains(org.Members, m => hasMembership(m) && m.Member.Organizations.Any(hasMembership));
 
                 _service.MockOrganizationRepository.Verify(x => x.InsertOnCommit(It.IsAny<Organization>()), Times.Once());
                 _service.MockSecurityPolicyService.Verify(

--- a/tests/NuGetGallery.Facts/Services/ValidationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ValidationServiceFacts.cs
@@ -366,7 +366,7 @@ namespace NuGetGallery
                 // Assert
                 _validationSets.Verify(x => x.GetAll(), Times.Once());
 
-                Assert.Equal(1, issues.Count());
+                Assert.Single(issues);
                 Assert.Equal(ValidationIssueCode.PackageIsSigned, issues.First().IssueCode);
             }
         }

--- a/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
@@ -139,7 +139,7 @@ namespace NuGetGallery.Telemetry
             return url.ToLower().Contains("username") || url.ToLower().Contains("accountname");
         }
 
-        public static IEnumerable<string[]> PIIUrlDataGenerator()
+        public static IEnumerable<object[]> PIIUrlDataGenerator()
         {
             foreach (var user in GenerateUserNames())
             {

--- a/tests/NuGetGallery.Facts/Telemetry/ObfuscatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/ObfuscatorFacts.cs
@@ -20,11 +20,11 @@ namespace NuGetGallery.Telemetry
             // Act and Assert
             foreach (var action in lowerInvariant)
             {
-                Assert.True(Obfuscator.ObfuscatedActions.Contains(action));
+                Assert.Contains(action, Obfuscator.ObfuscatedActions);
             }
             foreach (var action in upperInvariant)
             {
-                Assert.True(Obfuscator.ObfuscatedActions.Contains(action));
+                Assert.Contains(action, Obfuscator.ObfuscatedActions);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Telemetry/QuietLogFacts.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/QuietLogFacts.cs
@@ -28,7 +28,7 @@ namespace NuGetGallery.Telemetry
 
             // Assert
             Assert.True(result);
-            Assert.Equal<string>($"{controller}/{action}", operation);
+            Assert.Equal($"{controller}/{action}", operation);
         }
 
         [Theory]
@@ -46,11 +46,11 @@ namespace NuGetGallery.Telemetry
             var serverVariables = QuietLog.GetObfuscatedServerVariables(context);
 
             // Assert
-            Assert.Equal<string>(Obfuscator.DefaultObfuscatedUrl(context.Request.Url), serverVariables["HTTP_REFERER"]);
-            Assert.Equal<string>(context.Operation, serverVariables["PATH_INFO"]);
-            Assert.Equal<string>(context.Operation, serverVariables["PATH_TRANSLATED"]);
-            Assert.Equal<string>(context.Operation, serverVariables["SCRIPT_NAME"]);
-            Assert.Equal<string>(Obfuscator.DefaultObfuscatedUrl(context.Request.Url), serverVariables["URL"]);
+            Assert.Equal(Obfuscator.DefaultObfuscatedUrl(context.Request.Url), serverVariables["HTTP_REFERER"]);
+            Assert.Equal(context.Operation, serverVariables["PATH_INFO"]);
+            Assert.Equal(context.Operation, serverVariables["PATH_TRANSLATED"]);
+            Assert.Equal(context.Operation, serverVariables["SCRIPT_NAME"]);
+            Assert.Equal(Obfuscator.DefaultObfuscatedUrl(context.Request.Url), serverVariables["URL"]);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ namespace NuGetGallery.Telemetry
         }
 
 
-        public static IEnumerable<string[]> IsPIIRouteFactsValidDataGenerator()
+        public static IEnumerable<object[]> IsPIIRouteFactsValidDataGenerator()
         {
             return Obfuscator.ObfuscatedActions.Select(o => o.Split('/'));
         }

--- a/tests/NuGetGallery.Facts/UrlExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/UrlExtensionsFacts.cs
@@ -17,7 +17,7 @@ namespace NuGetGallery
             public void Works()
             {
                 string fixedUrl = UrlExtensions.EnsureTrailingSlash("http://nuget.org/packages/FooPackage.CS");
-                Assert.True(fixedUrl.EndsWith("/", StringComparison.Ordinal));
+                Assert.EndsWith("/", fixedUrl);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/ViewModels/DependencySetsViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DependencySetsViewModelFacts.cs
@@ -29,7 +29,7 @@ namespace NuGetGallery.ViewModels
                 Assert.Null(vm.DependencySets["Portable Class Library (.NETFramework 4.5, Windows 8.0)"].Single());
 
                 var actual = vm.DependencySets["Portable Class Library (.NETFramework 4.0, Silverlight 4.0, Windows 8.0, WindowsPhone 7.1)"].ToArray();
-                Assert.Equal(1, actual.Length);
+                Assert.Single(actual);
                 Assert.Equal("Microsoft.Net.Http", actual[0].Id);
                 Assert.Equal("(>= 2.1.0 && < 3.0.0)", actual[0].VersionSpec);
             }

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
@@ -117,7 +117,7 @@ namespace NuGetGallery.ViewModels
             var listPackageItemViewModel = new ListPackageItemViewModel(package, currentUser: null);
 
             Assert.Equal(description, listPackageItemViewModel.ShortDescription);
-            Assert.Equal(false, listPackageItemViewModel.IsDescriptionTruncated);
+            Assert.False(listPackageItemViewModel.IsDescriptionTruncated);
         }
 
         [Fact]
@@ -137,9 +137,9 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
             var listPackageItemViewModel = new ListPackageItemViewModel(package, currentUser: null);
 
             Assert.NotEqual(description, listPackageItemViewModel.ShortDescription);
-            Assert.Equal(true, listPackageItemViewModel.IsDescriptionTruncated);
-            Assert.True(listPackageItemViewModel.ShortDescription.EndsWith(omission));
-            Assert.True(description.Contains(listPackageItemViewModel.ShortDescription.Substring(0, listPackageItemViewModel.ShortDescription.Length - 1 - omission.Length)));
+            Assert.True(listPackageItemViewModel.IsDescriptionTruncated);
+            Assert.EndsWith(omission, listPackageItemViewModel.ShortDescription);
+            Assert.Contains(listPackageItemViewModel.ShortDescription.Substring(0, listPackageItemViewModel.ShortDescription.Length - 1 - omission.Length), description);
         }
 
         [Fact]
@@ -158,8 +158,8 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
             var listPackageItemViewModel = new ListPackageItemViewModel(package, currentUser: null);
 
             Assert.Equal(charLimit + omission.Length, listPackageItemViewModel.ShortDescription.Length);
-            Assert.Equal(true, listPackageItemViewModel.IsDescriptionTruncated);
-            Assert.True(listPackageItemViewModel.ShortDescription.EndsWith(omission));
+            Assert.True(listPackageItemViewModel.IsDescriptionTruncated);
+            Assert.EndsWith(omission, listPackageItemViewModel.ShortDescription);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
 
             var listPackageItemViewModel = new ListPackageItemViewModel(package, currentUser: null);
 
-            Assert.Equal(null, listPackageItemViewModel.Tags);
+            Assert.Null(listPackageItemViewModel.Tags);
         }
 
         [Fact]
@@ -187,9 +187,9 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
             var listPackageItemViewModel = new ListPackageItemViewModel(package, currentUser: null);
 
             Assert.Equal(3, listPackageItemViewModel.Tags.Count());
-            Assert.True(listPackageItemViewModel.Tags.Contains("tag1"));
-            Assert.True(listPackageItemViewModel.Tags.Contains("tag2"));
-            Assert.True(listPackageItemViewModel.Tags.Contains("tag3"));
+            Assert.Contains("tag1", listPackageItemViewModel.Tags);
+            Assert.Contains("tag2", listPackageItemViewModel.Tags);
+            Assert.Contains("tag3", listPackageItemViewModel.Tags);
         }
 
         [Fact]


### PR DESCRIPTION
While working on #6007, xunit analyzers started running when I initially migrated to PackageRefs.

I investigated whether we could enable them, but found some issues were non-trivial. These are the trivial fixes. This also found some tests that were never enabled, including one that required source change... see inline comment for more details.