### PR TITLE
Fix the mail template for the addition of a member to an org

### DIFF
--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -882,7 +882,7 @@ The {Config.GalleryOwner.DisplayName} Team");
 
             string subject = $"[{Config.GalleryOwner.DisplayName}] Membership request for organization '{organization.Username}'";
 
-            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{requestingUser.Username}' has requested that user '{pendingUser.Username}' be added as {membershipLevel} of organization '{organization.Username}'.
+            string body = string.Format(CultureInfo.CurrentCulture, $@"The user '{requestingUser.Username}' has requested that user '{pendingUser.Username}' be added as {membershipLevel} of organization '{organization.Username}'. A confirmation mail has been sent to user '{pendingUser.Username}' to accept the membership request. This mail is to inform you of the membership changes to organization '{organization.Username}' and there is no action required from you.
 
 Thanks,
 The {Config.GalleryOwner.DisplayName} Team");


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6022

```
The user 'requestor' has requested that user 'pending' be added as an administrator of organization 'org'. A confirmation mail has been sent to user 'pending' to accept the membership request. This mail is to inform you of the membership changes to organization 'org' and there is no action required from you.
```