### PR TITLE
Warn when an unsigned package is pushed after a signed one

### DIFF
--- a/src/NuGetGallery/Infrastructure/HttpStatusCodeWithServerWarningResult.cs
+++ b/src/NuGetGallery/Infrastructure/HttpStatusCodeWithServerWarningResult.cs
@@ -1,29 +1,36 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Web.Mvc;
-using NuGet.Protocol;
 
 namespace NuGetGallery
 {
     public class HttpStatusCodeWithServerWarningResult : HttpStatusCodeResult
     {
-        private readonly string _warningMessage;
+        public IReadOnlyList<string> Warnings { get; }
 
-        public HttpStatusCodeWithServerWarningResult(HttpStatusCode statusCode, string warningMessage)
+        public HttpStatusCodeWithServerWarningResult(HttpStatusCode statusCode, IReadOnlyList<string> warnings)
             : base((int)statusCode)
         {
-            _warningMessage = warningMessage;
+            Warnings = warnings ?? new string[0];
         }
 
         public override void ExecuteResult(ControllerContext context)
         {
             var response = context.RequestContext.HttpContext.Response;
 
-            if (!string.IsNullOrEmpty(_warningMessage) && !response.HeadersWritten)
+            if (Warnings.Any() && !response.HeadersWritten)
             {
-                response.AppendHeader(ProtocolConstants.ServerWarningHeader, _warningMessage);
+                foreach (var warning in Warnings)
+                {
+                    if (!string.IsNullOrWhiteSpace(warning))
+                    {
+                        response.AppendHeader(Constants.WarningHeaderName, warning);
+                    }
+                }
             }
 
             base.ExecuteResult(context);

--- a/src/NuGetGallery/RequestModels/SubmitPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/SubmitPackageRequest.cs
@@ -1,17 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using System.ComponentModel.DataAnnotations;
-using System.Web;
 
 namespace NuGetGallery
 {
     public class SubmitPackageRequest
     {
-        [Required]
-        [Hint("Your package file will be uploaded and hosted on the gallery server.")]
-        public HttpPostedFile PackageFile { get; set; }
-
-        public bool IsUploadInProgress { get; set; }
+        public bool IsUploadInProgress => InProgressUpload != null;
 
         public VerifyPackageRequest InProgressUpload { get; set; }
     }

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -10,7 +10,9 @@ namespace NuGetGallery
 {
     public class VerifyPackageRequest
     {
-        public VerifyPackageRequest() { }
+        public VerifyPackageRequest()
+        {
+        }
 
         public VerifyPackageRequest(PackageMetadata packageMetadata, IEnumerable<User> possibleOwners, PackageRegistration existingPackageRegistration)
         {
@@ -110,6 +112,8 @@ namespace NuGetGallery
         public string Summary { get; set; }
         public string Tags { get; set; }
         public string Title { get; set; }
+
+        public List<string> Warnings { get; set; } = new List<string>();
 
         private static IReadOnlyCollection<string> ParseUserList(IEnumerable<User> users)
         {

--- a/src/NuGetGallery/Services/IPackageUploadService.cs
+++ b/src/NuGetGallery/Services/IPackageUploadService.cs
@@ -10,6 +10,16 @@ namespace NuGetGallery
 {
     public interface IPackageUploadService
     {
+        /// <summary>
+        /// Validate the provided package archive reader before
+        /// <see cref="GeneratePackageAsync(string, PackageArchiveReader, PackageStreamMetadata, User, User)"/> is
+        /// called. This is useful for finding errors or warnings that should be caught before the user verifies their
+        /// UI package upload.
+        /// </summary>
+        /// <param name="nuGetPackage">The package archive reader.</param>
+        /// <returns>The package validation result.</returns>
+        Task<PackageValidationResult> ValidateBeforeGeneratePackageAsync(PackageArchiveReader nuGetPackage);
+
         Task<Package> GeneratePackageAsync(
             string id,
             PackageArchiveReader nugetPackage,
@@ -28,7 +38,7 @@ namespace NuGetGallery
         /// <param name="owner">The owner of the package.</param>
         /// <param name="currentUser">The current user.</param>
         /// <returns>The package validation result.</returns>
-        Task<PackageValidationResult> ValidatePackageAsync(
+        Task<PackageValidationResult> ValidateAfterGeneratePackageAsync(
             Package package,
             PackageArchiveReader nuGetPackage,
             User owner,

--- a/src/NuGetGallery/Services/PackageValidationResult.cs
+++ b/src/NuGetGallery/Services/PackageValidationResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace NuGetGallery
 {
@@ -11,7 +12,14 @@ namespace NuGetGallery
     /// </summary>
     public class PackageValidationResult
     {
+        private static readonly IReadOnlyList<string> EmptyList = new string[0];
+
         public PackageValidationResult(PackageValidationResultType type, string message)
+            : this(type, message, warnings: null)
+        {
+        }
+
+        public PackageValidationResult(PackageValidationResultType type, string message, IReadOnlyList<string> warnings)
         {
             if (type != PackageValidationResultType.Accepted && message == null)
             {
@@ -20,14 +28,27 @@ namespace NuGetGallery
 
             Type = type;
             Message = message;
+            Warnings = warnings ?? EmptyList;
         }
 
         public PackageValidationResultType Type { get; }
         public string Message { get; }
+        public IReadOnlyList<string> Warnings { get; }
 
         public static PackageValidationResult Accepted()
         {
-            return new PackageValidationResult(PackageValidationResultType.Accepted, message: null);
+            return new PackageValidationResult(
+                PackageValidationResultType.Accepted,
+                message: null,
+                warnings: null);
+        }
+
+        public static PackageValidationResult AcceptedWithWarnings(IReadOnlyList<string> warnings)
+        {
+            return new PackageValidationResult(
+                PackageValidationResultType.Accepted,
+                message: null,
+                warnings: warnings);
         }
 
         public static PackageValidationResult Invalid(string message)
@@ -37,7 +58,10 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(message));
             }
 
-            return new PackageValidationResult(PackageValidationResultType.Invalid, message);
+            return new PackageValidationResult(
+                PackageValidationResultType.Invalid,
+                message,
+                warnings: null);
         }
     }
 }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2221,6 +2221,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The previous package version &apos;{0}&apos; is author signed but the uploaded package is unsigned. To avoid this warning, sign the package before uploading..
+        /// </summary>
+        public static string UploadPackage_SignedToUnsignedTransition {
+            get {
+                return ResourceManager.GetString("UploadPackage_SignedToUnsignedTransition", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot upload file because an upload is already in progress..
         /// </summary>
         public static string UploadPackage_UploadInProgress {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -964,4 +964,8 @@ Policy violations: {0}</value>
   <data name="SymbolsPackage_ConflictValidating" xml:space="preserve">
     <value>It looks like there is another copy of this symbols package pending validation(s). Please wait for the validation(s) to finish before trying to replace the symbols package.</value>
   </data>
+  <data name="UploadPackage_SignedToUnsignedTransition" xml:space="preserve">
+    <value>The previous package version '{0}' is author signed but the uploaded package is unsigned. To avoid this warning, sign the package before uploading.</value>
+    <comment>{0} is the previous package's normalized version.</comment>
+  </data>
 </root>

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -27,8 +27,6 @@
                     <form aria-label="Upload a package" id="uploadForm" enctype="multipart/form-data">
                         @Html.AntiForgeryToken()
 
-                        @Html.ValidationSummary(true)
-
                         <div class="input-group">
                             <input type="text" class="form-control" id="file-select-feedback" value="Browse or Drop files to select a package..." aria-label="Upload Your Package" readonly />
                             <label for="input-select-file" id="PackageFileLabel" class="input-group-btn">
@@ -48,20 +46,16 @@
                 </div>
             </div>
 
-
             @if (Model != null && Model.IsUploadInProgress)
             {
                 <div id="warning-container">
-                    @ViewHelpers.AlertWarning(@<text>You had an upload in progress. You can continue it here or cancel to restart.</text>)
-                    @ViewHelpers.AlertPackageVerifyRecommendation()
+                    @ViewHelpers.AlertInfo(@<text>You had an upload in progress. You can continue it here or cancel to restart.</text>)
                 </div>
             }
-            else
-            {
-                <div id="verify-warning-container" class="hidden">
-                    @ViewHelpers.AlertPackageVerifyRecommendation()
-                </div>
-            }
+
+            <div id="verify-warning-container" class="hidden">
+                @ViewHelpers.AlertPackageVerifyRecommendation()
+            </div>
 
             @Html.Partial("_VerifyForm")
         </div>

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -44,6 +44,11 @@
 <script type="text/html" id="verify-metadata-template">
     <div class="collapse in" id="verify-package-section">
         <div data-bind="if: $data">
+                <!-- ko if: $data.Warnings -->
+                <div data-bind="foreach: $data.Warnings">
+                    @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
+                </div>
+                <!-- /ko -->
 
                 <div class="verify-package-field">
                     <label for="Id" class="verify-package-field-heading">Package ID</label>

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -106,6 +106,24 @@ namespace NuGetGallery
                     .Returns(new ReservedNamespace[0]);
             }
 
+            if (packageUploadService == null)
+            {
+                packageUploadService = new Mock<IPackageUploadService>();
+
+                packageUploadService
+                    .Setup(x => x.ValidateBeforeGeneratePackageAsync(
+                        It.IsAny<PackageArchiveReader>()))
+                    .ReturnsAsync(PackageValidationResult.Accepted());
+
+                packageUploadService
+                    .Setup(x => x.ValidateAfterGeneratePackageAsync(
+                        It.IsAny<Package>(),
+                        It.IsAny<PackageArchiveReader>(),
+                        It.IsAny<User>(),
+                        It.IsAny<User>()))
+                    .ReturnsAsync(PackageValidationResult.Accepted());
+            }
+
             packageUploadService = packageUploadService ?? new Mock<IPackageUploadService>();
 
             validationService = validationService ?? new Mock<IValidationService>();
@@ -161,6 +179,35 @@ namespace NuGetGallery
             }
 
             return controller.Object;
+        }
+
+        private static Mock<IPackageUploadService> GetValidPackageUploadService(string packageId, string packageVersion)
+        {
+            var fakePackageUploadService = new Mock<IPackageUploadService>();
+
+            fakePackageUploadService
+                .Setup(x => x.ValidateBeforeGeneratePackageAsync(
+                    It.IsAny<PackageArchiveReader>()))
+                .ReturnsAsync(PackageValidationResult.Accepted());
+
+            fakePackageUploadService
+                .Setup(x => x.GeneratePackageAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<PackageArchiveReader>(),
+                    It.IsAny<PackageStreamMetadata>(),
+                    It.IsAny<User>(),
+                    It.IsAny<User>()))
+                .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = packageId }, Version = packageVersion }));
+
+            fakePackageUploadService
+                .Setup(x => x.ValidateAfterGeneratePackageAsync(
+                    It.IsAny<Package>(),
+                    It.IsAny<PackageArchiveReader>(),
+                    It.IsAny<User>(),
+                    It.IsAny<User>()))
+                .ReturnsAsync(PackageValidationResult.Accepted());
+
+            return fakePackageUploadService;
         }
 
         public class TheCancelVerifyPackageAction
@@ -3442,6 +3489,76 @@ namespace NuGetGallery
                 Assert.NotNull(result);
             }
 
+            [Fact]
+            public async Task WillSetTheErrorMessageInTempDataWhenValidationFails()
+            {
+                var expectedMessage = "Bad, bad package!";
+                var currentUser = TestUtility.FakeUser;
+                var fakeFileStream = TestPackage.CreateTestPackageStream("CrestedGecko", "1.4.2");
+
+                var fakeUserService = new Mock<IUserService>();
+                fakeUserService
+                    .Setup(x => x.FindByUsername(currentUser.Username, false))
+                    .Returns(currentUser);
+
+                var fakeUploadFileService = new Mock<IUploadFileService>();
+                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(It.IsAny<int>())).Returns(Task.FromResult(fakeFileStream));
+
+                var fakePackageUploadService = new Mock<IPackageUploadService>();
+                fakePackageUploadService
+                    .Setup(x => x.ValidateBeforeGeneratePackageAsync(It.IsAny<PackageArchiveReader>()))
+                    .ReturnsAsync(PackageValidationResult.Invalid(expectedMessage));
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    userService: fakeUserService,
+                    uploadFileService: fakeUploadFileService,
+                    packageUploadService: fakePackageUploadService);
+                controller.SetCurrentUser(currentUser);
+
+                var result = (await controller.UploadPackage() as ViewResult).Model as SubmitPackageRequest;
+
+                Assert.NotNull(result);
+                Assert.Null(result.InProgressUpload);
+                Assert.Equal(controller.TempData["Message"], expectedMessage);
+            }
+
+            [Fact]
+            public async Task WillSetShowWarningsFromValidationBeforeGeneratePackage()
+            {
+                var expectedMessage = "Tricky package!";
+                var currentUser = TestUtility.FakeUser;
+                var fakeFileStream = TestPackage.CreateTestPackageStream("CrestedGecko", "1.4.2");
+
+                var fakeUserService = new Mock<IUserService>();
+                fakeUserService
+                    .Setup(x => x.FindByUsername(currentUser.Username, false))
+                    .Returns(currentUser);
+
+                var fakeUploadFileService = new Mock<IUploadFileService>();
+                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(It.IsAny<int>())).Returns(Task.FromResult(fakeFileStream));
+
+                var fakePackageUploadService = new Mock<IPackageUploadService>();
+                fakePackageUploadService
+                    .Setup(x => x.ValidateBeforeGeneratePackageAsync(It.IsAny<PackageArchiveReader>()))
+                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { expectedMessage }));
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    userService: fakeUserService,
+                    uploadFileService: fakeUploadFileService,
+                    packageUploadService: fakePackageUploadService);
+                controller.SetCurrentUser(currentUser);
+
+                var result = (await controller.UploadPackage() as ViewResult).Model as SubmitPackageRequest;
+
+                Assert.NotNull(result);
+                Assert.NotNull(result.InProgressUpload);
+                Assert.False(controller.TempData.ContainsKey("Message"));
+                var actualMessage = Assert.Single(result.InProgressUpload.Warnings);
+                Assert.Equal(expectedMessage, actualMessage);
+            }
+
             private void AssertIdenticalPossibleOwners(IEnumerable<string> possibleOwners, IEnumerable<User> expectedPossibleOwners)
             {
                 Assert.True(possibleOwners.SequenceEqual(expectedPossibleOwners.Select(u => u.Username)));
@@ -3451,6 +3568,9 @@ namespace NuGetGallery
         public class TheUploadFileActionForPostRequests
             : TestContainer
         {
+            private const string PackageId = "theId";
+            private const string PackageVersion = "1.0.0";
+
             [Fact]
             public async Task WillReturn409WhenThereIsAlreadyAnUploadInProgress()
             {
@@ -3478,7 +3598,6 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(null) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.False(controller.ModelState.IsValid);
                 Assert.Equal(Strings.UploadFileIsRequired, (result.Data as string[])[0]);
             }
 
@@ -3493,8 +3612,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.False(controller.ModelState.IsValid);
-                Assert.Equal(Strings.UploadFileMustBeNuGetPackage, controller.ModelState[String.Empty].Errors[0].ErrorMessage);
+                Assert.Equal(Strings.UploadFileMustBeNuGetPackage, (result.Data as string[])[0]);
             }
 
             [Fact]
@@ -3514,8 +3632,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.False(controller.ModelState.IsValid);
-                Assert.Equal(Strings.FailedToReadUploadFile, controller.ModelState[String.Empty].Errors[0].ErrorMessage);
+                Assert.Equal(Strings.FailedToReadUploadFile, (result.Data as string[])[0]);
             }
 
             private const string EnsureValidExceptionMessage = "naughty package";
