### PR TITLE
 Add custom query telemetry and response header to OData endpoint

### DIFF
--- a/src/NuGetGallery/Controllers/ODataV1FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV1FeedController.cs
@@ -30,8 +30,9 @@ namespace NuGetGallery.Controllers
         public ODataV1FeedController(
             IEntityRepository<Package> packagesRepository,
             IGalleryConfigurationService configurationService,
-            ISearchService searchService)
-            : base(configurationService)
+            ISearchService searchService,
+            ITelemetryService telemetryService)
+            : base(configurationService, telemetryService)
         {
             _packagesRepository = packagesRepository;
             _configurationService = configurationService;
@@ -56,7 +57,7 @@ namespace NuGetGallery.Controllers
                                 .WithoutSortOnColumn(Id, ShouldIgnoreOrderById(options))
                                 .ToV1FeedPackageQuery(_configurationService.GetSiteRoot(UseHttps()));
 
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery: true);
         }
 
         // /api/v1/Packages/$count
@@ -108,6 +109,8 @@ namespace NuGetGallery.Controllers
                 packages = packages.Where(p => p.Version == version);
             }
 
+            bool? customQuery = null;
+
             // try the search service
             try
             {
@@ -123,6 +126,8 @@ namespace NuGetGallery.Controllers
                 // If intercepted, create a paged queryresult
                 if (searchAdaptorResult.ResultsAreProvidedBySearchService)
                 {
+                    customQuery = false;
+
                     // Packages provided by search service
                     packages = searchAdaptorResult.Packages;
 
@@ -131,6 +136,7 @@ namespace NuGetGallery.Controllers
 
                     if (return404NotFoundWhenNoResults && totalHits == 0)
                     {
+                        _telemetryService.TrackODataCustomQuery(customQuery);
                         return NotFound();
                     }
 
@@ -138,8 +144,17 @@ namespace NuGetGallery.Controllers
                         .Take(options.Top != null ? Math.Min(options.Top.Value, MaxPageSize) : MaxPageSize)
                         .ToV1FeedPackageQuery(GetSiteRoot());
 
-                    return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                       SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s));
+                    return TrackedQueryResult(
+                        options,
+                        pagedQueryable,
+                        MaxPageSize,
+                        totalHits,
+                        (o, s, resultCount) => SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s),
+                        customQuery);
+                }
+                else
+                {
+                    customQuery = true;
                 }
             }
             catch (Exception ex)
@@ -151,11 +166,12 @@ namespace NuGetGallery.Controllers
 
             if (return404NotFoundWhenNoResults && !packages.Any())
             {
+                _telemetryService.TrackODataCustomQuery(customQuery);
                 return NotFound();
             }
 
             var queryable = packages.ToV1FeedPackageQuery(GetSiteRoot());
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery);
         }
 
         // /api/v1/Packages(Id=,Version=)/propertyName
@@ -213,24 +229,36 @@ namespace NuGetGallery.Controllers
                 packages,
                 searchTerm,
                 targetFramework,
-                false,
+                includePrerelease: false, 
                 curatedFeed: null,
                 semVerLevel: null);
 
             // Packages provided by search service (even when not hijacked)
             var query = searchAdaptorResult.Packages;
+            bool? customQuery = null;
 
             // If intercepted, create a paged queryresult
             if (searchAdaptorResult.ResultsAreProvidedBySearchService)
             {
+                customQuery = false;
+
                 // Add explicit Take() needed to limit search hijack result set size if $top is specified
                 var totalHits = query.LongCount();
                 var pagedQueryable = query
                     .Take(options.Top != null ? Math.Min(options.Top.Value, MaxPageSize) : MaxPageSize)
                     .ToV1FeedPackageQuery(GetSiteRoot());
 
-                return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                   SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { searchTerm, targetFramework }, o, s));
+                return TrackedQueryResult(
+                    options,
+                    pagedQueryable,
+                    MaxPageSize,
+                    totalHits,
+                    (o, s, resultCount) => SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { searchTerm, targetFramework }, o, s),
+                    customQuery);
+            }
+            else
+            {
+                customQuery = true;
             }
 
             if (!ODataQueryVerifier.AreODataOptionsAllowed(options, ODataQueryVerifier.V1Search,
@@ -241,7 +269,7 @@ namespace NuGetGallery.Controllers
 
             // If not, just let OData handle things
             var queryable = query.ToV1FeedPackageQuery(GetSiteRoot());
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery);
         }
 
         // /api/v1/Search()/$count?searchTerm=&targetFramework=&includePrerelease=

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -32,8 +32,9 @@ namespace NuGetGallery.Controllers
             IGalleryConfigurationService configurationService,
             ISearchService searchService,
             ICuratedFeedService curatedFeedService,
