### PR TITLE
Add configuration value to disable specific curated feeds

### DIFF
--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -344,5 +344,9 @@ namespace NuGetGallery.Configuration
         public bool RejectPackagesWithTooManyPackageEntries { get; set; }
 
         public bool BlockSearchEngineIndexing { get; set; }
+
+        [DefaultValue(null)]
+        [TypeConverter(typeof(StringArrayConverter))]
+        public string[] DisabledCuratedFeeds { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -349,5 +349,11 @@ namespace NuGetGallery.Configuration
         /// Whether or not to block search engines from indexing the web pages using the "noindex" meta tag.
         /// </summary>
         bool BlockSearchEngineIndexing { get; set; }
+
+        /// <summary>
+        /// The name of zero or more curated feeds that are disabled. If a curated feed is disabled, it appears as if
+        /// it doesn't exist.
+        /// </summary>
+        string[] DisabledCuratedFeeds { get; set; }
     }
 }

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -22,19 +22,16 @@ namespace NuGetGallery.Controllers
     {
         private const int MaxPageSize = 40;
 
-        private readonly IEntitiesContext _entities;
         private readonly IGalleryConfigurationService _configurationService;
         private readonly ISearchService _searchService;
         private readonly ICuratedFeedService _curatedFeedService;
 
         public ODataV2CuratedFeedController(
-            IEntitiesContext entities,
             IGalleryConfigurationService configurationService,
             ISearchService searchService,
             ICuratedFeedService curatedFeedService)
             : base(configurationService)
         {
-            _entities = entities;
             _configurationService = configurationService;
             _searchService = searchService;
             _curatedFeedService = curatedFeedService;
@@ -49,7 +46,7 @@ namespace NuGetGallery.Controllers
             string curatedFeedName,
             [FromUri] string semVerLevel = null)
         {
-            if (!_entities.CuratedFeeds.Any(cf => cf.Name == curatedFeedName))
+            if (_curatedFeedService.GetFeedByName(curatedFeedName) == null)
             {
                 return NotFound();
             }
@@ -133,7 +130,7 @@ namespace NuGetGallery.Controllers
             bool return404NotFoundWhenNoResults,
             string semVerLevel)
         {
-            var curatedFeed = _entities.CuratedFeeds.FirstOrDefault(cf => cf.Name == curatedFeedName);
+            var curatedFeed = _curatedFeedService.GetFeedByName(curatedFeedName);
             if (curatedFeed == null)
             {
                 return NotFound();
@@ -231,7 +228,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]bool includePrerelease = false,
             [FromUri]string semVerLevel = null)
         {
-            if (!_entities.CuratedFeeds.Any(cf => cf.Name == curatedFeedName))
+            if (_curatedFeedService.GetFeedByName(curatedFeedName) == null)
             {
                 return NotFound();
             }
@@ -254,7 +251,7 @@ namespace NuGetGallery.Controllers
             }
 
             // Perform actual search
-            var curatedFeed = _curatedFeedService.GetFeedByName(curatedFeedName, includePackages: false);
+            var curatedFeed = _curatedFeedService.GetFeedByName(curatedFeedName);
             var packages = _curatedFeedService.GetPackages(curatedFeedName)
                 .Where(p => p.PackageStatusKey == PackageStatus.Available)
                 .Where(SemVerLevelKey.IsPackageCompliantWithSemVerLevelPredicate(semVerLevel))

--- a/src/NuGetGallery/Services/CuratedFeedService.cs
+++ b/src/NuGetGallery/Services/CuratedFeedService.cs
@@ -1,59 +1,48 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Data.Entity;
+using System;
 using System.Linq;
+using NuGetGallery.Configuration;
 
 namespace NuGetGallery
 {
     public class CuratedFeedService : ICuratedFeedService
     {
         protected IEntityRepository<CuratedFeed> CuratedFeedRepository { get; set; }
-        protected IEntityRepository<CuratedPackage> CuratedPackageRepository { get; set; }
+        protected IAppConfiguration AppConfiguration { get; set; }
 
         protected CuratedFeedService()
         {
         }
 
         public CuratedFeedService(
-            IEntityRepository<CuratedFeed> curatedFeedRepository)
+            IEntityRepository<CuratedFeed> curatedFeedRepository,
+            IAppConfiguration appConfiguration)
         {
             CuratedFeedRepository = curatedFeedRepository;
+            AppConfiguration = appConfiguration;
         }
 
-        public CuratedFeed GetFeedByName(string name, bool includePackages)
+        public CuratedFeed GetFeedByName(string name)
         {
-            IQueryable<CuratedFeed> query = CuratedFeedRepository.GetAll();
-
-            if (includePackages)
+            if (IsCuratedFeedDisabled(name))
             {
-                query = query
-                    .Include(cf => cf.Packages)
-                    .Include(cf => cf.Packages.Select(cp => cp.PackageRegistration));
+                return null;
             }
 
-            return query
+            return CuratedFeedRepository
+                .GetAll()
                 .SingleOrDefault(cf => cf.Name == name);
-        }
-
-        public CuratedFeed GetFeedByKey(int key, bool includePackages)
-        {
-            IQueryable<CuratedFeed> query = CuratedFeedRepository.GetAll();
-
-            if (includePackages)
-            {
-                query = query
-                    .Include(cf => cf.Packages)
-                    .Include(cf => cf.Packages.Select(cp => cp.PackageRegistration));
-            }
-
-            return query
-                .SingleOrDefault(cf => cf.Key == key);
         }
 
         public IQueryable<Package> GetPackages(string curatedFeedName)
         {
+            if (IsCuratedFeedDisabled(curatedFeedName))
+            {
+                return Enumerable.Empty<Package>().AsQueryable();
+            }
+
             var packages = CuratedFeedRepository.GetAll()
                 .Where(cf => cf.Name == curatedFeedName)
                 .SelectMany(cf => cf.Packages.SelectMany(cp => cp.PackageRegistration.Packages));
@@ -61,22 +50,16 @@ namespace NuGetGallery
             return packages;
         }
 
-        public IQueryable<PackageRegistration> GetPackageRegistrations(string curatedFeedName)
+        private bool IsCuratedFeedDisabled(string name)
         {
-            var packageRegistrations = CuratedFeedRepository.GetAll()
-                .Where(cf => cf.Name == curatedFeedName)
-                .SelectMany(cf => cf.Packages.Select(cp => cp.PackageRegistration));
+            if (AppConfiguration.DisabledCuratedFeeds == null)
+            {
+                return false;
+            }
 
-            return packageRegistrations;
-        }
-
-        public int? GetKey(string curatedFeedName)
-        {
-            var results = CuratedFeedRepository.GetAll()
-                .Where(cf => cf.Name == curatedFeedName)
-                .Select(cf => cf.Key).Take(1).ToArray();
-
-            return results.Length > 0 ? (int?)results[0] : null;
+            return AppConfiguration
+                .DisabledCuratedFeeds
+                .Contains(name, StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/NuGetGallery/Services/ICuratedFeedService.cs
+++ b/src/NuGetGallery/Services/ICuratedFeedService.cs
@@ -7,10 +7,7 @@ namespace NuGetGallery
 {
     public interface ICuratedFeedService
     {
-        CuratedFeed GetFeedByName(string name, bool includePackages);
-        CuratedFeed GetFeedByKey(int key, bool includePackages);
+        CuratedFeed GetFeedByName(string name);
         IQueryable<Package> GetPackages(string curatedFeedName);
-        IQueryable<PackageRegistration> GetPackageRegistrations(string curatedFeedName);
-        int? GetKey(string curatedFeedName);
     }
 }

--- a/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
@@ -330,14 +330,9 @@ namespace NuGetGallery.Controllers
 
             var curatedFeedServiceMock = new Mock<ICuratedFeedService>(MockBehavior.Strict);
             curatedFeedServiceMock.Setup(m => m.GetPackages(_curatedFeedName)).Returns(AllPackages);
-            curatedFeedServiceMock.Setup(m => m.GetFeedByName(_curatedFeedName, false)).Returns(curatedFeed);
-
-            var entitiesContextMock = new Mock<IEntitiesContext>(MockBehavior.Strict);
-            var curatedFeedDbSet = GetQueryableMockDbSet(curatedFeed);
-            entitiesContextMock.SetupGet(m => m.CuratedFeeds).Returns(curatedFeedDbSet);
+            curatedFeedServiceMock.Setup(m => m.GetFeedByName(_curatedFeedName)).Returns(curatedFeed);
 
             return new ODataV2CuratedFeedController(
-                entitiesContextMock.Object,
                 configurationService,
                 searchService,
                 curatedFeedServiceMock.Object);

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Security\RequirePackageMetadataCompliancePolicyFacts.cs" />
     <Compile Include="Services\ActionRequiringEntityPermissionsFacts.cs" />
     <Compile Include="Services\CertificatesConfigurationFacts.cs" />
+    <Compile Include="Services\CuratedFeedServiceFacts.cs" />
     <Compile Include="Services\TyposquattingServiceFacts.cs" />
     <Compile Include="Services\CloudDownloadCountServiceFacts.cs" />
     <Compile Include="Services\CertificateServiceFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/CuratedFeedServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CuratedFeedServiceFacts.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Moq;
+using NuGetGallery.Configuration;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class CuratedFeedServiceFacts
+    {
+        public class TheGetFeedByNameMethod : Facts
+        {
+            [Fact]
+            public void ReturnsNullWhenFeedIsDisabled()
+            {
+                DisableFeed(_curatedFeed.Name);
+
+                var output = _target.GetFeedByName(_curatedFeed.Name);
+
+                Assert.Null(output);
+                _entityRepository.Verify(x => x.GetAll(), Times.Never);
+            }
+
+            [Fact]
+            public void ReturnsNullWhenFeedIsDisabledWithDifferentCasing()
+            {
+                _curatedFeed.Name = "curated-feed";
+                DisableFeed("CURATED-Feed");
+
+                var output = _target.GetFeedByName(_curatedFeed.Name);
+
+                Assert.Null(output);
+                _entityRepository.Verify(x => x.GetAll(), Times.Never);
+            }
+
+            [Fact]
+            public void ReturnsFeedWhenNameMatchesAndFeedIsNotDisabled()
+            {
+                var output = _target.GetFeedByName(_curatedFeed.Name);
+
+                Assert.Same(_curatedFeed, output);
+                _entityRepository.Verify(x => x.GetAll(), Times.Once);
+
+            }
+
+            [Fact]
+            public void ReturnsNullWhenFeedDoesNotExist()
+            {
+                var output = _target.GetFeedByName("something-else");
+
+                Assert.Null(output);
+                _entityRepository.Verify(x => x.GetAll(), Times.Once);
+            }
+        }
+
+        public class TheGetPackagesMethod : Facts
+        {
+            [Fact]
+            public void ReturnsEmptyListWhenFeedIsDisabled()
+            {
+                DisableFeed(_curatedFeed.Name);
+
+                var output = _target.GetPackages(_curatedFeed.Name);
+
+                Assert.Empty(output);
+                _entityRepository.Verify(x => x.GetAll(), Times.Never);
+            }
+
+            [Fact]
+            public void ReturnsPackagesWhenNameMatchesAndFeedIsNotDisabled()
+            {
+                var output = _target.GetPackages(_curatedFeed.Name);
+
+                var package = Assert.Single(output);
+                Assert.Same(_package, package);
+
+            }
+
+            [Fact]
+            public void ReturnsNullWhenFeedDoesNotExist()
+            {
+                var output = _target.GetPackages("something-else");
+
+                Assert.Empty(output);
+                _entityRepository.Verify(x => x.GetAll(), Times.Once);
+            }
+        }
+
+        public abstract class Facts
+        {
+            protected Package _package;
+            protected CuratedFeed _curatedFeed;
+            protected readonly Mock<IEntityRepository<CuratedFeed>> _entityRepository;
+            protected readonly Mock<IAppConfiguration> _config;
+            protected readonly CuratedFeedService _target;
+
+            protected Facts()
+            {
+                _package = new Package();
+                _curatedFeed = new CuratedFeed
+                {
+                    Name = "curated-feed",
+                    Packages = new[]
+                    {
+                        new CuratedPackage
+                        {
+                            PackageRegistration = new PackageRegistration
+                            {
+                                Packages = new[]
+                                {
+                                    _package,
+                                },
+                            },
+                        },
+                    },
+                };
+
+                _entityRepository = new Mock<IEntityRepository<CuratedFeed>>();
+                _config = new Mock<IAppConfiguration>();
+
+                _entityRepository
+                    .Setup(x => x.GetAll())
+                    .Returns(() => new[] { _curatedFeed }.AsQueryable());
+
+                _target = new CuratedFeedService(
+                    _entityRepository.Object,
+                    _config.Object);
+            }
+
+            protected void DisableFeed(string feedName)
+            {
+                _config
+                    .Setup(x => x.DisabledCuratedFeeds)
+                    .Returns(new[] { feedName });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6470. Depends on https://github.com/NuGet/NuGetGallery/pull/6483.

This will allow us to disable the 'webmatrix', 'windows8-packages', and 'dotnetframework' feeds before completely deleting them.

The 'microsoftdotnet' feed will eventually redirect to the main feed. This work is not yet done but is tracked here: https://github.com/NuGet/NuGetGallery/issues/6472.