### PR TITLE
ApiController actions should not throw exceptions when called with an unparseable version

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -765,20 +765,12 @@ namespace NuGetGallery
 
         private HttpStatusCodeWithBodyResult GetHttpResultFromFailedApiScopeEvaluation(ApiScopeEvaluationResult evaluationResult, string id, string versionString)
         {
-            if (NuGetVersion.TryParse(versionString, out var version))
-            {
-
-                return GetHttpResultFromFailedApiScopeEvaluation(evaluationResult, id, version);
-            }
-            else
-            {
-                return GetHttpResultFromFailedApiScopeEvaluation(evaluationResult, id, versionString);
-            }
+            return GetHttpResultFromFailedApiScopeEvaluationHelper(evaluationResult, id, versionString, HttpStatusCode.Forbidden);
         }
 
         private HttpStatusCodeWithBodyResult GetHttpResultFromFailedApiScopeEvaluation(ApiScopeEvaluationResult result, string id, NuGetVersion version)
         {
-            return GetHttpResultFromFailedApiScopeEvaluationHelper(result, id, version, HttpStatusCode.Forbidden);
+            return GetHttpResultFromFailedApiScopeEvaluation(result, id, ParseNuGetVersionForHttpResultForFailedApiScopeEvaluation(version));
         }
 
         /// <remarks>
@@ -787,12 +779,12 @@ namespace NuGetGallery
         /// </remarks>
         private HttpStatusCodeWithBodyResult GetHttpResultFromFailedApiScopeEvaluationForPush(ApiScopeEvaluationResult result, string id, NuGetVersion version)
         {
-            return GetHttpResultFromFailedApiScopeEvaluationHelper(result, id, version, HttpStatusCode.Unauthorized);
+            return GetHttpResultFromFailedApiScopeEvaluationHelper(result, id, ParseNuGetVersionForHttpResultForFailedApiScopeEvaluation(version), HttpStatusCode.Unauthorized);
         }
 
-        private HttpStatusCodeWithBodyResult GetHttpResultFromFailedApiScopeEvaluationHelper(ApiScopeEvaluationResult result, string id, NuGetVersion version, HttpStatusCode statusCodeOnFailure)
+        private string ParseNuGetVersionForHttpResultForFailedApiScopeEvaluation(NuGetVersion version)
         {
-            return GetHttpResultFromFailedApiScopeEvaluationHelper(result, id, version.ToNormalizedString(), HttpStatusCode.Unauthorized);
+            return version.ToNormalizedString();
         }
 
         private HttpStatusCodeWithBodyResult GetHttpResultFromFailedApiScopeEvaluationHelper(ApiScopeEvaluationResult result, string id, string versionString, HttpStatusCode statusCodeOnFailure)

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -768,23 +768,13 @@ namespace NuGetGallery
             return GetHttpResultFromFailedApiScopeEvaluationHelper(evaluationResult, id, versionString, HttpStatusCode.Forbidden);
         }
 
-        private HttpStatusCodeWithBodyResult GetHttpResultFromFailedApiScopeEvaluation(ApiScopeEvaluationResult result, string id, NuGetVersion version)
-        {
-            return GetHttpResultFromFailedApiScopeEvaluation(result, id, ParseNuGetVersionForHttpResultForFailedApiScopeEvaluation(version));
-        }
-
         /// <remarks>
         /// Push returns <see cref="HttpStatusCode.Unauthorized"/> instead of <see cref="HttpStatusCode.Forbidden"/> for failures not related to reserved namespaces.
         /// This is inconsistent with both the rest of our API and the HTTP standard, but it is an existing behavior that we must support.
         /// </remarks>
         private HttpStatusCodeWithBodyResult GetHttpResultFromFailedApiScopeEvaluationForPush(ApiScopeEvaluationResult result, string id, NuGetVersion version)
         {
-            return GetHttpResultFromFailedApiScopeEvaluationHelper(result, id, ParseNuGetVersionForHttpResultForFailedApiScopeEvaluation(version), HttpStatusCode.Unauthorized);
-        }
-
-        private string ParseNuGetVersionForHttpResultForFailedApiScopeEvaluation(NuGetVersion version)
-        {
-            return version.ToNormalizedString();
+            return GetHttpResultFromFailedApiScopeEvaluationHelper(result, id, version.ToNormalizedString(), HttpStatusCode.Unauthorized);
         }
 
         private HttpStatusCodeWithBodyResult GetHttpResultFromFailedApiScopeEvaluationHelper(ApiScopeEvaluationResult result, string id, string versionString, HttpStatusCode statusCodeOnFailure)

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -726,12 +726,13 @@ namespace NuGetGallery
             {
                 // Arrange
                 var packageId = "theId";
+                var packageVersion = "1.0.42";
                 var packageRegistration = new PackageRegistration { Id = packageId };
                 packageRegistration.Id = packageId;
                 var package = new Package
                 {
                     PackageRegistration = packageRegistration,
-                    Version = "1.0.42"
+                    Version = packageVersion
                 };
                 packageRegistration.Packages.Add(package);
 
@@ -743,7 +744,7 @@ namespace NuGetGallery
                 var currentUser = fakes.User;
                 controller.SetCurrentUser(currentUser);
 
-                var nuGetPackage = TestPackage.CreateTestPackageStream(packageId, "1.0.42");
+                var nuGetPackage = TestPackage.CreateTestPackageStream(packageId, packageVersion);
                 controller.SetupPackageFromInputStream(nuGetPackage);
 
                 controller.MockApiScopeEvaluator
@@ -917,9 +918,11 @@ namespace NuGetGallery
                 var currentUser = fakes.User;
 
                 var id = "theId";
+                var version = "some version"; // We are using an invalid version string to guarantee it is not attempted to be parsed into a NuGetVersion.
                 var package = new Package
                 {
-                    PackageRegistration = new PackageRegistration { Id = id }
+                    PackageRegistration = new PackageRegistration { Id = id },
+                    Version = version
                 };
 
                 var controller = new TestableApiController(GetConfigurationService());
@@ -936,7 +939,7 @@ namespace NuGetGallery
                         NuGetScopes.PackageUnlist))
                     .Returns(evaluationResult);
 