-            IEntityRepository<Package> packagesRepository)
-            : base(configurationService)
+            IEntityRepository<Package> packagesRepository,
+            ITelemetryService telemetryService)
+            : base(configurationService, telemetryService)
         {
             _configurationService = configurationService;
             _searchService = searchService;
@@ -68,7 +69,7 @@ namespace NuGetGallery.Controllers
                     semVerLevelKey)
                 .InterceptWith(new NormalizeVersionInterceptor());
 
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery: true);
         }
 
         // /api/v2/curated-feed/curatedFeedName/Packages/$count?semVerLevel=
@@ -108,7 +109,7 @@ namespace NuGetGallery.Controllers
                 var emptyResult = Enumerable.Empty<Package>().AsQueryable()
                     .ToV2FeedPackageQuery(GetSiteRoot(), _configurationService.Features.FriendlyLicenses, semVerLevelKey);
 
-                return QueryResult(options, emptyResult, MaxPageSize);
+                return TrackedQueryResult(options, emptyResult, MaxPageSize, customQuery: false);
             }
 
             return await GetCore(options, curatedFeedName, id, normalizedVersion: null, return404NotFoundWhenNoResults: false, semVerLevel: semVerLevel);
@@ -153,6 +154,7 @@ namespace NuGetGallery.Controllers
             }
 
             var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
+            bool? customQuery = null;
 
             // try the search service
             try
@@ -169,6 +171,8 @@ namespace NuGetGallery.Controllers
                 // If intercepted, create a paged queryresult
                 if (searchAdaptorResult.ResultsAreProvidedBySearchService)
                 {
+                    customQuery = false;
+
                     // Packages provided by search service
                     packages = searchAdaptorResult.Packages;
 
@@ -177,6 +181,7 @@ namespace NuGetGallery.Controllers
 
                     if (return404NotFoundWhenNoResults && totalHits == 0)
                     {
+                        _telemetryService.TrackODataCustomQuery(customQuery);
                         return NotFound();
                     }
 
@@ -184,8 +189,17 @@ namespace NuGetGallery.Controllers
                         .Take(options.Top != null ? Math.Min(options.Top.Value, MaxPageSize) : MaxPageSize)
                         .ToV2FeedPackageQuery(GetSiteRoot(), _configurationService.Features.FriendlyLicenses, semVerLevelKey);
 
-                    return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                       SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s, semVerLevelKey));
+                    return TrackedQueryResult(
+                        options,
+                        pagedQueryable,
+                        MaxPageSize,
+                        totalHits,
+                        (o, s, resultCount) => SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s, semVerLevelKey),
+                        customQuery);
+                }
+                else
+                {
+                    customQuery = true;
                 }
             }
             catch (Exception ex)
@@ -197,6 +211,7 @@ namespace NuGetGallery.Controllers
 
             if (return404NotFoundWhenNoResults && !packages.Any())
             {
+                _telemetryService.TrackODataCustomQuery(customQuery);
                 return NotFound();
             }
 
@@ -205,7 +220,7 @@ namespace NuGetGallery.Controllers
                 _configurationService.Features.FriendlyLicenses, 
                 semVerLevelKey);
 
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery);
         }
 
         // /api/v2/curated-feed/curatedFeedName/Packages(Id=,Version=)/propertyName
@@ -278,10 +293,13 @@ namespace NuGetGallery.Controllers
             var query = searchAdaptorResult.Packages;
 
             var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
+            bool? customQuery = null;
 
             // If intercepted, create a paged queryresult
             if (searchAdaptorResult.ResultsAreProvidedBySearchService)
             {
+                customQuery = false;
+
                 // Add explicit Take() needed to limit search hijack result set size if $top is specified
                 var totalHits = query.LongCount();
                 var pagedQueryable = query
@@ -291,22 +309,32 @@ namespace NuGetGallery.Controllers
                         _configurationService.Features.FriendlyLicenses, 
                         semVerLevelKey);
 
