### PR TITLE
Fail fast when package signing status does not match owner/ID requirements

### DIFF
--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -336,5 +336,7 @@ namespace NuGetGallery.Configuration
 
         [DefaultValue(true)]
         public bool IsHosted { get; set; }
+
+        public bool RejectSignedPackagesWithNoRegisteredCertificate { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -333,5 +333,11 @@ namespace NuGetGallery.Configuration
         /// gallery code is being used inside a console application.
         /// </summary>
         bool IsHosted { get; set; }
+
+        /// <summary>
+        /// Whether or not to synchronously reject signed packages on push/upload when no certificate is uploaded
+        /// by the owner.
+        /// </summary>
+        bool RejectSignedPackagesWithNoRegisteredCertificate { get; set; }
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -489,6 +489,23 @@ namespace NuGetGallery
                                 owner,
                                 currentUser);
 
+                            var validationResult = await PackageUploadService.ValidatePackageAsync(
+                                package,
+                                packageToPush,
+                                owner,
+                                currentUser);
+                            switch (validationResult.Type)
+                            {
+                                case PackageValidationResultType.Accepted:
+                                    break;
+                                case PackageValidationResultType.Invalid:
+                                case PackageValidationResultType.PackageShouldNotBeSigned:
+                                case PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates:
+                                    return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, validationResult.Message);
+                                default:
+                                    throw new NotImplementedException($"The package validation result type {validationResult.Type} is not supported.");
+                            }
+
                             await AutoCuratePackage.ExecuteAsync(package, packageToPush, commitChanges: false);
 
                             PackageCommitResult commitResult;

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -391,6 +391,7 @@
     <Compile Include="Services\ImmediatePackageValidator.cs" />
     <Compile Include="Services\ContentObjectService.cs" />
     <Compile Include="Services\ISymbolPackageService.cs" />
+    <Compile Include="Services\PackageCommitResult.cs" />
     <Compile Include="Services\PackageOwnershipManagementService.cs" />
     <Compile Include="Services\IPackageOwnershipManagementService.cs" />
     <Compile Include="Services\IPackageValidationInitiator.cs" />
@@ -472,6 +473,8 @@
     <Compile Include="Services\IReservedNamespaceService.cs" />
     <Compile Include="Services\IPackageUploadService.cs" />
     <Compile Include="Services\LoginDiscontinuationConfiguration.cs" />
+    <Compile Include="Services\PackageValidationResult.cs" />
+    <Compile Include="Services\PackageValidationResultType.cs" />
     <Compile Include="Services\PermissionsCheckResult.cs" />
     <Compile Include="Services\PermissionsRequirement.cs" />
     <Compile Include="Services\ReservedNamespaceService.cs" />
@@ -1382,7 +1385,7 @@
     <Compile Include="Controllers\AuthenticationController.cs" />
     <Compile Include="Controllers\UsersController.cs" />
     <Compile Include="Infrastructure\CookieTempDataProvider.cs" />
-    <Compile Include="Services\Extensions.cs" />
+    <Compile Include="Services\SearchExtensionMethods.cs" />
     <Compile Include="Services\IMessageService.cs" />
     <Compile Include="Services\MessageService.cs" />
     <Compile Include="ViewModels\ContactOwnersViewModel.cs" />

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -203,7 +203,7 @@
                 return;
             }
 
-            clearErrors()
+            clearErrors();
 
             var failureContainer = $("#validation-failure-container");
             var failureListContainer = document.createElement("div");
@@ -269,7 +269,10 @@
                     $('#icon-preview').attr('src', $('#iconurl-field').val());
                 });
 
-                $("#verify-warning-container").removeClass("hidden");
+                if ($("#validation-failure-list .alert").length === 0) {
+                    $("#verify-warning-container").removeClass("hidden");
+                }
+
                 $("#verify-collapser-container").removeClass("hidden");
                 $("#submit-collapser-container").removeClass("hidden");
 

