### PR TITLE
Retry failed emails

### DIFF
--- a/src/NuGetGallery.Core/Services/CoreMessageService.cs
+++ b/src/NuGetGallery.Core/Services/CoreMessageService.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Mail;
 using System.Text;
+using System.Threading.Tasks;
 using AnglicanGeek.MarkdownMailer;
 using NuGet.Services.Validation;
 using NuGet.Services.Validation.Issues;
@@ -15,9 +17,11 @@ namespace NuGetGallery.Services
 {
     public class CoreMessageService : ICoreMessageService
     {
-        protected CoreMessageService()
-        {
-        }
+        private static readonly ReadOnlyCollection<TimeSpan> RetryDelays = Array.AsReadOnly(new[] {
+            TimeSpan.FromSeconds(0.1),
+            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(10)
+        });
 
         public CoreMessageService(IMailSender mailSender, ICoreMessageServiceConfiguration coreConfiguration)
         {
@@ -28,7 +32,7 @@ namespace NuGetGallery.Services
         public IMailSender MailSender { get; protected set; }
         public ICoreMessageServiceConfiguration CoreConfiguration { get; protected set; }
 
-        public void SendPackageAddedNotice(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl, IEnumerable<string> warningMessages = null)
+        public async Task SendPackageAddedNoticeAsync(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl, IEnumerable<string> warningMessages = null)
         {
             bool hasWarnings = warningMessages != null && warningMessages.Any();
 
@@ -63,12 +67,12 @@ namespace NuGetGallery.Services
 
                 if (mailMessage.To.Any())
                 {
-                    SendMessage(mailMessage);
+                    await SendMessageAsync(mailMessage);
                 }
             }
         }
 
-        public void SendPackageAddedWithWarningsNotice(Package package, string packageUrl, string packageSupportUrl, IEnumerable<string> warningMessages)
+        public async Task SendPackageAddedWithWarningsNoticeAsync(Package package, string packageUrl, string packageSupportUrl, IEnumerable<string> warningMessages)
         {
             var subject = $"[{CoreConfiguration.GalleryOwner.DisplayName}] Package pushed with warnings - {package.PackageRegistration.Id} {package.Version}";
             var warningMessagesPlaceholder = Environment.NewLine + string.Join(Environment.NewLine, warningMessages);
@@ -87,12 +91,12 @@ namespace NuGetGallery.Services
 
                 if (mailMessage.To.Any())
                 {
-                    SendMessage(mailMessage);
+                    await SendMessageAsync(mailMessage);
                 }
             }
         }
 
-        public void SendPackageValidationFailedNotice(Package package, PackageValidationSet validationSet, string packageUrl, string packageSupportUrl, string announcementsUrl, string twitterUrl)
+        public async Task SendPackageValidationFailedNoticeAsync(Package package, PackageValidationSet validationSet, string packageUrl, string packageSupportUrl, string announcementsUrl, string twitterUrl)
         {
             var validationIssues = validationSet.GetValidationIssues();
 
@@ -133,7 +137,7 @@ Your package was not published on {CoreConfiguration.GalleryOwner.DisplayName} a
 
                 if (mailMessage.To.Any())
                 {
-                    SendMessage(mailMessage, copySender: false);
+                    await SendMessageAsync(mailMessage);
                 }
             }
         }
@@ -169,7 +173,7 @@ Your package was not published on {CoreConfiguration.GalleryOwner.DisplayName} a
             }
         }
 
-        public void SendValidationTakingTooLongNotice(Package package, string packageUrl)
+        public async Task SendValidationTakingTooLongNoticeAsync(Package package, string packageUrl)
         {
             string subject = "[{0}] Package validation taking longer than expected - {1} {2}";
             string body = "It is taking longer than expected for your package [{1} {2}]({3}) to get published.\n\n" +
@@ -201,7 +205,7 @@ Your package was not published on {CoreConfiguration.GalleryOwner.DisplayName} a
 
                 if (mailMessage.To.Any())
                 {
-                    SendMessage(mailMessage, copySender: false);
+                    await SendMessageAsync(mailMessage);
                 }
             }
         }
@@ -231,30 +235,54 @@ Your package was not published on {CoreConfiguration.GalleryOwner.DisplayName} a
             }
         }
 