-                return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                {
-                    // The nuget.exe 2.x list command does not like the next link at the bottom when a $top is passed.
-                    // Strip it of for backward compatibility.
-                    if (o.Top == null || (resultCount.HasValue && o.Top.Value >= resultCount.Value))
+                return TrackedQueryResult(
+                    options,
+                    pagedQueryable,
+                    MaxPageSize,
+                    totalHits,
+                    (o, s, resultCount) =>
                     {
-                        return SearchAdaptor.GetNextLink(
-                            Request.RequestUri, 
-                            resultCount, 
-                            new { searchTerm, targetFramework, includePrerelease }, 
-                            o, 
-                            s,
-                            semVerLevelKey);
-                    }
-                    return null;
-                });
+                        // The nuget.exe 2.x list command does not like the next link at the bottom when a $top is passed.
+                        // Strip it of for backward compatibility.
+                        if (o.Top == null || (resultCount.HasValue && o.Top.Value >= resultCount.Value))
+                        {
+                            return SearchAdaptor.GetNextLink(
+                                Request.RequestUri, 
+                                resultCount, 
+                                new { searchTerm, targetFramework, includePrerelease }, 
+                                o, 
+                                s,
+                                semVerLevelKey);
+                        }
+                        return null;
+                    },
+                    customQuery);
+            }
+            else
+            {
+                customQuery = true;
             }
 
             // If not, just let OData handle things
@@ -315,7 +343,7 @@ namespace NuGetGallery.Controllers
                 _configurationService.Features.FriendlyLicenses, 
                 semVerLevelKey);
 
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery);
         }
 
         // /api/v2/curated-feed/curatedFeedName/Search()/$count?searchTerm=&targetFramework=&includePrerelease=

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -36,8 +36,9 @@ namespace NuGetGallery.Controllers
         public ODataV2FeedController(
             IEntityRepository<Package> packagesRepository,
             IGalleryConfigurationService configurationService,
-            ISearchService searchService)
-            : base(configurationService)
+            ISearchService searchService,
+            ITelemetryService telemetryService)
+            : base(configurationService, telemetryService)
         {
             _packagesRepository = packagesRepository;
             _configurationService = configurationService;
@@ -61,6 +62,7 @@ namespace NuGetGallery.Controllers
                                 .InterceptWith(new NormalizeVersionInterceptor());
 
             var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
+            bool? customQuery = null;
 
             // Try the search service
             try
@@ -80,6 +82,8 @@ namespace NuGetGallery.Controllers
                     // If intercepted, create a paged queryresult
                     if (searchAdaptorResult.ResultsAreProvidedBySearchService)
                     {
+                        customQuery = false;
+
                         // Packages provided by search service
                         packages = searchAdaptorResult.Packages;
 
@@ -92,9 +96,22 @@ namespace NuGetGallery.Controllers
                                 _configurationService.Features.FriendlyLicenses,
                                 semVerLevelKey);
 
-                        return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                           SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, null, o, s, semVerLevelKey));
+                        return TrackedQueryResult(
+                            options,
+                            pagedQueryable,
+                            MaxPageSize,
+                            totalHits,
+                            (o, s, resultCount) => SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, null, o, s, semVerLevelKey),
+                            customQuery);
                     }
+                    else
+                    {
+                        customQuery = true;
+                    }
+                }
+                else
+                {
+                    customQuery = true;
                 }
             }
             catch (Exception ex)
@@ -116,7 +133,7 @@ namespace NuGetGallery.Controllers
                 _configurationService.Features.FriendlyLicenses, 
                 semVerLevelKey);
 
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery);
         }
 
         // /api/v2/Packages/$count?semVerLevel=
@@ -169,7 +186,7 @@ namespace NuGetGallery.Controllers
                         _configurationService.Features.FriendlyLicenses, 
                         semVerLevelKey);
 
-                return QueryResult(options, emptyResult, MaxPageSize);
+                return TrackedQueryResult(options, emptyResult, MaxPageSize, customQuery: false);
             }
 
             return await GetCore(
@@ -217,6 +234,7 @@ namespace NuGetGallery.Controllers
             }
 
             var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
+            bool? customQuery = null;
 
             // try the search service
             try
