### PR TITLE
Change button redirect

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1168,10 +1168,10 @@ namespace NuGetGallery
         [HttpPost]
         [RequiresAccountConfirmation("unlist a package")]
         [ValidateAntiForgeryToken]
-        public virtual async Task<ActionResult> UpdateListed(string id, string version, bool? listed)
+        public virtual async Task<ActionResult> UpdateListed(string id, string version, bool? listed, string returnUrl)
         {
             // Edit does exactly the same thing that Delete used to do... REUSE ALL THE CODE!
-            return await Edit(id, version, listed, Url.Package);
+            return await Edit(id, version, listed, (Package package, bool relativeUrl) => { if (returnUrl != null) { return returnUrl; } return Url.Package(package, relativeUrl); });
         }
 
         [HttpGet]
@@ -1618,7 +1618,7 @@ namespace NuGetGallery
 
                         return Json(HttpStatusCode.BadRequest, new[] { ex.Message });
                     }
-                                       
+
                     var packagePolicyResult = await _securityPolicyService.EvaluatePackagePoliciesAsync(
                                     SecurityPolicyAction.PackagePush,
                                     package,

--- a/src/NuGetGallery/UrlExtensions.cs
+++ b/src/NuGetGallery/UrlExtensions.cs
@@ -1385,6 +1385,19 @@ namespace NuGetGallery
             return url.HandleTransformAccount("RejectTransform", accountToTransformUsername, confirmationToken, relativeUrl);
         }
 
+        public static string Referrer(this UrlHelper url, string fallbackUrl)
+        {
+            try
+            {
+                if (url.RequestContext.HttpContext.Request.Url.Host == url.RequestContext.HttpContext.Request.UrlReferrer.Host)
+                {
+                    return url.RequestContext.HttpContext.Request.UrlReferrer.AbsolutePath;
+                }
+            }
+            catch { }
+            return fallbackUrl;
+        }
+
         private static string HandleTransformAccount(this UrlHelper url, string routeName, string accountToTransformUsername, string confirmationToken, bool relativeUrl = true)
         {
             return GetActionLink(

--- a/src/NuGetGallery/Views/Packages/Delete.cshtml
+++ b/src/NuGetGallery/Views/Packages/Delete.cshtml
@@ -84,6 +84,7 @@
                         {
                             @Html.AntiForgeryToken()
                             @Html.Hidden("version", @Model.Version)
+                            @Html.Hidden("returnUrl", @Url.Referrer(Url.Package(Model.Id, Model.Version)))
                             <div class="form-group @Html.HasErrorFor(package => package.Listed)">
                                 @Html.ShowCheckboxFor(package => package.Listed)
                                 @Html.ShowLabelFor(package => package.Listed, "List " + Model.Id + " " + Model.Version + " in search results.")

--- a/src/NuGetGallery/Views/Packages/Edit.cshtml
+++ b/src/NuGetGallery/Views/Packages/Edit.cshtml
@@ -97,7 +97,7 @@
             EditReadmeManager.init(
                 realModel,
                 '@Url.EditPackage(Model.PackageId, Model.Version)',
-                '@Url.Package(Model.PackageId, Model.Version)');
+                '@Url.Referrer(Url.Package(Model.PackageId, Model.Version))');
 
             if (document.referrer != null
                 && document.referrer.toLocaleLowerCase().endsWith("edit")


### PR DESCRIPTION
#2854 

- Edit page "Cancel" buttons redirect to previous page. "Submit" on the page still redirects to package detail page.(We can change submit button to redirect back to previous page. But do we want this? With current flow user has opportunity to see final result.)
- Delete page "Save" button redirect to previous page.