### PR TITLE
Add member/add owner/transform to org fails with specific message if email is input instead of username

### DIFF
--- a/src/NuGetGallery/Constants.cs
+++ b/src/NuGetGallery/Constants.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Versioning;
+using System;
 
 namespace NuGetGallery
 {
@@ -69,6 +70,7 @@ namespace NuGetGallery
         internal const string EmailValidationRegexFirstPart = @"[-A-Za-z0-9!#$%&'*+\/=?^_`{|}~\.]+";
         internal const string EmailValidationRegexSecondPart = @"[A-Za-z0-9]+[\w\.-]*[A-Za-z0-9]*\.[A-Za-z0-9][A-Za-z\.]*[A-Za-z]";
         public const string EmailValidationRegex = "^" + EmailValidationRegexFirstPart + "@" + EmailValidationRegexSecondPart + "$";
+        public static TimeSpan EmailValidationRegexTimeout = TimeSpan.FromSeconds(5);
 
         public const string EmailValidationErrorMessage = "This doesn't appear to be a valid email address.";
 

--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
@@ -108,8 +109,12 @@ namespace NuGetGallery
         [ValidateAntiForgeryToken]
         public async Task<JsonResult> AddPackageOwner(string id, string username, string message)
         {
-            ManagePackageOwnerModel model;
-            if (TryGetManagePackageOwnerModel(id, username, isAddOwner: true, model: out model))
+            if (Regex.IsMatch(username, Constants.EmailValidationRegex, RegexOptions.None, Constants.EmailValidationRegexTimeout))
+            {
+                return Json(new { success = false, message = Strings.AddOwner_NameIsEmail }, JsonRequestBehavior.AllowGet);
+            }
+
+            if (TryGetManagePackageOwnerModel(id, username, isAddOwner: true, model: out var model))
             {
                 var packageUrl = Url.Package(model.Package.Id, version: null, relativeUrl: false);
 

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using NuGetGallery.Areas.Admin;
@@ -137,11 +138,18 @@ namespace NuGetGallery
         {
             var accountToTransform = GetCurrentUser();
 
-            var adminUser = UserService.FindByUsername(transformViewModel.AdminUsername);
+            var adminUsername = transformViewModel.AdminUsername;
+            if (Regex.IsMatch(adminUsername, Constants.EmailValidationRegex, RegexOptions.None, Constants.EmailValidationRegexTimeout))
+            {
+                ModelState.AddModelError(string.Empty, Strings.TransformAccount_AdminNameIsEmail);
+                return View(transformViewModel);
+            }
+
+            var adminUser = UserService.FindByUsername(adminUsername);
             if (adminUser == null)
             {
-                ModelState.AddModelError(string.Empty, String.Format(CultureInfo.CurrentCulture,
-                    Strings.TransformAccount_AdminAccountDoesNotExist, transformViewModel.AdminUsername));
+                ModelState.AddModelError(string.Empty, string.Format(CultureInfo.CurrentCulture,
+                    Strings.TransformAccount_AdminAccountDoesNotExist, adminUsername));
                 return View(transformViewModel);
             }
 

--- a/src/NuGetGallery/Services/UserService.cs
+++ b/src/NuGetGallery/Services/UserService.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Data.Entity;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using NuGetGallery.Auditing;
 using NuGetGallery.Configuration;
@@ -85,6 +86,11 @@ namespace NuGetGallery
                 request.IsAdmin = isAdmin || request.IsAdmin;
                 await EntitiesContext.SaveChangesAsync();
                 return request;
+            }
+
+            if (Regex.IsMatch(memberName, Constants.EmailValidationRegex, RegexOptions.None, Constants.EmailValidationRegexTimeout))
+            {
+                throw new EntityException(Strings.AddMember_NameIsEmail);
             }
 
             var member = FindByUsername(memberName);

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -152,6 +152,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You cannot add a member by their email address. Please enter their username instead..
+        /// </summary>
+        public static string AddMember_NameIsEmail {
+            get {
+                return ResourceManager.GetString("AddMember_NameIsEmail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You cannot accept this request because you no longer meet the requirements of this organization. {0} Please contact support for more details..
         /// </summary>
         public static string AddMember_PolicyFailure {
@@ -220,6 +229,15 @@ namespace NuGetGallery {
         public static string AddOwner_CurrentUserNotFound {
             get {
                 return ResourceManager.GetString("AddOwner_CurrentUserNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You cannot add an owner by their emaill address. Please enter their username instead..
+        /// </summary>
+        public static string AddOwner_NameIsEmail {
+            get {
+                return ResourceManager.GetString("AddOwner_NameIsEmail", resourceCulture);
             }
         }
         
@@ -1982,6 +2000,15 @@ namespace NuGetGallery {
         public static string TransformAccount_AdminMustBeDifferentAccount {
             get {
                 return ResourceManager.GetString("TransformAccount_AdminMustBeDifferentAccount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You cannot choose an administrator by their email address. Please enter their username instead..
+        /// </summary>
+        public static string TransformAccount_AdminNameIsEmail {
+            get {
+                return ResourceManager.GetString("TransformAccount_AdminNameIsEmail", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -152,7 +152,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You cannot add a member by their email address. Please enter their username instead..
+        ///   Looks up a localized string similar to You must add a member by username, not an email address..
         /// </summary>
         public static string AddMember_NameIsEmail {
             get {
@@ -233,7 +233,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You cannot add an owner by their emaill address. Please enter their username instead..
+        ///   Looks up a localized string similar to You must add an owner by username, not an email address..
         /// </summary>
         public static string AddOwner_NameIsEmail {
             get {
@@ -2004,7 +2004,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You cannot choose an administrator by their email address. Please enter their username instead..
+        ///   Looks up a localized string similar to You must choose an administrator by username, not an email address..
         /// </summary>
         public static string TransformAccount_AdminNameIsEmail {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -971,4 +971,13 @@ Policy violations: {0}</value>
   <data name="SymbolsPackage_PackageNotAvailable" xml:space="preserve">
     <value>No available symbols package found for ID {0} and version {1}.</value>
   </data>
+  <data name="AddMember_NameIsEmail" xml:space="preserve">
+    <value>You cannot add a member by their email address. Please enter their username instead.</value>
+  </data>
+  <data name="AddOwner_NameIsEmail" xml:space="preserve">
+    <value>You cannot add an owner by their emaill address. Please enter their username instead.</value>
+  </data>
+  <data name="TransformAccount_AdminNameIsEmail" xml:space="preserve">
+    <value>You cannot choose an administrator by their email address. Please enter their username instead.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -972,12 +972,12 @@ Policy violations: {0}</value>
     <value>No available symbols package found for ID {0} and version {1}.</value>
   </data>
   <data name="AddMember_NameIsEmail" xml:space="preserve">
-    <value>You cannot add a member by their email address. Please enter their username instead.</value>
+    <value>You must add a member by username, not an email address.</value>
   </data>
   <data name="AddOwner_NameIsEmail" xml:space="preserve">
-    <value>You cannot add an owner by their emaill address. Please enter their username instead.</value>
+    <value>You must add an owner by username, not an email address.</value>
   </data>
   <data name="TransformAccount_AdminNameIsEmail" xml:space="preserve">
-    <value>You cannot choose an administrator by their email address. Please enter their username instead.</value>
+    <value>You must choose an administrator by username, not an email address.</value>
   </data>
 </root>

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -2463,6 +2463,50 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public async Task WhenAdminUsernameIsEmail_ShowsError()
+            {
+                // Arrange
+                var accountToTransform = "account";
+                var controller = CreateController(accountToTransform);
+
+                // Act
+                var result = await controller.TransformToOrganization(new TransformAccountViewModel()
+                {
+                    AdminUsername = "notAUsername@email.com"
+                });
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Single(controller.ModelState[string.Empty].Errors);
+                Assert.Equal(
+                    Strings.TransformAccount_AdminNameIsEmail,
+                    controller.ModelState[string.Empty].Errors.First().ErrorMessage);
+
+                GetMock<IMessageService>()
+                    .Verify(m =>
+                        m.SendOrganizationTransformRequestAsync(
+                            It.IsAny<User>(),
+                            It.IsAny<User>(),
+                            It.IsAny<string>(),
+                            It.IsAny<string>(),
+                            It.IsAny<string>()),
+                        Times.Never());
+
+                GetMock<IMessageService>()
+                    .Verify(m =>
+                        m.SendOrganizationTransformInitiatedNoticeAsync(
+                            It.IsAny<User>(),
+                            It.IsAny<User>(),
+                            It.IsAny<string>()),
+                        Times.Never());
+
+                GetMock<ITelemetryService>()
+                    .Verify(
+                        t => t.TrackOrganizationTransformInitiated(It.IsAny<User>()),
+                        Times.Never());
+            }
+
+            [Fact]
             public async Task WhenAdminIsNotFound_ShowsError()
             {
                 // Arrange

--- a/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
@@ -196,6 +196,30 @@ namespace NuGetGallery
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
+            public async Task WhenMemberNameIsEmail_ThrowEntityException(bool isAdmin)
+            {
+                // Arrange
+                var fakes = new Fakes();
+                var service = new TestableUserService();
+                service.MockUserRepository.Setup(r => r.GetAll())
+                    .Returns(new[] {
+                        fakes.Organization
+                    }.AsQueryable());
+
+                // Act
+                var e = await Assert.ThrowsAsync<EntityException>(async () =>
+                {
+                    await service.AddMembershipRequestAsync(fakes.Organization, "notAUser@email.com", isAdmin);
+                });
+
+                Assert.Equal(Strings.AddMember_NameIsEmail, e.Message);
+
+                service.MockEntitiesContext.Verify(c => c.SaveChangesAsync(), Times.Never);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
             public async Task WhenMemberNotFound_ThrowEntityException(bool isAdmin)
             {
                 // Arrange


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6133

For add member/add owner/transform to org, if an email address is input instead of a username, fail with a specific message telling the user to type in a username instead of "account not found".