### PR TITLE
Refactor CorePackageFileService 

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -188,7 +188,7 @@
     <Compile Include="Services\ICorePackageService.cs" />
     <Compile Include="Services\IFileReference.cs" />
     <Compile Include="Services\ICoreFileStorageService.cs" />
-    <Compile Include="Services\IMetadataFileService.cs" />
+    <Compile Include="Services\IFileMetadataService.cs" />
     <Compile Include="Services\ISimpleCloudBlob.cs" />
     <Compile Include="Services\PackageFileServiceMetadata.cs" />
     <Compile Include="Services\TestableStorageClientException.cs" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -188,7 +188,9 @@
     <Compile Include="Services\ICorePackageService.cs" />
     <Compile Include="Services\IFileReference.cs" />
     <Compile Include="Services\ICoreFileStorageService.cs" />
+    <Compile Include="Services\IMetadataFileService.cs" />
     <Compile Include="Services\ISimpleCloudBlob.cs" />
+    <Compile Include="Services\PackageFileServiceMetadata.cs" />
     <Compile Include="Services\TestableStorageClientException.cs" />
     <Compile Include="StreamExtensions.cs" />
     <Compile Include="CoreStrings.Designer.cs">

--- a/src/NuGetGallery.Core/Services/CorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageFileService.cs
@@ -13,12 +13,12 @@ namespace NuGetGallery
     public class CorePackageFileService : ICorePackageFileService
     {
         private readonly ICoreFileStorageService _fileStorageService;
-        private readonly IFileServiceMetadata _fileServiceMetadata;
+        private readonly IFileMetadataService _metadata;
 
-        public CorePackageFileService(ICoreFileStorageService fileStorageService, IFileServiceMetadata fileServiceMetadata)
+        public CorePackageFileService(ICoreFileStorageService fileStorageService, IFileMetadataService metadata)
         {
             _fileStorageService = fileStorageService ?? throw new ArgumentNullException(nameof(fileStorageService));
-            _fileServiceMetadata = fileServiceMetadata ?? throw new ArgumentNullException(nameof(fileServiceMetadata));
+            _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
         }
 
         public Task SavePackageFileAsync(Package package, Stream packageFile)
@@ -28,26 +28,26 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(packageFile));
             }
 
-            var fileName = BuildFileName(package, _fileServiceMetadata.FileSavePathTemplate, _fileServiceMetadata.FileExtension);
-            return _fileStorageService.SaveFileAsync(_fileServiceMetadata.FileFolderName, fileName, packageFile, overwrite: false);
+            var fileName = BuildFileName(package, _metadata.FileSavePathTemplate, _metadata.FileExtension);
+            return _fileStorageService.SaveFileAsync(_metadata.FileFolderName, fileName, packageFile, overwrite: false);
         }
 
         public Task<Stream> DownloadPackageFileAsync(Package package)
         {
-            var fileName = BuildFileName(package, _fileServiceMetadata.FileSavePathTemplate, _fileServiceMetadata.FileExtension);
-            return _fileStorageService.GetFileAsync(_fileServiceMetadata.FileFolderName, fileName);
+            var fileName = BuildFileName(package, _metadata.FileSavePathTemplate, _metadata.FileExtension);
+            return _fileStorageService.GetFileAsync(_metadata.FileFolderName, fileName);
         }
 
         public Task<Uri> GetPackageReadUriAsync(Package package)
         {
-            var fileName = BuildFileName(package, _fileServiceMetadata.FileSavePathTemplate, _fileServiceMetadata.FileExtension);
-            return _fileStorageService.GetFileReadUriAsync(_fileServiceMetadata.FileFolderName, fileName, endOfAccess: null);
+            var fileName = BuildFileName(package, _metadata.FileSavePathTemplate, _metadata.FileExtension);
+            return _fileStorageService.GetFileReadUriAsync(_metadata.FileFolderName, fileName, endOfAccess: null);
         }
 
         public Task<bool> DoesPackageFileExistAsync(Package package)
         {
-            var fileName = BuildFileName(package, _fileServiceMetadata.FileSavePathTemplate, _fileServiceMetadata.FileExtension);
-            return _fileStorageService.FileExistsAsync(_fileServiceMetadata.FileFolderName, fileName);
+            var fileName = BuildFileName(package, _metadata.FileSavePathTemplate, _metadata.FileExtension);
+            return _fileStorageService.FileExistsAsync(_metadata.FileFolderName, fileName);
         }
 
         public Task SaveValidationPackageFileAsync(Package package, Stream packageFile)
