### PR TITLE
Accessibility - Fix nav roles

### DIFF
--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -73,7 +73,7 @@
                              @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/logo-header-94x29.png")) />
                     </a>
                 </div>
-                <div id="navbar" class="navbar-collapse collapse" role="menubar">
+                <div id="navbar" class="navbar-collapse collapse">
                     <ul class="nav navbar-nav" role="tablist">
                         @DisplayNavigationItem("Packages", Url.PackageList())
                         @DisplayNavigationItem("Upload", Url.UploadPackage())


### PR DESCRIPTION
JAWS has a bug where they do not read our nav bar's tabs correctly.

After more analysis, it appears that we are using roles incorrectly, and we can avoid the bug by fixing our usage of roles.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/643637