--- a/src/NuGetGallery/Services/IPackageUploadService.cs
+++ b/src/NuGetGallery/Services/IPackageUploadService.cs
@@ -8,28 +8,29 @@ using NuGetGallery.Packaging;
 
 namespace NuGetGallery
 {
-    /// <summary>
-    /// Non-exceptional results of calling <see cref="IPackageUploadService.CommitPackageAsync(Package, Stream)"/>.
-    /// </summary>
-    public enum PackageCommitResult
-    {
-        /// <summary>
-        /// The package was successfully committed to the package file storage and to the database.
-        /// </summary>
-        Success,
-
-        /// <summary>
-        /// The package file conflicts with an existing package file. The package was not committed to the database.
-        /// </summary>
-        Conflict,
-    }
-
     public interface IPackageUploadService
     {
         Task<Package> GeneratePackageAsync(
             string id,
             PackageArchiveReader nugetPackage,
             PackageStreamMetadata packageStreamMetadata,
+            User owner,
+            User currentUser);
+
+        /// <summary>
+        /// Validate the provided package once the new packages owner is known. The validations performed by this
+        /// method should make sense for both the UI upload and command line push. This should be called after
+        /// <see cref="GeneratePackageAsync(string, PackageArchiveReader, PackageStreamMetadata, User, User)"/> but
+        /// before <see cref="CommitPackageAsync(Package, Stream)"/>.
+        /// </summary>
+        /// <param name="package">The package entity not yet committed to the database.</param>
+        /// <param name="nuGetPackage">The package archive reader.</param>
+        /// <param name="owner">The owner of the package.</param>
+        /// <param name="currentUser">The current user.</param>
+        /// <returns>The package validation result.</returns>
+        Task<PackageValidationResult> ValidatePackageAsync(
+            Package package,
+            PackageArchiveReader nuGetPackage,
             User owner,
             User currentUser);
 

--- a/src/NuGetGallery/Services/PackageCommitResult.cs
+++ b/src/NuGetGallery/Services/PackageCommitResult.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Non-exceptional results of calling <see cref="IPackageUploadService.CommitPackageAsync(Package, Stream)"/>.
+    /// </summary>
+    public enum PackageCommitResult
+    {
+        /// <summary>
+        /// The package was successfully committed to the package file storage and to the database.
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// The package file conflicts with an existing package file. The package was not committed to the database.
+        /// </summary>
+        Conflict,
+    }
+}

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -96,7 +96,7 @@ namespace NuGetGallery
 
                 ValidateNuGetPackageMetadata(packageMetadata);
 
-                packageRegistration = CreateOrGetPackageRegistration(owner, currentUser, packageMetadata, isVerified);
+                packageRegistration = CreateOrGetPackageRegistration(owner, packageMetadata, isVerified);
             }
             catch (Exception exception) when (exception is EntityException || exception is PackagingException)
             {
@@ -443,7 +443,7 @@ namespace NuGetGallery
             }
         }
 
