### PR TITLE
Fix inconsistent messaging around expired legacy API key

### DIFF
--- a/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
@@ -59,7 +59,7 @@
                 @ReadMePanel(
                     @<div class="form-group editable">
                         <input type="url" data-bind="value: Edit.ReadMe.SourceUrl" name="Edit.ReadMe.SourceUrl" class="form-control" id="ReadMeUrlInput"
-                               placeholder="https://raw.githubusercontent.com/*.md" aria-label="Enter documentation.md url" />
+                               placeholder="https://raw.githubusercontent.com/*.md" aria-label="Enter documentation.md URL" />
                         <label id="ReadMeURLLabel" class="input-group-btn"></label>
                     </div>,        
                    "readme-url", active: false)

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -125,16 +125,24 @@
                 <ul class="list-inline icon-details" role="presentation">
                     <li>
                         <i class="ms-Icon ms-Icon--Stopwatch" aria-hidden="true"></i>
-                        <!-- ko if: Expires -->
                         <!-- ko if: HasExpired -->
                         Expired
                         <!-- /ko -->
                         <!-- ko ifnot: HasExpired -->
+                        <!-- ko if: Expires -->
                         Expires <span data-bind="text: moment(Expires()).fromNow()"></span>
-                        <!-- /ko -->
                         <!-- /ko -->
                         <!-- ko ifnot: Expires -->
                         Never expires
+                        @if (Config.Current.ExpirationInDaysForApiKeyV1 > 0)
+                        {
+                            <text>
+                            (<a href="https://aka.ms/nugetlegacyapikeys">if used every
+                            @Config.Current.ExpirationInDaysForApiKeyV1
+                            day@(Config.Current.ExpirationInDaysForApiKeyV1 != 1 ? "s" : string.Empty)</a>)
+                            </text>
+                        }
+                        <!-- /ko -->
                         <!-- /ko -->
                     </li>
                     <li>

--- a/src/NuGetGallery/Views/Users/PasswordSent.cshtml
+++ b/src/NuGetGallery/Views/Users/PasswordSent.cshtml
@@ -9,7 +9,7 @@
         <h1>Password Reset Sent</h1>
 
         <p>
-            We've sent you an email containing a temporary url that will allow you to reset your NuGet.org
+            We've sent you an email containing a temporary URL that will allow you to reset your NuGet.org
             account password for the next @if (@ViewBag.Expiration == 1)
             {
                 <text>hour.</text>


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6318. This problem happens when the legacy API key was used more than 365 days ago but has not been used for an API call. This leads to the `HasExpired` boolean to be `true` but the `Expires` nullable `DateTime` to be null. The product code sets `HasExpired` but leaves `Expires` as null since this is set to `DateTime.UtcNow` at API call time.

The server side code is here:
https://github.com/NuGet/NuGetGallery/blob/1b9875706fb5fda0313de0e7c235603946ef3856/src/NuGetGallery/Authentication/AuthenticationService.cs#L591-L593

Also, fix some cases where we say "url" instead of "URL", because it bothered me.

# Expired

![image](https://user-images.githubusercontent.com/94054/45110293-b7fc2a80-b0f6-11e8-942d-f3a8d000e818.png)

# Not yet expired

![image](https://user-images.githubusercontent.com/94054/45110325-ca766400-b0f6-11e8-8199-2b4396e5a8be.png)

# Related

The aka.ms link in the PR goes here:
https://blog.nuget.org/20170202/introducing-scoped-api-keys.html#faqs

Eventually, this should go to a docs page. This work is non-blocking and is tracked here:
https://github.com/NuGet/docs.microsoft.com-nuget/issues/1050