### PR TITLE
[Status] Add the status folder

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -21,6 +21,7 @@ namespace NuGetGallery
         public const string OctetStreamContentType = "application/octet-stream";
         public const string TextContentType = "text/plain";
         public const string CertificateContentType = "application/pkix-cert";
+        public const string JsonContentType = "application/json";
 
         public const string UserCertificatesFolderName = "user-certificates";
         public const string ContentFolderName = "content";

--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -31,6 +31,7 @@ namespace NuGetGallery
         public const string UploadsFolderName = "uploads";
         public const string ValidationFolderName = "validation";
         public const string RevalidationFolderName = "revalidation";
+        public const string StatusFolderName = "status";
 
         public const string SymbolPackagesFolderName = "symbol-packages";
         public const string NuGetSymbolPackageFileExtension = ".snupkg";

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -543,9 +543,11 @@ namespace NuGetGallery
                     return CoreConstants.OctetStreamContentType;
 
                 case CoreConstants.PackageReadMesFolderName:
+                    return CoreConstants.TextContentType;
+
                 case CoreConstants.RevalidationFolderName:
                 case CoreConstants.StatusFolderName:
-                    return CoreConstants.TextContentType;
+                    return CoreConstants.JsonContentType;
 
                 case CoreConstants.UserCertificatesFolderName:
                     return CoreConstants.CertificateContentType;

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -40,6 +40,7 @@ namespace NuGetGallery
             CoreConstants.ValidationFolderName,
             CoreConstants.UserCertificatesFolderName,
             CoreConstants.RevalidationFolderName,
+            CoreConstants.StatusFolderName,
         };
 
         protected readonly ICloudBlobClient _client;

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -544,6 +544,7 @@ namespace NuGetGallery
 
                 case CoreConstants.PackageReadMesFolderName:
                 case CoreConstants.RevalidationFolderName:
+                case CoreConstants.StatusFolderName:
                     return CoreConstants.TextContentType;
 
                 case CoreConstants.UserCertificatesFolderName:


### PR DESCRIPTION
This will be needed by the revalidation job to determine the health of the ingestion pipeline (the revalidation job uses the Gallery's storage APIs).

Part of https://github.com/NuGet/Engineering/issues/1441