@@ -3543,8 +3660,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.False(controller.ModelState.IsValid);
-                Assert.Equal(expectExceptionMessageInResponse ? EnsureValidExceptionMessage : Strings.FailedToReadUploadFile, controller.ModelState[String.Empty].Errors[0].ErrorMessage);
+                Assert.Equal(expectExceptionMessageInResponse ? EnsureValidExceptionMessage : Strings.FailedToReadUploadFile, (result.Data as string[])[0]);
             }
 
             [Theory]
@@ -3554,8 +3670,6 @@ namespace NuGetGallery
             [InlineData("EndWithSeparator.")]
             [InlineData("EndsWithHyphen-")]
             [InlineData("$id$")]
-            [InlineData("Contains#Invalid$Characters!@#$%^&*")]
-            [InlineData("Contains#Invalid$Characters!@#$%^&*EndsOnValidCharacter")]
             public async Task WillShowViewWithErrorsIfPackageIdIsInvalid(string packageId)
             {
                 // Arrange
@@ -3572,7 +3686,29 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.False(controller.ModelState.IsValid);
+                Assert.Equal($"The package manifest contains an invalid ID: '{packageId}'", (result.Data as string[])[0]);
+            }
+
+            [Theory]
+            [InlineData("Contains#Invalid$Characters!@#$%^&*")]
+            [InlineData("Contains#Invalid$Characters!@#$%^&*EndsOnValidCharacter")]
+            public async Task WillShowViewWithErrorsIfPackageIdIsBreaksParsing(string packageId)
+            {
+                // Arrange
+                var fakeUploadedFile = new Mock<HttpPostedFileBase>();
+                fakeUploadedFile.Setup(x => x.FileName).Returns(packageId + ".nupkg");
+                var fakeFileStream = TestPackage.CreateTestPackageStream(packageId, "1.0.0");
+                fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    fakeNuGetPackage: TestPackage.CreateTestPackageStream(packageId, "1.0.0"));
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
+
+                Assert.NotNull(result);
+                Assert.StartsWith($"An error occurred while parsing EntityName.", (result.Data as string[])[0]);
             }
 
             public static IEnumerable<object[]> WillShowTheViewWithErrorsWhenThePackageIdIsAlreadyBeingUsed_Data
