### PR TITLE
[NuGet Symbol Server] Gallery upload - Refactoring

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Infrastructure\ElmahException.cs" />
     <Compile Include="Infrastructure\TableErrorLog.cs" />
     <Compile Include="Authentication\NuGetClaims.cs" />
+    <Compile Include="PackageMetadataExtensions.cs" />
     <Compile Include="PackageReaderCoreExtensions.cs" />
     <Compile Include="PackageStatus.cs" />
     <Compile Include="Packaging\InvalidPackageException.cs" />

--- a/src/NuGetGallery.Core/PackageMetadataExtensions.cs
+++ b/src/NuGetGallery.Core/PackageMetadataExtensions.cs
@@ -15,6 +15,12 @@ namespace NuGetGallery
         private const string SymbolPackageTypeName = "SymbolsPackage";
         private static readonly ClientPackageType SymbolPackageType = new ClientPackageType(SymbolPackageTypeName, ClientPackageType.EmptyVersion);
 
+        /// <summary>
+        /// The package is a symbol package, if and only if it has metadata 
+        /// element of type <see cref="SymbolPackageTypeName"/> and only that element in package types.
+        /// </summary>
+        /// <param name="metadata"><see cref="PackageMetadata"/> for package</param>
+        /// <returns>True if the package is a symbols package</returns>
         public static bool IsSymbolPackage(this PackageMetadata metadata)
         {
             var packageTypes = metadata.GetPackageTypes();

--- a/src/NuGetGallery.Core/PackageMetadataExtensions.cs
+++ b/src/NuGetGallery.Core/PackageMetadataExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetGallery.Packaging;
+using System.Linq;
+using ClientPackageType = NuGet.Packaging.Core.PackageType;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Utilities extending PackageMetadata
+    /// </summary>
+    public static class PackageMetadataExtensions
+    {
+        private const string SymbolPackageTypeName = "SymbolsPackage";
+        private static readonly ClientPackageType SymbolPackageType = new ClientPackageType(SymbolPackageTypeName, ClientPackageType.EmptyVersion);
+
+        public static bool IsSymbolPackage(this PackageMetadata metadata)
+        {
+            var packageTypes = metadata.GetPackageTypes();
+            return packageTypes.Any()
+                && packageTypes.Count() == 1
+                && packageTypes.First() == SymbolPackageType;
+        }
+    }
+}