@@ -59,11 +59,11 @@ namespace NuGetGallery
 
             var fileName = BuildFileName(
                 package,
-                _fileServiceMetadata.FileSavePathTemplate,
-                _fileServiceMetadata.FileExtension);
+                _metadata.FileSavePathTemplate,
+                _metadata.FileExtension);
 
             return _fileStorageService.SaveFileAsync(
-                _fileServiceMetadata.ValidationFolderName,
+                _metadata.ValidationFolderName,
                 fileName,
                 packageFile,
                 overwrite: false);
@@ -73,10 +73,10 @@ namespace NuGetGallery
         {
             var fileName = BuildFileName(
                 package,
-                _fileServiceMetadata.FileSavePathTemplate,
-                _fileServiceMetadata.FileExtension);
+                _metadata.FileSavePathTemplate,
+                _metadata.FileExtension);
 
-            return _fileStorageService.GetFileAsync(_fileServiceMetadata.ValidationFolderName, fileName);
+            return _fileStorageService.GetFileAsync(_metadata.ValidationFolderName, fileName);
         }
 
         public Task DeleteValidationPackageFileAsync(string id, string version)
@@ -90,10 +90,10 @@ namespace NuGetGallery
             var fileName = BuildFileName(
                 id,
                 normalizedVersion,
-                _fileServiceMetadata.FileSavePathTemplate,
-                _fileServiceMetadata.FileExtension);
+                _metadata.FileSavePathTemplate,
+                _metadata.FileExtension);
             
-            return _fileStorageService.DeleteFileAsync(_fileServiceMetadata.ValidationFolderName, fileName);
+            return _fileStorageService.DeleteFileAsync(_metadata.ValidationFolderName, fileName);
         }
 
         public Task DeletePackageFileAsync(string id, string version)
@@ -110,8 +110,8 @@ namespace NuGetGallery
 
             var normalizedVersion = NuGetVersionFormatter.Normalize(version);
 
-            var fileName = BuildFileName(id, normalizedVersion, _fileServiceMetadata.FileSavePathTemplate, _fileServiceMetadata.FileExtension);
-            return _fileStorageService.DeleteFileAsync(_fileServiceMetadata.FileFolderName, fileName);
+            var fileName = BuildFileName(id, normalizedVersion, _metadata.FileSavePathTemplate, _metadata.FileExtension);
+            return _fileStorageService.DeleteFileAsync(_metadata.FileFolderName, fileName);
         }
 
         public Task<Uri> GetValidationPackageReadUriAsync(Package package, DateTimeOffset endOfAccess)
@@ -120,16 +120,16 @@ namespace NuGetGallery
 
             var fileName = BuildFileName(
                 package,
-                _fileServiceMetadata.FileSavePathTemplate,
-                _fileServiceMetadata.FileExtension);
+                _metadata.FileSavePathTemplate,
+                _metadata.FileExtension);
 
-            return _fileStorageService.GetFileReadUriAsync(_fileServiceMetadata.ValidationFolderName, fileName, endOfAccess);
+            return _fileStorageService.GetFileReadUriAsync(_metadata.ValidationFolderName, fileName, endOfAccess);
         }
 
         public Task<bool> DoesValidationPackageFileExistAsync(Package package)
         {
-            var fileName = BuildFileName(package, _fileServiceMetadata.FileSavePathTemplate, _fileServiceMetadata.FileExtension);
-            return _fileStorageService.FileExistsAsync(_fileServiceMetadata.ValidationFolderName, fileName);
+            var fileName = BuildFileName(package, _metadata.FileSavePathTemplate, _metadata.FileExtension);
+            return _fileStorageService.FileExistsAsync(_metadata.ValidationFolderName, fileName);
         }
 
         public async Task StorePackageFileInBackupLocationAsync(Package package, Stream packageFile)
