### PR TITLE
Update bootstrap dependency versions

### DIFF
--- a/src/Bootstrap/package-lock.json
+++ b/src/Bootstrap/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.15",
+        "mime-types": "~2.1.11",
         "negotiator": "0.6.1"
       }
     },
@@ -38,7 +38,7 @@
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -55,8 +55,8 @@
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
+        "extend": "~3.0.0",
+        "semver": "~5.0.1"
       },
       "dependencies": {
         "semver": {
@@ -73,8 +73,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "align-text": {
@@ -83,9 +83,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -112,15 +112,15 @@
       "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "async": "2.5.0",
-        "buffer-crc32": "0.2.13",
-        "glob": "7.0.6",
-        "lodash": "4.17.4",
-        "readable-stream": "2.3.3",
-        "tar-stream": "1.5.4",
-        "walkdir": "0.0.11",
-        "zip-stream": "1.2.0"
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "walkdir": "^0.0.11",
+        "zip-stream": "^1.1.0"
       },
       "dependencies": {
         "async": {
@@ -129,7 +129,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "lodash": {
@@ -146,12 +146,12 @@
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
       "requires": {
-        "glob": "7.0.6",
-        "graceful-fs": "4.1.11",
-        "lazystream": "1.0.0",
-        "lodash": "4.17.4",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.3"
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -168,7 +168,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-differ": {
@@ -189,7 +189,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -240,10 +240,10 @@
       "integrity": "sha1-5kDEFK5Bmq4hwa1DyOoPPbgqVm0=",
       "dev": true,
       "requires": {
-        "browserslist": "0.4.0",
-        "caniuse-db": "1.0.30000696",
-        "num2fraction": "1.2.2",
-        "postcss": "4.1.16"
+        "browserslist": "~0.4.0",
+        "caniuse-db": "^1.0.30000214",
+        "num2fraction": "^1.1.0",
+        "postcss": "~4.1.12"
       }
     },
     "aws-sign2": {
@@ -264,8 +264,8 @@
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
       "dev": true,
       "requires": {
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.10.0"
       }
     },
     "babylon": {
@@ -299,7 +299,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
@@ -308,7 +308,7 @@
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "body-parser": {
@@ -318,15 +318,15 @@
       "dev": true,
       "requires": {
         "bytes": "2.2.0",
-        "content-type": "1.0.2",
-        "debug": "2.2.0",
-        "depd": "1.1.0",
-        "http-errors": "1.3.1",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.3.1",
         "iconv-lite": "0.4.13",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "5.2.0",
-        "raw-body": "2.1.7",
-        "type-is": "1.6.15"
+        "raw-body": "~2.1.5",
+        "type-is": "~1.6.10"
       },
       "dependencies": {
         "debug": {
@@ -344,8 +344,8 @@
           "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "statuses": "1.3.1"
+            "inherits": "~2.0.1",
+            "statuses": "1"
           }
         },
         "iconv-lite": {
@@ -374,7 +374,7 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
@@ -383,7 +383,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -393,7 +393,7 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "~0.2.0"
       }
     },
     "browserslist": {
@@ -402,7 +402,7 @@
       "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000696"
+        "caniuse-db": "^1.0.30000153"
       }
     },
     "btoa": {
@@ -435,8 +435,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -451,8 +451,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "caniuse-db": {
@@ -473,8 +473,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -483,11 +483,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "change-case": {
@@ -496,24 +496,24 @@
       "integrity": "sha1-7l9a0EFa0a2egHLPSc1M+nZgpVQ=",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "constant-case": "2.0.0",
-        "dot-case": "2.1.1",
-        "header-case": "1.0.1",
-        "is-lower-case": "1.1.3",
-        "is-upper-case": "1.1.2",
-        "lower-case": "1.1.4",
-        "lower-case-first": "1.0.2",
-        "no-case": "2.3.1",
-        "param-case": "2.1.1",
-        "pascal-case": "2.0.1",
-        "path-case": "2.1.1",
-        "sentence-case": "2.1.1",
-        "snake-case": "2.1.0",
-        "swap-case": "1.1.2",
-        "title-case": "2.1.1",
-        "upper-case": "1.1.3",
-        "upper-case-first": "1.1.2"
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.2.0",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "character-parser": {
@@ -522,7 +522,7 @@
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "dev": true,
       "requires": {
-        "is-regex": "1.0.4"
+        "is-regex": "^1.0.3"
       }
     },
     "clean-css": {
@@ -531,8 +531,8 @@
       "integrity": "sha1-re91sxwWD/pdcvTeZ5ZuJmDBolU=",
       "dev": true,
       "requires": {
-        "commander": "2.8.1",
-        "source-map": "0.4.4"
+        "commander": "2.8.x",
+        "source-map": "0.4.x"
       }
     },
     "cli": {
@@ -542,7 +542,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "7.1.2"
+        "glob": "^7.1.1"
       },
       "dependencies": {
         "glob": {
@@ -551,12 +551,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -584,8 +584,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -613,7 +613,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -622,7 +622,7 @@
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "comment-parser": {
@@ -631,7 +631,7 @@
       "integrity": "sha1-/WV6rIwUktMIyaYQD8m0nSQ1q6E=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.4"
       }
     },
     "compress-commons": {
@@ -640,10 +640,10 @@
       "integrity": "sha1-WFhwku8g03y1i68AARLJJ4/3O58=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "crc32-stream": "2.0.0",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.3"
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "concat-map": {
@@ -658,9 +658,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "connect": {
@@ -671,7 +671,7 @@
       "requires": {
         "debug": "2.6.7",
         "finalhandler": "1.0.3",
-        "parseurl": "1.3.1",
+        "parseurl": "~1.3.1",
         "utils-merge": "1.0.0"
       }
     },
@@ -687,7 +687,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constant-case": {
@@ -696,8 +696,8 @@
       "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
       "dev": true,
       "requires": {
-        "snake-case": "2.1.0",
-        "upper-case": "1.1.3"
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
       }
     },
     "constantinople": {
@@ -706,8 +706,8 @@
       "integrity": "sha1-dWnKqKo/jVk11i4fqW+fcCzYHHk=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "is-expression": "2.1.0"
+        "acorn": "^3.1.0",
+        "is-expression": "^2.0.1"
       }
     },
     "content-type": {
@@ -740,8 +740,8 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "3.4.4",
-        "readable-stream": "2.3.3"
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
       }
     },
     "cryptiles": {
@@ -750,7 +750,7 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "csscomb": {
@@ -791,8 +791,8 @@
           "integrity": "sha1-6oKgEqxmLH3fqhRPHBR+aUb12vs=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -803,7 +803,7 @@
       "integrity": "sha1-OmoE51Zcjp0ZvrSXZ8fslug2WAU=",
       "dev": true,
       "requires": {
-        "parserlib": "0.2.5"
+        "parserlib": "~0.2.2"
       }
     },
     "cst": {
@@ -812,9 +812,9 @@
       "integrity": "sha512-U5ETe1IOjq2h56ZcBE3oe9rT7XryCH6IKgPMv0L7sSk6w29yR3p5egCK0T3BDNHHV95OoUBgXsqiVG+3a900Ag==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
-        "babylon": "6.17.4",
-        "source-map-support": "0.4.15"
+        "babel-runtime": "^6.9.2",
+        "babylon": "^6.8.1",
+        "source-map-support": "^0.4.0"
       }
     },
     "currently-unhandled": {
@@ -823,7 +823,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "cycle": {
@@ -838,7 +838,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -861,7 +861,7 @@
       "integrity": "sha1-GIdtC9pMGf5w3Tv0sDTygbEqQLY=",
       "dev": true,
       "requires": {
-        "time-zone": "0.1.0"
+        "time-zone": "^0.1.0"
       }
     },
     "dateformat": {
@@ -870,8 +870,8 @@
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.3.0"
       }
     },
     "debug": {
@@ -931,8 +931,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -961,7 +961,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -970,8 +970,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-case": {
@@ -980,7 +980,7 @@
       "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1"
+        "no-case": "^2.2.0"
       }
     },
     "ecc-jsbn": {
@@ -990,7 +990,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -1011,7 +1011,7 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "entities": {
@@ -1027,7 +1027,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "~0.0.0"
       }
     },
     "error-ex": {
@@ -1036,7 +1036,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es6-promise": {
@@ -1111,9 +1111,9 @@
           "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
-            "typedarray": "0.0.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
           }
         },
         "debug": {
@@ -1143,12 +1143,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1177,7 +1177,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.6.5"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fd-slicer": {
@@ -1186,7 +1186,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "fg-lodash": {
@@ -1195,8 +1195,8 @@
       "integrity": "sha1-mINSU39CfaavIiEpu2OsyknmL6M=",
       "dev": true,
       "requires": {
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "lodash": "^2.4.1",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "lodash": {
@@ -1219,8 +1219,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-sync-cmp": {
@@ -1236,12 +1236,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.7",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       }
     },
     "find-up": {
@@ -1250,8 +1250,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -1260,7 +1260,7 @@
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
-        "glob": "5.0.15"
+        "glob": "~5.0.0"
       },
       "dependencies": {
         "glob": {
@@ -1269,11 +1269,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -1290,16 +1290,15 @@
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
-      "dev": true
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
       "version": "0.26.7",
@@ -1307,11 +1306,11 @@
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.2.8"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -1332,7 +1331,7 @@
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "^1.0.0"
       }
     },
     "generate-function": {
@@ -1347,7 +1346,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-stdin": {
@@ -1368,7 +1367,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1385,12 +1384,12 @@
       "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globule": {
@@ -1399,9 +1398,9 @@
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.4",
+        "minimatch": "~3.0.2"
       },
       "dependencies": {
         "glob": {
@@ -1410,12 +1409,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "lodash": {
@@ -1450,22 +1449,22 @@
       "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.10.0",
-        "dateformat": "1.0.12",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.3.0",
-        "glob": "7.0.6",
-        "grunt-cli": "1.2.0",
-        "grunt-known-options": "1.1.0",
-        "grunt-legacy-log": "1.0.0",
-        "grunt-legacy-util": "1.0.0",
-        "iconv-lite": "0.4.18",
-        "js-yaml": "3.5.5",
-        "minimatch": "3.0.4",
-        "nopt": "3.0.6",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.2.8"
+        "coffee-script": "~1.10.0",
+        "dateformat": "~1.0.12",
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.3.0",
+        "glob": "~7.0.0",
+        "grunt-cli": "~1.2.0",
+        "grunt-known-options": "~1.1.0",
+        "grunt-legacy-log": "~1.0.0",
+        "grunt-legacy-util": "~1.0.0",
+        "iconv-lite": "~0.4.13",
+        "js-yaml": "~3.5.2",
+        "minimatch": "~3.0.0",
+        "nopt": "~3.0.6",
+        "path-is-absolute": "~1.0.0",
+        "rimraf": "~2.2.8"
       },
       "dependencies": {
         "grunt-cli": {
@@ -1474,10 +1473,10 @@
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
-            "findup-sync": "0.3.0",
-            "grunt-known-options": "1.1.0",
-            "nopt": "3.0.6",
-            "resolve": "1.1.7"
+            "findup-sync": "~0.3.0",
+            "grunt-known-options": "~1.1.0",
+            "nopt": "~3.0.6",
+            "resolve": "~1.1.0"
           }
         }
       }
@@ -1488,10 +1487,10 @@
       "integrity": "sha1-/kLiR7z6ucKSoSwGLa1PNb3pAsU=",
       "dev": true,
       "requires": {
-        "autoprefixer-core": "5.2.1",
-        "chalk": "1.0.0",
-        "diff": "1.3.2",
-        "postcss": "4.1.16"
+        "autoprefixer-core": "^5.1.7",
+        "chalk": "~1.0.0",
+        "diff": "~1.3.0",
+        "postcss": "^4.1.11"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1506,11 +1505,11 @@
           "integrity": "sha1-s89O0P9Tl8mcdbj2edsvUoMfltw=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "1.0.3",
-            "strip-ansi": "2.0.1",
-            "supports-color": "1.3.1"
+            "ansi-styles": "^2.0.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^1.0.3",
+            "strip-ansi": "^2.0.1",
+            "supports-color": "^1.3.0"
           }
         },
         "has-ansi": {
@@ -1519,8 +1518,8 @@
           "integrity": "sha1-wLWxYV2eOCsP9nFp2We0JeSMpTg=",
           "dev": true,
           "requires": {
-            "ansi-regex": "1.1.1",
-            "get-stdin": "4.0.1"
+            "ansi-regex": "^1.1.0",
+            "get-stdin": "^4.0.1"
           }
         },
         "strip-ansi": {
@@ -1529,7 +1528,7 @@
           "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "1.1.1"
+            "ansi-regex": "^1.0.0"
           }
         },
         "supports-color": {
@@ -1546,8 +1545,8 @@
       "integrity": "sha1-ay7ZQRfix//jLuBFeMlv5GJam20=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "rimraf": "2.6.1"
+        "async": "^1.5.2",
+        "rimraf": "^2.5.1"
       },
       "dependencies": {
         "rimraf": {
@@ -1556,7 +1555,7 @@
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
-            "glob": "7.0.6"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -1567,11 +1566,11 @@
       "integrity": "sha1-XlwmogBJCCPH93KIr9LXNQ2Vxj0=",
       "dev": true,
       "requires": {
-        "archiver": "1.3.0",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
-        "pretty-bytes": "3.0.1",
-        "stream-buffers": "2.2.0"
+        "archiver": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.7.0",
+        "pretty-bytes": "^3.0.1",
+        "stream-buffers": "^2.1.0"
       },
       "dependencies": {
         "lodash": {
@@ -1588,8 +1587,8 @@
       "integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "source-map": "0.5.6"
+        "chalk": "^1.0.0",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "source-map": {
@@ -1606,15 +1605,15 @@
       "integrity": "sha1-XPkzuRpnOGBEJzwLJERgPNmIebo=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "connect": "3.6.2",
-        "connect-livereload": "0.5.4",
-        "http2": "3.3.6",
-        "morgan": "1.8.2",
-        "opn": "4.0.2",
-        "portscanner": "1.2.0",
-        "serve-index": "1.9.0",
-        "serve-static": "1.12.3"
+        "async": "^1.5.2",
+        "connect": "^3.4.0",
+        "connect-livereload": "^0.5.0",
+        "http2": "^3.3.4",
+        "morgan": "^1.6.1",
+        "opn": "^4.0.0",
+        "portscanner": "^1.0.0",
+        "serve-index": "^1.7.1",
+        "serve-static": "^1.10.0"
       }
     },
     "grunt-contrib-copy": {
@@ -1623,8 +1622,8 @@
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "file-sync-cmp": "0.1.1"
+        "chalk": "^1.1.1",
+        "file-sync-cmp": "^0.1.0"
       }
     },
     "grunt-contrib-csslint": {
@@ -1633,10 +1632,10 @@
       "integrity": "sha1-0Fk4y6KncYXEppdTwXUdYW6p+pg=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "csslint": "0.10.0",
-        "lodash": "3.10.1",
-        "strip-json-comments": "1.0.4"
+        "chalk": "^1.0.0",
+        "csslint": "^0.10.0",
+        "lodash": "^3.8.0",
+        "strip-json-comments": "^1.0.2"
       }
     },
     "grunt-contrib-cssmin": {
@@ -1645,9 +1644,9 @@
       "integrity": "sha1-FzTL09hMpzZHWLflj/GOUqpgu3Y=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "clean-css": "3.4.27",
-        "maxmin": "1.1.0"
+        "chalk": "^1.0.0",
+        "clean-css": "~3.4.2",
+        "maxmin": "^1.1.0"
       }
     },
     "grunt-contrib-htmlmin": {
@@ -1656,9 +1655,9 @@
       "integrity": "sha1-Stes838ClP6OqX83NFrnC6elglE=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "html-minifier": "2.1.7",
-        "pretty-bytes": "3.0.1"
+        "chalk": "^1.0.0",
+        "html-minifier": "~2.1.7",
+        "pretty-bytes": "^3.0.1"
       }
     },
     "grunt-contrib-jshint": {
@@ -1667,9 +1666,9 @@
       "integrity": "sha1-MPQFpR3mVr+m6wKbmkZLn+AqQCo=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "hooker": "0.2.3",
-        "jshint": "2.9.5"
+        "chalk": "^1.1.1",
+        "hooker": "^0.2.3",
+        "jshint": "~2.9.1"
       }
     },
     "grunt-contrib-less": {
@@ -1678,10 +1677,10 @@
       "integrity": "sha1-UY73yG3GDhWeZRCKp125OpyP9dQ=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "chalk": "1.1.3",
-        "less": "2.6.1",
-        "lodash": "4.17.4"
+        "async": "^1.5.2",
+        "chalk": "^1.0.0",
+        "less": "~2.6.0",
+        "lodash": "^4.8.2"
       },
       "dependencies": {
         "lodash": {
@@ -1698,8 +1697,8 @@
       "integrity": "sha1-tSWlwK/wRiL3Vw4x+SQQbxb4G0Y=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "pug": "2.0.0-rc.2"
+        "chalk": "^1.0.0",
+        "pug": "^2.0.0-alpha3"
       }
     },
     "grunt-contrib-qunit": {
@@ -1708,7 +1707,7 @@
       "integrity": "sha1-YqaaNv8NEeHKhxIJC55Qt3W4+CU=",
       "dev": true,
       "requires": {
-        "grunt-lib-phantomjs": "0.6.0"
+        "grunt-lib-phantomjs": "^0.6.0"
       }
     },
     "grunt-contrib-uglify": {
@@ -1717,11 +1716,11 @@
       "integrity": "sha1-rmekb5FT7dTLEYE6Vetpxw19svs=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
-        "maxmin": "1.1.0",
-        "uglify-js": "2.6.4",
-        "uri-path": "1.0.0"
+        "chalk": "^1.0.0",
+        "lodash": "^4.0.1",
+        "maxmin": "^1.1.0",
+        "uglify-js": "~2.6.2",
+        "uri-path": "^1.0.0"
       },
       "dependencies": {
         "lodash": {
@@ -1738,10 +1737,10 @@
       "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "gaze": "1.1.2",
-        "lodash": "3.10.1",
-        "tiny-lr": "0.2.1"
+        "async": "^1.5.0",
+        "gaze": "^1.0.0",
+        "lodash": "^3.10.1",
+        "tiny-lr": "^0.2.1"
       }
     },
     "grunt-csscomb": {
@@ -1750,7 +1749,7 @@
       "integrity": "sha1-RUfb9ESaN+MgoKpRCigodbKI6jw=",
       "dev": true,
       "requires": {
-        "csscomb": "3.1.8"
+        "csscomb": "~3.1.0"
       }
     },
     "grunt-exec": {
@@ -1775,7 +1774,7 @@
       "integrity": "sha1-U7ut6Grp0UEkUhjgs6tMM0DNIGc=",
       "dev": true,
       "requires": {
-        "tmp": "0.0.31"
+        "tmp": "^0.0.31"
       }
     },
     "grunt-jscs": {
@@ -1784,10 +1783,10 @@
       "integrity": "sha1-H65Q4+lV3546nZQlrsIqzK4AgJI=",
       "dev": true,
       "requires": {
-        "hooker": "0.2.3",
-        "jscs": "3.0.7",
-        "lodash": "4.6.1",
-        "vow": "0.4.4"
+        "hooker": "~0.2.3",
+        "jscs": "~3.0.5",
+        "lodash": "~4.6.1",
+        "vow": "~0.4.1"
       },
       "dependencies": {
         "lodash": {
@@ -1810,11 +1809,11 @@
       "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "grunt-legacy-log-utils": "1.0.0",
-        "hooker": "0.2.3",
-        "lodash": "3.10.1",
-        "underscore.string": "3.2.3"
+        "colors": "~1.1.2",
+        "grunt-legacy-log-utils": "~1.0.0",
+        "hooker": "~0.2.3",
+        "lodash": "~3.10.1",
+        "underscore.string": "~3.2.3"
       }
     },
     "grunt-legacy-log-utils": {
@@ -1823,8 +1822,8 @@
       "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "lodash": "4.3.0"
+        "chalk": "~1.1.1",
+        "lodash": "~4.3.0"
       },
       "dependencies": {
         "lodash": {
@@ -1841,13 +1840,13 @@
       "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "4.3.0",
-        "underscore.string": "3.2.3",
-        "which": "1.2.14"
+        "async": "~1.5.2",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~4.3.0",
+        "underscore.string": "~3.2.3",
+        "which": "~1.2.1"
       },
       "dependencies": {
         "lodash": {
@@ -1864,10 +1863,10 @@
       "integrity": "sha1-rR9/IS/EojJfMvzUnGoNo2h8H7Q=",
       "dev": true,
       "requires": {
-        "eventemitter2": "0.4.14",
-        "phantomjs": "1.9.20",
-        "semver": "1.0.14",
-        "temporary": "0.0.8"
+        "eventemitter2": "~0.4.9",
+        "phantomjs": "~1.9.0-1",
+        "semver": "~1.0.14",
+        "temporary": "~0.0.4"
       },
       "dependencies": {
         "semver": {
@@ -1884,12 +1883,12 @@
       "integrity": "sha1-1ogCWgVQHeysCp4SndTk9QpCAUo=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "lodash": "4.13.1",
-        "q": "1.4.1",
-        "requestretry": "1.9.1",
-        "sauce-tunnel": "2.5.0",
-        "saucelabs": "1.2.0"
+        "colors": "~1.1.2",
+        "lodash": "~4.13.1",
+        "q": "~1.4.1",
+        "requestretry": "~1.9.0",
+        "sauce-tunnel": "~2.5.0",
+        "saucelabs": "~1.2.0"
       },
       "dependencies": {
         "lodash": {
@@ -1906,8 +1905,8 @@
       "integrity": "sha1-Zs+LEBBHInuVus5uodoMF37Vwi8=",
       "dev": true,
       "requires": {
-        "browserify-zlib": "0.1.4",
-        "concat-stream": "1.6.0"
+        "browserify-zlib": "^0.1.4",
+        "concat-stream": "^1.4.1"
       }
     },
     "har-schema": {
@@ -1922,8 +1921,8 @@
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
+        "ajv": "^4.9.1",
+        "har-schema": "^1.0.5"
       }
     },
     "has": {
@@ -1932,7 +1931,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -1941,7 +1940,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-color": {
@@ -1956,8 +1955,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "hawk": {
@@ -1966,10 +1965,10 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "he": {
@@ -1984,8 +1983,8 @@
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
       }
     },
     "hoek": {
@@ -2012,13 +2011,13 @@
       "integrity": "sha1-kFHW/LvPIU7TB+GtdPQyu5rWVcw=",
       "dev": true,
       "requires": {
-        "change-case": "3.0.1",
-        "clean-css": "3.4.27",
-        "commander": "2.9.0",
-        "he": "1.1.1",
-        "ncname": "1.0.0",
-        "relateurl": "0.2.7",
-        "uglify-js": "2.6.4"
+        "change-case": "3.0.x",
+        "clean-css": "3.4.x",
+        "commander": "2.9.x",
+        "he": "1.1.x",
+        "ncname": "1.0.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "2.6.x"
       },
       "dependencies": {
         "commander": {
@@ -2027,7 +2026,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         }
       }
@@ -2038,11 +2037,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       },
       "dependencies": {
         "isarray": {
@@ -2057,10 +2056,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2080,7 +2079,7 @@
         "depd": "1.1.0",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": ">= 1.3.1 < 2"
       }
     },
     "http-signature": {
@@ -2089,9 +2088,9 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.1"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "http2": {
@@ -2106,9 +2105,9 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.7",
-        "extend": "3.0.1"
+        "agent-base": "2",
+        "debug": "2",
+        "extend": "3"
       }
     },
     "i": {
@@ -2136,7 +2135,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -2145,8 +2144,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherit": {
@@ -2185,7 +2184,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-expression": {
@@ -2194,8 +2193,8 @@
       "integrity": "sha1-kb6dR968/vB3l36XIr5tz7RGXvA=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "object-assign": "4.1.1"
+        "acorn": "~3.3.0",
+        "object-assign": "^4.0.1"
       }
     },
     "is-finite": {
@@ -2204,7 +2203,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-lower-case": {
@@ -2213,7 +2212,7 @@
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.0"
       }
     },
     "is-my-json-valid": {
@@ -2222,10 +2221,10 @@
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-promise": {
@@ -2246,7 +2245,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-stream": {
@@ -2267,7 +2266,7 @@
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "dev": true,
       "requires": {
-        "upper-case": "1.1.3"
+        "upper-case": "^1.1.0"
       }
     },
     "is-utf8": {
@@ -2312,8 +2311,8 @@
       "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.2",
+        "esprima": "^2.6.0"
       }
     },
     "jsbn": {
@@ -2329,32 +2328,32 @@
       "integrity": "sha1-cUG03/W4bjLQ6Z12S4NnZ8MNIBo=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "commander": "2.9.0",
-        "cst": "0.4.10",
-        "estraverse": "4.2.0",
-        "exit": "0.1.2",
-        "glob": "5.0.15",
+        "chalk": "~1.1.0",
+        "cli-table": "~0.3.1",
+        "commander": "~2.9.0",
+        "cst": "^0.4.3",
+        "estraverse": "^4.1.0",
+        "exit": "~0.1.2",
+        "glob": "^5.0.1",
         "htmlparser2": "3.8.3",
-        "js-yaml": "3.4.6",
-        "jscs-jsdoc": "2.0.0",
-        "jscs-preset-wikimedia": "1.0.0",
-        "jsonlint": "1.6.2",
-        "lodash": "3.10.1",
-        "minimatch": "3.0.4",
-        "natural-compare": "1.2.2",
-        "pathval": "0.1.1",
-        "prompt": "0.2.14",
-        "reserved-words": "0.1.1",
-        "resolve": "1.1.7",
-        "strip-bom": "2.0.0",
-        "strip-json-comments": "1.0.4",
-        "to-double-quotes": "2.0.0",
-        "to-single-quotes": "2.0.1",
-        "vow": "0.4.16",
-        "vow-fs": "0.3.6",
-        "xmlbuilder": "3.1.0"
+        "js-yaml": "~3.4.0",
+        "jscs-jsdoc": "^2.0.0",
+        "jscs-preset-wikimedia": "~1.0.0",
+        "jsonlint": "~1.6.2",
+        "lodash": "~3.10.0",
+        "minimatch": "~3.0.0",
+        "natural-compare": "~1.2.2",
+        "pathval": "~0.1.1",
+        "prompt": "~0.2.14",
+        "reserved-words": "^0.1.1",
+        "resolve": "^1.1.6",
+        "strip-bom": "^2.0.0",
+        "strip-json-comments": "~1.0.2",
+        "to-double-quotes": "^2.0.0",
+        "to-single-quotes": "^2.0.0",
+        "vow": "~0.4.8",
+        "vow-fs": "~0.3.4",
+        "xmlbuilder": "^3.1.0"
       },
       "dependencies": {
         "commander": {
@@ -2363,7 +2362,7 @@
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "glob": {
@@ -2372,11 +2371,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "js-yaml": {
@@ -2385,9 +2384,9 @@
           "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3",
-            "inherit": "2.2.6"
+            "argparse": "^1.0.2",
+            "esprima": "^2.6.0",
+            "inherit": "^2.2.2"
           }
         },
         "uuid": {
@@ -2408,10 +2407,10 @@
           "integrity": "sha1-LUxZviLivyYY3fWXq0uqkjvnIA0=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "uuid": "2.0.3",
-            "vow": "0.4.16",
-            "vow-queue": "0.4.2"
+            "glob": "^7.0.5",
+            "uuid": "^2.0.2",
+            "vow": "^0.4.7",
+            "vow-queue": "^0.4.1"
           },
           "dependencies": {
             "glob": {
@@ -2420,12 +2419,12 @@
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             }
           }
@@ -2436,7 +2435,7 @@
           "integrity": "sha1-5/4XFg4Vx8QYTRtmapvGThjjAYQ=",
           "dev": true,
           "requires": {
-            "vow": "0.4.16"
+            "vow": "~0.4.0"
           }
         }
       }
@@ -2447,8 +2446,8 @@
       "integrity": "sha1-9T684CmqMSW9iCkLpQ1k1FEKSHE=",
       "dev": true,
       "requires": {
-        "comment-parser": "0.3.1",
-        "jsdoctypeparser": "1.2.0"
+        "comment-parser": "^0.3.1",
+        "jsdoctypeparser": "~1.2.0"
       }
     },
     "jscs-preset-wikimedia": {
@@ -2463,7 +2462,7 @@
       "integrity": "sha1-597cFToRhJ/8UUEUSuhqfvDCU5I=",
       "dev": true,
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "^3.7.0"
       }
     },
     "jshint": {
@@ -2472,14 +2471,14 @@
       "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
-        "cli": "1.0.1",
-        "console-browserify": "1.1.0",
-        "exit": "0.1.2",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.7.0",
-        "minimatch": "3.0.4",
-        "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4"
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "3.7.x",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
       },
       "dependencies": {
         "lodash": {
@@ -2508,7 +2507,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -2523,7 +2522,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -2538,8 +2537,8 @@
       "integrity": "sha1-VzcEUIX1XrRVxosf9OvAG9UOiDA=",
       "dev": true,
       "requires": {
-        "JSV": "4.0.2",
-        "nomnom": "1.8.1"
+        "JSV": ">= 4.0.x",
+        "nomnom": ">= 1.5.x"
       }
     },
     "jsonpointer": {
@@ -2574,8 +2573,8 @@
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0",
-        "promise": "7.3.1"
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
       }
     },
     "kew": {
@@ -2590,7 +2589,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -2599,7 +2598,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazy-cache": {
@@ -2614,7 +2613,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "less": {
@@ -2623,14 +2622,14 @@
       "integrity": "sha1-ZY4B7JrDFJlZxrbfvPvAoXCv2no=",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
-        "graceful-fs": "4.1.11",
-        "image-size": "0.4.0",
-        "mime": "1.3.4",
-        "mkdirp": "0.5.1",
-        "promise": "7.3.1",
-        "request": "2.81.0",
-        "source-map": "0.5.6"
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.4.0",
+        "mime": "^1.2.11",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "request": "^2.51.0",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "source-map": {
@@ -2648,7 +2647,7 @@
       "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
       "dev": true,
       "requires": {
-        "uc.micro": "1.0.3"
+        "uc.micro": "^1.0.1"
       }
     },
     "livereload-js": {
@@ -2663,10 +2662,10 @@
       "integrity": "sha1-ByhWEYD9IP+KaSdQWFL8WKrqDIg=",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "multimatch": "2.1.0",
-        "pkg-up": "1.0.0",
-        "resolve-pkg": "0.1.0"
+        "arrify": "^1.0.0",
+        "multimatch": "^2.0.0",
+        "pkg-up": "^1.0.0",
+        "resolve-pkg": "^0.1.0"
       }
     },
     "load-json-file": {
@@ -2675,11 +2674,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "lodash": {
@@ -2700,15 +2699,14 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-      "dev": true
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lower-case-first": {
       "version": "1.0.2",
@@ -2716,7 +2714,7 @@
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.2"
       }
     },
     "lru-cache": {
@@ -2737,11 +2735,11 @@
       "integrity": "sha1-8S2LiKk+ZCVDSN/Rg71wv2BWekI=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "entities": "1.1.1",
-        "linkify-it": "2.0.3",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.3"
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.1"
       },
       "dependencies": {
         "entities": {
@@ -2758,10 +2756,10 @@
       "integrity": "sha1-cTZehKmd2Piz99X94vANHn9zvmE=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "figures": "1.7.0",
-        "gzip-size": "1.0.0",
-        "pretty-bytes": "1.0.4"
+        "chalk": "^1.0.0",
+        "figures": "^1.0.1",
+        "gzip-size": "^1.0.0",
+        "pretty-bytes": "^1.0.0"
       },
       "dependencies": {
         "pretty-bytes": {
@@ -2770,8 +2768,8 @@
           "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.1.0"
           }
         }
       }
@@ -2794,23 +2792,22 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
     "mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.27.0",
@@ -2824,7 +2821,7 @@
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
       "dev": true,
       "requires": {
-        "mime-db": "1.27.0"
+        "mime-db": "~1.27.0"
       }
     },
     "minimatch": {
@@ -2833,7 +2830,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2865,11 +2862,11 @@
       "integrity": "sha1-eErHc05KRTqcbm6GgKkyknXItoc=",
       "dev": true,
       "requires": {
-        "basic-auth": "1.1.0",
+        "basic-auth": "~1.1.0",
         "debug": "2.6.8",
-        "depd": "1.1.0",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
+        "depd": "~1.1.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -2895,10 +2892,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
     "mute-stream": {
@@ -2919,7 +2916,7 @@
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
       "dev": true,
       "requires": {
-        "xml-char-classes": "1.0.0"
+        "xml-char-classes": "^1.0.0"
       }
     },
     "ncp": {
@@ -2935,12 +2932,11 @@
       "dev": true
     },
     "no-case": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
-      "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
-      "dev": true,
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-uuid": {
@@ -2955,8 +2951,8 @@
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "underscore": "1.6.0"
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2971,9 +2967,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "strip-ansi": {
@@ -2990,7 +2986,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.0"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -2999,10 +2995,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -3011,7 +3007,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "num2fraction": {
@@ -3059,7 +3055,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "opn": {
@@ -3068,8 +3064,8 @@
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1"
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "os-tmpdir": {
@@ -3096,7 +3092,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1"
+        "no-case": "^2.2.0"
       }
     },
     "parse-json": {
@@ -3105,7 +3101,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-ms": {
@@ -3132,8 +3128,8 @@
       "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.0",
-        "upper-case-first": "1.1.2"
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
       }
     },
     "path-case": {
@@ -3142,7 +3138,7 @@
       "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1"
+        "no-case": "^2.2.0"
       }
     },
     "path-exists": {
@@ -3151,7 +3147,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -3166,9 +3162,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pathval": {
@@ -3195,14 +3191,14 @@
       "integrity": "sha1-RCSsog4U0lXAsIia9va4lz2hDg0=",
       "dev": true,
       "requires": {
-        "extract-zip": "1.5.0",
-        "fs-extra": "0.26.7",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.67.0",
-        "request-progress": "2.0.1",
-        "which": "1.2.14"
+        "extract-zip": "~1.5.0",
+        "fs-extra": "~0.26.4",
+        "hasha": "^2.2.0",
+        "kew": "~0.7.0",
+        "progress": "~1.1.8",
+        "request": "~2.67.0",
+        "request-progress": "~2.0.1",
+        "which": "~1.2.2"
       },
       "dependencies": {
         "async": {
@@ -3211,7 +3207,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "bl": {
@@ -3220,7 +3216,7 @@
           "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.0.6"
+            "readable-stream": "~2.0.5"
           }
         },
         "caseless": {
@@ -3241,9 +3237,9 @@
           "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
           "dev": true,
           "requires": {
-            "async": "2.5.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "async": "^2.0.1",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
           }
         },
         "har-validator": {
@@ -3252,10 +3248,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.11.0",
-            "is-my-json-valid": "2.16.0",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "lodash": {
@@ -3282,12 +3278,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -3296,26 +3292,26 @@
           "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "bl": "1.0.3",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "1.0.1",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.8.2",
-            "qs": "5.2.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.2.2",
-            "tunnel-agent": "0.4.3"
+            "aws-sign2": "~0.6.0",
+            "bl": "~1.0.0",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~1.0.0-rc3",
+            "har-validator": "~2.0.2",
+            "hawk": "~3.1.0",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.0",
+            "qs": "~5.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.2.0",
+            "tunnel-agent": "~0.4.1"
           }
         },
         "string_decoder": {
@@ -3356,7 +3352,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-up": {
@@ -3365,7 +3361,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pkginfo": {
@@ -3395,9 +3391,9 @@
       "integrity": "sha1-TESbTIr53zyvbTf44eV10DYXWNw=",
       "dev": true,
       "requires": {
-        "es6-promise": "2.3.0",
-        "js-base64": "2.1.9",
-        "source-map": "0.4.4"
+        "es6-promise": "~2.3.0",
+        "js-base64": "~2.1.8",
+        "source-map": "~0.4.2"
       }
     },
     "pretty-bytes": {
@@ -3406,7 +3402,7 @@
       "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "pretty-ms": {
@@ -3415,9 +3411,9 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2",
-        "parse-ms": "1.0.1",
-        "plur": "1.0.0"
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
       }
     },
     "process-nextick-args": {
@@ -3438,7 +3434,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "2.0.5"
+        "asap": "~2.0.3"
       }
     },
     "prompt": {
@@ -3447,11 +3443,11 @@
       "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
       "dev": true,
       "requires": {
-        "pkginfo": "0.4.0",
-        "read": "1.0.7",
-        "revalidator": "0.1.8",
-        "utile": "0.2.1",
-        "winston": "0.8.3"
+        "pkginfo": "0.x.x",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "utile": "0.2.x",
+        "winston": "0.8.x"
       }
     },
     "prr": {
@@ -3467,14 +3463,14 @@
       "integrity": "sha1-B4RVJ3kKssa+Z9z16x8xgECB8Eo=",
       "dev": true,
       "requires": {
-        "pug-code-gen": "1.1.1",
-        "pug-filters": "2.1.3",
-        "pug-lexer": "3.1.0",
-        "pug-linker": "3.0.1",
-        "pug-load": "2.0.7",
-        "pug-parser": "3.0.0",
-        "pug-runtime": "2.0.3",
-        "pug-strip-comments": "1.0.2"
+        "pug-code-gen": "^1.1.1",
+        "pug-filters": "^2.1.3",
+        "pug-lexer": "^3.1.0",
+        "pug-linker": "^3.0.1",
+        "pug-load": "^2.0.7",
+        "pug-parser": "^3.0.0",
+        "pug-runtime": "^2.0.3",
+        "pug-strip-comments": "^1.0.2"
       }
     },
     "pug-attrs": {
@@ -3483,9 +3479,9 @@
       "integrity": "sha1-i+KyIlVo/6ddG4Zpgr/59BEa/8s=",
       "dev": true,
       "requires": {
-        "constantinople": "3.1.0",
-        "js-stringify": "1.0.2",
-        "pug-runtime": "2.0.3"
+        "constantinople": "^3.0.1",
+        "js-stringify": "^1.0.1",
+        "pug-runtime": "^2.0.3"
       }
     },
     "pug-code-gen": {
@@ -3494,14 +3490,14 @@
       "integrity": "sha1-HPcnRO8qA56uajNAyqoRBYcSWOg=",
       "dev": true,
       "requires": {
-        "constantinople": "3.1.0",
-        "doctypes": "1.1.0",
-        "js-stringify": "1.0.2",
-        "pug-attrs": "2.0.2",
-        "pug-error": "1.3.2",
-        "pug-runtime": "2.0.3",
-        "void-elements": "2.0.1",
-        "with": "5.1.1"
+        "constantinople": "^3.0.1",
+        "doctypes": "^1.1.0",
+        "js-stringify": "^1.0.1",
+        "pug-attrs": "^2.0.2",
+        "pug-error": "^1.3.2",
+        "pug-runtime": "^2.0.3",
+        "void-elements": "^2.0.1",
+        "with": "^5.0.0"
       }
     },
     "pug-error": {
@@ -3516,13 +3512,13 @@
       "integrity": "sha1-1ZdnoiDeeX3XVUifZoNM+aqDqlQ=",
       "dev": true,
       "requires": {
-        "clean-css": "3.4.27",
-        "constantinople": "3.1.0",
+        "clean-css": "^3.3.0",
+        "constantinople": "^3.0.1",
         "jstransformer": "1.0.0",
-        "pug-error": "1.3.2",
-        "pug-walk": "1.1.3",
-        "resolve": "1.1.7",
-        "uglify-js": "2.6.4"
+        "pug-error": "^1.3.2",
+        "pug-walk": "^1.1.3",
+        "resolve": "^1.1.6",
+        "uglify-js": "^2.6.1"
       }
     },
     "pug-lexer": {
@@ -3531,9 +3527,9 @@
       "integrity": "sha1-/QhzdtSmdbT1n4/vQiiDQ06VgaI=",
       "dev": true,
       "requires": {
-        "character-parser": "2.2.0",
-        "is-expression": "3.0.0",
-        "pug-error": "1.3.2"
+        "character-parser": "^2.1.1",
+        "is-expression": "^3.0.0",
+        "pug-error": "^1.3.2"
       },
       "dependencies": {
         "acorn": {
@@ -3548,8 +3544,8 @@
           "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
           "dev": true,
           "requires": {
-            "acorn": "4.0.13",
-            "object-assign": "4.1.1"
+            "acorn": "~4.0.2",
+            "object-assign": "^4.0.1"
           }
         }
       }
@@ -3560,8 +3556,8 @@
       "integrity": "sha1-uj+P8hPKjzowSFm0T+0Tynud+hk=",
       "dev": true,
       "requires": {
-        "pug-error": "1.3.2",
-        "pug-walk": "1.1.3"
+        "pug-error": "^1.3.2",
+        "pug-walk": "^1.1.3"
       }
     },
     "pug-load": {
@@ -3570,8 +3566,8 @@
       "integrity": "sha1-Ux0MbhFUYBDphGMNA99AY2fS3nc=",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
-        "pug-walk": "1.1.3"
+        "object-assign": "^4.1.0",
+        "pug-walk": "^1.1.3"
       }
     },
     "pug-parser": {
@@ -3580,7 +3576,7 @@
       "integrity": "sha1-N8YZ3YAPZCGHzk1s4aFkzddUh6M=",
       "dev": true,
       "requires": {
-        "pug-error": "1.3.2",
+        "pug-error": "^1.3.2",
         "token-stream": "0.0.1"
       }
     },
@@ -3596,7 +3592,7 @@
       "integrity": "sha1-0xOvoBvMN0mA4TmeI+vy65vchRM=",
       "dev": true,
       "requires": {
-        "pug-error": "1.3.2"
+        "pug-error": "^1.3.2"
       }
     },
     "pug-walk": {
@@ -3608,8 +3604,7 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "q": {
       "version": "1.4.1",
@@ -3660,7 +3655,7 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "mute-stream": "0.0.7"
+        "mute-stream": "~0.0.4"
       }
     },
     "read-pkg": {
@@ -3669,9 +3664,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -3680,8 +3675,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -3690,13 +3685,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "rechoir": {
@@ -3705,7 +3700,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.1.7"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -3714,8 +3709,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regenerator-runtime": {
@@ -3748,7 +3743,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -3757,28 +3752,39 @@
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~4.2.1",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "performance-now": "^0.2.0",
+        "qs": "~6.4.0",
+        "safe-buffer": "^5.0.1",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "dev": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        }
       }
     },
     "request-progress": {
@@ -3787,7 +3793,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "1.0.0"
+        "throttleit": "^1.0.0"
       }
     },
     "requestretry": {
@@ -3796,10 +3802,10 @@
       "integrity": "sha1-CioATq8hGWnEzCz+vz/p5XuSx04=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
+        "extend": "^3.0.0",
         "fg-lodash": "0.0.2",
-        "request": "2.81.0",
-        "when": "3.7.8"
+        "request": "^2.74.x",
+        "when": "~3.7.5"
       }
     },
     "reserved-words": {
@@ -3826,7 +3832,7 @@
       "integrity": "sha1-AsyZNBDik2livZcWahsHfalyVTE=",
       "dev": true,
       "requires": {
-        "resolve-from": "2.0.0"
+        "resolve-from": "^2.0.0"
       }
     },
     "revalidator": {
@@ -3841,7 +3847,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -3862,9 +3868,9 @@
       "integrity": "sha1-DuTE/5tH4BPosHLL+sSVt/7Y6Os=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "request": "2.81.0",
-        "split": "1.0.0"
+        "chalk": "^1.1.3",
+        "request": "^2.72.0",
+        "split": "^1.0.0"
       }
     },
     "saucelabs": {
@@ -3873,7 +3879,7 @@
       "integrity": "sha1-XoBHazbaG0LRDzlwfprypTsD2Io=",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "1.0.0"
+        "https-proxy-agent": "^1.0.0"
       }
     },
     "semver": {
@@ -3889,18 +3895,32 @@
       "dev": true,
       "requires": {
         "debug": "2.6.7",
-        "depd": "1.1.0",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
         "fresh": "0.5.0",
-        "http-errors": "1.6.1",
+        "http-errors": "~1.6.1",
         "mime": "1.3.4",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "dependencies": {
+        "fresh": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+          "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+          "dev": true
+        },
+        "mime": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+          "dev": true
+        }
       }
     },
     "sentence-case": {
@@ -3909,8 +3929,8 @@
       "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1",
-        "upper-case-first": "1.1.2"
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
       }
     },
     "serve-index": {
@@ -3919,13 +3939,13 @@
       "integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.3",
+        "accepts": "~1.3.3",
         "batch": "0.6.1",
         "debug": "2.6.8",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.1",
-        "mime-types": "2.1.15",
-        "parseurl": "1.3.1"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.1",
+        "mime-types": "~2.1.15",
+        "parseurl": "~1.3.1"
       },
       "dependencies": {
         "debug": {
@@ -3945,9 +3965,9 @@
       "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
         "send": "0.15.3"
       }
     },
