### PR TITLE
Redirect HTTP 400 to a specific error page instead of the default for HTTP 500

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -322,6 +322,7 @@
     <customErrors mode="RemoteOnly" defaultRedirect="~/Errors/500" redirectMode="ResponseRedirect">
       <!-- Adding ? at the end of the redirect URL prevents the illegal request to be passed
            as a query parameter to the redirect URL and causing additional failures -->
+      <error statusCode="400" redirect="~/Errors/400"/>
       <error statusCode="404" redirect="~/Errors/404"/>
       <error statusCode="500" redirect="~/Errors/500"/>
     </customErrors>
@@ -366,8 +367,10 @@
     </modules>
     <validation validateIntegratedModeConfiguration="false"/>
     <httpErrors errorMode="DetailedLocalOnly">
+      <remove statusCode="400"/>
       <remove statusCode="404"/>
       <remove statusCode="500"/>
+      <error statusCode="400" path="/Errors/400" responseMode="ExecuteURL"/>
       <error statusCode="404" path="/Errors/404" responseMode="ExecuteURL"/>
       <error statusCode="500" path="/Errors/500" responseMode="ExecuteURL"/>
     </httpErrors>


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6601.

Currently, HTTP 400s produced by IIS (unsafe character validation for URL path) get redirected to the HTTP 500 error page.