### PR TITLE
Fix issue 6035 

### DIFF
--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -652,7 +652,7 @@ Thanks,
             body = String.Format(
                 CultureInfo.CurrentCulture,
                 body,
-                user,
+                user.Username,
                 Config.GalleryOwner.DisplayName,
                 Environment.NewLine);
 

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -106,7 +106,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to DeleteAccountRequest.
+        ///   Looks up a localized string similar to Account Deletion Request.
         /// </summary>
         public static string AccountDelete_SupportRequestTitle {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -610,7 +610,7 @@ For more information, please contact '{2}'.</value>
     <value>The request failed to be submitted. Please try again or contact support.</value>
   </data>
   <data name="AccountDelete_SupportRequestTitle" xml:space="preserve">
-    <value>DeleteAccountRequest</value>
+    <value>Account Deletion Request</value>
   </data>
   <data name="MessageIsRequired" xml:space="preserve">
     <value>Please enter a message.</value>

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -1948,6 +1948,32 @@ namespace NuGetGallery
             }
         }
 
+        public class TheSendAccountDeleteNoticeMethod
+            : TestContainer
+        {
+            [Fact]
+            public void VerifyTheMessageBody()
+            {
+                // Arrange
+                var userName = "deleteduser";
+                var userEmailAddress = "onedeleteduser@hotmail.com";
+                var userToDelete = new User(userName) { EmailAddress = userEmailAddress };
+
+                var messageService = TestableMessageService.Create(GetConfigurationService());
+
+                // Act
+                messageService.SendAccountDeleteNotice(userToDelete);
+
+                // Assert
+                var message = messageService.MockMailSender.Sent.Last();
+
+                Assert.Equal(userToDelete.EmailAddress, message.To[0].Address);
+                Assert.Equal(TestGalleryNoReplyAddress, message.From);
+                Assert.Equal("Account Deletion Request", message.Subject);
+                Assert.Contains($"We received a request to delete your account {userName}.", message.Body);
+            }
+        }
+
         private static void AssertMessageSentToAccountManagersOfOrganizationOnly(MailMessage message, Organization organization)
         {
             AssertMessageSentToMembersOfOrganizationWithPermissionOnly(message, organization, ActionsRequiringPermissions.ManageAccount);


### PR DESCRIPTION
- incorrect account name in the delete account email message body.

[Issue 6035](https://github.com/NuGet/NuGetGallery/issues/6035)