### PR TITLE
Add setting 'Gallery.FileStorageDirectory' to web.config

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -144,6 +144,7 @@
     <add key="Gallery.ExternalBrandingUrl" value=""/>
     <add key="Gallery.ExternalBrandingMessage" value=""/>
     <add key="Gallery.TrademarksUrl" value=""/>
+    <add key="Gallery.FileStorageDirectory" value="~/App_Data/Files"/>
     <add key="Gallery.EnforceDefaultSecurityPolicies" value="false"/>
     <add key="Gallery.RejectSignedPackagesWithNoRegisteredCertificate" value="false"/>
     <add key="Gallery.RejectPackagesWithTooManyPackageEntries" value="false"/>


### PR DESCRIPTION
Fixes #6557

Added configuration option to web.config for the default value of [`AppConfiguration.FileStorageDirectory`](https://github.com/NuGet/NuGetGallery/blob/619bede5c0580cd553d4b5332f35454a12ebebbf/src/NuGetGallery/Configuration/AppConfiguration.cs#L111)