@@ -172,19 +172,19 @@ namespace NuGetGallery
                 package.PackageRegistration.Id,
                 version,
                 hash,
-                _fileServiceMetadata.FileExtension,
-                _fileServiceMetadata.FileBackupSavePathTemplate);
+                _metadata.FileExtension,
+                _metadata.FileBackupSavePathTemplate);
 
             // If the package already exists, don't even bother uploading it. The file name is based off of the hash so
             // we know the upload isn't necessary.
-            if (await _fileStorageService.FileExistsAsync(_fileServiceMetadata.FileBackupsFolderName, fileName))
+            if (await _fileStorageService.FileExistsAsync(_metadata.FileBackupsFolderName, fileName))
             {
                 return;
             }
 
             try
             {
-                await _fileStorageService.SaveFileAsync(_fileServiceMetadata.FileBackupsFolderName, fileName, packageFile);
+                await _fileStorageService.SaveFileAsync(_metadata.FileBackupsFolderName, fileName, packageFile);
             }
             catch (FileAlreadyExistsException)
             {

--- a/src/NuGetGallery.Core/Services/IFileMetadataService.cs
+++ b/src/NuGetGallery.Core/Services/IFileMetadataService.cs
@@ -3,7 +3,7 @@
 
 namespace NuGetGallery
 {
-    public interface IFileServiceMetadata
+    public interface IFileMetadataService
     {
         /// <summary>
         /// This is the public folder name where files will be copied. For example <see cref="CoreConstants.PackagesFolderName"/>

--- a/src/NuGetGallery.Core/Services/IMetadataFileService.cs
+++ b/src/NuGetGallery.Core/Services/IMetadataFileService.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public interface IFileServiceMetadata
+    {
+        /// <summary>
+        /// This is the public folder name where files will be copied. For example <see cref="CoreConstants.PackagesFolderName"/>
+        /// </summary>
+        string FileFolderName { get; }
+
+        /// <summary>
+        /// The save file path template. For example <see cref="CoreConstants.PackageFileSavePathTemplate"/>
+        /// </summary>
+        string FileSavePathTemplate { get; }
+
+        /// <summary>
+        /// The file extension. For example <see cref="CoreConstants.NuGetPackageFileExtension"/>
+        /// </summary>
+        string FileExtension { get; }
+
+        /// <summary>
+        /// The validation folder name. For example <see cref="CoreConstants.ValidationFolderName"/>
+        /// </summary>
+        string ValidationFolderName { get; }
+
+        /// <summary>
+        /// The backups folder name. For example <see cref="CoreConstants.PackageBackupsFolderName"/>
+        /// </summary>
+        string FileBackupsFolderName { get; }
+
+        /// <summary>
+        /// The path template for the backup. For example <see cref="CoreConstants.PackageFileBackupSavePathTemplate"/>
+        /// </summary>
+        string FileBackupSavePathTemplate { get; }
+    }
+}

--- a/src/NuGetGallery.Core/Services/PackageFileServiceMetadata.cs
+++ b/src/NuGetGallery.Core/Services/PackageFileServiceMetadata.cs
@@ -3,7 +3,7 @@
 
 namespace NuGetGallery
 {
-    public class PackageFileServiceMetadata : IFileServiceMetadata
+    public class PackageFileMetadataService : IFileMetadataService
     {
         public string FileFolderName => CoreConstants.PackagesFolderName;
 

--- a/src/NuGetGallery.Core/Services/PackageFileServiceMetadata.cs
+++ b/src/NuGetGallery.Core/Services/PackageFileServiceMetadata.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public class PackageFileServiceMetadata : IFileServiceMetadata
+    {
+        public string FileFolderName => CoreConstants.PackagesFolderName;
+
+        public string FileSavePathTemplate => CoreConstants.PackageFileSavePathTemplate;
+
+        public string FileExtension => CoreConstants.NuGetPackageFileExtension;
+
+        public string ValidationFolderName => CoreConstants.ValidationFolderName;
+
+        public string FileBackupsFolderName => CoreConstants.PackageBackupsFolderName;
+
+        public string FileBackupSavePathTemplate => CoreConstants.PackageFileBackupSavePathTemplate;
+    }
+}

--- a/src/NuGetGallery/Services/PackageFileService.cs
+++ b/src/NuGetGallery/Services/PackageFileService.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery
         private readonly IFileStorageService _fileStorageService;
 
         public PackageFileService(IFileStorageService fileStorageService)
-            : base(fileStorageService)
+            : base(fileStorageService, new PackageFileServiceMetadata())
         {
             _fileStorageService = fileStorageService;
         }

--- a/src/NuGetGallery/Services/PackageFileService.cs
+++ b/src/NuGetGallery/Services/PackageFileService.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery
         private readonly IFileStorageService _fileStorageService;
 
         public PackageFileService(IFileStorageService fileStorageService)
-            : base(fileStorageService, new PackageFileServiceMetadata())
+            : base(fileStorageService, new PackageFileMetadataService())
         {
             _fileStorageService = fileStorageService;
         }

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -772,7 +772,7 @@ namespace NuGetGallery
             fileStorageService = fileStorageService ?? new Mock<ICoreFileStorageService>();
 
             return new CorePackageFileService(
-                fileStorageService.Object);
+                fileStorageService.Object, new PackageFileServiceMetadata());
         }
 
         public abstract class FactsBase

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -772,7 +772,7 @@ namespace NuGetGallery
             fileStorageService = fileStorageService ?? new Mock<ICoreFileStorageService>();
 
             return new CorePackageFileService(
-                fileStorageService.Object, new PackageFileServiceMetadata());
+                fileStorageService.Object, new PackageFileMetadataService());
         }
 
         public abstract class FactsBase

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Services\DeleteAccountServiceFacts.cs" />
     <Compile Include="Services\JsonStatisticsServiceFacts.cs" />
     <Compile Include="Services\ContentObjectServiceFacts.cs" />
