### PR TITLE
Functional tests for OData API api/v2/packages() caching 

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/ApiManagement/CachingTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ApiManagement/CachingTests.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using System.Xml;
 using Xunit;
@@ -31,13 +30,11 @@ namespace NuGetGallery.FunctionalTests.ApiManagement
             // Arrange
             string url = UrlHelper.V2FeedRootUrl + suffix;
 
-            Action<HttpResponseHeaders> verifyHeaders = (headers) => Assert.False(headers.Contains(CacheHeaderName));
-
             // Act
             var firstResponse = await MakeODataRequest(url);
 
             // sleep for 5 seconds so the clock will shift
-            await Task.Delay(5000);
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
             var secondResponse = await MakeODataRequest(url);
 
@@ -67,7 +64,7 @@ namespace NuGetGallery.FunctionalTests.ApiManagement
             var firstResponse = await MakeODataRequest(url);
 
             // sleep for 5 seconds so the clock will shift
-            await Task.Delay(5000);
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
             var secondResponse = await MakeODataRequest(url);
 
@@ -96,10 +93,10 @@ namespace NuGetGallery.FunctionalTests.ApiManagement
                 response.Headers.TryGetValues(CacheHeaderName, out IEnumerable<string> cacheHeaders);
 
                 string content = await response.Content.ReadAsStringAsync();
+
                 using (var stringReader = new StringReader(content))
+                using (var xmlReader = XmlReader.Create(stringReader))
                 {
-                    using (var xmlReader = XmlReader.Create(stringReader))
-                    {
                         var xmlConfig = new XmlDocument();
                         xmlConfig.XmlResolver = null;
 
@@ -107,7 +104,6 @@ namespace NuGetGallery.FunctionalTests.ApiManagement
                         var updatedTime = xmlConfig.GetElementsByTagName("updated")[0].InnerText;
 
                         return (DateTime.Parse(updatedTime), cacheHeaders);
-                    }
                 }
             }
         }