@@ -233,6 +251,8 @@ namespace NuGetGallery.Controllers
                 // If intercepted, create a paged queryresult
                 if (searchAdaptorResult.ResultsAreProvidedBySearchService)
                 {
+                    customQuery = false;
+
                     // Packages provided by search service
                     packages = searchAdaptorResult.Packages;
 
@@ -241,6 +261,7 @@ namespace NuGetGallery.Controllers
 
                     if (totalHits == 0 && return404NotFoundWhenNoResults)
                     {
+                        _telemetryService.TrackODataCustomQuery(customQuery);
                         return NotFound();
                     }
 
@@ -251,8 +272,17 @@ namespace NuGetGallery.Controllers
                             _configurationService.Features.FriendlyLicenses, 
                             semVerLevelKey);
 
-                    return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                       SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s, semVerLevelKey));
+                    return TrackedQueryResult(
+                        options,
+                        pagedQueryable,
+                        MaxPageSize,
+                        totalHits,
+                        (o, s, resultCount) => SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s, semVerLevelKey),
+                        customQuery);
+                }
+                else
+                {
+                    customQuery = true;
                 }
             }
             catch (Exception ex)
@@ -264,6 +294,7 @@ namespace NuGetGallery.Controllers
 
             if (return404NotFoundWhenNoResults && !packages.Any())
             {
+                _telemetryService.TrackODataCustomQuery(customQuery);
                 return NotFound();
             }
 
@@ -272,7 +303,7 @@ namespace NuGetGallery.Controllers
                 _configurationService.Features.FriendlyLicenses, 
                 semVerLevelKey);
 
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery);
         }
 
         // /api/v2/Packages(Id=,Version=)/propertyName
@@ -340,10 +371,13 @@ namespace NuGetGallery.Controllers
             var query = searchAdaptorResult.Packages;
 
             var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
+            bool? customQuery = null;
 
             // If intercepted, create a paged queryresult
             if (searchAdaptorResult.ResultsAreProvidedBySearchService)
             {
+                customQuery = false;
+
                 // Add explicit Take() needed to limit search hijack result set size if $top is specified
                 var totalHits = query.LongCount();
                 var pagedQueryable = query
@@ -353,17 +387,28 @@ namespace NuGetGallery.Controllers
                         _configurationService.Features.FriendlyLicenses, 
                         semVerLevelKey);
 
-                return QueryResult(options, pagedQueryable, MaxPageSize, totalHits, (o, s, resultCount) =>
-                {
-                    // The nuget.exe 2.x list command does not like the next link at the bottom when a $top is passed.
-                    // Strip it of for backward compatibility.
-                    if (o.Top == null || (resultCount.HasValue && o.Top.Value >= resultCount.Value))
-                    {
-                        return SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { searchTerm, targetFramework, includePrerelease }, o, s, semVerLevelKey);
-                    }
-                    return null;
-                });
+                return TrackedQueryResult(
+                    options,
+                    pagedQueryable,
+                    MaxPageSize,
+                    totalHits,
+                    (o, s, resultCount) =>
+                        {
+                            // The nuget.exe 2.x list command does not like the next link at the bottom when a $top is passed.
+                            // Strip it of for backward compatibility.
+                            if (o.Top == null || (resultCount.HasValue && o.Top.Value >= resultCount.Value))
+                            {
+                                return SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { searchTerm, targetFramework, includePrerelease }, o, s, semVerLevelKey);
+                            }
+                            return null;
+                        },
+                    customQuery);
             }
+            else
+            {
+                customQuery = true;
+            }
+
             //Reject only when try to reach database.
             if (!ODataQueryVerifier.AreODataOptionsAllowed(options, ODataQueryVerifier.V2Search,
                 _configurationService.Current.IsODataFilterEnabled, nameof(Search)))
@@ -377,7 +422,7 @@ namespace NuGetGallery.Controllers
                 _configurationService.Features.FriendlyLicenses, 
                 semVerLevelKey);
 
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery);
         }
 
         // /api/v2/Search()/$count?searchTerm=&targetFramework=&includePrerelease=&semVerLevel=
