### PR TITLE
Fix email verification issue for AAD/MSA registration

### DIFF
--- a/src/NuGetGallery/Authentication/AuthenticateExternalLoginResult.cs
+++ b/src/NuGetGallery/Authentication/AuthenticateExternalLoginResult.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Security.Claims;
 using NuGetGallery.Authentication.Providers;
 
@@ -15,6 +13,7 @@ namespace NuGetGallery.Authentication
         public Authenticator Authenticator { get; set; }
         public Credential Credential { get; set; }
         public ExternalLoginSessionDetails LoginDetails { get; set; }
+        public IdentityInformation UserInfo { get; set; }
     }
 
     public class ExternalLoginSessionDetails

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -299,7 +299,7 @@ namespace NuGetGallery.Authentication
             return claims.ToArray();
         }
 
-        public virtual async Task<AuthenticatedUser> Register(string username, string emailAddress, Credential credential)
+        public virtual async Task<AuthenticatedUser> Register(string username, string emailAddress, Credential credential, bool autoConfirm = false)
         {
             if (_config.FeedOnlyMode)
             {
@@ -332,7 +332,7 @@ namespace NuGetGallery.Authentication
             // Add a credential for the password
             newUser.Credentials.Add(credential);
 
-            if (!_config.ConfirmEmailAddresses || credential.IsExternal())
+            if (!_config.ConfirmEmailAddresses || (credential.IsExternal() && autoConfirm))
             {
                 newUser.ConfirmEmailAddress();
             }
@@ -651,7 +651,8 @@ namespace NuGetGallery.Authentication
                     ExternalIdentity = externalIdentity,
                     Authenticator = authenticator,
                     Credential = _credentialBuilder.CreateExternalCredential(userInfo.AuthenticationType, userInfo.Identifier, identity, userInfo.TenantId),
-                    LoginDetails = new ExternalLoginSessionDetails(userInfo.Email, userInfo.UsedMultiFactorAuthentication)
+                    LoginDetails = new ExternalLoginSessionDetails(userInfo.Email, userInfo.UsedMultiFactorAuthentication),
+                    UserInfo = userInfo
                 };
             }
             catch (Exception ex)

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -332,7 +332,7 @@ namespace NuGetGallery.Authentication
             // Add a credential for the password
             newUser.Credentials.Add(credential);
 
-            if (!_config.ConfirmEmailAddresses || (credential.IsExternal() && autoConfirm))
+            if (!_config.ConfirmEmailAddresses || autoConfirm)
             {
                 newUser.ConfirmEmailAddress();
             }

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -332,7 +332,7 @@ namespace NuGetGallery.Authentication
             // Add a credential for the password
             newUser.Credentials.Add(credential);
 
-            if (!_config.ConfirmEmailAddresses)
+            if (!_config.ConfirmEmailAddresses || credential.IsExternal())
             {
                 newUser.ConfirmEmailAddress();
             }

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -268,7 +268,7 @@ namespace NuGetGallery
                         model.Register.Username,
                         model.Register.EmailAddress,
                         result.Credential,
-                        string.Equals(result.UserInfo.Email, model.Register.EmailAddress, StringComparison.OrdinalIgnoreCase)
+                        string.Equals(result.UserInfo.Email, model.Register.EmailAddress)
                         );
                 }
                 else

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -267,7 +267,9 @@ namespace NuGetGallery
                     user = await _authService.Register(
                         model.Register.Username,
                         model.Register.EmailAddress,
-                        result.Credential);
+                        result.Credential,
+                        string.Equals(result.UserInfo.Email, model.Register.EmailAddress, StringComparison.OrdinalIgnoreCase)
+                        );
                 }
                 else
                 {

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -268,7 +268,7 @@ namespace NuGetGallery
                         model.Register.Username,
                         model.Register.EmailAddress,
                         result.Credential,
-                        string.Equals(result.UserInfo.Email, model.Register.EmailAddress)
+                        (result.Credential.IsExternal() && string.Equals(result.UserInfo?.Email, model.Register.EmailAddress))
                         );
                 }
                 else

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -844,6 +844,29 @@ namespace NuGetGallery.Authentication
                 auth.Entities.VerifyCommitChanges();
             }
 
