### PR TITLE
Fix potential race condition with etags returned by GetFileReferenceAsync

### DIFF
--- a/src/NuGetGallery.Core/Services/CloudFileReference.cs
+++ b/src/NuGetGallery.Core/Services/CloudFileReference.cs
@@ -26,9 +26,9 @@ namespace NuGetGallery
             return new CloudFileReference(null, contentId);
         }
 
-        public static CloudFileReference Modified(ISimpleCloudBlob blob, Stream data)
+        public static CloudFileReference Modified(Stream data, string contentId)
         {
-            return new CloudFileReference(data, blob.ETag);
+            return new CloudFileReference(data, contentId);
         }
     }
 }


### PR DESCRIPTION
This is preventing the reliable pattern:

1. Read
1. Business logic,
1. Write, if etag still matches

Added an integration test that catches the problem.