### PR TITLE
Add configuration value to redirect specific curated feeds to main feed

### DIFF
--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -348,5 +348,9 @@ namespace NuGetGallery.Configuration
         [DefaultValue(null)]
         [TypeConverter(typeof(StringArrayConverter))]
         public string[] DisabledCuratedFeeds { get; set; }
+
+        [DefaultValue(null)]
+        [TypeConverter(typeof(StringArrayConverter))]
+        public string[] RedirectedCuratedFeeds { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -355,5 +355,10 @@ namespace NuGetGallery.Configuration
         /// it doesn't exist.
         /// </summary>
         string[] DisabledCuratedFeeds { get; set; }
+
+        /// <summary>
+        /// The name of zero or more curated feeds that are redirected to the main feed.
+        /// </summary>
+        string[] RedirectedCuratedFeeds { get; set; }
     }
 }

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -25,16 +25,19 @@ namespace NuGetGallery.Controllers
         private readonly IGalleryConfigurationService _configurationService;
         private readonly ISearchService _searchService;
         private readonly ICuratedFeedService _curatedFeedService;
+        private readonly IEntityRepository<Package> _packagesRepository;
 
         public ODataV2CuratedFeedController(
             IGalleryConfigurationService configurationService,
             ISearchService searchService,
-            ICuratedFeedService curatedFeedService)
+            ICuratedFeedService curatedFeedService,
+            IEntityRepository<Package> packagesRepository)
             : base(configurationService)
         {
             _configurationService = configurationService;
             _searchService = searchService;
             _curatedFeedService = curatedFeedService;
+            _packagesRepository = packagesRepository;
         }
 
         // /api/v2/curated-feed/curatedFeedName/Packages?semVerLevel=
@@ -46,15 +49,16 @@ namespace NuGetGallery.Controllers
             string curatedFeedName,
             [FromUri] string semVerLevel = null)
         {
-            if (_curatedFeedService.GetFeedByName(curatedFeedName) == null)
+            var result = GetCuratedFeedResult(curatedFeedName);
+            if (result.ActionResult != null)
             {
-                return NotFound();
+                return result.ActionResult;
             }
 
             var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
 
-            var queryable = _curatedFeedService
-                .GetPackages(curatedFeedName)
+            var queryable = result
+                .Packages
                 .Where(p => p.PackageStatusKey == PackageStatus.Available)
                 .Where(SemVerLevelKey.IsPackageCompliantWithSemVerLevelPredicate(semVerLevel))
                 .ToV2FeedPackageQuery(
@@ -130,14 +134,14 @@ namespace NuGetGallery.Controllers
             bool return404NotFoundWhenNoResults,
             string semVerLevel)
         {
-            var curatedFeed = _curatedFeedService.GetFeedByName(curatedFeedName);
-            if (curatedFeed == null)
+            var result = GetCuratedFeedResult(curatedFeedName);
+            if (result.ActionResult != null)
             {
-                return NotFound();
+                return result.ActionResult;
             }
 
-            var packages = _curatedFeedService
-                .GetPackages(curatedFeedName)
+            var packages = result
+                .Packages
                 .Where(p => p.PackageStatusKey == PackageStatus.Available)
                 .Where(SemVerLevelKey.IsPackageCompliantWithSemVerLevelPredicate(semVerLevel))
                 .Where(p => p.PackageRegistration.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
@@ -158,7 +162,7 @@ namespace NuGetGallery.Controllers
                     packages,
                     id,
                     normalizedVersion,
-                    curatedFeed: curatedFeed,
+                    curatedFeed: result.CuratedFeed,
                     semVerLevel: semVerLevel);
 
                 // If intercepted, create a paged queryresult
@@ -228,9 +232,10 @@ namespace NuGetGallery.Controllers
             [FromODataUri]bool includePrerelease = false,
             [FromUri]string semVerLevel = null)
         {
-            if (_curatedFeedService.GetFeedByName(curatedFeedName) == null)
+            var result = GetCuratedFeedResult(curatedFeedName);
+            if (result.ActionResult != null)
             {
-                return NotFound();
+                return result.ActionResult;
             }
 
             // Handle OData-style |-separated list of frameworks.
@@ -251,8 +256,8 @@ namespace NuGetGallery.Controllers
             }
 
             // Perform actual search
-            var curatedFeed = _curatedFeedService.GetFeedByName(curatedFeedName);
-            var packages = _curatedFeedService.GetPackages(curatedFeedName)
+            var packages = result
+                .Packages
                 .Where(p => p.PackageStatusKey == PackageStatus.Available)
                 .Where(SemVerLevelKey.IsPackageCompliantWithSemVerLevelPredicate(semVerLevel))
                 .OrderBy(p => p.PackageRegistration.Id).ThenBy(p => p.Version);
@@ -265,7 +270,7 @@ namespace NuGetGallery.Controllers
                 searchTerm,
                 targetFramework,
                 includePrerelease,
-                curatedFeed: curatedFeed,
+                curatedFeed: result.CuratedFeed,
                 semVerLevel: semVerLevel);
 
             // Packages provided by search service (even when not hijacked)
