### PR TITLE
Include failure reasons in email sent when package validation fails

### DIFF
--- a/src/NuGetGallery.Core/Extensions/PackageValidationSetExtensions.cs
+++ b/src/NuGetGallery.Core/Extensions/PackageValidationSetExtensions.cs
@@ -1,0 +1,29 @@
+﻿using NuGet.Services.Validation;
+using NuGet.Services.Validation.Issues;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGetGallery
+{
+    public static class PackageValidationSetExtensions
+    {
+        public static IReadOnlyList<ValidationIssue> GetValidationIssues(this PackageValidationSet validationSet)
+        {
+            // Get the failed validation set's validation issues. The issues are ordered by their
+            // key so that it appears that issues are appended as more validations fail.
+            var issues = validationSet
+                .PackageValidations
+                .SelectMany(v => v.PackageValidationIssues)
+                .OrderBy(i => i.Key)
+                .Select(i => ValidationIssue.Deserialize(i.IssueCode, i.Data))
+                .ToList();
+
+            // Filter out unknown issues and deduplicate the issues by code and data. This also deduplicates cases
+            // where there is extraneous data in the serialized data field or if the issue code is unknown.
+            return issues
+                .GroupBy(x => new { x.IssueCode, Data = x.Serialize() })
+                .Select(x => x.First())
+                .ToList();
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Extensions/PackageValidationSetExtensions.cs
+++ b/src/NuGetGallery.Core/Extensions/PackageValidationSetExtensions.cs
@@ -9,29 +9,34 @@ namespace NuGetGallery
     {
         public static IReadOnlyList<ValidationIssue> GetValidationIssues(this PackageValidationSet validationSet)
         {
-            // Get the failed validation set's validation issues. The issues are ordered by their
-            // key so that it appears that issues are appended as more validations fail.
-            var issues = validationSet
-                .PackageValidations
-                .SelectMany(v => v.PackageValidationIssues)
-                .OrderBy(i => i.Key)
-                .Select(i => ValidationIssue.Deserialize(i.IssueCode, i.Data))
-                .ToList();
+            IReadOnlyList<ValidationIssue> issues = null;
 
-            // Filter out unknown issues and deduplicate the issues by code and data. This also deduplicates cases
-            // where there is extraneous data in the serialized data field or if the issue code is unknown.
-            IReadOnlyList<ValidationIssue> groupedIssues = issues
-                .GroupBy(x => new { x.IssueCode, Data = x.Serialize() })
-                .Select(x => x.First())
-                .ToList();
-
-            // If the package failed validation but we could not find an issue that explains why, use a generic error message.
-            if (groupedIssues == null || !groupedIssues.Any())
+            if (validationSet != null)
             {
-                groupedIssues = new[] { ValidationIssue.Unknown };
+                // Get the failed validation set's validation issues. The issues are ordered by their
+                // key so that it appears that issues are appended as more validations fail.
+                issues = validationSet
+                    .PackageValidations
+                    .SelectMany(v => v.PackageValidationIssues)
+                    .OrderBy(i => i.Key)
+                    .Select(i => ValidationIssue.Deserialize(i.IssueCode, i.Data))
+                    .ToList();
+
+                // Filter out unknown issues and deduplicate the issues by code and data. This also deduplicates cases
+                // where there is extraneous data in the serialized data field or if the issue code is unknown.
+                issues = issues
+                    .GroupBy(x => new { x.IssueCode, Data = x.Serialize() })
+                    .Select(x => x.First())
+                    .ToList();
             }
 
-            return groupedIssues;
+            // If the package failed validation but we could not find an issue that explains why, use a generic error message.
+            if (issues == null || !issues.Any())
+            {
+                issues = new[] { ValidationIssue.Unknown };
+            }
+
+            return issues;
         }
     }
 }

--- a/src/NuGetGallery.Core/Extensions/PackageValidationSetExtensions.cs
+++ b/src/NuGetGallery.Core/Extensions/PackageValidationSetExtensions.cs
@@ -20,10 +20,18 @@ namespace NuGetGallery
 
             // Filter out unknown issues and deduplicate the issues by code and data. This also deduplicates cases
             // where there is extraneous data in the serialized data field or if the issue code is unknown.
-            return issues
+            IReadOnlyList<ValidationIssue> groupedIssues = issues
                 .GroupBy(x => new { x.IssueCode, Data = x.Serialize() })
                 .Select(x => x.First())
                 .ToList();
+
+            // If the package failed validation but we could not find an issue that explains why, use a generic error message.
+            if (groupedIssues == null || !groupedIssues.Any())
+            {
+                groupedIssues = new[] { ValidationIssue.Unknown };
+            }
+
+            return groupedIssues;
         }
     }
 }

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Entities\User.cs" />
     <Compile Include="Extensions\EntitiesContextExtensions.cs" />
     <Compile Include="Extensions\PackageRegistrationExtensions.cs" />
