### PR TITLE
Add IsSigningAllowed method

### DIFF
--- a/src/NuGetGallery.Core/Extensions/PackageRegistrationExtensions.cs
+++ b/src/NuGetGallery.Core/Extensions/PackageRegistrationExtensions.cs
@@ -9,6 +9,30 @@ namespace NuGetGallery.Extensions
     public static class PackageRegistrationExtensions
     {
         /// <summary>
+        /// Determines if package signing is allowed for the specified package registration.
+        /// </summary>
+        /// <param name="packageRegistration">A package registration.</param>
+        /// <returns>A flag indicating whether package signing is allowed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="packageRegistration" />
+        /// is <c>null</c>.</exception>
+        public static bool IsSigningAllowed(this PackageRegistration packageRegistration)
+        {
+            if (packageRegistration == null)
+            {
+                throw new ArgumentNullException(nameof(packageRegistration));
+            }
+
+            var requiredSigner = packageRegistration.RequiredSigners.FirstOrDefault();
+
+            if (requiredSigner == null)
+            {
+                return packageRegistration.Owners.Any(owner => HasAnyCertificate(owner));
+            }
+
+            return HasAnyCertificate(requiredSigner);
+        }
+
+        /// <summary>
         /// Determines if package signing is required for the specified package registration.
         /// </summary>
         /// <param name="packageRegistration">A package registration.</param>

--- a/tests/NuGetGallery.Core.Facts/Extensions/PackageRegistrationExtensionsFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Extensions/PackageRegistrationExtensionsFacts.cs
@@ -8,6 +8,224 @@ namespace NuGetGallery.Extensions
 {
     public class PackageRegistrationExtensionsFacts
     {
+        public class TheIsSigningAllowedMethod
+        {
+            private readonly Package _package;
+            private readonly PackageRegistration _packageRegistration;
+            private readonly User _user;
+
+            public TheIsSigningAllowedMethod()
+            {
+                _user = new User()
+                {
+                    Key = 1,
+                    Username = "a"
+                };
+                _packageRegistration = new PackageRegistration()
+                {
+                    Key = 2,
+                    Id = "b"
+                };
+                _package = new Package()
+                {
+                    Key = 3,
+                    PackageRegistration = _packageRegistration
+                };
+
+                _packageRegistration.Owners.Add(_user);
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WhenPackageRegistrationIsNull_Throws()
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => PackageRegistrationExtensions.IsSigningRequired(packageRegistration: null));
+
+                Assert.Equal("packageRegistration", exception.ParamName);
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithOneOwner_WhenRequiredSignerIsNullAndOwnerHasNoCertificate_ReturnsFalse()
+            {
+                Assert.False(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithOneOwner_WhenRequiredSignerIsNullAndOwnerHasCertificate_ReturnsTrue()
+            {
+                _user.UserCertificates.Add(new UserCertificate()
+                {
+                    Key = 4,
+                    User = _user,
+                    UserKey = _user.Key
+                });
+
+                Assert.True(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithTwoOwners_WhenRequiredSignerIsNullAndOnlyOwnerHasCertificate_ReturnsTrue()
+            {
+                var otherOwner = new User()
+                {
+                    Key = 4,
+                    Username = "d"
+                };
+
+                _user.UserCertificates.Add(new UserCertificate()
+                {
+                    Key = 5,
+                    User = _user,
+                    UserKey = _user.Key
+                });
+
+                _packageRegistration.Owners.Add(otherOwner);
+
+                Assert.True(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithTwoOwners_WhenRequiredSignerIsNullAndOnlyOtherOwnerHasCertificate_ReturnsTrue()
+            {
+                var otherOwner = new User()
+                {
+                    Key = 4,
+                    Username = "d"
+                };
+                otherOwner.UserCertificates.Add(new UserCertificate()
+                {
+                    Key = 5,
+                    User = otherOwner,
+                    UserKey = otherOwner.Key
+                });
+
+                _packageRegistration.Owners.Add(otherOwner);
+
+                Assert.True(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithOneOwner_WhenRequiredSignerIsOwnerAndOwnerHasNoCertificate_ReturnsFalse()
+            {
+                _packageRegistration.RequiredSigners.Add(_user);
+
+                Assert.False(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithOneOwner_WhenRequiredSignerIsOwnerAndOwnerHasCertificate_ReturnsTrue()
+            {
+                _user.UserCertificates.Add(new UserCertificate()
+                {
+                    Key = 4,
+                    User = _user,
+                    UserKey = _user.Key
+                });
+
+                _packageRegistration.RequiredSigners.Add(_user);
+
+                Assert.True(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithTwoOwners_WhenRequiredSignerIsOwnerAndOnlyOwnerHasCertificate_ReturnsTrue()
+            {
+                var otherOwner = new User()
+                {
+                    Key = 4,
+                    Username = "d"
+                };
+                _user.UserCertificates.Add(new UserCertificate()
+                {
+                    Key = 5,
+                    User = _user,
+                    UserKey = _user.Key
+                });
+
+                _packageRegistration.Owners.Add(otherOwner);
+                _packageRegistration.RequiredSigners.Add(_user);
+
+                Assert.True(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithTwoOwners_WhenRequiredSignerIsOwnerAndOnlyOtherOwnerHasCertificate_ReturnsFalse()
+            {
+                var otherOwner = new User()
+                {
+                    Key = 4,
+                    Username = "d"
+                };
+                otherOwner.UserCertificates.Add(new UserCertificate()
+                {
+                    Key = 5,
+                    User = otherOwner,
+                    UserKey = otherOwner.Key
+                });
+
+                _packageRegistration.Owners.Add(otherOwner);
+                _packageRegistration.RequiredSigners.Add(_user);
+
+                Assert.False(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithTwoOwners_WhenRequiredSignerIsOwnerAndAllOwnersHaveCertificate_ReturnsTrue()
+            {
+                _user.UserCertificates.Add(new UserCertificate()
+                {
+                    Key = 5,
+                    User = _user,
+                    UserKey = _user.Key
+                });
+                var otherOwner = new User()
+                {
+                    Key = 4,
+                    Username = "d"
+                };
+                otherOwner.UserCertificates.Add(new UserCertificate()
+                {
+                    Key = 6,
+                    User = otherOwner,
+                    UserKey = otherOwner.Key
+                });
+
+                _packageRegistration.Owners.Add(otherOwner);
+                _packageRegistration.RequiredSigners.Add(_user);
+
+                Assert.True(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithTwoOwners_WhenRequiredSignerIsOwnerAndNoOwnersHaveCertificate_ReturnsFalse()
+            {
+                var otherOwner = new User()
+                {
+                    Key = 4,
+                    Username = "d"
+                };
+
+                _packageRegistration.Owners.Add(otherOwner);
+                _packageRegistration.RequiredSigners.Add(_user);
+
+                Assert.False(_packageRegistration.IsSigningAllowed());
+            }
+
+            [Fact]
+            public void IsSigningAllowed_WithTwoOwners_WhenRequiredSignerIsNullAndNeitherOwnerHasCertificate_ReturnsFalse()
+            {
+                var otherOwner = new User()
+                {
+                    Key = 4,
+                    Username = "d"
+                };
+
+                _packageRegistration.Owners.Add(otherOwner);
+
+                Assert.False(_packageRegistration.IsSigningAllowed());
+            }
+        }
+
         public class TheIsSigningRequiredMethod
         {
             private readonly Package _package;


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6181.

The fast check (not in this PR) will reject the package if any of these conditions are true:

- Signing is required on the ID and there is no signature file
   - signing is required if all signers have at least one certificate
- Signing is not allowed on the ID and there is a signature file
   - signing is not allowed if all signers have no certificates

It is possible for signing to be allowed but not required if there are two owners on a package: one with certificates and one without certificates. In this case we can't do a fast check based off of the presence of a signature file.

I chose to name the method `IsSigningAllowed` instead of `IsSigningNotAllowed` so the call sign can negate the behavior without a double negative. The usage I will be adding will be `!IsSigningAllowed()`.