### PR TITLE
Fix PackageFeedSortingTest functional test

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -221,6 +221,9 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 var condition = responseText.IndexOf(">" + last + "<", StringComparison.Ordinal)
                     < responseText.IndexOf(">" + current + "<", StringComparison.Ordinal);
                 Assert.True(condition, $"Expected string {last} to come before {current}.  Expected list is: {expectedNames}.");
+
+                Assert.NotEqual(last, current);
+                last = current;
             }
         }
 


### PR DESCRIPTION
Fixes #6168 (functional test failure when <10 distinct packages in feed)