### PR TITLE
If ConfirmEmailAddresses config is false, users should not be required to confirm changing their email

### DIFF
--- a/src/NuGetGallery.Core/Entities/User.cs
+++ b/src/NuGetGallery.Core/Entities/User.cs
@@ -154,7 +154,7 @@ namespace NuGetGallery
             UnconfirmedEmailAddress = null;
         }
 
-        public void UpdateEmailAddress(string newEmailAddress, Func<string> generateToken)
+        public void UpdateUnconfirmedEmailAddress(string newEmailAddress, Func<string> generateToken)
         {
             if (!string.IsNullOrEmpty(UnconfirmedEmailAddress))
             {

--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -252,7 +252,7 @@ namespace NuGetGallery
                 return AccountView(account, model);
             }
 
-            if (account.Confirmed)
+            if (account.Confirmed && !string.IsNullOrEmpty(account.UnconfirmedEmailAddress))
             {
                 SendEmailChangedConfirmationNotice(account);
             }

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -386,7 +386,13 @@ namespace NuGetGallery
 
             await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.ChangeEmail, newEmailAddress));
 
-            user.UpdateEmailAddress(newEmailAddress, Crypto.GenerateToken);
+            user.UpdateUnconfirmedEmailAddress(newEmailAddress, Crypto.GenerateToken);
+
+            if (!Config.ConfirmEmailAddresses)
+            {
+                user.ConfirmEmailAddress();
+            }
+
             await UserRepository.CommitChangesAsync();
         }
 
@@ -554,6 +560,11 @@ namespace NuGetGallery
                 CreatedUtc = DateTimeProvider.UtcNow,
                 Members = new List<Membership>()
             };
+
+            if (!Config.ConfirmEmailAddresses)
+            {
+                organization.ConfirmEmailAddress();
+            }
 
             var membership = new Membership { Organization = organization, Member = adminUser, IsAdmin = true };
 


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/5509