### PR TITLE
Add BlockSearchEngineIndexing to allow site-wide search engine indexing

### DIFF
--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -342,5 +342,7 @@ namespace NuGetGallery.Configuration
         public bool RejectSignedPackagesWithNoRegisteredCertificate { get; set; }
 
         public bool RejectPackagesWithTooManyPackageEntries { get; set; }
+
+        public bool BlockSearchEngineIndexing { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -344,5 +344,10 @@ namespace NuGetGallery.Configuration
         /// Whether or not to synchronously reject packages on push/upload that have too many package entries.
         /// </summary>
         bool RejectPackagesWithTooManyPackageEntries { get; set; }
+
+        /// <summary>
+        /// Whether or not to block search engines from indexing the web pages using the "noindex" meta tag.
+        /// </summary>
+        bool BlockSearchEngineIndexing { get; set; }
     }
 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -5,6 +5,7 @@
 @{
     ViewBag.Title = Model.Id + " " + Model.Version;
     ViewBag.Tab = "Packages";
+    ViewBag.BlockSearchEngineIndexing = !Model.Listed || !Model.Available;
 
     var absolutePackageUrl = Url.Absolute(Url.Package(Model.Id));
 
@@ -73,12 +74,6 @@
     <meta property="og:description" content="@Model.Description" />
     <meta property="og:determiner" content="a" />
     <meta property="og:image" content="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png"))" />
-}
-@section Meta {
-    @if (!Model.Listed || !Model.Available)
-    {
-        <meta name="robots" content="noindex">
-    }
 }
 
 @helper VersionListDivider(int rowCount, bool versionsExpanded)

--- a/src/NuGetGallery/Views/Shared/Gallery/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Layout.cshtml
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    @if (Config.Current.BlockSearchEngineIndexing || ViewBag.BlockSearchEngineIndexing == true)
+    {
+        <meta name="robots" content="noindex">
+    }
     @RenderSection("SocialMeta", required: false)
     @RenderSection("Meta", required: false)
 

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -147,6 +147,7 @@
     <add key="Gallery.EnforceDefaultSecurityPolicies" value="false"/>
     <add key="Gallery.RejectSignedPackagesWithNoRegisteredCertificate" value="false"/>
     <add key="Gallery.RejectPackagesWithTooManyPackageEntries" value="false"/>
+    <add key="Gallery.BlockSearchEngineIndexing" value="false"/>
     <!-- This is also the default so you can remove this setting if you really want. -->
     <!-- Set this to false if you want to disable search indexing in the background. -->
     <add key="Gallery.AutoUpdateSearchIndex" value="true"/>


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6381. I will set this to `true` on DEV and INT.

Setting `ViewBag.BlockSearchEngineIndexing` to `true` allows you block search engines _only_ when the site-wide configuration is `false`. There is currently no scenario where an individual page needs to be indexed but the site in general is not.