### PR TITLE
Fix Symbols-Configuration.json

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Symbols-Configuration.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Symbols-Configuration.json
@@ -2,6 +2,6 @@
     "isSymbolsUploadEnabledForAll": false,
     "alwaysEnabledForEmailAddresses": [
     ],
-    "alwasyEnabledForDomains": [
+    "alwaysEnabledForDomains": [
     ]
 }


### PR DESCRIPTION
This typo means that anybody running the gallery locally will get an exception at https://github.com/NuGet/NuGetGallery/blob/dev/src/NuGetGallery/Services/SymbolsConfiguration.cs#L30