--- a/src/NuGetGallery.Core/StreamExtensions.cs
+++ b/src/NuGetGallery.Core/StreamExtensions.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace NuGetGallery
 {
@@ -23,27 +19,6 @@ namespace NuGetGallery
             stream.CopyTo(memoryStream);
             memoryStream.Position = 0;
             return memoryStream;
-        }
-
-        public static bool FoundEntryInFuture(this Stream stream, out ZipArchiveEntry entry)
-        {
-            entry = null;
-
-            using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
-            {
-                var reference = DateTime.UtcNow.AddDays(1); // allow "some" clock skew
-
-                var entryInTheFuture = archive.Entries.FirstOrDefault(
-                    e => e.LastWriteTime.UtcDateTime > reference);
-
-                if (entryInTheFuture != null)
-                {
-                    entry = entryInTheFuture;
-                    return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/src/NuGetGallery.Core/StreamExtensions.cs
+++ b/src/NuGetGallery.Core/StreamExtensions.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace NuGetGallery
@@ -20,6 +23,27 @@ namespace NuGetGallery
             stream.CopyTo(memoryStream);
             memoryStream.Position = 0;
             return memoryStream;
+        }
+
+        public static bool FoundEntryInFuture(this Stream stream, out ZipArchiveEntry entry)
+        {
+            entry = null;
+
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
+            {
+                var reference = DateTime.UtcNow.AddDays(1); // allow "some" clock skew
+
+                var entryInTheFuture = archive.Entries.FirstOrDefault(
+                    e => e.LastWriteTime.UtcDateTime > reference);
+
+                if (entryInTheFuture != null)
+                {
+                    entry = entryInTheFuture;
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -1039,7 +1039,7 @@ namespace NuGetGallery
                     httpStatusCode = HttpStatusCode.Unauthorized;
                     break;
                 default:
-                    throw new NotImplementedException($"The package validation result type {validationResult.Type} is not supported.");
+                    throw new NotImplementedException($"The symbol package validation result type {validationResult.Type} is not supported.");
             }
 
             return new HttpStatusCodeWithBodyResult(httpStatusCode, validationResult.Message);

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -398,12 +398,11 @@ namespace NuGetGallery
                     {
                         // Get the user
                         var currentUser = GetCurrentUser();
-                        var packageUploadOperationResult = await SymbolPackageUploadService.ValidateUploadedSymbolPackage(symbolPackageStream, currentUser);
-
+                        var packageUploadOperationResult = await SymbolPackageUploadService.ValidateUploadedSymbolsPackage(symbolPackageStream, currentUser);
                         if (!packageUploadOperationResult.OperationSucceeded)
                         {
                             return new HttpStatusCodeWithBodyResult(
-                                PackageUploadOperationResult.GetHttpStatusCode(packageUploadOperationResult.ResultCode),
+                                packageUploadOperationResult.GetHttpStatusCode(),
                                 packageUploadOperationResult.Message);
                         }
 
@@ -429,19 +428,19 @@ namespace NuGetGallery
                             return GetHttpResultFromFailedApiScopeEvaluationForPush(apiScopeEvaluationResult, id, package.NormalizedVersion);
                         }
 
-                        PackageUploadOperationResult commitResult = await SymbolPackageUploadService
+                        PackageUploadOperationResult uploadResult = await SymbolPackageUploadService
                             .CreateAndUploadSymbolsPackage(package, symbolPackageStream);
 
-                        switch (commitResult.ResultCode)
+                        switch (uploadResult.ResultCode)
                         {
                             case PackageUploadResult.Created:
                                 break;
                             case PackageUploadResult.Conflict:
                                 return new HttpStatusCodeWithBodyResult(
-                                    PackageUploadOperationResult.GetHttpStatusCode(commitResult.ResultCode),
-                                    commitResult.Message);
+                                    uploadResult.GetHttpStatusCode(),
+                                    uploadResult.Message);
                             default:
-                                throw new NotImplementedException($"The package upload operation result {commitResult.ResultCode} is not supported.");
+                                throw new NotImplementedException($"The symbols package upload operation result {uploadResult.ResultCode} is not supported.");
                         }
 
                         await AuditingService.SaveAuditRecordAsync(

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -1032,7 +1032,7 @@ namespace NuGetGallery
                 case SymbolPackageValidationResultType.MissingPackage:
                     httpStatusCode = HttpStatusCode.NotFound;
                     break;
-                case SymbolPackageValidationResultType.SymbolsPackageExists:
+                case SymbolPackageValidationResultType.SymbolsPackagePendingValidation:
                     httpStatusCode = HttpStatusCode.Conflict;
                     break;
                 case SymbolPackageValidationResultType.UserNotAllowedToUpload:

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -493,7 +493,7 @@ namespace NuGetGallery
                 {
                     try
                     {
-                        if (packageStream.FoundEntryInFuture(out ZipArchiveEntry entryInTheFuture))
+                        if (ZipArchiveHelpers.FoundEntryInFuture(packageStream, out ZipArchiveEntry entryInTheFuture))
                         {
                             return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, string.Format(
                                 CultureInfo.CurrentCulture,

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -290,25 +290,6 @@ namespace NuGetGallery
             }
         }
 
-        private JsonResult FailedToReadFile(Exception ex)
-        {
-            ex.Log();
-
-            var message = Strings.FailedToReadUploadFile;
-            if (ex is InvalidPackageException || ex is InvalidDataException || ex is EntityException)
-            {
-                message = ex.Message;
-            }
-
-            return Json(HttpStatusCode.BadRequest, new[] { message });
-        }
-
-        private async Task<JsonResult> UploadSymbolsPackageInternal(PackageArchiveReader packageArchiveReader, Stream uploadStream)
-        {
-            // Setup protocol with SymbolPackageUploadService to process symbol package.
-            return await Task.FromResult(new JsonResult());
-        }
-
         private async Task<JsonResult> UploadPackageInternal(PackageArchiveReader packageArchiveReader, Stream uploadStream, NuspecReader nuspec, PackageMetadata packageMetadata)
         {
             var currentUser = GetCurrentUser();
@@ -340,10 +321,6 @@ namespace NuGetGallery
             catch (Exception ex)
             {
                 return FailedToReadFile(ex);
-            }
-            finally
-            {
-                _cacheService.RemoveProgress(currentUser.Username);
             }
 
             // Check min client version
@@ -1967,6 +1944,19 @@ namespace NuGetGallery
             await _packageService.SetRequiredSignerAsync(packageRegistration, signer);
 
             return Json(HttpStatusCode.OK);
+        }
+
+        private JsonResult FailedToReadFile(Exception ex)
+        {
+            ex.Log();
+
+            var message = Strings.FailedToReadUploadFile;
+            if (ex is InvalidPackageException || ex is InvalidDataException || ex is EntityException)
+            {
+                message = ex.Message;
+            }
+
+            return Json(HttpStatusCode.BadRequest, new[] { message });
         }
 
         // this method exists to make unit testing easier

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -59,8 +59,7 @@ namespace NuGetGallery
 
         private static readonly IReadOnlyCollection<string> AllowedPackageExtentions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            CoreConstants.NuGetPackageFileExtension,
-            CoreConstants.NuGetSymbolPackageFileExtension
+            CoreConstants.NuGetPackageFileExtension
         };
 
         // TODO: add support for URL-based package submission

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -270,14 +270,7 @@ namespace NuGetGallery
                     }
 
                     // The uploadStream should be disposed by the caller below after saving the upload file.
-                    if (packageMetadata.IsSymbolPackage())
-                    {
-                        return await UploadSymbolsPackageInternal(packageArchiveReader, uploadStream);
-                    }
-                    else
-                    {
-                        return await UploadPackageInternal(packageArchiveReader, uploadStream, nuspec, packageMetadata);
-                    }
+                    return await UploadPackageInternal(packageArchiveReader, uploadStream, nuspec, packageMetadata);
                 }
                 catch (Exception ex)
                 {

--- a/src/NuGetGallery/Helpers/ZipArchiveHelpers.cs
+++ b/src/NuGetGallery/Helpers/ZipArchiveHelpers.cs
@@ -10,6 +10,14 @@ namespace NuGetGallery
 {
     public static class ZipArchiveHelpers
     {
+        /// <summary>
+        /// This method checks all the <see cref="ZipArchiveEntry"/> in a given 
+        /// <see cref="Stream"/> if it has the entry in the future. It will return
+        /// the first entry found in the future.
+        /// </summary>
+        /// <param name="stream"><see cref="Stream"/> object to verify</param>
+        /// <param name="entry"><see cref="ZipArchiveEntry"/> found with future entry.</param>
+        /// <returns>True if <see cref="Stream"/> contains an entry in future, false otherwise.</returns>
         public static bool FoundEntryInFuture(Stream stream, out ZipArchiveEntry entry)
         {
             entry = null;

--- a/src/NuGetGallery/Helpers/ZipArchiveHelpers.cs
+++ b/src/NuGetGallery/Helpers/ZipArchiveHelpers.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace NuGetGallery
+{
+    public static class ZipArchiveHelpers
+    {
+        public static bool FoundEntryInFuture(Stream stream, out ZipArchiveEntry entry)
+        {
+            entry = null;
+
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
+            {
+                var reference = DateTime.UtcNow.AddDays(1); // allow "some" clock skew
+
+                var entryInTheFuture = archive.Entries.FirstOrDefault(
+                    e => e.LastWriteTime.UtcDateTime > reference);
+
+                if (entryInTheFuture != null)
+                {
+                    entry = entryInTheFuture;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -399,6 +399,7 @@
     <Compile Include="Services\ITyposquattingConfiguration.cs" />
     <Compile Include="Services\ISymbolsConfiguration.cs" />
     <Compile Include="Services\ITyposquattingService.cs" />
+    <Compile Include="Services\SymbolPackageValidationResult.cs" />
     <Compile Include="Services\SymbolPackageUploadService.cs" />
     <Compile Include="Services\SymbolPackageFileService.cs" />
     <Compile Include="Services\SymbolPackageService.cs" />

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -292,6 +292,7 @@
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Helpers\GravatarHelper.cs" />
     <Compile Include="Helpers\ObfuscationHelper.cs" />
+    <Compile Include="Helpers\ZipArchiveHelpers.cs" />
     <Compile Include="Helpers\PermissionsHelpers.cs" />
     <Compile Include="Helpers\RegexEx.cs" />
     <Compile Include="Helpers\RouteUrlTemplate.cs" />

--- a/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
@@ -20,9 +20,10 @@ namespace NuGetGallery
         /// cases (such as database failures). This method does not dispose the provided stream but does read it.
         /// </summary>
         /// <param name="package">The package for which the symbols are to be uploaded.</param>
-        /// <param name="packageStreamMetadata">The metadata object for the uploaded snupkg.</param>
-        /// <param name="symbolPackageFile">The seekable stream containing the symbol package content (.snupkg).</param>
+        /// <param name="symbolPackageStream">The Stream object for the uploaded snupkg.</param>
         /// <returns>Awaitable task with <see cref="PackageCommitResult"/></returns>
-        Task<PackageCommitResult> CreateAndUploadSymbolsPackage(Package package, PackageStreamMetadata packageStreamMetadata, Stream symbolPackageFile);
+        Task<PackageUploadOperationResult> CreateAndUploadSymbolsPackage(Package package, Stream symbolPackageStream);
+
+        Task<PackageUploadOperationResult> ValidateUploadedSymbolPackage(Stream uploadStream, User currentUser);
     }
 }

--- a/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
@@ -21,9 +21,18 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="package">The package for which the symbols are to be uploaded.</param>
         /// <param name="symbolPackageStream">The Stream object for the uploaded snupkg.</param>
-        /// <returns>Awaitable task with <see cref="PackageCommitResult"/></returns>
+        /// <returns>Awaitable task with <see cref="PackageUploadOperationResult"/></returns>
         Task<PackageUploadOperationResult> CreateAndUploadSymbolsPackage(Package package, Stream symbolPackageStream);
 
-        Task<PackageUploadOperationResult> ValidateUploadedSymbolPackage(Stream uploadStream, User currentUser);
+        /// <summary>
+        /// Validate the uploaded symbols package. This method will perform all required validations for symbols, including
+        /// synchronous package validations for fail fast scenario. This method will not perform the ownership validations
+        /// for the symbols package. It is the responsibility of the caller to perform ownership validations. This method
+        /// does not dispose the provided stream but does read it.
+        /// </summary>
+        /// <param name="uploadStream">The <see cref="Stream"/> object for the uploaded snupkg.</param>
+        /// <param name="currentUser">The user performing the uploads.</param>
+        /// <returns>Awaitable task with <see cref="PackageUploadOperationResult"/></returns>
+        Task<PackageUploadOperationResult> ValidateUploadedSymbolsPackage(Stream uploadStream, User currentUser);
     }
 }

--- a/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
@@ -21,8 +21,8 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="package">The package for which the symbols are to be uploaded.</param>
         /// <param name="symbolPackageStream">The Stream object for the uploaded snupkg.</param>
-        /// <returns>Awaitable task with <see cref="PackageUploadOperationResult"/></returns>
-        Task<PackageUploadOperationResult> CreateAndUploadSymbolsPackage(Package package, Stream symbolPackageStream);
+        /// <returns>Awaitable task with <see cref="PackageCommitResult"/></returns>
+        Task<PackageCommitResult> CreateAndUploadSymbolsPackage(Package package, Stream symbolPackageStream);
 
         /// <summary>
         /// Validate the uploaded symbols package. This method will perform all required validations for symbols, including
@@ -32,7 +32,7 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="uploadStream">The <see cref="Stream"/> object for the uploaded snupkg.</param>
         /// <param name="currentUser">The user performing the uploads.</param>
-        /// <returns>Awaitable task with <see cref="PackageUploadOperationResult"/></returns>
-        Task<PackageUploadOperationResult> ValidateUploadedSymbolsPackage(Stream uploadStream, User currentUser);
+        /// <returns>Awaitable task with <see cref="SymbolPackageValidationResult"/></returns>
+        Task<SymbolPackageValidationResult> ValidateUploadedSymbolsPackage(Stream uploadStream, User currentUser);
     }
 }

--- a/src/NuGetGallery/Services/PackageCommitResult.cs
+++ b/src/NuGetGallery/Services/PackageCommitResult.cs
@@ -58,9 +58,9 @@ namespace NuGetGallery
             OperationSucceeded = success;
         }
 
-        public static HttpStatusCode GetHttpStatusCode(PackageUploadResult resultCode)
+        public HttpStatusCode GetHttpStatusCode()
         {
-            switch(resultCode)
+            switch(ResultCode)
             {
                 case PackageUploadResult.Created:
                     return HttpStatusCode.Created;
@@ -73,7 +73,7 @@ namespace NuGetGallery
                 case PackageUploadResult.Conflict:
                     return HttpStatusCode.Conflict;
                 default:
-                    throw new InvalidDataException($"The Package upload operation result code {resultCode} is not supported.");
+                    throw new InvalidDataException($"The Package upload operation result code {ResultCode} is not supported.");
             }
         }
     }

--- a/src/NuGetGallery/Services/PackageCommitResult.cs
+++ b/src/NuGetGallery/Services/PackageCommitResult.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
-using System.Net;
 
 namespace NuGetGallery
 {
@@ -20,61 +19,5 @@ namespace NuGetGallery
         /// The package file conflicts with an existing package file. The package was not committed to the database.
         /// </summary>
         Conflict,
-    }
-
-    public enum PackageUploadResult
-    {
-        Created,
-        Unauthorized,
-        BadRequest,
-        NotFound,
-        Conflict,
-        Success
-    }
-
-    public class PackageUploadOperationResult
-    {
-        public PackageUploadResult ResultCode;
-
-        public string Message;
-
-        public bool OperationSucceeded;
-
-        public Package Package;
-
-        public PackageUploadOperationResult(Package package, bool success)
-            : this(PackageUploadResult.Success, message: null, success: success)
-        {
-            Package = package;
-        }
-
-        public PackageUploadOperationResult(PackageUploadResult resultCode, bool success)
-            : this(resultCode, message: null, success: success) { }
-
-        public PackageUploadOperationResult(PackageUploadResult resultCode, string message, bool success)
-        {
-            ResultCode = resultCode;
-            Message = message;
-            OperationSucceeded = success;
-        }
-
-        public HttpStatusCode GetHttpStatusCode()
-        {
-            switch(ResultCode)
-            {
-                case PackageUploadResult.Created:
-                    return HttpStatusCode.Created;
-                case PackageUploadResult.BadRequest:
-                    return HttpStatusCode.BadRequest;
-                case PackageUploadResult.Unauthorized:
-                    return HttpStatusCode.Unauthorized;
-                case PackageUploadResult.NotFound:
-                    return HttpStatusCode.NotFound;
-                case PackageUploadResult.Conflict:
-                    return HttpStatusCode.Conflict;
-                default:
-                    throw new InvalidDataException($"The Package upload operation result code {ResultCode} is not supported.");
-            }
-        }
     }
 }

--- a/src/NuGetGallery/Services/PackageCommitResult.cs
+++ b/src/NuGetGallery/Services/PackageCommitResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Net;
 
 namespace NuGetGallery
 {
@@ -19,5 +20,61 @@ namespace NuGetGallery
         /// The package file conflicts with an existing package file. The package was not committed to the database.
         /// </summary>
         Conflict,
+    }
+
+    public enum PackageUploadResult
+    {
+        Created,
+        Unauthorized,
+        BadRequest,
+        NotFound,
+        Conflict,
+        Success
+    }
+
+    public class PackageUploadOperationResult
+    {
+        public PackageUploadResult ResultCode;
+
+        public string Message;
+
+        public bool OperationSucceeded;
+
+        public Package Package;
+
+        public PackageUploadOperationResult(Package package, bool success)
+            : this(PackageUploadResult.Success, message: null, success: success)
+        {
+            Package = package;
+        }
+
+        public PackageUploadOperationResult(PackageUploadResult resultCode, bool success)
+            : this(resultCode, message: null, success: success) { }
+
+        public PackageUploadOperationResult(PackageUploadResult resultCode, string message, bool success)
+        {
+            ResultCode = resultCode;
+            Message = message;
+            OperationSucceeded = success;
+        }
+
+        public static HttpStatusCode GetHttpStatusCode(PackageUploadResult resultCode)
+        {
+            switch(resultCode)
+            {
+                case PackageUploadResult.Created:
+                    return HttpStatusCode.Created;
+                case PackageUploadResult.BadRequest:
+                    return HttpStatusCode.BadRequest;
+                case PackageUploadResult.Unauthorized:
+                    return HttpStatusCode.Unauthorized;
+                case PackageUploadResult.NotFound:
+                    return HttpStatusCode.NotFound;
+                case PackageUploadResult.Conflict:
+                    return HttpStatusCode.Conflict;
+                default:
+                    throw new InvalidDataException($"The Package upload operation result code {resultCode} is not supported.");
+            }
+        }
     }
 }

--- a/src/NuGetGallery/Services/SymbolPackageService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageService.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGetGallery.Packaging;
-using ClientPackageType = NuGet.Packaging.Core.PackageType;
 
 namespace NuGetGallery
 {
@@ -26,8 +25,6 @@ namespace NuGetGallery
             ".rels",
             ".p7s"
         };
-        private const string SymbolPackageTypeName = "SymbolsPackage";
-        private static readonly ClientPackageType SymbolPackageType = new ClientPackageType(SymbolPackageTypeName, ClientPackageType.EmptyVersion);
 
         public SymbolPackageService(
             IEntityRepository<SymbolPackage> symbolPackageRepository,
@@ -62,7 +59,7 @@ namespace NuGetGallery
                     symbolPackageArchiveReader.GetNuspecReader(),
                     strict: true);
 
-                if (!IsSymbolPackage(packageMetadata))
+                if (!packageMetadata.IsSymbolPackage())
                 {
                     throw new InvalidPackageException(Strings.SymbolsPackage_NotSymbolPackage);
                 }
@@ -171,14 +168,6 @@ namespace NuGetGallery
             }
 
             return true;
-        }
-
-        private static bool IsSymbolPackage(PackageMetadata metadata)
-        {
-            var packageTypes = metadata.GetPackageTypes();
-            return packageTypes.Any()
-                && packageTypes.Count() == 1
-                && packageTypes.First() == SymbolPackageType;
         }
 
         private static bool IsPortable(string pdbFile)

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -61,7 +61,7 @@ namespace NuGetGallery
 
             try
             {
-                if (symbolPackageStream.FoundEntryInFuture(out ZipArchiveEntry entryInTheFuture))
+                if (ZipArchiveHelpers.FoundEntryInFuture(symbolPackageStream, out ZipArchiveEntry entryInTheFuture))
                 {
                     return SymbolPackageValidationResult.Invalid(string.Format(
                         CultureInfo.CurrentCulture,

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -19,9 +19,9 @@ namespace NuGetGallery
         private readonly IValidationService _validationService;
         private readonly ISymbolPackageService _symbolPackageService;
         private readonly ISymbolPackageFileService _symbolPackageFileService;
-        private readonly IContentObjectService _contentObjectService;
         private readonly IPackageService _packageService;
         private readonly ITelemetryService _telemetryService;
+        private readonly IContentObjectService _contentObjectService;
 
         public SymbolPackageUploadService(
             ISymbolPackageService symbolPackageService,
@@ -41,7 +41,15 @@ namespace NuGetGallery
             _contentObjectService = contentObjectService ?? throw new ArgumentNullException(nameof(contentObjectService));
         }
 
-        public async Task<PackageUploadOperationResult> ValidateUploadedSymbolPackage(Stream symbolPackageStream, User currentUser)
+        /// <summary>
+        /// This method does not perform the ownership validations for the symbols package. It is the responsibility
+        /// of the caller to do it. Also, this method does not dispose the <see cref="Stream"/> object, the caller 
+        /// should take care of it.
+        /// </summary>
+        /// <param name="symbolPackageStream"><see cref="Stream"/> object for the symbols package.</param>
+        /// <param name="currentUser">The user performing the uploads.</param>
+        /// <returns>Awaitable task for <see cref="PackageUploadOperationResult"/></returns>
+        public async Task<PackageUploadOperationResult> ValidateUploadedSymbolsPackage(Stream symbolPackageStream, User currentUser)
         {
             Package package = null;
 
@@ -132,8 +140,7 @@ namespace NuGetGallery
         /// based on the result. It will then update the references in the database for persistence with appropriate status.
         /// </summary>
         /// <param name="package">The package for which symbols package is to be uplloaded</param>
-        /// <param name="packageStreamMetadata">The package stream metadata for the uploaded symbols package file.</param>
-        /// <param name="symbolPackageFile">The symbol package file stream.</param>
+        /// <param name="symbolPackageStream">The symbols package stream metadata for the uploaded symbols package file.</param>
         /// <returns>The <see cref="PackageUploadOperationResult"/> for the create and upload symbol package flow.</returns>
         public async Task<PackageUploadOperationResult> CreateAndUploadSymbolsPackage(Package package, Stream symbolPackageStream)
         {

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -2,9 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Frameworks;
+using NuGet.Packaging;
 using NuGetGallery.Packaging;
 
 namespace NuGetGallery
@@ -15,17 +19,111 @@ namespace NuGetGallery
         private readonly IValidationService _validationService;
         private readonly ISymbolPackageService _symbolPackageService;
         private readonly ISymbolPackageFileService _symbolPackageFileService;
+        private readonly IContentObjectService _contentObjectService;
+        private readonly IPackageService _packageService;
+        private readonly ITelemetryService _telemetryService;
 
         public SymbolPackageUploadService(
             ISymbolPackageService symbolPackageService,
             ISymbolPackageFileService symbolPackageFileService,
             IEntitiesContext entitiesContext,
-            IValidationService validationService)
+            IValidationService validationService,
+            IPackageService packageService,
+            ITelemetryService telemetryService,
+            IContentObjectService contentObjectService)
         {
             _symbolPackageService = symbolPackageService ?? throw new ArgumentNullException(nameof(symbolPackageService));
             _symbolPackageFileService = symbolPackageFileService ?? throw new ArgumentNullException(nameof(symbolPackageFileService));
             _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
             _validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
+            _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            _contentObjectService = contentObjectService ?? throw new ArgumentNullException(nameof(contentObjectService));
+        }
+
+        public async Task<PackageUploadOperationResult> ValidateUploadedSymbolPackage(Stream symbolPackageStream, User currentUser)
+        {
+            Package package = null;
+
+            // Check if symbol package upload is allowed for this user.
+            if (!_contentObjectService.SymbolsConfiguration.IsSymbolsUploadEnabledForUser(currentUser))
+            {
+                return new PackageUploadOperationResult(PackageUploadResult.Unauthorized,
+                    Strings.SymbolsPackage_UploadNotAllowed,
+                    success: false);
+            }
+
+            try
+            {
+                if (symbolPackageStream.FoundEntryInFuture(out ZipArchiveEntry entryInTheFuture))
+                {
+                    return new PackageUploadOperationResult(PackageUploadResult.BadRequest, string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.PackageEntryFromTheFuture,
+                        entryInTheFuture.Name),
+                        success: false);
+                }
+
+                using (var packageToPush = new PackageArchiveReader(symbolPackageStream, leaveStreamOpen: true))
+                {
+                    var nuspec = packageToPush.GetNuspecReader();
+                    var id = nuspec.GetId();
+                    var version = nuspec.GetVersion();
+                    var normalizedVersion = version.ToNormalizedStringSafe();
+
+                    // Ensure the corresponding package exists before pushing a snupkg.
+                    package = _packageService.FindPackageByIdAndVersionStrict(id, version.ToStringSafe());
+                    if (package == null || package.PackageStatusKey == PackageStatus.Deleted)
+                    {
+                        return new PackageUploadOperationResult(PackageUploadResult.NotFound, string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.SymbolsPackage_PackageIdAndVersionNotFound,
+                            id,
+                            normalizedVersion),
+                            success: false);
+                    }
+
+                    // Do not allow to upload a snupkg to a package which has symbols package pending validations.
+                    if (package.SymbolPackages.Any(sp => sp.StatusKey == PackageStatus.Validating))
+                    {
+                        return new PackageUploadOperationResult(PackageUploadResult.Conflict,
+                            Strings.SymbolsPackage_ConflictValidating,
+                            success: false);
+                    }
+
+                    try
+                    {
+                        await _symbolPackageService.EnsureValidAsync(packageToPush);
+                    }
+                    catch (Exception ex)
+                    {
+                        ex.Log();
+
+                        var message = Strings.SymbolsPackage_FailedToReadPackage;
+                        if (ex is InvalidPackageException || ex is InvalidDataException || ex is EntityException)
+                        {
+                            message = ex.Message;
+                        }
+
+                        _telemetryService.TrackSymbolPackageFailedGalleryValidationEvent(id, normalizedVersion);
+                        return new PackageUploadOperationResult(PackageUploadResult.BadRequest,
+                            message,
+                            success: false);
+                    }
+                }
+
+                return new PackageUploadOperationResult(package: package, success: true);
+            }
+            catch (Exception ex) when (ex is InvalidPackageException
+                || ex is InvalidDataException
+                || ex is EntityException
+                || ex is FrameworkException)
+            {
+                return new PackageUploadOperationResult(
+                    PackageUploadResult.BadRequest,
+                    string.Format(CultureInfo.CurrentCulture, Strings.UploadPackage_InvalidPackage, ex.Message),
+                    success: false);
+            }
         }
 
         /// <summary>
@@ -36,9 +134,20 @@ namespace NuGetGallery
         /// <param name="package">The package for which symbols package is to be uplloaded</param>
         /// <param name="packageStreamMetadata">The package stream metadata for the uploaded symbols package file.</param>
         /// <param name="symbolPackageFile">The symbol package file stream.</param>
-        /// <returns>The <see cref="PackageCommitResult"/> for the symbol package upload flow.</returns>
-        public async Task<PackageCommitResult> CreateAndUploadSymbolsPackage(Package package, PackageStreamMetadata packageStreamMetadata, Stream symbolPackageFile)
+        /// <returns>The <see cref="PackageUploadOperationResult"/> for the create and upload symbol package flow.</returns>
+        public async Task<PackageUploadOperationResult> CreateAndUploadSymbolsPackage(Package package, Stream symbolPackageStream)
         {
+            var packageStreamMetadata = new PackageStreamMetadata
+            {
+                HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
+                Hash = CryptographyService.GenerateHash(
+                    symbolPackageStream.AsSeekableStream(),
+                    CoreConstants.Sha512HashAlgorithmId),
+                Size = symbolPackageStream.Length
+            };
+
+            Stream symbolPackageFile = symbolPackageStream.AsSeekableStream();
+
             var symbolPackage = _symbolPackageService.CreateSymbolPackage(package, packageStreamMetadata);
 
             await _validationService.StartValidationAsync(symbolPackage);
@@ -66,7 +175,7 @@ namespace NuGetGallery
                     // Mark any other associated available symbol packages for deletion.
                     var availableSymbolPackages = package
                         .SymbolPackages
-                        .Where(sp => sp.StatusKey == PackageStatus.Available 
+                        .Where(sp => sp.StatusKey == PackageStatus.Available
                             && sp != symbolPackage);
 
                     var overwrite = false;
@@ -117,10 +226,15 @@ namespace NuGetGallery
             catch (FileAlreadyExistsException ex)
             {
                 ex.Log();
-                return PackageCommitResult.Conflict;
+                return new PackageUploadOperationResult(
+                    PackageUploadResult.Conflict,
+                    Strings.SymbolsPackage_ConflictValidating, 
+                    success: false);
             }
 
-            return PackageCommitResult.Success;
+            _telemetryService.TrackSymbolPackagePushEvent(package.Id, package.NormalizedVersion);
+
+            return new PackageUploadOperationResult(PackageUploadResult.Created, success: true);
         }
     }
 }

--- a/src/NuGetGallery/Services/SymbolPackageValidationResult.cs
+++ b/src/NuGetGallery/Services/SymbolPackageValidationResult.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Web.Mvc;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// The type of <see cref="SymbolPackageValidationResult"/>
+    /// </summary>
+    public enum SymbolPackageValidationResultType
+    {
+        /// <summary>
+        /// The symbols package is valid based on the performed validations. Note that the caller may perform other validations
+        /// so this is not an all inclusive validation.
+        /// </summary>
+        Accepted,
+
+        /// <summary>
+        /// The symbols package is invalid based on the package content.
+        /// </summary>
+        Invalid,
+
+        /// <summary>
+        /// The user is unauthorized to upload the symbols package.
+        /// </summary>
+        UserNotAllowedToUpload,
+
+        /// <summary>
+        /// There is no corresponding nuget package available for the uploaded symbols package.
+        /// </summary>
+        MissingPackage,
+
+        /// <summary>
+        /// There is a symbols package already present, pending validations.
+        /// </summary>
+        SymbolsPackageExists
+    }
+
+    public class SymbolPackageValidationResult
+    {
+        public SymbolPackageValidationResultType Type;
+        public string Message;
+        public Package Package;
+
+        public SymbolPackageValidationResult(SymbolPackageValidationResultType type, string message)
+            : this(type, message, package: null)
+        {
+        }
+
+        public SymbolPackageValidationResult(SymbolPackageValidationResultType type, string message, Package package)
+        { 
+            if (type != SymbolPackageValidationResultType.Accepted && message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            Type = type;
+            Message = message;
+            Package = package;
+        }
+
+        public static SymbolPackageValidationResult Accepted()
+        {
+            return new SymbolPackageValidationResult(
+                SymbolPackageValidationResultType.Accepted,
+                message: null);
+        }
+
+        public static SymbolPackageValidationResult AcceptedForPackage(Package package)
+        {
+            return new SymbolPackageValidationResult(
+                SymbolPackageValidationResultType.Accepted,
+                message: null,
+                package: package);
+        }
+
+        public static SymbolPackageValidationResult Invalid(string message)
+        {
+            return new SymbolPackageValidationResult(
+                SymbolPackageValidationResultType.Invalid,
+                message: message);
+        }
+
+        public static SymbolPackageValidationResult UserNotAllowedToUpload(string message)
+        {
+            return new SymbolPackageValidationResult(
+                SymbolPackageValidationResultType.UserNotAllowedToUpload,
+                message: message);
+        }
+
+        public static SymbolPackageValidationResult MissingPackage(string message)
+        {
+            return new SymbolPackageValidationResult(
+                SymbolPackageValidationResultType.MissingPackage,
+                message: message);
+        }
+
+        public static SymbolPackageValidationResult SymbolsPackageExists(string message)
+        {
+            return new SymbolPackageValidationResult(
+                SymbolPackageValidationResultType.SymbolsPackageExists,
+                message: message);
+        }
+    }
+}

--- a/src/NuGetGallery/Services/SymbolPackageValidationResult.cs
+++ b/src/NuGetGallery/Services/SymbolPackageValidationResult.cs
@@ -36,7 +36,7 @@ namespace NuGetGallery
         /// <summary>
         /// There is a symbols package already present, pending validations.
         /// </summary>
-        SymbolsPackageExists
+        SymbolsPackagePendingValidation
     }
 
     public class SymbolPackageValidationResult
@@ -101,7 +101,7 @@ namespace NuGetGallery
         public static SymbolPackageValidationResult SymbolsPackageExists(string message)
         {
             return new SymbolPackageValidationResult(
-                SymbolPackageValidationResultType.SymbolsPackageExists,
+                SymbolPackageValidationResultType.SymbolsPackagePendingValidation,
                 message: message);
         }
     }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2148,7 +2148,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The file must be a .nupkg file..
