### PR TITLE
Fix logging exceptions from background thread

### DIFF
--- a/src/NuGetGallery/Services/BackgroundMessageService.cs
+++ b/src/NuGetGallery/Services/BackgroundMessageService.cs
@@ -5,16 +5,20 @@ using System;
 using System.Net.Mail;
 using System.Threading.Tasks;
 using AnglicanGeek.MarkdownMailer;
+using Elmah;
 using NuGetGallery.Configuration;
 
 namespace NuGetGallery.Services
 {
     public class BackgroundMessageService : MessageService
     {
-        public BackgroundMessageService(IMailSender mailSender, IAppConfiguration config, ITelemetryService telemetryService)
+        public BackgroundMessageService(IMailSender mailSender, IAppConfiguration config, ITelemetryService telemetryService, ErrorLog errorLog)
             :base(mailSender, config, telemetryService)
         {
+            this.errorLog = errorLog;
         }
+
+        private ErrorLog errorLog;
 
         protected override Task SendMessageAsync(MailMessage mailMessage)
         {
@@ -34,7 +38,7 @@ namespace NuGetGallery.Services
                 catch (Exception ex)
                 {
                     // Log but swallow the exception.
-                    QuietLog.LogHandledException(ex);
+                    QuietLog.LogHandledException(ex, errorLog);
                 }
                 finally
                 {


### PR DESCRIPTION
QuietLog uses Elmah, which uses DI resolving at log time, rather than being contructed at HTTP request time. Autofac MVC's lifetime manager requires a HttpContext, which is null in a background thread, so there was no good/easy way to resolve the Elmah logger in a background thread. Logging only to app insights instead.