### PR TITLE
[NuGet Symbol Server] Add symbols delete support to gallery

### DIFF
--- a/src/NuGetGallery.Core/Auditing/PackageAuditReasons.cs
+++ b/src/NuGetGallery.Core/Auditing/PackageAuditReasons.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery.Auditing
     public static class PackageDeletedVia
     {
         /// <summary>
-        /// Package has been deleted via NuGet API (nuget.exe push)
+        /// Package has been deleted via NuGet API (nuget.exe delete)
         /// </summary>
         public const string Api = "Deleted via API.";
 

--- a/src/NuGetGallery.Core/Auditing/PackageCreatedVia.cs
+++ b/src/NuGetGallery.Core/Auditing/PackageCreatedVia.cs
@@ -15,4 +15,17 @@ namespace NuGetGallery.Auditing
         /// </summary>
         public const string Web = "Created via web.";
     }
+
+    public static class PackageDeletedVia
+    {
+        /// <summary>
+        /// Package has been deleted via NuGet API (nuget.exe push)
+        /// </summary>
+        public const string Api = "Deleted via API.";
+
+        /// <summary>
+        /// Package has been deleted via NuGet web interface (browser)
+        /// </summary>
+        public const string Web = "Deleted via web.";
+    }
 }

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -91,7 +91,7 @@
     <Compile Include="Auditing\CredentialAuditRecord.cs" />
     <Compile Include="Auditing\AuditedPackageAction.cs" />
     <Compile Include="Auditing\IAuditingService.cs" />
-    <Compile Include="Auditing\PackageCreatedVia.cs" />
+    <Compile Include="Auditing\PackageAuditReasons.cs" />
     <Compile Include="Auditing\AuditedPackageRegistrationAction.cs" />
     <Compile Include="Auditing\AuditedEntities\AuditedPackageRegistration.cs" />
     <Compile Include="Auditing\PackageRegistrationAuditRecord.cs" />

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1317,14 +1317,14 @@ namespace NuGetGallery
         [ValidateAntiForgeryToken]
         public virtual async Task<ActionResult> DeleteSymbolsPackage(string id, string version)
         {
-            var package = _packageService.FindPackageByIdAndVersion(id, version);
+            var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
             if (package == null)
             {
                 return new HttpStatusCodeResult(HttpStatusCode.NotFound,
                     string.Format(Strings.PackageWithIdAndVersionNotFound, id, version));
             }
 
-            if (ActionsRequiringPermissions.UploadSymbolPackage.CheckPermissionsOnBehalfOfAnyAccount(GetCurrentUser(), package)
+            if (ActionsRequiringPermissions.DeleteSymbolPackage.CheckPermissionsOnBehalfOfAnyAccount(GetCurrentUser(), package)
                 != PermissionsCheckResult.Allowed)
             {
                 return new HttpStatusCodeResult(HttpStatusCode.Forbidden, Strings.SymbolsPackage_UploadNotAllowed);
@@ -1354,7 +1354,7 @@ namespace NuGetGallery
                 await _auditingService.SaveAuditRecordAsync(
                     new PackageAuditRecord(package, AuditedPackageAction.SymbolsDelete, PackageDeletedVia.Web));
 
-                _telemetryService.TrackSymbolPackagePushEvent(package.Id, package.Version);
+                _telemetryService.TrackSymbolPackageDeleteEvent(package.Id, package.Version);
 
                 // Redirect to the package details page
                 return Redirect(Url.Package(package, relativeUrl: true));

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1780,6 +1780,7 @@
     <Content Include="Views\Shared\ConfirmationRequired.cshtml" />
     <Content Include="Views\Pages\Contact.cshtml" />
     <Content Include="Views\Shared\_DeletePackage.cshtml" />
+    <Content Include="Views\Packages\DeleteSymbols.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/src/NuGetGallery/Scripts/gallery/page-delete-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-delete-package.js
@@ -14,4 +14,10 @@
             e.preventDefault();
         }
     });
+
+    $('#delete-symbols-form').submit(function (e) {
+        if (!confirm('Deleting this symbols package will make it unavailable for download and remove all corresponding symbols from the symbol server. Are you sure you want to continue with the delete?')) {
+            e.preventDefault();
+        }
+    });
 });

--- a/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
+++ b/src/NuGetGallery/Services/ActionsRequiringPermissions.cs
@@ -45,12 +45,20 @@ namespace NuGetGallery
                 packageRegistrationPermissionsRequirement: PermissionsRequirement.Owner);
 
         /// <summary>