@@ -325,6 +330,60 @@ namespace NuGetGallery.Controllers
         {
             var searchResults = await Search(options, curatedFeedName, searchTerm, targetFramework, includePrerelease, semVerLevel);
             return searchResults.FormattedAsCountResult<V2FeedPackage>();
+        }
+
+        private bool IsCuratedFeedRedirected(string name)
+        {
+            if (_configurationService.Current.RedirectedCuratedFeeds == null)
+            {
+                return false;
+            }
+
+            return _configurationService
+                .Current
+                .RedirectedCuratedFeeds
+                .Contains(name, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private CuratedFeedResult GetCuratedFeedResult(string curatedFeedName)
+        {
+            IQueryable<Package> packages;
+            CuratedFeed curatedFeed;
+            if (IsCuratedFeedRedirected(curatedFeedName))
+            {
+                curatedFeed = null;
+                packages = _packagesRepository.GetAll();
+            }
+            else
+            {
+                curatedFeed = _curatedFeedService.GetFeedByName(curatedFeedName);
+                if (curatedFeed == null)
+                {
+                    return new CuratedFeedResult(NotFound());
+                }
+
+                packages = _curatedFeedService.GetPackages(curatedFeedName);
+            }
+
+            return new CuratedFeedResult(packages, curatedFeed);
+        }
+
+        private class CuratedFeedResult
+        {
+            public CuratedFeedResult(IHttpActionResult actionResult)
+            {
+                ActionResult = actionResult ?? throw new ArgumentNullException(nameof(actionResult));
+            }
+
+            public CuratedFeedResult(IQueryable<Package> packages, CuratedFeed curatedFeed)
+            {
+                Packages = packages ?? throw new ArgumentNullException(nameof(packages));
+                CuratedFeed = curatedFeed;
+            }
+
+            public IQueryable<Package> Packages { get; }
+            public CuratedFeed CuratedFeed { get; }
+            public IHttpActionResult ActionResult { get; }
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Controllers/ODataFeedControllerFactsBase.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataFeedControllerFactsBase.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery.Controllers
     public abstract class ODataFeedControllerFactsBase<TController>
         where TController : NuGetODataController
     {
-        private const string _siteRoot = "https://nuget.localtest.me";
+        protected const string _siteRoot = "https://nuget.localtest.me";
         protected const string TestPackageId = "Some.Awesome.Package";
 
         protected readonly IReadOnlyCollection<Package> AvailablePackages;
@@ -60,7 +60,14 @@ namespace NuGetGallery.Controllers
             configurationService.Current.SiteRoot = _siteRoot;
 
             var controller = CreateController(PackagesRepository, configurationService, searchService);
-            
+
+            AddRequestToController(request, controller);
+
+            return controller;
+        }
+
+        protected static void AddRequestToController(HttpRequestMessage request, TController controller)
+        {
             var httpRequest = new HttpRequest(string.Empty, request.RequestUri.AbsoluteUri, request.RequestUri.Query);
             var httpResponse = new HttpResponse(new StringWriter());
             var httpContext = new HttpContext(httpRequest, httpResponse);
@@ -72,8 +79,6 @@ namespace NuGetGallery.Controllers
 
             controller.ControllerContext.Controller = controller;
             controller.ControllerContext.Configuration = new HttpConfiguration();
-
-            return controller;
         }
 
         protected async Task<IReadOnlyCollection<TFeedPackage>> GetCollection<TFeedPackage>(
@@ -208,7 +213,7 @@ namespace NuGetGallery.Controllers
             return list.AsQueryable();
         }
 
-        private static ODataQueryContext CreateODataQueryContext<TFeedPackage>()
+        protected static ODataQueryContext CreateODataQueryContext<TFeedPackage>()
             where TFeedPackage : class
         {
             var oDataModelBuilder = new ODataConventionModelBuilder();

--- a/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
@@ -4,10 +4,16 @@
 using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.OData.Query;
+using System.Web.Http.Results;
 using Moq;
 using NuGetGallery.Configuration;
 using NuGetGallery.OData;
+using NuGetGallery.WebApi;
 using Xunit;
 
 namespace NuGetGallery.Controllers
@@ -16,6 +22,150 @@ namespace NuGetGallery.Controllers
         : ODataFeedControllerFactsBase<ODataV2CuratedFeedController>
     {
         private const string _curatedFeedName = "dummy";
+
+        public class TheGetMethod
+        {
+            private readonly CuratedFeed _curatedFeed;
+            private readonly Package _curatedFeedPackage;
+            private readonly Package _mainFeedPackage;
+            private readonly FeatureConfiguration _featureConfiguration;
+            private readonly Mock<IGalleryConfigurationService> _config;
+            private readonly Mock<IAppConfiguration> _appConfig;
+            private readonly Mock<ISearchService> _searchService;
+            private readonly Mock<ICuratedFeedService> _curatedFeedService;
+            private readonly Mock<IEntityRepository<Package>> _packages;
+            private readonly ODataV2CuratedFeedController _target;
+            private readonly HttpRequestMessage _request;
+            private readonly ODataQueryOptions<V2FeedPackage> _options;
+
+            public TheGetMethod()
+            {
+                _curatedFeed = new CuratedFeed { Name = _curatedFeedName };
+                _curatedFeedPackage = new Package
+                {
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "NuGet.Core",
+                    },
+                };
+                _mainFeedPackage = new Package
+                {
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "NuGet.Versioning",
+                    },
+                };
+                _featureConfiguration = new FeatureConfiguration();
+                _appConfig = new Mock<IAppConfiguration>();
+
+                _config = new Mock<IGalleryConfigurationService>();
+                _searchService = new Mock<ISearchService>();
+                _curatedFeedService = new Mock<ICuratedFeedService>();
+                _packages = new Mock<IEntityRepository<Package>>();
+
+                _config
+                    .Setup(x => x.Current)
+                    .Returns(() => _appConfig.Object);
+                _config
+                    .Setup(x => x.Features)
+                    .Returns(() => _featureConfiguration);
+                _config
+                    .Setup(x => x.GetSiteRoot(It.IsAny<bool>()))
+                    .Returns(() => _siteRoot);
+                _curatedFeedService
+                    .Setup(x => x.GetFeedByName(_curatedFeedName))
+                    .Returns(() => _curatedFeed);
+                _curatedFeedService
+                    .Setup(x => x.GetPackages(_curatedFeedName))
+                    .Returns(() => new[] { _curatedFeedPackage }.AsQueryable());
+                _packages
+                    .Setup(x => x.GetAll())
+                    .Returns(() => new[] { _mainFeedPackage }.AsQueryable());
+
+                _target = new ODataV2CuratedFeedController(
+                    _config.Object,
+                    _searchService.Object,
+                    _curatedFeedService.Object,
+                    _packages.Object);
+
+                _request = new HttpRequestMessage(HttpMethod.Get, $"{_siteRoot}/api/v2/curated-feed/{_curatedFeedName}/Packages");
+                _options = new ODataQueryOptions<V2FeedPackage>(CreateODataQueryContext<V2FeedPackage>(), _request);
+                AddRequestToController(_request, _target);
+            }
+
+            [Fact]
+            public async Task RedirectedCuratedFeedQueriesMainFeed()
+            {
+                _appConfig
+                    .Setup(x => x.RedirectedCuratedFeeds)
+                    .Returns(() => new[] { _curatedFeedName });
+
+                var actionResult = _target.Get(_options, _curatedFeedName);
+
+                var list = await GetPackageListAsync(actionResult);
+                var package = Assert.Single(list);
+                Assert.Equal(_mainFeedPackage.PackageRegistration.Id, package.Id);
+                _curatedFeedService.Verify(x => x.GetFeedByName(_curatedFeedName), Times.Never);
+                _curatedFeedService.Verify(x => x.GetPackages(It.IsAny<string>()), Times.Never);
+                _packages.Verify(x => x.GetAll(), Times.Once);
+            }
+
+            [Fact]
+            public async Task MissingAndRedirectedCuratedFeedQueriesMainFeed()
+            {
+                _appConfig
+                    .Setup(x => x.RedirectedCuratedFeeds)
+                    .Returns(() => new[] { _curatedFeedName });
+                _curatedFeedService
+                    .Setup(x => x.GetFeedByName(It.IsAny<string>()))
+                    .Returns<CuratedFeed>(null);
+
+                var actionResult = _target.Get(_options, _curatedFeedName);
+
+                var list = await GetPackageListAsync(actionResult);
+                var package = Assert.Single(list);
+                Assert.Equal(_mainFeedPackage.PackageRegistration.Id, package.Id);
+                _curatedFeedService.Verify(x => x.GetFeedByName(_curatedFeedName), Times.Never);
+                _curatedFeedService.Verify(x => x.GetPackages(It.IsAny<string>()), Times.Never);
+                _packages.Verify(x => x.GetAll(), Times.Once);
+            }
+
+            [Fact]
+            public void MissingCuratedFeedReturnsNotFound()
+            {
+                _curatedFeedService
+                    .Setup(x => x.GetFeedByName(It.IsAny<string>()))
+                    .Returns<CuratedFeed>(null);
+
+                var actionResult = _target.Get(_options, _curatedFeedName);
+
+                Assert.IsType<NotFoundResult>(actionResult);
+                _curatedFeedService.Verify(x => x.GetFeedByName(_curatedFeedName), Times.Once);
+                _curatedFeedService.Verify(x => x.GetPackages(It.IsAny<string>()), Times.Never);
+                _packages.Verify(x => x.GetAll(), Times.Never);
+            }
+
+            [Fact]
+            public async Task NonRedirectCuratedFeedQueriesCuratedPackages()
+            {
+                var actionResult = _target.Get(_options, _curatedFeedName);
+
+                var list = await GetPackageListAsync(actionResult);
+                var package = Assert.Single(list);
+                Assert.Equal(_curatedFeedPackage.PackageRegistration.Id, package.Id);
+                _curatedFeedService.Verify(x => x.GetFeedByName(_curatedFeedName), Times.Once);
+                _curatedFeedService.Verify(x => x.GetPackages(It.IsAny<string>()), Times.Once);
+                _packages.Verify(x => x.GetAll(), Times.Never);
+            }
+
+            private static async Task<List<V2FeedPackage>> GetPackageListAsync(IHttpActionResult actionResult)
+            {
+                var queryResult = (QueryResult<V2FeedPackage>)actionResult;
+                var httpResponseMessage = await queryResult.ExecuteAsync(CancellationToken.None);
+                var objectContent = (ObjectContent<IQueryable<V2FeedPackage>>)httpResponseMessage.Content;
+                return ((IQueryable<V2FeedPackage>)objectContent.Value).ToList();
+            }
+        }
 
         [Fact]
         public async Task Get_FiltersSemVerV2PackageVersions()
@@ -335,7 +485,8 @@ namespace NuGetGallery.Controllers
             return new ODataV2CuratedFeedController(
                 configurationService,
                 searchService,
-                curatedFeedServiceMock.Object);
+                curatedFeedServiceMock.Object,
+                packagesRepository);
         }
 
         private static IDbSet<T> GetQueryableMockDbSet<T>(params T[] sourceList) where T : class


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6472. Depends on https://github.com/NuGet/NuGetGallery/pull/6486.

If a curated feed name is in this new list, it will not even be checked for existence in the DB. It will just use all packages. I considered an HTTP redirect or calling the `ODataV2FeedController` but chose to take this approach since it has the best change of not breaking existing clients.