+            [Theory]
+            [InlineData("MicrosoftAccount")]
+            [InlineData("AzureActiveDirectory")]
+            public async Task WillSaveTheNewUserWithExternalCredentialAsConfirmed(string credType)
+            {
+                // Arrange
+                var configurationService = GetConfigurationService();
+                configurationService.Current.ConfirmEmailAddresses = true;
+
+                var auth = Get<AuthenticationService>();
+
+                // Act
+                var authUser = await auth.Register(
+                    "newUser",
+                    "theEmailAddress",
+                    new CredentialBuilder().CreateExternalCredential(credType, "blorg", "Bloog"));
+
+                // Assert
+                Assert.True(auth.Entities.Users.Contains(authUser.User));
+                Assert.True(authUser.User.Confirmed);
+                auth.Entities.VerifyCommitChanges();
+            }
+
             [Fact]
             public async Task SetsAConfirmationToken()
             {

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -866,6 +866,7 @@ namespace NuGetGallery.Authentication
                 // Assert
                 Assert.True(auth.Entities.Users.Contains(authUser.User));
                 Assert.True(authUser.User.Confirmed);
+                Assert.True(string.Equals(authUser.User.EmailAddress, "theEmailAddress"));
                 auth.Entities.VerifyCommitChanges();
             }
 
@@ -890,7 +891,7 @@ namespace NuGetGallery.Authentication
                 // Assert
                 Assert.True(auth.Entities.Users.Contains(authUser.User));
                 auth.Entities.VerifyCommitChanges();
-
+                Assert.True(string.Equals(authUser.User.UnconfirmedEmailAddress, "theEmailAddress"));
                 Assert.NotNull(authUser.User.EmailConfirmationToken);
                 Assert.False(authUser.User.Confirmed);
             }

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -797,10 +797,113 @@ namespace NuGetGallery.Controllers
                     }, "/theReturnUrl", linkingAccount: false);
 
                 // Assert
+                GetMock<AuthenticationService>()
+                    .Verify(x => x.Register("theUsername", "unconfirmed@example.com", It.IsAny<Credential>(), false));
+
                 GetMock<IMessageService>()
                     .Verify(x => x.SendNewAccountEmailAsync(
                         It.IsAny<User>(),
                         It.IsAny<string>()), Times.Never());
