### PR TITLE
Improve experience when users hit package size limit

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -10,6 +10,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Web;
 using System.Web.Mvc;
 using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
@@ -554,6 +555,13 @@ namespace NuGetGallery
                         return BadRequestForExceptionMessage(ex);
                     }
                 }
+            }
+            catch (HttpException ex) when (ex.IsMaxRequestLengthExceeded())
+            {
+                // ASP.NET throws HttpException when maxRequestLength limit is exceeded.
+                return new HttpStatusCodeWithBodyResult(
+                    HttpStatusCode.RequestEntityTooLarge,
+                    Strings.PackageFileTooLarge);
             }
             catch (Exception)
             {

--- a/src/NuGetGallery/Extensions/HttpExceptionExtensions.cs
+++ b/src/NuGetGallery/Extensions/HttpExceptionExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Web;
+
+namespace NuGetGallery
+{
+    public static class HttpExceptionExtensions
+    {
+        private const int UnspecifiedError = -2147467259; // HRESULT 0x80004005
+
+        public static bool IsMaxRequestLengthExceeded(this HttpException e)
+        {
+            return e.ErrorCode == UnspecifiedError
+                && e.Message.Equals("Maximum request length exceeded.", StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/src/NuGetGallery/Extensions/HttpRequestExtensions.cs
+++ b/src/NuGetGallery/Extensions/HttpRequestExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Globalization;
-using System.Linq;
 using System.Web;
 
 namespace NuGetGallery

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Controllers\AppController.cs" />
     <Compile Include="Controllers\ErrorsController.cs" />
     <Compile Include="Controllers\PagesController.cs" />
+    <Compile Include="Extensions\HttpExceptionExtensions.cs" />
     <Compile Include="Extensions\OrganizationExtensions.cs" />
     <Compile Include="Extensions\PrincipalExtensions.cs" />
     <Compile Include="Extensions\RouteExtensions.cs" />

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -177,7 +177,7 @@
                 case "error":
                     // IIS returns 404.13 (NotFound) when maxAllowedContentLength limit is exceeded.
                     if (fullResponse === "Not Found") {
-                        displayErrors(["The package file exceeds the size limit of 250MB. Please try again."]);
+                        displayErrors(["The package file exceeds the size limit. Please try again."]);
                     }
                     break;
                 default:

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -174,6 +174,12 @@
                 case "abort":
                     displayErrors(["The operation was aborted. Please try again."]);
                     break;
+                case "error":
+                    // IIS returns 404.13 (NotFound) when maxAllowedContentLength limit is exceeded.
+                    if (fullResponse === "Not Found") {
+                        displayErrors(["The package file exceeds the size limit of 250MB. Please try again."]);
+                    }
+                    break;
                 default:
                     displayErrors(model.responseJSON);
                     break;

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -113,6 +113,8 @@ namespace NuGetGallery
         public const string CreatedDateForAccountToBeDeleted = "CreatedDateForAccountToBeDeleted";
         public const string AccountDeleteSucceeded = "AccountDeleteSucceeded";
 
+        public const string ValueUnknown = "Unknown";
+
         public TelemetryService(IDiagnosticsService diagnosticsService, ITelemetryClient telemetryClient = null)
         {
             if (diagnosticsService == null)
@@ -184,11 +186,13 @@ namespace NuGetGallery
 
         public void TrackPackagePushFailureEvent(string id, NuGetVersion version)
         {
+            var normalizedVersion = version?.ToNormalizedString();
+
             TrackMetric(Events.PackagePushFailure, 1, properties => {
                 properties.Add(ClientVersion, GetClientVersion());
                 properties.Add(ProtocolVersion, GetProtocolVersion());
-                properties.Add(PackageId, id);
-                properties.Add(PackageVersion, version.ToNormalizedString());
+                properties.Add(PackageId, id ?? ValueUnknown);
+                properties.Add(PackageVersion, normalizedVersion ?? ValueUnknown);
             });
         }
 

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1256,7 +1256,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package file exceeds the size limit of 250MB..
+        ///   Looks up a localized string similar to The package file exceeds the size limit. Please try again..
         /// </summary>
         public static string PackageFileTooLarge {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1256,6 +1256,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package file exceeds the size limit of 250MB..
+        /// </summary>
+        public static string PackageFileTooLarge {
+            get {
+                return ResourceManager.GetString("PackageFileTooLarge", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package ID &apos;{0}&apos; is not available..
         /// </summary>
         public static string PackageIdNotAvailable {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -911,4 +911,7 @@ If you would like to update the linked Microsoft account you can do so from the 
   <data name="FailedValidationHardDeleteReason" xml:space="preserve">
     <value>Automatic hard-delete for reupload of package that failed validation</value>
   </data>
+  <data name="PackageFileTooLarge" xml:space="preserve">
+    <value>The package file exceeds the size limit of 250MB.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -912,6 +912,6 @@ If you would like to update the linked Microsoft account you can do so from the 
     <value>Automatic hard-delete for reupload of package that failed validation</value>
   </data>
   <data name="PackageFileTooLarge" xml:space="preserve">
-    <value>The package file exceeds the size limit of 250MB.</value>
+    <value>The package file exceeds the size limit. Please try again.</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/6143

**API push**
Hits `maxRequestLength` (ASP.NET) limit which throws HttpException.
We now handle this to return status 413 with better error message, and client no longer retries.

```
NuGet Version: 4.6.2.5055
Pushing chenriks252.nupkg to 'https://localhost/api/v2/package/'...
  PUT https://localhost/api/v2/package/
  RequestEntityTooLarge https://localhost/api/v2/package/ 8448ms
Response status code does not indicate success: 413 (The package file exceeds the size limit of 250MB.).
System.Net.Http.HttpRequestException: Response status code does not indicate success: 413 (The package file exceeds the
size limit of 250MB.).
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
   at NuGet.Protocol.Core.Types.PackageUpdateResource.<>c.<PushPackageToServer>b__18_0(HttpResponseMessage response)
   at NuGet.Protocol.HttpSource.<ProcessResponseAsync>d__14`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
```

Currently, we get 500/InternalServerError with retry:
```
NuGet Version: 4.6.2.5055
Pushing chenriks252.nupkg to 'https://dev.nugettest.org/api/v2/package/'...
  PUT https://dev.nugettest.org/api/v2/package/
  InternalServerError https://dev.nugettest.org/api/v2/package/ 71503ms
  PUT https://dev.nugettest.org/api/v2/package/
```

**UI upload**
Hits `maxAllowedContentLength` (IIS) limit which returns 404.13 before the request reaches ASP.NET.
We now handle this at the client to display an immediate error message, instead of silently failing.

![image](https://user-images.githubusercontent.com/15364949/42397737-db410188-811b-11e8-81c1-4717356bcc82.png)