+        ///   Looks up a localized string similar to The file must be a .nupkg or .snupkg file..
         /// </summary>
         public static string UploadFileMustBeNuGetPackage {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -157,7 +157,7 @@
     <value>A package file is required.</value>
   </data>
   <data name="UploadFileMustBeNuGetPackage" xml:space="preserve">
-    <value>The file must be a .nupkg file.</value>
+    <value>The file must be a .nupkg or .snupkg file.</value>
   </data>
   <data name="SuccessfullyUploadedPackage" xml:space="preserve">
     <value>You successfully uploaded {0} {1}.</value>

--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -30,7 +30,7 @@
                             <input type="text" class="form-control" id="file-select-feedback" value="Browse or Drop files to select a package..." aria-label="Upload Your Package" readonly />
                             <label for="input-select-file" id="PackageFileLabel" class="input-group-btn">
                                 <span id="browse-for-package-button" class="btn btn-primary form-control" tabindex="0" aria-label="Browse for package" role="button">
-                                    Browse&hellip;<input type="file" name="UploadFile" accept=".nupkg" aria-labelledby="PackageFileLabel" id="input-select-file" style="display:none;" />
+                                    Browse&hellip;<input type="file" name="UploadFile" accept=".nupkg,.snupkg" aria-labelledby="PackageFileLabel" id="input-select-file" style="display:none;" />
                                 </span>
                             </label>
                         </div>

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -148,7 +148,7 @@ namespace NuGetGallery
 
             MockSymbolPackageUploadService
                 .Setup(x => x.ValidateUploadedSymbolsPackage(It.IsAny<Stream>(), It.IsAny<User>()))
-                .ReturnsAsync(new PackageUploadOperationResult(PackageUploadResult.Success, success: true));
+                .ReturnsAsync(SymbolPackageValidationResult.Accepted());
 
             var requestMock = new Mock<HttpRequestBase>();
             requestMock.Setup(m => m.IsSecureConnection).Returns(true);
@@ -218,29 +218,6 @@ namespace NuGetGallery
 
         public class TheCreateSymbolPackageAction : TestContainer
         {
-            [Theory]
-            [InlineData(PackageUploadResult.Conflict, HttpStatusCode.Conflict)]
-            [InlineData(PackageUploadResult.Unauthorized, HttpStatusCode.Unauthorized)]
-            [InlineData(PackageUploadResult.BadRequest, HttpStatusCode.BadRequest)]
-            [InlineData(PackageUploadResult.NotFound, HttpStatusCode.NotFound)]
-            public async Task CreateSymbolPackage_ReturnsAppropriateHttpStatusCodeForFailedValidation(PackageUploadResult uploadResult, HttpStatusCode expectedStatusCode)
-            {
-                // Arrange
-                var controller = new TestableApiController(GetConfigurationService());
-                controller.MockSymbolPackageUploadService
-                    .Setup(x => x.ValidateUploadedSymbolsPackage(It.IsAny<Stream>(), It.IsAny<User>()))
-                    .ReturnsAsync(new PackageUploadOperationResult(uploadResult, success: false));
-
-                var user = new User("test");
-                controller.SetCurrentUser(user);
-
-                // Act
-                var result = await controller.CreateSymbolPackagePutAsync();
-
-                // Assert
-                Assert.NotNull(result);
-                ResultAssert.IsStatusCode(result, expectedStatusCode);
-            }
         }
 
         public class TheCreatePackageAction

--- a/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
@@ -158,7 +158,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.NotNull(result);
-                Assert.Equal(SymbolPackageValidationResultType.SymbolsPackageExists, result.Type);
+                Assert.Equal(SymbolPackageValidationResultType.SymbolsPackagePendingValidation, result.Type);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
@@ -119,7 +119,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.NotNull(result);
-                Assert.Equal(PackageUploadResult.Conflict, result.ResultCode);
+                Assert.Equal(PackageCommitResult.Conflict, result);
                 symbolPackageFileService.Verify(x => x.SavePackageFileAsync(package, It.IsAny<Stream>(), It.IsAny<bool>()), Times.Once);
             }
 
