### PR TITLE
[NuGet Symbol Server] Add download symbols support to Package details page

### DIFF
--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -657,6 +657,12 @@ namespace NuGetGallery
                 constraints: new { httpMethod = new HttpMethodConstraint("GET") });
 
             routes.MapRoute(
+                "v2" + RouteName.DownloadSymbolsPackage,
+                "api/v2/symbolpackage/{id}/{version}",
+                defaults: new { controller = "Api", action = "GetSymbolPackageApi", version = UrlParameter.Optional },
+                constraints: new { httpMethod = new HttpMethodConstraint("GET") });
+
+            routes.MapRoute(
                 "v2" + RouteName.PushPackageApi,
                 "api/v2/package",
                 defaults: new { controller = "Api", action = "PushPackageApi" },

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -177,14 +177,12 @@ namespace NuGetGallery
                 return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, "The format of the package id is invalid");
             }
 
-            // If version is null, get the latest version from the database.
-            // This ensures that on package restore scenario where version will be non null, we don't hit the database.
             Package package = null;
             try
             {
-                // if version is non-null, check if it's semantically correct and normalize it.
                 if (!string.IsNullOrEmpty(version))
                 {
+                    // if version is non-null, check if it's semantically correct and normalize it.
                     NuGetVersion dummy;
                     if (!NuGetVersion.TryParse(version, out dummy))
                     {
@@ -201,6 +199,8 @@ namespace NuGetGallery
                 }
                 else
                 {
+                    // If version is null, get the latest version from the database.
+                    // This ensures that on package restore scenario where version will be non null, we don't hit the database.
                     package = PackageService.FindPackageByIdAndVersion(
                         id,
                         version,

--- a/src/NuGetGallery/RouteName.cs
+++ b/src/NuGetGallery/RouteName.cs
@@ -27,7 +27,7 @@ namespace NuGetGallery
         public const string Profile = "Profile";
         public const string DisplayPackage = "package-route";
         public const string DownloadPackage = "DownloadPackage";
-        public const string DownloadSymbolsPackage = "DownloadSymbolPackage";
+        public const string DownloadSymbolsPackage = "DownloadSymbolsPackage";
         public const string DownloadNuGetExe = "DownloadNuGetExe";
         public const string Home = "Home";
         public const string Stats = "Stats";

--- a/src/NuGetGallery/RouteName.cs
+++ b/src/NuGetGallery/RouteName.cs
@@ -27,6 +27,7 @@ namespace NuGetGallery
         public const string Profile = "Profile";
         public const string DisplayPackage = "package-route";
         public const string DownloadPackage = "DownloadPackage";
+        public const string DownloadSymbolsPackage = "DownloadSymbolPackage";
         public const string DownloadNuGetExe = "DownloadNuGetExe";
         public const string Home = "Home";
         public const string Stats = "Stats";

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -278,6 +278,7 @@ namespace NuGetGallery
             switch (folderName)
             {
                 case CoreConstants.PackagesFolderName:
+                case CoreConstants.SymbolPackagesFolderName:
                     return CoreConstants.PackageContentType;
 
                 case CoreConstants.DownloadsFolderName:

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1832,7 +1832,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No availabe symbol package found for ID {0} and version {1}..
+        ///   Looks up a localized string similar to No available symbols package found for ID {0} and version {1}..
         /// </summary>
         public static string SymbolsPackage_PackageNotAvailable {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1832,6 +1832,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No availabe symbol package found ID {0} and version {1}..
+        /// </summary>
+        public static string SymbolsPackage_PackageNotAvailable {
+            get {
+                return ResourceManager.GetString("SymbolsPackage_PackageNotAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You do not have the permissions to upload symbol packages..
         /// </summary>
         public static string SymbolsPackage_UploadNotAllowed {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1832,7 +1832,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No availabe symbol package found ID {0} and version {1}..
+        ///   Looks up a localized string similar to No availabe symbol package found for ID {0} and version {1}..
         /// </summary>
         public static string SymbolsPackage_PackageNotAvailable {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -950,6 +950,6 @@ If you would like to update the linked Microsoft account you can do so from the 
     <comment>{0} is the previous package's normalized version.</comment>
   </data>
   <data name="SymbolsPackage_PackageNotAvailable" xml:space="preserve">
-    <value>No availabe symbol package found ID {0} and version {1}.</value>
+    <value>No availabe symbol package found for ID {0} and version {1}.</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -950,6 +950,6 @@ If you would like to update the linked Microsoft account you can do so from the 
     <comment>{0} is the previous package's normalized version.</comment>
   </data>
   <data name="SymbolsPackage_PackageNotAvailable" xml:space="preserve">
-    <value>No availabe symbol package found for ID {0} and version {1}.</value>
+    <value>No available symbols package found for ID {0} and version {1}.</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -949,4 +949,7 @@ If you would like to update the linked Microsoft account you can do so from the 
     <value>The previous package version '{0}' is author signed but the uploaded package is unsigned. To avoid this warning, sign the package before uploading.</value>
     <comment>{0} is the previous package's normalized version.</comment>
   </data>
+  <data name="SymbolsPackage_PackageNotAvailable" xml:space="preserve">
+    <value>No availabe symbol package found ID {0} and version {1}.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -307,6 +307,26 @@ namespace NuGetGallery
             return version == null ? EnsureTrailingSlash(result) : result;
         }
 
+        public static string SymbolPackageDownload(
+            this UrlHelper url,
+            int feedVersion,
+            string id,
+            string version,
+            bool relativeUrl = true)
+        {
+            string result = GetRouteLink(
+                url,
+                routeName: $"v{feedVersion}{RouteName.DownloadSymbolsPackage}",
+                relativeUrl: false,
+                routeValues: new RouteValueDictionary
+                {
+                    { "Id", id },
+                    { "Version", version }
+                });
+
+            // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions
+            return version == null ? EnsureTrailingSlash(result) : result;
+        }
         public static string ExplorerDeepLink(
             this UrlHelper url,
             int feedVersion,

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -28,7 +28,7 @@ namespace NuGetGallery
 
             LatestSymbolPackage = package
                 .SymbolPackages
-                .OrderBy(sp => sp.Created)
+                .OrderByDescending(sp => sp.Created)
                 .FirstOrDefault();
 
             if (packageHistory.Any())

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -26,9 +26,9 @@ namespace NuGetGallery
             PushedBy = GetPushedBy(package, currentUser);
             PackageFileSize = package.PackageFileSize;
 
-            AvailableSymbolPackage = package
+            LatestSymbolPackage = package
                 .SymbolPackages
-                .Where(sp => sp.StatusKey == PackageStatus.Available)
+                .OrderBy(sp => sp.Created)
                 .FirstOrDefault();
 
             if (packageHistory.Any())
@@ -67,8 +67,7 @@ namespace NuGetGallery
         public int DownloadsPerDay { get; private set; }
         public int TotalDaysSinceCreated { get; private set; }
         public long PackageFileSize { get; private set; }
-        public SymbolPackage AvailableSymbolPackage { get; private set; }
-        public SymbolPackage PendingSymbolPackage { get; private set; }
+        public SymbolPackage LatestSymbolPackage { get; private set; }
 
         public bool HasSemVer2Version { get; }
         public bool HasSemVer2Dependency { get; }

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -26,6 +26,11 @@ namespace NuGetGallery
             PushedBy = GetPushedBy(package, currentUser);
             PackageFileSize = package.PackageFileSize;
 
+            AvailableSymbolPackage = package
+                .SymbolPackages
+                .Where(sp => sp.StatusKey == PackageStatus.Available)
+                .FirstOrDefault();
+
             if (packageHistory.Any())
             {
                 // calculate the number of days since the package registration was created
@@ -62,6 +67,8 @@ namespace NuGetGallery
         public int DownloadsPerDay { get; private set; }
         public int TotalDaysSinceCreated { get; private set; }
         public long PackageFileSize { get; private set; }
+        public SymbolPackage AvailableSymbolPackage { get; private set; }
+        public SymbolPackage PendingSymbolPackage { get; private set; }
 
         public bool HasSemVer2Version { get; }
         public bool HasSemVer2Dependency { get; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -633,8 +633,13 @@
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
-                        <a href="@Url.PackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw nupkg file." rel="nofollow">Download</a>
+                        <a href="@Url.PackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw nupkg file." rel="nofollow">Download Package</a>
                         &nbsp;(@Model.PackageFileSize.ToUserFriendlyBytesLabel())
+                    </li>
+                    <li>
+                        <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
+                        <a href="@Url.SymbolPackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw snupkg file." rel="nofollow">Download Symbols</a>
+                        &nbsp;(@Model.AvailableSymbolPackage.FileSize.ToUserFriendlyBytesLabel())
                     </li>
                     <li class="no-clickonce">
                         <i class="ms-Icon ms-Icon--OpenInNewWindow" aria-hidden="true"></i>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -9,6 +9,8 @@
 
     var absolutePackageUrl = Url.Absolute(Url.Package(Model.Id));
 
+    var hasSymbolPackageAvailable = Model.LatestSymbolPackage != null && Model.LatestSymbolPackage.StatusKey == PackageStatus.Available;
+
     PackageManagerViewModel[] packageManagers;
 
     if (Model.IsDotnetToolPackageType)
@@ -636,11 +638,14 @@
                         <a href="@Url.PackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw nupkg file." rel="nofollow">Download Package</a>
                         &nbsp;(@Model.PackageFileSize.ToUserFriendlyBytesLabel())
                     </li>
-                    <li>
-                        <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
-                        <a href="@Url.SymbolPackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw snupkg file." rel="nofollow">Download Symbols</a>
-                        &nbsp;(@Model.AvailableSymbolPackage.FileSize.ToUserFriendlyBytesLabel())
-                    </li>
+                    if (hasSymbolPackageAvailable)
+                    {
+                        <li>
+                            <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
+                            <a href="@Url.SymbolPackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw snupkg file." rel="nofollow">Download Symbols</a>
+                            &nbsp;(@Model.LatestSymbolPackage.FileSize.ToUserFriendlyBytesLabel())
+                        </li>
+                    }
                     <li class="no-clickonce">
                         <i class="ms-Icon ms-Icon--OpenInNewWindow" aria-hidden="true"></i>
                         <a href="@Url.ExplorerDeepLink(2, Model.Id, Model.Version)" title="Explore the nupkg with the NuGet Package Explorer (IE only)" rel="nofollow">Open in Package Explorer</a>

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -226,7 +226,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task CreateSymbolPackage_WillReturn400IfFileIsNotANuGetPackage()
+            public async Task CreateSymbolPackage_WillReturn400IfFileIsNotANuGetPackageInternal()
             {
                 // Arrange
                 var user = new User() { EmailAddress = "confirmed@email.com" };
@@ -627,7 +627,7 @@ namespace NuGetGallery
             }
 
             [Fact]
-            public async Task CreatePackageWillReturn400IfFileIsNotANuGetPackage()
+            public async Task CreatePackageWillReturn400IfFileIsNotANuGetPackageInternal()
             {
                 // Arrange
                 var user = new User() { EmailAddress = "confirmed@email.com" };
@@ -1413,7 +1413,7 @@ namespace NuGetGallery
             public async Task GetPackageReturns400ForEvilPackageName()
             {
                 var controller = new TestableApiController(GetConfigurationService());
-                var result = await controller.GetPackage("../..", "1.0.0.0");
+                var result = await controller.GetPackageInternal("../..", "1.0.0.0");
                 var badRequestResult = (HttpStatusCodeWithBodyResult)result;
                 Assert.Equal(400, badRequestResult.StatusCode);
             }
@@ -1422,7 +1422,7 @@ namespace NuGetGallery
             public async Task GetPackageReturns400ForEvilPackageVersion()
             {
                 var controller = new TestableApiController(GetConfigurationService());
-                var result2 = await controller.GetPackage("Foo", "10../..1.0");
+                var result2 = await controller.GetPackageInternal("Foo", "10../..1.0");
                 var badRequestResult2 = (HttpStatusCodeWithBodyResult)result2;
                 Assert.Equal(400, badRequestResult2.StatusCode);
             }
@@ -1444,7 +1444,7 @@ namespace NuGetGallery
                               .Verifiable();
 
                 // Act
-                var result = await controller.GetPackage(packageId, packageVersion);
+                var result = await controller.GetPackageInternal(packageId, packageVersion);
 
                 // Assert
                 Assert.IsType<RedirectResult>(result); // all we want to check is that we're redirecting to storage
@@ -1482,7 +1482,7 @@ namespace NuGetGallery
                 controller.ControllerContext = controllerContext;
 
                 // Act
-                var result = await controller.GetPackage(packageId, "1.0.01");
+                var result = await controller.GetPackageInternal(packageId, "1.0.01");
 
                 // Assert
                 Assert.Same(actionResult, result);
@@ -1518,7 +1518,7 @@ namespace NuGetGallery
                 controller.ControllerContext = controllerContext;
 
                 // Act
-                var result = await controller.GetPackage("Baz", "1.0.0");
+                var result = await controller.GetPackageInternal("Baz", "1.0.0");
 
                 // Assert
                 Assert.Same(actionResult, result);
@@ -1558,7 +1558,7 @@ namespace NuGetGallery
                 controller.ControllerContext = controllerContext;
 
                 // Act
-                var result = await controller.GetPackage(packageId, "");
+                var result = await controller.GetPackageInternal(packageId, "");
 
                 // Assert
                 Assert.Same(actionResult, result);
@@ -1597,7 +1597,7 @@ namespace NuGetGallery
                 controller.ControllerContext = controllerContext;
 
                 // Act
-                var result = await controller.GetPackage("Baz", "");
+                var result = await controller.GetPackageInternal("Baz", "");
 
                 // Assert
                 ResultAssert.IsStatusCode(result, HttpStatusCode.ServiceUnavailable, Strings.DatabaseUnavailable_TrySpecificVersion);

--- a/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
@@ -119,6 +119,17 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public async Task WillSetTheResultContentTypeForTheSymbolPackagesFolder()
+            {
+                var service = CreateService();
+
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.SymbolPackagesFolderName, "theFileName") as FilePathResult;
+
+                Assert.NotNull(result);
+                Assert.Equal(CoreConstants.PackageContentType, result.ContentType);
+            }
+
+            [Fact]
             public async Task WillSetTheResultDownloadFilePath()
             {
                 var service = CreateService();


### PR DESCRIPTION
This PR adds support to download the snupkg from the package details page.

Addresses #5978  and #5970, also added tests.

The idea is to allow downloading a snupkg if the latest uploaded snupkg is "Available". If there is a newer uploaded snupkg that failed validations or still validating, no download allowed. This is taken care of in the download API and in the package details page view.

![image](https://user-images.githubusercontent.com/1646506/44238415-803e3a80-a169-11e8-918c-edda6157f86e.png)
