### PR TITLE
Autofac upgrade and cleanup

### DIFF
--- a/src/GalleryTools/GalleryTools.csproj
+++ b/src/GalleryTools/GalleryTools.csproj
@@ -64,7 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac">
-      <Version>3.5.2</Version>
+      <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils">
       <Version>1.1.1</Version>

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -107,7 +107,8 @@ namespace NuGetGallery
 
             builder.RegisterInstance(galleryDbConnectionFactory)
                 .AsSelf()
-                .Keyed<ISqlConnectionFactory>(nameof(EntitiesContext));
+                .As<ISqlConnectionFactory>()
+                .SingleInstance();
 
             builder.Register(c => new EntitiesContext(CreateDbConnection(galleryDbConnectionFactory), configuration.Current.ReadOnlyMode))
                 .AsSelf()

--- a/src/NuGetGallery/Areas/Admin/AdminAreaRegistration.cs
+++ b/src/NuGetGallery/Areas/Admin/AdminAreaRegistration.cs
@@ -16,10 +16,10 @@ namespace NuGetGallery.Areas.Admin
 
         public override void RegisterArea(AreaRegistrationContext context)
         {
-            var config = DependencyResolver.Current.GetService<IIndex<string, ISqlConnectionFactory>>();
+            var galleryDbConnectionFactory = DependencyResolver.Current.GetService<ISqlConnectionFactory>();
 
             context.Routes.Ignore("Admin/Errors.axd/{*pathInfo}"); // ELMAH owns this root
-            DynamicDataManager.Register(context.Routes, "Admin/Database", config);
+            DynamicDataManager.Register(context.Routes, "Admin/Database", galleryDbConnectionFactory);
 
             context.MapRoute(
                 "Admin_default",

--- a/src/NuGetGallery/Areas/Admin/DynamicData/DynamicDataManager.cs
+++ b/src/NuGetGallery/Areas/Admin/DynamicData/DynamicDataManager.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using System.Web.DynamicData;
 using System.Web.Routing;
-using Autofac.Features.Indexed;
 using Microsoft.AspNet.DynamicData.ModelProviders;
 using NuGet.Services.Sql;
 
@@ -21,13 +20,13 @@ namespace NuGetGallery.Areas.Admin.DynamicData
 
         private static DynamicDataRoute _route;
 
-        public static void Register(RouteCollection routes, string root, IIndex<string, ISqlConnectionFactory> connectionFactories)
+        public static void Register(RouteCollection routes, string root, ISqlConnectionFactory galleryDbSqlConnectionFactory)
         {
             // Set up unobtrusive validation
             InitializeValidation();
 
             // Set up dynamic data
-            InitializeDynamicData(routes, root, connectionFactories[nameof(EntitiesContext)]);
+            InitializeDynamicData(routes, root, galleryDbSqlConnectionFactory);
         }
 
         private static void InitializeValidation()

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1925,19 +1925,19 @@
       <Version>1.2.0</Version>
     </PackageReference>
     <PackageReference Include="Autofac">
-      <Version>3.5.2</Version>
+      <Version>4.6.2</Version>
     </PackageReference>
     <PackageReference Include="Autofac.Mvc5">
-      <Version>3.3.4</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
     <PackageReference Include="Autofac.Mvc5.Owin">
-      <Version>3.1.0</Version>
+      <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Autofac.Owin">
-      <Version>3.1.0</Version>
+      <Version>4.2.0</Version>
     </PackageReference>
     <PackageReference Include="Autofac.WebApi2">
-      <Version>3.4.0</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="CommonMark.NET">
       <Version>0.15.1</Version>

--- a/src/NuGetGallery/Services/SqlAggregateStatsService.cs
+++ b/src/NuGetGallery/Services/SqlAggregateStatsService.cs
@@ -20,10 +20,10 @@ namespace NuGetGallery
                             WHERE EXISTS (SELECT 1 FROM Packages p WITH (NOLOCK) WHERE p.PackageRegistrationKey = pr.[Key] AND p.Listed = 1 AND p.PackageDelete_Key IS NULL)) AS UniquePackages,
                     (SELECT COUNT([Key]) FROM Packages WITH (NOLOCK) WHERE Listed = 1) AS TotalPackages";
 
-        public SqlAggregateStatsService(IAppConfiguration configuration, IIndex<string, ISqlConnectionFactory> connectionFactories)
+        public SqlAggregateStatsService(IAppConfiguration configuration, ISqlConnectionFactory galleryDbConnectionFactory)
         {
             _configuration = configuration;
-            _connectionFactory = connectionFactories[nameof(EntitiesContext)];
+            _connectionFactory = galleryDbConnectionFactory;
         }
 
         public Task<AggregateStats> GetAggregateStats()

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -478,6 +478,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Autofac.Integration.Owin" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.Tracing" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
@@ -503,7 +507,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -63,9 +63,11 @@ namespace NuGetGallery.Controllers
                 Assert.NotNull(model.SignIn);
                 Assert.NotNull(model.Register);
                 Assert.Equal(3, model.Providers.Count);
-                Assert.Equal("AzureActiveDirectoryV2", model.Providers[0].ProviderName);
-                Assert.Equal("AzureActiveDirectory", model.Providers[1].ProviderName);
-                Assert.Equal("MicrosoftAccount", model.Providers[2].ProviderName);
+
+                var providerNames = model.Providers.Select(p => p.ProviderName);
+                Assert.Contains("AzureActiveDirectoryV2", providerNames);
+                Assert.Contains("AzureActiveDirectory", providerNames);
+                Assert.Contains("MicrosoftAccount", providerNames);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Framework/TestContainer.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestContainer.cs
@@ -30,7 +30,6 @@ namespace NuGetGallery.Framework
             {
                 var updater = new ContainerBuilder();
                 updater.RegisterType<TController>().PropertiesAutowired().AsSelf();
-                updater.Update(Container);
             }
 
             var c = Container.Resolve<TController>();
@@ -63,7 +62,6 @@ namespace NuGetGallery.Framework
         {
             var updater = new ContainerBuilder();
             updater.RegisterType<TService>().AsImplementedInterfaces().AsSelf();
-            updater.Update(Container);
 
             return Get<TService>();
         }
@@ -89,7 +87,9 @@ namespace NuGetGallery.Framework
             updater.RegisterInstance(new EntityRepository<PackageRegistration>(fakeContext))
                 .As<IEntityRepository<PackageRegistration>>();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             updater.Update(Container);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return fakeContext;
         }
@@ -125,7 +125,9 @@ namespace NuGetGallery.Framework
 
                 var updater = new ContainerBuilder();
                 updater.RegisterInstance(mockInstance).As<T>();
+#pragma warning disable CS0618 // Type or member is obsolete
                 updater.Update(Container);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             T instance = Container.Resolve<T>();


### PR DESCRIPTION
Addresses feedback from #6011 
- Removed `ISqlConnectionFactory` keyed registration (registration actually only needed for Gallery DB)
- Upgrade to Autofac v4.6.2
  - aligns with version from NuGet.Jobs
  - supports attribute-based keyed registrations, if we eventually need it
  - deprecates `Container.Update` which is discouraged
- Test updates related to Autofac v4.6.2 deprecation of `Container.Update`
