### PR TITLE
Hotfix: fix package delete through package details page

### DIFF
--- a/src/NuGetGallery/Views/Packages/Delete.cshtml
+++ b/src/NuGetGallery/Views/Packages/Delete.cshtml
@@ -122,7 +122,7 @@
                     {
                         foreach (var p in Model.DeletePackagesRequest.Packages)
                         {
-                            <input type="hidden" name="DeletePackagesRequest.Packages[]" value="@p" />
+                            <input type="hidden" name="Packages[]" value="@p" />
                         }
 
                         @Html.Partial("_DeletePackage", Model.DeletePackagesRequest)


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/commit/b1ba68e5d4a17d8c87b7686fbc6acd85f38185aa has a bug where if you try to delete a package through the package details page (id/version/delete) and not the admin flow, it fails.

Didn't catch this earlier because I forgot to verify on DEV/INT that the package page delete still worked in addition to verifying that the admin page delete worked.