### PR TITLE
[NuGet Symbol Server] Add core symbol package service

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -30,6 +30,7 @@ namespace NuGetGallery
         public const string PackagesFolderName = "packages";
         public const string UploadsFolderName = "uploads";
         public const string ValidationFolderName = "validation";
+        public const string RevalidationFolderName = "revalidation";
 
         public const string SymbolPackagesFolderName = "symbol-packages";
         public const string NuGetSymbolPackageFileExtension = ".snupkg";

--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -30,5 +30,9 @@ namespace NuGetGallery
         public const string PackagesFolderName = "packages";
         public const string UploadsFolderName = "uploads";
         public const string ValidationFolderName = "validation";
+
+        public const string SymbolPackagesFolderName = "symbol-packages";
+        public const string NuGetSymbolPackageFileExtension = ".snupkg";
+        public const string SymbolPackageBackupsFolderName = "symbol-package-backups";
     }
 }

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -191,6 +191,7 @@
     <Compile Include="Services\ICoreFileStorageService.cs" />
     <Compile Include="Services\IFileMetadataService.cs" />
     <Compile Include="Services\ISimpleCloudBlob.cs" />
+    <Compile Include="Services\SymbolPackageFileServiceMetadata.cs" />
     <Compile Include="Services\PackageFileServiceMetadata.cs" />
     <Compile Include="Services\TestableStorageClientException.cs" />
     <Compile Include="StreamExtensions.cs" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Services\CloudFileReference.cs" />
     <Compile Include="Services\CoreMessageService.cs" />
     <Compile Include="Services\CorePackageFileService.cs" />
+    <Compile Include="Services\CoreSymbolPackageService.cs" />
     <Compile Include="Services\CorePackageService.cs" />
     <Compile Include="Services\CryptographyService.cs" />
     <Compile Include="Services\FileAlreadyExistsException.cs" />
@@ -186,6 +187,7 @@
     <Compile Include="Services\ICoreMessageService.cs" />
     <Compile Include="Services\ICoreMessageServiceConfiguration.cs" />
     <Compile Include="Services\ICorePackageFileService.cs" />
+    <Compile Include="Services\ICoreSymbolPackageService.cs" />
     <Compile Include="Services\ICorePackageService.cs" />
     <Compile Include="Services\IFileReference.cs" />
     <Compile Include="Services\ICoreFileStorageService.cs" />

--- a/src/NuGetGallery.Core/Services/CorePackageService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageService.cs
@@ -291,6 +291,7 @@ namespace NuGetGallery
                 .Include(p => p.LicenseReports)
                 .Include(p => p.PackageRegistration)
                 .Include(p => p.User)
+                .Include(p => p.SymbolPackages)
                 .Where(p => p.PackageRegistration.Id == id);
         }
 

--- a/src/NuGetGallery.Core/Services/CoreSymbolPackageService.cs
+++ b/src/NuGetGallery.Core/Services/CoreSymbolPackageService.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGetGallery.Packaging;
+
+namespace NuGetGallery
+{
+    public class CoreSymbolPackageService : ICoreSymbolPackageService
+    {
+        protected readonly IEntityRepository<SymbolPackage> _symbolPackageRepository;
+        protected readonly ICorePackageService _corePackageService;
+
+        public CoreSymbolPackageService(
+            IEntityRepository<SymbolPackage> symbolPackageRepository,
+            ICorePackageService corePackageService)
+        {
+            _symbolPackageRepository = symbolPackageRepository ?? throw new ArgumentNullException(nameof(symbolPackageRepository));
+            _corePackageService = corePackageService ?? throw new ArgumentNullException(nameof(corePackageService));
+        }
+
+        public IEnumerable<SymbolPackage> FindSymbolPackageByIdAndVersion(string id, string version)
+        {
+            var package = _corePackageService.FindPackageByIdAndVersionStrict(id, version);
+
+            return package?.SymbolPackages;
+        }
+
+        public virtual async Task UpdateStatusAsync(SymbolPackage symbolPackage, PackageStatus newPackageStatus, bool commitChanges = true)
+        {
+            if (symbolPackage == null)
+            {
+                throw new ArgumentNullException(nameof(symbolPackage));
+            }
+
+            // Avoid all of this work if the package status is not changing.
+            if (symbolPackage.StatusKey != newPackageStatus)
+            {
+                symbolPackage.StatusKey = newPackageStatus;
+
+                /// If the package is being made available.
+                if (newPackageStatus == PackageStatus.Available)
+                {
+                    symbolPackage.Published = DateTime.UtcNow;
+                }
+
+                if (commitChanges)
+                {
+                    await _symbolPackageRepository.CommitChangesAsync();
+                }
+            }
+        }
+
+        /// <remarks>
+        /// Symbol package metadata doesn't need to be updated from any other jobs/orchestrator for now,
+        /// The support can be added when needed in future for adding signing for symbol packages. This would possibly involve
+        /// adding new last edited column for the SymbolPackages table.
+        /// </remarks>
+        public virtual Task UpdateMetadataAsync(SymbolPackage symbolPackage, PackageStreamMetadata metadata, bool commitChanges = true)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Services/CoreSymbolPackageService.cs
+++ b/src/NuGetGallery.Core/Services/CoreSymbolPackageService.cs
@@ -21,7 +21,7 @@ namespace NuGetGallery
             _corePackageService = corePackageService ?? throw new ArgumentNullException(nameof(corePackageService));
         }
 
-        public IEnumerable<SymbolPackage> FindSymbolPackageByIdAndVersion(string id, string version)
+        public IEnumerable<SymbolPackage> FindSymbolPackagesByIdAndVersion(string id, string version)
         {
             var package = _corePackageService.FindPackageByIdAndVersionStrict(id, version);
 

--- a/src/NuGetGallery.Core/Services/CoreSymbolPackageService.cs
+++ b/src/NuGetGallery.Core/Services/CoreSymbolPackageService.cs
@@ -52,15 +52,5 @@ namespace NuGetGallery
                 }
             }
         }