-        /// The action of uploading a symbol package for an existing package.
+        /// The action of uploading a symbols package for an existing package.
         /// </summary>
         public static ActionRequiringPackagePermissions UploadSymbolPackage =
             new ActionRequiringPackagePermissions(
                 accountOnBehalfOfPermissionsRequirement: RequireOwnerOrOrganizationMember,
                 packageRegistrationPermissionsRequirement: PermissionsRequirement.Owner);
+
+        /// <summary>
+        /// The action of deleting a symbols package for an existing package.
+        /// </summary>
+        public static ActionRequiringPackagePermissions DeleteSymbolPackage =
+            new ActionRequiringPackagePermissions(
+                accountOnBehalfOfPermissionsRequirement: RequireOwnerOrOrganizationMember,
+                packageRegistrationPermissionsRequirement: RequireOwnerOrSiteAdmin);
 
         /// <summary>
         /// The action of verify a package verification key.

--- a/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
@@ -34,5 +34,11 @@ namespace NuGetGallery
         /// <param name="currentUser">The user performing the uploads.</param>
         /// <returns>Awaitable task with <see cref="SymbolPackageValidationResult"/></returns>
         Task<SymbolPackageValidationResult> ValidateUploadedSymbolsPackage(Stream uploadStream, User currentUser);
+
+        /// <summary>
+        /// Mark the specifed symbol package for deletion and delete the corressponding snupkg as well.
+        /// </summary>
+        /// <param name="symbolPackage">The <see cref="SymbolPackage"/> entity to be marked for deletion</param>
+        Task DeleteSymbolsPackage(SymbolPackage symbolPackage);
     }
 }

--- a/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/ISymbolPackageUploadService.cs
@@ -39,6 +39,6 @@ namespace NuGetGallery
         /// Mark the specifed symbol package for deletion and delete the corressponding snupkg as well.
         /// </summary>
         /// <param name="symbolPackage">The <see cref="SymbolPackage"/> entity to be marked for deletion</param>
-        Task DeleteSymbolsPackage(SymbolPackage symbolPackage);
+        Task DeleteSymbolsPackageAsync(SymbolPackage symbolPackage);
     }
 }

--- a/src/NuGetGallery/Services/ITelemetryService.cs
+++ b/src/NuGetGallery/Services/ITelemetryService.cs
@@ -166,6 +166,13 @@ namespace NuGetGallery
         void TrackSymbolPackagePushEvent(string packageId, string packageVersion);
 
         /// <summary>
+        /// A telemetry event emitted when a symbol package is deleted.
+        /// </summary>
+        /// <param name="packageId">The id of the package for which symbols are deleted.</param>
+        /// <param name="packageVersion">The version of the package for which the symbols are delted.</param>
+        void TrackSymbolPackageDeleteEvent(string packageId, string packageVersion);
+
+        /// <summary>
         /// A telemetry event emitted when a symbol package fails to be pushed.
         /// </summary>
         /// <param name="packageId">The id of the package that has the symbols uploaded.</param>

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -230,5 +230,16 @@ namespace NuGetGallery
 
             return PackageCommitResult.Success;
         }
+
+        public async Task DeleteSymbolsPackage(SymbolPackage symbolPackage)
+        {
+            if (symbolPackage == null)
+            {
+                throw new ArgumentNullException(nameof(symbolPackage));
+            }
+
+            await _symbolPackageFileService.DeletePackageFileAsync(symbolPackage.Id, symbolPackage.Version);
+            await _symbolPackageService.UpdateStatusAsync(symbolPackage, PackageStatus.Deleted, commitChanges: true);
+        }
     }
 }

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -231,14 +231,18 @@ namespace NuGetGallery
             return PackageCommitResult.Success;
         }
 
-        public async Task DeleteSymbolsPackage(SymbolPackage symbolPackage)
+        public async Task DeleteSymbolsPackageAsync(SymbolPackage symbolPackage)
         {
             if (symbolPackage == null)
             {
                 throw new ArgumentNullException(nameof(symbolPackage));
             }
 
-            await _symbolPackageFileService.DeletePackageFileAsync(symbolPackage.Id, symbolPackage.Version);
+            if (await _symbolPackageFileService.DoesPackageFileExistAsync(symbolPackage.Package))
+            {
+                await _symbolPackageFileService.DeletePackageFileAsync(symbolPackage.Id, symbolPackage.Version);
+            }
+
             await _symbolPackageService.UpdateStatusAsync(symbolPackage, PackageStatus.Deleted, commitChanges: true);
         }
     }

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -50,6 +50,7 @@ namespace NuGetGallery
             public const string AccountDeleteCompleted = "AccountDeleteCompleted";
             public const string AccountDeleteRequested = "AccountDeleteRequested";
             public const string SymbolPackagePush = "SymbolPackagePush";