-        protected void SendMessage(MailMessage mailMessage)
+        protected virtual async Task SendMessageAsync(MailMessage mailMessage)
         {
-            SendMessage(mailMessage, copySender: false);
+            int attempt = 0;
+            bool success = false;
+            while (!success)
+            {
+                try
+                {
+                    await AttemptSendMessageAsync(mailMessage, attempt + 1);
+                    success = true;
+                }
+                catch (SmtpException)
+                {
+                    if (attempt < RetryDelays.Count)
+                    {
+                        await Task.Delay(RetryDelays[attempt]);
+                        attempt++;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
         }
 
-        virtual protected void SendMessage(MailMessage mailMessage, bool copySender)
+        protected virtual Task AttemptSendMessageAsync(MailMessage mailMessage, int attemptNumber)
         {
+            // AnglicanGeek.MarkdownMailer doesn't have an async overload
             MailSender.Send(mailMessage);
-            if (copySender)
+            return Task.CompletedTask;
+        }
+
+        protected async Task SendMessageToSenderAsync(MailMessage mailMessage)
+        {
+            using (var senderCopy = new MailMessage(
+                CoreConfiguration.GalleryOwner,
+                mailMessage.ReplyToList.First()))
             {
-                var senderCopy = new MailMessage(
-                    CoreConfiguration.GalleryOwner,
-                    mailMessage.ReplyToList.First())
-                {
-                    Subject = mailMessage.Subject + " [Sender Copy]",
-                    Body = string.Format(
-                            CultureInfo.CurrentCulture,
-                            "You sent the following message via {0}: {1}{1}{2}",
-                            CoreConfiguration.GalleryOwner.DisplayName,
-                            Environment.NewLine,
-                            mailMessage.Body),
-                };
+                senderCopy.Subject = mailMessage.Subject + " [Sender Copy]";
+                senderCopy.Body = string.Format(
+                        CultureInfo.CurrentCulture,
+                        "You sent the following message via {0}: {1}{1}{2}",
+                        CoreConfiguration.GalleryOwner.DisplayName,
+                        Environment.NewLine,
+                        mailMessage.Body);
                 senderCopy.ReplyToList.Add(mailMessage.ReplyToList.First());
-                MailSender.Send(senderCopy);
+                await SendMessageAsync(senderCopy);
             }
         }
     }

--- a/src/NuGetGallery.Core/Services/ICoreMessageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreMessageService.cs
@@ -3,14 +3,15 @@
 
 using System.Collections.Generic;
 using NuGet.Services.Validation;
+using System.Threading.Tasks;
 
 namespace NuGetGallery.Services
 {
     public interface ICoreMessageService
     {
-        void SendPackageAddedNotice(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl, IEnumerable<string> warningMessages = null);
-        void SendPackageAddedWithWarningsNotice(Package package, string packageUrl, string packageSupportUrl, IEnumerable<string> warningMessages);
-        void SendPackageValidationFailedNotice(Package package, PackageValidationSet validationSet, string packageUrl, string packageSupportUrl, string announcementsUrl, string twitterUrl);
-        void SendValidationTakingTooLongNotice(Package package, string packageUrl);
+        Task SendPackageAddedNoticeAsync(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl, IEnumerable<string> warningMessages = null);
+        Task SendPackageAddedWithWarningsNoticeAsync(Package package, string packageUrl, string packageSupportUrl, IEnumerable<string> warningMessages);
+        Task SendPackageValidationFailedNoticeAsync(Package package, PackageValidationSet validationSet, string packageUrl, string packageSupportUrl, string announcementsUrl, string twitterUrl);
+        Task SendValidationTakingTooLongNoticeAsync(Package package, string packageUrl);
     }
 }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -35,6 +35,7 @@ using NuGetGallery.Infrastructure;
 using NuGetGallery.Infrastructure.Authentication;
 using NuGetGallery.Infrastructure.Lucene;
 using NuGetGallery.Security;
+using NuGetGallery.Services;
 using SecretReaderFactory = NuGetGallery.Configuration.SecretReader.SecretReaderFactory;
 
 namespace NuGetGallery
@@ -364,7 +365,7 @@ namespace NuGetGallery
                 .As<IMailSender>()
                 .InstancePerLifetimeScope();
 
-            builder.RegisterType<MessageService>()
+            builder.RegisterType<BackgroundMessageService>()
                 .AsSelf()
                 .As<IMessageService>()
                 .InstancePerLifetimeScope();

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -363,12 +363,12 @@ namespace NuGetGallery
             builder.Register(c => mailSenderFactory())
                 .AsSelf()
                 .As<IMailSender>()
-                .InstancePerLifetimeScope();
+                .InstancePerDependency();
 
             builder.RegisterType<BackgroundMessageService>()
                 .AsSelf()
                 .As<IMessageService>()
-                .InstancePerLifetimeScope();
+                .InstancePerDependency();
 
             builder.Register(c => HttpContext.Current.User)
                 .AsSelf()

--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -92,7 +92,7 @@ namespace NuGetGallery
         [HttpPost]
         [ActionName("ConfirmationRequired")]
         [ValidateAntiForgeryToken]
-        public virtual ActionResult ConfirmationRequiredPost(string accountName = null)
+        public virtual async Task<ActionResult> ConfirmationRequiredPost(string accountName = null)
         {
             var account = GetAccount(accountName);
 
@@ -108,7 +108,7 @@ namespace NuGetGallery
             ConfirmationViewModel model;
             if (!alreadyConfirmed)
             {
-                SendNewAccountEmail(account);
+                await SendNewAccountEmailAsync(account);
 
                 model = new ConfirmationViewModel(account)
                 {
@@ -122,7 +122,7 @@ namespace NuGetGallery
             return View(model);
         }
 
-        protected abstract void SendNewAccountEmail(User account);
+        protected abstract Task SendNewAccountEmailAsync(User account);
 
         [UIAuthorize(allowDiscontinuedLogins: true)]
         public virtual async Task<ActionResult> Confirm(string accountName, string token)
@@ -163,7 +163,7 @@ namespace NuGetGallery
                 // Change notice not required for new accounts.
                 if (model.SuccessfulConfirmation && !model.ConfirmingNewAccount)
                 {
-                    MessageService.SendEmailChangeNoticeToPreviousEmailAddress(account, existingEmail);
+                    await MessageService.SendEmailChangeNoticeToPreviousEmailAddressAsync(account, existingEmail);
 
                     string returnUrl = HttpContext.GetConfirmationReturnUrl();
                     if (!String.IsNullOrEmpty(returnUrl))
@@ -254,13 +254,13 @@ namespace NuGetGallery
 
             if (account.Confirmed && !string.IsNullOrEmpty(account.UnconfirmedEmailAddress))
             {
-                SendEmailChangedConfirmationNotice(account);
+                await SendEmailChangedConfirmationNoticeAsync(account);
             }
 
             return RedirectToAction(AccountAction);
         }
 
-        protected abstract void SendEmailChangedConfirmationNotice(User account);
+        protected abstract Task SendEmailChangedConfirmationNoticeAsync(User account);
 
         [HttpPost]
         [UIAuthorize]

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -713,7 +713,7 @@ namespace NuGetGallery
                             if (!(ConfigurationService.Current.AsynchronousPackageValidationEnabled && ConfigurationService.Current.BlockingAsynchronousPackageValidationEnabled))
                             {
                                 // Notify user of push unless async validation in blocking mode is used
-                                MessageService.SendPackageAddedNotice(package,
+                                await MessageService.SendPackageAddedNoticeAsync(package,
                                     Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
                                     Url.ReportPackage(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
                                     Url.AccountSettings(relativeUrl: false),
@@ -723,7 +723,7 @@ namespace NuGetGallery
                             else if (packagePolicyResult.HasWarnings)
                             {
                                 // Notify user of push unless async validation in blocking mode is used
-                                MessageService.SendPackageAddedWithWarningsNotice(package,
+                                await MessageService.SendPackageAddedWithWarningsNoticeAsync(package,
                                     Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
                                     Url.ReportPackage(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
                                     packagePolicyResult.WarningMessages);

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -287,7 +287,7 @@ namespace NuGetGallery
             // Send a new account email
             if (NuGetContext.Config.Current.ConfirmEmailAddresses && !string.IsNullOrEmpty(user.User.UnconfirmedEmailAddress))
             {
-                _messageService.SendNewAccountEmail(
+                await _messageService.SendNewAccountEmailAsync(
                     user.User,
                     Url.ConfirmEmail(
                         user.User.Username,
@@ -325,7 +325,7 @@ namespace NuGetGallery
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public virtual JsonResult SignInAssistance(string username, string providedEmailAddress)
+        public virtual async Task<JsonResult> SignInAssistance(string username, string providedEmailAddress)
         {
             // If provided email address is empty or null, return the result with a formatted
             // email address, otherwise send sign-in assistance email to the associated mail address.
@@ -352,7 +352,7 @@ namespace NuGetGallery
                     else
                     {
                         var externalCredentials = user.Credentials.Where(cred => cred.IsExternal());
-                        _messageService.SendSigninAssistanceEmail(new MailAddress(email, user.Username), externalCredentials);
+                        await _messageService.SendSigninAssistanceEmailAsync(new MailAddress(email, user.Username), externalCredentials);
                         return Json(new { success = true });
                     }
                 }
@@ -674,7 +674,7 @@ namespace NuGetGallery
             await RemovePasswordCredential(user.User);
 
             // Notify the user of the change
-            _messageService.SendCredentialAddedNotice(user.User, _authService.DescribeCredential(result.Credential));
+            await _messageService.SendCredentialAddedNoticeAsync(user.User, _authService.DescribeCredential(result.Credential));
 
             return new LoginUserDetails
             {

--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -119,7 +119,7 @@ namespace NuGetGallery
 
                     foreach (var owner in model.Package.Owners)
                     {
-                        _messageService.SendPackageOwnerAddedNotice(owner, model.User, model.Package, packageUrl);
+                        await _messageService.SendPackageOwnerAddedNoticeAsync(owner, model.User, model.Package, packageUrl);
                     }
                 }
                 else
@@ -147,12 +147,12 @@ namespace NuGetGallery
                         model.User.Username,
                         relativeUrl: false);
 
-                    _messageService.SendPackageOwnerRequest(model.CurrentUser, model.User, model.Package, packageUrl,
+                    await _messageService.SendPackageOwnerRequestAsync(model.CurrentUser, model.User, model.Package, packageUrl,
                         confirmationUrl, rejectionUrl, encodedMessage, policyMessage: string.Empty);
 
                     foreach (var owner in model.Package.Owners)
                     {
-                        _messageService.SendPackageOwnerRequestInitiatedNotice(model.CurrentUser, owner, model.User, model.Package, cancellationUrl);
+                        await _messageService.SendPackageOwnerRequestInitiatedNoticeAsync(model.CurrentUser, owner, model.User, model.Package, cancellationUrl);
                     }
                 }
 
@@ -190,12 +190,12 @@ namespace NuGetGallery
                         throw new InvalidOperationException("You can't remove the only owner from a package.");
                     }
                     await _packageOwnershipManagementService.RemovePackageOwnerAsync(model.Package, model.CurrentUser, model.User, commitAsTransaction:true);
-                    _messageService.SendPackageOwnerRemovedNotice(model.CurrentUser, model.User, model.Package);
+                    await _messageService.SendPackageOwnerRemovedNoticeAsync(model.CurrentUser, model.User, model.Package);
                 }
                 else
                 {
                     await _packageOwnershipManagementService.DeletePackageOwnershipRequestAsync(model.Package, model.User);
-                    _messageService.SendPackageOwnerRequestCancellationNotice(model.CurrentUser, model.User, model.Package);
+                    await _messageService.SendPackageOwnerRequestCancellationNoticeAsync(model.CurrentUser, model.User, model.Package);
                 }
 
                 return Json(new { success = true });

--- a/src/NuGetGallery/Controllers/OrganizationsController.cs
+++ b/src/NuGetGallery/Controllers/OrganizationsController.cs
@@ -53,17 +53,17 @@ namespace NuGetGallery
             EmailUpdateCancelled = Strings.OrganizationEmailUpdateCancelled
         };
 
-        protected override void SendNewAccountEmail(User account)
+        protected override Task SendNewAccountEmailAsync(User account)
         {
             var confirmationUrl = Url.ConfirmOrganizationEmail(account.Username, account.EmailConfirmationToken, relativeUrl: false);
 
-            MessageService.SendNewAccountEmail(account, confirmationUrl);
+            return MessageService.SendNewAccountEmailAsync(account, confirmationUrl);
         }
 
-        protected override void SendEmailChangedConfirmationNotice(User account)
+        protected override Task SendEmailChangedConfirmationNoticeAsync(User account)
         {
             var confirmationUrl = Url.ConfirmOrganizationEmail(account.Username, account.EmailConfirmationToken, relativeUrl: false);
-            MessageService.SendEmailChangeConfirmationNotice(account, confirmationUrl);
+            return MessageService.SendEmailChangeConfirmationNoticeAsync(account, confirmationUrl);
         }
 
         [HttpGet]
@@ -85,7 +85,7 @@ namespace NuGetGallery
             try
             {
                 var organization = await UserService.AddOrganizationAsync(organizationName, organizationEmailAddress, adminUser);
-                SendNewAccountEmail(organization);
+                await SendNewAccountEmailAsync(organization);
                 TelemetryService.TrackOrganizationAdded(organization);
                 return RedirectToAction(nameof(ManageOrganization), new { accountName = organization.Username });
             }
@@ -134,8 +134,8 @@ namespace NuGetGallery
                 var rejectUrl = Url.RejectOrganizationMembershipRequest(request, relativeUrl: false);
                 var cancelUrl = Url.CancelOrganizationMembershipRequest(memberName, relativeUrl: false);
 
-                MessageService.SendOrganizationMembershipRequest(account, request.NewMember, currentUser, request.IsAdmin, profileUrl, confirmUrl, rejectUrl);
-                MessageService.SendOrganizationMembershipRequestInitiatedNotice(account, currentUser, request.NewMember, request.IsAdmin, cancelUrl);
+                await MessageService.SendOrganizationMembershipRequestAsync(account, request.NewMember, currentUser, request.IsAdmin, profileUrl, confirmUrl, rejectUrl);
+                await MessageService.SendOrganizationMembershipRequestInitiatedNoticeAsync(account, currentUser, request.NewMember, request.IsAdmin, cancelUrl);
 
                 return Json(new OrganizationMemberViewModel(request));
             }
@@ -159,7 +159,7 @@ namespace NuGetGallery
             try
             {
                 var member = await UserService.AddMemberAsync(account, GetCurrentUser().Username, confirmationToken);
-                MessageService.SendOrganizationMemberUpdatedNotice(account, member);
+                await MessageService.SendOrganizationMemberUpdatedNoticeAsync(account, member);
 
                 TempData["Message"] = String.Format(CultureInfo.CurrentCulture,
                     Strings.AddMember_Success, account.Username);
@@ -188,7 +188,7 @@ namespace NuGetGallery
             {
                 var member = GetCurrentUser();
                 await UserService.RejectMembershipRequestAsync(account, member.Username, confirmationToken);
-                MessageService.SendOrganizationMembershipRequestRejectedNotice(account, member);
+                await MessageService.SendOrganizationMembershipRequestRejectedNoticeAsync(account, member);
 
                 return HandleOrganizationMembershipRequestView(new HandleOrganizationMembershipRequestModel(false, account));
             }
@@ -221,7 +221,7 @@ namespace NuGetGallery
             try
             {
                 var removedUser = await UserService.CancelMembershipRequestAsync(account, memberName);
-                MessageService.SendOrganizationMembershipRequestCancelledNotice(account, removedUser);
+                await MessageService.SendOrganizationMembershipRequestCancelledNoticeAsync(account, removedUser);
                 return Json(Strings.CancelMemberRequest_Success);
             }
             catch (EntityException e)
@@ -252,7 +252,7 @@ namespace NuGetGallery
             try
             {
                 var membership = await UserService.UpdateMemberAsync(account, memberName, isAdmin);
-                MessageService.SendOrganizationMemberUpdatedNotice(account, membership);
+                await  MessageService.SendOrganizationMemberUpdatedNoticeAsync(account, membership);
 
                 return Json(new OrganizationMemberViewModel(membership));
             }
@@ -287,7 +287,7 @@ namespace NuGetGallery
             try
             {
                 var removedMember = await UserService.DeleteMemberAsync(account, memberName);
-                MessageService.SendOrganizationMemberRemovedNotice(account, removedMember);
+                await MessageService.SendOrganizationMemberRemovedNoticeAsync(account, removedMember);
                 return Json(Strings.DeleteMember_Success);
             }
             catch (EntityException e)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -740,7 +740,7 @@ namespace NuGetGallery
 
             await _supportRequestService.AddNewSupportRequestAsync(subject, reportForm.Message, requestorEmailAddress, reason, user, package);
 
-            _messageService.ReportAbuse(request);
+            await _messageService.ReportAbuseAsync(request);
 
             TempData["Message"] = "Your abuse report has been sent to the gallery operators.";
 
@@ -800,7 +800,7 @@ namespace NuGetGallery
 
             if (!deleted)
             {
-                NotifyReportMyPackageSupportRequest(reportForm, package, user, from);
+                await NotifyReportMyPackageSupportRequestAsync(reportForm, package, user, from);
             }
 
             return Redirect(Url.Package(package.PackageRegistration.Id, package.NormalizedVersion));
@@ -868,7 +868,7 @@ namespace NuGetGallery
             return null;
         }
 
-        private void NotifyReportMyPackageSupportRequest(ReportMyPackageViewModel reportForm, Package package, User user, MailAddress from)
+        private async Task NotifyReportMyPackageSupportRequestAsync(ReportMyPackageViewModel reportForm, Package package, User user, MailAddress from)
         {
             var request = new ReportPackageRequest
             {
@@ -881,7 +881,7 @@ namespace NuGetGallery
                 CopySender = reportForm.CopySender
             };
 
-            _messageService.ReportMyPackage(request);
+            await _messageService.ReportMyPackageAsync(request);
 
             TempData["Message"] = Strings.SupportRequestSentTransientMessage;
         }
@@ -919,7 +919,7 @@ namespace NuGetGallery
                     comment: null,
                     editedBy: user.Username);
 
-                _messageService.SendPackageDeletedNotice(
+                await _messageService.SendPackageDeletedNoticeAsync(
                     package,
                     Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
                     Url.ReportPackage(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false));
@@ -960,7 +960,7 @@ namespace NuGetGallery
         [ValidateAntiForgeryToken]
         [ValidateRecaptchaResponse]
         [RequiresAccountConfirmation("contact package owners")]
-        public virtual ActionResult ContactOwners(string id, string version, ContactOwnersViewModel contactForm)
+        public virtual async Task<ActionResult> ContactOwners(string id, string version, ContactOwnersViewModel contactForm)
         {
             // Html Encode the message
             contactForm.Message = System.Web.HttpUtility.HtmlEncode(contactForm.Message);
@@ -978,7 +978,7 @@ namespace NuGetGallery
 
             var user = GetCurrentUser();
             var fromAddress = new MailAddress(user.EmailAddress, user.Username);
-            _messageService.SendContactOwnersMessage(
+            await _messageService.SendContactOwnersMessageAsync(
                 fromAddress,
                 package,
                 Url.Package(package, false),
@@ -1344,7 +1344,7 @@ namespace NuGetGallery
             {
                 await _packageOwnershipManagementService.AddPackageOwnerAsync(package, user);
 
-                SendAddPackageOwnerNotification(package, user);
+                await SendAddPackageOwnerNotificationAsync(package, user);
 
                 return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, user.Username, ConfirmOwnershipResult.Success));
             }
@@ -1354,7 +1354,7 @@ namespace NuGetGallery
 
                 await _packageOwnershipManagementService.DeletePackageOwnershipRequestAsync(package, user);
 
-                _messageService.SendPackageOwnerRequestRejectionNotice(requestingUser, user, package);
+                await _messageService.SendPackageOwnerRequestRejectionNoticeAsync(requestingUser, user, package);
 
                 return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, user.Username, ConfirmOwnershipResult.Rejected));
             }
@@ -1396,7 +1396,7 @@ namespace NuGetGallery
 
             await _packageOwnershipManagementService.DeletePackageOwnershipRequestAsync(package, pendingUser);
 
-            _messageService.SendPackageOwnerRequestCancellationNotice(requestingUser, pendingUser, package);
+            await _messageService.SendPackageOwnerRequestCancellationNoticeAsync(requestingUser, pendingUser, package);
 
             return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, pendingUsername, ConfirmOwnershipResult.Cancelled));
         }
@@ -1406,14 +1406,15 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="package">Package to which owner was added.</param>
         /// <param name="newOwner">Owner added.</param>
-        private void SendAddPackageOwnerNotification(PackageRegistration package, User newOwner)
+        private Task SendAddPackageOwnerNotificationAsync(PackageRegistration package, User newOwner)
         {
             var packageUrl = Url.Package(package.Id, version: null, relativeUrl: false);
             Func<User, bool> notNewOwner = o => !o.Username.Equals(newOwner.Username, StringComparison.OrdinalIgnoreCase);
 
             // Notify existing owners
             var notNewOwners = package.Owners.Where(notNewOwner).ToList();
-            notNewOwners.ForEach(owner => _messageService.SendPackageOwnerAddedNotice(owner, newOwner, package, packageUrl));
+            var tasks = notNewOwners.Select(owner => _messageService.SendPackageOwnerAddedNoticeAsync(owner, newOwner, package, packageUrl));
+            return Task.WhenAll(tasks);
         }
 
         internal virtual async Task<ActionResult> Edit(string id, string version, bool? listed, Func<Package, bool, string> urlFactory)
@@ -1705,7 +1706,7 @@ namespace NuGetGallery
                         if (!(_config.AsynchronousPackageValidationEnabled && _config.BlockingAsynchronousPackageValidationEnabled))
                         {
                             // notify user unless async validation in blocking mode is used
-                            _messageService.SendPackageAddedNotice(package,
+                            await _messageService.SendPackageAddedNoticeAsync(package,
                                 Url.Package(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
                                 Url.ReportPackage(package.PackageRegistration.Id, package.NormalizedVersion, relativeUrl: false),
                                 Url.AccountSettings(relativeUrl: false));

--- a/src/NuGetGallery/Controllers/PagesController.cs
+++ b/src/NuGetGallery/Controllers/PagesController.cs
@@ -94,7 +94,7 @@ namespace NuGetGallery
             var subject = $"Support Request for user '{user.Username}'";
             await _supportRequestService.AddNewSupportRequestAsync(subject, contactForm.Message, user.EmailAddress, "Other", user);
 
-            _messageService.SendContactSupportEmail(request);
+            await _messageService.SendContactSupportEmailAsync(request);
 
             ModelState.Clear();
 

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -70,17 +70,17 @@ namespace NuGetGallery
             EmailUpdateCancelled = Strings.UserEmailUpdateCancelled
         };
 
-        protected override void SendNewAccountEmail(User account)
+        protected override Task SendNewAccountEmailAsync(User account)
         {
             var confirmationUrl = Url.ConfirmEmail(account.Username, account.EmailConfirmationToken, relativeUrl: false);
 
-            MessageService.SendNewAccountEmail(account, confirmationUrl);
+            return MessageService.SendNewAccountEmailAsync(account, confirmationUrl);
         }
 
-        protected override void SendEmailChangedConfirmationNotice(User account)
+        protected override Task SendEmailChangedConfirmationNoticeAsync(User account)
         {
             var confirmationUrl = Url.ConfirmEmail(account.Username, account.EmailConfirmationToken, relativeUrl: false);
-            MessageService.SendEmailChangeConfirmationNotice(account, confirmationUrl);
+            return MessageService.SendEmailChangeConfirmationNoticeAsync(account, confirmationUrl);
         }
 
         protected override User GetAccount(string accountName)
@@ -158,16 +158,16 @@ namespace NuGetGallery
 
             if (existingTransformRequestUser != null)
             {
-                MessageService.SendOrganizationTransformRequestCancelledNotice(accountToTransform, existingTransformRequestUser);
+                await MessageService.SendOrganizationTransformRequestCancelledNoticeAsync(accountToTransform, existingTransformRequestUser);
             }
 
             var returnUrl = Url.ConfirmTransformAccount(accountToTransform);
             var confirmUrl = Url.ConfirmTransformAccount(accountToTransform, relativeUrl: false);
             var rejectUrl = Url.RejectTransformAccount(accountToTransform, relativeUrl: false);
-            MessageService.SendOrganizationTransformRequest(accountToTransform, adminUser, Url.User(accountToTransform, relativeUrl: false), confirmUrl, rejectUrl);
+            await MessageService.SendOrganizationTransformRequestAsync(accountToTransform, adminUser, Url.User(accountToTransform, relativeUrl: false), confirmUrl, rejectUrl);
 
             var cancelUrl = Url.CancelTransformAccount(accountToTransform, relativeUrl: false);
-            MessageService.SendOrganizationTransformInitiatedNotice(accountToTransform, adminUser, cancelUrl);
+            await MessageService.SendOrganizationTransformInitiatedNoticeAsync(accountToTransform, adminUser, cancelUrl);
 
             TelemetryService.TrackOrganizationTransformInitiated(accountToTransform);
 
@@ -206,7 +206,7 @@ namespace NuGetGallery
                 return TransformToOrganizationFailed(errorReason);
             }
 
-            MessageService.SendOrganizationTransformRequestAcceptedNotice(accountToTransform, adminUser);
+            await MessageService.SendOrganizationTransformRequestAcceptedNoticeAsync(accountToTransform, adminUser);
 
             TelemetryService.TrackOrganizationTransformCompleted(accountToTransform);
 
@@ -234,7 +234,7 @@ namespace NuGetGallery
             {
                 if (await UserService.RejectTransformUserToOrganizationRequest(accountToTransform, adminUser, token))
                 {
-                    MessageService.SendOrganizationTransformRequestRejectedNotice(accountToTransform, adminUser);
+                    await MessageService.SendOrganizationTransformRequestRejectedNoticeAsync(accountToTransform, adminUser);
 
                     TelemetryService.TrackOrganizationTransformDeclined(accountToTransform);
 
@@ -262,7 +262,7 @@ namespace NuGetGallery
 
             if (await UserService.CancelTransformUserToOrganizationRequest(accountToTransform, token))
             {
-                MessageService.SendOrganizationTransformRequestCancelledNotice(accountToTransform, adminUser);
+                await MessageService.SendOrganizationTransformRequestCancelledNoticeAsync(accountToTransform, adminUser);
 
                 TelemetryService.TrackOrganizationTransformCancelled(accountToTransform);
 
@@ -314,7 +314,7 @@ namespace NuGetGallery
             var isSupportRequestCreated = await _supportRequestService.TryAddDeleteSupportRequestAsync(user);
             if (isSupportRequestCreated)
             {
-                MessageService.SendAccountDeleteNotice(user);
+                await MessageService.SendAccountDeleteNoticeAsync(user);
             }
             else
             {
@@ -527,7 +527,7 @@ namespace NuGetGallery
                         ModelState.AddModelError(string.Empty, Strings.CouldNotFindAnyoneWithThatUsernameOrEmail);
                         break;
                     case PasswordResetResultType.Success:
-                        return SendPasswordResetEmail(result.User, forgotPassword: true);
+                        return await SendPasswordResetEmailAsync(result.User, forgotPassword: true);
                     default:
                         throw new NotImplementedException($"The password reset result type '{result.Type}' is not supported.");
                 }
@@ -597,7 +597,7 @@ namespace NuGetGallery
             if (credential != null && !forgot)
             {
                 // Setting a password, so notify the user
-                MessageService.SendCredentialAddedNotice(credential.User, AuthenticationService.DescribeCredential(credential));
+                await MessageService.SendCredentialAddedNoticeAsync(credential.User, AuthenticationService.DescribeCredential(credential));
             }
 
             return RedirectToAction("PasswordChanged");
@@ -646,7 +646,7 @@ namespace NuGetGallery
                     return AccountView(user, model);
                 }
 
-                return SendPasswordResetEmail(user, forgotPassword: false);
+                return await SendPasswordResetEmailAsync(user, forgotPassword: false);
             }
             else
             {
@@ -831,7 +831,7 @@ namespace NuGetGallery
 
             var newCredentialViewModel = await GenerateApiKeyInternal(description, resolvedScopes, expiration);
 
-            MessageService.SendCredentialAddedNotice(GetCurrentUser(), newCredentialViewModel);
+            await MessageService.SendCredentialAddedNoticeAsync(GetCurrentUser(), newCredentialViewModel);
 
             return Json(new ApiKeyViewModel(newCredentialViewModel));
         }
@@ -987,7 +987,7 @@ namespace NuGetGallery
             await AuthenticationService.RemoveCredential(user, cred);
 
             // Notify the user of the change
-            MessageService.SendCredentialRemovedNotice(user, AuthenticationService.DescribeCredential(cred));
+            await MessageService.SendCredentialRemovedNoticeAsync(user, AuthenticationService.DescribeCredential(cred));
 
             return Json(Strings.CredentialRemoved);
         }
@@ -1017,7 +1017,7 @@ namespace NuGetGallery
                 }
 
                 // Notify the user of the change
-                MessageService.SendCredentialRemovedNotice(user, AuthenticationService.DescribeCredential(cred));
+                await MessageService.SendCredentialRemovedNoticeAsync(user, AuthenticationService.DescribeCredential(cred));
 
                 TempData["Message"] = message;
             }
@@ -1058,14 +1058,14 @@ namespace NuGetGallery
                 c.Type.StartsWith(CredentialTypes.External.Prefix, StringComparison.OrdinalIgnoreCase));
         }
 
-        private ActionResult SendPasswordResetEmail(User user, bool forgotPassword)
+        private async Task<ActionResult> SendPasswordResetEmailAsync(User user, bool forgotPassword)
         {
             var resetPasswordUrl = Url.ResetEmailOrPassword(
                 user.Username,
                 user.PasswordResetToken,
                 forgotPassword,
                 relativeUrl: false);
-            MessageService.SendPasswordResetInstructions(user, resetPasswordUrl, forgotPassword);
+            await MessageService.SendPasswordResetInstructionsAsync(user, resetPasswordUrl, forgotPassword);
 
             return RedirectToAction(actionName: "PasswordSent", controllerName: "Users");
         }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -391,6 +391,7 @@
     <Compile Include="Services\ActionRequiringReservedNamespacePermissions.cs" />
     <Compile Include="Services\ActionsRequiringPermissions.cs" />
     <Compile Include="Services\AsynchronousPackageValidationInitiator.cs" />
+    <Compile Include="Services\BackgroundMessageService.cs" />
     <Compile Include="Services\ISymbolPackageUploadService.cs" />
     <Compile Include="Services\ISymbolPackageFileService.cs" />
     <Compile Include="Services\ISymbolsConfiguration.cs" />

--- a/src/NuGetGallery/Services/BackgroundMessageService.cs
+++ b/src/NuGetGallery/Services/BackgroundMessageService.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Mail;
+using System.Threading.Tasks;
+using AnglicanGeek.MarkdownMailer;
+using Elmah;
+using NuGetGallery.Configuration;
+
+namespace NuGetGallery.Services
+{
+    public class BackgroundMessageService : MessageService
+    {
+        public BackgroundMessageService(IMailSender mailSender, IAppConfiguration config, ITelemetryService telemetryService, ErrorLog errorLog)
+            :base(mailSender, config, telemetryService)
+        {
+            this.errorLog = errorLog;
+        }
+
+        private ErrorLog errorLog;
+
+        protected override Task SendMessageAsync(MailMessage mailMessage)
+        {
+            // Send email as background task, as we don't want to delay the HTTP response.
+            // Particularly when sending email fails and needs to be retried with a delay.
+            // MailMessage is IDisposable, so first clone the  message, to ensure if the
+            // caller disposes it, the message is available until the async task is complete.
+
+            var messageCopy = CloneMessage(mailMessage);
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await base.SendMessageAsync(messageCopy);
+                }
+                catch (Exception ex)
+                {
+                    // Log but swallow the exception.
+                    QuietLog.LogHandledException(ex, errorLog);
+                }
+                finally
+                {
+                    messageCopy.Dispose();
+                }
+            });
+
+            return Task.CompletedTask;
+        }
+
+        private MailMessage CloneMessage(MailMessage mailMessage)
+        {
+            string from = mailMessage.From.ToString();
+            string to = mailMessage.To.ToString();
+
+            MailMessage copy = new MailMessage(from, to, mailMessage.Subject, mailMessage.Body);
+
+            copy.IsBodyHtml = mailMessage.IsBodyHtml;
+            copy.BodyTransferEncoding = mailMessage.BodyTransferEncoding;
+            copy.BodyEncoding = mailMessage.BodyEncoding;
+            copy.HeadersEncoding = mailMessage.HeadersEncoding;
+            foreach (System.Collections.Specialized.NameValueCollection header in mailMessage.Headers)
+            {
+                copy.Headers.Add(header);
+            }
+            copy.SubjectEncoding = mailMessage.SubjectEncoding;
+            copy.DeliveryNotificationOptions = mailMessage.DeliveryNotificationOptions;
+            foreach (var cc  in mailMessage.CC)
+            {
+                copy.CC.Add(cc);
+            }
+            foreach(var attachment in mailMessage.Attachments)
+            {
+                copy.Attachments.Add(attachment);
+            }
+            foreach (var bcc in mailMessage.Bcc)
+            {
+                copy.Bcc.Add(bcc);
+            }
+            foreach (var replyTo in mailMessage.ReplyToList)
+            {
+                copy.ReplyToList.Add(replyTo);
+            }
+            copy.Sender = mailMessage.Sender;
+            copy.Priority = mailMessage.Priority;
+            foreach (var view in mailMessage.AlternateViews)
+            {
+                copy.AlternateViews.Add(view);
+            }
+
+            return copy;
+        }
+    }
+}

