### PR TITLE
Add tool to verify the clear-text of an API key

### DIFF
--- a/src/GalleryTools/Commands/VerifyApiKeyCommand.cs
+++ b/src/GalleryTools/Commands/VerifyApiKeyCommand.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGetGallery;
+using NuGetGallery.Infrastructure.Authentication;
+
+namespace GalleryTools.Commands
+{
+    public static class VerifyApiKeyCommand
+    {
+        public static void Configure(CommandLineApplication config)
+        {
+            config.Description = "Verify a clear text API key matches a hashed API key.";
+            config.HelpOption("-? | -h | --help");
+
+            var plainTextOption = config.Option(
+                "--clear-text",
+                "The clear text value of the API key.",
+                CommandOptionType.SingleValue);
+
+            var credentialTypesOption = config.Option(
+                "--type",
+                "One or more credential types.",
+                CommandOptionType.MultipleValue);
+
+            var credentialValuesOption = config.Option(
+                "--value",
+                "One or more credential values.",
+                CommandOptionType.MultipleValue);
+
+            config.OnExecute(() => Execute(
+                plainTextOption,
+                credentialTypesOption,
+                credentialValuesOption));
+        }
+
+        private static int Execute(
+            CommandOption clearTextOption,
+            CommandOption credentialTypesOption,
+            CommandOption credentialValuesOption)
+        {
+            if (!clearTextOption.HasValue())
+            {
+                Console.Error.WriteLine($"The {clearTextOption.Template} option is required.");
+                return 1;
+            }
+
+            if (!credentialTypesOption.HasValue())
+            {
+                Console.Error.WriteLine($"The {credentialTypesOption.Template} option is required.");
+                return 1;
+            }
+
+            if (!credentialValuesOption.HasValue())
+            {
+                Console.Error.WriteLine($"The {credentialValuesOption.Template} option is required.");
+                return 1;
+            }
+
+            if (credentialTypesOption.Values.Count != credentialValuesOption.Values.Count)
+            {
+                Console.Error.WriteLine($"The should be the same number of {credentialTypesOption.Template} options as {credentialValuesOption.Template} options.");
+                return 1;
+            }
+
+            var credentialValidator = new CredentialValidator();
+
+            Console.WriteLine($"Testing {credentialTypesOption.Values.Count} API key(s).");
+
+            for (var i = 0; i < credentialTypesOption.Values.Count; i++)
+            {
+                var credential = new Credential
+                {
+                    Type = credentialTypesOption.Values[i],
+                    Value = credentialValuesOption.Values[i],
+                };
+
+                var validCredentials = credentialValidator.GetValidCredentialsForApiKey(
+                    new[] { credential }.AsQueryable(),
+                    clearTextOption.Value());
+
+                Console.WriteLine();
+                Console.WriteLine($"API key {i + 1}:");
+                Console.WriteLine($"  Type:    {credential.Type}");
+                Console.WriteLine($"  Value:   {credential.Value}");
+                Console.WriteLine($"  Matches: {validCredentials.Any().ToString().ToUpperInvariant()}");
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/GalleryTools/GalleryTools.csproj
+++ b/src/GalleryTools/GalleryTools.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Commands\BackfillRepositoryMetadataCommand.cs" />
     <Compile Include="Commands\HashCommand.cs" />
     <Compile Include="Commands\ReflowCommand.cs" />
+    <Compile Include="Commands\VerifyApiKeyCommand.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/GalleryTools/Program.cs
+++ b/src/GalleryTools/Program.cs
@@ -17,6 +17,7 @@ namespace GalleryTools
             commandLineApplication.Command("hash", HashCommand.Configure);
             commandLineApplication.Command("reflow", ReflowCommand.Configure);
             commandLineApplication.Command("fillrepodata", BackfillRepositoryMetadataCommand.Configure);
+            commandLineApplication.Command("verifyapikey", VerifyApiKeyCommand.Configure);
 
             try
             {


### PR DESCRIPTION
I had a support request where I had to verify the identity of a nuget.org account with a lost email. Part of this verification process was comparing an expired API key against what we have in the database.

I wrote this tool to support this.