### PR TITLE
Delete org with policies fix

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Controllers/DeleteAccountController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/DeleteAccountController.cs
@@ -30,7 +30,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             if (!string.IsNullOrWhiteSpace(query))
             {
                 var user = _userService.FindByUsername(query);
-                if (user !=  null && user.Username != null && !user.IsDeleted && !(user is Organization))
+                if (user !=  null && user.Username != null && !user.IsDeleted)
                 {
                     var result = new DeleteAccountSearchResult(user.Username);
                     results.Add(result);

--- a/src/NuGetGallery/Security/ISecurityPolicyService.cs
+++ b/src/NuGetGallery/Security/ISecurityPolicyService.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Web;
-using NuGetGallery.Filters;
 
 namespace NuGetGallery.Security
 {
@@ -17,6 +16,11 @@ namespace NuGetGallery.Security
         /// Available user security policy subscriptions.
         /// </summary>
         IEnumerable<IUserSecurityPolicySubscription> UserSubscriptions { get; }
+
+        /// <summary>
+        /// Available organization security policy subscriptions.
+        /// </summary>
+        IEnumerable<IUserSecurityPolicySubscription> OrganizationSubscriptions { get; }
 
         /// <summary>
         /// Check if a user is subscribed to one or more security policies.

--- a/src/NuGetGallery/Security/RequireOrganizationTenantPolicy.cs
+++ b/src/NuGetGallery/Security/RequireOrganizationTenantPolicy.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery.Security
 {
     public class RequireOrganizationTenantPolicy : UserSecurityPolicyHandler, IUserSecurityPolicySubscription
     {
-        public const string _SubscriptionName = "AzureActiveDirectoryTenant";
+        public const string _SubscriptionName = nameof(RequireOrganizationTenantPolicy);
         public const string PolicyName = nameof(RequireOrganizationTenantPolicy);
 
         public string SubscriptionName => _SubscriptionName;
@@ -25,18 +25,13 @@ namespace NuGetGallery.Security
             public string Tenant { get; set; }
         }
 
-        public RequireOrganizationTenantPolicy()
-            : base(PolicyName, SecurityPolicyAction.JoinOrganization)
-        {
-        }
-
         private RequireOrganizationTenantPolicy(IEnumerable<UserSecurityPolicy> policies)
             : base(PolicyName, SecurityPolicyAction.JoinOrganization)
         {
             Policies = policies;
         }
 
-        public static IUserSecurityPolicySubscription Create(string tenantId)
+        public static RequireOrganizationTenantPolicy Create(string tenantId = "")
         {
             var value = JsonConvert.SerializeObject(new State()
             {
@@ -45,7 +40,7 @@ namespace NuGetGallery.Security
 
             return new RequireOrganizationTenantPolicy(new []
             {
-                new UserSecurityPolicy(PolicyName, PolicyName, value)
+                new UserSecurityPolicy(PolicyName, _SubscriptionName, value)
             });
         }
 

--- a/src/NuGetGallery/Security/SecurityPolicyService.cs
+++ b/src/NuGetGallery/Security/SecurityPolicyService.cs
@@ -1,4 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,12 +18,14 @@ namespace NuGetGallery.Security
     /// </summary>
     public class SecurityPolicyService : ISecurityPolicyService
     {
-        private static Lazy<IEnumerable<UserSecurityPolicyHandler>> _userHandlers =
-            new Lazy<IEnumerable<UserSecurityPolicyHandler>>(CreateUserHandlers);
+        private static Lazy<IEnumerable<UserSecurityPolicyHandler>> _userHandlers
+            = new Lazy<IEnumerable<UserSecurityPolicyHandler>>(CreateUserHandlers);
         private static readonly ControlRequiredSignerPolicy _controlRequiredSignerPolicy
             = new ControlRequiredSignerPolicy();
         private static readonly AutomaticallyOverwriteRequiredSignerPolicy _automaticallyOverwriteRequiredSignerPolicy
             = new AutomaticallyOverwriteRequiredSignerPolicy();
+        private static readonly RequireOrganizationTenantPolicy _organizationTenantPolicy
+            = RequireOrganizationTenantPolicy.Create();
 
         protected IEntitiesContext EntitiesContext { get; set; }
 
@@ -74,6 +77,24 @@ namespace NuGetGallery.Security
                 yield return _controlRequiredSignerPolicy;
                 yield return _automaticallyOverwriteRequiredSignerPolicy;
             }
+        }
+
+        /// <summary>
+        /// Available organization security policy subscriptions.
+        /// </summary>
+        public virtual IEnumerable<IUserSecurityPolicySubscription> OrganizationSubscriptions
+        {
+            get
+            {
+                yield return _organizationTenantPolicy;
+            }
+        }
+
+        private IUserSecurityPolicySubscription GetSubscription(User user, string subscriptionName)
+        {
+            return (user is Organization)
+                ? OrganizationSubscriptions.FirstOrDefault(s => s.SubscriptionName.Equals(subscriptionName, StringComparison.OrdinalIgnoreCase))
+                : UserSubscriptions.FirstOrDefault(s => s.SubscriptionName.Equals(subscriptionName, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -198,7 +219,7 @@ namespace NuGetGallery.Security
                 throw new ArgumentException(nameof(subscriptionName));
             }
 
-            var subscription = UserSubscriptions.FirstOrDefault(s => s.SubscriptionName.Equals(subscriptionName, StringComparison.OrdinalIgnoreCase));
+            var subscription = GetSubscription(user, subscriptionName);
             if (subscription == null)
             {
                 throw new NotSupportedException($"Subscription '{subscriptionName}' not found.");
@@ -237,7 +258,7 @@ namespace NuGetGallery.Security
                 throw new ArgumentException(nameof(subscriptionName));
             }
 
-            var subscription = UserSubscriptions.FirstOrDefault(s => s.SubscriptionName.Equals(subscriptionName, StringComparison.OrdinalIgnoreCase));
+            var subscription = GetSubscription(user, subscriptionName);
             if (subscription == null)
             {
                 throw new NotSupportedException($"Subscription '{subscriptionName}' not found.");
@@ -300,7 +321,7 @@ namespace NuGetGallery.Security
                 throw new ArgumentException(nameof(subscriptionName));
             }
 
-            var subscription = UserSubscriptions.FirstOrDefault(s => s.SubscriptionName.Equals(subscriptionName, StringComparison.OrdinalIgnoreCase));
+            var subscription = GetSubscription(user, subscriptionName);
             if (subscription == null)
             {
                 throw new NotSupportedException($"Subscription '{subscriptionName}' not found.");
@@ -363,7 +384,7 @@ namespace NuGetGallery.Security
         {
             yield return new RequirePackageVerifyScopePolicy();
             yield return new RequireMinProtocolVersionForPushPolicy();
-            yield return new RequireOrganizationTenantPolicy();
+            yield return _organizationTenantPolicy;
             yield return _controlRequiredSignerPolicy;
             yield return _automaticallyOverwriteRequiredSignerPolicy;
         }

--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/DeleteAccountControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/DeleteAccountControllerFacts.cs
@@ -5,14 +5,16 @@ using System;
 using System.Collections.Generic;
 using System.Web.Mvc;
 using NuGetGallery.Areas.Admin.ViewModels;
+using NuGetGallery.Framework;
 using Moq;
 using Xunit;
-
 
 namespace NuGetGallery.Areas.Admin.Controllers
 {
     public class DeleteAccountControllerFacts
     {
+        private Fakes _fakes = new Fakes();
+
         [Fact]
         public void CtorThrowsOnNullArg()
         {
@@ -20,84 +22,86 @@ namespace NuGetGallery.Areas.Admin.Controllers
             Assert.Throws<ArgumentNullException>(() => new DeleteAccountController(null));
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
-        public void SearchNullOrEmptyQueryAccounts(string query)
+        public class TheSearchMethod
         {
-            // Arrange
-            var userService = new Mock<IUserService>();
-            var controller = new DeleteAccountController(userService.Object);
+            private Fakes _fakes = new Fakes();
 
-            // Act
-            var searchResult = controller.Search(query);
-
-            // Assert
-            var data = (List<DeleteAccountSearchResult>)((JsonResult)searchResult).Data;
-            Assert.Empty(data);
-        }
-
-        [Fact]
-        public void SearchNotExistentUser()
-        {
-            // Arrange
-            User currentUser = null;
-            var userService = new Mock<IUserService>();
-            userService.Setup(m => m.FindByUsername(It.IsAny<string>(), false)).Returns(currentUser);
-            var controller = new DeleteAccountController(userService.Object);
-
-            // Act
-            var searchResult = controller.Search("SomeAccount");
-
-            // Assert
-            var data = (List<DeleteAccountSearchResult>)((JsonResult)searchResult).Data;
-            Assert.Empty(data);
-        }
-
-        [Fact]
-        public void SearchDeletedAccont()
-        {
-            // Arrange
-            var userName = "TestUser";
-            var currentUser = new User()
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public void WhenQueryMissing_ReturnsEmpty(string query)
             {
-                Username = userName,
-                IsDeleted = true
-            };
+                // Arrange & Act
+                var searchResult = SearchAccount(query, findByUsernameTimes: 0);
 
-            var userService = new Mock<IUserService>();
-            userService.Setup(m => m.FindByUsername(userName, false)).Returns(currentUser);
-            var controller = new DeleteAccountController(userService.Object);
+                // Assert
+                Assert.Empty(searchResult);
+            }
 
-            // Act
-            var searchResult = controller.Search(userName);
-
-            // Assert
-            var data = (List<DeleteAccountSearchResult>)((JsonResult)searchResult).Data;
-            Assert.Empty(data);
-        }
-
-        [Fact]
-        public void SearchHappyAccont()
-        {
-            // Arrange
-            var userName = "TestUser";
-            var currentUser = new User()
+            [Fact]
+            public void WhenUser_ReturnsMatch()
             {
-                Username = userName,
-                IsDeleted = false
-            };
+                // Arrange & Act
+                var searchResult = SearchAccount(_fakes.User.Username, _fakes.User);
 
-            var userService = new Mock<IUserService>();
-            userService.Setup(m => m.FindByUsername(userName, false)).Returns(currentUser);
-            var controller = new DeleteAccountController(userService.Object);
+                // Assert
+                Assert.Single(searchResult);
+            }
 
-            // Act
-            var searchResult = controller.Search(userName);
+            [Fact]
+            public void WhenOrganization_ReturnsMatch()
+            {
+                // Arrange & Act
+                var searchResult = SearchAccount(_fakes.Organization.Username, _fakes.Organization);
 
-            // Assert
-            var data = (List<DeleteAccountSearchResult>)((JsonResult)searchResult).Data;
-            Assert.Single(data);
+                // Assert
+                Assert.Single(searchResult);
+            }
+
+            [Fact]
+            public void WhenNotFound_ReturnsEmpty()
+            {
+                // Arrange & Act
+                _fakes.ShaUser.IsDeleted = true;
+
+                var searchResult = SearchAccount("UserNotFound");
+
+                // Assert
+                Assert.Empty(searchResult);
+            }
+
+            [Fact]
+            public void WhenDeletedUser_ReturnsEmpty()
+            {
+                // Arrange & Act
+                _fakes.ShaUser.IsDeleted = true;
+
+                var searchResult = SearchAccount(_fakes.ShaUser.Username);
+
+                // Assert
+                Assert.Empty(searchResult);
+            }
+
+            private List<DeleteAccountSearchResult> SearchAccount(string userName, User findByUsernameResult = null, int findByUsernameTimes = 1)
+            {
+                // Arrange
+                var userService = new Mock<IUserService>();
+
+                userService.Setup(m => m.FindByUsername(It.IsAny<string>(), It.IsAny<bool>()))
+                    .Returns(findByUsernameResult)
+                    .Verifiable();
+
+                var controller = new DeleteAccountController(userService.Object);
+
+                // Act
+                var result = controller.Search(userName) as JsonResult;
+
+                // Assert
+                userService.Verify(m => m.FindByUsername(userName, false), Times.Exactly(findByUsernameTimes));
+
+                Assert.NotNull(result);
+                return result.Data as List<DeleteAccountSearchResult>;
+            }
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/SecurityPolicyControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/SecurityPolicyControllerFacts.cs
@@ -95,7 +95,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             // Arrange.
             var policyService = new TestSecurityPolicyService();
             var dbUsers = TestUsers.ToArray();
-            var subscription = policyService.Mocks.Subscription.Object;
+            var subscription = policyService.Mocks.UserPoliciesSubscription.Object;
             var subscriptionName = subscription.SubscriptionName;
             await policyService.SubscribeAsync(dbUsers[1], subscription);
 
@@ -135,7 +135,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             var entitiesMock = policyService.MockEntitiesContext;
             entitiesMock.Setup(c => c.Users).Returns(users.MockDbSet().Object);
             var controller = new SecurityPolicyController(entitiesMock.Object, policyService);
-            var subscription = policyService.Mocks.Subscription.Object;
+            var subscription = policyService.Mocks.UserPoliciesSubscription.Object;
 
             Assert.DoesNotContain(users, u => policyService.IsSubscribed(u, subscription));
 
@@ -165,7 +165,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             var entitiesMock = policyService.MockEntitiesContext;
             entitiesMock.Setup(c => c.Users).Returns(users.MockDbSet().Object);
             var controller = new SecurityPolicyController(entitiesMock.Object, policyService);
-            var subscription = policyService.Mocks.Subscription.Object;
+            var subscription = policyService.Mocks.UserPoliciesSubscription.Object;
 
             users.ForEach(async u => await policyService.SubscribeAsync(u, subscription));
             policyService.MockEntitiesContext.ResetCalls();
@@ -196,7 +196,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             var entitiesMock = policyService.MockEntitiesContext;
             entitiesMock.Setup(c => c.Users).Returns(users.MockDbSet().Object);
             var controller = new SecurityPolicyController(entitiesMock.Object, policyService);
-            var subscription = policyService.Mocks.Subscription.Object;
+            var subscription = policyService.Mocks.UserPoliciesSubscription.Object;
 
             // Act.
             var model = new List<string>

--- a/tests/NuGetGallery.Facts/Security/RequireOrganizationTenantPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/RequireOrganizationTenantPolicyFacts.cs
@@ -61,7 +61,9 @@ namespace NuGetGallery.Security
                     targetAccount: fakes.User
                     );
 
-                return new RequireOrganizationTenantPolicy().Evaluate(context);
+                return RequireOrganizationTenantPolicy
+                    .Create()
+                    .Evaluate(context);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Security/SecurityPolicyServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/SecurityPolicyServiceFacts.cs
@@ -94,7 +94,7 @@ namespace NuGetGallery.Security
             // Arrange
             var service = new TestSecurityPolicyService();
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
@@ -115,7 +115,7 @@ namespace NuGetGallery.Security
             var policyData = new TestUserSecurityPolicyData(policy1Result: false, policy2Result: true);
             var service = new TestSecurityPolicyService(policyData);
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
@@ -134,7 +134,7 @@ namespace NuGetGallery.Security
             var policyData = new TestUserSecurityPolicyData(policy1Result: success, policy2Result: success);
             var service = new TestSecurityPolicyService(policyData);
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
@@ -158,7 +158,7 @@ namespace NuGetGallery.Security
 
             var service = new TestSecurityPolicyService(policyData, policyHandlers);
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
 
             var userSecurityPolicies = new List<UserSecurityPolicy>(subscription.Policies);
             userSecurityPolicies.Add(new UserSecurityPolicy(extraPolicyName, "ExtraSubscription"));
@@ -183,7 +183,7 @@ namespace NuGetGallery.Security
             var policyData = new TestUserSecurityPolicyData(policy1Result: true, policy2Result: true, defaultPolicy1Result: false, defaultPolicy2Result: false);
             var service = new TestSecurityPolicyService(policyData);
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
@@ -203,9 +203,9 @@ namespace NuGetGallery.Security
             // Arrange
             var policyData = new TestUserSecurityPolicyData(policy1Result: true, policy2Result: true, defaultPolicy1Result: true, defaultPolicy2Result: false);
             var configuration = new AppConfiguration() { EnforceDefaultSecurityPolicies = true };
-            var service = new TestSecurityPolicyService(policyData, null, null, null, null, configuration);
+            var service = new TestSecurityPolicyService(policyData, configuration: configuration);
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
@@ -233,9 +233,9 @@ namespace NuGetGallery.Security
             // Arrange
             var policyData = new TestUserSecurityPolicyData(policy1Result: true, policy2Result: userPolicyMet, defaultPolicy1Result: true, defaultPolicy2Result: true);
             var configuration = new AppConfiguration() { EnforceDefaultSecurityPolicies = true };
-            var service = new TestSecurityPolicyService(policyData, null, null, null, null, configuration);
+            var service = new TestSecurityPolicyService(policyData, configuration: configuration);
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act
@@ -277,7 +277,7 @@ namespace NuGetGallery.Security
             // Arrange.
             var service = new TestSecurityPolicyService();
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             user.SecurityPolicies = subscription.Policies.ToList();
 
             // Act & Assert.
@@ -291,7 +291,7 @@ namespace NuGetGallery.Security
             var service = new TestSecurityPolicyService();
             var user = new User("testUser");
             user.SecurityPolicies.Add(new UserSecurityPolicy("OtherPolicy", "OtherSubscription"));
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             foreach (var policy in subscription.Policies)
             {
                 user.SecurityPolicies.Add(policy);
@@ -307,7 +307,7 @@ namespace NuGetGallery.Security
             // Arrange.
             var service = new TestSecurityPolicyService();
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             user.SecurityPolicies.Add(subscription.Policies.First());
 
             // Act & Assert.
@@ -352,7 +352,7 @@ namespace NuGetGallery.Security
             Assert.Equal(2, user.SecurityPolicies.Count);
             service.Mocks.VerifySubscriptionPolicies(user.SecurityPolicies);
 
-            service.Mocks.Subscription.Verify(s => s.OnSubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Once);
+            service.Mocks.UserPoliciesSubscription.Verify(s => s.OnSubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Once);
             service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
         }
 
@@ -363,7 +363,7 @@ namespace NuGetGallery.Security
             var service = new TestSecurityPolicyService();
             var user = new User("testUser");
             var subscriptionName2 = "MockSubscription2";
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             foreach (var policy in subscription.Policies)
             {
                 user.SecurityPolicies.Add(new UserSecurityPolicy(policy.Name, subscriptionName2));
@@ -381,7 +381,7 @@ namespace NuGetGallery.Security
             Assert.Equal(subscriptionName2, policies[0].Subscription);
             service.Mocks.VerifySubscriptionPolicies(policies.Skip(2));
 
-            service.Mocks.Subscription.Verify(s => s.OnSubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Once);
+            service.Mocks.UserPoliciesSubscription.Verify(s => s.OnSubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Once);
             service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
         }
 
@@ -391,7 +391,7 @@ namespace NuGetGallery.Security
             // Arrange.
             var service = new TestSecurityPolicyService();
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             foreach (var policy in subscription.Policies)
             {
                 user.SecurityPolicies.Add(new UserSecurityPolicy(policy));
@@ -406,7 +406,7 @@ namespace NuGetGallery.Security
             Assert.Equal(2, user.SecurityPolicies.Count);
             service.Mocks.VerifySubscriptionPolicies(user.SecurityPolicies);
 
-            service.Mocks.Subscription.Verify(s => s.OnSubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Never);
+            service.Mocks.UserPoliciesSubscription.Verify(s => s.OnSubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Never);
             service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
         }
 
@@ -471,7 +471,7 @@ namespace NuGetGallery.Security
             // Arrange.
             var service = new TestSecurityPolicyService();
             var user = new User("testUser");
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             foreach (var policy in subscription.Policies)
             {
                 user.SecurityPolicies.Add(new UserSecurityPolicy(policy));
@@ -484,7 +484,7 @@ namespace NuGetGallery.Security
             // Act & Assert.
             Assert.Equal(0, user.SecurityPolicies.Count);
 
-            service.Mocks.Subscription.Verify(s => s.OnUnsubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Once);
+            service.Mocks.UserPoliciesSubscription.Verify(s => s.OnUnsubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Once);
             service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
             service.MockUserSecurityPolicies.Verify(p => p.Remove(It.IsAny<UserSecurityPolicy>()), Times.Exactly(2));
         }
@@ -496,7 +496,7 @@ namespace NuGetGallery.Security
             var service = new TestSecurityPolicyService();
             var user = new User("testUser");
             var subscriptionName2 = "MockSubscription2";
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             foreach (var policy in subscription.Policies)
             {
                 user.SecurityPolicies.Add(new UserSecurityPolicy(policy));
@@ -513,7 +513,7 @@ namespace NuGetGallery.Security
             Assert.Equal(subscriptionName2, policies[0].Subscription);
             Assert.Equal(subscriptionName2, policies[1].Subscription);
 
-            service.Mocks.Subscription.Verify(s => s.OnUnsubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Once);
+            service.Mocks.UserPoliciesSubscription.Verify(s => s.OnUnsubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Once);
             service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
             service.MockUserSecurityPolicies.Verify(p => p.Remove(It.IsAny<UserSecurityPolicy>()), Times.Exactly(2));
         }
@@ -525,7 +525,7 @@ namespace NuGetGallery.Security
             var service = new TestSecurityPolicyService();
             var user = new User("testUser");
             var subscriptionName2 = "MockSubscription2";
-            var subscription = service.Mocks.Subscription.Object;
+            var subscription = service.Mocks.UserPoliciesSubscription.Object;
             foreach (var policy in subscription.Policies)
             {
                 user.SecurityPolicies.Add(new UserSecurityPolicy(policy.Name, subscriptionName2));
@@ -538,7 +538,7 @@ namespace NuGetGallery.Security
             // Act & Assert.
             Assert.Equal(2, user.SecurityPolicies.Count);
 
-            service.Mocks.Subscription.Verify(s => s.OnUnsubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Never);
+            service.Mocks.UserPoliciesSubscription.Verify(s => s.OnUnsubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Never);
             service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
             service.MockUserSecurityPolicies.Verify(p => p.Remove(It.IsAny<UserSecurityPolicy>()), Times.Never);
         }
@@ -573,6 +573,30 @@ namespace NuGetGallery.Security
 
             // Act & Assert.
             service.MockAuditingService.Verify(s => s.SaveAuditRecordAsync(It.IsAny<AuditRecord>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task UnsubscribeAsync_RemovesAllOrganizationSubscriptionPolicies()
+        {
+            // Arrange.
+            var service = new TestSecurityPolicyService();
+            var organization = new Organization("testOrganization");
+            var subscription = service.Mocks.OrganizationPoliciesSubscription.Object;
+            foreach (var policy in subscription.Policies)
+            {
+                organization.SecurityPolicies.Add(new UserSecurityPolicy(policy));
+            }
+            Assert.Equal(2, organization.SecurityPolicies.Count);
+
+            // Act.
+            await service.UnsubscribeAsync(organization, service.OrganizationSubscriptions.First());
+
+            // Act & Assert.
+            Assert.Equal(0, organization.SecurityPolicies.Count);
+
+            service.Mocks.OrganizationPoliciesSubscription.Verify(s => s.OnUnsubscribeAsync(It.IsAny<UserSecurityPolicySubscriptionContext>()), Times.Once);
+            service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+            service.MockUserSecurityPolicies.Verify(p => p.Remove(It.IsAny<UserSecurityPolicy>()), Times.Exactly(2));
         }
 
         private HttpContextBase CreateHttpContext(User user)

--- a/tests/NuGetGallery.Facts/Security/TestSecurityPolicyService.cs
+++ b/tests/NuGetGallery.Facts/Security/TestSecurityPolicyService.cs
@@ -26,12 +26,15 @@ namespace NuGetGallery.Security
 
         public override IEnumerable<IUserSecurityPolicySubscription> UserSubscriptions { get; }
 
+        public override IEnumerable<IUserSecurityPolicySubscription> OrganizationSubscriptions { get; }
+
         protected override IEnumerable<UserSecurityPolicyHandler> UserHandlers { get; }
 
         public TestSecurityPolicyService(
             TestUserSecurityPolicyData mocks = null,
             IEnumerable<UserSecurityPolicyHandler> userHandlers = null,
             IEnumerable<IUserSecurityPolicySubscription> userSubscriptions = null,
+            IEnumerable<IUserSecurityPolicySubscription> organizationSubscriptions = null,
             Mock<IEntitiesContext> mockEntities = null,
             Mock<IAuditingService> mockAuditing = null,
             IAppConfiguration configuration = null)
@@ -40,7 +43,8 @@ namespace NuGetGallery.Security
             Mocks = mocks ?? new TestUserSecurityPolicyData();
 
             UserHandlers = userHandlers ?? Mocks.Handlers.Select(m => m.Object);
-            UserSubscriptions = userSubscriptions ?? new [] { Mocks.Subscription.Object };
+            UserSubscriptions = userSubscriptions ?? new [] { Mocks.UserPoliciesSubscription.Object };
+            OrganizationSubscriptions = organizationSubscriptions ?? new[] { Mocks.OrganizationPoliciesSubscription.Object };
             DefaultSubscription = Mocks.DefaultSubscription.Object;
         }
 


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/5923
- Allow search of organization accounts from Delete Account admin view
- Allow unsubscribe of organization tenant policy (used by delete account)
