### PR TITLE
Signing owner selection box on Manage Packages page can cause table to overflow

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1205,6 +1205,10 @@ img.reserved-indicator-icon {
 .page-manage-packages .inner-table {
   margin-bottom: 0;
 }
+.page-manage-packages .requiredSigner {
+  width: 100%;
+  max-width: 90%;
+}
 .page-delete-package h1 {
   margin-bottom: 0;
 }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1205,7 +1205,7 @@ img.reserved-indicator-icon {
 .page-manage-packages .inner-table {
   margin-bottom: 0;
 }
-.page-manage-packages .requiredSigner {
+.page-manage-packages .required-signer {
   width: 100%;
   max-width: 90%;
 }

--- a/src/Bootstrap/less/theme/page-manage-packages.less
+++ b/src/Bootstrap/less/theme/page-manage-packages.less
@@ -44,7 +44,7 @@
   .panel {
     margin-top: 5px;
   }
-  
+
   .manage-package-listing {
     .ms-Icon {
       position: relative;
@@ -54,5 +54,10 @@
 
   .inner-table {
     margin-bottom: 0px;
+  }
+
+  .requiredSigner {
+    width: 100%;
+    max-width: 90%;
   }
 }

--- a/src/Bootstrap/less/theme/page-manage-packages.less
+++ b/src/Bootstrap/less/theme/page-manage-packages.less
@@ -56,7 +56,7 @@
     margin-bottom: 0px;
   }
 
-  .requiredSigner {
+  .required-signer {
     width: 100%;
     max-width: 90%;
   }

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -154,8 +154,7 @@
                             <span data-bind="text: RequiredSigner" />
                             <!-- /ko -->
                             <!-- ko ifnot: $data.ShowTextBox -->
-                            <select class="form-control"
-                                    style="width:100%;max-width:90%;"
+                            <select class="form-control requiredSigner"
                                     aria-label="Select the signing owner"
                                     data-bind="options: AllSigners,
                                     optionsText: 'OptionText',

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -155,6 +155,7 @@
                             <!-- /ko -->
                             <!-- ko ifnot: $data.ShowTextBox -->
                             <select class="form-control"
+                                    style="width:100%;max-width:90%;"
                                     aria-label="Select the signing owner"
                                     data-bind="options: AllSigners,
                                     optionsText: 'OptionText',

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -154,7 +154,7 @@
                             <span data-bind="text: RequiredSigner" />
                             <!-- /ko -->
                             <!-- ko ifnot: $data.ShowTextBox -->
-                            <select class="form-control requiredSigner"
+                            <select class="form-control required-signer"
                                     aria-label="Select the signing owner"
                                     data-bind="options: AllSigners,
                                     optionsText: 'OptionText',


### PR DESCRIPTION
Fixes #5909 

Explanation of fix: https://stackoverflow.com/questions/10672586/how-to-make-select-elements-shrink-to-max-width-percent-style-within-fieldset

Screenshot:
![image](https://user-images.githubusercontent.com/880728/43640880-e09af6d6-9721-11e8-8931-3674781557d8.png)
