### PR TITLE
Handle ArgumentNullException and HTTP 500 when readme host is invalid.

### DIFF
--- a/src/NuGetGallery/Services/ReadMeService.cs
+++ b/src/NuGetGallery/Services/ReadMeService.cs
@@ -338,6 +338,8 @@ namespace NuGetGallery
         
         private static string NormalizeNewLines(string content)
         {
+            if (content == null) return null;
+
             return NewLineRegex.Replace(content, Environment.NewLine);
         }
     }

--- a/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
@@ -173,7 +173,7 @@ namespace NuGetGallery
                 // Assert
                 var exception = await Assert.ThrowsAsync<ArgumentException>(() => saveTask);
 
-                Assert.True(exception.Message.Contains(Strings.ReadMeUrlHostInvalid));
+                Assert.Contains(Strings.ReadMeUrlHostInvalid, exception.Message);
                 _entitiesContext.Verify(
                     x => x.SaveChangesAsync(),
                     Times.Never());


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/5778