### PR TITLE
Typo-squatting: finish functional tests

### DIFF
--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -770,6 +770,7 @@ namespace NuGetGallery
 
                 Assert.Equal(PackageValidationResultType.Invalid, result.Type);
                 Assert.Equal(string.Format(Strings.TyposquattingCheckFails, string.Join(",", _typosquattingCheckCollisionIds)), result.Message);
+                Assert.Contains("similar", result.Message);
                 Assert.Empty(result.Warnings);
             }
         }

--- a/tests/NuGetGallery.FunctionalTests.Core/GalleryConfiguration.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/GalleryConfiguration.cs
@@ -38,6 +38,8 @@ namespace NuGetGallery.FunctionalTests
         public OrganizationConfiguration CollaboratorOrganization { get; private set; }
         [JsonProperty]
         public BrandingConfiguration Branding { get; private set; }
+        [JsonProperty]
+        public bool TyposquattingCheckAndBlockUsers { get; private set; }
 
         static GalleryConfiguration()
         {

--- a/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
+++ b/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Helpers\NuspecHelper.cs" />
     <Compile Include="Helpers\ODataHelper.cs" />
     <Compile Include="Helpers\PackageCreationHelper.cs" />
+    <Compile Include="XunitExtensions\TyposquattingTestFactAttribute.cs" />
     <Compile Include="XunitExtensions\PriorityAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="XunitExtensions\CategoryDiscoverer.cs" />

--- a/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/TyposquattingTestFactAttribute.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/TyposquattingTestFactAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGetGallery.FunctionalTests.XunitExtensions
+{
+    public class TyposquattingTestFactAttribute : FactAttribute
+    {
+        public TyposquattingTestFactAttribute()
+        {
+            if (!GalleryConfiguration.Instance.TyposquattingCheckAndBlockUsers)
+            {
+                Skip = string.Format("Typosquatting checking and user blocking are disabled");
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/TyposquattingTestFactAttribute.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/TyposquattingTestFactAttribute.cs
@@ -11,7 +11,7 @@ namespace NuGetGallery.FunctionalTests.XunitExtensions
         {
             if (!GalleryConfiguration.Instance.TyposquattingCheckAndBlockUsers)
             {
-                Skip = string.Format("Typosquatting checking and user blocking are disabled");
+                Skip = string.Format("Typosquatting checking or user blocking are disabled");
             }
         }
     }

--- a/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/TyposquattingTestFactAttribute.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/TyposquattingTestFactAttribute.cs
@@ -11,7 +11,7 @@ namespace NuGetGallery.FunctionalTests.XunitExtensions
         {
             if (!GalleryConfiguration.Instance.TyposquattingCheckAndBlockUsers)
             {
-                Skip = string.Format("Typosquatting checking or user blocking are disabled");
+                Skip = "Typosquatting checking or user blocking are disabled";
             }
         }
     }

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Security\HttpToHttpsRedirectTests.cs" />
     <Compile Include="Statistics\PackageStatisticsTests.cs" />
     <Compile Include="ODataFeeds\V2FeedTests.cs" />
+    <Compile Include="TyposquattingCheck\TyposquattingCheckForUploadPackageTests.cs" />
     <Compile Include="WebPages\FluentLinkChecker.cs" />
     <Compile Include="WebPages\LinksTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/NuGetGallery.FunctionalTests/TyposquattingCheck/TyposquattingCheckForUploadPackageTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/TyposquattingCheck/TyposquattingCheckForUploadPackageTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using NuGetGallery.FunctionalTests.XunitExtensions;
+
+namespace NuGetGallery.FunctionalTests.TyposquattingCheck
+{
+    public class TyposquattingCheckForUploadPackageTests : GalleryTestBase
+    {
+        private readonly CommandlineHelper _commandlineHelper;
+        private readonly PackageCreationHelper _packageCreationHelper;
+        public TyposquattingCheckForUploadPackageTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+            _commandlineHelper = new CommandlineHelper(TestOutputHelper);
+            _packageCreationHelper = new PackageCreationHelper(testOutputHelper);
+        }
+
+        [TyposquattingTestFact]
+        public async Task UploadNotTyposquattingPackage()
+        {
+            string packageId = DateTime.Now.Ticks + "PackageWithDotCsNames.Cs";
+            string version = "1.0.0";
+            string packageFullPath = await _packageCreationHelper.CreatePackageWithMinClientVersion(packageId, version, "2.3");
+
+            var processResult = await _commandlineHelper.UploadPackageAsync(packageFullPath, UrlHelper.V2FeedPushSourceUrl);
+
+            Assert.True(processResult.ExitCode == 0, Constants.UploadFailureMessage);
+        }
+
+        [TyposquattingTestFact]
+        public async Task UploadTyposquattingPackageAndBlockUser()
+        {
+            var packageId = "newtonsoft-json";
+            string version = "1.0.0";
+            string packageFullPath = await _packageCreationHelper.CreatePackageWithMinClientVersion(packageId, version, "2.3");
+
+            var processResult = await _commandlineHelper.UploadPackageAsync(packageFullPath, UrlHelper.V2FeedPushSourceUrl);
+
+            Assert.True(processResult.ExitCode == 1, Constants.UploadFailureMessage);
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/TyposquattingCheck/TyposquattingCheckForUploadPackageTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/TyposquattingCheck/TyposquattingCheckForUploadPackageTests.cs
@@ -20,18 +20,6 @@ namespace NuGetGallery.FunctionalTests.TyposquattingCheck
         }
 
         [TyposquattingTestFact]
-        public async Task UploadNotTyposquattingPackage()
-        {
-            string packageId = DateTime.Now.Ticks + "PackageWithDotCsNames.Cs";
-            string version = "1.0.0";
-            string packageFullPath = await _packageCreationHelper.CreatePackageWithMinClientVersion(packageId, version, "2.3");
-
-            var processResult = await _commandlineHelper.UploadPackageAsync(packageFullPath, UrlHelper.V2FeedPushSourceUrl);
-
-            Assert.True(processResult.ExitCode == 0, Constants.UploadFailureMessage);
-        }
-
-        [TyposquattingTestFact]
         public async Task UploadTyposquattingPackageAndBlockUser()
         {
             var packageId = "newtonsoft-json";
@@ -40,6 +28,7 @@ namespace NuGetGallery.FunctionalTests.TyposquattingCheck
 
             var processResult = await _commandlineHelper.UploadPackageAsync(packageFullPath, UrlHelper.V2FeedPushSourceUrl);
 
+            Assert.Contains("similar", processResult.StandardError);
             Assert.True(processResult.ExitCode == 1, Constants.UploadFailureMessage);
         }
     }

--- a/tests/NuGetGallery.FunctionalTests/TyposquattingCheck/TyposquattingCheckForUploadPackageTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/TyposquattingCheck/TyposquattingCheckForUploadPackageTests.cs
@@ -28,8 +28,8 @@ namespace NuGetGallery.FunctionalTests.TyposquattingCheck
 
             var processResult = await _commandlineHelper.UploadPackageAsync(packageFullPath, UrlHelper.V2FeedPushSourceUrl);
 
-            Assert.Contains("similar", processResult.StandardError);
             Assert.True(processResult.ExitCode == 1, Constants.UploadFailureMessage);
+            Assert.Contains("similar", processResult.StandardError);
         }
     }
 }


### PR DESCRIPTION
Finish the basic typo-squatting functional tests. 

Fix: https://github.com/NuGet/Engineering/issues/1595