### PR TITLE
Use mock IDbContextTransaction instead of concrete transaction object

### DIFF
--- a/src/NuGetGallery.Core/Entities/DatabaseWrapper.cs
+++ b/src/NuGetGallery.Core/Entities/DatabaseWrapper.cs
@@ -23,9 +23,9 @@ namespace NuGetGallery
             return _database.ExecuteSqlCommandAsync(sql, parameters);
         }
 
-        public DbContextTransaction BeginTransaction()
+        public IDbContextTransaction BeginTransaction()
         {
-            return _database.BeginTransaction();
+            return new DbContextTransactionWrapper(_database.BeginTransaction());
         }
 
         /// <summary>

--- a/src/NuGetGallery.Core/Entities/DbContextTransactionWrapper.cs
+++ b/src/NuGetGallery.Core/Entities/DbContextTransactionWrapper.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Entity;
+
+namespace NuGetGallery
+{
+    public class DbContextTransactionWrapper : IDbContextTransaction
+    {
+        private readonly DbContextTransaction _transaction;
+
+        public DbContextTransactionWrapper(DbContextTransaction transaction)
+        {
+            _transaction = transaction ?? throw new ArgumentNullException(nameof(transaction));
+        }
+
+        public void Commit()
+        {
+            _transaction.Commit();
+        }
+
+        public void Dispose()
+        {
+            _transaction.Dispose();
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Entities/IDatabase.cs
+++ b/src/NuGetGallery.Core/Entities/IDatabase.cs
@@ -8,7 +8,7 @@ namespace NuGetGallery
 {
     public interface IDatabase
     {
-        DbContextTransaction BeginTransaction();
+        IDbContextTransaction BeginTransaction();
 
         Task<int> ExecuteSqlCommandAsync(string sql, params object[] parameters);
 

--- a/src/NuGetGallery.Core/Entities/IDbContextTransaction.cs
+++ b/src/NuGetGallery.Core/Entities/IDbContextTransaction.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery
+{
+    public interface IDbContextTransaction : IDisposable
+    {
+        void Commit();
+    }
+}

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -118,7 +118,9 @@
     <Compile Include="Entities\CuratedFeed.cs" />
     <Compile Include="Entities\CuratedPackage.cs" />
     <Compile Include="Entities\DatabaseWrapper.cs" />
+    <Compile Include="Entities\DbContextTransactionWrapper.cs" />
     <Compile Include="Entities\IDatabase.cs" />
+    <Compile Include="Entities\IDbContextTransaction.cs" />
     <Compile Include="Entities\Membership.cs" />
     <Compile Include="Entities\Organization.cs" />
     <Compile Include="Entities\AccountDelete.cs" />

--- a/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
@@ -3,16 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
+using Moq;
 using NuGetGallery.Areas.Admin;
 using NuGetGallery.Areas.Admin.Models;
 using NuGetGallery.Auditing;
 using NuGetGallery.Authentication;
 using NuGetGallery.Security;
 using Xunit;
-using Moq;
 
 namespace NuGetGallery.Services
 {
@@ -466,8 +465,9 @@ namespace NuGetGallery.Services
             private Mock<IEntitiesContext> SetupEntitiesContext()
             {
                 var mockContext = new Mock<IEntitiesContext>();
-                var dbContext = new Mock<DbContext>();
-                mockContext.Setup(m => m.GetDatabase()).Returns(new DatabaseWrapper(dbContext.Object.Database));
+                var database = new Mock<IDatabase>();
+                database.Setup(x => x.BeginTransaction()).Returns(() => new Mock<IDbContextTransaction>().Object);
+                mockContext.Setup(m => m.GetDatabase()).Returns(database.Object);
                 return mockContext;
             }
 

--- a/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeleteServiceFacts.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.Entity;
 using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
@@ -41,9 +40,10 @@ namespace NuGetGallery
             packageRegistrationRepository = packageRegistrationRepository ?? new Mock<IEntityRepository<PackageRegistration>>();
             packageDeletesRepository = packageDeletesRepository ?? new Mock<IEntityRepository<PackageDelete>>();
 
-            var dbContext = new Mock<DbContext>();
             entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
-            entitiesContext.Setup(m => m.GetDatabase()).Returns(new DatabaseWrapper(dbContext.Object.Database));
+            var database = new Mock<IDatabase>();
+            database.Setup(x => x.BeginTransaction()).Returns(() => new Mock<IDbContextTransaction>().Object);
+            entitiesContext.Setup(m => m.GetDatabase()).Returns(database.Object);
 
             packageService = packageService ?? new Mock<IPackageService>();
             indexingService = indexingService ?? new Mock<IIndexingService>();

--- a/tests/NuGetGallery.Facts/Services/PackageOwnershipManagementServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageOwnershipManagementServiceFacts.cs
@@ -1,16 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Moq;
-using Xunit;
 using System;
-using System.Linq;
-using System.Data.Entity;
-using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
 using NuGetGallery.Auditing;
 using NuGetGallery.Framework;
 using NuGetGallery.TestUtils;
+using Xunit;
 
 namespace NuGetGallery
 {
@@ -24,9 +23,10 @@ namespace NuGetGallery
             IAuditingService auditingService = null,
             bool useDefaultSetup = true)
         {
-            var dbContext = new Mock<DbContext>();
             entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
-            entitiesContext.Setup(m => m.GetDatabase()).Returns(new DatabaseWrapper(dbContext.Object.Database));
+            var database = new Mock<IDatabase>();
+            database.Setup(x => x.BeginTransaction()).Returns(() => new Mock<IDbContextTransaction>().Object);
+            entitiesContext.Setup(m => m.GetDatabase()).Returns(database.Object);
             packageService = packageService ?? new Mock<IPackageService>();
             reservedNamespaceService = reservedNamespaceService ?? new Mock<IReservedNamespaceService>();
             packageOwnerRequestService = packageOwnerRequestService ?? new Mock<IPackageOwnerRequestService>();

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -2,19 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Data.Entity;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using NuGet.Packaging;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
-using Xunit;
-using NuGetGallery.TestUtils;
 using NuGetGallery.Security;
+using NuGetGallery.TestUtils;
+using Xunit;
 
 namespace NuGetGallery
 {
@@ -27,9 +24,10 @@ namespace NuGetGallery
             Mock<ITelemetryService> telemetryService = null,
             Action<Mock<ReflowPackageService>> setup = null)
         {
-            var dbContext = new Mock<DbContext>();
             entitiesContext = entitiesContext ?? new Mock<IEntitiesContext>();
-            entitiesContext.Setup(m => m.GetDatabase()).Returns(new DatabaseWrapper(dbContext.Object.Database));
+            var database = new Mock<IDatabase>();
+            database.Setup(x => x.BeginTransaction()).Returns(() => new Mock<IDbContextTransaction>().Object);
+            entitiesContext.Setup(m => m.GetDatabase()).Returns(database.Object);
 
             packageService = packageService ?? new Mock<PackageService>();
             packageFileService = packageFileService ?? new Mock<IPackageFileService>();

--- a/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.Entity;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
@@ -290,9 +289,13 @@ namespace NuGetGallery.TestUtils
         private Mock<IEntitiesContext> SetupEntitiesContext()
         {
             var mockContext = new Mock<IEntitiesContext>();
-            var dbContext = new Mock<DbContext>();
-            mockContext.Setup(m => m.GetDatabase())
-                .Returns(new DatabaseWrapper(dbContext.Object.Database));
+            var database = new Mock<IDatabase>();
+            database
+                .Setup(x => x.BeginTransaction())
+                .Returns(() => new Mock<IDbContextTransaction>().Object);
+            mockContext
+                .Setup(m => m.GetDatabase())
+                .Returns(database.Object);
 
             return mockContext;
         }


### PR DESCRIPTION
Fix https://github.com/NuGet/Engineering/issues/1745. This uses a mocked `IDatabase` instead of LocalDB. 

Services that only use `IDatabase` for a transaction:

- `DeleteAccountService`
- `PackageOwnershipManagementService`
- `ReflowPackageService`
- `ReservedNamespaceService`

Services that run SQL, but don't unit test the outcome:

- `PackageDeleteService`

In other words, the concrete database was being connected to but never used for test assertions.