### PR TITLE
Configurable rejection of packages with <license>

### DIFF
--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -352,5 +352,8 @@ namespace NuGetGallery.Configuration
         [DefaultValue(null)]
         [TypeConverter(typeof(StringArrayConverter))]
         public string[] RedirectedCuratedFeeds { get; set; }
+
+        [DefaultValue(false)]
+        public bool RejectPackagesWithLicense { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -360,5 +360,10 @@ namespace NuGetGallery.Configuration
         /// The name of zero or more curated feeds that are redirected to the main feed.
         /// </summary>
         string[] RedirectedCuratedFeeds { get; set; }
+
+        /// <summary>
+        /// Flag that indicates whether packages with `license` node in them should be rejected.
+        /// </summary>
+        bool RejectPackagesWithLicense { get; set; }
     }
 }

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -78,7 +78,6 @@ namespace NuGetGallery
                 return result;
             }
 
-
             return PackageValidationResult.AcceptedWithWarnings(warnings);
         }
         

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -71,7 +71,7 @@ namespace NuGetGallery
                 return result;
             }
 
-            result = CheckLicenseMetadata(nuGetPackage, warnings);
+            result = CheckLicenseMetadata(nuGetPackage);
 
             if (result != null)
             {
@@ -96,7 +96,7 @@ namespace NuGetGallery
                     .Any(e => LicenseNodeName == e.Name.LocalName);
         }
 
