### PR TITLE
Symbol-packages cache control

### DIFF
--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -569,12 +569,12 @@ namespace NuGetGallery
             switch (folderName)
             {
                 case CoreConstants.PackagesFolderName:
+                case CoreConstants.SymbolPackagesFolderName:
                     return CoreConstants.DefaultCacheControl;
 
                 case CoreConstants.PackageBackupsFolderName:
                 case CoreConstants.UploadsFolderName:
                 case CoreConstants.ValidationFolderName:
-                case CoreConstants.SymbolPackagesFolderName:
                 case CoreConstants.SymbolPackageBackupsFolderName:
                 case CoreConstants.DownloadsFolderName:
                 case CoreConstants.PackageReadMesFolderName:

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -53,6 +53,7 @@ namespace NuGetGallery
                     new object[] { CoreConstants.PackageBackupsFolderName, true, CoreConstants.PackageContentType },
                     new object[] { CoreConstants.PackageReadMesFolderName, false, CoreConstants.TextContentType },
                     new object[] { CoreConstants.PackagesFolderName, true, CoreConstants.PackageContentType },
+                    new object[] { CoreConstants.SymbolPackagesFolderName, true, CoreConstants.PackageContentType },
                     new object[] { CoreConstants.UploadsFolderName, false, CoreConstants.PackageContentType },
                     new object[] { CoreConstants.UserCertificatesFolderName, false, CoreConstants.CertificateContentType },
                     new object[] { CoreConstants.ValidationFolderName, false, CoreConstants.PackageContentType }
@@ -535,7 +536,7 @@ namespace NuGetGallery
 
                 fakeBlob.Verify();
 
-                if (folderName == CoreConstants.PackagesFolderName)
+                if (folderName == CoreConstants.PackagesFolderName || folderName == CoreConstants.SymbolPackagesFolderName)
                 {
                     Assert.Equal(CoreConstants.DefaultCacheControl, fakeBlob.Object.Properties.CacheControl);
                 }


### PR DESCRIPTION
Set the same max-age for the symbol packages blobs as for the packages.