### PR TITLE
Update bootstrap dependencies

### DIFF
--- a/src/Bootstrap/package-lock.json
+++ b/src/Bootstrap/package-lock.json
@@ -375,6 +375,14 @@
       "dev": true,
       "requires": {
         "hoek": "2.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -673,6 +681,17 @@
         "finalhandler": "1.0.3",
         "parseurl": "~1.3.1",
         "utils-merge": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "connect-livereload": {
@@ -875,10 +894,9 @@
       }
     },
     "debug": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-      "dev": true,
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1242,6 +1260,17 @@
         "parseurl": "~1.3.1",
         "statuses": "~1.3.1",
         "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "find-up": {
@@ -1969,6 +1998,14 @@
         "cryptiles": "2.x.x",
         "hoek": "2.x.x",
         "sntp": "1.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "he": {
@@ -1988,10 +2025,9 @@
       }
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hooker": {
       "version": "0.2.3",
@@ -2883,8 +2919,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multimatch": {
       "version": "2.1.0",
@@ -3909,6 +3944,15 @@
         "statuses": "~1.3.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "fresh": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
@@ -4026,6 +4070,14 @@
       "dev": true,
       "requires": {
         "hoek": "2.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
       }
     },
     "source-map": {

--- a/src/Bootstrap/package.json
+++ b/src/Bootstrap/package.json
@@ -87,7 +87,9 @@
     ]
   },
   "dependencies": {
+    "debug": "^2.6.9",
     "fresh": "^0.5.2",
+    "hoek": "^4.2.1",
     "mime": "^1.4.1",
     "no-case": "^2.3.2",
     "tough-cookie": "^2.3.3"


### PR DESCRIPTION
Recommended updates, per https://github.com/NuGet/NuGetGallery/network/dependencies

- debug, 2.6.9 (recommend >= 2.6.9)
- hoek, 4.2.1. (recommend >= 4.2.1)

Applied updates with the following commands, from .\src\Bootstrap (npm version 6.2.0). Note that there were no changes to the generated files under .\dist

```
npm install debug@2.6.9
npm install hoek@4.2.1
rm .\dist\css\*
rm .\dist\js\*.js
grunt
```

Addresses https://github.com/NuGet/Engineering/issues/1634