@@ -3603,8 +3739,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.False(controller.ModelState.IsValid);
-                Assert.Equal(String.Format(Strings.PackageIdNotAvailable, "theId"), controller.ModelState[String.Empty].Errors[0].ErrorMessage);
+                Assert.Equal(String.Format(Strings.PackageIdNotAvailable, "theId"), (result.Data as string[])[0]);
             }
 
             public static IEnumerable<object[]> WillShowTheViewWithErrorsWhenThePackageIdMatchesUnownedNamespace_Data
@@ -3654,9 +3789,14 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.False(controller.ModelState.IsValid);
-                Assert.Equal(String.Format(Strings.UploadPackage_IdNamespaceConflict), controller.ModelState[String.Empty].Errors[0].ErrorMessage);
-                fakeTelemetryService.Verify(x => x.TrackPackagePushNamespaceConflictEvent(It.IsAny<string>(), It.IsAny<string>(), currentUser, controller.OwinContext.Request.User.Identity), Times.Once);
+                Assert.Equal(String.Format(Strings.UploadPackage_IdNamespaceConflict), (result.Data as string[])[0]);
+                fakeTelemetryService.Verify(
+                    x => x.TrackPackagePushNamespaceConflictEvent(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        currentUser,
+                        controller.OwinContext.Request.User.Identity),
+                    Times.Once);
             }
 
             public static IEnumerable<object[]> WillUploadThePackageWhenIdMatchesOwnedNamespace_Data
