### PR TITLE
Correct path to local migrate.exe

### DIFF
--- a/tools/Update-Databases.ps1
+++ b/tools/Update-Databases.ps1
@@ -5,7 +5,7 @@ param(
 
 function Initialize-MigrateExe() {
     [string] $migrateDirectory = [System.IO.Path]::Combine($PSScriptRoot, '__temp_migrate_directory_' + [guid]::NewGuid().ToString("N") )
-    [string] $efDirectory = [System.IO.Path]::Combine($PSScriptRoot, '${env:userprofile}\.nuget\packages\EntityFramework\6.1.3')
+    [string] $efDirectory = "$env:userprofile\.nuget\packages\EntityFramework\6.1.3"
     [string] $migrate = ([System.IO.Path]::Combine($migrateDirectory, 'migrate.exe'))
 
     if (-not (New-Item -ItemType Directory -Path $migrateDirectory -Force).Exists) {


### PR DESCRIPTION
I was following the "Build and run..." steps to setup a fresh dev environment and it failed during the "Update-Database.ps1" step.

Maybe this issue came up because my "GitHub work folder" is located on drive D and my user profile is located on drive C.

When I run the Setup-DevEnvironment.ps1 I got this error message:

```
Copy-Item : Cannot find path
 'D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\${env:userprofile}\.nuget\packages\EntityFramework\6.1.3\lib\net45'
because it does not exist.
```

This was the full console output:

<details>
Copyright (C) Microsoft Corporation. All rights reserved.

PS C:\WINDOWS\system32> cd D:\Code\GitHub\NuGetGallery\NuGetGallery
PS D:\Code\GitHub\NuGetGallery\NuGetGallery> .\tools\Setup-DevEnvironment.ps1
[BEGIN] Setting up IIS Express
WARNING: Site 'NuGet Gallery (localhost)' already exists. Deleting and recreating.
SITE object "NuGet Gallery (localhost)" deleted
SITE object "NuGet Gallery (localhost)" added
APP object "NuGet Gallery (localhost)/" added
VDIR object "NuGet Gallery (localhost)/" added
[DONE] Setting up IIS Express
[BEGIN] Setting SSL Certificate
Using SSL Certificate: 66D5A474BD5DD0FB0381E11B85933F97B95C43D2
[DONE] Setting SSL Certificate
[BEGIN] Running Migrations
Copy-Item : Cannot find path 'D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\${env:userprofile}\.nuget\packages\EntityF
ramework\6.1.3\tools\migrate.exe' because it does not exist.
At D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\Update-Databases.ps1:15 char:5
+     Copy-Item `
+     ~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (D:\Code\GitHub\...ols\migrate.exe:String) [Copy-Item], ItemNotFoundExce
   ption
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.CopyItemCommand

Copy-Item : Cannot find path
'D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\${env:userprofile}\.nuget\packages\EntityFramework\6.1.3\lib\net45'
because it does not exist.
At D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\Update-Databases.ps1:15 char:5
+     Copy-Item `
+     ~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (D:\Code\GitHub\...6.1.3\lib\net45:String) [Copy-Item], ItemNotFoundExce
   ption
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.CopyItemCommand

Test-Path : Cannot bind argument to parameter 'Path' because it is an empty string.
At D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\Update-Databases.ps1:61 char:62
+ ... irectory -ne $null -and (Test-Path -Path $migrateExeDirectory -PathTy ...
+                                              ~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.Test
   PathCommand

migrate.exe could not be provisioned.
At D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\Update-Databases.ps1:23 char:9
+         throw 'migrate.exe could not be provisioned.'
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (migrate.exe could not be provisioned.:String) [], RuntimeException
    + FullyQualifiedErrorId : migrate.exe could not be provisioned.
Copyright (C) Microsoft Corporation. All rights reserved.

PS C:\WINDOWS\system32> cd D:\Code\GitHub\NuGetGallery\NuGetGallery
PS D:\Code\GitHub\NuGetGallery\NuGetGallery> .\tools\Setup-DevEnvironment.ps1
[BEGIN] Setting up IIS Express
WARNING: Site 'NuGet Gallery (localhost)' already exists. Deleting and recreating.
SITE object "NuGet Gallery (localhost)" deleted
SITE object "NuGet Gallery (localhost)" added
APP object "NuGet Gallery (localhost)/" added
VDIR object "NuGet Gallery (localhost)/" added
[DONE] Setting up IIS Express
[BEGIN] Setting SSL Certificate
Using SSL Certificate: 66D5A474BD5DD0FB0381E11B85933F97B95C43D2
[DONE] Setting SSL Certificate
[BEGIN] Running Migrations
Copy-Item : Cannot find path 'D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\${env:userprofile}\.nuget\packages\EntityF
ramework\6.1.3\tools\migrate.exe' because it does not exist.
At D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\Update-Databases.ps1:15 char:5
+     Copy-Item `
+     ~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (D:\Code\GitHub\...ols\migrate.exe:String) [Copy-Item], ItemNotFoundExce
   ption
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.CopyItemCommand

Copy-Item : Cannot find path
'D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\${env:userprofile}\.nuget\packages\EntityFramework\6.1.3\lib\net45'
because it does not exist.
At D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\Update-Databases.ps1:15 char:5
+     Copy-Item `
+     ~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (D:\Code\GitHub\...6.1.3\lib\net45:String) [Copy-Item], ItemNotFoundExce
   ption
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.CopyItemCommand

Test-Path : Cannot bind argument to parameter 'Path' because it is an empty string.
At D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\Update-Databases.ps1:61 char:62
+ ... irectory -ne $null -and (Test-Path -Path $migrateExeDirectory -PathTy ...
+                                              ~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.Test
   PathCommand

migrate.exe could not be provisioned.
At D:\Code\GitHub\NuGetGallery\NuGetGallery\tools\Update-Databases.ps1:23 char:9
+         throw 'migrate.exe could not be provisioned.'
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (migrate.exe could not be provisioned.:String) [], RuntimeException
    + FullyQualifiedErrorId : migrate.exe could not be provisioned.
</details>

It seems the code tries to copy the migrate.exe from the local nuget folder, but this Path.Combine operation seems wrong to locate it.

The "fixed" version worked on my system and I would think it should be OK if the cloned repository lives on the same drive as the nuget package folder.