### PR TITLE
Emails should not be sent synchronously

### DIFF
--- a/src/NuGetGallery.Core/Infrastructure/mail/AsynchronousEmailMessageService.cs
+++ b/src/NuGetGallery.Core/Infrastructure/mail/AsynchronousEmailMessageService.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Services.Messaging;
+
+namespace NuGetGallery.Infrastructure.Mail
+{
+    public class AsynchronousEmailMessageService : IMessageService
+    {
+        private readonly IMessageServiceConfiguration _configuration;
+        private readonly IEmailMessageEnqueuer _emailMessageEnqueuer;
+
+        public AsynchronousEmailMessageService(
+            IMessageServiceConfiguration configuration,
+            IEmailMessageEnqueuer emailMessageEnqueuer)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _emailMessageEnqueuer = emailMessageEnqueuer ?? throw new ArgumentNullException(nameof(emailMessageEnqueuer));
+        }
+
+        public Task SendMessageAsync(
+            IEmailBuilder emailBuilder,
+            bool copySender = false,
+            bool discloseSenderAddress = false)
+        {
+            var message = CreateMessage(
+                emailBuilder,
+                copySender,
+                discloseSenderAddress);
+
+            return EnqueueMessageAsync(message);
+        }
+
+        private static EmailMessageData CreateMessage(
+            IEmailBuilder emailBuilder,
+            bool copySender = false,
+            bool discloseSenderAddress = false)
+        {
+            var recipients = emailBuilder.GetRecipients();
+
+            return new EmailMessageData(
+                emailBuilder.GetSubject(),
+                emailBuilder.GetBody(EmailFormat.PlainText),
+                emailBuilder.GetBody(EmailFormat.Html),
+                emailBuilder.Sender.Address,
+                to: recipients.To.Select(e => e.Address).ToList(),
+                cc: GenerateCC(
+                    emailBuilder.Sender.Address,
+                    recipients.CC.Select(e => e.Address).ToList(),
+                    copySender,
+                    discloseSenderAddress),
+                bcc: recipients.Bcc.Select(e => e.Address).ToList(),
+                replyTo: recipients.ReplyTo.Select(e => e.Address).ToList(),
+                messageTrackingId: Guid.NewGuid());
+        }
+
+        private static IReadOnlyList<string> GenerateCC(
+            string fromAddress,
+            IReadOnlyList<string> cc, bool copySender,
+            bool discloseSenderAddress)
+        {
+            var ccList = new List<string>();
+            if (cc != null)
+            {
+                ccList.AddRange(cc);
+            }
+
+            if (copySender && discloseSenderAddress && !ccList.Contains(fromAddress))
+            {
+                ccList.Add(fromAddress);
+            }
+
+            return ccList;
+        }
+
+        private Task EnqueueMessageAsync(EmailMessageData message)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (!message.To.Any())
+            {
+                return Task.CompletedTask;
+            }
+
+            return _emailMessageEnqueuer.SendEmailMessageAsync(message);
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Infrastructure/mail/EmailBuilder.cs
+++ b/src/NuGetGallery.Core/Infrastructure/mail/EmailBuilder.cs
@@ -22,6 +22,8 @@ namespace NuGetGallery.Infrastructure.Mail
                     return GetPlainTextBody();
                 case EmailFormat.Markdown:
                     return GetMarkdownBody();
+                case EmailFormat.Html:
+                    return GetHtmlBody();
                 default:
                     throw new ArgumentOutOfRangeException(nameof(format));
             }
@@ -33,6 +35,7 @@ namespace NuGetGallery.Infrastructure.Mail
 
         protected abstract string GetPlainTextBody();
         protected abstract string GetMarkdownBody();
+        protected abstract string GetHtmlBody();
 
         /// <summary>
         /// Markdown sees the underscore as italics indicator, so underscores are stripped in the message.

--- a/src/NuGetGallery.Core/Infrastructure/mail/EmailFormat.cs
+++ b/src/NuGetGallery.Core/Infrastructure/mail/EmailFormat.cs
@@ -18,6 +18,11 @@ namespace NuGetGallery.Infrastructure.Mail
         /// Indicates that <see cref="EmailBuilder"/> will create email messages using Markdown formatting,
         /// which will be rendered as HTML by email clients.
         /// </summary>
-        Markdown
+        Markdown,
+
+        /// <summary>
+        /// Indicates that <see cref="EmailBuilder"/> will create email messages using HTML formatting.
+        /// </summary>
+        Html
     }
 }

