### PR TITLE
Update README.md

### DIFF
--- a/docs/Deploying/README.md
+++ b/docs/Deploying/README.md
@@ -66,7 +66,7 @@ Replacing '[servername]', 'sa' and '[sapassword]' with the name of your Azure SQ
 In the Package Manager console, type the following command
 
 ```PowerShell
-Update-Database -ConnectionString "[ConnectionString]" -ConnectionProviderName System.Data.SqlClient
+Update-Database -ConnectionString "[ConnectionString]" -ConnectionProviderName System.Data.SqlClient -ConfigurationTypeName MigrationsConfiguration
 ```
 
 Replacing '[ConnectionString]' with the connection string you just crafted. The command should succeed and you should have a fully prepared database!


### PR DESCRIPTION
Fixed the Update-Database command as per the following issue thread (https://github.com/NuGet/NuGetGallery/issues/2923#issuecomment-192675346), multiple configurations have been added since this readme was authored, so you must now explicitly state which configuration you want to use, otherwise you will get the following error:

System.Data.Entity.Migrations.Infrastructure.MigrationsException: More than one migrations configuration type was found in the assembly 'NuGetGallery'.