@@ -414,7 +459,11 @@ namespace NuGetGallery.Controllers
         {
             if (string.IsNullOrEmpty(packageIds) || string.IsNullOrEmpty(versions))
             {
-                return Ok(Enumerable.Empty<V2FeedPackage>().AsQueryable());
+                return TrackedQueryResult(
+                    options,
+                    Enumerable.Empty<V2FeedPackage>().AsQueryable(),
+                    MaxPageSize,
+                    customQuery: false);
             }
 
             if (!ODataQueryVerifier.AreODataOptionsAllowed(options, ODataQueryVerifier.V2GetUpdates,
@@ -444,7 +493,11 @@ namespace NuGetGallery.Controllers
             if (idValues.Length == 0 || idValues.Length != versionValues.Length || idValues.Length != versionConstraintValues.Length)
             {
                 // Exit early if the request looks invalid
-                return Ok(Enumerable.Empty<V2FeedPackage>().AsQueryable());
+                return TrackedQueryResult(
+                    options,
+                    Enumerable.Empty<V2FeedPackage>().AsQueryable(),
+                    MaxPageSize,
+                    customQuery: false);
             }
 
             var versionLookup = idValues.Select((id, i) =>
@@ -483,7 +536,7 @@ namespace NuGetGallery.Controllers
                     _configurationService.Features.FriendlyLicenses, 
                     semVerLevelKey);
 
-            return QueryResult(options, queryable, MaxPageSize);
+            return TrackedQueryResult(options, queryable, MaxPageSize, customQuery: false);
         }
 
         // /api/v2/GetUpdates()/$count?packageIds=&versions=&includePrerelease=&includeAllVersions=&targetFrameworks=&versionConstraints=&semVerLevel=

--- a/src/NuGetGallery/GalleryConstants.cs
+++ b/src/NuGetGallery/GalleryConstants.cs
@@ -87,6 +87,17 @@ namespace NuGetGallery
         internal const string NuGetProtocolHeaderName = "X-NuGet-Protocol-Version";
         internal const string WarningHeaderName = "X-NuGet-Warning";
         internal const string UserAgentHeaderName = "User-Agent";
+        
+        /// <summary>
+        /// This header is for internal use only. It indicates whether an OData query is "custom". Custom means not
+        /// not optimized for search hijacking. Queries made by the official client should be optimized and therefore
+        /// not marked as custom queries (as to not overload the database). The value is either "true" or "false". If
+        /// the header is not present on an OData query response, that means that the search hijack detection is
+        /// failing, perhaps due to search service outage. The value of this header corresponds to the
+        /// <see cref="ITelemetryService.TrackODataCustomQuery(bool?)"/> telemetry emitted while generating the
+        /// response.
+        /// </summary>
+        internal const string CustomQueryHeaderName = "X-NuGet-CustomQuery";
 
         public static readonly string ReturnUrlParameterName = "ReturnUrl";
         public static readonly string CurrentUserOwinEnvironmentKey = "nuget.user";

--- a/src/NuGetGallery/Services/ITelemetryService.cs
+++ b/src/NuGetGallery/Services/ITelemetryService.cs
@@ -13,6 +13,8 @@ namespace NuGetGallery
     {
         void TrackODataQueryFilterEvent(string callContext, bool isEnabled, bool isAllowed, string queryPattern);
 
+        void TrackODataCustomQuery(bool? customQuery);
+
         void TrackPackagePushEvent(Package package, User user, IIdentity identity);
 
         void TrackPackagePushFailureEvent(string id, NuGetVersion version);

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -19,6 +19,7 @@ namespace NuGetGallery
         internal class Events
         {
             public const string ODataQueryFilter = "ODataQueryFilter";
+            public const string ODataCustomQuery = "ODataCustomQuery";
             public const string PackagePush = "PackagePush";
             public const string PackagePushFailure = "PackagePushFailure";
             public const string CreatePackageVerificationKey = "CreatePackageVerificationKey";
@@ -72,12 +73,15 @@ namespace NuGetGallery
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
             Formatting = Formatting.None
         };
-        
+
         // ODataQueryFilter properties
         public const string CallContext = "CallContext";
         public const string IsEnabled = "IsEnabled";
         public const string IsAllowed = "IsAllowed";
         public const string QueryPattern = "QueryPattern";
+
+        // ODataCustomQuery properties
+        public const string IsCustomQuery = "IsCustomQuery";
 
         // Package push properties
         public const string AuthenticationMethod = "AuthenticationMethod";
@@ -183,6 +187,14 @@ namespace NuGetGallery
 
                 properties.Add(IsAllowed, $"{isAllowed}");
                 properties.Add(QueryPattern, queryPattern);
+            });
+        }
+
+        public void TrackODataCustomQuery(bool? customQuery)
+        {
+            TrackMetric(Events.ODataCustomQuery, 1, properties =>
+            {
+                properties.Add(IsCustomQuery, customQuery?.ToString() ?? "Unknown");
             });
         }
 