+    <Compile Include="Services\PackageFileServiceMetadataFacts.cs" />
     <Compile Include="Services\PackageOwnerRequestServiceFacts.cs" />
     <Compile Include="Services\PackageOwnershipManagementServiceFacts.cs" />
     <Compile Include="Services\LoginDiscontinuationConfigurationFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceMetadataFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceMetadataFacts.cs
@@ -10,7 +10,7 @@ namespace NuGetGallery
         public void ValidatePropertyValues()
         {
             // Arrange + Act 
-            var data = new PackageFileServiceMetadata();
+            var data = new PackageFileMetadataService();
 
             // Assert
             Assert.Equal("packages", data.FileFolderName);

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceMetadataFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceMetadataFacts.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+namespace NuGetGallery
+{
+    public class PackageFileServiceMetadataFacts
+    {
+        [Fact]
+        public void ValidatePropertyValues()
+        {
+            // Arrange + Act 
+            var data = new PackageFileServiceMetadata();
+
+            // Assert
+            Assert.Equal("packages", data.FileFolderName);
+            Assert.Equal("{0}.{1}{2}", data.FileSavePathTemplate);
+            Assert.Equal(".nupkg", data.FileExtension);
+            Assert.Equal("validation", data.ValidationFolderName);
+            Assert.Equal("package-backups", data.FileBackupsFolderName);
+            Assert.Equal("{0}/{1}/{2}.{3}", data.FileBackupSavePathTemplate);
+        }
+    }
+}


### PR DESCRIPTION
Refactor CorePackageFileService to allow the file metadata to be passed at construction time instead to use directly the CoreConstants values. This will allow the same logic for file manipulation to be used for packages and symbols. 