### PR TITLE
Defer open of DB connection to EF context

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2168,7 +2168,7 @@
       <Version>2.26.0-master-33065</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.26.0-master-33065</Version>
+      <Version>2.26.0-chenriks-sqlconnection-33142</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
       <Version>2.26.0-master-33065</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2153,7 +2153,7 @@
       <Version>4.3.0-preview1-2524</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.26.0-master-33065</Version>
+      <Version>2.26.0-master-33196</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
       <Version>2.2.3</Version>
@@ -2165,16 +2165,16 @@
       <Version>3.0.29-r-master</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.26.0-master-33065</Version>
+      <Version>2.26.0-master-33196</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.26.0-chenriks-sqlconnection-33142</Version>
+      <Version>2.26.0-master-33196</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.26.0-master-33065</Version>
+      <Version>2.26.0-master-33196</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.26.0-master-33065</Version>
+      <Version>2.26.0-master-33196</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>4.3.0-preview1-2524</Version>


### PR DESCRIPTION
Depends on https://github.com/NuGet/ServerCommon/pull/162
Fixes https://github.com/NuGet/Engineering/issues/1472

Alternative to https://github.com/NuGet/NuGetGallery/pull/6063, but I think we should do both:
- Don't connect to validation DB unless feature flag is enabled
- Defer DB connection open to the EF context