--- a/src/NuGetGallery.Core/Infrastructure/mail/EmailMessageFooter.cs
+++ b/src/NuGetGallery.Core/Infrastructure/mail/EmailMessageFooter.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery.Infrastructure.Mail
+{
+    /// <summary>
+    /// Utility class to construct common email message footers.
+    /// </summary>
+    public static class EmailMessageFooter
+    {
+        public static string ForPackageOwnerNotifications(EmailFormat format, string galleryOwnerDisplayName, string emailSettingsUrl)
+        {
+            return ForReason(
+                format,
+                galleryOwnerDisplayName,
+                emailSettingsUrl,
+                "To stop receiving emails as an owner of this package");
+        }
+
+        public static string ForContactOwnerNotifications(EmailFormat format, string galleryOwnerDisplayName, string emailSettingsUrl)
+        {
+            return ForReason(
+                format, 
+                galleryOwnerDisplayName, 
+                emailSettingsUrl, 
+                "To stop receiving contact emails as an owner of this package");
+        }
+               
+        private static string ForReason(EmailFormat format, string galleryOwnerDisplayName, string emailSettingsUrl, string reason)
+        {
+            switch (format)
+            {
+                case EmailFormat.PlainText:
+                    // Hyperlinks within an HTML emphasis tag are not supported by the Plain Text renderer in Markdig.
+                    return $@"
+
+-----------------------------------------------
+    {reason}, sign in to the {galleryOwnerDisplayName} and
+    change your email notification settings ({emailSettingsUrl}).";
+                case EmailFormat.Html:
+                    // Hyperlinks within an HTML emphasis tag are not supported by the HTML renderer in Markdig.
+                    return $@"<hr />
+<em style=""font-size: 0.8em;"">
+    {reason}, sign in to the {galleryOwnerDisplayName} and
+    <a href=""{emailSettingsUrl}"">change your email notification settings</a>.
+</em>";
+                case EmailFormat.Markdown:
+                    return $@"
+
+-----------------------------------------------
+<em style=""font-size: 0.8em;"">
+    {reason}, sign in to the {galleryOwnerDisplayName} and
+    [change your email notification settings]({emailSettingsUrl}).
+</em>";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(format));
+            }
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Infrastructure/mail/MarkdownEmailBuilder.cs
+++ b/src/NuGetGallery.Core/Infrastructure/mail/MarkdownEmailBuilder.cs
@@ -15,6 +15,11 @@ namespace NuGetGallery.Infrastructure.Mail
         {
             var markdown = GetMarkdownBody();
 
+            return ToPlainText(markdown);
+        }
+
+        protected string ToPlainText(string markdown)
+        {
             var writer = new StringWriter();
             var pipeline = new MarkdownPipelineBuilder().Build();
 
@@ -28,6 +33,11 @@ namespace NuGetGallery.Infrastructure.Mail
             writer.Flush();
 
             return writer.ToString();
+        }
+
+        protected override string GetHtmlBody()
+        {
+            return Markdown.ToHtml(GetMarkdownBody());
         }
     }
 }

--- a/src/NuGetGallery.Core/Infrastructure/mail/Messages/PackageAddedMessage.cs
+++ b/src/NuGetGallery.Core/Infrastructure/mail/Messages/PackageAddedMessage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
+using Markdig;
 
 namespace NuGetGallery.Infrastructure.Mail.Messages
 {
@@ -58,38 +59,57 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
         protected override string GetMarkdownBody()
         {
-            var warningMessagesPlaceholder = string.Empty;
-            if (_hasWarnings)
-            {
-                warningMessagesPlaceholder = Environment.NewLine + string.Join(Environment.NewLine, _warningMessages);
-            }
-
-            return $@"The package [{Package.PackageRegistration.Id} {Package.Version}]({_packageUrl}) was recently published on {_configuration.GalleryOwner.DisplayName} by {Package.User.Username}. If this was not intended, please [contact support]({_packageSupportUrl}).
-{warningMessagesPlaceholder}
-
------------------------------------------------
-<em style=""font-size: 0.8em;"">
-    To stop receiving emails as an owner of this package, sign in to the {_configuration.GalleryOwner.DisplayName} and
-    [change your email notification settings]({_emailSettingsUrl}).
-</em>";
+            return GetBodyInternal(EmailFormat.Markdown);
         }
 
         protected override string GetPlainTextBody()
         {
-            // The HTML emphasis tag is not supported by the Plain Text renderer in Markdig.
-            // Manually overriding this one.
+            return GetBodyInternal(EmailFormat.PlainText);
+        }
+
+        protected override string GetHtmlBody()
+        {
+            return GetBodyInternal(EmailFormat.Html);
+        }
+
+        private string GetBodyInternal(EmailFormat format)
+        {
+            var warningMessages = GetWarningMessages();
+
+            var markdown = $@"The package [{Package.PackageRegistration.Id} {Package.Version}]({_packageUrl}) was recently published on {_configuration.GalleryOwner.DisplayName} by {Package.User.Username}. If this was not intended, please [contact support]({_packageSupportUrl}).";
+
+            if (!string.IsNullOrEmpty(warningMessages))
+            {
+                markdown += warningMessages;
+            }
+
+            string body;
+            switch (format)
+            {
+                case EmailFormat.PlainText:
+                    body = ToPlainText(markdown);
+                    break;
+                case EmailFormat.Markdown:
+                    body = markdown;
+                    break;
+                case EmailFormat.Html:
+                    body = Markdown.ToHtml(markdown);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(format));
+            }
+
+            return body + EmailMessageFooter.ForPackageOwnerNotifications(format, _configuration.GalleryOwner.DisplayName, _emailSettingsUrl);
+        }
+
+        private string GetWarningMessages()
+        {
             var warningMessagesPlaceholder = string.Empty;
             if (_hasWarnings)
             {
-                warningMessagesPlaceholder = Environment.NewLine + string.Join(Environment.NewLine, _warningMessages);
+                warningMessagesPlaceholder = Environment.NewLine + Environment.NewLine + string.Join(Environment.NewLine, _warningMessages);
             }
-
-            return $@"The package {Package.PackageRegistration.Id} {Package.Version} ({_packageUrl}) was recently published on {_configuration.GalleryOwner.DisplayName} by {Package.User.Username}. If this was not intended, please contact support ({_packageSupportUrl}).
-{warningMessagesPlaceholder}
-
------------------------------------------------
-    To stop receiving emails as an owner of this package, sign in to the {_configuration.GalleryOwner.DisplayName} and
-    change your email notification settings ({_emailSettingsUrl}).";
+            return warningMessagesPlaceholder;
         }
     }
 }

--- a/src/NuGetGallery.Core/Infrastructure/mail/Messages/SymbolPackageAddedMessage.cs
+++ b/src/NuGetGallery.Core/Infrastructure/mail/Messages/SymbolPackageAddedMessage.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Mail;
+using Markdig;
 
 namespace NuGetGallery.Infrastructure.Mail.Messages
 {
@@ -57,38 +58,57 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
         protected override string GetMarkdownBody()
         {
-            var warningMessagesPlaceholder = string.Empty;
-            if (_hasWarnings)
-            {
-                warningMessagesPlaceholder = Environment.NewLine + string.Join(Environment.NewLine, _warningMessages);
-            }
-
-            return $@"The symbol package [{_symbolPackage.Id} {_symbolPackage.Version}]({_packageUrl}) was recently published on {_configuration.GalleryOwner.DisplayName} by {_symbolPackage.Package.User.Username}. If this was not intended, please [contact support]({_packageSupportUrl}).
-{warningMessagesPlaceholder}
-
------------------------------------------------
-<em style=""font-size: 0.8em;"">
-    To stop receiving emails as an owner of this package, sign in to the {_configuration.GalleryOwner.DisplayName} and
-    [change your email notification settings]({_emailSettingsUrl}).
-</em>";
+            return GetBodyInternal(EmailFormat.Markdown);
         }
 
         protected override string GetPlainTextBody()
         {
-            // The HTML emphasis tag is not supported by the Plain Text renderer in Markdig.
-            // Manually overriding this one.
+            return GetBodyInternal(EmailFormat.PlainText);
+        }
+
+        protected override string GetHtmlBody()
+        {
+            return GetBodyInternal(EmailFormat.Html);
+        }
+
+        private string GetBodyInternal(EmailFormat format)
+        {
+            var warningMessages = GetWarningMessages();
+
+            var markdown = $@"The symbol package [{_symbolPackage.Id} {_symbolPackage.Version}]({_packageUrl}) was recently published on {_configuration.GalleryOwner.DisplayName} by {_symbolPackage.Package.User.Username}. If this was not intended, please [contact support]({_packageSupportUrl}).";
+
+            if (!string.IsNullOrEmpty(warningMessages))
+            {
+                markdown += warningMessages;
+            }
+
+            string body;
+            switch (format)
+            {
+                case EmailFormat.PlainText:
+                    body = ToPlainText(markdown);
+                    break;
+                case EmailFormat.Markdown:
+                    body = markdown;
+                    break;
+                case EmailFormat.Html:
+                    body = Markdown.ToHtml(markdown);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(format));
+            }
+
+            return body + EmailMessageFooter.ForPackageOwnerNotifications(format, _configuration.GalleryOwner.DisplayName, _emailSettingsUrl);
+        }
+
+        private string GetWarningMessages()
+        {
             var warningMessagesPlaceholder = string.Empty;
             if (_hasWarnings)
             {
-                warningMessagesPlaceholder = Environment.NewLine + string.Join(Environment.NewLine, _warningMessages);
+                warningMessagesPlaceholder = Environment.NewLine + Environment.NewLine + string.Join(Environment.NewLine, _warningMessages);
             }
-
-            return $@"The symbol package {_symbolPackage.Id} {_symbolPackage.Version} ({_packageUrl}) was recently published on {_configuration.GalleryOwner.DisplayName} by {_symbolPackage.Package.User.Username}. If this was not intended, please contact support ({_packageSupportUrl}).
-{warningMessagesPlaceholder}
-
------------------------------------------------
-    To stop receiving emails as an owner of this package, sign in to the {_configuration.GalleryOwner.DisplayName} and
-    change your email notification settings ({_emailSettingsUrl}).";
+            return warningMessagesPlaceholder;
         }
     }
 }

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -168,9 +168,11 @@
     <Compile Include="ICloudStorageStatusDependency.cs" />
     <Compile Include="Infrastructure\AzureEntityList.cs" />
     <Compile Include="Infrastructure\ElmahException.cs" />