-
-        /// <remarks>
-        /// Symbol package metadata doesn't need to be updated from any other jobs/orchestrator for now,
-        /// The support can be added when needed in future for adding signing for symbol packages. This would possibly involve
-        /// adding new last edited column for the SymbolPackages table.
-        /// </remarks>
-        public virtual Task UpdateMetadataAsync(SymbolPackage symbolPackage, PackageStreamMetadata metadata, bool commitChanges = true)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/src/NuGetGallery.Core/Services/CoreSymbolPackageService.cs
+++ b/src/NuGetGallery.Core/Services/CoreSymbolPackageService.cs
@@ -4,14 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using NuGetGallery.Packaging;
 
 namespace NuGetGallery
 {
     public class CoreSymbolPackageService : ICoreSymbolPackageService
     {
-        protected readonly IEntityRepository<SymbolPackage> _symbolPackageRepository;
-        protected readonly ICorePackageService _corePackageService;
+        private readonly IEntityRepository<SymbolPackage> _symbolPackageRepository;
+        private readonly ICorePackageService _corePackageService;
 
         public CoreSymbolPackageService(
             IEntityRepository<SymbolPackage> symbolPackageRepository,

--- a/src/NuGetGallery.Core/Services/ICoreSymbolPackageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreSymbolPackageService.cs
@@ -18,7 +18,7 @@ namespace NuGetGallery
         /// <param name="id">The package ID.</param>
         /// <param name="version">The package version.</param>
         /// <returns></returns>
-        IEnumerable<SymbolPackage> FindSymbolPackageByIdAndVersion(string id, string version);
+        IEnumerable<SymbolPackage> FindSymbolPackagesByIdAndVersion(string id, string version);
 
         /// <summary>
         /// Update the status of the symbol package.

--- a/src/NuGetGallery.Core/Services/ICoreSymbolPackageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreSymbolPackageService.cs
@@ -28,13 +28,5 @@ namespace NuGetGallery
         /// <param name="commitChanges">Whether or not to commit the changes to the entity context</param>
         /// <returns>Awaitable task</returns>
         Task UpdateStatusAsync(SymbolPackage symbolPackage, PackageStatus status, bool commitChanges = true);
-
-        /// <summary>
-        /// Updates the symbol package properties related to the package stream itself.
-        /// </summary>
-        /// <param name="symbolPackage">The symbol package to update the stream details of.</param>
-        /// <param name="metadata">The new package stream metadata.</param>
-        /// <param name="commitChanges">Whether or not to commit the changes to the entity context.</param>
-        Task UpdateMetadataAsync(SymbolPackage symbolPackage, PackageStreamMetadata metadata, bool commitChanges = true);
     }
 }

--- a/src/NuGetGallery.Core/Services/ICoreSymbolPackageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreSymbolPackageService.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGetGallery.Packaging;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Symbol Package business logic that is needed in multiple components (not just the Gallery process).
+    /// </summary>
+    public interface ICoreSymbolPackageService
+    {
+        /// <summary>
+        /// Gets all the symbol packages associated with the Package ID and version
+        /// </summary>
+        /// <param name="id">The package ID.</param>
+        /// <param name="version">The package version.</param>
+        /// <returns></returns>
+        IEnumerable<SymbolPackage> FindSymbolPackageByIdAndVersion(string id, string version);
+
+        /// <summary>
+        /// Update the status of the symbol package.
+        /// </summary>
+        /// <param name="symbolPackage">The symbol package to update the status of.</param>
+        /// <param name="status">Enum value for <see cref="PackageStatus"/></param>
+        /// <param name="commitChanges">Whether or not to commit the changes to the entity context</param>
+        /// <returns>Awaitable task</returns>
+        Task UpdateStatusAsync(SymbolPackage symbolPackage, PackageStatus status, bool commitChanges = true);
+
+        /// <summary>
+        /// Updates the symbol package properties related to the package stream itself.
+        /// </summary>
+        /// <param name="symbolPackage">The symbol package to update the stream details of.</param>
+        /// <param name="metadata">The new package stream metadata.</param>
+        /// <param name="commitChanges">Whether or not to commit the changes to the entity context.</param>
+        Task UpdateMetadataAsync(SymbolPackage symbolPackage, PackageStreamMetadata metadata, bool commitChanges = true);
+    }
+}