--- a/src/NuGetGallery/Services/IMessageService.cs
+++ b/src/NuGetGallery/Services/IMessageService.cs
@@ -3,43 +3,44 @@
 
 using System.Collections.Generic;
 using System.Net.Mail;
+using System.Threading.Tasks;
 using NuGetGallery.Services;
 
 namespace NuGetGallery
 {
     public interface IMessageService
     {
-        void SendContactOwnersMessage(MailAddress fromAddress, Package package, string packageUrl, string message, string emailSettingsUrl, bool copyFromAddress);
-        void ReportAbuse(ReportPackageRequest report);
-        void ReportMyPackage(ReportPackageRequest report);
-        void SendNewAccountEmail(User newUser, string confirmationUrl);
-        void SendEmailChangeConfirmationNotice(User user, string confirmationUrl);
-        void SendPasswordResetInstructions(User user, string resetPasswordUrl, bool forgotPassword);
-        void SendEmailChangeNoticeToPreviousEmailAddress(User user, string oldEmailAddress);
-        void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string packageUrl, string confirmationUrl, string rejectionUrl, string message, string policyMessage);
-        void SendPackageOwnerRequestInitiatedNotice(User requestingOwner, User receivingOwner, User newOwner, PackageRegistration package, string cancellationUrl);
-        void SendPackageOwnerRequestRejectionNotice(User requestingOwner, User newOwner, PackageRegistration package);
-        void SendPackageOwnerRequestCancellationNotice(User requestingOwner, User newOwner, PackageRegistration package);
-        void SendPackageOwnerAddedNotice(User toUser, User newOwner, PackageRegistration package, string packageUrl);
-        void SendPackageOwnerRemovedNotice(User fromUser, User toUser, PackageRegistration package);
-        void SendCredentialRemovedNotice(User user, CredentialViewModel removedCredentialViewModel);
-        void SendCredentialAddedNotice(User user, CredentialViewModel addedCredentialViewModel);
-        void SendContactSupportEmail(ContactSupportRequest request);
-        void SendPackageAddedNotice(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl, IEnumerable<string> warningMessages = null);
-        void SendPackageAddedWithWarningsNotice(Package package, string packageUrl, string packageSupportUrl, IEnumerable<string> warningMessages);
-        void SendAccountDeleteNotice(User user);
-        void SendPackageDeletedNotice(Package package, string packageUrl, string packageSupportUrl);
-        void SendSigninAssistanceEmail(MailAddress emailAddress, IEnumerable<Credential> credentials);
-        void SendOrganizationTransformRequest(User accountToTransform, User adminUser, string profileUrl, string confirmationUrl, string rejectionUrl);
-        void SendOrganizationTransformInitiatedNotice(User accountToTransform, User adminUser, string cancellationUrl);
-        void SendOrganizationTransformRequestAcceptedNotice(User accountToTransform, User adminUser);
-        void SendOrganizationTransformRequestRejectedNotice(User accountToTransform, User adminUser);
-        void SendOrganizationTransformRequestCancelledNotice(User accountToTransform, User adminUser);
-        void SendOrganizationMembershipRequest(Organization organization, User newUser, User adminUser, bool isAdmin, string profileUrl, string confirmationUrl, string rejectionUrl);
-        void SendOrganizationMembershipRequestInitiatedNotice(Organization organization, User requestingUser, User pendingUser, bool isAdmin, string cancellationUrl);
-        void SendOrganizationMembershipRequestRejectedNotice(Organization organization, User pendingUser);
-        void SendOrganizationMembershipRequestCancelledNotice(Organization organization, User pendingUser);
-        void SendOrganizationMemberUpdatedNotice(Organization organization, Membership membership);
-        void SendOrganizationMemberRemovedNotice(Organization organization, User removedUser);
+        Task SendContactOwnersMessageAsync(MailAddress fromAddress, Package package, string packageUrl, string message, string emailSettingsUrl, bool copyFromAddress);
+        Task ReportAbuseAsync(ReportPackageRequest report);
+        Task ReportMyPackageAsync(ReportPackageRequest report);
+        Task SendNewAccountEmailAsync(User newUser, string confirmationUrl);
+        Task SendEmailChangeConfirmationNoticeAsync(User user, string confirmationUrl);
+        Task SendPasswordResetInstructionsAsync(User user, string resetPasswordUrl, bool forgotPassword);
+        Task SendEmailChangeNoticeToPreviousEmailAddressAsync(User user, string oldEmailAddress);
+        Task SendPackageOwnerRequestAsync(User fromUser, User toUser, PackageRegistration package, string packageUrl, string confirmationUrl, string rejectionUrl, string message, string policyMessage);
+        Task SendPackageOwnerRequestInitiatedNoticeAsync(User requestingOwner, User receivingOwner, User newOwner, PackageRegistration package, string cancellationUrl);
+        Task SendPackageOwnerRequestRejectionNoticeAsync(User requestingOwner, User newOwner, PackageRegistration package);
+        Task SendPackageOwnerRequestCancellationNoticeAsync(User requestingOwner, User newOwner, PackageRegistration package);
+        Task SendPackageOwnerAddedNoticeAsync(User toUser, User newOwner, PackageRegistration package, string packageUrl);
+        Task SendPackageOwnerRemovedNoticeAsync(User fromUser, User toUser, PackageRegistration package);
+        Task SendCredentialRemovedNoticeAsync(User user, CredentialViewModel removedCredentialViewModel);
+        Task SendCredentialAddedNoticeAsync(User user, CredentialViewModel addedCredentialViewModel);
+        Task SendContactSupportEmailAsync(ContactSupportRequest request);
+        Task SendPackageAddedNoticeAsync(Package package, string packageUrl, string packageSupportUrl, string emailSettingsUrl, IEnumerable<string> warningMessages = null);
+        Task SendPackageAddedWithWarningsNoticeAsync(Package package, string packageUrl, string packageSupportUrl, IEnumerable<string> warningMessages);
+        Task SendAccountDeleteNoticeAsync(User user);
+        Task SendPackageDeletedNoticeAsync(Package package, string packageUrl, string packageSupportUrl);
+        Task SendSigninAssistanceEmailAsync(MailAddress emailAddress, IEnumerable<Credential> credentials);
+        Task SendOrganizationTransformRequestAsync(User accountToTransform, User adminUser, string profileUrl, string confirmationUrl, string rejectionUrl);
+        Task SendOrganizationTransformInitiatedNoticeAsync(User accountToTransform, User adminUser, string cancellationUrl);
+        Task SendOrganizationTransformRequestAcceptedNoticeAsync(User accountToTransform, User adminUser);
+        Task SendOrganizationTransformRequestRejectedNoticeAsync(User accountToTransform, User adminUser);
+        Task SendOrganizationTransformRequestCancelledNoticeAsync(User accountToTransform, User adminUser);
+        Task SendOrganizationMembershipRequestAsync(Organization organization, User newUser, User adminUser, bool isAdmin, string profileUrl, string confirmationUrl, string rejectionUrl);
+        Task SendOrganizationMembershipRequestInitiatedNoticeAsync(Organization organization, User requestingUser, User pendingUser, bool isAdmin, string cancellationUrl);
+        Task SendOrganizationMembershipRequestRejectedNoticeAsync(Organization organization, User pendingUser);
+        Task SendOrganizationMembershipRequestCancelledNoticeAsync(Organization organization, User pendingUser);
+        Task SendOrganizationMemberUpdatedNoticeAsync(Organization organization, Membership membership);
+        Task SendOrganizationMemberRemovedNoticeAsync(Organization organization, User removedUser);
     }
 }

--- a/src/NuGetGallery/Services/ITelemetryClient.cs
+++ b/src/NuGetGallery/Services/ITelemetryClient.cs
@@ -14,5 +14,15 @@ namespace NuGetGallery
         void TrackMetric(string metricName, double value, IDictionary<string, string> properties = null);
 
         void TrackException(Exception exception, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null);
+
+        void TrackDependency(string dependencyTypeName,
+                             string target,
+                             string dependencyName,
+                             string data,
+                             DateTimeOffset startTime,
+                             TimeSpan duration,
+                             string resultCode,
+                             bool success,
+                             IDictionary<string, string> properties);
     }
 }

--- a/src/NuGetGallery/Services/ITelemetryService.cs
+++ b/src/NuGetGallery/Services/ITelemetryService.cs
@@ -136,5 +136,15 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="user">The <see cref="User"/> requesting the delete.</param>
         void TrackRequestForAccountDeletion(User user);
+
+        /// <summary>
+        /// A telemetry event emitted when an email is sent.
+        /// </summary>
+        /// <param name="smtpUri">URI to the SMTP server</param>
+        /// <param name="startTime">The start time of when sending the email is attempted.</param>
+        /// <param name="duration">The duration of how long the send took.</param>
+        /// <param name="success">Whether sending the email was successful.</param>
+        /// <param name="attemptNumber">The number of attempts the message has tried to be sent.</param>
+        void TrackSendEmail(string smtpUri, DateTimeOffset startTime, TimeSpan duration, bool success, int attemptNumber);
     }
 }

--- a/src/NuGetGallery/Services/MessageService.cs
+++ b/src/NuGetGallery/Services/MessageService.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net.Mail;
 using System.Text;
+using System.Threading.Tasks;
 using System.Web;
 using AnglicanGeek.MarkdownMailer;
 using NuGetGallery.Configuration;
