### PR TITLE
[MSA] Pass the error messages from AADv2 to gallery

### DIFF
--- a/src/NuGetGallery/Helpers/UriExtensions.cs
+++ b/src/NuGetGallery/Helpers/UriExtensions.cs
@@ -60,14 +60,14 @@ namespace NuGetGallery
             return uriBuilder.Uri;
         }
 
-        public static string AppendQueryStringToRelativeUri(string relativeUrl, IDictionary<string, string> queryStringCollection)
+        public static string AppendQueryStringToRelativeUri(string relativeUrl, IReadOnlyCollection<KeyValuePair<string, string>> queryStringCollection)
         {
             var tempUri = new Uri("http://www.nuget.org/");
             var builder = new UriBuilder(new Uri(tempUri, relativeUrl));
             var query = HttpUtility.ParseQueryString(builder.Query);
-            foreach (var key in queryStringCollection.Keys)
+            foreach (var pair in queryStringCollection)
             {
-                query[key] = queryStringCollection[key];
+                query[pair.Key] = pair.Value;
             }
 
             builder.Query = query.ToString();

--- a/src/NuGetGallery/Helpers/UriExtensions.cs
+++ b/src/NuGetGallery/Helpers/UriExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Web;
 
 namespace NuGetGallery
 {
@@ -56,6 +58,20 @@ namespace NuGetGallery
             uriBuilder.Port = -1;
 
             return uriBuilder.Uri;
+        }
+
+        public static string AppendQueryStringToRelativeUri(string relativeUrl, IDictionary<string, string> queryStringCollection)
+        {
+            var tempUri = new Uri("http://www.nuget.org/");
+            var builder = new UriBuilder(new Uri(tempUri, relativeUrl));
+            var query = HttpUtility.ParseQueryString(builder.Query);
+            foreach (var key in queryStringCollection.Keys)
+            {
+                query[key] = queryStringCollection[key];
+            }
+
+            builder.Query = query.ToString();
+            return builder.Uri.PathAndQuery;
         }
     }
 }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -487,6 +487,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unknown error!.