@@ -3706,7 +3846,6 @@ namespace NuGetGallery
 
                 var result = await controller.UploadPackage(fakeUploadedFile.Object);
 
-                Assert.True(controller.ModelState.IsValid);
                 fakeUploadFileService.Verify(x => x.SaveUploadFileAsync(currentUser.Key, fakeUploadedFileStream));
                 fakeUploadedFileStream.Dispose();
 
@@ -3763,7 +3902,6 @@ namespace NuGetGallery
 
                 var result = await controller.UploadPackage(fakeUploadedFile.Object);
 
-                Assert.True(controller.ModelState.IsValid);
                 fakeUploadFileService.Verify(x => x.SaveUploadFileAsync(currentUser.Key, fakeUploadedFileStream));
                 fakeUploadedFileStream.Dispose();
 
@@ -3799,10 +3937,9 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.False(controller.ModelState.IsValid);
                 Assert.Equal(
                     String.Format(Strings.PackageExistsAndCannotBeModified, "theId", "1.0.0"),
-                    controller.ModelState[String.Empty].Errors[0].ErrorMessage);
+                    (result.Data as string[])[0]);
                 fakePackageDeleteService.Verify(
                     x => x.HardDeletePackagesAsync(
                         It.IsAny<IEnumerable<Package>>(),
@@ -3842,10 +3979,9 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.False(controller.ModelState.IsValid);
                 Assert.Equal(
                     String.Format(Strings.PackageVersionDiffersOnlyByMetadataAndCannotBeModified, "theId", "1.0.0+metadata"),
-                    controller.ModelState[String.Empty].Errors[0].ErrorMessage);
+                    (result.Data as string[])[0]);
                 fakePackageDeleteService.Verify(
                     x => x.HardDeletePackagesAsync(
                         It.IsAny<IEnumerable<Package>>(),
@@ -3986,11 +4122,82 @@ namespace NuGetGallery
                 Assert.IsType<JsonResult>(result);
                 Assert.Equal(403, controller.Response.StatusCode);
             }
+
+            [Fact]
+            public async Task WillShowValidationErrorsFoundBeforeGeneratePackage()
+            {
+                var expectedMessage = "Bad package.";
+                var fakeUploadedFile = new Mock<HttpPostedFileBase>();
+                fakeUploadedFile.Setup(x => x.FileName).Returns(PackageId + ".nupkg");
+                var fakeFileStream = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
+                fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
+                var fakeUploadFileService = new Mock<IUploadFileService>();
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                fakeUploadFileService.SetupSequence(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key))
+                    .Returns(Task.FromResult<Stream>(null))
+                    .Returns(Task.FromResult(fakeFileStream));
+                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
+
+                var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                fakePackageUploadService
+                    .Setup(x => x.ValidateBeforeGeneratePackageAsync(It.IsAny<PackageArchiveReader>()))
+                    .ReturnsAsync(PackageValidationResult.Invalid(expectedMessage));
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    uploadFileService: fakeUploadFileService,
+                    packageUploadService: fakePackageUploadService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
+
+                Assert.NotNull(result);
+                Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
+                Assert.Equal(expectedMessage, (result.Data as string[])[0]);
+            }
+            
+
+            [Fact]
+            public async Task WillShowValidationWarningsFoundBeforeGeneratePackage()
+            {
+                var expectedMessage = "Iffy package.";
+                var fakeUploadedFile = new Mock<HttpPostedFileBase>();
+                fakeUploadedFile.Setup(x => x.FileName).Returns(PackageId + ".nupkg");
+                var fakeFileStream = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
+                fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
+                var fakeUploadFileService = new Mock<IUploadFileService>();
+                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                fakeUploadFileService.SetupSequence(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key))
+                    .Returns(Task.FromResult<Stream>(null))
+                    .Returns(Task.FromResult(fakeFileStream));
+                fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
+
+                var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                fakePackageUploadService
+                    .Setup(x => x.ValidateBeforeGeneratePackageAsync(It.IsAny<PackageArchiveReader>()))
+                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { expectedMessage }));
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    uploadFileService: fakeUploadFileService,
+                    packageUploadService: fakePackageUploadService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
+
+                Assert.NotNull(result);
+                var data = Assert.IsAssignableFrom<VerifyPackageRequest>(result.Data);
+                var actualMessage = Assert.Single(data.Warnings);
+                Assert.Equal(expectedMessage, actualMessage);
+            }
         }
 
         public class TheVerifyPackageActionForPostRequests
             : TestContainer
         {
+            private const string PackageId = "theId";
+            private const string PackageVersion = "1.0.0";
+
             [Fact]
             public async Task WillTrackFailureIfUnexpectedExceptionWithoutIdVersion()
             {
@@ -4018,8 +4225,6 @@ namespace NuGetGallery
             public async Task WillTrackFailureIfUnexpectedExceptionWithIdVersion()
             {
                 // Arrange
-                var packageId = "theId";
-                var packageVersion = "1.0.0";
                 var currentUser = TestUtility.FakeUser;
                 var ownerInForm = currentUser;
 
@@ -4033,16 +4238,8 @@ namespace NuGetGallery
 
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(currentUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(currentUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = packageId }, Version = packageVersion }));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(packageId, packageVersion);
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(ownerInForm.Username, false)).Returns(ownerInForm);
@@ -4063,7 +4260,7 @@ namespace NuGetGallery
                     await Assert.ThrowsAnyAsync<Exception>(() => controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Owner = ownerInForm.Username }));
 
                     // Assert