+    <Compile Include="Extensions\PackageValidationSetExtensions.cs" />
     <Compile Include="Extensions\UserExtensionsCore.cs" />
     <Compile Include="ICloudStorageStatusDependency.cs" />
     <Compile Include="Infrastructure\AzureEntityList.cs" />
@@ -241,6 +242,12 @@
     </PackageReference>
     <PackageReference Include="NuGet.Packaging.Core">
       <Version>4.8.0-preview4.5287</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Validation">
+      <Version>2.26.0-master-33196</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Validation.Issues">
+      <Version>2.26.0-master-33196</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>4.8.0-preview4.5287</Version>

--- a/src/NuGetGallery.Core/Services/CoreMessageService.cs
+++ b/src/NuGetGallery.Core/Services/CoreMessageService.cs
@@ -105,7 +105,7 @@ Your package was not published on {CoreConfiguration.GalleryOwner.DisplayName} a
                     return $"This package could not be published since it is signed. We do not accept signed packages at this moment. To be notified about package signing and more, watch our [Announcements]({announcementsUrl}) page or follow us on [Twitter]({twitterUrl}).";
                 case ValidationIssueCode.ClientSigningVerificationFailure:
                     var clientIssue = (ClientSigningVerificationFailure)validationIssue;
-                    return $"*{clientIssue.ClientCode}*: {clientIssue.ClientMessage}";
+                    return $"**{clientIssue.ClientCode}**: {clientIssue.ClientMessage}";
                 case ValidationIssueCode.PackageIsZip64:
                     return "Zip64 packages are not supported.";
                 case ValidationIssueCode.OnlyAuthorSignaturesSupported:
@@ -113,7 +113,7 @@ Your package was not published on {CoreConfiguration.GalleryOwner.DisplayName} a
                 case ValidationIssueCode.AuthorAndRepositoryCounterSignaturesNotSupported:
                     return "Author countersignatures and repository countersignatures are not supported.";
                 case ValidationIssueCode.OnlySignatureFormatVersion1Supported:
-                    return "*NU3007:* Package signatures must have format version 1.";
+                    return "**NU3007:** Package signatures must have format version 1.";
                 case ValidationIssueCode.AuthorCounterSignaturesNotSupported:
                     return "Author countersignatures are not supported.";
                 case ValidationIssueCode.PackageIsNotSigned:

--- a/src/NuGetGallery.Core/Services/CoreMessageService.cs
+++ b/src/NuGetGallery.Core/Services/CoreMessageService.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Mail;
 using AnglicanGeek.MarkdownMailer;
+using NuGet.Services.Validation;
+using NuGet.Services.Validation.Issues;
 
 namespace NuGetGallery.Services
 {
@@ -50,21 +52,35 @@ namespace NuGetGallery.Services
             }
         }
 