--- a/src/NuGetGallery.Core/Services/ICoreSymbolPackageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreSymbolPackageService.cs
@@ -17,7 +17,7 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="id">The package ID.</param>
         /// <param name="version">The package version.</param>
-        /// <returns></returns>
+        /// <returns>The list of <see cref="SymbolPackage"/> associated with this package</returns>
         IEnumerable<SymbolPackage> FindSymbolPackagesByIdAndVersion(string id, string version);
 
         /// <summary>

--- a/src/NuGetGallery.Core/Services/SymbolPackageFileServiceMetadata.cs
+++ b/src/NuGetGallery.Core/Services/SymbolPackageFileServiceMetadata.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery
 
         public string ValidationFolderName => CoreConstants.ValidationFolderName;
 
-        public string FileBackupsFolderName => CoreConstants.PackageBackupsFolderName;
+        public string FileBackupsFolderName => CoreConstants.SymbolPackageBackupsFolderName;
 
         public string FileBackupSavePathTemplate => CoreConstants.PackageFileBackupSavePathTemplate;
     }

--- a/src/NuGetGallery.Core/Services/SymbolPackageFileServiceMetadata.cs
+++ b/src/NuGetGallery.Core/Services/SymbolPackageFileServiceMetadata.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public class SymbolPackageFileMetadataService : IFileMetadataService
+    {
+        public string FileFolderName => CoreConstants.SymbolPackagesFolderName;
+
+        public string FileSavePathTemplate => CoreConstants.PackageFileSavePathTemplate;
+
+        public string FileExtension => CoreConstants.NuGetSymbolPackageFileExtension;
+
+        public string ValidationFolderName => CoreConstants.ValidationFolderName;
+
+        public string FileBackupsFolderName => CoreConstants.PackageBackupsFolderName;
+
+        public string FileBackupSavePathTemplate => CoreConstants.PackageFileBackupSavePathTemplate;
+    }
+}

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -449,8 +449,7 @@ namespace NuGetGallery
                                         string.Format(CultureInfo.CurrentCulture, Strings.PackageIsLocked, packageRegistration.Id));
                                 }
 
-                                var nuspecVersion = nuspec.GetVersion();
-                                var existingPackage = PackageService.FindPackageByIdAndVersionStrict(nuspec.GetId(), nuspecVersion.ToStringSafe());
+                                var existingPackage = PackageService.FindPackageByIdAndVersionStrict(id, version.ToStringSafe());
                                 if (existingPackage != null)
                                 {
                                     if (existingPackage.PackageStatusKey == PackageStatus.FailedValidation)
@@ -469,7 +468,7 @@ namespace NuGetGallery
                                         return new HttpStatusCodeWithBodyResult(
                                             HttpStatusCode.Conflict,
                                             string.Format(CultureInfo.CurrentCulture, Strings.PackageExistsAndCannotBeModified,
-                                                id, nuspecVersion.ToNormalizedStringSafe()));
+                                                id, version.ToNormalizedStringSafe()));
                                     }
                                 }
                             }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -380,6 +380,7 @@
     <Compile Include="Services\IContentObjectService.cs" />
     <Compile Include="Services\ImmediatePackageValidator.cs" />
     <Compile Include="Services\ContentObjectService.cs" />