+        /// </summary>
+        public static string AuthenticationFailure_UnkownError {
+            get {
+                return ResourceManager.GetString("AuthenticationFailure_UnkownError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; authentication provider is disabled and cannot be used to authenticate
         ///.
         /// </summary>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1002,4 +1002,7 @@ The {1} Team</value>
   <data name="UploadPackage_NotAcceptingPackagesWithLicense" xml:space="preserve">
     <value>This package contains a &lt;license&gt; metadata which is currently not supported.</value>
   </data>
+  <data name="AuthenticationFailure_UnkownError" xml:space="preserve">
+    <value>Unknown error!</value>
+  </data>
 </root>

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -1457,8 +1457,10 @@ namespace NuGetGallery.Controllers
 
         public class TheLinkExternalAccountAction : TestContainer
         {
-            [Fact]
-            public async Task GivenExpiredExternalAuth_ItRedirectsBackToLogOnWithExternalAuthExpiredMessage()
+            [Theory]
+            [InlineData("access_denied")]
+            [InlineData("consent_required")]
+            public async Task GivenExpiredExternalAuth_ItRedirectsBackToLogOnWithExternalAuthExpiredMessage(string error)
             {
                 // Arrange
                 GetMock<AuthenticationService>(); // Force a mock to be created
@@ -1468,10 +1470,31 @@ namespace NuGetGallery.Controllers
                     .CompletesWith(new AuthenticateExternalLoginResult());
 
                 // Act
-                var result = await controller.LinkExternalAccount("theReturnUrl");
+                var result = await controller.LinkExternalAccount("theReturnUrl", error);
 
                 // Assert
                 VerifyExternalLinkExpiredResult(controller, result);
+            }
+
+            [Theory]
+            [InlineData("server_error", "The server encountered an unexpected error.")]
+            [InlineData("temporarily_unavailable", "The server is temporarily too busy to handle the request.")]
+            [InlineData("invalid_resource", "The target resource is invalid because either it does not exist, Azure AD cannot find it, or it is not correctly configured.")]
+            [InlineData("invalid_request", "Protocol error, such as a missing, required parameter.")]
+            public async Task GivenExpiredExternalAuth_ItRedirectsBackToLogOnWithPassedErrorMessage(string error, string errorDescription)
+            {
+                // Arrange
+                GetMock<AuthenticationService>(); // Force a mock to be created
+                var controller = GetController<AuthenticationController>();
+                GetMock<AuthenticationService>()
+                    .Setup(x => x.AuthenticateExternalLogin(controller.OwinContext))
+                    .CompletesWith(new AuthenticateExternalLoginResult());
+
+                // Act
+                var result = await controller.LinkExternalAccount("theReturnUrl", error, errorDescription);
+
+                // Assert
+                VerifyExternalLinkExpiredResult(controller, result, errorDescription);
             }
 
             [Fact]
@@ -2213,10 +2236,11 @@ namespace NuGetGallery.Controllers
             }
         }
 
-        public static void VerifyExternalLinkExpiredResult(AuthenticationController controller, ActionResult result)
+        public static void VerifyExternalLinkExpiredResult(AuthenticationController controller, ActionResult result, string expectedMessage = null)
         {
+            expectedMessage = expectedMessage ?? Strings.ExternalAccountLinkExpired;
             ResultAssert.IsRedirect(result, permanent: false, url: controller.Url.LogOn(relativeUrl: false));
-            Assert.Equal(Strings.ExternalAccountLinkExpired, controller.TempData["Message"]);
+            Assert.Equal(expectedMessage, controller.TempData["Message"]);
         }
 
         private static void EnableAllAuthenticators(AuthenticationService authService)

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -261,6 +261,7 @@
     <Compile Include="TestUtils\TestServiceUtility.cs" />
     <Compile Include="TestUtils\TestDataUtility.cs" />
     <Compile Include="TestUtils\TestUtility.cs" />
+    <Compile Include="UriExtensionsFacts.cs" />
     <Compile Include="UrlHelperExtensionsFacts.cs" />
     <Compile Include="ViewModels\DependencySetsViewModelFacts.cs" />
     <Compile Include="ViewModels\DisplayPackageViewModelFacts.cs" />

--- a/tests/NuGetGallery.Facts/UriExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/UriExtensionsFacts.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class UriExtensionsFacts
+    {
+        public class TheAppendQueryStringToRelativeUriMethod
+        {
+            [Theory]
+            [InlineData("/abac/something?q1=123", "q2=ads&q3=4324", "/abac/something?q1=123&q2=ads&q3=4324")]
+            [InlineData("/abac/something?q1=123", "q2=ads", "/abac/something?q1=123&q2=ads")]
+            [InlineData("/abac/something", "q2=ads", "/abac/something?q2=ads")]
+            [InlineData("/abac/something/", "", "/abac/something/")]
+            public void ReturnsExpectedUrl(string url, string queryParameters, string expectedUrl)
+            {
+                // Arrange
+                var queryString = string.IsNullOrEmpty(queryParameters)
+                    ? new List<KeyValuePair<string, string>>()
+                    : queryParameters
+                        .Split('&')
+                        .Select(qv => qv.Split('='))
+                        .Select(qv => new KeyValuePair<string, string>(qv[0], qv[1]))
+                        .ToList();
+
+                // Act
+                var returnUrl = UriExtensions.AppendQueryStringToRelativeUri(url, queryString);
+
+                // Assert
+                Assert.Equal(expectedUrl, returnUrl);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addresses #6100 - It is likely that the users were seeing 500 due to unhandled exceptions in AADv2 OIDC middleware. With this change, we will handle all the exceptions/failures that might occur during authentication and surface the received error message to the user for easier analysis and debugging.