### PR TITLE
Log search service exceptions encountered during retry

### DIFF
--- a/src/NuGet.Services.Search.Client/Client/RetryingHttpClientWrapper.cs
+++ b/src/NuGet.Services.Search.Client/Client/RetryingHttpClientWrapper.cs
@@ -15,6 +15,7 @@ namespace NuGet.Services.Search.Client
     {
         private readonly HttpClient _httpClient;
         private readonly IEndpointHealthIndicatorStore _endpointHealthIndicatorStore;
+        private readonly Action<Exception> _onException;
 
         private static readonly int PeriodToDelayAlternateRequest = 3000;
         private static readonly IComparer<int> HealthComparer;
@@ -24,16 +25,16 @@ namespace NuGet.Services.Search.Client
             HealthComparer = new WeightedRandomComparer();
         }
 
-        public RetryingHttpClientWrapper(HttpClient httpClient)
-            : this (httpClient, new BaseUrlHealthIndicatorStore(new NullHealthIndicatorLogger()))
+        public RetryingHttpClientWrapper(HttpClient httpClient, Action<Exception> onException)
+            : this (httpClient, new BaseUrlHealthIndicatorStore(new NullHealthIndicatorLogger()), onException)
         {
-            _httpClient = httpClient;
         }
 
-        public RetryingHttpClientWrapper(HttpClient httpClient, IEndpointHealthIndicatorStore endpointHealthIndicatorStore)
+        public RetryingHttpClientWrapper(HttpClient httpClient, IEndpointHealthIndicatorStore endpointHealthIndicatorStore, Action<Exception> onException)
         {
             _httpClient = httpClient;
             _endpointHealthIndicatorStore = endpointHealthIndicatorStore;
+            _onException = onException;
         }
 
         public async Task<string> GetStringAsync(IEnumerable<Uri> endpoints)
@@ -89,6 +90,11 @@ namespace NuGet.Services.Search.Client
             if (!cancellationTokenSource.IsCancellationRequested)
             {
                 cancellationTokenSource.Cancel(false);
+            }
+
+            foreach (var exception in exceptions)
+            {
+                _onException(exception);
             }
 
             if (completedTask.IsFaulted || completedTask.IsCanceled)

--- a/src/NuGet.Services.Search.Client/Client/RetryingHttpClientWrapper.cs
+++ b/src/NuGet.Services.Search.Client/Client/RetryingHttpClientWrapper.cs
@@ -32,9 +32,9 @@ namespace NuGet.Services.Search.Client
 
         public RetryingHttpClientWrapper(HttpClient httpClient, IEndpointHealthIndicatorStore endpointHealthIndicatorStore, Action<Exception> onException)
         {
-            _httpClient = httpClient;
-            _endpointHealthIndicatorStore = endpointHealthIndicatorStore;
-            _onException = onException;
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _endpointHealthIndicatorStore = endpointHealthIndicatorStore ?? throw new ArgumentNullException(nameof(endpointHealthIndicatorStore));
+            _onException = onException ?? throw new ArgumentNullException(nameof(onException));
         }
 
         public async Task<string> GetStringAsync(IEnumerable<Uri> endpoints)

--- a/src/NuGet.Services.Search.Client/Client/SearchClient.cs
+++ b/src/NuGet.Services.Search.Client/Client/SearchClient.cs
@@ -25,8 +25,8 @@ namespace NuGet.Services.Search.Client
         /// </summary>
         /// <param name="baseUri">The URL to the root of the service</param>
         /// <param name="handlers">Handlers to apply to the request in order from first to last</param>
-        public SearchClient(Uri baseUri, params DelegatingHandler[] handlers)
-            : this(baseUri, "SearchGalleryQueryService/3.0.0-rc", null, new BaseUrlHealthIndicatorStore(new NullHealthIndicatorLogger()), handlers)
+        public SearchClient(Uri baseUri, Action<Exception> onException, params DelegatingHandler[] handlers)
+            : this(baseUri, "SearchGalleryQueryService/3.0.0-rc", null, new BaseUrlHealthIndicatorStore(new NullHealthIndicatorLogger()), onException, handlers)
         {
         }
 
@@ -38,7 +38,7 @@ namespace NuGet.Services.Search.Client
         /// <param name="credentials">The credentials to connect to the service with</param>
         /// <param name="healthIndicatorStore">Health indicator store</param>
         /// <param name="handlers">Handlers to apply to the request in order from first to last</param>
-        public SearchClient(Uri baseUri, string resourceType, ICredentials credentials, IEndpointHealthIndicatorStore healthIndicatorStore, params DelegatingHandler[] handlers)
+        public SearchClient(Uri baseUri, string resourceType, ICredentials credentials, IEndpointHealthIndicatorStore healthIndicatorStore, Action<Exception> onException, params DelegatingHandler[] handlers)
         {
             _resourceType = resourceType;
 
@@ -58,7 +58,7 @@ namespace NuGet.Services.Search.Client
 
             _httpClient = new HttpClient(handler, disposeHandler: true);
 
-            _retryingHttpClientWrapper = new RetryingHttpClientWrapper(_httpClient, healthIndicatorStore);
+            _retryingHttpClientWrapper = new RetryingHttpClientWrapper(_httpClient, healthIndicatorStore, onException);
             _discoveryClient = new ServiceDiscoveryClient(_httpClient, baseUri);
         }
 

