### PR TITLE
Use strong name version of third party dependencies

### DIFF
--- a/src/NuGet.Services.Search.Client/Client/SearchClient.cs
+++ b/src/NuGet.Services.Search.Client/Client/SearchClient.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using NuGet.Services.Client;
 using NuGet.Services.Search.Models;
 
 namespace NuGet.Services.Search.Client

--- a/src/NuGet.Services.Search.Client/Client/ServiceResponse.cs
+++ b/src/NuGet.Services.Search.Client/Client/ServiceResponse.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Search.Client
+{
+    public class ServiceResponse<T>
+    {
+        private readonly Func<Task<T>> _reader;
+
+        public ServiceResponse(HttpResponseMessage httpResponse)
+            : this(httpResponse, () => httpResponse.Content.ReadAsAsync<T>())
+        {
+        }
+
+        public ServiceResponse(HttpResponseMessage httpResponse, Func<Task<T>> reader)
+        {
+            HttpResponse = httpResponse ?? throw new ArgumentNullException(nameof(httpResponse));
+            _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        }
+
+        public HttpResponseMessage HttpResponse { get; }
+        public HttpStatusCode StatusCode => HttpResponse.StatusCode;
+        public bool IsSuccessStatusCode => HttpResponse.IsSuccessStatusCode;
+
+        public Task<T> ReadContent()
+        {
+            return _reader();
+        }
+    }
+}

--- a/src/NuGet.Services.Search.Client/NuGet.Services.Search.Client.csproj
+++ b/src/NuGet.Services.Search.Client/NuGet.Services.Search.Client.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Client\SearchClient.cs" />
     <Compile Include="Client\ServiceDiscovery.cs" />
     <Compile Include="Client\ServiceDiscoveryClient.cs" />
+    <Compile Include="Client\ServiceResponse.cs" />
     <Compile Include="Client\ThreadSafeRandom.cs" />
     <Compile Include="Correlation\CorrelatingHttpClientHandler.cs" />
     <Compile Include="Correlation\WebApiCorrelationHandler.cs" />
@@ -77,9 +78,6 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Platform.Client">
-      <Version>3.0.29-r-master</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1977,7 +1977,7 @@
     <PackageReference Include="d3">
       <Version>5.4.0</Version>
     </PackageReference>
-    <PackageReference Include="DynamicData.EFCodeFirstProvider">
+    <PackageReference Include="DynamicData.EFCodeFirstProvider.StrongName">
       <Version>0.3.0</Version>
     </PackageReference>
     <PackageReference Include="elmah.corelibrary.strongname">
@@ -2061,7 +2061,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Core">
       <Version>5.2.3</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNet.WebApi.MessageHandlers.Compression">
+    <PackageReference Include="Microsoft.AspNet.WebApi.MessageHandlers.Compression.StrongName">
       <Version>1.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.OData">
@@ -2190,13 +2190,13 @@
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>
     </PackageReference>
-    <PackageReference Include="QueryInterceptor">
+    <PackageReference Include="QueryInterceptor.StrongName">
       <Version>0.1.4237.2400</Version>
     </PackageReference>
     <PackageReference Include="RouteMagic">
       <Version>1.1.3</Version>
     </PackageReference>
-    <PackageReference Include="Strathweb.CacheOutput.WebApi2">
+    <PackageReference Include="Strathweb.CacheOutput.WebApi2.StrongName">
       <Version>0.9.0</Version>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.Debug">
@@ -2211,14 +2211,17 @@
     <PackageReference Include="System.Net.Http">
       <Version>4.3.1</Version>
     </PackageReference>
+    <PackageReference Include="WebActivator.StrongName">
+      <Version>1.4.4</Version>
+    </PackageReference>
     <PackageReference Include="WebActivatorEx">
       <Version>2.0.6</Version>
     </PackageReference>
-    <PackageReference Include="WebBackgrounder">
-      <Version>0.2.0</Version>
-    </PackageReference>
-    <PackageReference Include="WebBackgrounder.EntityFramework">
+    <PackageReference Include="WebBackgrounder.EntityFramework.StrongName">
       <Version>0.1.0</Version>
+    </PackageReference>
+    <PackageReference Include="WebBackgrounder.StrongName">
+      <Version>0.2.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Caching">
       <Version>1.7.0</Version>


### PR DESCRIPTION
I've created a strong name version of all dependencies that are not already strong named. These packages are on `nuget-build`. The same SNK was used for all of these packages and is stored in our KeyVault.

This is the same process taken over a year ago to enable strong naming on NuGetGallery.Core, with:

- elmah.corelibrary.strongname
- elmah.sqlserver.strongname
- elmah.strongname

Progress on https://github.com/NuGet/Engineering/issues/1577.