### PR TITLE
Improve gallery user experience for package reupload

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -801,6 +801,10 @@ img.reserved-indicator-icon {
 .page-package-details .package-title .reserved-indicator {
   width: 25px;
 }
+.page-package-details .failed-validation-alert-list {
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
 .page-package-details .package-details-main {
   word-break: normal;
   word-break: break-word;
@@ -1153,7 +1157,8 @@ img.reserved-indicator-icon {
 .page-manage-owners .current-owner .remove-owner-disabled .icon-link:hover span {
   text-decoration: none;
 }
-.page-manage-packages .organizations-divider {
+.page-manage-packages .organizations-divider,
+.page-manage-packages .packages-divider {
   color: #dbdbdb;
 }
 .page-manage-packages h1 {

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -19,6 +19,11 @@
     }
   }
 
+  .failed-validation-alert-list {
+    margin-top: 15px;
+    margin-bottom: 15px;
+  }
+
   .package-details-main {
     .break-word;
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1,3 +1,5 @@
+@using NuGet.Services.Validation;
+
 @model DisplayPackageViewModel
 @{
     ViewBag.Title = Model.Id + " " + Model.Version;
@@ -196,13 +198,25 @@
 
             @if (Model.FailedValidation)
             {
-                foreach (var issue in Model.ValidationIssues)
-                {
-                    @ViewHelpers.AlertDanger(
-                        @<text>
-                            @Html.Partial("_ValidationIssue", issue)
-                        </text>)
-                }
+                @ViewHelpers.AlertDanger(
+                    @<text>
+                        <strong>Package publishing failed.</strong> This package could not be published due to the following reason(s):
+                        <ul class="failed-validation-alert-list">
+                            @foreach (var issue in Model.ValidationIssues)
+                            {
+                                <li>@Html.Partial("_ValidationIssue", issue)</li>
+                            }
+                        </ul>
+                        @if (!Model.ValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+                        {
+                            var issuePluralString = Model.ValidationIssues.Count() > 1 ? "all the issues" : "the issue";
+                            <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
+                        }
+                        else
+                        {
+                            <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
+                        }
+                    </text>)
             }
 
             @if (Model.Deleted)

--- a/src/NuGetGallery/Views/Packages/_ValidationIssue.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ValidationIssue.cshtml
@@ -6,8 +6,7 @@
 {
     case ValidationIssueCode.PackageIsSigned:
         <text>
-            <b>Package publishing failed.</b> This package could not be published since it is signed. We do not accept
-            signed packages at this moment. To be notified about package signing and more, watch our
+            We do not accept signed packages at this moment. To be notified about package signing and more, watch our
             <a href="https://github.com/nuget/announcements/issues">Announcements</a> page or follow us on
             <a href="https://twitter.com/nuget">Twitter</a>.
         </text>
@@ -47,21 +46,21 @@
         break;
     case ValidationIssueCode.PackageIsNotSigned:
         <text>
-            <b>Package publishing failed.</b> The package must be signed with a registered certificate. <a href="https://aka.ms/nuget-signed-ref">Read more...</a>
+            This package must be signed with a registered certificate. <a href="https://aka.ms/nuget-signed-ref">Read more...</a>
         </text>
         break;
     case ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate:
         {
             var typedIssue = (UnauthorizedCertificateFailure)Model;
             <text>
-                <b>Package publishing failed.</b> The package was signed, but the signing certificate (SHA-1 thumbprint @typedIssue.Sha1Thumbprint) is not associated with your account. You must register this certificate to publish signed packages. <a href="https://aka.ms/nuget-signed-ref">Read more...</a>
+                The package was signed, but the signing certificate (SHA-1 thumbprint @typedIssue.Sha1Thumbprint) is not associated with your account.
+                You must register this certificate to publish signed packages. <a href="https://aka.ms/nuget-signed-ref">Read more...</a>
             </text>
             break;
         }
     default:
         <text>
-            <strong>Package publishing failed.</strong> This package could not be published since package validation
-            failed. Please contact <a href="mailto:support@nuget.org">support@nuget.org</a>.
+            There was an unknown failure when validating your package.
         </text>
         break;
 }

--- a/tests/NuGetGallery.Facts/Views/Packages/ValidationIssueFacts.cs
+++ b/tests/NuGetGallery.Facts/Views/Packages/ValidationIssueFacts.cs
@@ -16,9 +16,7 @@ namespace NuGetGallery.Views.Packages
 {
     public class ValidationIssueFacts
     {
-        private const string UnknownIssueMessage = "<strong>Package publishing failed.</strong> This package could " +
-            "not be published since package validation failed. Please contact <a href=\"mailto:support@nuget.org\">" +
-            "support@nuget.org</a>.";
+        private const string UnknownIssueMessage = "There was an unknown failure when validating your package.";
         private readonly ITestOutputHelper _output;
 
         public ValidationIssueFacts(ITestOutputHelper output)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18014088/41928445-0d456b6e-792a-11e8-8916-a9024d2fa7dc.png)

In other words:
- show all errors in a single display
- explain that you can reupload the package once you've fixed the issues (or to contact support if validation failed for an unknown reason)