@@ -16,14 +18,15 @@ namespace NuGetGallery
 {
     public class MessageService : CoreMessageService, IMessageService
     {
-        protected MessageService()
-        {
-        }
-
-        public MessageService(IMailSender mailSender, IAppConfiguration config)
+        public MessageService(IMailSender mailSender, IAppConfiguration config, ITelemetryService telemetryService)
             : base(mailSender, config)
         {
+            this.telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            smtpUri = config.SmtpUri?.Host;
         }
+
+        private readonly ITelemetryService telemetryService;
+        private readonly string smtpUri;
 
         public IAppConfiguration Config
         {
@@ -31,7 +34,7 @@ namespace NuGetGallery
             set { CoreConfiguration = value; }
         }
 
-        public void ReportAbuse(ReportPackageRequest request)
+        public async Task ReportAbuseAsync(ReportPackageRequest request)
         {
             string subject = "[{GalleryOwnerName}] Support Request for '{Id}' version {Version} (Reason: {Reason})";
             subject = request.FillIn(subject, Config);
@@ -79,11 +82,11 @@ namespace NuGetGallery
                     // CCing helps to create a thread of email that can be augmented by the sending user
                     mailMessage.CC.Add(request.FromAddress);
                 }
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void ReportMyPackage(ReportPackageRequest request)
+        public async Task ReportMyPackageAsync(ReportPackageRequest request)
         {
             string subject = "[{GalleryOwnerName}] Owner Support Request for '{Id}' version {Version} (Reason: {Reason})";
             subject = request.FillIn(subject, Config);
@@ -126,11 +129,11 @@ namespace NuGetGallery
                     // CCing helps to create a thread of email that can be augmented by the sending user
                     mailMessage.CC.Add(request.FromAddress);
                 }
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendContactOwnersMessage(MailAddress fromAddress, Package package, string packageUrl, string message, string emailSettingsUrl, bool copySender)
+        public async Task SendContactOwnersMessageAsync(MailAddress fromAddress, Package package, string packageUrl, string message, string emailSettingsUrl, bool copySender)
         {
             string subject = "[{0}] Message for owners of the package '{1}'";
             string body = @"_User {0} &lt;{1}&gt; sends the following message to the owners of Package '[{2} {3}]({4})'._
@@ -168,12 +171,16 @@ namespace NuGetGallery
 
                 if (mailMessage.To.Any())
                 {
-                    SendMessage(mailMessage, copySender);
+                    await SendMessageAsync(mailMessage);
+                    if (copySender)
+                    {
+                        await SendMessageToSenderAsync(mailMessage);
+                    }
                 }
             }
         }
 
-        public void SendNewAccountEmail(User newUser, string confirmationUrl)
+        public async Task SendNewAccountEmailAsync(User newUser, string confirmationUrl)
         {
             var isOrganization = newUser is Organization;
 
@@ -194,11 +201,11 @@ The {Config.GalleryOwner.DisplayName} Team";
                 mailMessage.From = Config.GalleryNoReplyAddress;
 
                 mailMessage.To.Add(newUser.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
         
-        public void SendSigninAssistanceEmail(MailAddress emailAddress, IEnumerable<Credential> credentials)
+        public async Task SendSigninAssistanceEmailAsync(MailAddress emailAddress, IEnumerable<Credential> credentials)
         {
             string body = @"Hi there,
 
@@ -235,12 +242,12 @@ The {0} Team";
                 mailMessage.From = Config.GalleryNoReplyAddress;
 
                 mailMessage.To.Add(emailAddress);
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
 
         }
         
-        public void SendEmailChangeConfirmationNotice(User user, string confirmationUrl)
+        public async Task SendEmailChangeConfirmationNoticeAsync(User user, string confirmationUrl)
         {
             string body = @"You recently changed your {0}'s {1} email address.
 
@@ -272,11 +279,11 @@ The {1} Team";
                 mailMessage.From = Config.GalleryNoReplyAddress;
 
                 mailMessage.To.Add(newEmailAddress);
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendEmailChangeNoticeToPreviousEmailAddress(User user, string oldEmailAddress)
+        public async Task SendEmailChangeNoticeToPreviousEmailAddressAsync(User user, string oldEmailAddress)
         {
             string body = @"The email address associated with your {0} {1} was recently changed from _{2}_ to _{3}_.
 
@@ -302,11 +309,11 @@ The {0} Team";
                 mailMessage.From = Config.GalleryNoReplyAddress;
 
                 mailMessage.To.Add(new MailAddress(oldEmailAddress, user.Username));
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendPasswordResetInstructions(User user, string resetPasswordUrl, bool forgotPassword)
+        public async Task SendPasswordResetInstructionsAsync(User user, string resetPasswordUrl, bool forgotPassword)
         {
             string body = string.Format(
                 CultureInfo.CurrentCulture,
@@ -325,11 +332,11 @@ The {0} Team";
                 mailMessage.From = Config.GalleryNoReplyAddress;
 
                 mailMessage.To.Add(user.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendPackageOwnerRequest(User fromUser, User toUser, PackageRegistration package, string packageUrl, string confirmationUrl, string rejectionUrl, string message, string policyMessage)
+        public async Task SendPackageOwnerRequestAsync(User fromUser, User toUser, PackageRegistration package, string packageUrl, string confirmationUrl, string rejectionUrl, string message, string policyMessage)
         {
             if (!string.IsNullOrEmpty(policyMessage))
             {
@@ -372,11 +379,11 @@ The {Config.GalleryOwner.DisplayName} Team";
                     return;
                 }
 
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendPackageOwnerRequestInitiatedNotice(User requestingOwner, User receivingOwner, User newOwner, PackageRegistration package, string cancellationUrl)
+        public async Task SendPackageOwnerRequestInitiatedNoticeAsync(User requestingOwner, User receivingOwner, User newOwner, PackageRegistration package, string cancellationUrl)
         {
             var subject = string.Format(CultureInfo.CurrentCulture, $"[{Config.GalleryOwner.DisplayName}] Package ownership request for '{package.Id}'");
 
@@ -401,11 +408,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                     return;
                 }
 
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendPackageOwnerRequestRejectionNotice(User requestingOwner, User newOwner, PackageRegistration package)
+        public async Task SendPackageOwnerRequestRejectionNoticeAsync(User requestingOwner, User newOwner, PackageRegistration package)
         {
             if (!requestingOwner.EmailAllowed)
             {
@@ -431,11 +438,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                     return;
                 }
 
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendPackageOwnerRequestCancellationNotice(User requestingOwner, User newOwner, PackageRegistration package)
+        public async Task SendPackageOwnerRequestCancellationNoticeAsync(User requestingOwner, User newOwner, PackageRegistration package)
         {
             var subject = string.Format(CultureInfo.CurrentCulture, $"[{Config.GalleryOwner.DisplayName}] Package ownership request for '{package.Id}' cancelled");
 
@@ -456,11 +463,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                     return;
                 }
 
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendPackageOwnerAddedNotice(User toUser, User newOwner, PackageRegistration package, string packageUrl)
+        public async Task SendPackageOwnerAddedNoticeAsync(User toUser, User newOwner, PackageRegistration package, string packageUrl)
         {
             var subject = $"[{Config.GalleryOwner.DisplayName}] Package ownership update for '{package.Id}'";
 
@@ -480,11 +487,11 @@ The {Config.GalleryOwner.DisplayName} Team";
                 {
                     return;
                 }
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendPackageOwnerRemovedNotice(User fromUser, User toUser, PackageRegistration package)
+        public async Task SendPackageOwnerRemovedNoticeAsync(User fromUser, User toUser, PackageRegistration package)
         {
             var subject = $"[{Config.GalleryOwner.DisplayName}] Package ownership removal for '{package.Id}'";
 
@@ -505,7 +512,7 @@ The {Config.GalleryOwner.DisplayName} Team";
                     return;
                 }
 
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
@@ -514,11 +521,11 @@ The {Config.GalleryOwner.DisplayName} Team";
             return AddAddressesWithPermissionToEmail(mailMessage, user, ActionsRequiringPermissions.HandlePackageOwnershipRequest);
         }
 
-        public void SendCredentialRemovedNotice(User user, CredentialViewModel removedCredentialViewModel)
+        public Task SendCredentialRemovedNoticeAsync(User user, CredentialViewModel removedCredentialViewModel)
         {
             if (CredentialTypes.IsApiKey(removedCredentialViewModel.Type))
             {
-                SendApiKeyChangeNotice(
+                return SendApiKeyChangeNoticeAsync(
                     user,
                     removedCredentialViewModel,
                     Strings.Emails_ApiKeyRemoved_Body,
@@ -526,7 +533,7 @@ The {Config.GalleryOwner.DisplayName} Team";
             }
             else
             {
-                SendCredentialChangeNotice(
+                return SendCredentialChangeNoticeAsync(
                     user,
                     removedCredentialViewModel,
                     Strings.Emails_CredentialRemoved_Body,
@@ -534,11 +541,11 @@ The {Config.GalleryOwner.DisplayName} Team";
             }
         }
 
-        public void SendCredentialAddedNotice(User user, CredentialViewModel addedCredentialViewModel)
+        public Task SendCredentialAddedNoticeAsync(User user, CredentialViewModel addedCredentialViewModel)
         {
             if (CredentialTypes.IsApiKey(addedCredentialViewModel.Type))
             {
-                SendApiKeyChangeNotice(
+                return SendApiKeyChangeNoticeAsync(
                     user,
                     addedCredentialViewModel,
                     Strings.Emails_ApiKeyAdded_Body,
@@ -546,7 +553,7 @@ The {Config.GalleryOwner.DisplayName} Team";
             }
             else
             {
-                SendCredentialChangeNotice(
+                return SendCredentialChangeNoticeAsync(
                     user,
                     addedCredentialViewModel,
                     Strings.Emails_CredentialAdded_Body,
@@ -554,7 +561,7 @@ The {Config.GalleryOwner.DisplayName} Team";
             }
         }
 
-        private void SendApiKeyChangeNotice(User user, CredentialViewModel changedCredentialViewModel, string bodyTemplate, string subjectTemplate)
+        private Task SendApiKeyChangeNoticeAsync(User user, CredentialViewModel changedCredentialViewModel, string bodyTemplate, string subjectTemplate)
         {
             string body = String.Format(
                 CultureInfo.CurrentCulture,
@@ -567,10 +574,10 @@ The {Config.GalleryOwner.DisplayName} Team";
                 Config.GalleryOwner.DisplayName,
                 Strings.CredentialType_ApiKey);
 
-            SendSupportMessage(user, body, subject);
+            return SendSupportMessageAsync(user, body, subject);
         }
 
-        private void SendCredentialChangeNotice(User user, CredentialViewModel changedCredentialViewModel, string bodyTemplate, string subjectTemplate)
+        private Task SendCredentialChangeNoticeAsync(User user, CredentialViewModel changedCredentialViewModel, string bodyTemplate, string subjectTemplate)
         {
             // What kind of credential is this?
             string name = changedCredentialViewModel.AuthUI == null ? changedCredentialViewModel.TypeCaption : changedCredentialViewModel.AuthUI.AccountNoun;
@@ -586,10 +593,10 @@ The {Config.GalleryOwner.DisplayName} Team";
                 Config.GalleryOwner.DisplayName,
                 name);
 
-            SendSupportMessage(user, body, subject);
+            return SendSupportMessageAsync(user, body, subject);
         }
 
-        public void SendContactSupportEmail(ContactSupportRequest request)
+        public async Task SendContactSupportEmailAsync(ContactSupportRequest request)
         {
             string subject = string.Format(CultureInfo.CurrentCulture, "Support Request (Reason: {0})", request.SubjectLine);
 
@@ -614,11 +621,11 @@ The {Config.GalleryOwner.DisplayName} Team";
                 {
                     mailMessage.CC.Add(request.FromAddress);
                 }
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        private void SendSupportMessage(User user, string body, string subject)
+        private async Task SendSupportMessageAsync(User user, string body, string subject)
         {
             if (user == null)
             {
@@ -632,11 +639,11 @@ The {Config.GalleryOwner.DisplayName} Team";
                 mailMessage.From = Config.GalleryOwner;
 
                 mailMessage.To.Add(user.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendAccountDeleteNotice(User user)
+        public async Task SendAccountDeleteNoticeAsync(User user)
         {
             string body = @"We received a request to delete your account {0}. If you did not initiate this request, please contact the {1} team immediately.
 {2}When your account will be deleted, we will:{2}
@@ -663,11 +670,11 @@ Thanks,
                 mailMessage.From = Config.GalleryNoReplyAddress;
 
                 mailMessage.To.Add(user.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendPackageDeletedNotice(Package package, string packageUrl, string packageSupportUrl)
+        public async Task SendPackageDeletedNoticeAsync(Package package, string packageUrl, string packageSupportUrl)
         {
             string subject = "[{0}] Package deleted - {1} {2}";
             string body = @"The package [{1} {2}]({3}) was just deleted from {0}. If this was not intended, please [contact support]({4}).
@@ -701,12 +708,12 @@ The {0} Team";
 
                 if (mailMessage.To.Any())
                 {
-                    SendMessage(mailMessage);
+                    await SendMessageAsync(mailMessage);
                 }
             }
         }
 
-        public void SendOrganizationTransformRequest(User accountToTransform, User adminUser, string profileUrl, string confirmationUrl, string rejectionUrl)
+        public async Task SendOrganizationTransformRequestAsync(User accountToTransform, User adminUser, string profileUrl, string confirmationUrl, string rejectionUrl)
         {
             if (!adminUser.EmailAllowed)
             {
@@ -736,11 +743,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.ReplyToList.Add(accountToTransform.ToMailAddress());
 
                 mailMessage.To.Add(adminUser.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendOrganizationTransformInitiatedNotice(User accountToTransform, User adminUser, string cancellationUrl)
+        public async Task SendOrganizationTransformInitiatedNoticeAsync(User accountToTransform, User adminUser, string cancellationUrl)
         {
             if (!accountToTransform.EmailAllowed)
             {
@@ -768,11 +775,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.ReplyToList.Add(adminUser.ToMailAddress());
 
                 mailMessage.To.Add(accountToTransform.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendOrganizationTransformRequestAcceptedNotice(User accountToTransform, User adminUser)
+        public async Task SendOrganizationTransformRequestAcceptedNoticeAsync(User accountToTransform, User adminUser)
         {
             if (!accountToTransform.EmailAllowed)
             {
@@ -794,21 +801,21 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.ReplyToList.Add(adminUser.ToMailAddress());
 
                 mailMessage.To.Add(accountToTransform.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendOrganizationTransformRequestRejectedNotice(User accountToTransform, User adminUser)
+        public Task SendOrganizationTransformRequestRejectedNoticeAsync(User accountToTransform, User adminUser)
         {
-            SendOrganizationTransformRequestRejectedNoticeInternal(accountToTransform, adminUser, isCancelledByAdmin: true);
+            return SendOrganizationTransformRequestRejectedNoticeInternalAsync(accountToTransform, adminUser, isCancelledByAdmin: true);
         }
 
-        public void SendOrganizationTransformRequestCancelledNotice(User accountToTransform, User adminUser)
+        public Task SendOrganizationTransformRequestCancelledNoticeAsync(User accountToTransform, User adminUser)
         {
-            SendOrganizationTransformRequestRejectedNoticeInternal(accountToTransform, adminUser, isCancelledByAdmin: false);
+            return SendOrganizationTransformRequestRejectedNoticeInternalAsync(accountToTransform, adminUser, isCancelledByAdmin: false);
         }
 
-        private void SendOrganizationTransformRequestRejectedNoticeInternal(User accountToTransform, User adminUser, bool isCancelledByAdmin)
+        private async Task SendOrganizationTransformRequestRejectedNoticeInternalAsync(User accountToTransform, User adminUser, bool isCancelledByAdmin)
         {
             var accountToSendTo = isCancelledByAdmin ? accountToTransform : adminUser;
             var accountToReplyTo = isCancelledByAdmin ? adminUser : accountToTransform;
@@ -833,11 +840,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.ReplyToList.Add(accountToReplyTo.ToMailAddress());
 
                 mailMessage.To.Add(accountToSendTo.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendOrganizationMembershipRequest(Organization organization, User newUser, User adminUser, bool isAdmin, string profileUrl, string confirmationUrl, string rejectionUrl)
+        public async Task SendOrganizationMembershipRequestAsync(Organization organization, User newUser, User adminUser, bool isAdmin, string profileUrl, string confirmationUrl, string rejectionUrl)
         {
             if (!newUser.EmailAllowed)
             {
@@ -872,11 +879,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.ReplyToList.Add(adminUser.ToMailAddress());
 
                 mailMessage.To.Add(newUser.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendOrganizationMembershipRequestInitiatedNotice(Organization organization, User requestingUser, User pendingUser, bool isAdmin, string cancellationUrl)
+        public async Task SendOrganizationMembershipRequestInitiatedNoticeAsync(Organization organization, User requestingUser, User pendingUser, bool isAdmin, string cancellationUrl)
         {
             var membershipLevel = isAdmin ? "an administrator" : "a collaborator";
 
@@ -899,11 +906,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                     return;
                 }
 
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendOrganizationMembershipRequestRejectedNotice(Organization organization, User pendingUser)
+        public async Task SendOrganizationMembershipRequestRejectedNoticeAsync(Organization organization, User pendingUser)
         {
             string subject = $"[{Config.GalleryOwner.DisplayName}] Membership request for organization '{organization.Username}' declined";
 
@@ -924,11 +931,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                     return;
                 }
 
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendOrganizationMembershipRequestCancelledNotice(Organization organization, User pendingUser)
+        public async Task SendOrganizationMembershipRequestCancelledNoticeAsync(Organization organization, User pendingUser)
         {
             if (!pendingUser.EmailAllowed)
             {
@@ -950,11 +957,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.ReplyToList.Add(organization.ToMailAddress());
 
                 mailMessage.To.Add(pendingUser.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendOrganizationMemberUpdatedNotice(Organization organization, Membership membership)
+        public async Task SendOrganizationMemberUpdatedNoticeAsync(Organization organization, Membership membership)
         {
             if (!organization.EmailAllowed)
             {
@@ -979,11 +986,11 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.ReplyToList.Add(member.ToMailAddress());
 
                 mailMessage.To.Add(organization.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
-        public void SendOrganizationMemberRemovedNotice(Organization organization, User removedUser)
+        public async Task SendOrganizationMemberRemovedNoticeAsync(Organization organization, User removedUser)
         {
             if (!organization.EmailAllowed)
             {
@@ -1005,7 +1012,7 @@ The {Config.GalleryOwner.DisplayName} Team");
                 mailMessage.ReplyToList.Add(removedUser.ToMailAddress());
 
                 mailMessage.To.Add(organization.ToMailAddress());
-                SendMessage(mailMessage);
+                await SendMessageAsync(mailMessage);
             }
         }
 
@@ -1014,21 +1021,20 @@ The {Config.GalleryOwner.DisplayName} Team");
             return AddAddressesWithPermissionToEmail(mailMessage, user, ActionsRequiringPermissions.ManageAccount);
         }
 
-        protected override void SendMessage(MailMessage mailMessage, bool copySender)
+        protected override async Task AttemptSendMessageAsync(MailMessage mailMessage, int attemptNumber)
         {
+            bool success = false;
+            DateTimeOffset startTime = DateTimeOffset.UtcNow;
+            Stopwatch sw = Stopwatch.StartNew();
             try
             {
-                base.SendMessage(mailMessage, copySender);
+                await base.AttemptSendMessageAsync(mailMessage, attemptNumber);
+                success = true;
             }
-            catch (InvalidOperationException ex)
+            finally
             {
-                // Log but swallow the exception
-                QuietLog.LogHandledException(ex);
-            }
-            catch (SmtpException ex)
-            {
-                // Log but swallow the exception
-                QuietLog.LogHandledException(ex);
+                sw.Stop();
+                telemetryService.TrackSendEmail(smtpUri, startTime, sw.Elapsed, success, attemptNumber);
             }
         }
 

--- a/src/NuGetGallery/Services/TelemetryClientWrapper.cs
+++ b/src/NuGetGallery/Services/TelemetryClientWrapper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 
 namespace NuGetGallery
 {
@@ -46,6 +47,32 @@ namespace NuGetGallery
             try
             {
                 UnderlyingClient.TrackMetric(metricName, value, properties);
+            }
+            catch
+            {
+                // logging failed, don't allow exception to escape
+            }
+        }
+
+        public void TrackDependency(string dependencyTypeName,
+                                    string target,
+                                    string dependencyName,
+                                    string data,
+                                    DateTimeOffset startTime,
+                                    TimeSpan duration,
+                                    string resultCode,
+                                    bool success,
+                                    IDictionary<string, string> properties)
+        {
+            try
+            {
+                var telemetry = new DependencyTelemetry(dependencyTypeName, target, dependencyName, data, startTime, duration, resultCode, success);
+                foreach (var property in properties)
+                {
+                    telemetry.Properties.Add(property);
+                }
+
+                UnderlyingClient.TrackDependency(telemetry);
             }
             catch
             {

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -594,6 +594,15 @@ namespace NuGetGallery
             });
         }
 
+        public void TrackSendEmail(string smtpUri, DateTimeOffset startTime, TimeSpan duration, bool success, int attemptNumber)
+        {
+            var properties = new Dictionary<string, string>
+            {
+                { "attempt", attemptNumber.ToString() }
+            };
+            _telemetryClient.TrackDependency("SMTP", smtpUri, "SendMessage", null, startTime, duration, null, success, properties);
+        }
+
         /// <summary>
         /// We use <see cref="ITelemetryClient.TrackMetric(string, double, IDictionary{string, string})"/> instead of
         /// <see cref="ITelemetryClient.TrackEvent(string, IDictionary{string, string}, IDictionary{string, double})"/>

--- a/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AccountsControllerFacts.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web.Mvc;
+using Autofac;
 using Moq;
 using NuGetGallery.Framework;
 using Xunit;
@@ -259,7 +260,7 @@ namespace NuGetGallery
                 ResultAssert.IsRedirectToRoute(result, new { action = controller.AccountAction });
 
                 GetMock<IMessageService>()
-                    .Verify(m => m.SendEmailChangeConfirmationNotice(It.IsAny<User>(), It.IsAny<string>()),
+                    .Verify(m => m.SendEmailChangeConfirmationNoticeAsync(It.IsAny<User>(), It.IsAny<string>()),
                     newEmailIsConfirmed ? Times.Never() : Times.Once());
             }
 
@@ -284,7 +285,7 @@ namespace NuGetGallery
                 ResultAssert.IsRedirectToRoute(result, new { action = controller.AccountAction });
 
                 GetMock<IMessageService>()
-                    .Verify(m => m.SendEmailChangeConfirmationNotice(It.IsAny<User>(), It.IsAny<string>()),
+                    .Verify(m => m.SendEmailChangeConfirmationNoticeAsync(It.IsAny<User>(), It.IsAny<string>()),
                     Times.Never);
             }
 
@@ -308,7 +309,8 @@ namespace NuGetGallery
                 controller.SetCurrentUser(getCurrentUser(Fakes));
 
                 var messageService = GetMock<IMessageService>();
-                messageService.Setup(m => m.SendEmailChangeConfirmationNotice(It.IsAny<User>(), It.IsAny<string>()))
+                messageService.Setup(m => m.SendEmailChangeConfirmationNoticeAsync(It.IsAny<User>(), It.IsAny<string>()))
+                    .Returns(Task.CompletedTask)
                     .Verifiable();
 
                 var userService = GetMock<IUserService>();
@@ -490,18 +492,18 @@ namespace NuGetGallery
         {
             [Theory]
             [MemberData(AllowedCurrentUsersDataName)]
-            public virtual void WhenAlreadyConfirmed_DoesNotSendEmail(Func<Fakes, User> getCurrentUser)
+            public virtual async Task WhenAlreadyConfirmed_DoesNotSendEmail(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = InvokeConfirmationRequiredPost(controller, account, getCurrentUser);
+                var result = await InvokeConfirmationRequiredPostAsync(controller, account, getCurrentUser);
 
                 // Assert
                 var mailService = GetMock<IMessageService>();
-                mailService.Verify(m => m.SendNewAccountEmail(It.IsAny<User>(), It.IsAny<string>()), Times.Never);
+                mailService.Verify(m => m.SendNewAccountEmailAsync(It.IsAny<User>(), It.IsAny<string>()), Times.Never);
 
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
                 Assert.False(model.SentEmail);
@@ -509,7 +511,7 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(AllowedCurrentUsersDataName)]
-            public virtual void WhenIsNotConfirmed_SendsEmail(Func<Fakes, User> getCurrentUser)
+            public virtual async Task WhenIsNotConfirmed_SendsEmail(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
@@ -523,17 +525,17 @@ namespace NuGetGallery
                 var confirmationUrl = (account is Organization)
                     ? TestUtility.GallerySiteRootHttps + $"organization/{account.Username}/Confirm?token=confirmation"
                     : TestUtility.GallerySiteRootHttps + $"account/confirm/{account.Username}/confirmation";
-                var result = InvokeConfirmationRequiredPost(controller, account, getCurrentUser, confirmationUrl);
+                var result = await InvokeConfirmationRequiredPostAsync(controller, account, getCurrentUser, confirmationUrl);
 
                 // Assert
                 var mailService = GetMock<IMessageService>();
-                mailService.Verify(m => m.SendNewAccountEmail(It.IsAny<User>(), confirmationUrl), Times.Once);
+                mailService.Verify(m => m.SendNewAccountEmailAsync(It.IsAny<User>(), confirmationUrl), Times.Once);
 
                 var model = ResultAssert.IsView<ConfirmationViewModel>(result);
                 Assert.True(model.SentEmail);
             }
 
-            protected virtual ActionResult InvokeConfirmationRequiredPost(
+            protected virtual Task<ActionResult> InvokeConfirmationRequiredPostAsync(
                 TAccountsController controller,
                 TUser account,
                 Func<Fakes, User> getCurrentUser,
@@ -546,9 +548,10 @@ namespace NuGetGallery
                     .Returns(account as User);
 
                 GetMock<IMessageService>()
-                    .Setup(m => m.SendNewAccountEmail(
+                    .Setup(m => m.SendNewAccountEmailAsync(
                         account,
                         string.IsNullOrEmpty(confirmationUrl) ? It.IsAny<string>() : confirmationUrl))
+                    .Returns(Task.CompletedTask)
                     .Verifiable();
 
                 // Act
@@ -621,7 +624,7 @@ namespace NuGetGallery
                         Times.Never);
 
                 var mailService = GetMock<IMessageService>();
-                mailService.Verify(m => m.SendEmailChangeNoticeToPreviousEmailAddress(
+                mailService.Verify(m => m.SendEmailChangeNoticeToPreviousEmailAddressAsync(
                     It.IsAny<TUser>(),
                     It.IsAny<string>()),
                         Times.Never);
@@ -654,7 +657,7 @@ namespace NuGetGallery
                         Times.Once);
 
                 var mailService = GetMock<IMessageService>();
-                mailService.Verify(m => m.SendEmailChangeNoticeToPreviousEmailAddress(
+                mailService.Verify(m => m.SendEmailChangeNoticeToPreviousEmailAddressAsync(
                     It.IsAny<TUser>(),
                     It.IsAny<string>()),
                         Times.Never);
@@ -686,7 +689,7 @@ namespace NuGetGallery
                         Times.Once);
 
                 var mailService = GetMock<IMessageService>();
-                mailService.Verify(m => m.SendEmailChangeNoticeToPreviousEmailAddress(
+                mailService.Verify(m => m.SendEmailChangeNoticeToPreviousEmailAddressAsync(
                     It.IsAny<TUser>(),
                     It.IsAny<string>()),
                         Times.Once);
@@ -757,9 +760,10 @@ namespace NuGetGallery
                 }
 
                 GetMock<IMessageService>()
-                    .Setup(m => m.SendEmailChangeNoticeToPreviousEmailAddress(
+                    .Setup(m => m.SendEmailChangeNoticeToPreviousEmailAddressAsync(
                         It.IsAny<TUser>(),
                         It.IsAny<string>()))
+                    .Returns(Task.CompletedTask)
                     .Verifiable();
 
                 // Act

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -690,7 +690,7 @@ namespace NuGetGallery
 
                 // Assert
                 controller.MockMessageService
-                    .Verify(ms => ms.SendPackageAddedNotice(package, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()),
+                    .Verify(ms => ms.SendPackageAddedNoticeAsync(package, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()),
                     Times.Exactly(callExpected ? 1 : 0));
             }
 

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -107,11 +107,11 @@ namespace NuGetGallery.Controllers
         public class TheSigninAssistanceAction : TestContainer
         {
             [Fact]
-            public void NullUsernameReturnsFalse()
+            public async Task NullUsernameReturnsFalse()
             {
                 var controller = GetController<AuthenticationController>();
 
-                var result = controller.SignInAssistance(username: null, providedEmailAddress: null);
+                var result = await controller.SignInAssistance(username: null, providedEmailAddress: null);
                 dynamic data = result.Data;
                 Assert.False(data.success);
             }
@@ -121,7 +121,7 @@ namespace NuGetGallery.Controllers
             [InlineData("rm@address.com", "r**********m@address.com")]
             [InlineData("r@address.com", "r**********@address.com")]
             [InlineData("random.very.long.address@address.com", "r**********s@address.com")]
-            public void NullProvidedEmailReturnsFormattedEmail(string email, string expectedEmail)
+            public async Task NullProvidedEmailReturnsFormattedEmail(string email, string expectedEmail)
             {
                 var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "blorg", identity: "John Doe <random@address.com>");
                 var existingUser = new User("existingUser") { EmailAddress = email, Credentials = new[] { cred } };
@@ -133,7 +133,7 @@ namespace NuGetGallery.Controllers
 
                 var controller = GetController<AuthenticationController>();
 
-                var result = controller.SignInAssistance(username: "existingUser", providedEmailAddress: null);
+                var result = await controller.SignInAssistance(username: "existingUser", providedEmailAddress: null);
                 dynamic data = result.Data;
                 Assert.True(data.success);
                 Assert.Equal(expectedEmail, data.EmailAddress);
@@ -144,7 +144,7 @@ namespace NuGetGallery.Controllers
             [InlineData("rm@address.com", "r**********m@address.com")]
             [InlineData("r@address.com", "r**********@address.com")]
             [InlineData("random.very.long.address@address.com", "r**********s@address.com")]
-            public void NullProvidedEmailReturnsFormattedEmailForUnconfirmedAccount(string email, string expectedEmail)
+            public async Task NullProvidedEmailReturnsFormattedEmailForUnconfirmedAccount(string email, string expectedEmail)
             {
                 var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "blorg", identity: "John Doe <random@address.com>");
                 var existingUser = new User("existingUser") { UnconfirmedEmailAddress = email, Credentials = new[] { cred } };
@@ -156,7 +156,7 @@ namespace NuGetGallery.Controllers
 
                 var controller = GetController<AuthenticationController>();
 
-                var result = controller.SignInAssistance(username: "existingUser", providedEmailAddress: null);
+                var result = await controller.SignInAssistance(username: "existingUser", providedEmailAddress: null);
                 dynamic data = result.Data;
                 Assert.True(data.success);
                 Assert.Equal(expectedEmail, data.EmailAddress);
@@ -166,7 +166,7 @@ namespace NuGetGallery.Controllers
             [InlineData("blarg")]
             [InlineData("wrong@email")]
             [InlineData("nonmatching@emailaddress.com")]
-            public void InvalidProvidedEmailReturnsFalse(string providedEmail)
+            public async Task InvalidProvidedEmailReturnsFalse(string providedEmail)
             {
                 var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "blorg", identity: "existing@example.com");
                 var existingUser = new User("existingUser") { EmailAddress = "existing@example.com", Credentials = new[] { cred } };
@@ -178,13 +178,13 @@ namespace NuGetGallery.Controllers
 
                 var controller = GetController<AuthenticationController>();
 
-                var result = controller.SignInAssistance(username: "existingUser", providedEmailAddress: providedEmail);
+                var result = await controller.SignInAssistance(username: "existingUser", providedEmailAddress: providedEmail);
                 dynamic data = result.Data;
                 Assert.False(data.success);
             }
 
             [Fact]
-            public void SendsNotificationForAssistance()
+            public async Task SendsNotificationForAssistance()
             {
                 var email = "existing@example.com";
                 var fakes = Get<Fakes>();
@@ -197,12 +197,13 @@ namespace NuGetGallery.Controllers
                     .Returns(existingUser);
                 var messageServiceMock = GetMock<IMessageService>();
                 messageServiceMock
-                .Setup(m => m.SendSigninAssistanceEmail(It.IsAny<MailAddress>(), It.IsAny<IEnumerable<Credential>>()))
+                .Setup(m => m.SendSigninAssistanceEmailAsync(It.IsAny<MailAddress>(), It.IsAny<IEnumerable<Credential>>()))
+                .Returns(Task.CompletedTask)
                 .Verifiable();
 
                 var controller = GetController<AuthenticationController>();
 
-                var result = controller.SignInAssistance(username: "existingUser", providedEmailAddress: email);
+                var result = await controller.SignInAssistance(username: "existingUser", providedEmailAddress: email);
                 dynamic data = result.Data;
                 Assert.True(data.success);
                 messageServiceMock.Verify();
@@ -396,7 +397,7 @@ namespace NuGetGallery.Controllers
                     .Verify(x => x.RemoveCredential(user, passwordCredential));
 
                 GetMock<IMessageService>()
-                    .Verify(x => x.SendCredentialAddedNotice(It.IsAny<User>(), It.IsAny<CredentialViewModel>()));
+                    .Verify(x => x.SendCredentialAddedNoticeAsync(It.IsAny<User>(), It.IsAny<CredentialViewModel>()));
             }
 
             public async Task WhenAttemptingToLinkExternalToAccountWithExistingExternals_RejectsLinking()
@@ -491,7 +492,7 @@ namespace NuGetGallery.Controllers
                     .Verify(x => x.CreateSessionAsync(controller.OwinContext, authUser, false));
 
                 GetMock<IMessageService>()
-                    .Verify(x => x.SendCredentialAddedNotice(authUser.User, credentialViewModel));
+                    .Verify(x => x.SendCredentialAddedNoticeAsync(authUser.User, credentialViewModel));
             }
 
             [Fact]
@@ -548,8 +549,9 @@ namespace NuGetGallery.Controllers
                     .Completes()
                     .Verifiable();
                 GetMock<IMessageService>()
-                    .Setup(x => x.SendCredentialAddedNotice(authUser.User,
+                    .Setup(x => x.SendCredentialAddedNoticeAsync(authUser.User,
                                                             It.Is<CredentialViewModel>(c => c.Type == CredentialTypes.External.MicrosoftAccount)))
+                    .Returns(Task.CompletedTask)
                     .Verifiable();
 
                 var controller = GetController<AuthenticationController>();
@@ -617,8 +619,9 @@ namespace NuGetGallery.Controllers
                     .Verifiable();
 
                 GetMock<IMessageService>()
-                    .Setup(x => x.SendCredentialAddedNotice(authUser.User,
+                    .Setup(x => x.SendCredentialAddedNoticeAsync(authUser.User,
                                                             It.Is<CredentialViewModel>(c => c.Type == CredentialTypes.External.Prefix + providerUsedForLogin)))
+                    .Returns(Task.CompletedTask)
                     .Verifiable();
 
                 EnableAllAuthenticators(Get<AuthenticationService>());
@@ -749,7 +752,7 @@ namespace NuGetGallery.Controllers
                 GetMock<AuthenticationService>().VerifyAll();
 
                 GetMock<IMessageService>()
-                    .Verify(x => x.SendNewAccountEmail(
+                    .Verify(x => x.SendNewAccountEmailAsync(
                         authUser.User,
                         TestUtility.GallerySiteRootHttps + "account/confirm/" + authUser.User.Username + "/" + authUser.User.EmailConfirmationToken));
                 ResultAssert.IsSafeRedirectTo(result, "/theReturnUrl");
@@ -795,7 +798,7 @@ namespace NuGetGallery.Controllers
 
                 // Assert
                 GetMock<IMessageService>()
-                    .Verify(x => x.SendNewAccountEmail(
+                    .Verify(x => x.SendNewAccountEmailAsync(
                         It.IsAny<User>(),
                         It.IsAny<string>()), Times.Never());
             }
@@ -885,7 +888,7 @@ namespace NuGetGallery.Controllers
                 authenticationServiceMock.VerifyAll();
 
                 GetMock<IMessageService>()
-                    .Verify(x => x.SendNewAccountEmail(
+                    .Verify(x => x.SendNewAccountEmailAsync(
                         authUser.User,
                         TestUtility.GallerySiteRootHttps + "account/confirm/" + authUser.User.Username + "/" + authUser.User.EmailConfirmationToken));
 

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -365,7 +365,7 @@ namespace NuGetGallery.Controllers
                                     .Verifiable();
                                 
                                 messageServiceMock
-                                    .Setup(m => m.SendPackageOwnerRequest(
+                                    .Setup(m => m.SendPackageOwnerRequestAsync(
                                         currentUser,
                                         userToAdd,
                                         fakes.Package,
@@ -374,17 +374,19 @@ namespace NuGetGallery.Controllers
                                         TestUtility.GallerySiteRootHttps + $"packages/FakePackage/owners/{userToAdd.Username}/reject/confirmation-code",
                                         "Hello World! Html Encoded &lt;3",
                                         ""))
+                                    .Returns(Task.CompletedTask)
                                     .Verifiable();
 
                                 foreach (var owner in fakes.Package.Owners)
                                 {
                                     messageServiceMock
-                                        .Setup(m => m.SendPackageOwnerRequestInitiatedNotice(
+                                        .Setup(m => m.SendPackageOwnerRequestInitiatedNoticeAsync(
                                             currentUser,
                                             owner,
                                             userToAdd,
                                             fakes.Package,
                                             It.IsAny<string>()))
+                                        .Returns(Task.CompletedTask)
                                         .Verifiable();
                                 }
                             }
@@ -398,11 +400,12 @@ namespace NuGetGallery.Controllers
                                 foreach (var owner in fakes.Package.Owners)
                                 {
                                     messageServiceMock
-                                        .Setup(m => m.SendPackageOwnerAddedNotice(
+                                        .Setup(m => m.SendPackageOwnerAddedNoticeAsync(
                                             owner,
                                             userToAdd,
                                             fakes.Package,
                                             It.IsAny<string>()))
+                                        .Returns(Task.CompletedTask)
                                         .Verifiable();
                                 }
                             }
@@ -540,7 +543,7 @@ namespace NuGetGallery.Controllers
                         packageOwnershipManagementService.Verify(x => x.DeletePackageOwnershipRequestAsync(package, requestedUser, true));
 
                         GetMock<IMessageService>()
-                            .Verify(x => x.SendPackageOwnerRequestCancellationNotice(currentUser, requestedUser, package));
+                            .Verify(x => x.SendPackageOwnerRequestCancellationNoticeAsync(currentUser, requestedUser, package));
                     }
 
                     [Theory]
@@ -571,7 +574,7 @@ namespace NuGetGallery.Controllers
                         packageOwnershipManagementService.Verify(x => x.RemovePackageOwnerAsync(package, currentUser, userToRemove, It.IsAny<bool>()));
 
                         GetMock<IMessageService>()
-                            .Verify(x => x.SendPackageOwnerRemovedNotice(currentUser, userToRemove, package));
+                            .Verify(x => x.SendPackageOwnerRemovedNoticeAsync(currentUser, userToRemove, package));
                     }
                 }
 

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -257,14 +257,14 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(WithNonOrganizationAdmin_ReturnsForbidden_Data))]
-            public void WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
+            public async Task WithNonOrganizationAdmin_ReturnsForbidden(Func<Fakes, User> getCurrentUser)
             {
                 // Arrange
                 var controller = GetController();
                 var account = GetAccount(controller);
 
                 // Act
-                var result = InvokeConfirmationRequiredPost(controller, account, getCurrentUser) as HttpStatusCodeResult;
+                var result = await InvokeConfirmationRequiredPostAsync(controller, account, getCurrentUser) as HttpStatusCodeResult;
 
                 // Assert
                 Assert.NotNull(result);
@@ -381,7 +381,7 @@ namespace NuGetGallery
                     new { accountName = org.Username, action = nameof(OrganizationsController.ManageOrganization) });
 
                 messageService.Verify(
-                    x => x.SendNewAccountEmail(
+                    x => x.SendNewAccountEmailAsync(
                         org, 
                         It.Is<string>(s => s.Contains(token))), 
                     Times.Once());
@@ -499,7 +499,7 @@ namespace NuGetGallery
 
                 GetMock<IUserService>().Verify(s => s.AddMembershipRequestAsync(account, defaultMemberName, isAdmin), Times.Once);
                 GetMock<IMessageService>()
-                    .Verify(s => s.SendOrganizationMembershipRequest(
+                    .Verify(s => s.SendOrganizationMembershipRequestAsync(
                         account,
                         It.Is<User>(u => u.Username == defaultMemberName),
                         controller.GetCurrentUser(),
@@ -508,7 +508,7 @@ namespace NuGetGallery
                         It.IsAny<string>(),
                         It.IsAny<string>()));
                 GetMock<IMessageService>()
-                    .Verify(s => s.SendOrganizationMembershipRequestInitiatedNotice(
+                    .Verify(s => s.SendOrganizationMembershipRequestInitiatedNoticeAsync(
                         account,
                         controller.GetCurrentUser(),
                         It.Is<User>(u => u.Username == defaultMemberName),
@@ -571,7 +571,7 @@ namespace NuGetGallery
                 ResultAssert.IsStatusCode(result, HttpStatusCode.NotFound);
 
                 GetMock<IUserService>().Verify(s => s.AddMemberAsync(It.IsAny<Organization>(), Fakes.User.Username, defaultConfirmationToken), Times.Never);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberUpdatedNotice(It.IsAny<Organization>(), It.IsAny<Membership>()), Times.Never);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberUpdatedNoticeAsync(It.IsAny<Organization>(), It.IsAny<Membership>()), Times.Never);
             }
 
             [Theory]
@@ -597,7 +597,7 @@ namespace NuGetGallery
                 Assert.False(model.Successful);
 
                 GetMock<IUserService>().Verify(s => s.AddMemberAsync(account, Fakes.User.Username, defaultConfirmationToken), Times.Once);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberUpdatedNotice(It.IsAny<Organization>(), It.IsAny<Membership>()), Times.Never);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberUpdatedNoticeAsync(It.IsAny<Organization>(), It.IsAny<Membership>()), Times.Never);
             }
 
             [Theory]
@@ -623,7 +623,7 @@ namespace NuGetGallery
 
                 GetMock<IUserService>().Verify(s => s.AddMemberAsync(account, Fakes.User.Username, defaultConfirmationToken), Times.Once);
                 GetMock<IMessageService>()
-                    .Verify(s => s.SendOrganizationMemberUpdatedNotice(
+                    .Verify(s => s.SendOrganizationMemberUpdatedNoticeAsync(
                         account,
                         It.Is<Membership>(m => Fakes.User.Username == m.Member.Username && m.Organization == account && m.IsAdmin == isAdmin)), Times.Once);
             }
@@ -686,7 +686,7 @@ namespace NuGetGallery
                 ResultAssert.IsStatusCode(result, HttpStatusCode.NotFound);
 
                 GetMock<IUserService>().Verify(s => s.RejectMembershipRequestAsync(It.IsAny<Organization>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestRejectedNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestRejectedNoticeAsync(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
             [Theory]
@@ -712,7 +712,7 @@ namespace NuGetGallery
                 Assert.False(model.Successful);
 
                 GetMock<IUserService>().Verify(s => s.RejectMembershipRequestAsync(account, Fakes.User.Username, defaultConfirmationToken), Times.Once);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestRejectedNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestRejectedNoticeAsync(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
             [Theory]
@@ -735,7 +735,7 @@ namespace NuGetGallery
                 Assert.True(model.Successful);
 
                 GetMock<IUserService>().Verify(s => s.RejectMembershipRequestAsync(account, Fakes.User.Username, defaultConfirmationToken), Times.Once);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestRejectedNotice(account, Fakes.User), Times.Once);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestRejectedNoticeAsync(account, Fakes.User), Times.Once);
             }
 
             private Task<ActionResult> InvokeRejectMember(
@@ -883,7 +883,7 @@ namespace NuGetGallery
 
                 GetMock<IUserService>().Verify(s => s.UpdateMemberAsync(account, defaultMemberName, isAdmin), Times.Once);
                 GetMock<IMessageService>()
-                    .Verify(s => s.SendOrganizationMemberUpdatedNotice(
+                    .Verify(s => s.SendOrganizationMemberUpdatedNoticeAsync(
                         account,
                         It.Is<Membership>(m => m.Organization == account && m.Member.Username == defaultMemberName && m.IsAdmin == isAdmin)));
             }
@@ -962,7 +962,7 @@ namespace NuGetGallery
                 Assert.Equal(Strings.Unauthorized, result.Data);
 
                 GetMock<IUserService>().Verify(s => s.DeleteMemberAsync(It.IsAny<Organization>(), It.IsAny<string>()), Times.Never);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNoticeAsync(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
             [Theory]
@@ -983,7 +983,7 @@ namespace NuGetGallery
                 Assert.Equal(Strings.Member_OrganizationUnconfirmed, result.Data);
 
                 GetMock<IUserService>().Verify(s => s.DeleteMemberAsync(It.IsAny<Organization>(), It.IsAny<string>()), Times.Never);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNoticeAsync(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
             [Theory]
@@ -1003,7 +1003,7 @@ namespace NuGetGallery
                 Assert.Equal("error", result.Data);
 
                 GetMock<IUserService>().Verify(s => s.DeleteMemberAsync(account, defaultMemberName), Times.Once);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMemberRemovedNoticeAsync(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
             [Theory]
@@ -1025,7 +1025,7 @@ namespace NuGetGallery
                 GetMock<IUserService>()
                     .Verify(s => s.DeleteMemberAsync(account, defaultMemberName), Times.Once);
                 GetMock<IMessageService>()
-                    .Verify(s => s.SendOrganizationMemberRemovedNotice(account, It.Is<User>(u => u.Username == defaultMemberName)), Times.Once);
+                    .Verify(s => s.SendOrganizationMemberRemovedNoticeAsync(account, It.Is<User>(u => u.Username == defaultMemberName)), Times.Once);
             }
 
             [Fact]
@@ -1116,7 +1116,7 @@ namespace NuGetGallery
                 Assert.Equal(Strings.Unauthorized, result.Data);
 
                 GetMock<IUserService>().Verify(s => s.CancelMembershipRequestAsync(It.IsAny<Organization>(), It.IsAny<string>()), Times.Never);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestCancelledNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestCancelledNoticeAsync(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
             [Theory]
@@ -1136,7 +1136,7 @@ namespace NuGetGallery
                 Assert.Equal("error", result.Data);
 
                 GetMock<IUserService>().Verify(s => s.CancelMembershipRequestAsync(account, defaultMemberName), Times.Once);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestCancelledNotice(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestCancelledNoticeAsync(It.IsAny<Organization>(), It.IsAny<User>()), Times.Never);
             }
 
             [Theory]
@@ -1156,7 +1156,7 @@ namespace NuGetGallery
                 Assert.Equal(Strings.CancelMemberRequest_Success, result.Data);
 
                 GetMock<IUserService>().Verify(s => s.CancelMembershipRequestAsync(account, defaultMemberName), Times.Once);
-                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestCancelledNotice(account, It.Is<User>(u => u.Username == defaultMemberName)), Times.Once);
+                GetMock<IMessageService>().Verify(s => s.SendOrganizationMembershipRequestCancelledNoticeAsync(account, It.Is<User>(u => u.Username == defaultMemberName)), Times.Once);
             }
 
             private Task<JsonResult> InvokeCancelMemberRequestMember(

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -942,7 +942,7 @@ namespace NuGetGallery
 
             private static Expression<Action<IMessageService>> MessageServiceForConfirmOwnershipRequestExpression(PackageOwnerRequest request)
             {
-                return messageService => messageService.SendPackageOwnerAddedNotice(
+                return messageService => messageService.SendPackageOwnerAddedNoticeAsync(
                     request.RequestingOwner,
                     request.NewOwner,
                     request.PackageRegistration,
@@ -951,7 +951,7 @@ namespace NuGetGallery
 
             private static Expression<Action<IMessageService>> MessageServiceForRejectOwnershipRequestExpression(PackageOwnerRequest request)
             {
-                return messageService => messageService.SendPackageOwnerRequestRejectionNotice(request.RequestingOwner, request.NewOwner, request.PackageRegistration);
+                return messageService => messageService.SendPackageOwnerRequestRejectionNoticeAsync(request.RequestingOwner, request.NewOwner, request.PackageRegistration);
             }
 
             public static IEnumerable<object[]> ReturnsSuccessIfTokenIsValid_Data
@@ -1217,7 +1217,7 @@ namespace NuGetGallery
                     Assert.Equal(packageId, model.PackageId);
                     packageService.Verify();
                     packageOwnershipManagementRequestService.Verify();
-                    messageService.Verify(m => m.SendPackageOwnerRequestCancellationNotice(userA, userB, package));
+                    messageService.Verify(m => m.SendPackageOwnerRequestCancellationNoticeAsync(userA, userB, package));
                 }
             }
         }
@@ -1417,7 +1417,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void HtmlEncodesMessageContent()
+            public async Task HtmlEncodesMessageContent()
             {
                 // arrange
                 var packageId = "factory";
@@ -1429,7 +1429,7 @@ namespace NuGetGallery
                 var messageService = new Mock<IMessageService>();
                 string sentMessage = null;
                 messageService.Setup(
-                    s => s.SendContactOwnersMessage(
+                    s => s.SendContactOwnersMessageAsync(
                         It.IsAny<MailAddress>(),
                         It.IsAny<Package>(),
                         It.IsAny<string>(),
@@ -1440,7 +1440,8 @@ namespace NuGetGallery
                     {
                         sentPackageUrl = packageUrl;
                         sentMessage = msg;
-                    });
+                    })
+                    .Returns(Task.CompletedTask);
                 var package = new Package
                 {
                     PackageRegistration = new PackageRegistration {Id = packageId},
@@ -1461,14 +1462,14 @@ namespace NuGetGallery
                 };
 
                 // act
-                var result = controller.ContactOwners(packageId, packageVersion, model) as RedirectToRouteResult;
+                var result = await controller.ContactOwners(packageId, packageVersion, model) as RedirectToRouteResult;
 
                 Assert.Equal(encodedMessage, sentMessage);
                 Assert.Equal(controller.Url.Package(package, false), sentPackageUrl);
             }
 
             [Fact]
-            public void CallsSendContactOwnersMessageWithUserInfo()
+            public async Task CallsSendContactOwnersMessageWithUserInfo()
             {
                 // arrange
                 var packageId = "factory";
@@ -1477,12 +1478,13 @@ namespace NuGetGallery
 
                 var messageService = new Mock<IMessageService>();
                 messageService.Setup(
-                    s => s.SendContactOwnersMessage(
+                    s => s.SendContactOwnersMessageAsync(
                         It.IsAny<MailAddress>(),
                         It.IsAny<Package>(),
                         It.IsAny<string>(),
                         message,
-                        It.IsAny<string>(), false));
+                        It.IsAny<string>(), false))
+                        .Returns(Task.CompletedTask);
                 var package = new Package
                 {
                     PackageRegistration = new PackageRegistration { Id = packageId },
@@ -1503,7 +1505,7 @@ namespace NuGetGallery
                 };
 
                 // act
-                var result = controller.ContactOwners(packageId, packageVersion, model) as RedirectToRouteResult;
+                var result = await controller.ContactOwners(packageId, packageVersion, model) as RedirectToRouteResult;
 
                 // assert
                 Assert.NotNull(result);
@@ -2647,7 +2649,7 @@ namespace NuGetGallery
 
                 Assert.NotNull(result);
                 messageService.Verify(
-                    s => s.ReportAbuse(
+                    s => s.ReportAbuseAsync(
                         It.Is<ReportPackageRequest>(
                             r => r.FromAddress.Address == ReporterEmailAddress
                                  && r.Package == package
@@ -2681,7 +2683,7 @@ namespace NuGetGallery
 
                 Assert.NotNull(result);
                 messageService.Verify(
-                    s => s.ReportAbuse(
+                    s => s.ReportAbuseAsync(
                         It.Is<ReportPackageRequest>(
                             r => r.Message == EncodedMessage
                                  && r.FromAddress.Address == currentUser.EmailAddress
@@ -2695,7 +2697,7 @@ namespace NuGetGallery
             {
                 messageService = new Mock<IMessageService>();
                 messageService.Setup(
-                    s => s.ReportAbuse(It.Is<ReportPackageRequest>(r => r.Message == UnencodedMessage)));
+                    s => s.ReportAbuseAsync(It.Is<ReportPackageRequest>(r => r.Message == UnencodedMessage)));
                 package = new Package
                 {
                     PackageRegistration = new PackageRegistration { Id = PackageId, Owners = new[] { owner } },
@@ -2934,8 +2936,9 @@ namespace NuGetGallery
 
                 ReportPackageRequest reportRequest = null;
                 _messageService
-                    .Setup(s => s.ReportMyPackage(It.IsAny<ReportPackageRequest>()))
-                    .Callback<ReportPackageRequest>(r => reportRequest = r);
+                    .Setup(s => s.ReportMyPackageAsync(It.IsAny<ReportPackageRequest>()))
+                    .Callback<ReportPackageRequest>(r => reportRequest = r)
+                    .Returns(Task.CompletedTask);
 
                 // Act
                 await _controller.ReportMyPackage(
@@ -3060,7 +3063,7 @@ namespace NuGetGallery
                         currentUser.Username),
                     Times.Once);
                 _messageService.Verify(
-                    x => x.SendPackageDeletedNotice(
+                    x => x.SendPackageDeletedNoticeAsync(
                         _package,
                         It.IsAny<string>(),
                         It.IsAny<string>()),
@@ -3068,7 +3071,7 @@ namespace NuGetGallery
                 Assert.Equal(Strings.UserPackageDeleteCompleteTransientMessage, _controller.TempData["Message"]);
 
                 _messageService.Verify(
-                    x => x.ReportMyPackage(It.IsAny<ReportPackageRequest>()),
+                    x => x.ReportMyPackageAsync(It.IsAny<ReportPackageRequest>()),
                     Times.Never);
             }
 
@@ -3120,13 +3123,13 @@ namespace NuGetGallery
                         It.IsAny<string>()),
                     Times.Never);
                 _messageService.Verify(
-                    x => x.SendPackageDeletedNotice(
+                    x => x.SendPackageDeletedNoticeAsync(
                         It.IsAny<Package>(),
                         It.IsAny<string>(),
                         It.IsAny<string>()),
                     Times.Never);
                 _messageService.Verify(
-                    x => x.ReportMyPackage(It.IsAny<ReportPackageRequest>()),
+                    x => x.ReportMyPackageAsync(It.IsAny<ReportPackageRequest>()),
                     Times.Once);
             }
 
@@ -3286,7 +3289,7 @@ namespace NuGetGallery
                         It.IsAny<string>()),
                     Times.Never);
                 _messageService.Verify(
-                    x => x.ReportMyPackage(It.IsAny<ReportPackageRequest>()),
+                    x => x.ReportMyPackageAsync(It.IsAny<ReportPackageRequest>()),
                     Times.Once);
             }
 
@@ -3326,7 +3329,7 @@ namespace NuGetGallery
                         It.IsAny<string>()),
                     Times.Never);
                 _messageService.Verify(
-                    x => x.ReportMyPackage(It.IsAny<ReportPackageRequest>()),
+                    x => x.ReportMyPackageAsync(It.IsAny<ReportPackageRequest>()),
                     Times.Once);
             }
         }
@@ -5405,7 +5408,7 @@ namespace NuGetGallery
 
                     // Assert
                     fakeMessageService
-                        .Verify(ms => ms.SendPackageAddedNotice(fakePackage, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()),
+                        .Verify(ms => ms.SendPackageAddedNoticeAsync(fakePackage, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IEnumerable<string>>()),
                         Times.Exactly(callExpected ? 1 : 0));
                 }
             }

--- a/tests/NuGetGallery.Facts/Controllers/PagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PagesControllerFacts.cs
@@ -43,7 +43,7 @@ namespace NuGetGallery
 
                 // assert: the HTML encoded message was passed to the service
                 GetMock<IMessageService>()
-                    .Verify(m => m.SendContactSupportEmail(
+                    .Verify(m => m.SendContactSupportEmailAsync(
                         It.Is<ContactSupportRequest>(c =>
                             c.Message == expectedMessage
                             && c.SubjectLine == expectedSubjectLine)));

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -258,7 +258,8 @@ namespace NuGetGallery
                     PasswordResetTokenExpirationDate = DateTime.UtcNow.AddHours(Constants.PasswordResetTokenExpirationHours)
                 };
                 GetMock<IMessageService>()
-                    .Setup(s => s.SendPasswordResetInstructions(user, resetUrl, true));
+                    .Setup(s => s.SendPasswordResetInstructionsAsync(user, resetUrl, true))
+                    .Returns(Task.CompletedTask);
                 GetMock<IUserService>()
                     .Setup(s => s.FindByEmailAddress("user"))
                     .Returns(user);
@@ -271,7 +272,7 @@ namespace NuGetGallery
                 await controller.ForgotPassword(model);
 
                 GetMock<IMessageService>()
-                    .Verify(s => s.SendPasswordResetInstructions(user, resetUrl, true));
+                    .Verify(s => s.SendPasswordResetInstructionsAsync(user, resetUrl, true));
             }
 
             [Fact]
@@ -447,7 +448,7 @@ namespace NuGetGallery
                 await controller.ResetPassword("user", "token", model, forgot: false);
 
                 GetMock<IMessageService>()
-                    .Verify(m => m.SendCredentialAddedNotice(cred.User,
+                    .Verify(m => m.SendCredentialAddedNoticeAsync(cred.User,
                                                              It.Is<CredentialViewModel>(c => c.Type == cred.Type)));
             }
 
@@ -952,7 +953,7 @@ namespace NuGetGallery
                     expirationInDays: 90);
 
                 GetMock<IMessageService>()
-                    .Verify(m => m.SendCredentialAddedNotice(user, It.IsAny<CredentialViewModel>()));
+                    .Verify(m => m.SendCredentialAddedNoticeAsync(user, It.IsAny<CredentialViewModel>()));
             }
         }
 
@@ -1309,7 +1310,7 @@ namespace NuGetGallery
                     .Verifiable();
                 GetMock<IMessageService>()
                     .Setup(m =>
-                                m.SendCredentialRemovedNotice(
+                                m.SendCredentialRemovedNoticeAsync(
                                     user,
                                     It.Is<CredentialViewModel>(c => c.Type == CredentialTypes.External.MicrosoftAccount)))
                     .Verifiable();
@@ -1378,8 +1379,12 @@ namespace NuGetGallery
 
                 string actualConfirmUrl = null;
                 GetMock<IMessageService>()
-                    .Setup(a => a.SendPasswordResetInstructions(user, It.IsAny<string>(), false))
-                    .Callback<User, string, bool>((_, url, __) => actualConfirmUrl = url)
+                    .Setup(a => a.SendPasswordResetInstructionsAsync(user, It.IsAny<string>(), false))
+                    .Returns<User, string, bool>((_, url, __) =>
+                    {
+                        actualConfirmUrl = url;
+                        return Task.CompletedTask;
+                    })
                     .Verifiable();
 
                 var controller = GetController<UsersController>();
@@ -1510,9 +1515,10 @@ namespace NuGetGallery
                     .Completes()
                     .Verifiable();
                 GetMock<IMessageService>()
-                    .Setup(m => m.SendCredentialRemovedNotice(
+                    .Setup(m => m.SendCredentialRemovedNoticeAsync(
                                     user,
                                     It.Is<CredentialViewModel>(c => c.Type == cred.Type)))
+                    .Returns(Task.CompletedTask)
                     .Verifiable();
 
                 var controller = GetController<UsersController>();
@@ -1616,9 +1622,10 @@ namespace NuGetGallery
                     .Verifiable();
                 GetMock<IMessageService>()
                     .Setup(m =>
-                                m.SendCredentialRemovedNotice(
+                                m.SendCredentialRemovedNoticeAsync(
                                     user,
                                     It.Is<CredentialViewModel>(c => c.Type == CredentialTypes.External.MicrosoftAccount)))
+                    .Returns(Task.CompletedTask)
                     .Verifiable();
 
                 var controller = GetController<UsersController>();
@@ -2305,7 +2312,7 @@ namespace NuGetGallery
                 Assert.Equal(!successOnSentRequest, tempData);
                 GetMock<IMessageService>()
                     .Verify(
-                        stub => stub.SendAccountDeleteNotice(testUser), 
+                        stub => stub.SendAccountDeleteNoticeAsync(testUser), 
                         successOnSentRequest ? Times.Once() : Times.Never());
             }
 
@@ -2433,7 +2440,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequest(
+                        m.SendOrganizationTransformRequestAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>(),
                             It.IsAny<string>(),
@@ -2443,7 +2450,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(
-                        m => m.SendOrganizationTransformInitiatedNotice(
+                        m => m.SendOrganizationTransformInitiatedNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>(),
                             It.IsAny<string>()),
@@ -2478,7 +2485,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequest(
+                        m.SendOrganizationTransformRequestAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>(),
                             It.IsAny<string>(),
@@ -2488,7 +2495,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformInitiatedNotice(
+                        m.SendOrganizationTransformInitiatedNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>(),
                             It.IsAny<string>()),
@@ -2517,7 +2524,7 @@ namespace NuGetGallery
                 Assert.IsType<RedirectResult>(result);
 
                 GetMock<IMessageService>()
-                    .Verify(m => m.SendOrganizationTransformRequest(
+                    .Verify(m => m.SendOrganizationTransformRequestAsync(
                         It.IsAny<User>(),
                         It.IsAny<User>(),
                         It.IsAny<string>(),
@@ -2525,7 +2532,7 @@ namespace NuGetGallery
                         It.IsAny<string>()));
 
                 GetMock<IMessageService>()
-                    .Verify(m => m.SendOrganizationTransformInitiatedNotice(
+                    .Verify(m => m.SendOrganizationTransformInitiatedNoticeAsync(
                         It.IsAny<User>(),
                         It.IsAny<User>(),
                         It.IsAny<string>()));
@@ -2559,7 +2566,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequestAcceptedNotice(
+                        m.SendOrganizationTransformRequestAcceptedNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>()),
                         Times.Never());
@@ -2590,7 +2597,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequestAcceptedNotice(
+                        m.SendOrganizationTransformRequestAcceptedNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>()),
                         Times.Never());
@@ -2622,7 +2629,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequestAcceptedNotice(
+                        m.SendOrganizationTransformRequestAcceptedNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>()),
                         Times.Never());
@@ -2649,7 +2656,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequestAcceptedNotice(
+                        m.SendOrganizationTransformRequestAcceptedNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>()));
 
@@ -2711,7 +2718,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequestRejectedNotice(
+                        m.SendOrganizationTransformRequestRejectedNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>()),
                         Times.Never());
@@ -2738,7 +2745,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequestRejectedNotice(
+                        m.SendOrganizationTransformRequestRejectedNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>()),
                         Times.Never());
@@ -2767,7 +2774,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequestRejectedNotice(
+                        m.SendOrganizationTransformRequestRejectedNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>()));
 
@@ -2819,7 +2826,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequestCancelledNotice(
+                        m.SendOrganizationTransformRequestCancelledNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>()),
                         Times.Never());
@@ -2847,7 +2854,7 @@ namespace NuGetGallery
 
                 GetMock<IMessageService>()
                     .Verify(m =>
-                        m.SendOrganizationTransformRequestCancelledNotice(
+                        m.SendOrganizationTransformRequestCancelledNoticeAsync(
                             It.IsAny<User>(),
                             It.IsAny<User>()));
 

--- a/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MessageServiceFacts.cs
@@ -16,6 +16,7 @@ using Xunit;
 using NuGet.Versioning;
 using NuGet.Services.Validation;
 using NuGet.Services.Validation.Issues;
+using System.Threading.Tasks;
 
 namespace NuGetGallery
 {
@@ -28,7 +29,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailToGalleryOwner()
+            public async Task WillSendEmailToGalleryOwner()
             {
                 // Arrange
                 var from = new MailAddress("legit@example.com", "too");
@@ -41,7 +42,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.ReportAbuse(
+                await messageService.ReportAbuseAsync(
                     new ReportPackageRequest
                     {
                         AlreadyContactedOwners = true,
@@ -69,7 +70,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillCopySenderIfAsked()
+            public async Task WillCopySenderIfAsked()
             {
                 var from = new MailAddress("legit@example.com", "too");
                 var package = new Package
@@ -96,7 +97,7 @@ namespace NuGetGallery
                     Url = TestUtility.MockUrlHelper(),
                     CopySender = true,
                 };
-                messageService.ReportAbuse(reportPackageRequest);
+                await messageService.ReportAbuseAsync(reportPackageRequest);
 
                 var message = messageService.MockMailSender.Sent.Single();
                 Assert.Equal(TestGalleryOwner, message.To.Single());
@@ -111,7 +112,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailToGalleryOwner()
+            public async Task WillSendEmailToGalleryOwner()
             {
                 var from = new MailAddress("legit@example.com", "too");
                 var owner = new User
@@ -131,7 +132,7 @@ namespace NuGetGallery
                 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
-                messageService.ReportMyPackage(
+                await messageService.ReportMyPackageAsync(
                     new ReportPackageRequest
                     {
                         FromAddress = from,
@@ -157,7 +158,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillCopySenderIfAsked()
+            public async Task WillCopySenderIfAsked()
             {
                 var from = new MailAddress("legit@example.com", "too");
                 var package = new Package
@@ -184,7 +185,7 @@ namespace NuGetGallery
                     Url = TestUtility.MockUrlHelper(),
                     CopySender = true,
                 };
-                messageService.ReportMyPackage(reportPackageRequest);
+                await messageService.ReportMyPackageAsync(reportPackageRequest);
 
                 var message = messageService.MockMailSender.Sent.Single();
                 Assert.Equal(TestGalleryOwner, message.To.Single());
@@ -199,7 +200,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillCopySenderIfAsked()
+            public async Task WillCopySenderIfAsked()
             {
                 // arrange
                 var packageId = "smangit";
@@ -227,7 +228,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // act
-                messageService.SendContactOwnersMessage(from, package, "http://someurl/", "Test message", "http://someotherurl/", true);
+                await messageService.SendContactOwnersMessageAsync(from, package, "http://someurl/", "Test message", "http://someotherurl/", true);
                 var messages = messageService.MockMailSender.Sent;
 
                 // assert
@@ -244,7 +245,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillSendEmailToAllOwners()
+            public async Task WillSendEmailToAllOwners()
             {
                 var id = "smangit";
                 var version = "1.0.0";
@@ -270,7 +271,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 var packageUrl = "http://packageUrl/";
-                messageService.SendContactOwnersMessage(from, package, packageUrl, "Test message", "http://emailSettingsUrl/", false);
+                await messageService.SendContactOwnersMessageAsync(from, package, packageUrl, "Test message", "http://emailSettingsUrl/", false);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(owner1Email, message.To[0].Address);
@@ -285,7 +286,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailToOwnerThatOptsOut()
+            public async Task WillNotSendEmailToOwnerThatOptsOut()
             {
                 // arrange
                 var packageId = "smangit";
@@ -312,7 +313,7 @@ namespace NuGetGallery
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
-                messageService.SendContactOwnersMessage(from, package, "http://someurl/", "Test message", "http://someotherurl/", false);
+                await messageService.SendContactOwnersMessageAsync(from, package, "http://someurl/", "Test message", "http://someotherurl/", false);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 // assert
@@ -321,7 +322,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotAttemptToSendIfNoOwnersAllow()
+            public async Task WillNotAttemptToSendIfNoOwnersAllow()
             {
                 // arrange
                 var packageId = "smangit";
@@ -347,14 +348,14 @@ namespace NuGetGallery
                 };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendContactOwnersMessage(from, package, "http://someurl/", "Test message", "http://someotherurl/", false);
+                await messageService.SendContactOwnersMessageAsync(from, package, "http://someurl/", "Test message", "http://someotherurl/", false);
 
                 // assert
                 Assert.Empty(messageService.MockMailSender.Sent);
             }
 
             [Fact]
-            public void WillNotCopySenderIfNoOwnersAllow()
+            public async Task WillNotCopySenderIfNoOwnersAllow()
             {
                 // arrange
                 var packageId = "smangit";
@@ -380,7 +381,7 @@ namespace NuGetGallery
                 };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendContactOwnersMessage(from, package, "http://someurl/", "Test message", "http://someotherurl/", false);
+                await messageService.SendContactOwnersMessageAsync(from, package, "http://someurl/", "Test message", "http://someotherurl/", false);
 
                 // assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -393,14 +394,14 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void WillSendEmailToNewUser(bool isOrganization)
+            public async Task WillSendEmailToNewUser(bool isOrganization)
             {
                 var unconfirmedEmailAddress = "unconfirmed@unconfirmed.com";
                 var user = isOrganization ? new Organization("organization") : new User("user");
                 user.UnconfirmedEmailAddress = unconfirmedEmailAddress;
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendNewAccountEmail(user, "http://example.com/confirmation-token-url");
+                await messageService.SendNewAccountEmailAsync(user, "http://example.com/confirmation-token-url");
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(unconfirmedEmailAddress, message.To[0].Address);
@@ -417,7 +418,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void WillSendEmail(bool isOrganization)
+            public async Task WillSendEmail(bool isOrganization)
             {
                 var unconfirmedEmailAddress = "unconfirmed@unconfirmed.com";
                 var user = isOrganization ? new Organization("organization") : new User("user");
@@ -425,7 +426,7 @@ namespace NuGetGallery
                 var tokenUrl = "http://example.com/confirmation-token-url";
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendEmailChangeConfirmationNotice(user, tokenUrl);
+                await messageService.SendEmailChangeConfirmationNoticeAsync(user, tokenUrl);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(user.UnconfirmedEmailAddress, message.To[0].Address);
@@ -441,7 +442,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void WillSendEmail(bool isOrganization)
+            public async Task WillSendEmail(bool isOrganization)
             {
                 var newEmail = "new@email.com";
                 var user = isOrganization ? new Organization("organization") : new User("user");
@@ -449,7 +450,7 @@ namespace NuGetGallery
                 var oldEmail = "old@email.com";
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendEmailChangeNoticeToPreviousEmailAddress(user, oldEmail);
+                await messageService.SendEmailChangeNoticeToPreviousEmailAddressAsync(user, oldEmail);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 var accountString = isOrganization ? "organization" : "account";
@@ -467,7 +468,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void SendsPackageOwnerRequestConfirmationUrl(bool isOrganization)
+            public async Task SendsPackageOwnerRequestConfirmationUrl(bool isOrganization)
             {
                 var to = isOrganization ? GetOrganizationWithRecipients() : new User();
                 to.Username = "Noob";
@@ -482,7 +483,7 @@ namespace NuGetGallery
                 const string userMessage = "Hello World!";
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRequest(from, to, package, packageUrl, confirmationUrl, rejectionUrl, userMessage, string.Empty);
+                await messageService.SendPackageOwnerRequestAsync(from, to, package, packageUrl, confirmationUrl, rejectionUrl, userMessage, string.Empty);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 var yourString = isOrganization ? "your organization" : "you";
@@ -508,7 +509,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void SendsPackageOwnerRequestConfirmationUrlWithoutUserMessage(bool isOrganization)
+            public async Task SendsPackageOwnerRequestConfirmationUrlWithoutUserMessage(bool isOrganization)
             {
                 var to = isOrganization ? GetOrganizationWithRecipients() : new User();
                 to.Username = "Noob";
@@ -521,7 +522,7 @@ namespace NuGetGallery
                 const string rejectionUrl = "http://example.com/rejection-token-url";
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRequest(from, to, package, packageUrl, confirmationUrl, rejectionUrl, string.Empty, string.Empty);
+                await messageService.SendPackageOwnerRequestAsync(from, to, package, packageUrl, confirmationUrl, rejectionUrl, string.Empty, string.Empty);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.DoesNotContain("The user 'Existing' added the following message for you", message.Body);
@@ -530,7 +531,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void DoesNotSendRequestIfUserDoesNotAllowEmails(bool isOrganization)
+            public async Task DoesNotSendRequestIfUserDoesNotAllowEmails(bool isOrganization)
             {
                 var to = isOrganization ? GetOrganizationWithoutRecipients() : new User();
                 to.Username = "Noob";
@@ -543,7 +544,7 @@ namespace NuGetGallery
                 const string rejectionUrl = "http://example.com/rejection-token-url";
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRequest(from, to, package, packageUrl, confirmationUrl, rejectionUrl, string.Empty, string.Empty);
+                await messageService.SendPackageOwnerRequestAsync(from, to, package, packageUrl, confirmationUrl, rejectionUrl, string.Empty, string.Empty);
 
                 Assert.Empty(messageService.MockMailSender.Sent);
             }
@@ -553,7 +554,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void SendsNotice()
+            public async Task SendsNotice()
             {
                 var requestingOwner = new User("Existing") { EmailAddress = "existing-owner@example.com" };
                 var receivingOwner = new User("Receiving")
@@ -574,7 +575,7 @@ namespace NuGetGallery
                 };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRequestInitiatedNotice(requestingOwner, receivingOwner, newOwner, package, cancelUrl);
+                await messageService.SendPackageOwnerRequestInitiatedNoticeAsync(requestingOwner, receivingOwner, newOwner, package, cancelUrl);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(receivingOwner.EmailAddress, message.To[0].Address);
@@ -586,7 +587,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void DoesNotSendNoticeIfUserDoesNotAllowEmails()
+            public async Task DoesNotSendNoticeIfUserDoesNotAllowEmails()
             {
                 var requestingOwner = new User("Existing") { EmailAddress = "existing-owner@example.com" };
                 var receivingOwner = new User("Receiving")
@@ -607,7 +608,7 @@ namespace NuGetGallery
                 };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRequestInitiatedNotice(requestingOwner, receivingOwner, newOwner, package, cancelUrl);
+                await messageService.SendPackageOwnerRequestInitiatedNoticeAsync(requestingOwner, receivingOwner, newOwner, package, cancelUrl);
 
                 Assert.Empty(messageService.MockMailSender.Sent);
             }
@@ -619,7 +620,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void SendsNotice(bool isOrganization)
+            public async Task SendsNotice(bool isOrganization)
             {
                 var requestingOwner = isOrganization ? GetOrganizationWithRecipients() : new User();
                 requestingOwner.Username = "Existing";
@@ -636,7 +637,7 @@ namespace NuGetGallery
                 };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRequestRejectionNotice(requestingOwner, newOwner, package);
+                await messageService.SendPackageOwnerRequestRejectionNoticeAsync(requestingOwner, newOwner, package);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 var yourString = isOrganization ? "your organization's" : "your";
@@ -658,7 +659,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void DoesNotSendNoticeIfUserDoesNotAllowEmails(bool isOrganization)
+            public async Task DoesNotSendNoticeIfUserDoesNotAllowEmails(bool isOrganization)
             {
                 var requestingOwner = isOrganization ? GetOrganizationWithoutRecipients() : new User();
                 requestingOwner.Username = "Existing";
@@ -675,7 +676,7 @@ namespace NuGetGallery
                 };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRequestRejectionNotice(requestingOwner, newOwner, package);
+                await messageService.SendPackageOwnerRequestRejectionNoticeAsync(requestingOwner, newOwner, package);
 
                 Assert.Empty(messageService.MockMailSender.Sent);
             }
@@ -687,7 +688,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void SendsNotice(bool isOrganization)
+            public async Task SendsNotice(bool isOrganization)
             {
                 var requestingOwner = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
                 var newOwner = isOrganization ? GetOrganizationWithRecipients() : new User();
@@ -697,7 +698,7 @@ namespace NuGetGallery
                 var package = new PackageRegistration { Id = "CoolStuff" };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRequestCancellationNotice(requestingOwner, newOwner, package);
+                await messageService.SendPackageOwnerRequestCancellationNoticeAsync(requestingOwner, newOwner, package);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 var yourString = isOrganization ? "your organization" : "you";
@@ -719,7 +720,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void DoesNotSendNoticeIfUserDoesNotAllowEmails(bool isOrganization)
+            public async Task DoesNotSendNoticeIfUserDoesNotAllowEmails(bool isOrganization)
             {
                 var requestingOwner = new User { Username = "Existing", EmailAddress = "existing-owner@example.com" };
 
@@ -737,7 +738,7 @@ namespace NuGetGallery
                 };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRequestCancellationNotice(requestingOwner, newOwner, package);
+                await  messageService.SendPackageOwnerRequestCancellationNoticeAsync(requestingOwner, newOwner, package);
 
                 Assert.Empty(messageService.MockMailSender.Sent);
             }
@@ -749,7 +750,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void SendsPackageOwnerAddedNotice(bool isOrganization)
+            public async Task SendsPackageOwnerAddedNotice(bool isOrganization)
             {
                 // Arrange
                 var toUser = isOrganization ? GetOrganizationWithRecipients() : new User();
@@ -762,7 +763,7 @@ namespace NuGetGallery
                 var packageUrl = "packageUrl";
 
                 // Act
-                messageService.SendPackageOwnerAddedNotice(toUser, newUser, package, packageUrl);
+                await messageService.SendPackageOwnerAddedNoticeAsync(toUser, newUser, package, packageUrl);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -782,7 +783,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void DoesNotSendPackageOwnerAddedNoticeIfUserDoesNotAllowEmails(bool isOrganization)
+            public async Task DoesNotSendPackageOwnerAddedNoticeIfUserDoesNotAllowEmails(bool isOrganization)
             {
                 // Arrange
                 var toUser = isOrganization ? GetOrganizationWithoutRecipients() : new User();
@@ -794,7 +795,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendPackageOwnerAddedNotice(toUser, newUser, package, "packageUrl");
+                await messageService.SendPackageOwnerAddedNoticeAsync(toUser, newUser, package, "packageUrl");
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -807,7 +808,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void SendsPackageOwnerRemovedNotice(bool isOrganization)
+            public async Task SendsPackageOwnerRemovedNotice(bool isOrganization)
             {
                 var to = isOrganization ? GetOrganizationWithRecipients() : new User();
                 to.Username = "Noob";
@@ -817,7 +818,7 @@ namespace NuGetGallery
                 var package = new PackageRegistration { Id = "CoolStuff" };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRemovedNotice(from, to, package);
+                await messageService.SendPackageOwnerRemovedNoticeAsync(from, to, package);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 if (isOrganization)
@@ -837,7 +838,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void DoesNotSendRemovedNoticeIfUserDoesNotAllowEmails(bool isOrganization)
+            public async Task DoesNotSendRemovedNoticeIfUserDoesNotAllowEmails(bool isOrganization)
             {
                 var to = isOrganization ? GetOrganizationWithoutRecipients() : new User();
                 to.Username = "Noob";
@@ -847,7 +848,7 @@ namespace NuGetGallery
                 var package = new PackageRegistration { Id = "CoolStuff" };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageOwnerRemovedNotice(from, to, package);
+                await messageService.SendPackageOwnerRemovedNoticeAsync(from, to, package);
 
                 Assert.Empty(messageService.MockMailSender.Sent);
             }
@@ -862,12 +863,12 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendInstructions()
+            public async Task WillSendInstructions()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "too" };
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPasswordResetInstructions(user, "http://example.com/pwd-reset-token-url", true);
+                await messageService.SendPasswordResetInstructionsAsync(user, "http://example.com/pwd-reset-token-url", true);
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal("legit@example.com", message.To[0].Address);
@@ -889,7 +890,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void UsesProviderNounToDescribeCredentialIfPresent()
+            public async Task UsesProviderNounToDescribeCredentialIfPresent()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
                 var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "abc123", "Test User");
@@ -897,7 +898,7 @@ namespace NuGetGallery
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
-                messageService.SendCredentialRemovedNotice(user, _authenticationService.DescribeCredential(cred));
+                await messageService.SendCredentialRemovedNoticeAsync(user, _authenticationService.DescribeCredential(cred));
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
@@ -907,13 +908,13 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void UsesTypeCaptionToDescribeCredentialIfNoProviderNounPresent()
+            public async Task UsesTypeCaptionToDescribeCredentialIfNoProviderNounPresent()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
                 var cred = new CredentialBuilder().CreatePasswordCredential("bogus");
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendCredentialRemovedNotice(user, _authenticationService.DescribeCredential(cred));
+                await messageService.SendCredentialRemovedNoticeAsync(user, _authenticationService.DescribeCredential(cred));
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
@@ -923,7 +924,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void ApiKeyRemovedMessageIsCorrect()
+            public async Task ApiKeyRemovedMessageIsCorrect()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
                 var cred = TestCredentialHelper.CreateV2ApiKey(Guid.NewGuid(), TimeSpan.FromDays(1)).WithDefaultScopes();
@@ -931,7 +932,7 @@ namespace NuGetGallery
                 cred.User = user;
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendCredentialRemovedNotice(user, _authenticationService.DescribeCredential(cred));
+                await messageService.SendCredentialRemovedNoticeAsync(user, _authenticationService.DescribeCredential(cred));
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
@@ -952,14 +953,14 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void UsesProviderNounToDescribeCredentialIfPresent()
+            public async Task UsesProviderNounToDescribeCredentialIfPresent()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
                 var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "abc123", "Test User");
                 const string MicrosoftAccountCredentialName = "Microsoft account";
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendCredentialAddedNotice(user, _authenticationService.DescribeCredential(cred));
+                await messageService.SendCredentialAddedNoticeAsync(user, _authenticationService.DescribeCredential(cred));
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
@@ -969,13 +970,13 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void UsesTypeCaptionToDescribeCredentialIfNoProviderNounPresent()
+            public async Task UsesTypeCaptionToDescribeCredentialIfNoProviderNounPresent()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
                 var cred = new CredentialBuilder().CreatePasswordCredential("bogus");
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendCredentialAddedNotice(user, _authenticationService.DescribeCredential(cred));
+                await messageService.SendCredentialAddedNoticeAsync(user, _authenticationService.DescribeCredential(cred));
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
@@ -985,7 +986,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void ApiKeyAddedMessageIsCorrect()
+            public async Task ApiKeyAddedMessageIsCorrect()
             {
                 var user = new User { EmailAddress = "legit@example.com", Username = "foo" };
                 var cred = TestCredentialHelper.CreateV2ApiKey(Guid.NewGuid(), TimeSpan.FromDays(1)).WithDefaultScopes();
@@ -993,7 +994,7 @@ namespace NuGetGallery
                 cred.User = user;
 
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendCredentialAddedNotice(user, _authenticationService.DescribeCredential(cred));
+                await messageService.SendCredentialAddedNoticeAsync(user, _authenticationService.DescribeCredential(cred));
                 var message = messageService.MockMailSender.Sent.Last();
 
                 Assert.Equal(user.ToMailAddress(), message.To[0]);
@@ -1013,7 +1014,7 @@ namespace NuGetGallery
             [InlineData("1.2.3+metadata")]
             [InlineData("1.2.3-alpha+metadata")]
             [InlineData("1.2.3-alpha.1+metadata")]
-            public void WillSendEmailToAllOwners(string version)
+            public async Task WillSendEmailToAllOwners(string version)
             {
                 // Arrange
                 var nugetVersion = new NuGetVersion(version);
@@ -1039,7 +1040,7 @@ namespace NuGetGallery
                 var packageUrl = $"https://localhost/packages/{packageRegistration.Id}/{nugetVersion.ToNormalizedString()}";
                 var supportUrl = $"https://localhost/packages/{packageRegistration.Id}/{nugetVersion.ToNormalizedString()}/ReportMyPackage";
                 var emailSettingsUrl = "https://localhost/account";
-                messageService.SendPackageAddedNotice(package, packageUrl, supportUrl, emailSettingsUrl);
+                await messageService.SendPackageAddedNoticeAsync(package, packageUrl, supportUrl, emailSettingsUrl);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1053,7 +1054,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailToOwnerThatOptsOut()
+            public async Task WillNotSendEmailToOwnerThatOptsOut()
             {
                 // Arrange
                 var packageRegistration = new PackageRegistration
@@ -1075,7 +1076,7 @@ namespace NuGetGallery
 
                 // Act
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageAddedNotice(package, "http://dummy1", "http://dummy2", "http://dummy3");
+                await messageService.SendPackageAddedNoticeAsync(package, "http://dummy1", "http://dummy2", "http://dummy3");
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1085,7 +1086,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotAttemptToSendIfNoOwnersAllow()
+            public async Task WillNotAttemptToSendIfNoOwnersAllow()
             {
                 // Arrange
                 var packageRegistration = new PackageRegistration
@@ -1107,7 +1108,7 @@ namespace NuGetGallery
 
                 // Act
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendPackageAddedNotice(package, "http://dummy1", "http://dummy2", "http://dummy3");
+                await messageService.SendPackageAddedNoticeAsync(package, "http://dummy1", "http://dummy2", "http://dummy3");
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1152,7 +1153,7 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(WillSendEmailToAllOwners_Data))]
-            public void WillSendEmailToAllOwners(ValidationIssue validationIssue, bool user1PushAllowed, bool user2PushAllowed, bool user1EmailAllowed, bool user2EmailAllowed)
+            public async Task WillSendEmailToAllOwners(ValidationIssue validationIssue, bool user1PushAllowed, bool user2PushAllowed, bool user1EmailAllowed, bool user2EmailAllowed)
             {
                 // Arrange
                 var packageRegistration = new PackageRegistration
@@ -1196,7 +1197,7 @@ namespace NuGetGallery
                 var supportUrl = $"https://supportUrl";
                 var announcementsUrl = "https://announcementsUrl";
                 var twitterUrl = "https://twitterUrl";
-                messageService.SendPackageValidationFailedNotice(package, packageValidationSet, packageUrl, supportUrl, announcementsUrl, twitterUrl);
+                await messageService.SendPackageValidationFailedNoticeAsync(package, packageValidationSet, packageUrl, supportUrl, announcementsUrl, twitterUrl);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1260,7 +1261,7 @@ namespace NuGetGallery
             [InlineData("1.2.3+metadata")]
             [InlineData("1.2.3-alpha+metadata")]
             [InlineData("1.2.3-alpha.1+metadata")]
-            public void WillSendEmailToAllOwners(string version)
+            public async Task WillSendEmailToAllOwners(string version)
             {
                 // Arrange
                 var nugetVersion = new NuGetVersion(version);
@@ -1283,7 +1284,7 @@ namespace NuGetGallery
                 // Act
                 var messageService = TestableMessageService.Create(GetConfigurationService());
                 var packageUrl = $"https://localhost/packages/{packageRegistration.Id}/{nugetVersion.ToNormalizedString()}";
-                messageService.SendValidationTakingTooLongNotice(package, packageUrl);
+                await messageService.SendValidationTakingTooLongNoticeAsync(package, packageUrl);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1307,7 +1308,7 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(EmailSettingsCombinations))]
-            public void WillHonorPushSettings(bool user1PushAllowed, bool user2PushAllowed, bool user1EmailAllowed, bool user2EmailAllowed)
+            public async Task WillHonorPushSettings(bool user1PushAllowed, bool user2PushAllowed, bool user1EmailAllowed, bool user2EmailAllowed)
             {
                 // Arrange
                 var packageRegistration = new PackageRegistration
@@ -1331,7 +1332,7 @@ namespace NuGetGallery
 
                 // Act
                 var messageService = TestableMessageService.Create(GetConfigurationService());
-                messageService.SendValidationTakingTooLongNotice(package, "http://dummy1");
+                await messageService.SendValidationTakingTooLongNoticeAsync(package, "http://dummy1");
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.LastOrDefault();
@@ -1359,7 +1360,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailToAllOwners()
+            public async Task WillSendEmailToAllOwners()
             {
                 // Arrange
                 var nugetVersion = new NuGetVersion("3.1.0");
@@ -1384,7 +1385,7 @@ namespace NuGetGallery
                 var supportUrl = $"https://localhost/packages/{packageRegistration.Id}/{nugetVersion.ToNormalizedString()}/ReportMyPackage";
 
                 // Act
-                messageService.SendPackageDeletedNotice(package, packageUrl, supportUrl);
+                await messageService.SendPackageDeletedNoticeAsync(package, packageUrl, supportUrl);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1401,7 +1402,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailIfEmailAllowed()
+            public async Task WillSendEmailIfEmailAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
@@ -1413,7 +1414,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformRequest(accountToTransform, adminUser, profileUrl, confirmationUrl, rejectionUrl);
+                await messageService.SendOrganizationTransformRequestAsync(accountToTransform, adminUser, profileUrl, confirmationUrl, rejectionUrl);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1428,7 +1429,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailIfEmailNotAllowed()
+            public async Task WillNotSendEmailIfEmailNotAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
@@ -1440,7 +1441,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformRequest(accountToTransform, adminUser, profileUrl, confirmationUrl, rejectionUrl);
+                await messageService.SendOrganizationTransformRequestAsync(accountToTransform, adminUser, profileUrl, confirmationUrl, rejectionUrl);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1451,7 +1452,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailIfEmailAllowed()
+            public async Task WillSendEmailIfEmailAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = true };
@@ -1461,7 +1462,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformInitiatedNotice(accountToTransform, adminUser, cancelUrl);
+                await messageService.SendOrganizationTransformInitiatedNoticeAsync(accountToTransform, adminUser, cancelUrl);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1476,7 +1477,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailIfEmailNotAllowed()
+            public async Task WillNotSendEmailIfEmailNotAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = false };
@@ -1486,7 +1487,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformInitiatedNotice(accountToTransform, adminUser, cancelUrl);
+                await messageService.SendOrganizationTransformInitiatedNoticeAsync(accountToTransform, adminUser, cancelUrl);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1497,7 +1498,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailIfEmailAllowed()
+            public async Task WillSendEmailIfEmailAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = true };
@@ -1506,7 +1507,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformRequestAcceptedNotice(accountToTransform, adminUser);
+                await messageService.SendOrganizationTransformRequestAcceptedNoticeAsync(accountToTransform, adminUser);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1519,7 +1520,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailIfEmailNotAllowed()
+            public async Task WillNotSendEmailIfEmailNotAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = false };
@@ -1528,7 +1529,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformRequestAcceptedNotice(accountToTransform, adminUser);
+                await messageService.SendOrganizationTransformRequestAcceptedNoticeAsync(accountToTransform, adminUser);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1539,7 +1540,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailIfEmailAllowed()
+            public async Task WillSendEmailIfEmailAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = true };
@@ -1548,7 +1549,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformRequestRejectedNotice(accountToTransform, adminUser);
+                await messageService.SendOrganizationTransformRequestRejectedNoticeAsync(accountToTransform, adminUser);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1561,7 +1562,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailIfEmailNotAllowed()
+            public async Task WillNotSendEmailIfEmailNotAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com", EmailAllowed = false };
@@ -1570,7 +1571,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformRequestRejectedNotice(accountToTransform, adminUser);
+                await messageService.SendOrganizationTransformRequestRejectedNoticeAsync(accountToTransform, adminUser);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1581,7 +1582,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailIfEmailAllowed()
+            public async Task WillSendEmailIfEmailAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
@@ -1590,7 +1591,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformRequestCancelledNotice(accountToTransform, adminUser);
+                await messageService.SendOrganizationTransformRequestCancelledNoticeAsync(accountToTransform, adminUser);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1603,7 +1604,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailIfEmailNotAllowed()
+            public async Task WillNotSendEmailIfEmailNotAllowed()
             {
                 // Arrange
                 var accountToTransform = new User("bumblebee") { EmailAddress = "bumblebee@transformers.com" };
@@ -1612,7 +1613,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationTransformRequestCancelledNotice(accountToTransform, adminUser);
+                await messageService.SendOrganizationTransformRequestCancelledNoticeAsync(accountToTransform, adminUser);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1625,7 +1626,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void WillSendEmailIfEmailAllowed(bool isAdmin)
+            public async Task WillSendEmailIfEmailAllowed(bool isAdmin)
             {
                 // Arrange
                 var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com" };
@@ -1638,7 +1639,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMembershipRequest(organization, newUser, adminUser, isAdmin, profileUrl, confirmationUrl, rejectionUrl);
+                await messageService.SendOrganizationMembershipRequestAsync(organization, newUser, adminUser, isAdmin, profileUrl, confirmationUrl, rejectionUrl);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1657,7 +1658,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void WillNotSendEmailIfEmailNotAllowed(bool isAdmin)
+            public async Task WillNotSendEmailIfEmailNotAllowed(bool isAdmin)
             {
                 // Arrange
                 var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com" };
@@ -1670,7 +1671,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMembershipRequest(organization, newUser, adminUser, isAdmin, profileUrl, confirmationUrl, rejectionUrl);
+                await messageService.SendOrganizationMembershipRequestAsync(organization, newUser, adminUser, isAdmin, profileUrl, confirmationUrl, rejectionUrl);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1683,7 +1684,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void WillSendEmailIfEmailAllowed(bool isAdmin)
+            public async Task WillSendEmailIfEmailAllowed(bool isAdmin)
             {
                 // Arrange
                 var organization = GetOrganizationWithRecipients();
@@ -1694,7 +1695,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMembershipRequestInitiatedNotice(organization, requestingUser, pendingUser, isAdmin, cancelUrl);
+                await messageService.SendOrganizationMembershipRequestInitiatedNoticeAsync(organization, requestingUser, pendingUser, isAdmin, cancelUrl);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1710,7 +1711,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void WillNotSendEmailIfEmailNotAllowed(bool isAdmin)
+            public async Task WillNotSendEmailIfEmailNotAllowed(bool isAdmin)
             {
                 // Arrange
                 var organization = GetOrganizationWithoutRecipients();
@@ -1721,7 +1722,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMembershipRequestInitiatedNotice(organization, requestingUser, pendingUser, isAdmin, cancelUrl);
+                await messageService.SendOrganizationMembershipRequestInitiatedNoticeAsync(organization, requestingUser, pendingUser, isAdmin, cancelUrl);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1732,7 +1733,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailIfEmailAllowed()
+            public async Task WillSendEmailIfEmailAllowed()
             {
                 // Arrange
                 var organization = GetOrganizationWithRecipients();
@@ -1741,7 +1742,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMembershipRequestRejectedNotice(organization, pendingUser);
+                await messageService.SendOrganizationMembershipRequestRejectedNoticeAsync(organization, pendingUser);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1755,7 +1756,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailIfEmailNotAllowed()
+            public async Task WillNotSendEmailIfEmailNotAllowed()
             {
                 // Arrange
                 var organization = GetOrganizationWithoutRecipients();
@@ -1764,7 +1765,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMembershipRequestRejectedNotice(organization, pendingUser);
+                await messageService.SendOrganizationMembershipRequestRejectedNoticeAsync(organization, pendingUser);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1775,7 +1776,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailIfEmailAllowed()
+            public async Task WillSendEmailIfEmailAllowed()
             {
                 // Arrange
                 var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com" };
@@ -1784,7 +1785,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMembershipRequestCancelledNotice(organization, pendingUser);
+                await messageService.SendOrganizationMembershipRequestCancelledNoticeAsync(organization, pendingUser);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1797,7 +1798,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailIfEmailNotAllowed()
+            public async Task WillNotSendEmailIfEmailNotAllowed()
             {
                 // Arrange
                 var accountToTransform = new Organization("transformers") { EmailAddress = "transformers@transformers.com" };
@@ -1806,7 +1807,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMembershipRequestCancelledNotice(accountToTransform, pendingUser);
+                await messageService.SendOrganizationMembershipRequestCancelledNoticeAsync(accountToTransform, pendingUser);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1819,7 +1820,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void WillSendEmailIfEmailAllowed(bool isAdmin)
+            public async Task WillSendEmailIfEmailAllowed(bool isAdmin)
             {
                 // Arrange
                 var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = true };
@@ -1829,7 +1830,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMemberUpdatedNotice(organization, membership);
+                await messageService.SendOrganizationMemberUpdatedNoticeAsync(organization, membership);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1845,7 +1846,7 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
-            public void WillNotSendEmailIfEmailNotAllowed(bool isAdmin)
+            public async Task WillNotSendEmailIfEmailNotAllowed(bool isAdmin)
             {
                 // Arrange
                 var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = false };
@@ -1855,7 +1856,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMemberUpdatedNotice(organization, membership);
+                await messageService.SendOrganizationMemberUpdatedNoticeAsync(organization, membership);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1866,7 +1867,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void WillSendEmailIfEmailAllowed()
+            public async Task WillSendEmailIfEmailAllowed()
             {
                 // Arrange
                 var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = true };
@@ -1875,7 +1876,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMemberRemovedNotice(organization, removedUser);
+                await messageService.SendOrganizationMemberRemovedNoticeAsync(organization, removedUser);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -1888,7 +1889,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public void WillNotSendEmailIfEmailNotAllowed()
+            public async Task WillNotSendEmailIfEmailNotAllowed()
             {
                 // Arrange
                 var organization = new Organization("transformers") { EmailAddress = "transformers@transformers.com", EmailAllowed = false };
@@ -1897,7 +1898,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendOrganizationMemberRemovedNotice(organization, member);
+                await messageService.SendOrganizationMemberRemovedNoticeAsync(organization, member);
 
                 // Assert
                 Assert.Empty(messageService.MockMailSender.Sent);
@@ -1908,7 +1909,7 @@ namespace NuGetGallery
             : TestContainer
         {
             [Fact]
-            public void VerifyTheMessageBody()
+            public async Task VerifyTheMessageBody()
             {
                 // Arrange
                 var userName = "deleteduser";
@@ -1918,7 +1919,7 @@ namespace NuGetGallery
                 var messageService = TestableMessageService.Create(GetConfigurationService());
 
                 // Act
-                messageService.SendAccountDeleteNotice(userToDelete);
+                await messageService.SendAccountDeleteNoticeAsync(userToDelete);
 
                 // Assert
                 var message = messageService.MockMailSender.Sent.Last();
@@ -2005,12 +2006,12 @@ namespace NuGetGallery
             : MessageService
         {
             private TestableMessageService(IGalleryConfigurationService configurationService)
+                : base(new TestMailSender(), configurationService.Current, new Mock<ITelemetryService>().Object)
             {
                 configurationService.Current.GalleryOwner = TestGalleryOwner;
                 configurationService.Current.GalleryNoReplyAddress = TestGalleryNoReplyAddress;
 
-                Config = configurationService.Current;
-                MailSender = MockMailSender = new TestMailSender();
+                MockMailSender = (TestMailSender)MailSender;
             }
 
             public Mock<AuthenticationService> MockAuthService { get; protected set; }
@@ -2018,6 +2019,7 @@ namespace NuGetGallery
 
             public static TestableMessageService Create(IGalleryConfigurationService configurationService)
             {
+                configurationService.Current.SmtpUri = new Uri("smtp://fake.mail.server");
                 return new TestableMessageService(configurationService);
             }
         }


### PR DESCRIPTION
The first commit is just a revert of what was previously reviewed and merged in dev. So, you can save yourself some time by just looking at the second commit's changes.

The problem with the previous PR that needed to be reverted was that previously emails are sent synchronously, so only one email being sent at a time. In order to prevent users waiting a long time for HTTP responses, emails now are sent in the background. However, when a single MVC action sends two or more messages, only the first would be sent and the others would throw an exception because the SmtpClient couldn't start sending a new message while an async operation was already in progress.

This PR fixes that issue by creating a BackgroundMessageServiceFactory. When an instance of BackgroundMessageService detects that it is being reused, it calls the factory to create a new instance, and sends the new email using the new instance.