+    <Compile Include="Services\ISymbolPackageService.cs" />
     <Compile Include="Services\PackageOwnershipManagementService.cs" />
     <Compile Include="Services\IPackageOwnershipManagementService.cs" />
     <Compile Include="Services\IPackageValidationInitiator.cs" />

--- a/src/NuGetGallery/Services/ISymbolPackageService.cs
+++ b/src/NuGetGallery/Services/ISymbolPackageService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Packaging;
 using NuGetGallery.Packaging;
@@ -10,18 +8,11 @@ using NuGetGallery.Packaging;
 namespace NuGetGallery
 {
     /// <summary>
-    /// Business logic related to <see cref="SymbolPackage"/>.
+    /// Business logic related to <see cref="SymbolPackage"/>. This logic is only used by the NuGet Gallery,
+    /// as opposed to the <see cref="CoreSymbolPackageService"/> which is intended for other components.
     /// </summary>
-    public interface ISymbolPackageService
+    public interface ISymbolPackageService : ICoreSymbolPackageService
     {
-        /// <summary>
-        /// Gets all the symbol packages associated with the Package ID and version
-        /// </summary>
-        /// <param name="id">The package ID.</param>
-        /// <param name="version">The package version.</param>
-        /// <returns></returns>
-        IEnumerable<SymbolPackage> FindSymbolPackageByIdAndVersion(string id, string version);
-
         /// <summary>
         /// Populate the related database tables to create the specified symbol package.
         /// </summary>
@@ -34,12 +25,5 @@ namespace NuGetGallery
         /// <param name="currentUser">The user that pushed the package on behalf of <paramref name="owner"/></param>
         /// <returns>The created symbol package entity.</returns>
         Task<SymbolPackage> CreateSymbolPackageAsync(PackageArchiveReader symbolPackage, PackageStreamMetadata packageStreamMetadata, User owner, User currentUser);
-
-        /// <summary>
-        /// Update the status of the symbol package.
-        /// </summary>
-        /// <param name="status">Enum value for <see cref="PackageStatus"/></param>
-        /// <returns>Awaitable task</returns>
-        Task SetSymbolPacakgeStatus(PackageStatus status);
     }
 }

