### PR TITLE
Add Zip Entry restriction

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -231,19 +231,19 @@
       <Version>9.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Common">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging.Core">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>7.1.2</Version>

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -365,7 +365,7 @@ namespace NuGetGallery
                     {
                         try
                         {
-                            PackageService.EnsureValid(packageToPush);
+                            await PackageService.EnsureValid(packageToPush);
                         }
                         catch (Exception ex)
                         {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -273,7 +273,7 @@ namespace NuGetGallery
                 {
                     packageArchiveReader = CreatePackage(uploadStream);
 
-                    _packageService.EnsureValid(packageArchiveReader);
+                    await _packageService.EnsureValid(packageArchiveReader);
                 }
                 catch (Exception ex)
                 {

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -442,12 +442,12 @@ namespace NuGetGallery
 
             var packages = PackageService.FindPackagesByAnyMatchingOwner(currentUser, includeUnlisted: true);
             var listedPackages = packages
-                .Where(p => p.Listed)
+                .Where(p => p.Listed && p.PackageStatusKey == PackageStatus.Available)
                 .Select(p => new ListPackageItemRequiredSignerViewModel(p, currentUser, SecurityPolicyService, wasAADLoginOrMultiFactorAuthenticated))
                 .OrderBy(p => p.Id)
                 .ToList();
             var unlistedPackages = packages
-                .Where(p => !p.Listed)
+                .Where(p => !p.Listed || p.PackageStatusKey != PackageStatus.Available)
                 .Select(p => new ListPackageItemRequiredSignerViewModel(p, currentUser, SecurityPolicyService, wasAADLoginOrMultiFactorAuthenticated))
                 .OrderBy(p => p.Id)
                 .ToList();

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2135,22 +2135,22 @@
       <Version>9.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Common">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Configuration">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging.Core">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
       <Version>2.26.0-master-33196</Version>
@@ -2177,7 +2177,7 @@
       <Version>2.26.0-master-33196</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
-      <Version>4.8.0-preview1.5156</Version>
+      <Version>4.8.0-preview4.5287</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -72,7 +72,7 @@ namespace NuGetGallery
 
         Task SetLicenseReportVisibilityAsync(Package package, bool visible, bool commitChanges = true);
 
-        void EnsureValid(PackageArchiveReader packageArchiveReader);
+        Task EnsureValid(PackageArchiveReader packageArchiveReader);
 
         Task IncrementDownloadCountAsync(string id, string version, bool commitChanges = true);
 

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
 using NuGet.Packaging;
@@ -67,7 +68,7 @@ namespace NuGetGallery
                 }
 
                 // This will throw if the package contains an entry which will extract outside of the target extraction directory
-                await packageArchiveReader.ValidatePackageEntriesAsync(new System.Threading.CancellationToken());
+                await packageArchiveReader.ValidatePackageEntriesAsync(CancellationToken.None);
             }
             catch (Exception exception) when (exception is EntityException || exception is PackagingException)
             {

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -48,7 +48,7 @@ namespace NuGetGallery
         /// <exception cref="InvalidPackageException">
         /// This exception will be thrown when a package metadata property violates a data validation constraint.
         /// </exception>
-        public void EnsureValid(PackageArchiveReader packageArchiveReader)
+        public async Task EnsureValid(PackageArchiveReader packageArchiveReader)
         {
             try
             {
@@ -67,7 +67,7 @@ namespace NuGetGallery
                 }
 
                 // This will throw if the package contains an entry which will extract outside of the target extraction directory
-                packageArchiveReader.ValidatePackageEntriesAsync(new System.Threading.CancellationToken()).GetAwaiter().GetResult();
+                await packageArchiveReader.ValidatePackageEntriesAsync(new System.Threading.CancellationToken());
             }
             catch (Exception exception) when (exception is EntityException || exception is PackagingException)
             {

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -65,6 +65,9 @@ namespace NuGetGallery
                 {
                     ValidateSupportedFrameworks(supportedFrameworks);
                 }
+
+                // This will throw if the package contains an entry which will extract outside of the target extraction directory
+                packageArchiveReader.ValidatePackageEntriesAsync(new System.Threading.CancellationToken()).GetAwaiter().GetResult();
             }
             catch (Exception exception) when (exception is EntityException || exception is PackagingException)
             {


### PR DESCRIPTION
Adds an additional nupkg validation that will fail if a package contains any entries that would result in extraction outside of the target extraction directory.

See https://github.com/NuGet/NuGet.Client/pull/2296 and https://github.com/NuGet/NuGet.Client/pull/2302 for client change details

NuGet Client:
![image](https://user-images.githubusercontent.com/11051729/41493142-2e918f88-70b9-11e8-9c69-3291b20a8f5c.png)

NuGet Website:
![image](https://user-images.githubusercontent.com/11051729/41493153-48d8918e-70b9-11e8-9686-728619eb1ca6.png)