-        public void SendPackageValidationFailedNotice(Package package, string packageUrl, string packageSupportUrl)
+        public void SendPackageValidationFailedNotice(Package package, PackageValidationSet validationSet, string packageUrl, string packageSupportUrl, string announcementsUrl, string twitterUrl)
         {
-            string subject = "[{0}] Package validation failed - {1} {2}";
-            string body = @"The package [{1} {2}]({3}) failed validation and was therefore not published on {0}. Note that the package will not be available for consumption and you will not be able to push the same package ID and version until further action is taken. Please [contact support]({4}) for next steps.";
+            var validationIssues = validationSet.GetValidationIssues();
 
-            body = string.Format(
-                CultureInfo.CurrentCulture,
-                body,
-                CoreConfiguration.GalleryOwner.DisplayName,
-                package.PackageRegistration.Id,
-                package.Version,
-                packageUrl,
-                packageSupportUrl);
+            var subject = $"[{CoreConfiguration.GalleryOwner.DisplayName}] Package validation failed - {package.PackageRegistration.Id} {package.Version}";
+            var body = $@"The package [{package.PackageRegistration.Id} {package.Version}]({packageUrl}) failed validation because of the following reason(s):
+";
 
-            subject = string.Format(CultureInfo.CurrentCulture, subject, CoreConfiguration.GalleryOwner.DisplayName, package.PackageRegistration.Id, package.Version);
+            foreach (var validationIssue in validationIssues)
+            {
+                body += $@"
+- {ParseValidationIssue(validationIssue, announcementsUrl, twitterUrl)}";
+            }
+
+            body += $@"
+
+Your package was not published on {CoreConfiguration.GalleryOwner.DisplayName} and is not available for consumption.
+
+";
+
+            if (validationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+            {
+                body += $"Please [contact support]({packageSupportUrl}) to help fix your package.";
+            }
+            else
+            {
+                var issuePluralString = validationIssues.Count() > 1 ? "all the issues" : "the issue";
+                body += $"Once you've fixed {issuePluralString} with your package, you can reupload it with the same ID and version.";
+            }
 
             using (var mailMessage = new MailMessage())
             {
@@ -81,35 +97,32 @@ namespace NuGetGallery.Services
             }
         }
 
-        public void SendSignedPackageNotAllowedNotice(Package package, string packageUrl, string announcementsUrl, string twitterUrl)
+        private static string ParseValidationIssue(ValidationIssue validationIssue, string announcementsUrl, string twitterUrl)
         {
-            string subject = "[{0}] Package validation failed - {1} {2}";
-            string body = @"The package [{1} {2}]({3}) could not be published since it is signed. {0} does not accept signed packages at this moment. To be notified when {0} starts accepting signed packages, and more, watch our [Announcements]({4}) page or follow us on [Twitter]({5}).";
-
-            body = string.Format(
-                CultureInfo.CurrentCulture,
-                body,
-                CoreConfiguration.GalleryOwner.DisplayName,
-                package.PackageRegistration.Id,
-                package.Version,
-                packageUrl,
-                announcementsUrl,
-                twitterUrl);
-
-            subject = string.Format(CultureInfo.CurrentCulture, subject, CoreConfiguration.GalleryOwner.DisplayName, package.PackageRegistration.Id, package.Version);
-
-            using (var mailMessage = new MailMessage())
+            switch (validationIssue.IssueCode)
             {
-                mailMessage.Subject = subject;
-                mailMessage.Body = body;
-                mailMessage.From = CoreConfiguration.GalleryNoReplyAddress;
-
-                AddAllOwnersToMailMessage(package.PackageRegistration, mailMessage);
-
-                if (mailMessage.To.Any())
-                {
-                    SendMessage(mailMessage, copySender: false);
-                }
+                case ValidationIssueCode.PackageIsSigned:
+                    return $"This package could not be published since it is signed. We do not accept signed packages at this moment. To be notified about package signing and more, watch our [Announcements]({announcementsUrl}) page or follow us on [Twitter]({twitterUrl}).";
+                case ValidationIssueCode.ClientSigningVerificationFailure:
+                    var clientIssue = (ClientSigningVerificationFailure)validationIssue;
+                    return $"*{clientIssue.ClientCode}*: {clientIssue.ClientMessage}";
+                case ValidationIssueCode.PackageIsZip64:
+                    return "Zip64 packages are not supported.";
+                case ValidationIssueCode.OnlyAuthorSignaturesSupported:
+                    return "Signed packages must only have an author signature. Other signature types are not supported.";
+                case ValidationIssueCode.AuthorAndRepositoryCounterSignaturesNotSupported:
+                    return "Author countersignatures and repository countersignatures are not supported.";
+                case ValidationIssueCode.OnlySignatureFormatVersion1Supported:
+                    return "*NU3007:* Package signatures must have format version 1.";
+                case ValidationIssueCode.AuthorCounterSignaturesNotSupported:
+                    return "Author countersignatures are not supported.";
+                case ValidationIssueCode.PackageIsNotSigned:
+                    return "This package must be signed with a registered certificate. [Read more...](https://aka.ms/nuget-signed-ref)";
+                case ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate:
+                    var certIssue = (UnauthorizedCertificateFailure)validationIssue;
+                    return $"The package was signed, but the signing certificate (SHA-1 thumbprint {certIssue.Sha1Thumbprint}) is not associated with your account. You must register this certificate to publish signed packages. [Read more...](https://aka.ms/nuget-signed-ref)";
+                default:
+                    return "There was an unknown failure when validating your package.";
             }
         }
 

--- a/src/NuGetGallery.Core/Services/ICoreMessageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreMessageService.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.Services.Validation;
+
 namespace NuGetGallery.Services
 {
     public interface ICoreMessageService
     {
         void SendPackageAddedNotice(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl);
-        void SendPackageValidationFailedNotice(Package package, string packageUrl, string packageSupportUrl);
-        void SendSignedPackageNotAllowedNotice(Package package, string packageUrl, string announcementsUrl, string twitterUrl);
+        void SendPackageValidationFailedNotice(Package package, PackageValidationSet validationSet, string packageUrl, string packageSupportUrl, string announcementsUrl, string twitterUrl);
         void SendValidationTakingTooLongNotice(Package package, string packageUrl);
     }
 }

--- a/src/NuGetGallery/Services/ValidationService.cs
+++ b/src/NuGetGallery/Services/ValidationService.cs
@@ -91,12 +91,6 @@ namespace NuGetGallery
                 {
                     issues = validationSet.GetValidationIssues();
                 }
-
-                // If the package failed validation but we could not find an issue that explains why, use a generic error message.
-                if (issues == null || !issues.Any())
-                {
-                    issues = new[] { ValidationIssue.Unknown };
-                }
             }
 
             return issues;