-                    fakeTelemetryService.Verify(x => x.TrackPackagePushFailureEvent(packageId, new NuGetVersion(packageVersion)), Times.Once());
+                    fakeTelemetryService.Verify(x => x.TrackPackagePushFailureEvent(PackageId, new NuGetVersion(PackageVersion)), Times.Once());
                 }
             }
 
@@ -4091,28 +4288,14 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
+
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
                     fakePackageUploadService
                         .Setup(x => x.CommitPackageAsync(
                             It.IsAny<Package>(),
                             It.IsAny<Stream>()))
                         .ReturnsAsync(PackageCommitResult.Conflict);
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4140,16 +4323,8 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var controller = CreateController(
                         GetConfigurationService(),
@@ -4172,16 +4347,8 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     var owner = new User { Key = 999, Username = "invalidOwner" };
@@ -4215,28 +4382,8 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(new PackageValidationResult(type, "Some message"));
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                    fakePackageUploadService
-                        .Setup(x => x.CommitPackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<Stream>()))
-                        .ReturnsAsync(PackageCommitResult.Success);
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4252,7 +4399,7 @@ namespace NuGetGallery
                     await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Owner = TestUtility.FakeUser.Username });
 
                     fakePackageUploadService.Verify(
-                        x => x.ValidatePackageAsync(
+                        x => x.ValidateAfterGeneratePackageAsync(
                             It.IsAny<Package>(),
                             It.IsAny<PackageArchiveReader>(),
                             It.IsAny<User>(),
@@ -4275,28 +4422,13 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
                     fakePackageUploadService
                         .Setup(x => x.CommitPackageAsync(
                             It.IsAny<Package>(),
                             It.IsAny<Stream>()))
                         .ReturnsAsync(commitResult);
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4316,9 +4448,6 @@ namespace NuGetGallery
                         It.IsAny<Stream>()), Times.Once);
                 }
             }
-
-            private static readonly string VerifyCreateTestsPackageId = "thePackageId";
-            private static readonly string VerifyCreateTestsPackageVersion = "1.4.2";
 
             public static IEnumerable<object[]> WillCreateThePackageForNewId_Data
             {
@@ -4399,7 +4528,7 @@ namespace NuGetGallery
             [MemberData(nameof(WillNotCreateThePackageIfOwnerInFormDoesNotOwnTheExistingPackage_Data))]
             public Task WillNotCreateThePackageIfOwnerInFormDoesNotOwnTheExistingPackage(User currentUser, User ownerInForm, User existingPackageOwner)
             {
-                var message = string.Format(CultureInfo.CurrentCulture, Strings.VerifyPackage_OwnerInvalid, ownerInForm.Username, VerifyCreateTestsPackageId);
+                var message = string.Format(CultureInfo.CurrentCulture, Strings.VerifyPackage_OwnerInvalid, ownerInForm.Username, PackageId);
 
                 return VerifyCreateThePackage(
                     currentUser, 
@@ -4492,7 +4621,7 @@ namespace NuGetGallery
             [InlineData(PackageValidationResultType.Invalid)]
             [InlineData(PackageValidationResultType.PackageShouldNotBeSigned)]
             [InlineData(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates)]
-            public async Task WillShowTheValidationMessageWhenValidationFails(PackageValidationResultType type)
+            public async Task WillShowTheValidationMessageWhenValidationAfterGenerateFails(PackageValidationResultType type)
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
                 using (var fakeFileStream = new MemoryStream())
@@ -4501,23 +4630,15 @@ namespace NuGetGallery
 
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
                     fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" });
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
+                        .Setup(x => x.ValidateAfterGeneratePackageAsync(
                             It.IsAny<Package>(),
                             It.IsAny<PackageArchiveReader>(),
                             It.IsAny<User>(),
                             It.IsAny<User>()))
                         .ReturnsAsync(new PackageValidationResult(type, expectedMessage));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4532,64 +4653,104 @@ namespace NuGetGallery
 
                     var result = await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Owner = TestUtility.FakeUser.Username });
 
-                    var jsonResult = Assert.IsType<JsonResult>(result);
-                    Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
-                    var message = (jsonResult.Data as string[])[0];
+                    VerifyPackageValidationResultMessage(type, expectedMessage, controller, result);
+                    fakePackageUploadService.Verify(
+                        x => x.GeneratePackageAsync(
+                            It.IsAny<string>(),
+                            It.IsAny<PackageArchiveReader>(),
+                            It.IsAny<PackageStreamMetadata>(),
+                            It.IsAny<User>(),
+                            It.IsAny<User>()),
+                        Times.Once);
+                }
+            }
 