@@ -197,7 +197,7 @@ namespace NuGetGallery
                 Assert.Equal(PackageStatus.Deleted, existingDeletedSymbolPackage.StatusKey);
                 symbolPackageFileService.Verify(x => x.SavePackageFileAsync(package, It.IsAny<Stream>(), true), Times.Once);
                 Assert.NotNull(result);
-                Assert.Equal(PackageUploadResult.Created, result.ResultCode);
+                Assert.Equal(PackageCommitResult.Success, result);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
@@ -89,7 +89,7 @@ namespace NuGetGallery
                 var service = CreateService(validationService: validationService);
 
                 var package = new Package();
-                await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.CreateAndUploadSymbolsPackage(package, new PackageStreamMetadata(), new MemoryStream()));
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.CreateAndUploadSymbolsPackage(package, new MemoryStream()));
             }
 
             [Fact]
@@ -106,11 +106,11 @@ namespace NuGetGallery
                 var package = new Package();
 
                 // Act
-                var result = await service.CreateAndUploadSymbolsPackage(package, new PackageStreamMetadata(), new MemoryStream());
+                var result = await service.CreateAndUploadSymbolsPackage(package, new MemoryStream());
 
                 // Assert
                 Assert.NotNull(result);
-                Assert.Equal(PackageCommitResult.Conflict, result);
+                Assert.Equal(PackageUploadResult.Conflict, result.ResultCode);
                 symbolPackageFileService.Verify(x => x.SavePackageFileAsync(package, It.IsAny<Stream>(), It.IsAny<bool>()), Times.Once);
             }
 