+            public const string SymbolPackageDelete = "SymbolPackageDelete";
             public const string SymbolPackagePushFailure = "SymbolPackagePushFailure";
             public const string SymbolPackageGalleryValidation = "SymbolPackageGalleryValidation";
             public const string PackageMetadataComplianceError = "PackageMetadataComplianceError";
@@ -408,6 +409,10 @@ namespace NuGetGallery
         public void TrackSymbolPackagePushEvent(string packageId, string packageVersion)
         {
             TrackMetricForSymbolPackage(Events.SymbolPackagePush, packageId, packageVersion);
+        }
+        public void TrackSymbolPackageDeleteEvent(string packageId, string packageVersion)
+        {
+            TrackMetricForSymbolPackage(Events.SymbolPackageDelete, packageId, packageVersion);
         }
 
         public void TrackSymbolPackagePushFailureEvent(string packageId, string packageVersion)

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1851,6 +1851,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The symbols package associated with this package have been deleted..
+        /// </summary>
+        public static string SymbolsPackage_Deleted {
+            get {
+                return ResourceManager.GetString("SymbolsPackage_Deleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to read the symbols package. Ensure it is a valid symbols package (.snupkg)..
         /// </summary>
         public static string SymbolsPackage_FailedToReadPackage {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1851,7 +1851,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The symbols package associated with this package have been deleted..
+        ///   Looks up a localized string similar to The symbols package associated with this package has been deleted..
         /// </summary>
         public static string SymbolsPackage_Deleted {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -994,6 +994,6 @@ Policy violations: {0}</value>
     <value>Successfully uploaded the symbols package for package with ID {0} and version {1}.</value>
   </data>
   <data name="SymbolsPackage_Deleted" xml:space="preserve">
-    <value>The symbols package associated with this package have been deleted.</value>
+    <value>The symbols package associated with this package has been deleted.</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -993,4 +993,7 @@ Policy violations: {0}</value>
   <data name="SymbolsPackage_UploadSuccessful" xml:space="preserve">
     <value>Successfully uploaded the symbols package for package with ID {0} and version {1}.</value>
   </data>
+  <data name="SymbolsPackage_Deleted" xml:space="preserve">
+    <value>The symbols package associated with this package have been deleted.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -752,7 +752,8 @@ namespace NuGetGallery
         /// that only need a single link should call Url.DeletePackage instead.
         public static RouteUrlTemplate<IPackageVersionModel> DeletePackageTemplate(
             this UrlHelper url,
-            bool relativeUrl = true)
+            bool relativeUrl = true,
+            string action = "Delete")
         {
             var routesGenerator = new Dictionary<string, Func<IPackageVersionModel, object>>
             {
@@ -762,7 +763,7 @@ namespace NuGetGallery
 
             Func<RouteValueDictionary, string> linkGenerator = rv => GetActionLink(
                 url,
-                "Delete",
+                action,
                 "Packages",
                 relativeUrl,
                 routeValues: rv);
@@ -776,6 +777,14 @@ namespace NuGetGallery
             bool relativeUrl = true)
         {
             return url.DeletePackageTemplate(relativeUrl).Resolve(package);
+        }
+
+        public static string DeleteSymbolsPackage(
+            this UrlHelper url,
+            IPackageVersionModel package,
+            bool relativeUrl = true)
+        {
+            return url.DeletePackageTemplate(relativeUrl, action: "DeleteSymbols").Resolve(package);
         }
 
         public static string AccountSettings(

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -26,10 +26,7 @@ namespace NuGetGallery
             PushedBy = GetPushedBy(package, currentUser);
             PackageFileSize = package.PackageFileSize;
 
-            LatestSymbolsPackage = package
-                .SymbolPackages
-                .OrderByDescending(sp => sp.Created)
-                .FirstOrDefault();
+            LatestSymbolsPackage = GetLatestSymbolPackage(package);
 
             if (packageHistory.Any())
             {
@@ -55,6 +52,8 @@ namespace NuGetGallery
             DownloadsPerDay = 0;
 
             PushedBy = pushedBy;
+
+            LatestSymbolsPackage = GetLatestSymbolPackage(package);
 
             InitializeRepositoryMetadata(package.RepositoryUrl, package.RepositoryType);
 
@@ -198,6 +197,14 @@ namespace NuGetGallery
                     RepositoryType = RepositoryKind.Git;
                 }
             }
+        }
+
+        private SymbolPackage GetLatestSymbolPackage(Package package)
+        {
+            return package
+                .SymbolPackages
+                .OrderByDescending(sp => sp.Created)
+                .FirstOrDefault();
         }
 
         public enum RepositoryKind

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -39,6 +39,7 @@ namespace NuGetGallery
             CanManageOwners = CanPerformAction(currentUser, package, ActionsRequiringPermissions.ManagePackageOwnership);
             CanReportAsOwner = CanPerformAction(currentUser, package, ActionsRequiringPermissions.ReportPackageAsOwner);
             CanSeeBreadcrumbWithProfile = CanPerformAction(currentUser, package, ActionsRequiringPermissions.ShowProfileBreadcrumb);
+            CanDeleteSymbolsPackage = CanPerformAction(currentUser, package, ActionsRequiringPermissions.DeleteSymbolPackage);
         }
 
         public string Authors { get; set; }
@@ -104,6 +105,7 @@ namespace NuGetGallery
         public bool CanManageOwners { get; set; }
         public bool CanReportAsOwner { get; set; }
         public bool CanSeeBreadcrumbWithProfile { get; set; }
+        public bool CanDeleteSymbolsPackage { get; set; }
 
         private static bool CanPerformAction(User currentUser, Package package, ActionRequiringPackagePermissions action)
         {

--- a/src/NuGetGallery/Views/Packages/DeleteSymbols.cshtml
+++ b/src/NuGetGallery/Views/Packages/DeleteSymbols.cshtml
@@ -59,10 +59,7 @@
                             })
                     </div>
                 </div>
-            }
 
-            @if (User.IsAdministrator())
-            {
                 <h2>
                     <a href="#" role="button" data-toggle="collapse" data-target="#delete-package"
                        aria-expanded="false" aria-controls="delete-package" id="show-delete-package">

--- a/src/NuGetGallery/Views/Packages/DeleteSymbols.cshtml
+++ b/src/NuGetGallery/Views/Packages/DeleteSymbols.cshtml
@@ -1,0 +1,137 @@
+﻿@model DeletePackageViewModel
+@{
+    ViewBag.Title = "Manage Symbols Package " + Model.Id;
+    ViewBag.Tab = "Symbol Packages";
+    ViewBag.MdPageColumns = Constants.ColumnsFormMd;
+}
+
+<section role="main" class="container main-container page-delete-package">
+    <div class="row">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
+            @Html.Partial(
+                "_PackageHeading",
+                new PackageHeadingModel(
+                    Model,
+                    "Delete Symbols",
+                    linkIdOnly: true))
+
+            @if (Model.IsLocked && !User.IsAdministrator())
+            {
+                <div class="validation-error-message-list">
+                    @ViewHelpers.AlertDanger(
+                        @<text>
+                            <span>
+                                Package '@Model.Id' has been locked. This means you cannot delete the symbols for this package. Please contact
+                                <a href="mailto:support@nuget.org?subject=@HttpUtility.UrlPathEncode(string.Format("Requesting support for a locked package - '{0}'", Model.Id))">support@nuget.org</a>.
+                            </span>
+                        </text>)
+                </div>
+            }
+            else
+            {
+                if (Model.IsLocked && User.IsAdministrator())
+                {
+                    <div class="validation-error-message-list">
+                        @ViewHelpers.AlertDanger(
+                            @<text>
+                                <span>Package '@Model.Id' has been locked.</span>
+                            </text>)
+                    </div>
+                }
+
+                <h2>
+                    <a href="#" role="button" data-toggle="collapse" data-target="#select-version" aria-expanded="true" aria-controls="select-version" id="show-select-version">
+                        <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                        <span>Select Version</span>
+                    </a>
+                </h2>
+
+                <div class="panel-collapse collapse in" aria-expanded="true" id="select-version">
+                    <div class="form-group">
+                        <label for="input-select-version" id="package-version-label">Select Package Version</label>
+
+                        @Html.DropDownList("version-selection", Model.VersionSelectList,
+                            new
+                            {
+                                @class = "form-control",
+                                title = "Select a version",
+                                id = "input-select-version"
+                            })
+                    </div>
+                </div>
+            }
+
+            @if (User.IsAdministrator())
+            {
+                <h2>
+                    <a href="#" role="button" data-toggle="collapse" data-target="#delete-package"
+                       aria-expanded="false" aria-controls="delete-package" id="show-delete-package">
+                        <i class="ms-Icon ms-Icon--ChevronRight" aria-hidden="true"></i>
+                        <span>Delete Symbols Package Version</span>
+                    </a>
+                </h2>
+                <div class="list-unstyled panel-collapse collapse" id="delete-package">
+                    @ViewHelpers.AlertDanger(
+                        @<text>
+                            <strong>Deleting this symbols package will remove all the symbols from the symbol server and make them unavailable.</strong><br />
+                        </text>)
+
+                    @using (Html.BeginForm("DeleteSymbolsPackage", "Packages", FormMethod.Post, new { id = "delete-symbols-form" }))
+                    {
+                        @Html.AntiForgeryToken()
+
+                        foreach (var p in Model.DeletePackagesRequest.Packages)
+                        {
+                            <input type="hidden" name="Packages[]" value="@p" />
+                        }
+
+                        <div id="form-field-reason" class="form-group @Html.HasErrorFor(m => m.DeletePackagesRequest.Reason)">
+                            @Html.ShowLabelFor(m => m.DeletePackagesRequest.Reason)
+                            @Html.ShowEnumDropDownListFor(m => m.DeletePackagesRequest.Reason, Model.DeletePackagesRequest.ReasonChoices, "<Choose a Reason>")
+                            @Html.ShowValidationMessagesFor(m => m.DeletePackagesRequest.Reason)
+                        </div>
+
+                        <div class="form-group @Html.HasErrorFor(m => m.DeletePackagesRequest.Signature)">
+                            @Html.ShowLabelFor(m => m.DeletePackagesRequest.Signature)
+                            @Html.ShowTextBoxFor(m => m.DeletePackagesRequest.Signature)
+                            @Html.ShowValidationMessagesFor(m => m.DeletePackagesRequest.Signature)
+                        </div>
+
+                        <hr />
+                        <p>
+                            This action <strong>CANNOT</strong> be undone. This will permanently delete the symbols package and make it unavailable for download as well as remove all the published symbols(.pdbs) from the symbol server for debugging!
+                        </p>
+                        <hr />
+
+                        <div class="form-group">
+                            <input type="submit" class="btn btn-danger form-control" value="I understand the consequences, delete this symbols package" />
+                        </div>
+                    }
+                </div>
+            }
+        </div>
+    </div>
+</section>
+
+@section BottomScripts {
+    <script type="text/javascript">
+        $(function () {
+            window.nuget.configureExpanderHeading("select-version");
+            window.nuget.configureExpanderHeading("list-package");
+            window.nuget.configureExpanderHeading("delete-package");
+
+            if (!!document.referrer) {
+                var referrer = document.referrer.toLowerCase();
+
+                if (referrer.endsWith("/delete") && referrer.indexOf("@Model.Id".toLowerCase()) != -1) {
+                    $("#input-select-version").focus();
+                }
+            }
+
+            $('#input-select-version').change(function () {
+                window.location.href = this.value;
+            });
+        });
+    </script>
+    @Scripts.Render("~/Scripts/gallery/page-delete-package.js")
+}

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -699,6 +699,13 @@
                         <a href="@Url.DeletePackage(Model)" class="delete">Delete package</a>
                     </li>
                 }
+                @if (!Model.Deleted && hasSymbolsPackageAvailable && Model.CanDeleteSymbolsPackage)
+                {
+                    <li>
+                        <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
+                        <a href="@Url.DeleteSymbolsPackage(Model)" class="delete">Delete symbols</a>
+                    </li>
+                }
 
                 @if (Model.Available && User.IsAdministrator())
                 {

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -25,6 +25,7 @@ using NuGetGallery.AsyncFileUpload;
 using NuGetGallery.Auditing;
 using NuGetGallery.Authentication;
 using NuGetGallery.Configuration;
+using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Helpers;
 using NuGetGallery.Packaging;
@@ -155,7 +156,7 @@ namespace NuGetGallery
                     .Setup(x => x.DeleteSymbolsPackageAsync(It.IsAny<SymbolPackage>()))
                     .Completes();
             }
-
+            var diagnosticsService = new Mock<IDiagnosticsService>();
             var controller = new Mock<PackagesController>(
                 packageService.Object,
                 uploadFileService.Object,
@@ -178,7 +179,8 @@ namespace NuGetGallery
                 validationService.Object,
                 packageOwnershipManagementService.Object,
                 contentObjectService.Object,
-                symbolPackageUploadService.Object);
+                symbolPackageUploadService.Object,
+                diagnosticsService.Object);
 
             controller.CallBase = true;
             controller.Object.SetOwinContextOverride(Fakes.CreateOwinContext());

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -151,6 +151,9 @@ namespace NuGetGallery
                         Version = "1.0.42",
                         NormalizedVersion = "1.0.42"
                     }));