--- a/tests/NuGetGallery.Facts/Controllers/ODataFeedControllerFactsBase.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataFeedControllerFactsBase.cs
@@ -52,15 +52,21 @@ namespace NuGetGallery.Controllers
         protected abstract TController CreateController(
             IEntityRepository<Package> packagesRepository,
             IGalleryConfigurationService configurationService,
-            ISearchService searchService);
+            ISearchService searchService,
+            ITelemetryService telemetryService);
 
         protected TController CreateTestableODataFeedController(HttpRequestMessage request)
         {
             var searchService = new Mock<ISearchService>().Object;
             var configurationService = new TestGalleryConfigurationService();
             configurationService.Current.SiteRoot = _siteRoot;
+            var telemetryService = new Mock<ITelemetryService>();
 
-            var controller = CreateController(PackagesRepository, configurationService, searchService);
+            var controller = CreateController(
+                PackagesRepository,
+                configurationService,
+                searchService,
+                telemetryService.Object);
 
             AddRequestToController(request, controller);
 

--- a/tests/NuGetGallery.Facts/Controllers/ODataV1FeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV1FeedControllerFacts.cs
@@ -89,10 +89,17 @@ namespace NuGetGallery.Controllers
             Assert.Equal(NonSemVer2Packages.Where(p => !p.IsPrerelease).Count(), searchCount);
         }
 
-        protected override ODataV1FeedController CreateController(IEntityRepository<Package> packagesRepository,
-            IGalleryConfigurationService configurationService, ISearchService searchService)
+        protected override ODataV1FeedController CreateController(
+            IEntityRepository<Package> packagesRepository,
+            IGalleryConfigurationService configurationService,
+            ISearchService searchService,
+            ITelemetryService telemetryService)
         {
-            return new ODataV1FeedController(packagesRepository, configurationService, searchService);
+            return new ODataV1FeedController(
+                packagesRepository,
+                configurationService,
+                searchService,
+                telemetryService);
         }
 
         private void AssertSemVer2PackagesFilteredFromResult(IEnumerable<V1FeedPackage> resultSet)

--- a/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV2CuratedFeedControllerFacts.cs
@@ -35,6 +35,7 @@ namespace NuGetGallery.Controllers
             private readonly Mock<ISearchService> _searchService;
             private readonly Mock<ICuratedFeedService> _curatedFeedService;
             private readonly Mock<IEntityRepository<Package>> _packages;
+            private readonly Mock<ITelemetryService> _telemetryService;
             private readonly ODataV2CuratedFeedController _target;
             private readonly HttpRequestMessage _request;
             private readonly ODataQueryOptions<V2FeedPackage> _options;
@@ -63,6 +64,7 @@ namespace NuGetGallery.Controllers
                 _searchService = new Mock<ISearchService>();
                 _curatedFeedService = new Mock<ICuratedFeedService>();
                 _packages = new Mock<IEntityRepository<Package>>();
+                _telemetryService = new Mock<ITelemetryService>();
 
                 _config
                     .Setup(x => x.Current)
@@ -87,7 +89,8 @@ namespace NuGetGallery.Controllers
                     _config.Object,
                     _searchService.Object,
                     _curatedFeedService.Object,
-                    _packages.Object);
+                    _packages.Object,
+                    _telemetryService.Object);
 
                 _request = new HttpRequestMessage(HttpMethod.Get, $"{_siteRoot}/api/v2/curated-feed/{_curatedFeedName}/Packages");
                 _options = new ODataQueryOptions<V2FeedPackage>(CreateODataQueryContext<V2FeedPackage>(), _request);