--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -52,7 +52,14 @@ namespace NuGetGallery.Infrastructure.Lucene
 
             if (_client == null)
             {
-                _client = new SearchClient(ServiceUri, "SearchGalleryQueryService/3.0.0-rc", null, _healthIndicatorStore, new TracingHttpHandler(Trace), new CorrelatingHttpClientHandler());
+                _client = new SearchClient(
+                    ServiceUri, 
+                    "SearchGalleryQueryService/3.0.0-rc", 
+                    null, 
+                    _healthIndicatorStore, 
+                    (exception) => QuietLog.LogHandledException(exception), 
+                    new TracingHttpHandler(Trace), 
+                    new CorrelatingHttpClientHandler());
             }
         }
 
@@ -90,7 +97,14 @@ namespace NuGetGallery.Infrastructure.Lucene
 
             if (_client == null)
             {
-                _client = new SearchClient(ServiceUri, config.SearchServiceResourceType, credentials, _healthIndicatorStore, new TracingHttpHandler(Trace), new CorrelatingHttpClientHandler());
+                _client = new SearchClient(
+                    ServiceUri, 
+                    config.SearchServiceResourceType, 
+                    credentials, 
+                    _healthIndicatorStore,
+                    (exception) => QuietLog.LogHandledException(exception),
+                    new TracingHttpHandler(Trace), 
+                    new CorrelatingHttpClientHandler());
             }
         }
 

--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -57,7 +57,7 @@ namespace NuGetGallery.Infrastructure.Lucene
                     "SearchGalleryQueryService/3.0.0-rc", 
                     null, 
                     _healthIndicatorStore, 
-                    (exception) => QuietLog.LogHandledException(exception), 
+                    QuietLog.LogHandledException, 
                     new TracingHttpHandler(Trace), 
                     new CorrelatingHttpClientHandler());
             }
@@ -102,7 +102,7 @@ namespace NuGetGallery.Infrastructure.Lucene
                     config.SearchServiceResourceType, 
                     credentials, 
                     _healthIndicatorStore,
-                    (exception) => QuietLog.LogHandledException(exception),
+                    QuietLog.LogHandledException,
                     new TracingHttpHandler(Trace), 
                     new CorrelatingHttpClientHandler());
             }

--- a/src/NuGetGallery/Queries/AutoCompleteServiceQuery.cs
+++ b/src/NuGetGallery/Queries/AutoCompleteServiceQuery.cs
@@ -28,7 +28,7 @@ namespace NuGetGallery
 
             _serviceDiscoveryClient = new ServiceDiscoveryClient(configuration.ServiceDiscoveryUri);
             _autocompleteServiceResourceType = configuration.AutocompleteServiceResourceType;
-            _httpClient = new RetryingHttpClientWrapper(new HttpClient(), (exception) => QuietLog.LogHandledException(exception));
+            _httpClient = new RetryingHttpClientWrapper(new HttpClient(), QuietLog.LogHandledException);
         }
 
         public async Task<IEnumerable<string>> RunServiceQuery(

--- a/src/NuGetGallery/Queries/AutoCompleteServiceQuery.cs
+++ b/src/NuGetGallery/Queries/AutoCompleteServiceQuery.cs
@@ -28,7 +28,7 @@ namespace NuGetGallery
 
             _serviceDiscoveryClient = new ServiceDiscoveryClient(configuration.ServiceDiscoveryUri);
             _autocompleteServiceResourceType = configuration.AutocompleteServiceResourceType;
-            _httpClient = new RetryingHttpClientWrapper(new HttpClient());
+            _httpClient = new RetryingHttpClientWrapper(new HttpClient(), (exception) => QuietLog.LogHandledException(exception));
         }
 
         public async Task<IEnumerable<string>> RunServiceQuery(

--- a/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
+++ b/tests/NuGetGallery.Facts/SearchClient/RetryingHttpClientWrapperFacts.cs
@@ -23,12 +23,12 @@ namespace NuGetGallery.SearchClient
 
         private RetryingHttpClientWrapper CreateWrapperClient(HttpMessageHandler handler)
         {
-            return new RetryingHttpClientWrapper(new HttpClient(handler));
+            return new RetryingHttpClientWrapper(new HttpClient(handler), (exception) => { });
         }
 
         private RetryingHttpClientWrapper CreateWrapperClient()
         {
-            return new RetryingHttpClientWrapper(new HttpClient());
+            return new RetryingHttpClientWrapper(new HttpClient(), (exception) => { });
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6229

Unfortunately we can't use `QuietLog` directly because `NuGet.Services.Search.Client` doesn't have a dependency on `NuGetGallery`, so I've added an `Action` parameter.