### PR TITLE
Regression fix: validation db dependency

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -406,7 +406,7 @@ namespace NuGetGallery
             return Task.Run(() => connectionFactory.CreateAsync()).Result;
         }
 
-        private static void ConfigureValidationAdmin(ContainerBuilder builder, ConfigurationService configuration, ISecretInjector secretInjector)
+        private static void ConfigureValidationEntitiesContext(ContainerBuilder builder, ConfigurationService configuration, ISecretInjector secretInjector)
         {
             var connectionString = configuration.Current.SqlConnectionStringValidation;
             var validationDbConnectionFactory = new AzureSqlConnectionFactory(connectionString, secretInjector);
@@ -422,16 +422,10 @@ namespace NuGetGallery
             builder.RegisterType<ValidationEntityRepository<PackageValidation>>()
                 .As<IEntityRepository<PackageValidation>>()
                 .InstancePerLifetimeScope();
-
-            builder.RegisterType<ValidationAdminService>()
-                .AsSelf()
-                .InstancePerLifetimeScope();
         }
 
         private void RegisterAsynchronousValidation(ContainerBuilder builder, ConfigurationService configuration, ISecretInjector secretInjector)
         {
-            ConfigureValidationAdmin(builder, configuration, secretInjector);
-
             builder
                 .RegisterType<ServiceBusMessageSerializer>()
                 .As<IServiceBusMessageSerializer>();
@@ -442,6 +436,8 @@ namespace NuGetGallery
 
             if (configuration.Current.AsynchronousPackageValidationEnabled)
             {
+                ConfigureValidationEntitiesContext(builder, configuration, secretInjector);
+
                 builder
                     .RegisterType<AsynchronousPackageValidationInitiator>()
                     .As<IPackageValidationInitiator>();
@@ -465,6 +461,10 @@ namespace NuGetGallery
                     .RegisterType<ImmediatePackageValidator>()
                     .As<IPackageValidationInitiator>();
             }
+
+            builder.RegisterType<ValidationAdminService>()
+                .AsSelf()
+                .InstancePerLifetimeScope();
         }
 
         private static void ConfigureSearch(ContainerBuilder builder, IGalleryConfigurationService configuration)

--- a/tests/NuGetGallery.Facts/Services/ValidationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ValidationServiceFacts.cs
@@ -395,8 +395,8 @@ namespace NuGetGallery
                     _appConfiguration.Object,
                     _packageService.Object,
                     _initiator.Object,
-                    _validationSets.Object,
-                    _telemetryService.Object);
+                    _telemetryService.Object,
+                    _validationSets.Object);
             }
         }
     }


### PR DESCRIPTION
Regression: The SQL AAD work changed EF context behavior by creating/opening DB connections upfront at EF context construction... instead of passing in connectionString and deferring the connection until EF execution. This caused a dependency on the validation DB when creating the `ValidationService`, which isn't done behind a feature flag. Note that the `ValidationAdminService` is used by `ValidationController`, which is behind the feature flag... so I left it alone.

Fix: make the `IEntityRepository<PackageValidationSet>` an optional argument to the ValidationService.

Also opened the following to investigate deferring connections when I have more time:
- https://github.com/NuGet/Engineering/issues/1472