-                var result = await controller.DeletePackage("theId", "1.0.42");
+                var result = await controller.DeletePackage(id, version);
 
                 ResultAssert.IsStatusCode(
                     result,
@@ -1248,9 +1251,11 @@ namespace NuGetGallery
                 var currentUser = fakes.User;
 
                 var id = "theId";
+                var version = "some version"; // We are using an invalid version string to guarantee it is not attempted to be parsed into a NuGetVersion.
                 var package = new Package
                 {
-                    PackageRegistration = new PackageRegistration { Id = id }
+                    PackageRegistration = new PackageRegistration { Id = id },
+                    Version = version
                 };
 
                 var controller = new TestableApiController(GetConfigurationService());
@@ -1267,7 +1272,7 @@ namespace NuGetGallery
                         NuGetScopes.PackageUnlist))
                     .Returns(evaluationResult);
 
-                var result = await controller.PublishPackage("theId", "1.0.42");
+                var result = await controller.PublishPackage(id, version);
 
                 ResultAssert.IsStatusCode(
                     result,
@@ -1569,6 +1574,7 @@ namespace NuGetGallery
             public async Task Returns403IfScopeDoesNotMatch(string credentialType, string[] expectedRequestedActions, ApiScopeEvaluationResult apiScopeEvaluationResult, HttpStatusCode expectedStatusCode, string description)
             {
                 // Arrange
+                PackageVersion = "some version"; // We are using an invalid version string to guarantee it is not attempted to be parsed into a NuGetVersion.
                 var package = new Package
                 {
                     PackageRegistration = new PackageRegistration() { Id = PackageId },

--- a/tests/NuGetGallery.Facts/Framework/MemberDataHelper.cs
+++ b/tests/NuGetGallery.Facts/Framework/MemberDataHelper.cs
@@ -18,13 +18,25 @@ namespace NuGetGallery.Framework
             return dataSet.Select(d => new[] { d });
         }
 
-        public static IEnumerable<object[]> Combine(IEnumerable<object[]> firstDataSet, IEnumerable<object[]> secondDataSet)
+        public static IEnumerable<object[]> Combine(params IEnumerable<object[]>[] dataSets)
         {
+            if (!dataSets.Any())
+            {
+                yield break;
+            }
+
+            var firstDataSet = dataSets.First();
+            var lastDataSet = Combine(dataSets.Skip(1).ToArray()).ToArray();
             foreach (var firstData in firstDataSet)
             {
-                foreach (var secondData in secondDataSet)
+                foreach (var lastData in lastDataSet)
                 {
-                    yield return firstData.Concat(secondData).ToArray();
+                    yield return firstData.Concat(lastData).ToArray();
+                }
+
+                if (!lastDataSet.Any())
+                {
+                    yield return firstData;
                 }
             }
         }


### PR DESCRIPTION
If `VerifyPackageKeyAsync`, `DeletePackage`, or `PublishPackage` were called without a valid version string, they could throw because the `NuGetVersion.Parse` used in `GetHttpResultFromFailedApiScopeEvaluation` would throw. This fixes that issue.