+            }
+
+            [Fact]
+            public async Task WillNotAutoConfirmWhenNotExternalCredential()
+            {
+                // Arrange
+                var authUser = new AuthenticatedUser(
+                    new User("theUsername")
+                    {
+                        UnconfirmedEmailAddress = "unconfirmed@example.com",
+                        EmailConfirmationToken = "t0k3n"
+                    },
+                    new Credential());
+
+                var authenticationServiceMock = GetMock<AuthenticationService>();
+                var controller = GetController<AuthenticationController>();
+                authenticationServiceMock
+                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>(), It.IsAny<bool>()))
+                    .CompletesWith(authUser);
+                authenticationServiceMock
+                    .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser, false))
+                    .Returns(Task.FromResult(0))
+                    .Verifiable();
+                authenticationServiceMock
+                    .Setup(x => x.ReadExternalLoginCredential(controller.OwinContext))
+                    .CompletesWith(new AuthenticateExternalLoginResult()
+                    {
+                        ExternalIdentity = new ClaimsIdentity(),
+                        Credential = new Credential(),
+                        UserInfo = new IdentityInformation("", "", authUser.User.UnconfirmedEmailAddress, "")
+                    });
+
+                // Act
+                var result = await controller.Register(
+                    new LogOnViewModel()
+                    {
+                        Register = new RegisterViewModel
+                        {
+                            Username = "theUsername",
+                            EmailAddress = authUser.User.UnconfirmedEmailAddress,
+                        }
+                    }, "/theReturnUrl", linkingAccount: true);
+
+                // Assert
+                authenticationServiceMock.VerifyAll();
+
+                GetMock<AuthenticationService>()
+                    .Verify(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>(), false));
+            }
+
+            [Theory]
+            [InlineData("unconfirmed@example.com", true)]
+            [InlineData("anotherunconfirmed@example.com", false)]
+            public async Task GivenModelRegisterEmailAddress_ItWillAutoConfirmWhenModelRegisterEmailAndExternalCredentialEmailMatch(string modelRegisterEmailAddress, bool shouldAutoConfirm)
+            {
+                // Arrange
+                var authUser = new AuthenticatedUser(
+                    new User("theUsername")
+                    {
+                        UnconfirmedEmailAddress = "unconfirmed@example.com",
+                        EmailConfirmationToken = "t0k3n"
+                    },
+                    new Credential());
+
+                var externalCred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "blorg", "Bloog");
+
+                var authenticationServiceMock = GetMock<AuthenticationService>();
+                var controller = GetController<AuthenticationController>();
+                authenticationServiceMock
+                    .Setup(x => x.Register(authUser.User.Username, modelRegisterEmailAddress, externalCred, It.IsAny<bool>()))
+                    .CompletesWith(authUser);
+                authenticationServiceMock
+                    .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser, false))
+                    .Returns(Task.FromResult(0))
+                    .Verifiable();
+                authenticationServiceMock
+                    .Setup(x => x.ReadExternalLoginCredential(controller.OwinContext))
+                    .CompletesWith(new AuthenticateExternalLoginResult()
+                    {
+                        ExternalIdentity = new ClaimsIdentity(),
+                        Credential = externalCred,
+                        UserInfo = new IdentityInformation("", "", authUser.User.UnconfirmedEmailAddress, "")
+                    });
+
+                // Act
+                var result = await controller.Register(
+                    new LogOnViewModel()
+                    {
+                        Register = new RegisterViewModel
+                        {
+                            Username = "theUsername",
+                            EmailAddress = modelRegisterEmailAddress,
+                        }
+                    }, "/theReturnUrl", linkingAccount: true);
+
+                // Assert
+                authenticationServiceMock.VerifyAll();
+
+                GetMock<AuthenticationService>()
+                    .Verify(x => x.Register(authUser.User.Username, modelRegisterEmailAddress, externalCred, shouldAutoConfirm));
             }
 
             [Fact]
@@ -868,7 +971,7 @@ namespace NuGetGallery.Controllers
                     {
                         ExternalIdentity = new ClaimsIdentity(),
                         Credential = externalCred,
-                        UserInfo = new IdentityInformation("", "", "", "")
+                        UserInfo = new IdentityInformation("", "", authUser.User.UnconfirmedEmailAddress, "")
                     });
 
                 // Simulate the model state error that will be added when doing an external account registration (since password is not present)
@@ -892,6 +995,9 @@ namespace NuGetGallery.Controllers
                     .Verify(x => x.SendNewAccountEmailAsync(
                         authUser.User,
                         TestUtility.GallerySiteRootHttps + "account/confirm/" + authUser.User.Username + "/" + authUser.User.EmailConfirmationToken));
+
+                GetMock<AuthenticationService>()
+                    .Verify(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, externalCred, true));
 
                 ResultAssert.IsSafeRedirectTo(result, "/theReturnUrl");
             }