--- a/src/NuGetGallery/Services/ISymbolPackageService.cs
+++ b/src/NuGetGallery/Services/ISymbolPackageService.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Packaging;
+using NuGetGallery.Packaging;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Business logic related to <see cref="SymbolPackage"/>.
+    /// </summary>
+    public interface ISymbolPackageService
+    {
+        /// <summary>
+        /// Gets all the symbol packages associated with the Package ID and version
+        /// </summary>
+        /// <param name="id">The package ID.</param>
+        /// <param name="version">The package version.</param>
+        /// <returns></returns>
+        IEnumerable<SymbolPackage> FindSymbolPackageByIdAndVersion(string id, string version);
+
+        /// <summary>
+        /// Populate the related database tables to create the specified symbol package.
+        /// </summary>
+        /// <remarks>
+        /// This method doesn't upload the package binary to the blob storage. The caller must do it after this call.
+        /// </remarks>
+        /// <param name="symbolPackage">The package to be created.</param>
+        /// <param name="packageStreamMetadata">The package stream's metadata.</param>
+        /// <param name="owner">The owner of the package</param>
+        /// <param name="currentUser">The user that pushed the package on behalf of <paramref name="owner"/></param>
+        /// <returns>The created symbol package entity.</returns>
+        Task<SymbolPackage> CreateSymbolPackageAsync(PackageArchiveReader symbolPackage, PackageStreamMetadata packageStreamMetadata, User owner, User currentUser);
+
+        /// <summary>
+        /// Update the status of the symbol package.
+        /// </summary>
+        /// <param name="status">Enum value for <see cref="PackageStatus"/></param>
+        /// <returns>Awaitable task</returns>
+        Task SetSymbolPacakgeStatus(PackageStatus status);
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Packaging\NupkgRewriterFacts.cs" />
     <Compile Include="SemVerLevelKeyFacts.cs" />
     <Compile Include="Services\AccessConditionWrapperFacts.cs" />
+    <Compile Include="Services\CoreSymbolPackageServiceFacts.cs" />
     <Compile Include="Services\FileUriPermissionsFacts.cs" />
     <Compile Include="Services\RevalidationStateServiceFacts.cs" />
     <Compile Include="TestUtils\BlobStorageCollection.cs" />

--- a/tests/NuGetGallery.Core.Facts/Services/CoreSymbolPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CoreSymbolPackageServiceFacts.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class CoreSymbolPackageServiceFacts
+    {
+        public class TheConstructor
+        {
+            [Fact]
+            public void Constructor_WhenSymbolPackageRepositoryIsNull_Throws()
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => new CoreSymbolPackageService(symbolPackageRepository: null, corePackageService: Mock.Of<ICorePackageService>()));
+
+                Assert.Equal("symbolPackageRepository", exception.ParamName);
+            }
+
+            [Fact]
+            public void Constructor_CorePackageServiceIsNull_Throws()
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => new CoreSymbolPackageService(Mock.Of<IEntityRepository<SymbolPackage>>(), corePackageService: null));
+
+                Assert.Equal("corePackageService", exception.ParamName);
+            }
+        }
+
+        public class TheUpdatePackageStatusMethod
+        {
+            [Fact]
+            public async Task RejectsNullPackage()
+            {
+                // Arrange
+                SymbolPackage symbolPackage = null;
+                var service = CreateService();
+
+                // Act & Assert
+                await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => service.UpdateStatusAsync(symbolPackage, PackageStatus.Deleted, commitChanges: true));
+            }
+
+            [Fact]
+            public async Task DoesNotCommitWhenNoChangeOfStatus()
+            {
+                // Arrange
+                var symbolPackageRepository = new Mock<IEntityRepository<SymbolPackage>>();
+                var symbolPackage = new SymbolPackage
+                {
+                    Package = new Package
+                    {
+                        PackageRegistration = new PackageRegistration(),
+                    },
+                    StatusKey = PackageStatus.Available
+                };
+
+                var service = CreateService(symbolPackageRepository: symbolPackageRepository);
+
+                // Act
+                await service.UpdateStatusAsync(symbolPackage, PackageStatus.Available, commitChanges: true);
+
+                // Assert
+                symbolPackageRepository.Verify(x => x.CommitChangesAsync(), Times.Never);
+            }
+
+            [Theory]
+            [InlineData(false, 0)]
+            [InlineData(true, 1)]
+            public async Task CommitsTheCorrectNumberOfTimes(bool commitChanges, int commitCount)
+            {
+                // Arrange
+                var symbolPackageRepository = new Mock<IEntityRepository<SymbolPackage>>();
+                var symbolPackage = new SymbolPackage
+                {
+                    Package = new Package
+                    {
+                        PackageRegistration = new PackageRegistration(),
+                    },
+                    StatusKey = PackageStatus.Validating
+                };
+
+                var service = CreateService(symbolPackageRepository: symbolPackageRepository);
+
+                // Act
+                await service.UpdateStatusAsync(symbolPackage, PackageStatus.Available, commitChanges);
+
+                // Assert
+                symbolPackageRepository.Verify(x => x.CommitChangesAsync(), Times.Exactly(commitCount));
+            }
+        }
+
+        private static ICoreSymbolPackageService CreateService(
+            Mock<IEntityRepository<SymbolPackage>> symbolPackageRepository = null,
+            Mock<ICorePackageService> corePackageService = null)
+        {
+            return CreateMockService(symbolPackageRepository, corePackageService).Object;
+        }
+
+        private static Mock<CoreSymbolPackageService> CreateMockService(
+            Mock<IEntityRepository<SymbolPackage>> symbolPackageRepository = null,
+            Mock<ICorePackageService> corePackageService = null)
+        {
+            symbolPackageRepository = symbolPackageRepository ?? new Mock<IEntityRepository<SymbolPackage>>();
+            corePackageService = corePackageService ?? new Mock<ICorePackageService>();
+
+            var packageService = new Mock<CoreSymbolPackageService>(
+                symbolPackageRepository.Object,
+                corePackageService.Object);
+
+            packageService.CallBase = true;
+
+            return packageService;
+        }
+    }
+}


### PR DESCRIPTION
Adds the entity and definitions required by gallery, jobs and orchestrator. Also added tests.