--- a/tests/NuGetGallery.FunctionalTests/ApiManagement/CachingTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ApiManagement/CachingTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit;
+
+namespace NuGetGallery.FunctionalTests.ApiManagement
+{
+    public class CachingTests
+    {
+        private const string CacheHeaderName = "x-cache";
+        private const string CacheHeaderHit = "HIT";
+        private const string CacheHeaderMiss = "MISS";
+
+        [Theory]
+        [InlineData("Packages?$skip=8356600&$top=80&$filter=(tolower(Id)%20eq%20'nlog')")]
+        [InlineData("Packages()?$skip=8356600&$top=80&$filter=(tolower(Id)%20eq%20'nlog')&$orderby=Id")]
+        [InlineData("Packages?IsLatestVersion%20and%20substringof('sample-data',Tags)&$top=250")]
+        [InlineData("Packages()?IsLatestVersion%20and%20substringof('sample-data',description)&$top=250")]
+        [Category("ApiManagementTests")]
+        public async Task RequestsThatShouldNotBeCachedAreNotCached(string suffix)
+        {
+            // Arrange
+            string url = UrlHelper.V2FeedRootUrl + suffix;
+
+            Action<HttpResponseHeaders> verifyHeaders = (headers) => Assert.False(headers.Contains(CacheHeaderName));
+
+            // Act
+            var firstResponse = await MakeODataRequest(url);
+
+            // sleep for 5 seconds so the clock will shift
+            await Task.Delay(5000);
+
+            var secondResponse = await MakeODataRequest(url);
+
+            // Assert
+
+            Assert.Null(firstResponse.cacheHeaderValues);
+            Assert.Null(secondResponse.cacheHeaderValues);
+
+            // If there's no cache the update time should differ
+            Assert.NotEqual(firstResponse.updateTime, secondResponse.updateTime);
+        }
+
+        [Theory]
+        [InlineData("Packages()?$skip=0&$top=40&$filter=substringof('|{0}',Dependencies)%20or%20startswith(Dependencies,'{0}')%20or%20Id%20eq%20'{0}'&$select=DownloadCount,Id,Version")]
+        [InlineData("Packages?$skip=0&$top=40&$filter=substringof('|{0}',Dependencies)%20or%20startswith(Dependencies,'{0}')%20or%20Id%20eq%20'{0}'&$select=DownloadCount,Id,Version")]
+        [InlineData("Packages()?$filter=IsLatestVersion and substringof('{0}:',Dependencies)&$top=250")]
+        [InlineData("Packages?$filter=IsLatestVersion and substringof('{0}:',Dependencies)&$top=250")]
+        [Category("ApiManagementTests")]
+        public async Task RequestsThatShouldBeCachedAreCached(string format)
+        {
+            // Arrange
+            // Create a random request so we won't get a cached response
+            string suffix = string.Format(format, Guid.NewGuid());
+            string url = UrlHelper.V2FeedRootUrl + suffix;
+
+            // Act
+            var firstResponse = await MakeODataRequest(url);
+
+            // sleep for 5 seconds so the clock will shift
+            await Task.Delay(5000);
+
+            var secondResponse = await MakeODataRequest(url);
+
+            // Assert
+            Assert.NotNull(firstResponse.cacheHeaderValues);
+            Assert.NotNull(secondResponse.cacheHeaderValues);
+
+            Assert.Single(firstResponse.cacheHeaderValues);
+            Assert.Single(secondResponse.cacheHeaderValues);
+
+            Assert.Equal(CacheHeaderMiss, firstResponse.cacheHeaderValues.First());
+            Assert.Equal(CacheHeaderHit, secondResponse.cacheHeaderValues.First());
+
+            // Update time should be identical for a cached response
+            Assert.Equal(firstResponse.updateTime, secondResponse.updateTime);
+        }
+
+
+        private async Task<(DateTime updateTime, IEnumerable<string> cacheHeaderValues)> MakeODataRequest(string url)
+        {
+            using (HttpClient client = new HttpClient())
+            using (HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url)))
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                response.Headers.TryGetValues(CacheHeaderName, out IEnumerable<string> cacheHeaders);
+
+                string content = await response.Content.ReadAsStringAsync();
+                using (var stringReader = new StringReader(content))
+                {
+                    using (var xmlReader = XmlReader.Create(stringReader))
+                    {
+                        var xmlConfig = new XmlDocument();
+                        xmlConfig.XmlResolver = null;
+
+                        xmlConfig.Load(xmlReader);
+                        var updatedTime = xmlConfig.GetElementsByTagName("updated")[0].InnerText;
+
+                        return (DateTime.Parse(updatedTime), cacheHeaders);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -45,6 +45,10 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -75,6 +79,7 @@
     <Compile Include="WebPages\FluentLinkChecker.cs" />
     <Compile Include="WebPages\LinksTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ApiManagement\CachingTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/tests/NuGetGallery.FunctionalTests/packages.config
+++ b/tests/NuGetGallery.FunctionalTests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="FluentLinkChecker" version="1.0.0.10" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
   <package id="xunit" version="2.3.1" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net45" />
   <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />

--- a/tests/Scripts/BuildTests.ps1
+++ b/tests/Scripts/BuildTests.ps1
@@ -8,7 +8,7 @@ param(
 $rootName = (Get-Item $PSScriptRoot).parent.FullName
 
 # Required tools
-$msBuild = "${Env:ProgramFiles(x86)}\MsBuild\14.0\Bin\msbuild"
+$msBuild = "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild"
 $nuget = "$rootName\nuget.exe"
 & "$rootName\Scripts\DownloadLatestNuGetExeRelease.ps1" $rootName
 

--- a/tests/Scripts/RunTests.ps1
+++ b/tests/Scripts/RunTests.ps1
@@ -41,7 +41,7 @@ if(Test-Path $webTestsDirectory -PathType Container) {
 	& $msTest "/TestContainer:$webTestsDirectory\NuGetGallery.WebUITests.$TestCategory.dll" "/TestSettings:$rootName\Local.testsettings" "/detail:stdout" "/resultsfile:$webUITestResults"
 	if ($LastExitCode) {
 		$exitCode = 1
-	}    
+	}
 }
 
 # Run load tests

--- a/tests/Scripts/RunTests.ps1
+++ b/tests/Scripts/RunTests.ps1
@@ -36,9 +36,12 @@ if ($LastExitCode) {
 
 # Run web UI tests
 $webTestsDirectory = "$rootName\NuGetGallery.WebUITests.$TestCategory\bin\$Config"
-& $msTest "/TestContainer:$webTestsDirectory\NuGetGallery.WebUITests.$TestCategory.dll" "/TestSettings:$rootName\Local.testsettings" "/detail:stdout" "/resultsfile:$webUITestResults"
-if ($LastExitCode) {
-    $exitCode = 1
+
+if(Test-Path $webTestsDirectory -PathType Container) { 
+	& $msTest "/TestContainer:$webTestsDirectory\NuGetGallery.WebUITests.$TestCategory.dll" "/TestSettings:$rootName\Local.testsettings" "/detail:stdout" "/resultsfile:$webUITestResults"
+	if ($LastExitCode) {
+		$exitCode = 1
+	}    
 }
 
 # Run load tests


### PR DESCRIPTION
1. APIM behavior:
- If a request meets the criteria it will be cached
- If a request meets the criteria and it's a cache miss we add header x-cache: MISS
- If a request meets the criteria and it's a cache hit we add header x-cache: HIT

2. The tests belong to a new Category (ApiManagement) and will NOT run normaly. In the future, when we automate APIM config deployment we can use them for verification. Until then, we will run them from VSTS manually during config deployment.

3. Changed the build to use MSBuild 15.0. Tested in VSTS for all tests.
