### PR TITLE
Package history current version highlight

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -462,7 +462,7 @@
                             {
                                 rowCount++;
                                 @VersionListDivider(rowCount, versionsExpanded)
-                                <tr>
+                                <tr class="@(packageVersion.IsCurrent(Model) ? "bg-info" : null)">
                                     <td class="signature-info-cell">
                                         @if (Model.IsCertificatesUIEnabled && !string.IsNullOrEmpty(packageVersion.SignatureInformation))
                                         {
@@ -471,13 +471,7 @@
                                     </td>
                                     <td>
                                         <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion">
-                                            <b>
                                                 @packageVersion.Version.Abbreviate(30)
-                                                @if (packageVersion.IsCurrent(Model))
-                                                {
-                                                    @:(current)
-                                                }
-                                            </b>
                                         </a>
                                     </td>
                                     <td>


### PR DESCRIPTION
Fixes #6247.

As discussed offline with @anangaur, remove bold and (current) text, and use a background colour instead of simply removing bold from non-current versions as asked in original issue.

Viewing most recent version:
![image](https://user-images.githubusercontent.com/5030577/44176404-86b3b000-a09e-11e8-9206-3ac474e9d5de.png)

Viewing older version:
![image](https://user-images.githubusercontent.com/5030577/44176416-90d5ae80-a09e-11e8-9f9b-b950e5dcf1a7.png)

package with only a single version:
![image](https://user-images.githubusercontent.com/5030577/44176426-99c68000-a09e-11e8-921b-583ba0be83f5.png)

hover link:
![image](https://user-images.githubusercontent.com/5030577/44176452-b662b800-a09e-11e8-9061-0ef94a1f4a52.png)
