### PR TITLE
Correctly unverify packages when they are removed from their reserved namespaces (HOTFIX)

### DIFF
--- a/src/NuGetGallery/Services/ReservedNamespaceService.cs
+++ b/src/NuGetGallery/Services/ReservedNamespaceService.cs
@@ -296,6 +296,7 @@ namespace NuGetGallery
             }
 
             reservedNamespace.PackageRegistrations.Remove(packageRegistration);
+            packageRegistration.ReservedNamespaces.Remove(reservedNamespace);
         }
 
         public virtual ReservedNamespace FindReservedNamespaceForPrefix(string prefix)

--- a/tests/NuGetGallery.Facts/Services/ReservedNamespaceServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReservedNamespaceServiceFacts.cs
@@ -574,11 +574,13 @@ namespace NuGetGallery.Services
                 var testPackageRegistrations = ReservedNamespaceServiceTestData.GetRegistrations();
                 var existingReg = testPackageRegistrations.First();
                 existingNamespace.PackageRegistrations.Add(existingReg);
+                existingReg.ReservedNamespaces.Add(existingNamespace);
                 var service = new TestableReservedNamespaceService(reservedNamespaces: testNamespaces, packageRegistrations: testPackageRegistrations);
 
                 service.RemovePackageRegistrationFromNamespace(existingNamespace, existingReg);
 
                 Assert.False(existingNamespace.PackageRegistrations.Contains(existingReg));
+                Assert.False(existingReg.ReservedNamespaces.Contains(existingNamespace));
             }
 
             [Fact]
@@ -589,6 +591,7 @@ namespace NuGetGallery.Services
                 var testPackageRegistrations = ReservedNamespaceServiceTestData.GetRegistrations();
                 var existingReg = testPackageRegistrations.First();
                 existingNamespace.PackageRegistrations.Add(existingReg);
+                existingReg.ReservedNamespaces.Add(existingNamespace);
                 var service = new TestableReservedNamespaceService(reservedNamespaces: testNamespaces, packageRegistrations: testPackageRegistrations);
 
                 service.RemovePackageRegistrationFromNamespace(existingNamespace, existingReg);


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6039

(also see https://github.com/NuGet/NuGetGallery/pull/6043)