### PR TITLE
Fix IMessageServiceConfiguration DI config

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -84,7 +84,7 @@ namespace NuGetGallery
 
             builder.Register(c => configuration.Current)
                 .AsSelf()
-                .As<IAppConfiguration>();
+                .AsImplementedInterfaces();
 
             // Force the read of this configuration, so it will be initialized on startup
             builder.Register(c => configuration.Features)


### PR DESCRIPTION
`IAppConfiguration` extends `IMessageServiceConfiguration`, and both should be made available to DI container.