-                    if (type == PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates)
-                    {
-                        Assert.Equal(
-                            expectedMessage + " You can manage your certificates on the Account Settings page.",
-                            message);
-                    }
-                    else
-                    {
-                        Assert.Equal(expectedMessage, message);
-                    }
+            [Theory]
+            [InlineData(PackageValidationResultType.Invalid)]
+            [InlineData(PackageValidationResultType.PackageShouldNotBeSigned)]
+            [InlineData(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates)]
+            public async Task WillShowTheValidationMessageWhenValidationBeforeGenerateFails(PackageValidationResultType type)
+            {
+                var fakeUploadFileService = new Mock<IUploadFileService>();
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    var expectedMessage = "The package is just bad.";
+
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    fakePackageUploadService
+                        .Setup(x => x.ValidateBeforeGeneratePackageAsync(
+                            It.IsAny<PackageArchiveReader>()))
+                        .ReturnsAsync(new PackageValidationResult(type, expectedMessage));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
+
+                    var fakeUserService = new Mock<IUserService>();
+                    fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
+
+                    var controller = CreateController(
+                        GetConfigurationService(),
+                        packageUploadService: fakePackageUploadService,
+                        uploadFileService: fakeUploadFileService,
+                        fakeNuGetPackage: fakeNuGetPackage,
+                        userService: fakeUserService);
+                    controller.SetCurrentUser(TestUtility.FakeUser);
+
+                    var result = await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Owner = TestUtility.FakeUser.Username });
+
+                    VerifyPackageValidationResultMessage(type, expectedMessage, controller, result);
+                    fakePackageUploadService.Verify(
+                        x => x.GeneratePackageAsync(
+                            It.IsAny<string>(),
+                            It.IsAny<PackageArchiveReader>(),
+                            It.IsAny<PackageStreamMetadata>(),
+                            It.IsAny<User>(),
+                            It.IsAny<User>()),
+                        Times.Never);
+                }
+            }
+
+            private static void VerifyPackageValidationResultMessage(PackageValidationResultType type, string expectedMessage, PackagesController controller, JsonResult result)
+            {
+                var jsonResult = Assert.IsType<JsonResult>(result);
+                Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
+                var message = (jsonResult.Data as string[])[0];
+
+                if (type == PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates)
+                {
+                    Assert.Equal(
+                        expectedMessage + " You can manage your certificates on the Account Settings page.",
+                        message);
+                }
+                else
+                {
+                    Assert.Equal(expectedMessage, message);
                 }
             }
 
             private async Task VerifyCreateThePackage(User currentUser, User ownerInForm, bool succeeds, User existingPackageOwner = null, User reservedNamespaceOwner = null, HttpStatusCode errorResponseCode = HttpStatusCode.BadRequest, string expectedMessage = null)
             {
-                var packageId = VerifyCreateTestsPackageId;
-                var packageVersion = VerifyCreateTestsPackageVersion;
-
                 var fakeUploadFileService = new Mock<IUploadFileService>();
                 using (var fakeFileStream = new MemoryStream())
                 {
                     var fakePackageService = new Mock<IPackageService>();
-                    var existingPackageRegistration = existingPackageOwner == null ? 
-                        null : 
-                        new PackageRegistration { Id = packageId, Owners = new[] { existingPackageOwner } };
+                    var existingPackageRegistration = existingPackageOwner == null ?
+                        null :
+                        new PackageRegistration { Id = PackageId, Owners = new[] { existingPackageOwner } };
                     fakePackageService
                         .Setup(x => x.FindPackageRegistrationById(It.IsAny<string>()))
                         .Returns(existingPackageRegistration);
 
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(currentUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(currentUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = packageId }, Version = packageVersion }));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(packageId, packageVersion);
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeReservedNamespaceService = new Mock<IReservedNamespaceService>();
-                    var matchingReservedNamespaces = reservedNamespaceOwner == null ? 
-                        Enumerable.Empty<ReservedNamespace>() : 
+                    var matchingReservedNamespaces = reservedNamespaceOwner == null ?
+                        Enumerable.Empty<ReservedNamespace>() :
                         new[] { new ReservedNamespace { Owners = new[] { reservedNamespaceOwner } } };
-                    fakeReservedNamespaceService.Setup(x => x.GetReservedNamespacesForId(packageId)).Returns(matchingReservedNamespaces.ToList().AsReadOnly());
+                    fakeReservedNamespaceService.Setup(x => x.GetReservedNamespacesForId(PackageId)).Returns(matchingReservedNamespaces.ToList().AsReadOnly());
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(ownerInForm.Username, false)).Returns(ownerInForm);
@@ -4638,15 +4799,8 @@ namespace NuGetGallery
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = PackageId }, Version = PackageVersion };
                     fakePackageUploadService
                         .Setup(x => x.GeneratePackageAsync(
                             It.IsAny<string>(),
@@ -4655,7 +4809,7 @@ namespace NuGetGallery
                             It.IsAny<User>(),
                             It.IsAny<User>()))
                         .Returns(Task.FromResult(fakePackage));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
                     var fakePackageFileService = new Mock<IPackageFileService>();
                     fakePackageFileService.Setup(x => x.SavePackageFileAsync(fakePackage, It.IsAny<Stream>())).Returns(Task.FromResult(0)).Verifiable();
 