-        private PackageValidationResult CheckLicenseMetadata(PackageArchiveReader nuGetPackage, List<string> warnings)
+        private PackageValidationResult CheckLicenseMetadata(PackageArchiveReader nuGetPackage)
         {
             if (!_config.RejectPackagesWithLicense)
             {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2238,6 +2238,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This package contains a &lt;license&gt; metadata which is currently not supported..
+        /// </summary>
+        public static string UploadPackage_NotAcceptingPackagesWithLicense {
+            get {
+                return ResourceManager.GetString("UploadPackage_NotAcceptingPackagesWithLicense", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package contains too many files and/or folders..
         /// </summary>
         public static string UploadPackage_PackageContainsTooManyEntries {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -996,4 +996,7 @@ Note that NuGet.org password login is deprecated. Please use Microsoft account t
 Thanks,
 The {1} Team</value>
   </data>
+  <data name="UploadPackage_NotAcceptingPackagesWithLicense" xml:space="preserve">
+    <value>This package contains a &lt;license&gt; metadata which is currently not supported.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -179,6 +179,8 @@
     <add key="PackageDelete.StatisticsUpdateFrequencyInHours" value=""/>
     <add key="PackageDelete.HourLimitWithMaximumDownloads" value=""/>
     <add key="PackageDelete.MaximumDownloadsForPackageVersion" value=""/>
+
+    <add key="Gallery.RejectPackagesWithLicense" value="true" />
   </appSettings>
   <connectionStrings>
     <add name="Gallery.SqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=NuGetGallery; Integrated Security=True; MultipleActiveResultSets=True" providerName="System.Data.SqlClient"/>

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -442,7 +442,9 @@ namespace NuGetGallery
 
             private static string[] LicenseNodeVariants => new string[]
             {
+                "<license/>",
                 "<license></license>",
+                "<license> </license>",
                 "<license>ttt</license>",
                 "<license type='file'>fff</license>",
                 "<license type='expression'>ee</license>",

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -439,6 +438,47 @@ namespace NuGetGallery
                 Assert.Equal(PackageValidationResultType.Accepted, result.Type);
                 Assert.Null(result.Message);
                 Assert.Empty(result.Warnings);
+            }
+
+            private static string[] LicenseNodeVariants => new string[]
+            {
+                "<license></license>",
+                "<license>ttt</license>",
+                "<license type='file'>fff</license>",
+                "<license type='expression'>ee</license>",
+                "<license type='foobar'>ttt</license>",
+            };
+
+            public static IEnumerable<object[]> RejectsLicensedPackagesWhenConfigured_Input =>
+                from licenseNode in LicenseNodeVariants
+                from rejectLicenseSetting in new[] { false, true }
+                select new object[] { licenseNode, rejectLicenseSetting, !rejectLicenseSetting };
+
+            [Theory]
+            [MemberData(nameof(RejectsLicensedPackagesWhenConfigured_Input))]
+            public async Task RejectsLicensedPackagesWhenConfigured(string licenseNode, bool rejectPackagesWithLicense, bool expectedSuccess)
+            {
+                _config
+                    .SetupGet(x => x.RejectPackagesWithLicense)
+                    .Returns(rejectPackagesWithLicense);
+                _nuGetPackage = GeneratePackage(getCustomNuspecNodes: () => licenseNode);
+
+                var result = await _target.ValidateBeforeGeneratePackageAsync(
+                    _nuGetPackage.Object,
+                    GetPackageMetadata(_nuGetPackage));
+
+                if (expectedSuccess)
+                {
+                    Assert.Equal(PackageValidationResultType.Accepted, result.Type);
+                    Assert.Null(result.Message);
+                    Assert.Empty(result.Warnings);
+                }
+                else
+                {
+                    Assert.Equal(PackageValidationResultType.Invalid, result.Type);
+                    Assert.Contains("license", result.Message);
+                    Assert.Empty(result.Warnings);
+                }
             }
 
             private PackageMetadata GetPackageMetadata(Mock<TestPackageReader> mockPackage)
@@ -1100,14 +1140,16 @@ namespace NuGetGallery
                 string version = "1.2.3-alpha.0",
                 RepositoryMetadata repositoryMetadata = null,
                 bool isSigned = true,
-                int? desiredTotalEntryCount = null)
+                int? desiredTotalEntryCount = null,
+                Func<string> getCustomNuspecNodes = null)
             {
                 return PackageServiceUtility.CreateNuGetPackage(
                     id: "theId",
                     version: version,
                     repositoryMetadata: repositoryMetadata,
                     isSigned: isSigned,
-                    desiredTotalEntryCount: desiredTotalEntryCount);
+                    desiredTotalEntryCount: desiredTotalEntryCount,
+                    getCustomNuspecNodes: getCustomNuspecNodes);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/TestPackage.cs
+++ b/tests/NuGetGallery.Facts/TestPackage.cs
@@ -37,7 +37,8 @@ namespace NuGetGallery
             IEnumerable<PackageDependencyGroup> packageDependencyGroups = null,
             IEnumerable<ClientPackageType> packageTypes = null,
             bool isSymbolPackage = false,
-            RepositoryMetadata repositoryMetadata = null)
+            RepositoryMetadata repositoryMetadata = null,
+            Func<string> getCustomNodes = null)
         {
             var fullNuspec = (@"<?xml version=""1.0""?>
                 <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
@@ -60,6 +61,7 @@ namespace NuGetGallery
                         <packageTypes>" + WritePackageTypes(packageTypes) + @"</packageTypes>
                         <dependencies>" + WriteDependencies(packageDependencyGroups) + @"</dependencies>
                         " + WriteRepositoryMetadata(repositoryMetadata) + @"
+                        " + (getCustomNodes != null ? getCustomNodes() : "") + @"
                     </metadata>
                 </package>");
 
@@ -172,7 +174,8 @@ namespace NuGetGallery
             RepositoryMetadata repositoryMetadata = null,
             Action<ZipArchive> populatePackage = null,
             bool isSymbolPackage = false,
-            int? desiredTotalEntryCount = null)
+            int? desiredTotalEntryCount = null,
+            Func<string> getCustomNuspecNodes = null)
         {
             return CreateTestPackageStream(packageArchive =>
             {
@@ -181,7 +184,8 @@ namespace NuGetGallery
                 {
                     WriteNuspec(stream, true, id, version, title, summary, authors, owners, description, tags, language,
                         copyright, releaseNotes, minClientVersion, licenseUrl, projectUrl, iconUrl,
-                        requireLicenseAcceptance, packageDependencyGroups, packageTypes, isSymbolPackage, repositoryMetadata);
+                        requireLicenseAcceptance, packageDependencyGroups, packageTypes, isSymbolPackage, repositoryMetadata,
+                        getCustomNuspecNodes);
                 }
 
                 if (populatePackage != null)

--- a/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
@@ -81,7 +81,8 @@ namespace NuGetGallery.TestUtils
             IEnumerable<NuGet.Packaging.Core.PackageType> packageTypes = null,
             RepositoryMetadata repositoryMetadata = null,
             bool isSigned = false,
-            int? desiredTotalEntryCount = null)
+            int? desiredTotalEntryCount = null,
+            Func<string> getCustomNuspecNodes = null)
         {
             if (packageDependencyGroups == null)
             {
@@ -139,7 +140,9 @@ namespace NuGetGallery.TestUtils
                             writer.Write("Fake signature file.");
                         }
                     }
-                }, desiredTotalEntryCount: desiredTotalEntryCount);
+                },
+                desiredTotalEntryCount: desiredTotalEntryCount,
+                getCustomNuspecNodes: getCustomNuspecNodes);
 
             var mock = new Mock<TestPackageReader>(testPackage);
             mock.CallBase = true;


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/6558

Added configuration option to reject the packages that have <license> metadata node in them in preparation for proper implementation of license metadata processing, so we don't create a backlog of packages to reprocess.