@@ -142,7 +142,7 @@ namespace NuGetGallery
                 };
 
                 // Act and Assert
-                await Assert.ThrowsAsync<EntityException>(async () => await service.CreateAndUploadSymbolsPackage(package, new PackageStreamMetadata(), new MemoryStream()));
+                await Assert.ThrowsAsync<EntityException>(async () => await service.CreateAndUploadSymbolsPackage(package, new MemoryStream()));
 
                 symbolPackageFileService.Verify(x => x.SavePackageFileAsync(package, It.IsAny<Stream>(), It.IsAny<bool>()), Times.Once);
                 symbolPackageFileService.Verify(x => x.DeletePackageFileAsync(package.PackageRegistration.Id, package.Version), Times.Once);
@@ -181,14 +181,14 @@ namespace NuGetGallery
                 package.SymbolPackages.Add(existingDeletedSymbolPackage);
 
                 // Act
-                var result = await service.CreateAndUploadSymbolsPackage(package, new PackageStreamMetadata(), new MemoryStream());
+                var result = await service.CreateAndUploadSymbolsPackage(package, new MemoryStream());
 
                 // Assert
                 Assert.Equal(PackageStatus.Deleted, existingAvailableSymbolPackage.StatusKey);
                 Assert.Equal(PackageStatus.Deleted, existingDeletedSymbolPackage.StatusKey);
                 symbolPackageFileService.Verify(x => x.SavePackageFileAsync(package, It.IsAny<Stream>(), true), Times.Once);
                 Assert.NotNull(result);
