### PR TITLE
Fix NullRef from StorageException.ExtendedErrorInformation

### DIFF
--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -470,7 +470,7 @@ namespace NuGetGallery
                 {
                     return new StorageResult(HttpStatusCode.NotModified, null);
                 }
-                else if (ex.RequestInformation.ExtendedErrorInformation.ErrorCode == BlobErrorCodeStrings.BlobNotFound)
+                else if (ex.RequestInformation.ExtendedErrorInformation?.ErrorCode == BlobErrorCodeStrings.BlobNotFound)
                 {
                     return new StorageResult(HttpStatusCode.NotFound, null);
                 }


### PR DESCRIPTION
Issue #https://github.com/NuGet/NuGetGallery/issues/6081

Was unable to reproduce the NullRefException, and don't see more instances in AI. Originating source from the stack is
https://github.com/NuGet/NuGetGallery/blob/a171bd1a86fad6950e1d0c6531a3c286e9276812/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs#L408

Per https://github.com/Azure/azure-storage-net/issues/271, looks like the Storage SDK can generate `StorageException`'s with `ExtendedErrorInformation` set to null.

Note that WebJobs found the root cause for their null `StorageException.ExtendedErrorInformation` to be a missing binding redirect. I'm doubtful that it's the case here, as there's only 4 instances of this seen in AI. This fix will result in throwing the original exception instead of a `NullReferenceException` which may give us more diagnostics should this continue.