@@ -3963,9 +3983,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.0.6",
-        "interpret": "1.0.3",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "shx": {
@@ -3974,8 +3994,8 @@
       "integrity": "sha1-mjqUJx5su3iBSf3GaWI3FUq2N58=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0",
-        "shelljs": "0.7.8"
+        "minimist": "^1.2.0",
+        "shelljs": "^0.7.0"
       }
     },
     "sigmund": {
@@ -3996,7 +4016,7 @@
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1"
+        "no-case": "^2.2.0"
       }
     },
     "sntp": {
@@ -4005,7 +4025,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "source-map": {
@@ -4014,7 +4034,7 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "source-map-support": {
@@ -4023,7 +4043,7 @@
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.6"
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "source-map": {
@@ -4040,7 +4060,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -4061,7 +4081,7 @@
       "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "sprintf-js": {
@@ -4076,14 +4096,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -4118,7 +4138,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -4133,7 +4153,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -4142,7 +4162,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -4151,7 +4171,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -4172,8 +4192,8 @@
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4",
-        "upper-case": "1.1.3"
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
       }
     },
     "tar-stream": {
@@ -4182,10 +4202,10 @@
       "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "temporary": {
@@ -4194,7 +4214,7 @@
       "integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
       "dev": true,
       "requires": {
-        "package": "1.0.1"
+        "package": ">= 1.0.0 < 1.2.0"
       }
     },
     "text-table": {
@@ -4221,13 +4241,13 @@
       "integrity": "sha1-BiIT5mDJB+hvRAVWwB6mWXtxJCA=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "date-time": "1.1.0",
-        "figures": "1.7.0",
-        "hooker": "0.2.3",
-        "number-is-nan": "1.0.1",
-        "pretty-ms": "2.1.0",
-        "text-table": "0.2.0"
+        "chalk": "^1.0.0",
+        "date-time": "^1.1.0",
+        "figures": "^1.0.0",
+        "hooker": "^0.2.3",
+        "number-is-nan": "^1.0.0",
+        "pretty-ms": "^2.1.0",
+        "text-table": "^0.2.0"
       }
     },
     "time-zone": {
@@ -4242,12 +4262,12 @@
       "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
       "dev": true,
       "requires": {
-        "body-parser": "1.14.2",
-        "debug": "2.2.0",
-        "faye-websocket": "0.10.0",
-        "livereload-js": "2.2.2",
-        "parseurl": "1.3.1",
-        "qs": "5.1.0"
+        "body-parser": "~1.14.0",
+        "debug": "~2.2.0",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.2.0",
+        "parseurl": "~1.3.0",
+        "qs": "~5.1.0"
       },
       "dependencies": {
         "debug": {
@@ -4279,8 +4299,8 @@
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.1",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
       }
     },
     "tmp": {
@@ -4289,7 +4309,7 @@
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "to-double-quotes": {
@@ -4311,12 +4331,11 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-newlines": {
@@ -4331,7 +4350,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -4348,7 +4367,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.15"
+        "mime-types": "~2.1.15"
       }
     },
     "typedarray": {
@@ -4369,10 +4388,10 @@
       "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "source-map": "0.5.6",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "async": "~0.2.6",
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "async": {
@@ -4425,7 +4444,7 @@
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "dev": true,
       "requires": {
-        "upper-case": "1.1.3"
+        "upper-case": "^1.1.1"
       }
     },
     "uri-path": {
@@ -4446,12 +4465,12 @@
       "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "deep-equal": "1.0.1",
-        "i": "0.3.5",
-        "mkdirp": "0.5.1",
-        "ncp": "0.4.2",
-        "rimraf": "2.2.8"
+        "async": "~0.2.9",
+        "deep-equal": "*",
+        "i": "0.3.x",
+        "mkdirp": "0.x.x",
+        "ncp": "0.4.x",
+        "rimraf": "2.x.x"
       },
       "dependencies": {
         "async": {
@@ -4480,8 +4499,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "verror": {
@@ -4523,8 +4542,8 @@
           "integrity": "sha1-VQb0MRchvMYYx9jboUQYh1AwcHM=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.2.14"
+            "inherits": "2",
+            "minimatch": "~0.2.11"
           }
         },
         "minimatch": {
@@ -4533,8 +4552,8 @@
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -4545,7 +4564,7 @@
       "integrity": "sha1-WYxRoVsKgabV/AX0dhzrRi3h6Gg=",
       "dev": true,
       "requires": {
-        "vow": "0.4.4"
+        "vow": "~0.4.0"
       }
     },
     "walkdir": {
@@ -4560,7 +4579,7 @@
       "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
       "dev": true,
       "requires": {
-        "websocket-extensions": "0.1.1"
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -4581,7 +4600,7 @@
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "window-size": {
@@ -4596,13 +4615,13 @@
       "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "colors": "0.6.2",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "pkginfo": "0.3.1",
-        "stack-trace": "0.0.10"
+        "async": "0.2.x",
+        "colors": "0.6.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "pkginfo": "0.3.x",
+        "stack-trace": "0.0.x"
       },
       "dependencies": {
         "async": {
@@ -4631,8 +4650,8 @@
       "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "acorn-globals": "3.1.0"
+        "acorn": "^3.1.0",
+        "acorn-globals": "^3.0.0"
       }
     },
     "wordwrap": {
@@ -4659,7 +4678,7 @@
       "integrity": "sha1-LIaIjy1OrehQ+jjKf3Ij9yCVFuE=",
       "dev": true,
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "^3.5.0"
       }
     },
     "xtend": {
@@ -4674,9 +4693,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       },
       "dependencies": {
@@ -4694,7 +4713,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "zip-stream": {
@@ -4703,10 +4722,10 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "compress-commons": "1.2.0",
-        "lodash": "4.17.4",
-        "readable-stream": "2.3.3"
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "lodash": {

--- a/src/Bootstrap/package.json
+++ b/src/Bootstrap/package.json
@@ -85,5 +85,11 @@
       "fonts",
       "js"
     ]
+  },
+  "dependencies": {
+    "fresh": "^0.5.2",
+    "mime": "^1.4.1",
+    "no-case": "^2.3.2",
+    "tough-cookie": "^2.3.3"
   }
 }


### PR DESCRIPTION
Should fix https://github.com/NuGet/Engineering/issues/1565

Recommended updates, per https://github.com/NuGet/NuGetGallery/network/dependencies
- fresh, 0.5.0 (recommend >= 0.5.2)
- mime, 1.3.4 (recommend >= 1.4.1)
- no-case, 2.3.1 (recommend >= 2.3.2)
- tough-cookie, 2.3.2 (recommend >= 2.3.3)

Applied updates with the following commands, from .\src\Bootstrap (npm version 6.1.0). Note that there were no changes to the generated files under .\dist
```
npm install tough-cookie@2.3.3
npm install no-case@2.3.2
npm install mime@1.4.1
npm install fresh@0.5.2
rm .\dist\css\*
rm .\dist\js\*.js
grunt
```