-                Assert.Equal(PackageCommitResult.Success, result);
+                Assert.Equal(PackageUploadResult.Success, result.ResultCode);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
@@ -16,7 +16,10 @@ namespace NuGetGallery
             Mock<ISymbolPackageService> symbolPackageService = null,
             Mock<ISymbolPackageFileService> symbolPackageFileService = null,
             Mock<IEntitiesContext> entitiesContext = null,
-            Mock<IValidationService> validationService = null)
+            Mock<IValidationService> validationService = null,
+            Mock<IPackageService> packageService = null,
+            Mock<ITelemetryService> telemetryService = null,
+            Mock<IContentObjectService> contentObjectService = null)
         {
             if (symbolPackageService == null)
             {
@@ -60,12 +63,18 @@ namespace NuGetGallery
             }
 
             validationService = validationService ?? new Mock<IValidationService>();
+            packageService = packageService ?? new Mock<IPackageService>();
+            telemetryService = telemetryService ?? new Mock<ITelemetryService>();
+            contentObjectService = contentObjectService ?? new Mock<IContentObjectService>();
 
             var symbolPackageUploadService = new Mock<SymbolPackageUploadService>(
                 symbolPackageService.Object,
                 symbolPackageFileService.Object,
                 entitiesContext.Object,
-                validationService.Object);
+                validationService.Object,
+                packageService.Object,
+                telemetryService.Object,
+                contentObjectService.Object);
 
             return symbolPackageUploadService.Object;
         }
@@ -188,7 +197,7 @@ namespace NuGetGallery
                 Assert.Equal(PackageStatus.Deleted, existingDeletedSymbolPackage.StatusKey);
                 symbolPackageFileService.Verify(x => x.SavePackageFileAsync(package, It.IsAny<Stream>(), true), Times.Once);
                 Assert.NotNull(result);
-                Assert.Equal(PackageUploadResult.Success, result.ResultCode);
+                Assert.Equal(PackageUploadResult.Created, result.ResultCode);
             }
         }
     }


### PR DESCRIPTION
This is a preparation PR for adding support to gallery for symbols package upload.

I have refactored code out from the `ApiController` for the symbols upload, so that we can reuse the code in `PackagesController` and keep common code in single place. Also, as part of this I had to refactor/re-write some tests for the coverage. I do not touch the Package upload flow(which should also be refactored) as part of this PR, since its a lot more refactor and out of scope for the symbol upload flow. 

Also, refactored some part of `PackagesController` to reuse upload page in gallery. In subsequent PRs I will be doing additive changes to enhance this controller for symbols upload.

Apologies for the big PR(refactoring is a pain)