+    <Compile Include="Infrastructure\Mail\AsynchronousEmailMessageService.cs" />
     <Compile Include="Infrastructure\Mail\ConfirmationEmailBuilder.cs" />
     <Compile Include="Infrastructure\Mail\EmailBuilder.cs" />
     <Compile Include="Infrastructure\Mail\EmailFormat.cs" />
+    <Compile Include="Infrastructure\Mail\EmailMessageFooter.cs" />
     <Compile Include="Infrastructure\Mail\IEmailBuilder.cs" />
     <Compile Include="Infrastructure\Mail\IEmailRecipients.cs" />
     <Compile Include="Infrastructure\Mail\EmailRecipients.cs" />
@@ -261,6 +263,9 @@
   <ItemGroup>
     <PackageReference Include="Markdig.Signed">
       <Version>0.15.3</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Messaging">
+      <Version>2.28.0-master-42092</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -18,8 +18,11 @@ using AnglicanGeek.MarkdownMailer;
 using Autofac;
 using Autofac.Core;
 using Elmah;
+using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.ServiceRuntime;
 using NuGet.Services.KeyVault;
+using NuGet.Services.Logging;
+using NuGet.Services.Messaging;
 using NuGet.Services.ServiceBus;
 using NuGet.Services.Sql;
 using NuGet.Services.Validation;
@@ -48,6 +51,7 @@ namespace NuGetGallery
             public const string SymbolsPackageValidationTopic = "SymbolsPackageValidationBindingKey";
             public const string PackageValidationEnqueuer = "PackageValidationEnqueuerBindingKey";
             public const string SymbolsPackageValidationEnqueuer = "SymbolsPackageValidationEnqueuerBindingKey";
+            public const string EmailPublisherTopic = "EmailPublisherBindingKey";
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -84,7 +88,7 @@ namespace NuGetGallery
 
             builder.Register(c => configuration.Current)
                 .AsSelf()
-                .As<IAppConfiguration>();
+                .AsImplementedInterfaces();
 
             // Force the read of this configuration, so it will be initialized on startup
             builder.Register(c => configuration.Features)
