### PR TITLE
Minor fixes for verify page.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -269,6 +269,8 @@
             }
 
             bindReadMeData(model);
+
+            document.getElementById("validation-failure-container").scrollIntoView();
         }
 
         function navigateToPage(verifyResponse) {


### PR DESCRIPTION
This addresses most of https://github.com/NuGet/NuGetGallery/issues/5850

* Adds AI logging for any failure fed back to gallery during validation flow.
* Scrolls error message container into view on Upload page when Submit is pressed (if there are any errors to show). scrollIntoView tested on IE, Edge, Firefox, Chrome.