### PR TITLE
Set the CacheControl property on stored blobs

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -23,6 +23,8 @@ namespace NuGetGallery
         public const string CertificateContentType = "application/pkix-cert";
         public const string JsonContentType = "application/json";
 
+        public const string DefaultCacheControl = "max-age=120";
+
         public const string UserCertificatesFolderName = "user-certificates";
         public const string ContentFolderName = "content";
         public const string DownloadsFolderName = "downloads";

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -318,7 +318,7 @@ namespace NuGetGallery
             }
 
             blob.Properties.ContentType = GetContentType(folderName);
-            blob.Properties.CacheControl = CoreConstants.DefaultCacheControl;
+            blob.Properties.CacheControl = GetCacheControl(folderName);
             await blob.SetPropertiesAsync();
         }
 
@@ -550,12 +550,39 @@ namespace NuGetGallery
                 case CoreConstants.PackageReadMesFolderName:
                     return CoreConstants.TextContentType;
 
+                case CoreConstants.ContentFolderName:
                 case CoreConstants.RevalidationFolderName:
                 case CoreConstants.StatusFolderName:
                     return CoreConstants.JsonContentType;
 
                 case CoreConstants.UserCertificatesFolderName:
                     return CoreConstants.CertificateContentType;
+
+                default:
+                    throw new InvalidOperationException(
+                        String.Format(CultureInfo.CurrentCulture, "The folder name {0} is not supported.", folderName));
+            }
+        }
+
+        private static string GetCacheControl(string folderName)
+        {
+            switch (folderName)
+            {
+                case CoreConstants.PackagesFolderName:
+                    return CoreConstants.DefaultCacheControl;
+
+                case CoreConstants.PackageBackupsFolderName:
+                case CoreConstants.UploadsFolderName:
+                case CoreConstants.ValidationFolderName:
+                case CoreConstants.SymbolPackagesFolderName:
+                case CoreConstants.SymbolPackageBackupsFolderName:
+                case CoreConstants.DownloadsFolderName:
+                case CoreConstants.PackageReadMesFolderName:
+                case CoreConstants.ContentFolderName:
+                case CoreConstants.RevalidationFolderName:
+                case CoreConstants.StatusFolderName:
+                case CoreConstants.UserCertificatesFolderName:
+                    return null;
 
                 default:
                     throw new InvalidOperationException(

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -318,6 +318,7 @@ namespace NuGetGallery
             }
 
             blob.Properties.ContentType = GetContentType(folderName);
+            blob.Properties.CacheControl = CoreConstants.DefaultCacheControl;
             await blob.SetPropertiesAsync();
         }
 

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -48,7 +48,7 @@ namespace NuGetGallery
             {
                 var folderNames = new List<object[]>
                 {
-                    new object[] { CoreConstants.ContentFolderName, false, null, },
+                    new object[] { CoreConstants.ContentFolderName, false, CoreConstants.JsonContentType, },
                     new object[] { CoreConstants.DownloadsFolderName, true, CoreConstants.OctetStreamContentType },
                     new object[] { CoreConstants.PackageBackupsFolderName, true, CoreConstants.PackageContentType },
                     new object[] { CoreConstants.PackageReadMesFolderName, false, CoreConstants.TextContentType },

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -73,7 +73,6 @@ namespace NuGetGallery
                 else if (!IncludePermissions && IncludeContentTypes)
                 {
                     folderNames = folderNames
-                        .Where(fn => fn[2] != null)
                         .Select(fn => new[] { fn[0], fn[2] })
                         .ToList();
                 }

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -472,6 +472,7 @@ namespace NuGetGallery
 
                 await service.SaveFileAsync(CoreConstants.PackagesFolderName, "theFileName", fakePackageFile);
 
+                Assert.Equal(CoreConstants.DefaultCacheControl, fakeBlob.Object.Properties.CacheControl);
                 fakeBlob.Verify();
             }
 


### PR DESCRIPTION
This sets the `CacheControl` property on all blobs to 2 minutes. This affects all uploaded blobs for all blob containers.

Fixes https://github.com/NuGet/NuGetGallery/issues/6285