### PR TITLE
Add gallery UI to display new certificate information

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -624,6 +624,10 @@ img.reserved-indicator-icon {
   display: inline-block;
   width: 100%;
 }
+.page-account-settings .expired-certificate {
+  font-weight: bold;
+  color: #a94442;
+}
 .page-api-keys .example-commands {
   padding: 8px 10px;
   font-family: Consolas, Menlo, Monaco, "Courier New", monospace;

--- a/src/Bootstrap/less/theme/page-account-settings.less
+++ b/src/Bootstrap/less/theme/page-account-settings.less
@@ -49,4 +49,9 @@
     display: inline-block;
     width: 100%;
   }
+
+  .expired-certificate {
+    color: @state-danger-text;
+    font-weight: bold;
+  }
 }

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -47,6 +47,16 @@
     </div>
 }
 
+@helper Alert(string htmlContent, string subclass, string icon, bool isAlertRole = false)
+{
+    @Alert(s => new HelperResult(t => t.Write(htmlContent)), subclass, icon, isAlertRole);
+}
+
+@helper AlertInfo(string htmlContent, bool isAlertRole = false)
+{
+    @Alert(htmlContent, "info", "Info", isAlertRole)
+}
+
 @helper AlertInfo(Func<MvcHtmlString, HelperResult> htmlContent, bool isAlertRole = false)
 {
     @Alert(htmlContent, "info", "Info", isAlertRole)

--- a/src/NuGetGallery/Scripts/gallery/certificates.js
+++ b/src/NuGetGallery/Scripts/gallery/certificates.js
@@ -93,6 +93,15 @@
                 _model = {
                     certificates: ko.observableArray(data),
                     deleteCertificate: deleteCertificateAsync,
+                    hasMissingInfo: function () {
+                        var currentCertificates = this.certificates();
+                        for (var i = 0; i < currentCertificates.length; i++) {
+                            if (!currentCertificates[i].HasInfo) {
+                                return true;
+                            }
+                        }
+                        return false;
+                    },
                     hasCertificates: function () {
                         return this.certificates().length > 0;
                     }

--- a/src/NuGetGallery/ViewModels/ListCertificateItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListCertificateItemViewModel.cs
@@ -2,12 +2,27 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using NuGetGallery.Helpers;
 
 namespace NuGetGallery
 {
     public sealed class ListCertificateItemViewModel
     {
+        /// <summary>
+        /// This value allows an abbreviated issuer and subject to show up on a single line in the web UI in the
+        /// "MD" Bootstrap screen size. This is approximately the P75 of CN length on NuGet.org.
+        /// </summary>
+        private const int AbbreviationLength = 36;
+
         public string Sha1Thumbprint { get; }
+        public bool HasInfo { get; }
+        public bool IsExpired { get; }
+        public string ExpirationDisplay { get; }
+        public string ExpirationIso { get; }
+        public string Subject { get; }
+        public string Issuer { get; }
+        public string ShortSubject { get; }
+        public string ShortIssuer { get; }
         public bool CanDelete { get; }
         public string DeleteUrl { get; }
 
@@ -19,6 +34,19 @@ namespace NuGetGallery
             }
 
             Sha1Thumbprint = certificate.Sha1Thumbprint;
+            HasInfo = certificate.Expiration.HasValue;
+            if (certificate.Expiration.HasValue)
+            {
+                // The value stored in the database is assumed to be UTC.
+                var expirationUtc = DateTime.SpecifyKind(certificate.Expiration.Value, DateTimeKind.Utc);
+                IsExpired = expirationUtc < DateTime.UtcNow;
+                ExpirationDisplay = expirationUtc.ToNuGetShortDateString();
+                ExpirationIso = expirationUtc.ToString("O");
+            }
+            Subject = certificate.Subject;
+            Issuer = certificate.Issuer;
+            ShortSubject = certificate.ShortSubject ?? certificate.Subject?.Abbreviate(AbbreviationLength);
+            ShortIssuer = certificate.ShortIssuer ?? certificate.Issuer?.Abbreviate(AbbreviationLength);
             CanDelete = !string.IsNullOrEmpty(deleteUrl);
             DeleteUrl = deleteUrl;
         }

--- a/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
+++ b/src/NuGetGallery/Views/CuratedFeeds/CuratedFeed.cshtml
@@ -1,7 +1,6 @@
 ﻿@model CuratedFeedViewModel
 @{
     ViewBag.Title = "Curated Feed: " + Model.Name;
-    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 
@@ -9,7 +8,7 @@
     @ViewHelpers.AjaxAntiForgeryToken(Html)
 
     <div class="row">
-        <div class="col-md-12">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h1 class="text-center">Curated Feed <a href="@Url.CuratedPackageList(0, "", Model.Name)" class="ms-noWrap">@Model.Name</a></h1>
         </div>
     </div>

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -2,7 +2,6 @@
 @{
     ViewBag.Title = "Upload Package";
     ViewBag.Tab = "Upload";
-    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 

--- a/src/NuGetGallery/Views/Shared/_AccountCertificates.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountCertificates.cshtml
@@ -58,6 +58,10 @@
             }
             
             @InformAboutOrgSettingsPage()
+
+            <!-- ko if: $data.hasMissingInfo() -->
+            @ViewHelpers.AlertInfo("The certificate details will be available when you push a package signed by the registered certificate(s).")
+            <!-- /ko -->
             
             <div class="row" data-bind="ifnot: $data && $data.hasCertificates && $data.hasCertificates()">
                 <div class="col-xs-12 clearfix">
@@ -72,12 +76,22 @@
                         <thead>
                             <tr class="manage-certificate-headings">
                                 <th>Fingerprint</th>
+                                <th>Subject</th>
+                                <th>Expiration</th>
+                                <th>Issuer</th>
                                 <th><span class="hidden">Icon</span></th>
                             </tr>
                         </thead>
                         <tbody data-bind="foreach: $data.certificates">
                             <tr class="manage-certificate-listing" role="listitem">
-                                <td class="align-middle" data-bind="text: Sha1Thumbprint"></td>
+                                <td data-bind="text: Sha1Thumbprint"></td>
+                                <td data-bind="text: ShortSubject, attr: { title: Subject }"></td>
+                                <td data-bind="text: ExpirationDisplay, attr: {
+                                    title: IsExpired ? 'This certificate\'s expiration date is in the past. Future packages signed with this certificate will fail validation. Upload a renewed certificate to enable signed package uploads.' : ExpirationIso,
+                                    class: IsExpired ? 'expired-certificate' : ''
+                                    }">
+                                </td>
+                                <td data-bind="text: ShortIssuer, attr: { title: Issuer }"></td>
                                 <td class="text-right align-middle package-controls">
                                     <span data-bind="visible: CanDelete">
                                         <a class="btn" title="Delete certificate" tabindex="0" data-bind="attr: { 'data-href': DeleteUrl, 'aria-label': 'Delete certificate' }, click: $parent.deleteCertificate">

--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -1,7 +1,6 @@
 ﻿@model UserAccountViewModel
 @{
     ViewBag.Title = "Account Settings";
-    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 
     TempData["Parent"] = this;

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -2,7 +2,6 @@
 @using NuGetGallery.Authentication
 @{
     ViewBag.Title = "API Keys";
-    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
     Layout = "~/Views/Shared/Gallery/Layout.cshtml";
 }
 


### PR DESCRIPTION
The process signature job (part of package push validation) populates the certificate details when a package is first pushed with that author signing certificate.

Progress on https://github.com/NuGet/NuGetGallery/issues/6183.

## No cert info yet

![image](https://user-images.githubusercontent.com/94054/43485286-aa1b0b72-94c5-11e8-8c09-f15b1360a7dd.png)
## Cert info

![image](https://user-images.githubusercontent.com/94054/43485319-bf42d840-94c5-11e8-8fb1-c134e451990a.png)

## Expired cert

![image](https://user-images.githubusercontent.com/94054/43485355-d60974e4-94c5-11e8-9e7b-6dc88ef8802a.png)
