### PR TITLE
Update client library references

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -231,19 +231,19 @@
       <Version>9.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Common">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging.Core">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>7.1.2</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2135,22 +2135,22 @@
       <Version>9.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Common">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Configuration">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging.Core">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
       <Version>2.26.0-master-33065</Version>
@@ -2177,7 +2177,7 @@
       <Version>2.26.0-master-33065</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
-      <Version>4.3.0-preview1-2524</Version>
+      <Version>4.8.0-preview1.5156</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>


### PR DESCRIPTION
Updating our references to NuGet.Client libraries in preparation to consume an upcoming change.

All tests pass. Manual scenario pass doesn't seem to indicate any obvious scenario failures.