### PR TITLE
Display errors fix.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -179,6 +179,9 @@
                     if (fullResponse === "Not Found") {
                         displayErrors(["The package file exceeds the size limit. Please try again."]);
                     }
+                    else {
+                        displayErrors(model.responseJSON);
+                    }
                     break;
                 default:
                     displayErrors(model.responseJSON);


### PR DESCRIPTION
The error messages are not displayed correclty. 
Example:
![image](https://user-images.githubusercontent.com/16580006/42611581-ad67d564-854b-11e8-8660-5ef897343a0b.png)



With this change the error is displayed:
![image](https://user-images.githubusercontent.com/16580006/42611561-9ad6abe6-854b-11e8-9b1f-5de376f24840.png)
