### PR TITLE
Setup: packageRef migration fix

### DIFF
--- a/tools/Update-Databases.ps1
+++ b/tools/Update-Databases.ps1
@@ -5,7 +5,7 @@ param(
 
 function Initialize-MigrateExe() {
     [string] $migrateDirectory = [System.IO.Path]::Combine($PSScriptRoot, '__temp_migrate_directory_' + [guid]::NewGuid().ToString("N") )
-    [string] $efDirectory = [System.IO.Path]::Combine($PSScriptRoot, '..\packages\EntityFramework.6.1.3')
+    [string] $efDirectory = [System.IO.Path]::Combine($PSScriptRoot, '${env:userprofile}\.nuget\packages\EntityFramework\6.1.3')
     [string] $migrate = ([System.IO.Path]::Combine($migrateDirectory, 'migrate.exe'))
 
     if (-not (New-Item -ItemType Directory -Path $migrateDirectory -Force).Exists) {


### PR DESCRIPTION
Fixes setup script by using the global packages cache, which PackageRef restore uses.