@@ -377,6 +381,20 @@ namespace NuGetGallery
 
         private static void RegisterMessagingService(ContainerBuilder builder, ConfigurationService configuration)
         {
+            if (configuration.Current.AsynchronousEmailServiceEnabled)
+            {
+                // Register NuGet.Services.Messaging infrastructure
+                RegisterAsynchronousEmailMessagingService(builder, configuration);
+            }
+            else
+            {
+                // Register legacy SMTP messaging infrastructure
+                RegisterSmtpEmailMessagingService(builder, configuration);
+            }
+        }
+
+        private static void RegisterSmtpEmailMessagingService(ContainerBuilder builder, ConfigurationService configuration)
+        {
             MailSender mailSenderFactory()
             {
                 var settings = configuration;
@@ -425,6 +443,42 @@ namespace NuGetGallery
                 .InstancePerDependency();
         }
 
+        private static void RegisterAsynchronousEmailMessagingService(ContainerBuilder builder, ConfigurationService configuration)
+        {
+            builder
+                .RegisterType<NuGet.Services.Messaging.ServiceBusMessageSerializer>()
+                .As<NuGet.Services.Messaging.IServiceBusMessageSerializer>();
+
+            var emailPublisherConnectionString = configuration.ServiceBus.EmailPublisher_ConnectionString;
+            var emailPublisherTopicName = configuration.ServiceBus.EmailPublisher_TopicName;
+
+            builder
+                .Register(c => new TopicClientWrapper(emailPublisherConnectionString, emailPublisherTopicName))
+                .As<ITopicClient>()
+                .SingleInstance()
+                .Keyed<ITopicClient>(BindingKeys.EmailPublisherTopic)
+                .OnRelease(x => x.Close());
+
+            // Create an ILoggerFactory
+            var loggerConfiguration = LoggingSetup.CreateDefaultLoggerConfiguration(withConsoleLogger: false);
+            var loggerFactory = LoggingSetup.CreateLoggerFactory(loggerConfiguration);
+
+            builder
+                .RegisterType<EmailMessageEnqueuer>()
+                .WithParameter(new ResolvedParameter(
+                    (pi, ctx) => pi.ParameterType == typeof(ITopicClient),
+                    (pi, ctx) => ctx.ResolveKeyed<ITopicClient>(BindingKeys.EmailPublisherTopic)))
+                .WithParameter(new ResolvedParameter(
+                    (pi, ctx) => pi.ParameterType == typeof(ILogger<EmailMessageEnqueuer>),
+                    (pi, ctx) => loggerFactory.CreateLogger<EmailMessageEnqueuer>()))
+                .As<IEmailMessageEnqueuer>();
+
+            builder.RegisterType<AsynchronousEmailMessageService>()
+                .AsSelf()
+                .As<IMessageService>()
+                .InstancePerDependency();
+        }
+
         private static ISqlConnectionFactory CreateDbConnectionFactory(IDiagnosticsService diagnostics, string name,
             string connectionString, ISecretInjector secretInjector)
         {
@@ -467,8 +521,8 @@ namespace NuGetGallery
             ConfigurationService configuration, ISecretInjector secretInjector)
         {
             builder
-                .RegisterType<ServiceBusMessageSerializer>()
-                .As<IServiceBusMessageSerializer>();
+                .RegisterType<NuGet.Services.Validation.ServiceBusMessageSerializer>()
+                .As<NuGet.Services.Validation.IServiceBusMessageSerializer>();
 
             // We need to setup two enqueuers for Package validation and symbol validation each publishes 
             // to a different topic for validation.

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -352,5 +352,7 @@ namespace NuGetGallery.Configuration
         [DefaultValue(null)]
         [TypeConverter(typeof(StringArrayConverter))]
         public string[] RedirectedCuratedFeeds { get; set; }
+
+        public bool AsynchronousEmailServiceEnabled { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -360,5 +360,10 @@ namespace NuGetGallery.Configuration
         /// The name of zero or more curated feeds that are redirected to the main feed.
         /// </summary>
         string[] RedirectedCuratedFeeds { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag indicating whether asynchronous email service is enabled.
+        /// </summary>
+        bool AsynchronousEmailServiceEnabled { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/IServiceBusConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IServiceBusConfiguration.cs
@@ -35,5 +35,19 @@ namespace NuGetGallery.Configuration
         /// time as the <see cref="SymbolsValidation_ConnectionString"/>.
         /// </summary>
         string SymbolsValidation_TopicName { get; set; }
+
+        /// <summary>
+        /// The connection string to use when connecting to the email publisher topic. This connection string should not
+        /// contain the topic name as the name is explicitly specified by <see cref="EmailPublisher_TopicName"/>. This
+        /// connection string only needs to have the "Send" privilege. This topic is used for requesting asynchronous
+        /// publishing of email messages.
+        /// </summary>
+        string EmailPublisher_ConnectionString { get; set; }
+
+        /// <summary>
+        /// The name of the Azure Service Bus topic to send email messages to. This topic name is used at the same
+        /// time as the <see cref="EmailPublisher_ConnectionString"/>.
+        /// </summary>
+        string EmailPublisher_TopicName { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/ServiceBusConfiguration.cs
+++ b/src/NuGetGallery/Configuration/ServiceBusConfiguration.cs
@@ -18,5 +18,11 @@ namespace NuGetGallery.Configuration
 
         [DisplayName("SymbolsValidation.TopicName")]
         public string SymbolsValidation_TopicName { get; set; }
+
+        [DisplayName("EmailPublisher.ConnectionString")]
+        public string EmailPublisher_ConnectionString { get; set; }
+
+        [DisplayName("EmailPublisher.TopicName")]
+        public string EmailPublisher_TopicName { get; set; }
     }
 }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1975,6 +1975,9 @@
     <PackageReference Include="Markdig.Signed">
       <Version>0.15.3</Version>
     </PackageReference>
+    <PackageReference Include="NuGet.Services.Messaging">
+      <Version>2.28.0-master-42092</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
     </PackageReference>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -45,6 +45,8 @@
     <add key="AzureServiceBus.Validation.TopicName" value=""/>
     <add key="AzureServiceBus.SymbolsValidation.ConnectionString" value=""/>
     <add key="AzureServiceBus.SymbolsValidation.TopicName" value=""/>
+    <add key="AzureServiceBus.EmailPublisher.ConnectionString" value=""/>
+    <add key="AzureServiceBus.EmailPublisher.TopicName" value=""/>
 
     <!--
     If Gallery.AsynchronousPackageValidationEnabled is true, all the AzureServiceBus.Validation.*
@@ -113,6 +115,7 @@
     <!-- Depending on your policy, these likely do not need to vary -->
     <!-- SmtpUri is expected to be of the format: smtps://username:password@host:port. Note that if username contains an "@", you need to URI Encode it! -->
     <!--<add key="Gallery.SmtpUri" value="" />-->
+    <add key="Gallery.AsynchronousEmailServiceEnabled" value="false" />
     <!--
         Location for the Lucene Index.
             AppData -> ~/App_Data/Lucene,

--- a/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/ContactSupportMessageFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/ContactSupportMessageFacts.cs
@@ -101,6 +101,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -146,5 +147,12 @@ reason
 
 Message:
 message";
+
+        private const string _expectedHtmlBody =
+            "<p><strong>Email:</strong> requestingUser (requestUser@gallery.org)</p>\n" +
+            "<p><strong>Reason:</strong>\n" +
+            "reason</p>\n" +
+            "<p><strong>Message:</strong>\n" +
+            "message</p>\n";
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/PackageAddedMessageFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/PackageAddedMessageFacts.cs
@@ -102,6 +102,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -133,7 +134,6 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
         private const string _expectedMarkdownBody =
             @"The package [PackageId 1.0.0](packageUrl) was recently published on NuGetGallery by Username. If this was not intended, please [contact support](packageSupportUrl).
 
-
 -----------------------------------------------
 <em style=""font-size: 0.8em;"">
     To stop receiving emails as an owner of this package, sign in to the NuGetGallery and
@@ -143,9 +143,16 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
         private const string _expectedPlainTextBody =
             @"The package PackageId 1.0.0 (packageUrl) was recently published on NuGetGallery by Username. If this was not intended, please contact support (packageSupportUrl).
 
-
 -----------------------------------------------
     To stop receiving emails as an owner of this package, sign in to the NuGetGallery and
     change your email notification settings (emailSettingsUrl).";
+
+        private const string _expectedHtmlBody =
+            "<p>The package <a href=\"packageUrl\">PackageId 1.0.0</a> was recently published on NuGetGallery by Username. If this was not intended, please <a href=\"packageSupportUrl\">contact support</a>.</p>\n" +
+@"<hr />
+<em style=""font-size: 0.8em;"">
+    To stop receiving emails as an owner of this package, sign in to the NuGetGallery and
+    <a href=""emailSettingsUrl"">change your email notification settings</a>.
+</em>";
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/PackageAddedWithWarningsMessageFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/PackageAddedWithWarningsMessageFacts.cs
@@ -100,6 +100,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -137,5 +138,9 @@ Warning message
             @"The package PackageId 1.0.0 (packageUrl) was recently pushed to NuGetGallery by Username. If this was not intended, please contact support (packageSupportUrl).
 
 Warning message";
+
+        private const string _expectedHtmlBody =
+            "<p>The package <a href=\"packageUrl\">PackageId 1.0.0</a> was recently pushed to NuGetGallery by Username. If this was not intended, please <a href=\"packageSupportUrl\">contact support</a>.</p>\n" +
+"<p>Warning message</p>\n";
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/PackageValidationFailedMessageFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/PackageValidationFailedMessageFacts.cs
@@ -104,6 +104,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -150,5 +151,13 @@ Please [contact support](packageSupportUrl) to help fix your package.";
 Your package was not published on NuGetGallery and is not available for consumption.
 
 Please contact support (packageSupportUrl) to help fix your package.";
+
+        private const string _expectedHtmlBody =
+            "<p>The package <a href=\"packageUrl\">PackageId 1.0.0</a> failed validation because of the following reason(s):</p>\n" +
+"<ul>\n" +
+"<li>There was an unknown failure when validating your package.</li>\n" +
+"</ul>\n" +
+"<p>Your package was not published on NuGetGallery and is not available for consumption.</p>\n" +
+"<p>Please <a href=\"packageSupportUrl\">contact support</a> to help fix your package.</p>\n";
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/PackageValidationTakingTooLongMessageFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/PackageValidationTakingTooLongMessageFacts.cs
@@ -93,6 +93,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -131,5 +132,10 @@ Thank you for your patience.";
 We are looking into it and there is no action on you at this time. We’ll send you an email notification when your package has been published.
 
 Thank you for your patience.";
+
+        private const string _expectedHtmlBody =
+            "<p>It is taking longer than expected for your package <a href=\"packageUrl\">PackageId 1.0.0</a> to get published.</p>\n" +
+"<p>We are looking into it and there is no action on you at this time. We’ll send you an email notification when your package has been published.</p>\n" +
+"<p>Thank you for your patience.</p>\n";
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/SymbolPackageAddedMessageFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/SymbolPackageAddedMessageFacts.cs
@@ -102,6 +102,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -133,7 +134,6 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
         private const string _expectedMarkdownBody =
             @"The symbol package [PackageId 1.0.0](packageUrl) was recently published on NuGetGallery by Username. If this was not intended, please [contact support](packageSupportUrl).
 
-
 -----------------------------------------------
 <em style=""font-size: 0.8em;"">
     To stop receiving emails as an owner of this package, sign in to the NuGetGallery and
@@ -143,9 +143,16 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
         private const string _expectedPlainTextBody =
             @"The symbol package PackageId 1.0.0 (packageUrl) was recently published on NuGetGallery by Username. If this was not intended, please contact support (packageSupportUrl).
 
-
 -----------------------------------------------
     To stop receiving emails as an owner of this package, sign in to the NuGetGallery and
     change your email notification settings (emailSettingsUrl).";
+
+        private const string _expectedHtmlBody =
+            "<p>The symbol package <a href=\"packageUrl\">PackageId 1.0.0</a> was recently published on NuGetGallery by Username. If this was not intended, please <a href=\"packageSupportUrl\">contact support</a>.</p>\n" +
+@"<hr />
+<em style=""font-size: 0.8em;"">
+    To stop receiving emails as an owner of this package, sign in to the NuGetGallery and
+    <a href=""emailSettingsUrl"">change your email notification settings</a>.
+</em>";
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/SymbolPackageValidationFailedMessageFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/SymbolPackageValidationFailedMessageFacts.cs
@@ -104,6 +104,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -150,5 +151,13 @@ Please [contact support](packageSupportUrl) to help.";
 Your symbol package was not published on NuGetGallery and is not available for consumption.
 
 Please contact support (packageSupportUrl) to help.";
+
+        private const string _expectedHtmlBody =
+            "<p>The symbol package <a href=\"packageUrl\">PackageId 1.0.0</a> failed validation because of the following reason(s):</p>\n" +
+"<ul>\n" +
+"<li>There was an unknown failure when validating your package.</li>\n" +
+"</ul>\n" +
+"<p>Your symbol package was not published on NuGetGallery and is not available for consumption.</p>\n" +
+"<p>Please <a href=\"packageSupportUrl\">contact support</a> to help.</p>\n";
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/SymbolPackageValidationTakingTooLongMessageFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/Mail/Messages/SymbolPackageValidationTakingTooLongMessageFacts.cs
@@ -94,6 +94,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -132,5 +133,10 @@ Thank you for your patience.";
 We are looking into it and there is no action on you at this time. We’ll send you an email notification when your symbol package has been published.
 
 Thank you for your patience.";
+
+        private const string _expectedHtmlBody =
+            "<p>It is taking longer than expected for your symbol package <a href=\"packageUrl\">PackageId 1.0.0</a> to get published.</p>\n" +
+"<p>We are looking into it and there is no action on you at this time. We’ll send you an email notification when your symbol package has been published.</p>\n" +
+"<p>Thank you for your patience.</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/AccountDeleteNoticeMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/AccountDeleteNoticeMessageFacts.cs
@@ -78,6 +78,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBody)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -116,5 +117,17 @@ We will not delete the NuGet packages associated with the account.
 Thanks,
 
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>We received a request to delete your account requestingUser. If you did not initiate this request, please contact the NuGetGallery team immediately.</p>\n" +
+"<p>When your account will be deleted, we will:</p>\n" +
+"<ul>\n" +
+"<li>revoke your API key(s)</li>\n" +
+"<li>remove you as the owner for any package you own</li>\n" +
+"<li>remove your ownership from any ID prefix reservations and delete any ID prefix reservations that you were the only owner of</li>\n" +
+"</ul>\n" +
+"<p>We will not delete the NuGet packages associated with the account.</p>\n" +
+"<p>Thanks,</p>\n" +
+"<p>The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ContactOwnersMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ContactOwnersMessageFacts.cs
@@ -105,6 +105,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -153,5 +154,14 @@ user input
 -----------------------------------------------
     To stop receiving contact emails as an owner of this package, sign in to the NuGetGallery and
     change your email notification settings (emailSettingsUrl).";
+
+        private const string _expectedHtmlBody =
+            "<p><em>User Sender &lt;sender@gallery.org&gt; sends the following message to the owners of Package '<a href=\"packageUrl\">PackageId 1.0.0</a>'.</em></p>\n" +
+"<p>user input</p>\n" +
+@"<hr />
+<em style=""font-size: 0.8em;"">
+    To stop receiving contact emails as an owner of this package, sign in to the NuGetGallery and
+    <a href=""emailSettingsUrl"">change your email notification settings</a>.
+</em>";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/CredentialAddedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/CredentialAddedMessageFacts.cs
@@ -82,6 +82,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForApiKey)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForApiKey)]
+            [InlineData(EmailFormat.Html, "<p>" + _expectedMessageBodyForApiKey + "</p>\n")]
             public void ReturnsExpectedBodyForApiKey(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(Fakes.ApiKeyCredentialTypeInfo);
@@ -93,6 +94,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForNonApiKey)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForNonApiKey)]
+            [InlineData(EmailFormat.Html, "<p>" + _expectedMessageBodyForNonApiKey + "</p>\n")]
             public void ReturnsExpectedBodyForNonApiKey(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(Fakes.NonApiKeyCredentialTypeInfo);

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/CredentialRemovedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/CredentialRemovedMessageFacts.cs
@@ -81,6 +81,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForApiKey)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForApiKey)]
+            [InlineData(EmailFormat.Html, "<p>" + _expectedMessageBodyForApiKey + "</p>\n")]
             public void ReturnsExpectedBodyForApiKey(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(Fakes.ApiKeyCredentialTypeInfo);
@@ -92,6 +93,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForNonApiKey)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForNonApiKey)]
+            [InlineData(EmailFormat.Html, "<p>" + _expectedMessageBodyForNonApiKey + "</p>\n")]
             public void ReturnsExpectedBodyForNonApiKey(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(Fakes.NonApiKeyCredentialTypeInfo);

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/EmailChangeConfirmationMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/EmailChangeConfirmationMessageFacts.cs
@@ -83,6 +83,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBodyForUser)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBodyForUser)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForUser)]
             public void ReturnsExpectedBodyForUser(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(Fakes.UnconfirmedUser);
@@ -94,6 +95,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBodyForOrganization)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBodyForOrganization)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForOrganization)]
             public void ReturnsExpectedBodyForOrganization(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(Fakes.UnconfirmedOrganization);
@@ -158,5 +160,17 @@ confirmationUrl
 
 Thanks,
 The NuGetGallery Team";
+        private const string _expectedHtmlBodyForUser =
+            "<p>You recently changed your account's NuGetGallery email address.</p>\n" +
+"<p>To verify account new email address:</p>\n" +
+"<p><a href=\"confirmationUrl\">confirmationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
+        private const string _expectedHtmlBodyForOrganization =
+            "<p>You recently changed your organization's NuGetGallery email address.</p>\n" +
+"<p>To verify organization new email address:</p>\n" +
+"<p><a href=\"confirmationUrl\">confirmationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/EmailChangeNoticeToPreviousEmailAddressMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/EmailChangeNoticeToPreviousEmailAddressMessageFacts.cs
@@ -83,6 +83,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -119,5 +120,10 @@ The NuGetGallery Team";
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>The email address associated with your NuGetGallery account was recently changed from <em>previousAddress@gallery.org</em> to <em>requestUser@gallery.org</em>.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/NewAccountMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/NewAccountMessageFacts.cs
@@ -80,6 +80,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBodyForUser)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBodyForUser)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForUser)]
             public void ReturnsExpectedBodyForUser(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(Fakes.RequestingUser);
@@ -91,6 +92,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBodyForOrganization)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBodyForOrganization)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForOrganization)]
             public void ReturnsExpectedBodyForOrganization(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(Fakes.RequestingOrganization);
@@ -156,5 +158,19 @@ confirmationUrl
 
 Thanks,
 The NuGetGallery Team";
+        private const string _expectedHtmlBodyForUser =
+            "<p>Thank you for registering with the NuGetGallery.\n" +
+"We can't wait to see what packages you'll upload.</p>\n" +
+"<p>So we can be sure to contact you, please verify your email address using the following link:</p>\n" +
+"<p><a href=\"confirmationUrl\">confirmationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
+        private const string _expectedHtmlBodyForOrganization =
+            "<p>Thank you for creating an organization on the NuGetGallery.\n" +
+"We can't wait to see what packages you'll upload.</p>\n" +
+"<p>So we can be sure to contact you, please verify your email address using the following link:</p>\n" +
+"<p><a href=\"confirmationUrl\">confirmationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMemberRemovedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMemberRemovedMessageFacts.cs
@@ -90,6 +90,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBody)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(organizationEmailAllowed: true);
@@ -123,5 +124,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>The user 'requestingUser' is no longer a member of organization 'requestingOrganization'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMemberUpdatedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMemberUpdatedMessageFacts.cs
@@ -90,6 +90,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyNonAdmin)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyNonAdmin)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyNonAdmin)]
             public void ReturnsExpectedBodyForNonAdmin(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(organizationEmailAllowed: true);
@@ -101,6 +102,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyAdmin)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyAdmin)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyAdmin)]
             public void ReturnsExpectedBodyForAdmin(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(organizationEmailAllowed: true, isAdmin: true);
@@ -145,5 +147,15 @@ The NuGetGallery Team";
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBodyNonAdmin =
+            "<p>The user 'requestingUser' is now a collaborator of organization 'requestingOrganization'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
+
+        private const string _expectedHtmlBodyAdmin =
+            "<p>The user 'requestingUser' is now an administrator of organization 'requestingOrganization'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestCanceledMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestCanceledMessageFacts.cs
@@ -90,6 +90,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBody)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(pendingUserEmailAllowed: true);
@@ -123,5 +124,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>The request for you to become a member of 'requestingOrganization' has been cancelled.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestDeclinedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestDeclinedMessageFacts.cs
@@ -99,6 +99,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBody)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -143,5 +144,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>The user 'requestingUser' has declined your request to become a member of your organization.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestInitiatedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestInitiatedMessageFacts.cs
@@ -108,6 +108,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForAdmin)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForAdmin)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForAdmin)]
             public void ReturnsExpectedBodyForAdmin(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(isAdmin: true);
@@ -119,6 +120,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForNonAdmin)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForNonAdmin)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForNonAdmin)]
             public void ReturnsExpectedBodyForNonAdmin(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -172,5 +174,15 @@ The NuGetGallery Team";
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBodyForAdmin =
+            "<p>The user 'requestingUser' has requested that user 'requestingUser' be added as an administrator of organization 'requestingOrganization'. A confirmation mail has been sent to user 'requestingUser' to accept the membership request. This mail is to inform you of the membership changes to organization 'requestingOrganization' and there is no action required from you.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
+
+        private const string _expectedHtmlBodyForNonAdmin =
+            "<p>The user 'requestingUser' has requested that user 'requestingUser' be added as a collaborator of organization 'requestingOrganization'. A confirmation mail has been sent to user 'requestingUser' to accept the membership request. This mail is to inform you of the membership changes to organization 'requestingOrganization' and there is no action required from you.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestMessageFacts.cs
@@ -106,6 +106,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBodyForAdmin)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBodyForAdmin)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForAdmin)]
             public void ReturnsExpectedBodyForAdmin(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(newUserEmailAllowed: true, isAdmin: true);
@@ -117,6 +118,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBodyForNonAdmin)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBodyForNonAdmin)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForNonAdmin)]
             public void ReturnsExpectedBodyForNonAdmin(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(newUserEmailAllowed: true);
@@ -212,5 +214,25 @@ cancellationUrl
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBodyForAdmin =
+            "<p>The user 'requestingUser' would like you to become an administrator of their organization, <a href=\"profileUrl\">'requestingOrganization'</a>.</p>\n" +
+"<p>To learn more about organization roles, <a href=\"https://go.microsoft.com/fwlink/?linkid=870439\">refer to the documentation.</a></p>\n" +
+"<p>To accept the request and become an administrator of 'requestingOrganization':</p>\n" +
+"<p><a href=\"confirmationUrl\">confirmationUrl</a></p>\n" +
+"<p>To decline the request:</p>\n" +
+"<p><a href=\"cancellationUrl\">cancellationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
+
+        private const string _expectedHtmlBodyForNonAdmin =
+            "<p>The user 'requestingUser' would like you to become a collaborator of their organization, <a href=\"profileUrl\">'requestingOrganization'</a>.</p>\n" +
+"<p>To learn more about organization roles, <a href=\"https://go.microsoft.com/fwlink/?linkid=870439\">refer to the documentation.</a></p>\n" +
+"<p>To accept the request and become a collaborator of 'requestingOrganization':</p>\n" +
+"<p><a href=\"confirmationUrl\">confirmationUrl</a></p>\n" +
+"<p>To decline the request:</p>\n" +
+"<p><a href=\"cancellationUrl\">cancellationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationTransformAcceptedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationTransformAcceptedMessageFacts.cs
@@ -90,6 +90,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBody)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -123,5 +124,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>Account 'requestingUser' has been transformed into an organization with user 'organizationAdmin' as its administrator. If you did not request this change, please contact support by responding to this email.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationTransformInitiatedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationTransformInitiatedMessageFacts.cs
@@ -93,6 +93,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -145,5 +146,13 @@ If you did not request this change, please contact support by responding to this
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>We have received a request to transform account 'requestingUser' into an organization with user 'organizationAdmin' as its admin.</p>\n" +
+"<p>To cancel the transformation:</p>\n" +
+"<p><a href=\"cancellationUrl\">cancellationUrl</a></p>\n" +
+"<p>If you did not request this change, please contact support by responding to this email.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationTransformRejectedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationTransformRejectedMessageFacts.cs
@@ -113,6 +113,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBody)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -152,5 +153,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>Transformation of account 'requestingUser' has been cancelled by user 'requestingUser'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationTransformRequestMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationTransformRequestMessageFacts.cs
@@ -100,6 +100,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownMessage)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextMessage)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(adminUserEmailAllowed: true);
@@ -158,5 +159,14 @@ cancellationUrl
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>We have received a request to transform account <a href=\"profileUrl\">'requestingUser'</a> into an organization.</p>\n" +
+"<p>To proceed with the transformation and become an administrator of 'requestingUser':</p>\n" +
+"<p><a href=\"confirmationUrl\">confirmationUrl</a></p>\n" +
+"<p>To cancel the transformation:</p>\n" +
+"<p><a href=\"cancellationUrl\">cancellationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageDeletedNoticeMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageDeletedNoticeMessageFacts.cs
@@ -87,6 +87,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -123,5 +124,10 @@ The NuGetGallery Team";
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>The package <a href=\"packageUrl\">PackageId 1.0.0</a> was just deleted from NuGetGallery. If this was not intended, please <a href=\"packageSupportUrl\">contact support</a>.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnerAddedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnerAddedMessageFacts.cs
@@ -105,6 +105,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -151,5 +152,10 @@ The NuGetGallery Team";
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>User 'requestingUser' is now an owner of the package <a href=\"packageUrl\">'PackageId'</a>.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnerRemovedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnerRemovedMessageFacts.cs
@@ -102,6 +102,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForUser)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForUser)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForUser)]
             public void ReturnsExpectedBodyForUser(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(isOrganization: false);
@@ -113,6 +114,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForOrganization)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForOrganization)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForOrganization)]
             public void ReturnsExpectedBodyForOrganization(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage(isOrganization: true);
@@ -161,5 +163,15 @@ The NuGetGallery Team";
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBodyForUser =
+            "<p>The user 'requestingOrganization' removed you as an owner of the package 'PackageId'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
+
+        private const string _expectedHtmlBodyForOrganization =
+            "<p>The user 'requestingOrganization' removed your organization as an owner of the package 'PackageId'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnershipRequestCanceledMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnershipRequestCanceledMessageFacts.cs
@@ -101,8 +101,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForUser, false)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForUser, false)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForUser, false)]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForOrganization, true)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForOrganization, true)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForOrganization, true)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString, bool isNewOwnerOrganization)
             {
                 var message = CreateMessage(isNewOwnerOrganization: isNewOwnerOrganization);
@@ -150,5 +152,15 @@ The NuGetGallery Team";
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBodyForUser =
+            "<p>The user 'requestingUser' has cancelled their request for you to be added as an owner of the package 'PackageId'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
+
+        private const string _expectedHtmlBodyForOrganization =
+            "<p>The user 'requestingUser' has cancelled their request for your organization to be added as an owner of the package 'PackageId'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnershipRequestDeclinedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnershipRequestDeclinedMessageFacts.cs
@@ -114,8 +114,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForUser, false)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForUser, false)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForUser, false)]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForOrganization, true)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForOrganization, true)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForOrganization, true)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString, bool isRequestingOwnerOrganization)
             {
                 var message = CreateMessage(isRequestingOwnerOrganization: isRequestingOwnerOrganization);
@@ -167,5 +169,15 @@ The NuGetGallery Team";
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBodyForUser =
+            "<p>The user 'organizationAdmin' has declined your request to add them as an owner of the package 'PackageId'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
+
+        private const string _expectedHtmlBodyForOrganization =
+            "<p>The user 'organizationAdmin' has declined your organization's request to add them as an owner of the package 'PackageId'.</p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnershipRequestInitiatedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnershipRequestInitiatedMessageFacts.cs
@@ -108,6 +108,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -165,5 +166,12 @@ cancellationUrl
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBody =
+            "<p>The user 'requestingUser' has requested that user 'emailAllowed' be added as an owner of the package 'PackageId'.</p>\n" +
+"<p>To cancel this request:</p>\n" +
+"<p><a href=\"cancellationUrl\">cancellationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnershipRequestMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/PackageOwnershipRequestMessageFacts.cs
@@ -117,8 +117,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownMessageForUser, false)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextMessageForUser, false)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForUser, false)]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownMessageForOrganization, true)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextMessageForOrganization, true)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForOrganization, true)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString, bool isToUserOrganization)
             {
                 var message = CreateMessage(isToUserOrganization: isToUserOrganization);
@@ -238,5 +240,29 @@ cancellationUrl
 
 Thanks,
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBodyForUser =
+            "<p>The user 'requestingUser' would like to add you as an owner of the package <a href=\"packageUrl\">'PackageId'</a>.</p>\n" +
+"<p>policy message</p>\n" +
+"<p>The user 'requestingUser' added the following message for you:</p>\n" +
+"<p>'html encoded message'</p>\n" +
+"<p>To accept this request and become a listed owner of the package:</p>\n" +
+"<p><a href=\"confirmationUrl\">confirmationUrl</a></p>\n" +
+"<p>To decline:</p>\n" +
+"<p><a href=\"cancellationUrl\">cancellationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
+
+        private const string _expectedHtmlBodyForOrganization =
+            "<p>The user 'requestingUser' would like to add your organization as an owner of the package <a href=\"packageUrl\">'PackageId'</a>.</p>\n" +
+"<p>policy message</p>\n" +
+"<p>The user 'requestingUser' added the following message for you:</p>\n" +
+"<p>'html encoded message'</p>\n" +
+"<p>To accept this request and make your organization a listed owner of the package:</p>\n" +
+"<p><a href=\"confirmationUrl\">confirmationUrl</a></p>\n" +
+"<p>To decline:</p>\n" +
+"<p><a href=\"cancellationUrl\">cancellationUrl</a></p>\n" +
+"<p>Thanks,\n" +
+"The NuGetGallery Team</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ReportAbuseMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ReportAbuseMessageFacts.cs
@@ -92,6 +92,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -182,5 +183,22 @@ Message:
 message
 
 Message sent from NuGetGallery";
+
+        private const string _expectedHtmlBody =
+            "<p><strong>Email</strong>: Sender (sender@gallery.org)</p>\n" +
+"<p><strong>Signature</strong>: signature</p>\n" +
+"<p><strong>Package</strong>: PackageId\n" +
+"packageUrl</p>\n" +
+"<p><strong>Version</strong>: 1.0.0\n" +
+"packageVersionUrl</p>\n" +
+"<p><strong>User:</strong> requestingUser (requestUser@gallery.org)\n" +
+"profileUrl</p>\n" +
+"<p><strong>Reason</strong>:\n" +
+"reason</p>\n" +
+"<p><strong>Has the package owner been contacted?</strong>\n" +
+"No</p>\n" +
+"<p><strong>Message:</strong>\n" +
+"message</p>\n" +
+"<p>Message sent from NuGetGallery</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ReportMyPackageMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ReportMyPackageMessageFacts.cs
@@ -89,6 +89,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMarkdownBody)]
             [InlineData(EmailFormat.PlainText, _expectedPlainTextBody)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBody)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString)
             {
                 var message = CreateMessage();
@@ -167,5 +168,19 @@ Message:
 message
 
 Message sent from NuGetGallery";
+
+        private const string _expectedHtmlBody =
+            "<p><strong>Email</strong>: Sender (sender@gallery.org)</p>\n" +
+"<p><strong>Package</strong>: PackageId\n" +
+"packageUrl</p>\n" +
+"<p><strong>Version</strong>: 1.0.0\n" +
+"packageVersionUrl</p>\n" +
+"<p><strong>User:</strong> requestingUser (requestUser@gallery.org)\n" +
+"profileUrl</p>\n" +
+"<p><strong>Reason</strong>:\n" +
+"reason</p>\n" +
+"<p><strong>Message</strong>:\n" +
+"message</p>\n" +
+"<p>Message sent from NuGetGallery</p>\n";
     }
 }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/SigninAssistanceMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/SigninAssistanceMessageFacts.cs