-        private PackageRegistration CreateOrGetPackageRegistration(User owner, User currentUser, PackageMetadata packageMetadata, bool isVerified)
+        private PackageRegistration CreateOrGetPackageRegistration(User owner, PackageMetadata packageMetadata, bool isVerified)
         {
             var packageRegistration = FindPackageRegistrationById(packageMetadata.Id);
 

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging;
+using NuGetGallery.Configuration;
+using NuGetGallery.Extensions;
 using NuGetGallery.Packaging;
 
 namespace NuGetGallery
@@ -18,19 +20,109 @@ namespace NuGetGallery
         private readonly IEntitiesContext _entitiesContext;
         private readonly IReservedNamespaceService _reservedNamespaceService;
         private readonly IValidationService _validationService;
+        private readonly IAppConfiguration _config;
 
         public PackageUploadService(
             IPackageService packageService,
             IPackageFileService packageFileService,
             IEntitiesContext entitiesContext,
             IReservedNamespaceService reservedNamespaceService,
-            IValidationService validationService)
+            IValidationService validationService,
+            IAppConfiguration config)
         {
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
             _packageFileService = packageFileService ?? throw new ArgumentNullException(nameof(packageFileService));
             _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
             _reservedNamespaceService = reservedNamespaceService ?? throw new ArgumentNullException(nameof(reservedNamespaceService));
             _validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        public async Task<PackageValidationResult> ValidatePackageAsync(
+            Package package,
+            PackageArchiveReader nuGetPackage,
+            User owner,
+            User currentUser)
+        {
+            var result = await ValidateSignatureFilePresenceAsync(
+                package.PackageRegistration,
+                nuGetPackage,
+                owner,
+                currentUser);
+            if (result != null)
+            {
+                return result;
+            }
+
+            return PackageValidationResult.Accepted();
+        }
+
+        private async Task<PackageValidationResult> ValidateSignatureFilePresenceAsync(
+            PackageRegistration packageRegistration,
+            PackageArchiveReader nugetPackage,
+            User owner,
+            User currentUser)
+        {
+            if (await nugetPackage.IsSignedAsync(CancellationToken.None))
+            {
+                if (_config.RejectSignedPackagesWithNoRegisteredCertificate
+                    && !packageRegistration.IsSigningAllowed())
+                {
+                    var requiredSigner = packageRegistration.RequiredSigners.FirstOrDefault();
+                    var hasRequiredSigner = requiredSigner != null;
+
+                    if (hasRequiredSigner)
+                    {
+                        if (requiredSigner == currentUser)
+                        {
+                            return new PackageValidationResult(
+                                PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates,
+                                Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates);
+                        }
+                        else
+                        {
+                            return new PackageValidationResult(
+                               PackageValidationResultType.PackageShouldNotBeSigned,
+                               string.Format(
+                                   Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner,
+                                   requiredSigner.Username));
+                        }
+                    }
+                    else
+                    {
+                        var isCurrentUserAnOwner = packageRegistration.Owners.Contains(currentUser);
+
+                        // Technically, if there is no required signer, any one of the owners can register a
+                        // certificate to resolve this issue. However, we favor either the current user or the provided
+                        // owner since these are both accounts the current user can push on behalf of. In other words
+                        // we provide a message that leads the current user to remedying the problem rather than asking
+                        // someone else for help.
+                        if (isCurrentUserAnOwner)
+                        {
+                            return new PackageValidationResult(
+                                PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates,
+                                Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates);
+                        }
+                        else
+                        {
+                            return new PackageValidationResult(
+                               PackageValidationResultType.PackageShouldNotBeSigned,
+                               string.Format(
+                                   Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner,
+                                   owner.Username));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (packageRegistration.IsSigningRequired())
+                {
+                    return PackageValidationResult.Invalid(Strings.UploadPackage_PackageIsNotSigned);
+                }
+            }
+
+            return null;
         }
 
         public async Task<Package> GeneratePackageAsync(

--- a/src/NuGetGallery/Services/PackageValidationResult.cs
+++ b/src/NuGetGallery/Services/PackageValidationResult.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Non-exception result of calling
+    /// <see cref="IPackageUploadService.ValidatePackageAsync(string, PackageArchiveReader, User)"/>.
+    /// </summary>
+    public class PackageValidationResult
+    {
+        public PackageValidationResult(PackageValidationResultType type, string message)
+        {
+            if (type != PackageValidationResultType.Accepted && message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            Type = type;
+            Message = message;
+        }
+
+        public PackageValidationResultType Type { get; }
+        public string Message { get; }
+
+        public static PackageValidationResult Accepted()
+        {
+            return new PackageValidationResult(PackageValidationResultType.Accepted, message: null);
+        }
+
+        public static PackageValidationResult Invalid(string message)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            return new PackageValidationResult(PackageValidationResultType.Invalid, message);
+        }
+    }
+}

--- a/src/NuGetGallery/Services/PackageValidationResultType.cs
+++ b/src/NuGetGallery/Services/PackageValidationResultType.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// The type of <see cref="PackageValidationResult"/>.
+    /// </summary>
+    public enum PackageValidationResultType
+    {
+        /// <summary>
+        /// The package is valid based on the performed validations. Note that the caller may perform other validations
+        /// so this is not an all inclusive validation.
+        /// </summary>
+        Accepted,
+
+        /// <summary>
+        /// The package is invalid based on the package content.
+        /// </summary>
+        Invalid,
+
+        /// <summary>
+        /// The package is invalid because it should not be signed given the current required signer certificates (or
+        /// lack thereof).
+        /// </summary>
+        PackageShouldNotBeSigned,
+
+        /// <summary>
+        /// Similar to <see cref="PackageShouldNotBeSigned"/> but the current user can manage certificates and
+        /// potentially remediate the situation.
+        /// </summary>
+        PackageShouldNotBeSignedButCanManageCertificates,
+    }
+}

--- a/src/NuGetGallery/Services/SearchExtensionMethods.cs
+++ b/src/NuGetGallery/Services/SearchExtensionMethods.cs
@@ -7,7 +7,7 @@ using System.Linq.Expressions;
 
 namespace NuGetGallery
 {
-    public static class Extensions
+    public static class SearchExtensionMethods
     {
         // Search criteria
         private static readonly Func<string, Expression<Func<Package, bool>>> IdCriteria = term =>

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2066,6 +2066,43 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This package must be signed with a registered certificate..
+        /// </summary>
+        public static string UploadPackage_PackageIsNotSigned {
+            get {
+                return ResourceManager.GetString("UploadPackage_PackageIsNotSigned", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package was signed. You must register the signing certificate to publish signed packages..
+        /// </summary>
+        public static string UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates {
+            get {
+                return ResourceManager.GetString("UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificat" +
+                        "es", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You can manage your certificates on the Account Settings page..
+        /// </summary>
+        public static string UploadPackage_PackageIsSignedButMissingCertificate_ManageCertificate {
+            get {
+                return ResourceManager.GetString("UploadPackage_PackageIsSignedButMissingCertificate_ManageCertificate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package was signed. The owner &apos;{0}&apos; must register the signing certificate to publish signed packages..
+        /// </summary>
+        public static string UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner {
+            get {
+                return ResourceManager.GetString("UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot upload file because an upload is already in progress..
         /// </summary>
         public static string UploadPackage_UploadInProgress {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -911,4 +911,17 @@ If you would like to update the linked Microsoft account you can do so from the 
   <data name="PackageFileTooLarge" xml:space="preserve">
     <value>The package file exceeds the size limit. Please try again.</value>
   </data>
+  <data name="UploadPackage_PackageIsNotSigned" xml:space="preserve">
+    <value>This package must be signed with a registered certificate.</value>
+  </data>
+  <data name="UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates" xml:space="preserve">
+    <value>The package was signed. You must register the signing certificate to publish signed packages.</value>
+  </data>
+  <data name="UploadPackage_PackageIsSignedButMissingCertificate_ManageCertificate" xml:space="preserve">
+    <value>You can manage your certificates on the Account Settings page.</value>
+  </data>
+  <data name="UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner" xml:space="preserve">
+    <value>The package was signed. The owner '{0}' must register the signing certificate to publish signed packages.</value>
+    <comment>{0} is the signer name.</comment>
+  </data>
 </root>

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -53,7 +53,7 @@
             @if (Model != null && Model.IsUploadInProgress)
             {
                 <div id="warning-container">
-                    @ViewHelpers.AlertWarning(@<text>You had an upload in progress. You can continue it here or cancel to restart.</text>                    )
+                    @ViewHelpers.AlertWarning(@<text>You had an upload in progress. You can continue it here or cancel to restart.</text>)
                     @ViewHelpers.AlertPackageVerifyRecommendation()
                 </div>
             }

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -146,6 +146,7 @@
     <add key="Gallery.ExternalBrandingMessage" value=""/>
     <add key="Gallery.TrademarksUrl" value=""/>
     <add key="Gallery.EnforceDefaultSecurityPolicies" value="false"/>
+    <add key="Gallery.RejectSignedPackagesWithNoRegisteredCertificate" value="false"/>
     <!-- This is also the default so you can remove this setting if you really want. -->
     <!-- Set this to false if you want to disable search indexing in the background. -->
     <add key="Gallery.AutoUpdateSearchIndex" value="true"/>

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -10,6 +10,7 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
+using NuGetGallery.Configuration;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
 using NuGetGallery.Security;
@@ -165,7 +166,7 @@ namespace NuGetGallery
         public class TheCreatePackageMethod
         {
             [Fact]
-            public void WillCreateANewPackageRegistrationUsingTheNugetPackIdWhenOneDoesNotAlreadyExist()
+            public async Task WillCreateANewPackageRegistrationUsingTheNugetPackIdWhenOneDoesNotAlreadyExist()
             {
                 var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
                 var service = CreateService(packageRegistrationRepository: packageRegistrationRepository, setup: mockPackageService =>
@@ -176,13 +177,13 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
+                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 packageRegistrationRepository.Verify(x => x.InsertOnCommit(It.Is<PackageRegistration>(pr => pr.Id == "theId")));
             }
 
             [Fact]
-            public void WillMakeTheCurrentUserTheOwnerWhenCreatingANewPackageRegistration()
+            public async Task WillMakeTheCurrentUserTheOwnerWhenCreatingANewPackageRegistration()
             {
                 var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
                 var service = CreateService(packageRegistrationRepository: packageRegistrationRepository, setup:
@@ -190,7 +191,7 @@ namespace NuGetGallery
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
                 var currentUser = new User();
 
-                service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
+                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
 
                 packageRegistrationRepository.Verify(x => x.InsertOnCommit(It.Is<PackageRegistration>(pr => pr.Owners.Contains(currentUser))));
             }
@@ -407,19 +408,21 @@ namespace NuGetGallery
             [Fact]
             private async Task DoesNotThrowIfTheNuGetPackageSpecialVersionContainsADot()
             {
+                var user = new User();
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: "theId", version: "1.2.3-alpha.0");
 
-                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false);
+                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: user, currentUser: user, isVerified: false);
             }
 
             [Fact]
             private async Task DoesNotThrowIfTheNuGetPackageSpecialVersionContainsOnlyNumbers()
             {
+                var user = new User();
                 var service = CreateService();
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage(id: "theId", version: "1.2.3-12345");
 
-                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false);
+                await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: user, currentUser: user, isVerified: false);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Packaging;
+using NuGetGallery.Configuration;
 using NuGetGallery.Packaging;
 using NuGetGallery.TestUtils;
 using Xunit;
@@ -24,12 +26,10 @@ namespace NuGetGallery
         private static PackageUploadService CreateService(
             Mock<IPackageService> packageService = null,
             Mock<IReservedNamespaceService> reservedNamespaceService = null,
-            Mock<IValidationService> validationService = null)
+            Mock<IValidationService> validationService = null,
+            Mock<IAppConfiguration> config = null)
         {
-            if (packageService == null)
-            {
-                packageService = new Mock<IPackageService>();
-            }
+            packageService = packageService ?? new Mock<IPackageService>();
 
             packageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
             packageService.Setup(x => x
@@ -57,17 +57,16 @@ namespace NuGetGallery
                     .Returns(new ReservedNamespace[0]);
             }
 
-            if (validationService == null)
-            {
-                validationService = new Mock<IValidationService>();
-            }
+            validationService = validationService ?? new Mock<IValidationService>();
+            config = config ?? new Mock<IAppConfiguration>();
 
             var packageUploadService = new Mock<PackageUploadService>(
                 packageService.Object,
                 new Mock<IPackageFileService>().Object,
                 new Mock<IEntitiesContext>().Object,
                 reservedNamespaceService.Object,
-                validationService.Object);
+                validationService.Object,
+                config.Object);
 
             return packageUploadService.Object;
         }
@@ -159,6 +158,238 @@ namespace NuGetGallery
                 var package = await packageUploadService.GeneratePackageAsync(id, nugetPackage.Object, new PackageStreamMetadata(), lastUser, lastUser);
 
                 Assert.False(package.PackageRegistration.IsVerified);
+            }
+        }
+
+        public class TheValidatePackageMethod : FactsBase
+        {
+            private readonly User _currentUser;
+            private User _owner;
+            private Mock<TestPackageReader> _nuGetPackage;
+
+            public TheValidatePackageMethod()
+            {
+                _currentUser = new User
+                {
+                    Key = 1,
+                    UserCertificates = { new UserCertificate() },
+                };
+                _owner = _currentUser;
+                _package.PackageRegistration.Owners = new List<User> { _currentUser };
+                _nuGetPackage = GeneratePackage(isSigned: true);
+                _config
+                    .Setup(x => x.RejectSignedPackagesWithNoRegisteredCertificate)
+                    .Returns(true);
+            }
+
+            [Fact]
+            public async Task RejectsSignedPackageIfSigningIsNotAllowed_HasAnySignerAndOneOwner()
+            {
+                _currentUser.UserCertificates.Clear();
+
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates, result.Type);
+                Assert.Equal(Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates, result.Message);
+            }
+
+            [Fact]
+            public async Task RejectsSignedPackageIfSigningIsNotAllowed_HasAnySignerAndMultipleOwners()
+            {
+                _currentUser.UserCertificates.Clear();
+                _package.PackageRegistration.Owners.Add(new User { Key = _currentUser.Key + 1 });
+
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates, result.Type);
+                Assert.Equal(Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates, result.Message);
+            }
+
+            [Fact]
+            public async Task RejectsSignedPackageIfSigningIsNotAllowed_HasRequiredSignerThatIsCurrentUser()
+            {
+                _currentUser.UserCertificates.Clear();
+                _package.PackageRegistration.RequiredSigners.Add(_currentUser);
+
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates, result.Type);
+                Assert.Equal(Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates, result.Message);
+            }
+
+            [Fact]
+            public async Task RejectsSignedPackageIfSigningIsNotAllowed_HasRequiredSignerThatIsOtherUser()
+            {
+                var otherUser = new User
+                {
+                    Key = _currentUser.Key + 1,
+                    Username = "Other",
+                };
+                _currentUser.UserCertificates.Clear();
+                _package.PackageRegistration.RequiredSigners.Add(otherUser);
+
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSigned, result.Type);
+                Assert.Equal(
+                    string.Format(Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner, otherUser.Username),
+                    result.Message);
+            }
+
+            [Fact]
+            public async Task RejectsSignedPackageIfSigningIsNotAllowed_HasAnySignerAndOwnerThatIsOtherUser()
+            {
+                _owner = new User
+                {
+                    Key = _currentUser.Key + 1,
+                    Username = "OtherA",
+                };
+                var ownerB = new User
+                {
+                    Key = _owner.Key + 2,
+                    Username = "OtherB",
+                };
+                _package.PackageRegistration.Owners.Clear();
+                _package.PackageRegistration.Owners.Add(_owner);
+                _package.PackageRegistration.Owners.Add(ownerB);
+
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSigned, result.Type);
+                Assert.Equal(
+                    string.Format(Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner, _owner.Username),
+                    result.Message);
+            }
+
+            [Fact]
+            public async Task RejectsSignedPackageIfSigningIsNotAllowed_HasRequiredSignerAndOwnerThatIsOtherUser()
+            {
+                _owner = new User
+                {
+                    Key = _currentUser.Key + 1,
+                    Username = "OtherA",
+                };
+                var ownerB = new User
+                {
+                    Key = _currentUser.Key + 2,
+                    Username = "OtherB",
+                };
+                _package.PackageRegistration.Owners.Clear();
+                _package.PackageRegistration.Owners.Add(_owner);
+                _package.PackageRegistration.Owners.Add(ownerB);
+                _package.PackageRegistration.RequiredSigners.Add(ownerB);
+
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSigned, result.Type);
+                Assert.Equal(
+                    string.Format(Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner, ownerB.Username),
+                    result.Message);
+            }
+
+            [Fact]
+            public async Task AllowsSignedPackageOnOwnerWithNoCertificatesIfConfigAllows()
+            {
+                _currentUser.UserCertificates.Clear();
+                _config
+                    .Setup(x => x.RejectSignedPackagesWithNoRegisteredCertificate)
+                    .Returns(false);
+
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.Accepted, result.Type);
+                Assert.Null(result.Message);
+            }
+
+            [Fact]
+            public async Task AllowsSignedPackageIfSigningIsRequired()
+            {
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.Accepted, result.Type);
+                Assert.Null(result.Message);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public async Task RejectsUnsignedPackageIfSigningIsRequiredIrrespectiveOfConfig(bool configFlag)
+            {
+                _nuGetPackage = GeneratePackage(isSigned: false);
+                _config
+                    .Setup(x => x.RejectSignedPackagesWithNoRegisteredCertificate)
+                    .Returns(configFlag);
+
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.Invalid, result.Type);
+                Assert.Equal(Strings.UploadPackage_PackageIsNotSigned, result.Message);
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public async Task AllowsBothSignedAndUnsignedPackagesIfSigningIsNotRequired(bool isSigned)
+            {
+                var ownerB = new User
+                {
+                    Key = _currentUser.Key + 1,
+                };
+                _package.PackageRegistration.Owners.Add(ownerB);
+                _nuGetPackage = GeneratePackage(isSigned);
+
+                var result = await _target.ValidatePackageAsync(
+                    _package,
+                    _nuGetPackage.Object,
+                    _owner,
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.Accepted, result.Type);
+                Assert.Null(result.Message);
+            }
+
+            private static Mock<TestPackageReader> GeneratePackage(bool isSigned)
+            {
+                return PackageServiceUtility.CreateNuGetPackage(
+                    id: "theId",
+                    version: "1.2.3-alpha.0",
+                    isSigned: isSigned);
             }
         }
 
@@ -441,10 +672,12 @@ namespace NuGetGallery
             protected readonly Mock<IEntitiesContext> _entitiesContext;
             protected readonly Mock<IReservedNamespaceService> _reservedNamespaceService;
             protected readonly Mock<IValidationService> _validationService;
+            protected readonly Mock<IAppConfiguration> _config;
             protected Package _package;
             protected Stream _packageFile;
             protected ArgumentException _unexpectedException;
             protected FileAlreadyExistsException _conflictException;
+            protected readonly CancellationToken _token;
             protected readonly PackageUploadService _target;
 
             public FactsBase()
@@ -454,6 +687,7 @@ namespace NuGetGallery
                 _entitiesContext = new Mock<IEntitiesContext>();
                 _reservedNamespaceService = new Mock<IReservedNamespaceService>();
                 _validationService = new Mock<IValidationService>();
+                _config = new Mock<IAppConfiguration>();
 
                 _package = new Package
                 {
@@ -466,13 +700,15 @@ namespace NuGetGallery
                 _packageFile = Stream.Null;
                 _unexpectedException = new ArgumentException("Fail!");
                 _conflictException = new FileAlreadyExistsException("Conflict!");
+                _token = CancellationToken.None;
 
                 _target = new PackageUploadService(
                     _packageService.Object,
                     _packageFileService.Object,
                     _entitiesContext.Object,
                     _reservedNamespaceService.Object,
-                    _validationService.Object);
+                    _validationService.Object,
+                    _config.Object);
             }
         }
     }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6181.

## Command line experience

Pushing an unsigned package when a signed one is required.

```
> nuget.exe push .\testunsigned.1.0.0.nupkg -apikey FOO -source https://localhost
Pushing testunsigned.1.0.0.nupkg to 'https://localhost'...
  PUT https://localhost/api/v2/package/
  BadRequest https://localhost/api/v2/package/ 387ms
Response status code does not indicate success: 400 (This package must be signed with a registered certificate.).
```

Pushing a signed package when an unsigned one is required.

```
> nuget.exe push .\system.rido.1.0.1.nupkg -apikey FOO -source https://localhost
Pushing system.rido.1.0.1.nupkg to 'https://localhost'...
  PUT https://localhost/api/v2/package/
  BadRequest https://localhost/api/v2/package/ 974ms
Response status code does not indicate success: 400 (The package was signed. You must register the signing certificate to publish signed packages.).
```

## Web UI upload

Uploading an unsigned package when a signed one is required:

![image](https://user-images.githubusercontent.com/94054/43409613-482e4312-93d9-11e8-8747-61323487f598.png)

Uploading a signed package when an unsigned one is required.

![image](https://user-images.githubusercontent.com/94054/43409424-bba6f646-93d8-11e8-92bf-53a063b03984.png)
