### PR TITLE
Upgrade gallery to stable ServerCommon v2.30 dependencies

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -202,10 +202,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
@@ -241,10 +241,10 @@
       <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>7.1.2</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1977,13 +1977,13 @@
       <Version>0.15.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
@@ -2210,16 +2210,16 @@
       <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.30.0-master-42731</Version>
+      <Version>2.30.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>


### PR DESCRIPTION
This PR upgrades the gallery to rely on the latest stable ServerCommon dependencies.
This way, it is also in sync with the email publisher job.