### PR TITLE
Move delete outside of using so FileStorage can delete the file.

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -151,7 +150,7 @@ namespace NuGetGallery
 
         [UIAuthorize]
         [RequiresAccountConfirmation("upload a package")]
-        public async virtual Task<ActionResult> UploadPackage()
+        public virtual async Task<ActionResult> UploadPackage()
         {
             var currentUser = GetCurrentUser();
             var model = new SubmitPackageRequest();
@@ -366,10 +365,10 @@ namespace NuGetGallery
 
                         // Packages that failed validation can be reuploaded.
                         await _packageDeleteService.HardDeletePackagesAsync(
-                            new[] { existingPackage }, 
+                            new[] { existingPackage },
                             currentUser,
                             Strings.FailedValidationHardDeleteReason,
-                            Strings.AutomatedPackageDeleteSignature, 
+                            Strings.AutomatedPackageDeleteSignature,
                             deleteEmptyPackageRegistration: false);
                     }
                     else
@@ -1708,11 +1707,11 @@ namespace NuGetGallery
                     // delete the uploaded binary in the Uploads container
                     await _uploadFileService.DeleteUploadFileAsync(currentUser.Key);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     // Log the exception here and swallow it for now.
                     // We want to know the delete has failed, but the user shouldn't get a failed request here since everything has actually gone through
-                    // Note that this will still lead to the strange behavioru where the next time a user comes to the upload page, an upload will be "in progress"
+                    // Note that this will still lead to the strange behavior where the next time a user comes to the upload page, an upload will be "in progress"
                     //  but verify will fail as the package has actually already been added, at which point, cancel will attempt the delete of this blob again.
                     e.Log();
                 }
@@ -1849,7 +1848,7 @@ namespace NuGetGallery
             var currentUser = GetCurrentUser();
 
             var wasAADLoginOrMultiFactorAuthenticated = User.WasMultiFactorAuthenticated() || User.WasAzureActiveDirectoryAccountUsedForSignin();
-            var canManagePackageRequiredSigner = wasAADLoginOrMultiFactorAuthenticated 
+            var canManagePackageRequiredSigner = wasAADLoginOrMultiFactorAuthenticated
                 && ActionsRequiringPermissions
                     .ManagePackageRequiredSigner
                     .CheckPermissionsOnBehalfOfAnyAccount(currentUser, packageRegistration) == PermissionsCheckResult.Allowed;

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1713,6 +1713,7 @@ namespace NuGetGallery
                     // We want to know the delete has failed, but the user shouldn't get a failed request here since everything has actually gone through
                     // Note that this will still lead to the strange behavior where the next time a user comes to the upload page, an upload will be "in progress"
                     //  but verify will fail as the package has actually already been added, at which point, cancel will attempt the delete of this blob again.
+                    // An issue to clear in progress if it already exists has been logged at https://github.com/NuGet/NuGetGallery/issues/6192
                     e.Log();
                 }
 


### PR DESCRIPTION
There was a bug introduced by #6038 that caused FileStorage uploads to behave incorrectly.
The behaviour is detailed by #6175 

This PR moves the delete outside of the Using statement and swallows if it fails.
Behaviour can change from swallow if we decide this is not how we want to handle this.