--- a/src/NuGetGallery/Services/ValidationService.cs
+++ b/src/NuGetGallery/Services/ValidationService.cs
@@ -71,7 +71,7 @@ namespace NuGetGallery
 
         public IReadOnlyList<ValidationIssue> GetLatestValidationIssues(Package package)
         {
-            var issues = Enumerable.Empty<ValidationIssue>();
+            IReadOnlyList<ValidationIssue> issues = new ValidationIssue[0];
 
             // Only query the database for validation issues if the package has failed validation.
             if (package.PackageStatusKey == PackageStatus.FailedValidation)
@@ -89,30 +89,17 @@ namespace NuGetGallery
 
                 if (validationSet != null)
                 {
-                    // Get the failed validation set's validation issues. The issues are ordered by their
-                    // key so that it appears that issues are appended as more validations fail.
-                    issues = validationSet
-                        .PackageValidations
-                        .SelectMany(v => v.PackageValidationIssues)
-                        .OrderBy(i => i.Key)
-                        .Select(i => ValidationIssue.Deserialize(i.IssueCode, i.Data))
-                        .ToList();
+                    issues = validationSet.GetValidationIssues();
                 }
 
-                // If the package failed validation, use the generic error message.
+                // If the package failed validation but we could not find an issue that explains why, use a generic error message.
                 if (issues == null || !issues.Any())
                 {
                     issues = new[] { ValidationIssue.Unknown };
                 }
             }
 
-            // Filter out unknown issues and deduplicate the issues by code and data. This also deduplicates cases
-            // where there is extraneous data in the serialized data field or if the issue code is unknown to the
-            // gallery.
-            return issues
-                .GroupBy(x => new { x.IssueCode, Data = x.Serialize() })
-                .Select(x => x.First())
-                .ToList();
+            return issues;
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -1228,7 +1228,7 @@ namespace NuGetGallery
                         return $"This package could not be published since it is signed. We do not accept signed packages at this moment. To be notified about package signing and more, watch our [Announcements]({announcementsUrl}) page or follow us on [Twitter]({twitterUrl}).";
                     case ValidationIssueCode.ClientSigningVerificationFailure:
                         var clientIssue = (ClientSigningVerificationFailure)validationIssue;
-                        return $"*{clientIssue.ClientCode}*: {clientIssue.ClientMessage}";
+                        return $"**{clientIssue.ClientCode}**: {clientIssue.ClientMessage}";
                     case ValidationIssueCode.PackageIsZip64:
                         return "Zip64 packages are not supported.";
                     case ValidationIssueCode.OnlyAuthorSignaturesSupported:
@@ -1236,7 +1236,7 @@ namespace NuGetGallery
                     case ValidationIssueCode.AuthorAndRepositoryCounterSignaturesNotSupported:
                         return "Author countersignatures and repository countersignatures are not supported.";
                     case ValidationIssueCode.OnlySignatureFormatVersion1Supported:
-                        return "*NU3007:* Package signatures must have format version 1.";
+                        return "**NU3007:** Package signatures must have format version 1.";
                     case ValidationIssueCode.AuthorCounterSignaturesNotSupported:
                         return "Author countersignatures are not supported.";
                     case ValidationIssueCode.PackageIsNotSigned:

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -1216,7 +1216,7 @@ namespace NuGetGallery
                 }
                 else
                 {
-                    Assert.Contains($"Once you've fixed the issue with your package, you can reupload it with the same ID and version.", message.Body);
+                    Assert.Contains($"You can reupload your package once you've fixed the issue with it.", message.Body);
                 }
             }
 


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6098

Example:

The package [MyPackage 1.0.0]({packageUrl}) failed validation because of the following reason(s):

- *NU3007:* Package signatures must have format version 1.
- This package must be signed with a registered certificate. [Read more...](https://aka.ms/nuget-signed-ref)

Your package was not published on NuGet Gallery and is not available for consumption.

Once you've fixed all the issues with your package, you can reupload it with the same ID and version.