### PR TITLE
Fix organization's profile picture wording

### DIFF
--- a/src/NuGetGallery/Views/Shared/_AccountProfilePicture.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountProfilePicture.cshtml
@@ -6,13 +6,13 @@
     {
         ViewBag.UnconfirmedEmailAddressMessage = "This is a preview of how the profile picture will look once the organization email address is verified.";
         ViewBag.GravatarProfileMessage = "We use the verified email address for your organization and {0} to get the publicly visible profile picture. "
-            + "{1} to change the profile picture for your organization.";
+            + "Go to {0} to change the profile picture for your organization.";
     }
     else
     {
         ViewBag.UnconfirmedEmailAddressMessage = "This is a preview of how your profile picture will look once you have verified your current email address.";
         ViewBag.GravatarProfileMessage = "We use your verified email address and {0} to get the publicly visible profile picture. "
-            + "{1} to change your profile picture";
+            + "Go to {0} to change your profile picture";
     }
 }
 
@@ -32,8 +32,7 @@
         }
 
         @Html.Raw(string.Format(@ViewBag.GravatarProfileMessage,
-             GravatarLink("gravatar.com"),
-             GravatarLink("Go to gravatar.com")))
+             GravatarLink("gravatar.com")))
     </text>,
     disabled: !Model.CanManage)
 

--- a/src/NuGetGallery/Views/Shared/_AccountProfilePicture.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountProfilePicture.cshtml
@@ -6,7 +6,7 @@
     {
         ViewBag.UnconfirmedEmailAddressMessage = "This is a preview of how the profile picture will look once the organization email address is verified.";
         ViewBag.GravatarProfileMessage = "We use the verified email address for your organization and {0} to get the publicly visible profile picture. "
-            + "{0} to change the profile picture for your organization.";
+            + "{1} to change the profile picture for your organization.";
     }
     else
     {


### PR DESCRIPTION
Current wording:

> We use the verified email address for your organization and gravatar.com to get the publicly visible profile picture. gravatar.com to change the profile picture for your organization.

Fixed wording:

> We use the verified email address for your organization and gravatar.com to get the publicly visible profile picture. Go to gravatar.com to change the profile picture for your organization.

Fixes https://github.com/NuGet/NuGetGallery/issues/6096