@@ -4696,15 +4850,8 @@ namespace NuGetGallery
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key))
                         .Returns(Task.CompletedTask);
                     var fakePackageService = new Mock<IPackageService>(MockBehavior.Strict);
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = PackageId }, Version = PackageVersion };
                     fakePackageUploadService
                         .Setup(x => x.GeneratePackageAsync(
                             It.IsAny<string>(),
@@ -4719,7 +4866,7 @@ namespace NuGetGallery
                         .Returns(Task.CompletedTask);
                     fakePackageService.Setup(x => x.FindPackageRegistrationById(fakePackage.PackageRegistration.Id))
                         .Returns((PackageRegistration)null);
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4749,16 +4896,9 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = PackageId }, Version = PackageVersion };
                     var fakePackageService = new Mock<IPackageService>();
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
                     fakePackageUploadService
                         .Setup(x => x.GeneratePackageAsync(
                             It.IsAny<string>(),
@@ -4767,7 +4907,7 @@ namespace NuGetGallery
                             It.IsAny<User>(),
                             It.IsAny<User>()))
                         .Returns(Task.FromResult(fakePackage));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4796,14 +4936,7 @@ namespace NuGetGallery
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     var fakePackageService = new Mock<IPackageService>();
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
                     fakePackageUploadService
                         .Setup(x => x.GeneratePackageAsync(
                             It.IsAny<string>(),
@@ -4811,8 +4944,8 @@ namespace NuGetGallery
                             It.IsAny<PackageStreamMetadata>(),
                             It.IsAny<User>(),
                             It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId", Owners = new[] { TestUtility.FakeUser } }, Version = "theVersion" }));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = PackageId, Owners = new[] { TestUtility.FakeUser } }, Version = PackageVersion }));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4829,7 +4962,7 @@ namespace NuGetGallery
                     await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Owner = TestUtility.FakeUser.Username });
 
                     fakePackageService.Verify(
-                        x => x.MarkPackageUnlistedAsync(It.Is<Package>(p => p.PackageRegistration.Id == "theId" && p.Version == "theVersion"), It.IsAny<bool>()));
+                        x => x.MarkPackageUnlistedAsync(It.Is<Package>(p => p.PackageRegistration.Id == PackageId && p.Version == PackageVersion), It.IsAny<bool>()));
                 }
             }
 
@@ -4844,23 +4977,8 @@ namespace NuGetGallery
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
                     var fakePackageService = new Mock<IPackageService>();
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4888,14 +5006,7 @@ namespace NuGetGallery
                 using (var fakeFileStream = new MemoryStream())
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
                     fakePackageUploadService
                         .Setup(x => x.GeneratePackageAsync(
                             It.IsAny<string>(),
@@ -4903,8 +5014,8 @@ namespace NuGetGallery
                             It.IsAny<PackageStreamMetadata>(),
                             It.IsAny<User>(),
                             It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId", Owners = new[] { TestUtility.FakeUser } }, Version = "theVersion" }));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = PackageId, Owners = new[] { TestUtility.FakeUser } }, Version = PackageVersion }));
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4932,23 +5043,8 @@ namespace NuGetGallery
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -4963,7 +5059,7 @@ namespace NuGetGallery
 
                     await controller.VerifyPackage(new VerifyPackageRequest() { Listed = false, Owner = TestUtility.FakeUser.Username });
 
-                    Assert.Equal(String.Format(Strings.SuccessfullyUploadedPackage, "theId", "theVersion"), controller.TempData["Message"]);
+                    Assert.Equal(controller.TempData["Message"], String.Format(Strings.SuccessfullyUploadedPackage, PackageId, PackageVersion));
                 }
             }
 
@@ -4975,23 +5071,8 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" }));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -5010,7 +5091,7 @@ namespace NuGetGallery
                     Assert.NotNull(result);
                     Assert.NotNull(result.Data);
                     Assert.Equal(
-                        "{ location = /?id=theId }",
+                        "{ location = /?id=" + PackageId + " }",
                         result.Data.ToString());
                 }
             }
@@ -5023,15 +5104,8 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId", Owners = new[] { TestUtility.FakeUser } }, Version = "theVersion" };
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = PackageId, Owners = new[] { TestUtility.FakeUser } }, Version = PackageVersion };
                     fakePackageUploadService
                         .Setup(x => x.GeneratePackageAsync(
                             It.IsAny<string>(),
@@ -5040,7 +5114,7 @@ namespace NuGetGallery
                             It.IsAny<User>(),
                             It.IsAny<User>()))
                         .Returns(Task.FromResult(fakePackage));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -5070,24 +5144,16 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
                     fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
+                        .Setup(x => x.ValidateAfterGeneratePackageAsync(
                             It.IsAny<Package>(),
                             It.IsAny<PackageArchiveReader>(),
                             It.IsAny<User>(),
                             It.IsAny<User>()))
                         .ReturnsAsync(PackageValidationResult.Accepted());
-                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId", Owners = new[] { TestUtility.FakeUser } }, Version = "theVersion" };
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(fakePackage));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = PackageId, Owners = new[] { TestUtility.FakeUser } }, Version = PackageVersion };
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
                     fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
@@ -5129,21 +5195,14 @@ namespace NuGetGallery
                         .Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key))
                         .Returns(Task.CompletedTask);
 
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
                     var fakePackage = new Package
                     {
                         PackageRegistration = new PackageRegistration
                         {
-                            Id = "theId",
+                            Id = PackageId,
                         },
-                        Version = "theVersion"
+                        Version = PackageVersion
                     };
                     fakePackageUploadService
                         .Setup(x => x.GeneratePackageAsync(
@@ -5153,7 +5212,7 @@ namespace NuGetGallery
                             It.IsAny<User>(),
                             It.IsAny<User>()))
                         .Returns(Task.FromResult(fakePackage));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
                     var fakeTelemetryService = new Mock<ITelemetryService>();
 
                     var fakeUserService = new Mock<IUserService>();
@@ -5209,24 +5268,8 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    fakePackageUploadService
-                        .Setup(x => x.GeneratePackageAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<PackageStreamMetadata>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .Returns(Task.FromResult(fakePackage));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
                     var fakeTelemetryService = new Mock<ITelemetryService>();
 
                     var fakeUserService = new Mock<IUserService>();
@@ -5263,15 +5306,8 @@ namespace NuGetGallery
                 {
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
-                    var fakePackageUploadService = new Mock<IPackageUploadService>();
-                    fakePackageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
-                            It.IsAny<PackageArchiveReader>(),
-                            It.IsAny<User>(),
-                            It.IsAny<User>()))
-                        .ReturnsAsync(PackageValidationResult.Accepted());
-                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "theId" }, Version = "theVersion" };
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = PackageId }, Version = PackageVersion };
                     fakePackageUploadService
                         .Setup(x => x.GeneratePackageAsync(
                             It.IsAny<string>(),
@@ -5280,7 +5316,7 @@ namespace NuGetGallery
                             It.IsAny<User>(),
                             It.IsAny<User>()))
                         .Returns(Task.FromResult(fakePackage));