@@ -475,7 +478,8 @@ namespace NuGetGallery.Controllers
         protected override ODataV2CuratedFeedController CreateController(
             IEntityRepository<Package> packagesRepository,
             IGalleryConfigurationService configurationService,
-            ISearchService searchService)
+            ISearchService searchService,
+            ITelemetryService telemetryService)
         {
             var curatedFeed = new CuratedFeed { Name = _curatedFeedName };
 
@@ -487,7 +491,8 @@ namespace NuGetGallery.Controllers
                 configurationService,
                 searchService,
                 curatedFeedServiceMock.Object,
-                packagesRepository);
+                packagesRepository,
+                telemetryService);
         }
 
         private static IDbSet<T> GetQueryableMockDbSet<T>(params T[] sourceList) where T : class

--- a/tests/NuGetGallery.Facts/Controllers/ODataV2FeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV2FeedControllerFacts.cs
@@ -405,9 +405,14 @@ namespace NuGetGallery.Controllers
         protected override ODataV2FeedController CreateController(
             IEntityRepository<Package> packagesRepository,
             IGalleryConfigurationService configurationService,
-            ISearchService searchService)
+            ISearchService searchService,
+            ITelemetryService telemetryService)
         {
-            return new ODataV2FeedController(packagesRepository, configurationService, searchService);
+            return new ODataV2FeedController(
+                packagesRepository,
+                configurationService,
+                searchService,
+                telemetryService);
         }
 
         private void AssertSemVer2PackagesFilteredFromResult(IEnumerable<V2FeedPackage> resultSet)

--- a/tests/NuGetGallery.Facts/TestUtils/Infrastructure/TestableV1Feed.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/Infrastructure/TestableV1Feed.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Web;
+using Moq;
 using NuGet.Services.Entities;
 using NuGetGallery.Configuration;
 using NuGetGallery.Controllers;
@@ -14,12 +15,27 @@ namespace NuGetGallery.TestUtils.Infrastructure
             IEntityRepository<Package> repo,
             IGalleryConfigurationService configuration,
             ISearchService searchService)
-            : base(repo, configuration, searchService)
+            : base(repo, configuration, searchService, Mock.Of<ITelemetryService>())
         {
         }
 
+        public TestableV1Feed(
+            IEntityRepository<Package> repo,
+            IGalleryConfigurationService configuration,
+            ISearchService searchService,
+            ITelemetryService telemetryService)
+            : base(repo, configuration, searchService, telemetryService)
+        {
+        }
+
+        public string RawUrl { get; set; }
+
         protected override HttpContextBase GetTraditionalHttpContext()
         {
+            if (!string.IsNullOrEmpty(RawUrl))
+            {
+                return FeedServiceHelpers.GetMockContext(RawUrl.StartsWith("https"), RawUrl);
+            }
             return FeedServiceHelpers.GetMockContext();
         }
 

--- a/tests/NuGetGallery.Facts/TestUtils/Infrastructure/TestableV2Feed.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/Infrastructure/TestableV2Feed.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Web;
+using Moq;
 using NuGet.Services.Entities;
 using NuGetGallery.Configuration;
 using NuGetGallery.Controllers;
@@ -14,7 +15,16 @@ namespace NuGetGallery.TestUtils.Infrastructure
             IEntityRepository<Package> repo,
             IGalleryConfigurationService configuration,
             ISearchService searchService)
-            : base(repo, configuration, searchService)
+            : base(repo, configuration, searchService, Mock.Of<ITelemetryService>())
+        {
+        }
+
+        public TestableV2Feed(
+            IEntityRepository<Package> repo,
+            IGalleryConfigurationService configuration,
+            ISearchService searchService,
+            ITelemetryService telemetryService)
+            : base(repo, configuration, searchService, telemetryService)
         {
         }
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1798.

This PR does two things:

1. Add custom metric `ODataCustomQuery` to OData queries.
   - This has a property `IsCustomQuery = True | False | Unknown`
1. Add a response header `X-NuGet-CustomQuery: true | false`
   - This can be used by APIM

The telemetry will allow us to verify that official clients are not doing custom queries. Note that "custom query" does not necessarily mean executed without the database. I chose to make this distinction for the `GetUpdates` OData function. This can be called by official client (2.x for many cases, 3.x+ for `nuget.exe update -self`) so it should not be throttled like custom OData queries.

~Another case: when search hijack throws an exception, some (maybe all?) codepaths fall back to DB. This should probably not be throttled...~