@@ -81,8 +81,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             [Theory]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForNoCredentials, false)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForNoCredentials, false)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForNoCredentials, false)]
             [InlineData(EmailFormat.Markdown, _expectedMessageBodyForCredentials, true)]
             [InlineData(EmailFormat.PlainText, _expectedMessageBodyForCredentials, true)]
+            [InlineData(EmailFormat.Html, _expectedHtmlBodyForCredentials, true)]
             public void ReturnsExpectedBody(EmailFormat format, string expectedString, bool hasCredentials)
             {
                 var message = CreateMessage(hasCredentials);
@@ -140,5 +142,19 @@ Our records indicate the associated Microsoft login(s): Credential identity.
 Thanks,
 
 The NuGetGallery Team";
+
+        private const string _expectedHtmlBodyForNoCredentials =
+            "<p>Hi there,</p>\n" +
+"<p>We heard you were looking for Microsoft logins associated with your account on NuGetGallery.</p>\n" +
+"<p>No associated Microsoft logins were found.</p>\n" +
+"<p>Thanks,</p>\n" +
+"<p>The NuGetGallery Team</p>\n";
+
+        private const string _expectedHtmlBodyForCredentials =
+            "<p>Hi there,</p>\n" +
+"<p>We heard you were looking for Microsoft logins associated with your account on NuGetGallery.</p>\n" +
+"<p>Our records indicate the associated Microsoft login(s): Credential identity.</p>\n" +
+"<p>Thanks,</p>\n" +
+"<p>The NuGetGallery Team</p>\n";
     }
 }


### PR DESCRIPTION
Now that the [refactoring PR](https://github.com/NuGet/NuGetGallery/issues/6505) has been completed, this PR supersedes https://github.com/NuGet/NuGetGallery/pull/6495.

This PR introduces async email messaging to the NuGetGallery, leveraging the new ServerCommon `NuGet.Services.Messaging` library (for which an official release needs to be created still, after which I can upgrade the nupkg dependencies here).

To enable it, configure the following settings in `web.config`:

```xml
    <add key="Gallery.AsynchronousEmailServiceEnabled" value="true"/>
    <add key="AzureServiceBus.EmailPublisher.ConnectionString" value=""/>
    <add key="AzureServiceBus.EmailPublisher.TopicName" value=""/>
```

By default, `Gallery.AsynchronousEmailServiceEnabled` will be `false` (or even missing), returning the NuGetGallery email functionality into its current SMTP-mode (still using the Markdown infrastructure we already had).