### PR TITLE
[NuGet Symbol Server] Auditing - Gallery core changes

### DIFF
--- a/src/NuGetGallery.Core/Auditing/AuditedAuthenticatedOperationAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedAuthenticatedOperationAction.cs
@@ -28,6 +28,6 @@ namespace NuGetGallery.Auditing
         /// <summary>
         /// Symbol package push was attempted by a non-owner of the package
         /// </summary>
-        SymbolPackagePushAttemptByNonOwner
+        SymbolsPackagePushAttemptByNonOwner
     }
 }

--- a/src/NuGetGallery.Core/Auditing/AuditedAuthenticatedOperationAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedAuthenticatedOperationAction.cs
@@ -23,6 +23,11 @@ namespace NuGetGallery.Auditing
         /// <summary>
         /// Login failed, user is an organization and should not have credentials.
         /// </summary>
-        FailedLoginUserIsOrganization
+        FailedLoginUserIsOrganization,
+
+        /// <summary>
+        /// Symbol package push was attempted by a non-owner of the package
+        /// </summary>
+        SymbolPackagePushAttemptByNonOwner
     }
 }

--- a/src/NuGetGallery.Core/Auditing/AuditedPackageAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedPackageAction.cs
@@ -15,6 +15,8 @@ namespace NuGetGallery.Auditing
         Edit,
         [Obsolete("Undo package edit functionality is being retired.")]
         UndoEdit,
-        Verify
+        Verify,
+        SymbolCreate,
+        SymbolDelete
     }
 }

--- a/src/NuGetGallery.Core/Auditing/AuditedPackageAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedPackageAction.cs
@@ -16,7 +16,7 @@ namespace NuGetGallery.Auditing
         [Obsolete("Undo package edit functionality is being retired.")]
         UndoEdit,
         Verify,
-        SymbolCreate,
-        SymbolDelete
+        SymbolsCreate,
+        SymbolsDelete
     }
 }


### PR DESCRIPTION
Adding the needed enums with this PR, so that I can modify `Shims` which I can use in `NuGetGallery` project. 

I decided to keep auditing simple and simply reuse existing logic for auditing packages and authentication options, given that there isn't anything new needed for symbols package.