+                symbolPackageUploadService
+                    .Setup(x => x.DeleteSymbolsPackageAsync(It.IsAny<SymbolPackage>()))
+                    .Completes();
             }
 
             var controller = new Mock<PackagesController>(
@@ -1745,6 +1748,409 @@ namespace NuGetGallery
                 packageService.Verify();
 
                 return result;
+            }
+        }
+
+        public class TheDeleteSymbolsMethod : TestContainer
+        {
+            private string _packageId = "CrestedGecko";
+            private PackageRegistration _packageRegistration;
+            private Package _package;
+
+            public TheDeleteSymbolsMethod()
+            {
+                var symbolPackage1 = new SymbolPackage() { StatusKey = PackageStatus.Available };
+                var symbolPackage2 = new SymbolPackage() { StatusKey = PackageStatus.Available };
+                _packageRegistration = new PackageRegistration { Id = _packageId };
+
+                _package = new Package
+                {
+                    Key = 2,
+                    PackageRegistration = _packageRegistration,
+                    Version = "1.0.0+metadata",
+                    Listed = true,
+                    IsLatestSemVer2 = true,
+                    HasReadMe = false,
+                    SymbolPackages = new List<SymbolPackage>() { symbolPackage1 }
+                };
+                var olderPackageVersion = new Package
+                {
+                    Key = 1,
+                    PackageRegistration = _packageRegistration,
+                    Version = "1.0.0-alpha",
+                    IsLatest = true,
+                    IsLatestSemVer2 = true,
+                    Listed = true,
+                    HasReadMe = false,
+                    SymbolPackages = new List<SymbolPackage>() { symbolPackage2 }
+                };
+
+                _packageRegistration.Packages.Add(_package);
+                _packageRegistration.Packages.Add(olderPackageVersion);
+                symbolPackage1.Package = _package;
+                symbolPackage2.Package = olderPackageVersion;
+            }
+
+            [Fact]
+            public void Returns404IfPackageNotFound()
+            {
+                var controller = CreateController(GetConfigurationService());
+
+                var result = controller.DeleteSymbols(_packageRegistration.Id, _package.Version);
+
+                Assert.IsType<HttpNotFoundResult>(result);
+            }
+            public static IEnumerable<object[]> NotOwner_Data
+            {
+                get
+                {
+                    yield return new object[]
+                    {
+                        null,
+                        TestUtility.FakeUser
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeUser,
+                        new User { Key = 5535 }
+                    };
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(NotOwner_Data))]
+            public void Returns403IfNotOwner(User currentUser, User owner)
+            {
+                var result = GetDeleteSymbolsResult(currentUser, owner, out var controller);
+
+                Assert.IsType<HttpStatusCodeResult>(result);
+                var httpStatusCodeResult = result as HttpStatusCodeResult;
+                Assert.Equal((int)HttpStatusCode.Forbidden, httpStatusCodeResult.StatusCode);
+            }
+
+            public static IEnumerable<object[]> Owner_Data
+            {
+                get
+                {
+                    yield return new object[]
+                    {
+                        TestUtility.FakeUser,
+                        TestUtility.FakeUser
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeAdminUser,
+                        TestUtility.FakeUser
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeOrganizationAdmin,
+                        TestUtility.FakeOrganization
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeOrganizationCollaborator,
+                        TestUtility.FakeOrganization
+                    };
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(Owner_Data))]
+            public void DisplaysFullVersionStringAndUsesNormalizedVersionsInUrlsInSelectList(User currentUser, User owner)
+            {
+                var result = GetDeleteSymbolsResult(currentUser, owner, out var controller);
+
+                Assert.IsType<ViewResult>(result);
+                var model = ((ViewResult)result).Model as DeletePackageViewModel;
+                Assert.NotNull(model);
+                Assert.False(model.IsLocked);
+
+                // Verify version select list
+                Assert.Equal(_packageRegistration.Packages.Count, model.VersionSelectList.Count());
+
+                foreach (var pkg in _packageRegistration.Packages)
+                {
+                    var valueField = controller.Url.DeleteSymbolsPackage(model);
+                    var textField = model.NuGetVersion.ToFullString() + (pkg.IsLatestSemVer2 ? " (Latest)" : string.Empty);
+
+                    var selectListItem = model.VersionSelectList
+                        .SingleOrDefault(i => string.Equals(i.Text, textField) && string.Equals(i.Value, valueField));
+
+                    Assert.NotNull(selectListItem);
+                    Assert.Equal(valueField, selectListItem.Value);
+                    Assert.Equal(textField, selectListItem.Text);
+                }
+            }
+
+            [Fact]
+            public void WhenPackageRegistrationIsLockedReturnsLockedState()
+            {
+                // Arrange
+                var user = new User("Frodo") { Key = 1 };
+                var packageRegistration = new PackageRegistration { Id = "Foo", IsLocked = true };
+                packageRegistration.Owners.Add(user);
+
+                var package = new Package
+                {
+                    Key = 2,
+                    PackageRegistration = packageRegistration,
+                    Version = "1.0.0+metadata",
+                };
+
+                var packageService = new Mock<IPackageService>(MockBehavior.Strict);
+                packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0.0", SemVerLevelKey.Unknown, true))
+                    .Returns(package);
+
+                var controller = CreateController(GetConfigurationService(), packageService: packageService);
+                controller.SetCurrentUser(user);
+
+                // Act
+                var result = controller.DeleteSymbols("Foo", "1.0.0");
+
+                // Assert
+                var model = ResultAssert.IsView<DeletePackageViewModel>(result);
+                Assert.True(model.IsLocked);
+            }
+
+            private ActionResult GetDeleteSymbolsResult(User currentUser, User owner, out PackagesController controller)
+            {
+                _packageRegistration.Owners.Add(owner);
+
+                var packageService = new Mock<IPackageService>(MockBehavior.Strict);
+                packageService
+                    .Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.Unknown, true))
+                    .Returns(_package).Verifiable();
+
+                controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService);
+                controller.SetCurrentUser(currentUser);
+
+                var routeCollection = new RouteCollection();
+                Routes.RegisterRoutes(routeCollection);
+                controller.Url = new UrlHelper(controller.ControllerContext.RequestContext, routeCollection);
+
+                var result = controller.DeleteSymbols(_packageId, _package.Version);
+
+                packageService.Verify();
+                return result;
+            }
+        }
+
+        public class TheDeleteSymbolsPackageMethod : TestContainer
+        {
+            [Fact]
+            public async Task WhenPackageNotFoundReturns404()
+            {
+                // Arrange
+                var packageService = new Mock<IPackageService>();
+                packageService
+                    .Setup(svc => svc.FindPackageByIdAndVersionStrict("Foo", "1.0"))
+                    .Returns((Package)null);
+
+                var controller = CreateController(GetConfigurationService(), packageService: packageService);
+
+                // Act
+                var result = await controller.DeleteSymbolsPackage("Foo", "1.0");
+
+                // Assert
+                ResultAssert.IsStatusCode(result, HttpStatusCode.NotFound);
+            }
+
+            public static IEnumerable<object[]> NotOwner_Data
+            {
+                get
+                {
+                    yield return new object[]
+                    {
+                        null,
+                        TestUtility.FakeUser
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeUser,
+                        new User { Key = 5535 }
+                    };
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(NotOwner_Data))]
+            public async Task Returns403IfNotOwner(User currentUser, User owner)
+            {
+                // Arrange
+                var package = new Package
+                {
+                    PackageRegistration = new PackageRegistration { Id = "Foo" },
+                    Version = "1.0",
+                    Listed = true
+                };
+                package.PackageRegistration.Owners.Add(owner);
+
+                var packageService = new Mock<IPackageService>();
+                packageService
+                    .Setup(svc => svc.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns(package)
+                    .Verifiable();
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService);
+                controller.SetCurrentUser(currentUser);
+
+                // Act
+                var result = await controller.DeleteSymbolsPackage("Foo", "1.0");
+
+                // Assert
+                Assert.IsType<HttpStatusCodeResult>(result);
+                var httpStatusCodeResult = result as HttpStatusCodeResult;
+                Assert.Equal((int)HttpStatusCode.Forbidden, httpStatusCodeResult.StatusCode);
+            }
+
+            public static IEnumerable<object[]> Owner_Data
+            {
+                get
+                {
+                    yield return new object[]
+                    {
+                        TestUtility.FakeUser,
+                        TestUtility.FakeUser
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeAdminUser,
+                        TestUtility.FakeUser
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeOrganizationAdmin,
+                        TestUtility.FakeOrganization
+                    };
+
+                    yield return new object[]
+                    {
+                        TestUtility.FakeOrganizationCollaborator,
+                        TestUtility.FakeOrganization
+                    };
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(Owner_Data))]
+            public async Task Returns400IfThereAreNoSymbolsPackage(User currentUser, User owner)
+            {
+                // Arrange
+                var package = new Package
+                {
+                    PackageRegistration = new PackageRegistration { Id = "Foo" },
+                    Version = "1.0",
+                    Listed = true
+                };
+                package.PackageRegistration.Owners.Add(owner);
+
+                var packageService = new Mock<IPackageService>();
+                packageService
+                    .Setup(svc => svc.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns(package);
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService);
+                controller.SetCurrentUser(currentUser);
+
+                // Act
+                var result = await controller.DeleteSymbolsPackage("Foo", "1.0");
+
+                // Assert
+                Assert.IsType<HttpStatusCodeResult>(result);
+                var httpStatusCodeResult = result as HttpStatusCodeResult;
+                Assert.Equal((int)HttpStatusCode.BadRequest, httpStatusCodeResult.StatusCode);
+            }
+
+            [Theory]
+            [MemberData(nameof(Owner_Data))]
+            public async Task RedirectsToPackagePageAfterSymbolsPackageDeletion(User currentUser, User owner)
+            {
+                // Arrange
+                var symbolPackage = new SymbolPackage()
+                {
+                    StatusKey = PackageStatus.Available
+                };
+
+                var package = new Package
+                {
+                    PackageRegistration = new PackageRegistration { Id = "Foo" },
+                    Version = "1.0",
+                    NormalizedVersion = "1.0.0",
+                    SymbolPackages = new List<SymbolPackage>() { symbolPackage }
+                };
+                package.PackageRegistration.Owners.Add(owner);
+                symbolPackage.Package = package;
+
+                var packageService = new Mock<IPackageService>();
+                packageService
+                    .Setup(svc => svc.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns(package);
+                var auditingService = new TestAuditingService();
+                var telemetryService = new Mock<ITelemetryService>();
+                telemetryService
+                    .Setup(x => x.TrackSymbolPackageDeleteEvent(It.IsAny<string>(), It.IsAny<string>()));
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService,
+                    auditingService: auditingService,
+                    telemetryService: telemetryService);
+
+                controller.SetCurrentUser(currentUser);
+
+                // Act
+                var result = await controller.DeleteSymbolsPackage("Foo", "1.0");
+
+                // Assert
+                Assert.IsType<RedirectResult>(result);
+                Assert.Equal($"/?id={package.Id}&version={package.NormalizedVersion}", ((RedirectResult)result).Url);
+                Assert.True(auditingService.WroteRecord<PackageAuditRecord>(ar =>
+                    ar.Action == AuditedPackageAction.SymbolsDelete
+                    && ar.Id == package.PackageRegistration.Id
+                    && ar.Version == package.Version));
+                telemetryService
+                    .Verify(x => x.TrackSymbolPackageDeleteEvent(package.Id, package.Version), Times.Once);
+            }
+
+            [Fact]
+            public async Task WhenPackageRegistrationIsLockedReturns403()
+            {
+                // Arrange
+                var package = new Package
+                {
+                    PackageRegistration = new PackageRegistration { Id = "Foo", IsLocked = true },
+                    Version = "1.0",
+                };
+                package.PackageRegistration.Owners.Add(new User("Frodo"));
+
+                var packageService = new Mock<IPackageService>(MockBehavior.Strict);
+                packageService
+                    .Setup(svc => svc.FindPackageByIdAndVersionStrict("Foo", "1.0"))
+                    .Returns(package);
+
+                var controller = CreateController(GetConfigurationService(), packageService: packageService);
+
+                controller.SetCurrentUser(new User("Frodo"));
+
+                // Act
+                var result = await controller.DeleteSymbolsPackage("Foo", "1.0");
+
+                // Assert
+                ResultAssert.IsStatusCode(result, HttpStatusCode.Forbidden);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -184,6 +184,10 @@ namespace NuGetGallery
                         (TrackAction)(s => s.TrackSymbolPackagePushEvent("id", "version"))
                     };
 
+                    yield return new object[] { "SymbolPackageDelete",
+                        (TrackAction)(s => s.TrackSymbolPackageDeleteEvent("id", "version"))
+                    };
+
                     yield return new object[] { "SymbolPackagePushFailure",
                         (TrackAction)(s => s.TrackSymbolPackagePushFailureEvent("id", "version"))
                     };


### PR DESCRIPTION
This PR adds delete support based on the spec: https://github.com/NuGet/Home/wiki/Symbols-Package-Upload-and-Delete-Workflow 

Also, added tests. 

Screenshot:
Signed in Owner:
![image](https://user-images.githubusercontent.com/1646506/46511146-b9a63480-c801-11e8-83c7-6a650945f2b9.png)

Everyone else;
![image](https://user-images.githubusercontent.com/1646506/46511192-fd00a300-c801-11e8-8236-2acd6a7970dd.png)

Delete page;

![image](https://user-images.githubusercontent.com/1646506/46511231-3802d680-c802-11e8-99fd-20ea0a4c4196.png)

Confirm:

![image](https://user-images.githubusercontent.com/1646506/46511250-54067800-c802-11e8-8d74-c08890b8a0dc.png)

Symbols deleted! Yay!! no more option to delete the symbols package/or download symbols

![image](https://user-images.githubusercontent.com/1646506/46511282-929c3280-c802-11e8-9c3f-8143fba52fc8.png)