-                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.0");
+                    var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
                     var fakeTelemetryService = new Mock<ITelemetryService>();
 
                     var configurationService = GetConfigurationService();
@@ -5312,68 +5348,60 @@ namespace NuGetGallery
                         Times.Exactly(callExpected ? 1 : 0));
                 }
             }
-        }
 
-        public static IEnumerable<object[]> WillApplyReadMe_Data
-        {
-            get
+            public static IEnumerable<object[]> WillApplyReadMe_Data
             {
-                yield return new object[] { new EditPackageVersionReadMeRequest() {
+                get
+                {
+                    yield return new object[] { new EditPackageVersionReadMeRequest() {
                     ReadMe = new ReadMeRequest { SourceType = "Written", SourceText = "markdown"} }
                 };
+                }
             }
-        }
 
-        [Theory]
-        [MemberData(nameof(WillApplyReadMe_Data))]
-        public async Task WillApplyReadMeForWrittenReadMeData(EditPackageVersionReadMeRequest edit)
-        {
-            // Arrange
-            using (var fakeFileStream = new MemoryStream())
+            [Theory]
+            [MemberData(nameof(WillApplyReadMe_Data))]
+            public async Task WillApplyReadMeForWrittenReadMeData(EditPackageVersionReadMeRequest edit)
             {
-                var fakeUploadFileService = new Mock<IUploadFileService>();
-                fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
-                fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
+                // Arrange
+                using (var fakeFileStream = new MemoryStream())
+                {
+                    var fakeUploadFileService = new Mock<IUploadFileService>();
+                    fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
+                    fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.CompletedTask);
 
-                var packageUploadService = new Mock<IPackageUploadService>();
-
-                var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = "thePackageId" }, Version = "1.0.0" };
-                packageUploadService
-                        .Setup(x => x.ValidatePackageAsync(
-                            It.IsAny<Package>(),
+                    var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                    var fakePackage = new Package { PackageRegistration = new PackageRegistration { Id = PackageId }, Version = PackageVersion };
+                    fakePackageUploadService
+                        .Setup(x => x.GeneratePackageAsync(
+                            It.IsAny<string>(),
                             It.IsAny<PackageArchiveReader>(),
+                            It.IsAny<PackageStreamMetadata>(),
                             It.IsAny<User>(),
                             It.IsAny<User>()))
-                    .ReturnsAsync(PackageValidationResult.Accepted());
-                packageUploadService
-                    .Setup(x => x.GeneratePackageAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<PackageArchiveReader>(),
-                        It.IsAny<PackageStreamMetadata>(),
-                        It.IsAny<User>(),
-                        It.IsAny<User>()))
-                    .ReturnsAsync(fakePackage);
-                
-                var fakePackageFileService = new Mock<IPackageFileService>();
-                fakePackageFileService.Setup(x => x.SaveReadMeMdFileAsync(fakePackage, It.IsAny<string>())).Returns(Task.CompletedTask);
+                        .ReturnsAsync(fakePackage);
 
-                var fakeUserService = new Mock<IUserService>();
-                fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
+                    var fakePackageFileService = new Mock<IPackageFileService>();
+                    fakePackageFileService.Setup(x => x.SaveReadMeMdFileAsync(fakePackage, It.IsAny<string>())).Returns(Task.CompletedTask);
 
-                var controller = CreateController(
-                    GetConfigurationService(),
-                    packageUploadService: packageUploadService,
-                    uploadFileService: fakeUploadFileService,
-                    packageFileService: fakePackageFileService,
-                    userService: fakeUserService);
+                    var fakeUserService = new Mock<IUserService>();
+                    fakeUserService.Setup(x => x.FindByUsername(TestUtility.FakeUser.Username, false)).Returns(TestUtility.FakeUser);
 
-                controller.SetCurrentUser(TestUtility.FakeUser);
+                    var controller = CreateController(
+                        GetConfigurationService(),
+                        packageUploadService: fakePackageUploadService,
+                        uploadFileService: fakeUploadFileService,
+                        packageFileService: fakePackageFileService,
+                        userService: fakeUserService);
 
-                // Act
-                await controller.VerifyPackage(new VerifyPackageRequest { Listed = true, Owner = TestUtility.FakeUser.Username, Edit = edit });
+                    controller.SetCurrentUser(TestUtility.FakeUser);
 
-                var hasReadMe = !string.IsNullOrEmpty(edit.ReadMe?.SourceType);
-                fakePackageFileService.Verify(x => x.SaveReadMeMdFileAsync(fakePackage, "markdown"), Times.Exactly(hasReadMe ? 1 : 0));
+                    // Act
+                    await controller.VerifyPackage(new VerifyPackageRequest { Listed = true, Owner = TestUtility.FakeUser.Username, Edit = edit });
+
+                    var hasReadMe = !string.IsNullOrEmpty(edit.ReadMe?.SourceType);
+                    fakePackageFileService.Verify(x => x.SaveReadMeMdFileAsync(fakePackage, "markdown"), Times.Exactly(hasReadMe ? 1 : 0));
+                }
             }
         }
 


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6184.
Address https://github.com/NuGet/NuGetGallery/issues/6253.

## UI upload

![image](https://user-images.githubusercontent.com/94054/43651594-a65a2f5c-96f7-11e8-9a92-b7cb3d571eec.png)

## Command line

```
> nuget.exe push "system.rido.1.0.3 (unsigned).nupkg" -source https://localhost/api/v2/package -apikey myapikey
Pushing system.rido.1.0.3 (unsigned).nupkg to 'https://localhost/api/v2/package'...
  PUT https://localhost/api/v2/package/
WARNING: The previous package version '1.0.1' is signed but the uploaded package is unsigned. To avoid this warning, sign the package before uploading.
  Created https://localhost/api/v2/package/ 38504ms
Your package was pushed.