@@ -950,7 +1056,7 @@ namespace NuGetGallery.Controllers
                     {
                         ExternalIdentity = new ClaimsIdentity(),
                         Credential = externalCred,
-                        UserInfo = new IdentityInformation("", "", "", "")
+                        UserInfo = new IdentityInformation("", "", "theEmailAddress", "")
                     });
 
                 // Act

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -692,7 +692,7 @@ namespace NuGetGallery.Controllers
             public async Task WillInvalidateModelStateAndShowTheViewWhenAnEntityExceptionIsThrow()
             {
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.Register(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Credential>()))
+                    .Setup(x => x.Register(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Credential>(), It.IsAny<bool>()))
                     .Throws(new EntityException("aMessage"));
 
                 var controller = GetController<AuthenticationController>();
@@ -728,7 +728,7 @@ namespace NuGetGallery.Controllers
                 var authenticationService = GetMock<AuthenticationService>();
                 var controller = GetController<AuthenticationController>();
 
-                authenticationService.Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>()))
+                authenticationService.Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, It.IsAny<Credential>(), It.IsAny<bool>()))
                     .CompletesWith(authUser);
 
                 authenticationService
@@ -774,7 +774,7 @@ namespace NuGetGallery.Controllers
                 configurationService.Current.ConfirmEmailAddresses = false;
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.Register("theUsername", "unconfirmed@example.com", It.IsAny<Credential>()))
+                    .Setup(x => x.Register("theUsername", "unconfirmed@example.com", It.IsAny<Credential>(), It.IsAny<bool>()))
                     .CompletesWith(authUser);
 
                 var controller = GetController<AuthenticationController>();
@@ -835,7 +835,7 @@ namespace NuGetGallery.Controllers
                 GetMock<AuthenticationService>()
                     .Verify(x => x.CreateSessionAsync(It.IsAny<IOwinContext>(), It.IsAny<AuthenticatedUser>(), false), Times.Never());
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.Register("theUsername", "theEmailAddress", It.IsAny<Credential>()), Times.Never());
+                    .Verify(x => x.Register("theUsername", "theEmailAddress", It.IsAny<Credential>(), It.IsAny<bool>()), Times.Never());
             }
 
             [Fact]
@@ -855,7 +855,7 @@ namespace NuGetGallery.Controllers
                 var authenticationServiceMock = GetMock<AuthenticationService>();
                 var controller = GetController<AuthenticationController>();
                 authenticationServiceMock
-                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, externalCred))
+                    .Setup(x => x.Register(authUser.User.Username, authUser.User.UnconfirmedEmailAddress, externalCred, It.IsAny<bool>()))
                     .CompletesWith(authUser);
                 authenticationServiceMock
                     .Setup(x => x.CreateSessionAsync(controller.OwinContext, authUser, false))
@@ -867,7 +867,8 @@ namespace NuGetGallery.Controllers
                     .CompletesWith(new AuthenticateExternalLoginResult()
                     {
                         ExternalIdentity = new ClaimsIdentity(),
-                        Credential = externalCred
+                        Credential = externalCred,
+                        UserInfo = new IdentityInformation("", "", "", "")
                     });
 
                 // Simulate the model state error that will be added when doing an external account registration (since password is not present)
@@ -922,7 +923,7 @@ namespace NuGetGallery.Controllers
                     externalCred);
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.Register("theUsername", "theEmailAddress", externalCred))
+                    .Setup(x => x.Register("theUsername", "theEmailAddress", externalCred, It.IsAny<bool>()))
                     .CompletesWith(authUser);
 
                 EnableAllAuthenticators(Get<AuthenticationService>());
@@ -948,7 +949,8 @@ namespace NuGetGallery.Controllers
                     .CompletesWith(new AuthenticateExternalLoginResult()
                     {
                         ExternalIdentity = new ClaimsIdentity(),
-                        Credential = externalCred
+                        Credential = externalCred,
+                        UserInfo = new IdentityInformation("", "", "", "")
                     });
 
                 // Act


### PR DESCRIPTION
Fix issue https://github.com/NuGet/NuGetGallery/issues/6389

If the user registers using the MSA/AAD account, we will confirm the account and set up the email address automatically without sending any confirmation email. 

When the user changes email address, we will send the confirmation email as before. 

