### PR TITLE
Validation message enhancements

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -712,12 +712,12 @@ namespace NuGetGallery
 
                             TelemetryService.TrackPackagePushEvent(package, currentUser, User.Identity);
 
-                            var warnings = new List<string>();
+                            var warnings = new List<IValidationMessage>();
                             warnings.AddRange(beforeValidationResult.Warnings);
                             warnings.AddRange(afterValidationResult.Warnings);
                             if (package.SemVerLevelKey == SemVerLevelKey.SemVer2)
                             {
-                                warnings.Add(Strings.WarningSemVer2PackagePushed);
+                                warnings.Add(new PlainTextOnlyValidationMessage(Strings.WarningSemVer2PackagePushed));
                             }
 
                             return new HttpStatusCodeWithServerWarningResult(HttpStatusCode.Created, warnings);
@@ -762,9 +762,7 @@ namespace NuGetGallery
                 case PackageValidationResultType.Accepted:
                     return null;
                 case PackageValidationResultType.Invalid:
-                case PackageValidationResultType.PackageShouldNotBeSigned:
-                case PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates:
-                    return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, validationResult.Message);
+                    return new HttpStatusCodeWithBodyResult(HttpStatusCode.BadRequest, validationResult.Message.PlainTextMessage);
                 default:
                     throw new NotImplementedException($"The package validation result type {validationResult.Type} is not supported.");
             }

--- a/src/NuGetGallery/Infrastructure/HttpStatusCodeWithServerWarningResult.cs
+++ b/src/NuGetGallery/Infrastructure/HttpStatusCodeWithServerWarningResult.cs
@@ -21,7 +21,6 @@ namespace NuGetGallery
         public HttpStatusCodeWithServerWarningResult(HttpStatusCode statusCode, IReadOnlyList<IValidationMessage> warnings)
             : this(statusCode, warnings.Select(w => w.PlainTextMessage).ToList())
         {
-
         }
 
         public override void ExecuteResult(ControllerContext context)

--- a/src/NuGetGallery/Infrastructure/HttpStatusCodeWithServerWarningResult.cs
+++ b/src/NuGetGallery/Infrastructure/HttpStatusCodeWithServerWarningResult.cs
@@ -18,6 +18,12 @@ namespace NuGetGallery
             Warnings = warnings ?? new string[0];
         }
 
+        public HttpStatusCodeWithServerWarningResult(HttpStatusCode statusCode, IReadOnlyList<IValidationMessage> warnings)
+            : this(statusCode, warnings.Select(w => w.PlainTextMessage).ToList())
+        {
+
+        }
+
         public override void ExecuteResult(ControllerContext context)
         {
             var response = context.RequestContext.HttpContext.Response;

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -426,6 +426,10 @@
     <Compile Include="Services\ITyposquattingConfiguration.cs" />
     <Compile Include="Services\ISymbolsConfiguration.cs" />
     <Compile Include="Services\ITyposquattingService.cs" />
+    <Compile Include="Services\IValidationMessage.cs" />
+    <Compile Include="Services\JsonValidationMessage.cs" />
+    <Compile Include="Services\PackageShouldNotBeSignedUserFixableValidationMessage.cs" />
+    <Compile Include="Services\PlainTextOnlyValidationMessage.cs" />
     <Compile Include="Services\SymbolPackageValidationResult.cs" />
     <Compile Include="Infrastructure\Mail\MarkdownMessageService.cs" />
     <Compile Include="Services\SymbolPackageUploadService.cs" />

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -120,7 +120,7 @@ namespace NuGetGallery
         public bool IsSymbolsPackage { get; set; }
         public bool HasExistingAvailableSymbols { get; set; }
 
-        public List<string> Warnings { get; set; } = new List<string>();
+        public List<JsonValidationMessage> Warnings { get; set; } = new List<JsonValidationMessage>();
 
         private static IReadOnlyCollection<string> ParseUserList(IEnumerable<User> users)
         {

--- a/src/NuGetGallery/Services/IValidationMessage.cs
+++ b/src/NuGetGallery/Services/IValidationMessage.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Represents a validation message that may include a raw HTML message (if we want to present some links in the message, for example).
+    /// </summary>
+    /// <remarks>
+    /// Implementations should sanitize all input used to generate <see cref="IValidationMessage.RawHtmlMessage"/> value.
+    /// We should never have a generic implementation that would accept a raw HTML message as a constructor argument and
+    /// simply returns it as a value of <see cref="IValidationMessage.RawHtmlMessage"/>.
+    /// </remarks>
+    public interface IValidationMessage
+    {
+        /// <summary>
+        /// Plain text representation of the validation message. If pasted into HTML, will be html encoded.
+        /// </summary>
+        string PlainTextMessage { get; }
+
+        /// <summary>
+        /// An indicator that raw HTML representation is available.
+        /// </summary>
+        bool HasRawHtmlRepresentation { get; }
+
+        /// <summary>
+        /// HANDLE WITH EXTREME CARE. Raw HTML representation of the message.
+        /// Under no conditions it may contain unvalidated user data.
+        /// </summary>
+        string RawHtmlMessage { get; }
+    }
+}

--- a/src/NuGetGallery/Services/IValidationMessage.cs
+++ b/src/NuGetGallery/Services/IValidationMessage.cs
@@ -25,7 +25,7 @@ namespace NuGetGallery
 
         /// <summary>
         /// HANDLE WITH EXTREME CARE. Raw HTML representation of the message.
-        /// Under no conditions it may contain unvalidated user data.
+        /// Under no conditions may it contain unvalidated user data.
         /// </summary>
         string RawHtmlMessage { get; }
     }

--- a/src/NuGetGallery/Services/JsonValidationMessage.cs
+++ b/src/NuGetGallery/Services/JsonValidationMessage.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace NuGetGallery
 {
     /// <summary>
@@ -10,12 +12,17 @@ namespace NuGetGallery
     {
         public JsonValidationMessage(string message)
         {
-            PlainTextMessage = message;
+            PlainTextMessage = message ?? throw new ArgumentNullException(nameof(message));
             RawHtmlMessage = null;
         }
 
         public JsonValidationMessage(IValidationMessage message)
         {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             if (message.HasRawHtmlRepresentation)
             {
                 PlainTextMessage = null;

--- a/src/NuGetGallery/Services/JsonValidationMessage.cs
+++ b/src/NuGetGallery/Services/JsonValidationMessage.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Validation message representation for returning in Json responses for Gallery web pages.
+    /// </summary>
+    public class JsonValidationMessage
+    {
+        public JsonValidationMessage(string message)
+        {
+            PlainTextMessage = message;
+            RawHtmlMessage = null;
+        }
+
+        public JsonValidationMessage(IValidationMessage message)
+        {
+            if (message.HasRawHtmlRepresentation)
+            {
+                PlainTextMessage = null;
+                RawHtmlMessage = message.RawHtmlMessage;
+            }
+            else
+            {
+                PlainTextMessage = message.PlainTextMessage;
+                RawHtmlMessage = null;
+            }
+        }
+
+        public string PlainTextMessage { get; }
+        public string RawHtmlMessage { get; }
+    }
+}

--- a/src/NuGetGallery/Services/PackageShouldNotBeSignedUserFixableValidationMessage.cs
+++ b/src/NuGetGallery/Services/PackageShouldNotBeSignedUserFixableValidationMessage.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace NuGetGallery
+{
+    public class PackageShouldNotBeSignedUserFixableValidationMessage : IValidationMessage
+    {
+        public string PlainTextMessage => Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates;
+
+        public bool HasRawHtmlRepresentation => true;
+
+        public string RawHtmlMessage 
+            => Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates 
+                + " " 
+                + Strings.UploadPackage_PackageIsSignedButMissingCertificate_ManageCertificate;
+    }
+}

--- a/src/NuGetGallery/Services/PackageShouldNotBeSignedUserFixableValidationMessage.cs
+++ b/src/NuGetGallery/Services/PackageShouldNotBeSignedUserFixableValidationMessage.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 namespace NuGetGallery
 {
     public class PackageShouldNotBeSignedUserFixableValidationMessage : IValidationMessage

--- a/src/NuGetGallery/Services/PackageShouldNotBeSignedUserFixableValidationMessage.cs
+++ b/src/NuGetGallery/Services/PackageShouldNotBeSignedUserFixableValidationMessage.cs
@@ -1,8 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Web;
+
 namespace NuGetGallery
 {
+    /// <summary>
+    /// Represents an error message to be displayed when user uploads a signed package but theirs account
+    /// was not setup to accept signed packages. We want to display some additional text when the error is
+    /// presented on a web page, so this class abuses the messaging a little, no actual HTML is generated.
+    /// </summary>
     public class PackageShouldNotBeSignedUserFixableValidationMessage : IValidationMessage
     {
         public string PlainTextMessage => Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates;
@@ -10,8 +17,9 @@ namespace NuGetGallery
         public bool HasRawHtmlRepresentation => true;
 
         public string RawHtmlMessage 
-            => Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates 
+            => HttpUtility.HtmlEncode(
+                Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates 
                 + " " 
-                + Strings.UploadPackage_PackageIsSignedButMissingCertificate_ManageCertificate;
+                + Strings.UploadPackage_PackageIsSignedButMissingCertificate_ManageCertificate);
     }
 }

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -46,7 +46,7 @@ namespace NuGetGallery
 
         public async Task<PackageValidationResult> ValidateBeforeGeneratePackageAsync(PackageArchiveReader nuGetPackage, PackageMetadata packageMetadata)
         {
-            var warnings = new List<string>();
+            var warnings = new List<IValidationMessage>();
 
             var result = await CheckPackageEntryCountAsync(nuGetPackage, warnings);
 
@@ -119,7 +119,7 @@ namespace NuGetGallery
 
         private async Task<PackageValidationResult> CheckPackageEntryCountAsync(
             PackageArchiveReader nuGetPackage,
-            List<string> warnings)
+            List<IValidationMessage> warnings)
         {
             if (!_config.RejectPackagesWithTooManyPackageEntries)
             {
@@ -150,7 +150,7 @@ namespace NuGetGallery
         /// 1. If the type is "git" - allow the URL scheme "git://" or "https://". We will translate "git://" to "https://" at display time for known domains.
         /// 2. For types other then "git" - URL scheme should be "https://"
         /// </summary>
-        private PackageValidationResult CheckRepositoryMetadata(PackageMetadata packageMetadata, List<string> warnings)
+        private PackageValidationResult CheckRepositoryMetadata(PackageMetadata packageMetadata, List<IValidationMessage> warnings)
         {
             if (packageMetadata.RepositoryUrl == null)
             {
@@ -162,14 +162,14 @@ namespace NuGetGallery
             {
                 if (!packageMetadata.RepositoryUrl.IsGitProtocol() && !packageMetadata.RepositoryUrl.IsHttpsProtocol())
                 {
-                    warnings.Add(Strings.WarningNotHttpsOrGitRepositoryUrlScheme);
+                    warnings.Add(new PlainTextOnlyValidationMessage(Strings.WarningNotHttpsOrGitRepositoryUrlScheme));
                 }
             }
             else
             {
                 if (!packageMetadata.RepositoryUrl.IsHttpsProtocol())
                 {
-                    warnings.Add(Strings.WarningNotHttpsRepositoryUrlScheme);
+                    warnings.Add(new PlainTextOnlyValidationMessage(Strings.WarningNotHttpsRepositoryUrlScheme));
                 }
             }
 
@@ -187,7 +187,7 @@ namespace NuGetGallery
         /// <returns>The package validation result or null.</returns>
         private async Task<PackageValidationResult> CheckForUnsignedPushAfterAuthorSignedAsync(
             PackageArchiveReader nuGetPackage,
-            List<string> warnings)
+            List<IValidationMessage> warnings)
         {
             // If the package is signed, there's no problem.
             if (await nuGetPackage.IsSignedAsync(CancellationToken.None))
@@ -218,9 +218,10 @@ namespace NuGetGallery
 
             if (previousPackage != null && previousPackage.CertificateKey.HasValue)
             {
-                warnings.Add(string.Format(
-                    Strings.UploadPackage_SignedToUnsignedTransition,
-                    previousPackage.Version.ToNormalizedString()));
+                warnings.Add(new PlainTextOnlyValidationMessage(
+                    string.Format(
+                        Strings.UploadPackage_SignedToUnsignedTransition,
+                        previousPackage.Version.ToNormalizedString())));
             }
 
             return null;
@@ -269,14 +270,11 @@ namespace NuGetGallery
                     {
                         if (requiredSigner == currentUser)
                         {
-                            return new PackageValidationResult(
-                                PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates,
-                                Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates);
+                            return PackageValidationResult.Invalid(new PackageShouldNotBeSignedUserFixableValidationMessage());
                         }
                         else
                         {
-                            return new PackageValidationResult(
-                               PackageValidationResultType.PackageShouldNotBeSigned,
+                            return PackageValidationResult.Invalid(
                                string.Format(
                                    Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner,
                                    requiredSigner.Username));
@@ -293,14 +291,11 @@ namespace NuGetGallery
                         // someone else for help.
                         if (isCurrentUserAnOwner)
                         {
-                            return new PackageValidationResult(
-                                PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates,
-                                Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates);
+                            return PackageValidationResult.Invalid(new PackageShouldNotBeSignedUserFixableValidationMessage());
                         }
                         else
                         {
-                            return new PackageValidationResult(
-                                PackageValidationResultType.PackageShouldNotBeSigned,
+                            return PackageValidationResult.Invalid(
                                 string.Format(
                                     Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner,
                                     owner.Username));

--- a/src/NuGetGallery/Services/PackageValidationResult.cs
+++ b/src/NuGetGallery/Services/PackageValidationResult.cs
@@ -12,14 +12,19 @@ namespace NuGetGallery
     /// </summary>
     public class PackageValidationResult
     {
-        private static readonly IReadOnlyList<string> EmptyList = new string[0];
+        private static readonly IReadOnlyList<IValidationMessage> EmptyList = new IValidationMessage[0];
 
-        public PackageValidationResult(PackageValidationResultType type, string message)
+        public PackageValidationResult(PackageValidationResultType type, IValidationMessage message)
             : this(type, message, warnings: null)
         {
         }
 
-        public PackageValidationResult(PackageValidationResultType type, string message, IReadOnlyList<string> warnings)
+        public PackageValidationResult(PackageValidationResultType type, string message)
+            : this(type, new PlainTextOnlyValidationMessage(message))
+        {
+        }
+
+        public PackageValidationResult(PackageValidationResultType type, IValidationMessage message, IReadOnlyList<IValidationMessage> warnings)
         {
             if (type != PackageValidationResultType.Accepted && message == null)
             {
@@ -32,8 +37,8 @@ namespace NuGetGallery
         }
 
         public PackageValidationResultType Type { get; }
-        public string Message { get; }
-        public IReadOnlyList<string> Warnings { get; }
+        public IValidationMessage Message { get; }
+        public IReadOnlyList<IValidationMessage> Warnings { get; }
 
         public static PackageValidationResult Accepted()
         {
@@ -43,7 +48,7 @@ namespace NuGetGallery
                 warnings: null);
         }
 
-        public static PackageValidationResult AcceptedWithWarnings(IReadOnlyList<string> warnings)
+        public static PackageValidationResult AcceptedWithWarnings(IReadOnlyList<IValidationMessage> warnings)
         {
             return new PackageValidationResult(
                 PackageValidationResultType.Accepted,
@@ -52,6 +57,9 @@ namespace NuGetGallery
         }
 
         public static PackageValidationResult Invalid(string message)
+            => Invalid(new PlainTextOnlyValidationMessage(message));
+
+        public static PackageValidationResult Invalid(IValidationMessage message)
         {
             if (message == null)
             {

--- a/src/NuGetGallery/Services/PackageValidationResultType.cs
+++ b/src/NuGetGallery/Services/PackageValidationResultType.cs
@@ -18,17 +18,5 @@ namespace NuGetGallery
         /// The package is invalid based on the package content.
         /// </summary>
         Invalid,
-
-        /// <summary>
-        /// The package is invalid because it should not be signed given the current required signer certificates (or
-        /// lack thereof).
-        /// </summary>
-        PackageShouldNotBeSigned,
-
-        /// <summary>
-        /// Similar to <see cref="PackageShouldNotBeSigned"/> but the current user can manage certificates and
-        /// potentially remediate the situation.
-        /// </summary>
-        PackageShouldNotBeSignedButCanManageCertificates,
     }
 }

--- a/src/NuGetGallery/Services/PlainTextOnlyValidationMessage.cs
+++ b/src/NuGetGallery/Services/PlainTextOnlyValidationMessage.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Cautious default implementation of <see cref="IValidationMessage"/> that does not allow
+    /// user to specify raw html response.
+    /// </summary>
+    public class PlainTextOnlyValidationMessage : IValidationMessage
+    {
+        public PlainTextOnlyValidationMessage(string validationMessage)
+        {
+            PlainTextMessage = validationMessage;
+        }
+
+        public string PlainTextMessage { get; }
+
+        public bool HasRawHtmlRepresentation => false;
+
+        public string RawHtmlMessage => null;
+    }
+}

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -65,7 +65,7 @@
                         <!-- ko if: typeof($data) === "string" -->
                         <li><span data-bind="text: $data"></span></li>
                         <!-- /ko -->
-                        <!-- ko ifnot: typeof($data) === "string" -->
+                        <!-- ko if: typeof($data) === "object" -->
                             <!-- ko if: $data.PlainTextMessage -->
                             <li><span data-bind="text: $data.PlainTextMessage"></span></li>
                             <!-- /ko -->

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -1,6 +1,14 @@
 ﻿<script type="text/html" id="validation-errors">
     <div data-bind="foreach:$data" class="validation-error-message-list">
-        @ViewHelpers.AlertDanger(@<text><span data-bind="text:$data"></span></text>)
+        @ViewHelpers.AlertDanger(
+            @<text>
+                <!-- ko if: $data.PlainTextMessage -->
+                <span data-bind="text:$data.PlainTextMessage"></span>
+                <!-- /ko -->
+                <!-- ko ifnot: $data.PlainTextMessage -->
+                <span data-bind="html:$data.RawHtmlMessage"></span>
+                <!-- /ko -->
+            </text>)
     </div>
 </script>
 
@@ -46,14 +54,19 @@
         <div data-bind="if: $data">
             <!-- ko if: $data.Warnings && $data.Warnings.length > 0 -->
             @ViewHelpers.AlertWarning(
-                            @<span>
-                                We found the following issue(s):
-                                <ul data-bind="foreach: $data.Warnings">
-                                    <li><span data-bind="text: $data"></span></li>
-                                </ul>
-                                We recommend that you fix these issues and upload a new package.
-                                <a href="https://docs.microsoft.com/en-us/nuget/policies/nuget-faq#managing-packages-on-nugetorg" alt="Read more">Read more</a><br />
-                            </span>)
+                @<span>
+                    We found the following issue(s):
+                    <ul data-bind="foreach: $data.Warnings">
+                        <!-- ko if: $data.PlainTextMessage -->
+                        <li><span data-bind="text: $data.PlainTextMessage"></span></li>
+                        <!-- /ko -->
+                        <!-- ko ifnot: $data.PlainTextMessage -->
+                        <li><span data-bind="text: $data.RawHtmlMessage"></span></li>
+                        <!-- /ko -->
+                    </ul>
+                    We recommend that you fix these issues and upload a new package.
+                    <a href="https://docs.microsoft.com/en-us/nuget/policies/nuget-faq#managing-packages-on-nugetorg" alt="Read more">Read more</a><br />
+                </span>)
             <!-- /ko -->
 
             <div class="verify-package-field">

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -1,16 +1,16 @@
 ﻿<script type="text/html" id="validation-errors">
-    <div data-bind="foreach:$data" class="validation-error-message-list">
+    <div data-bind="foreach: $data" class="validation-error-message-list">
         @ViewHelpers.AlertDanger(
             @<text>
                 <!-- ko if: typeof($data) === "string" -->
-                <span data-bind="text:$data"></span>
+                <span data-bind="text: $data"></span>
                 <!-- /ko -->
                 <!-- ko if: typeof($data) === "object" -->
                     <!-- ko if: $data.PlainTextMessage -->
-                    <span data-bind="text:$data.PlainTextMessage"></span>
+                    <span data-bind="text: $data.PlainTextMessage"></span>
                     <!-- /ko -->
                     <!-- ko ifnot: $data.PlainTextMessage -->
-                    <span data-bind="html:$data.RawHtmlMessage"></span>
+                    <span data-bind="html: $data.RawHtmlMessage"></span>
                     <!-- /ko -->
                 <!-- /ko -->
             </text>)

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -2,11 +2,16 @@
     <div data-bind="foreach:$data" class="validation-error-message-list">
         @ViewHelpers.AlertDanger(
             @<text>
-                <!-- ko if: $data.PlainTextMessage -->
-                <span data-bind="text:$data.PlainTextMessage"></span>
+                <!-- ko if: typeof($data) === "string" -->
+                <span data-bind="text:$data"></span>
                 <!-- /ko -->
-                <!-- ko ifnot: $data.PlainTextMessage -->
-                <span data-bind="html:$data.RawHtmlMessage"></span>
+                <!-- ko if: typeof($data) === "object" -->
+                    <!-- ko if: $data.PlainTextMessage -->
+                    <span data-bind="text:$data.PlainTextMessage"></span>
+                    <!-- /ko -->
+                    <!-- ko ifnot: $data.PlainTextMessage -->
+                    <span data-bind="html:$data.RawHtmlMessage"></span>
+                    <!-- /ko -->
                 <!-- /ko -->
             </text>)
     </div>
@@ -57,11 +62,16 @@
                 @<span>
                     We found the following issue(s):
                     <ul data-bind="foreach: $data.Warnings">
-                        <!-- ko if: $data.PlainTextMessage -->
-                        <li><span data-bind="text: $data.PlainTextMessage"></span></li>
+                        <!-- ko if: typeof($data) === "string" -->
+                        <li><span data-bind="text: $data"></span></li>
                         <!-- /ko -->
-                        <!-- ko ifnot: $data.PlainTextMessage -->
-                        <li><span data-bind="text: $data.RawHtmlMessage"></span></li>
+                        <!-- ko ifnot: typeof($data) === "string" -->
+                            <!-- ko if: $data.PlainTextMessage -->
+                            <li><span data-bind="text: $data.PlainTextMessage"></span></li>
+                            <!-- /ko -->
+                            <!-- ko ifnot: $data.PlainTextMessage -->
+                            <li><span data-bind="html: $data.RawHtmlMessage"></span></li>
+                            <!-- /ko -->
                         <!-- /ko -->
                     </ul>
                     We recommend that you fix these issues and upload a new package.

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -859,7 +859,7 @@ namespace NuGetGallery
                     .MockPackageUploadService
                     .Setup(x => x.ValidateBeforeGeneratePackageAsync(
                         It.IsAny<PackageArchiveReader>(), It.IsAny<PackageMetadata>()))
-                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { messageA }));
+                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { new PlainTextOnlyValidationMessage(messageA) }));
                 controller
                     .MockPackageUploadService
                     .Setup(x => x.ValidateAfterGeneratePackageAsync(
@@ -868,7 +868,7 @@ namespace NuGetGallery
                         It.IsAny<User>(),
                         It.IsAny<User>(),
                         It.IsAny<bool>()))
-                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { messageB }));
+                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { new PlainTextOnlyValidationMessage(messageB) }));
 
                 // Act
                 ActionResult result = await controller.CreatePackagePut();
@@ -883,8 +883,6 @@ namespace NuGetGallery
 
             [Theory]
             [InlineData(PackageValidationResultType.Invalid)]
-            [InlineData(PackageValidationResultType.PackageShouldNotBeSigned)]
-            [InlineData(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates)]
             public async Task WillReturnValidationMessageWhenValidationFails(PackageValidationResultType type)
             {
                 // Arrange

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -275,7 +275,7 @@ namespace NuGetGallery
                     It.IsAny<User>(),
                     It.IsAny<bool>()))
                 .ReturnsAsync(new PackageValidationResult(
-                    type, message: "Something", warnings: null));
+                    type, message: new PlainTextOnlyValidationMessage("Something"), warnings: null));
 
             return fakePackageUploadService;
         }
@@ -4081,7 +4081,7 @@ namespace NuGetGallery
                 var fakePackageUploadService = new Mock<IPackageUploadService>();
                 fakePackageUploadService
                     .Setup(x => x.ValidateBeforeGeneratePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageMetadata>()))
-                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { expectedMessage }));
+                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { new PlainTextOnlyValidationMessage(expectedMessage) }));
 
                 var controller = CreateController(
                     GetConfigurationService(),
@@ -4096,7 +4096,7 @@ namespace NuGetGallery
                 Assert.NotNull(result.InProgressUpload);
                 Assert.False(controller.TempData.ContainsKey("Message"));
                 var actualMessage = Assert.Single(result.InProgressUpload.Warnings);
-                Assert.Equal(expectedMessage, actualMessage);
+                Assert.Equal(expectedMessage, actualMessage.PlainTextMessage);
             }
 
             [Fact]
@@ -4177,7 +4177,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(null) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.Equal(Strings.UploadFileIsRequired, (result.Data as string[])[0]);
+                Assert.Equal(Strings.UploadFileIsRequired, (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             [Fact]
@@ -4191,7 +4191,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.Equal(Strings.UploadFileMustBeNuGetPackage, (result.Data as string[])[0]);
+                Assert.Equal(Strings.UploadFileMustBeNuGetPackage, (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             [Fact]
@@ -4211,7 +4211,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.Equal(Strings.FailedToReadUploadFile, (result.Data as string[])[0]);
+                Assert.Equal(Strings.FailedToReadUploadFile, (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             private const string EnsureValidExceptionMessage = "naughty package";
@@ -4239,7 +4239,9 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.Equal(expectExceptionMessageInResponse ? EnsureValidExceptionMessage : Strings.FailedToReadUploadFile, (result.Data as string[])[0]);
+                Assert.Equal(
+                    expectExceptionMessageInResponse ? EnsureValidExceptionMessage : Strings.FailedToReadUploadFile,
+                    (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             [Theory]
@@ -4265,7 +4267,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.Equal($"The package manifest contains an invalid ID: '{packageId}'", (result.Data as string[])[0]);
+                Assert.Equal($"The package manifest contains an invalid ID: '{packageId}'", (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             [Theory]
@@ -4287,7 +4289,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.StartsWith($"An error occurred while parsing EntityName.", (result.Data as string[])[0]);
+                Assert.StartsWith($"An error occurred while parsing EntityName.", (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             public static IEnumerable<object[]> WillShowTheViewWithErrorsWhenThePackageIdIsAlreadyBeingUsed_Data
@@ -4318,7 +4320,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.Equal(String.Format(Strings.PackageIdNotAvailable, "theId"), (result.Data as string[])[0]);
+                Assert.Equal(String.Format(Strings.PackageIdNotAvailable, "theId"), (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             public static IEnumerable<object[]> WillShowTheViewWithErrorsWhenThePackageIdMatchesUnownedNamespace_Data
@@ -4368,7 +4370,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.Equal(String.Format(Strings.UploadPackage_IdNamespaceConflict), (result.Data as string[])[0]);
+                Assert.Equal(String.Format(Strings.UploadPackage_IdNamespaceConflict), (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
                 fakeTelemetryService.Verify(
                     x => x.TrackPackagePushNamespaceConflictEvent(
                         It.IsAny<string>(),
@@ -4518,7 +4520,7 @@ namespace NuGetGallery
                 Assert.NotNull(result);
                 Assert.Equal(
                     String.Format(Strings.PackageExistsAndCannotBeModified, "theId", "1.0.0"),
-                    (result.Data as string[])[0]);
+                    (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
                 fakePackageDeleteService.Verify(
                     x => x.HardDeletePackagesAsync(
                         It.IsAny<IEnumerable<Package>>(),
@@ -4560,7 +4562,7 @@ namespace NuGetGallery
                 Assert.NotNull(result);
                 Assert.Equal(
                     String.Format(Strings.PackageVersionDiffersOnlyByMetadataAndCannotBeModified, "theId", "1.0.0+metadata"),
-                    (result.Data as string[])[0]);
+                    (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
                 fakePackageDeleteService.Verify(
                     x => x.HardDeletePackagesAsync(
                         It.IsAny<IEnumerable<Package>>(),
@@ -4732,7 +4734,7 @@ namespace NuGetGallery
 
                 Assert.NotNull(result);
                 Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
-                Assert.Equal(expectedMessage, (result.Data as string[])[0]);
+                Assert.Equal(expectedMessage, (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
 
@@ -4754,7 +4756,7 @@ namespace NuGetGallery
                 var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
                 fakePackageUploadService
                     .Setup(x => x.ValidateBeforeGeneratePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageMetadata>()))
-                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { expectedMessage }));
+                    .ReturnsAsync(PackageValidationResult.AcceptedWithWarnings(new[] { new PlainTextOnlyValidationMessage(expectedMessage) }));
 
                 var controller = CreateController(
                     GetConfigurationService(),
@@ -4767,7 +4769,7 @@ namespace NuGetGallery
                 Assert.NotNull(result);
                 var data = Assert.IsAssignableFrom<VerifyPackageRequest>(result.Data);
                 var actualMessage = Assert.Single(data.Warnings);
-                Assert.Equal(expectedMessage, actualMessage);
+                Assert.Equal(expectedMessage, actualMessage.PlainTextMessage);
             }
 
             [Fact]
@@ -4791,7 +4793,7 @@ namespace NuGetGallery
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
 
                 Assert.NotNull(result);
-                Assert.Equal(Strings.FailedToReadUploadFile, (result.Data as string[])[0]);
+                Assert.Equal(Strings.FailedToReadUploadFile, (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             [Fact]
@@ -4826,7 +4828,7 @@ namespace NuGetGallery
 
                 Assert.NotNull(result);
                 Assert.Equal((int)HttpStatusCode.Conflict, controller.Response.StatusCode);
-                Assert.Equal(string.Format(Strings.PackageIdNotAvailable, packageId), (result.Data as string[])[0]);
+                Assert.Equal(string.Format(Strings.PackageIdNotAvailable, packageId), (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             [Fact]
@@ -4862,7 +4864,7 @@ namespace NuGetGallery
 
                 Assert.NotNull(result);
                 Assert.Equal((int)HttpStatusCode.Forbidden, controller.Response.StatusCode);
-                Assert.Equal(string.Format(Strings.PackageIsLocked, packageId), (result.Data as string[])[0]);
+                Assert.Equal(string.Format(Strings.PackageIsLocked, packageId), (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
             public static IEnumerable<object[]> SymbolValidationResultTypes => Enum
@@ -5468,21 +5470,31 @@ namespace NuGetGallery
 
                     var jsonResult = Assert.IsType<JsonResult>(result);
                     Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
-                    var message = (jsonResult.Data as string[])[0];
-                    Assert.Equal(expectedMessage, message);
+                    var message = (jsonResult.Data as JsonValidationMessage[])[0];
+                    Assert.Equal(expectedMessage, message.PlainTextMessage);
                 }
             }
 
             [Theory]
-            [InlineData(PackageValidationResultType.Invalid)]
-            [InlineData(PackageValidationResultType.PackageShouldNotBeSigned)]
-            [InlineData(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates)]
-            public async Task WillShowTheValidationMessageWhenValidationAfterGenerateFails(PackageValidationResultType type)
+            [InlineData(PackageValidationResultType.Invalid, false)]
+            [InlineData(PackageValidationResultType.Invalid, true)]
+            public async Task WillShowTheValidationMessageWhenValidationAfterGenerateFails(PackageValidationResultType type, bool hasRawHtml)
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
                 using (var fakeFileStream = new MemoryStream())
                 {
-                    var expectedMessage = "The package is just bad.";
+                    const string expectedMessage = "The package is just bad.";
+                    var messageMock = new Mock<IValidationMessage>();
+                    messageMock
+                        .SetupGet(m => m.PlainTextMessage)
+                        .Returns(expectedMessage);
+                    messageMock
+                        .SetupGet(m => m.HasRawHtmlRepresentation)
+                        .Returns(hasRawHtml);
+                    messageMock
+                        .SetupGet(m => m.RawHtmlMessage)
+                        .Returns(hasRawHtml ? null : expectedMessage);
+                    var expectedResult = new PackageValidationResult(type, messageMock.Object);
 
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
@@ -5494,7 +5506,7 @@ namespace NuGetGallery
                             It.IsAny<User>(),
                             It.IsAny<User>(),
                             It.IsAny<bool>()))
-                        .ReturnsAsync(new PackageValidationResult(type, expectedMessage));
+                        .ReturnsAsync(expectedResult);
                     var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
@@ -5510,7 +5522,7 @@ namespace NuGetGallery
 
                     var result = await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Owner = TestUtility.FakeUser.Username });
 
-                    VerifyPackageValidationResultMessage(type, expectedMessage, controller, result);
+                    VerifyPackageValidationResultMessage(type, expectedResult, controller, result);
                     fakePackageUploadService.Verify(
                         x => x.GeneratePackageAsync(
                             It.IsAny<string>(),
@@ -5523,15 +5535,25 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(PackageValidationResultType.Invalid)]
-            [InlineData(PackageValidationResultType.PackageShouldNotBeSigned)]
-            [InlineData(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates)]
-            public async Task WillShowTheValidationMessageWhenValidationBeforeGenerateFails(PackageValidationResultType type)
+            [InlineData(PackageValidationResultType.Invalid, false)]
+            [InlineData(PackageValidationResultType.Invalid, true)]
+            public async Task WillShowTheValidationMessageWhenValidationBeforeGenerateFails(PackageValidationResultType type, bool hasRawHtml)
             {
                 var fakeUploadFileService = new Mock<IUploadFileService>();
                 using (var fakeFileStream = new MemoryStream())
                 {
-                    var expectedMessage = "The package is just bad.";
+                    const string expectedMessage = "The package is just bad.";
+                    var messageMock = new Mock<IValidationMessage>();
+                    messageMock
+                        .SetupGet(m => m.PlainTextMessage)
+                        .Returns(expectedMessage);
+                    messageMock
+                        .SetupGet(m => m.HasRawHtmlRepresentation)
+                        .Returns(hasRawHtml);
+                    messageMock
+                        .SetupGet(m => m.RawHtmlMessage)
+                        .Returns(hasRawHtml ? null : expectedMessage);
+                    var expectedResult = new PackageValidationResult(type, messageMock.Object);
 
                     fakeUploadFileService.Setup(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult<Stream>(fakeFileStream));
                     fakeUploadFileService.Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key)).Returns(Task.FromResult(0));
@@ -5540,7 +5562,7 @@ namespace NuGetGallery
                         .Setup(x => x.ValidateBeforeGeneratePackageAsync(
                             It.IsAny<PackageArchiveReader>(),
                             It.IsAny<PackageMetadata>()))
-                        .ReturnsAsync(new PackageValidationResult(type, expectedMessage));
+                        .ReturnsAsync(expectedResult);
                     var fakeNuGetPackage = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
 
                     var fakeUserService = new Mock<IUserService>();
@@ -5556,7 +5578,7 @@ namespace NuGetGallery
 
                     var result = await controller.VerifyPackage(new VerifyPackageRequest() { Listed = true, Owner = TestUtility.FakeUser.Username });
 
-                    VerifyPackageValidationResultMessage(type, expectedMessage, controller, result);
+                    VerifyPackageValidationResultMessage(type, expectedResult, controller, result);
                     fakePackageUploadService.Verify(
                         x => x.GeneratePackageAsync(
                             It.IsAny<string>(),
@@ -5568,21 +5590,21 @@ namespace NuGetGallery
                 }
             }
 
-            private static void VerifyPackageValidationResultMessage(PackageValidationResultType type, string expectedMessage, PackagesController controller, JsonResult result)
+            private static void VerifyPackageValidationResultMessage(PackageValidationResultType type, PackageValidationResult expectedResult, PackagesController controller, JsonResult result)
             {
                 var jsonResult = Assert.IsType<JsonResult>(result);
                 Assert.Equal((int)HttpStatusCode.BadRequest, controller.Response.StatusCode);
-                var message = (jsonResult.Data as string[])[0];
+                var message = (jsonResult.Data as JsonValidationMessage[])[0];
 
-                if (type == PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates)
+                if (!expectedResult.Message.HasRawHtmlRepresentation)
                 {
-                    Assert.Equal(
-                        expectedMessage + " You can manage your certificates on the Account Settings page.",
-                        message);
+                    Assert.Null(message.RawHtmlMessage);
+                    Assert.Equal(expectedResult.Message.PlainTextMessage, message.PlainTextMessage);
                 }
                 else
                 {
-                    Assert.Equal(expectedMessage, message);
+                    Assert.Null(message.PlainTextMessage);
+                    Assert.Equal(expectedResult.Message.RawHtmlMessage, message.RawHtmlMessage);
                 }
             }
 
@@ -5640,8 +5662,8 @@ namespace NuGetGallery
                         var jsonResult = Assert.IsType<JsonResult>(result);
                         if (expectedMessage != null)
                         {
-                            var message = (jsonResult.Data as string[])[0];
-                            Assert.Equal(expectedMessage, message);
+                            var message = (jsonResult.Data as JsonValidationMessage[])[0];
+                            Assert.Equal(expectedMessage, message.PlainTextMessage);
                         }
                     }
                 }
@@ -6337,7 +6359,7 @@ namespace NuGetGallery
                     var result = await controller.VerifyPackage(new VerifyPackageRequest() { Owner = TestUtility.FakeUser.Username });
 
                     Assert.NotNull(result);
-                    Assert.Equal(message, (result.Data as string[])[0]);
+                    Assert.Equal(message, (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
                 }
             }
 
@@ -6374,7 +6396,7 @@ namespace NuGetGallery
                     var result = await controller.VerifyPackage(new VerifyPackageRequest() { Owner = TestUtility.FakeUser.Username });
 
                     Assert.NotNull(result);
-                    Assert.Equal(Strings.VerifyPackage_UnexpectedError, (result.Data as string[])[0]);
+                    Assert.Equal(Strings.VerifyPackage_UnexpectedError, (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
                     telemetryService
                         .Verify(x => x.TrackSymbolPackagePushFailureEvent(PackageId, PackageVersion), Times.Once);
                 }

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -201,7 +201,7 @@ namespace NuGetGallery
                 Assert.Equal(
                     $"The previous package version '{previous.NormalizedVersion}' is author signed but the uploaded " +
                     $"package is unsigned. To avoid this warning, sign the package before uploading.",
-                    Assert.Single(result.Warnings));
+                    Assert.Single(result.Warnings).PlainTextMessage);
                 _packageService.Verify(
                     x => x.FindPackageRegistrationById(It.IsAny<string>()),
                     Times.Once);
@@ -345,7 +345,7 @@ namespace NuGetGallery
                 else
                 {
                     Assert.Equal(1, result.Warnings.Count());
-                    Assert.Equal(expectedWarning, result.Warnings.First());
+                    Assert.Equal(expectedWarning, result.Warnings.First().PlainTextMessage);
                 }
             }
 
@@ -416,7 +416,7 @@ namespace NuGetGallery
                     GetPackageMetadata(_nuGetPackage));
 
                 Assert.Equal(PackageValidationResultType.Invalid, result.Type);
-                Assert.Equal("The package contains too many files and/or folders.", result.Message);
+                Assert.Equal("The package contains too many files and/or folders.", result.Message.PlainTextMessage);
                 Assert.Empty(result.Warnings);
             }
 
@@ -479,7 +479,7 @@ namespace NuGetGallery
                 else
                 {
                     Assert.Equal(PackageValidationResultType.Invalid, result.Type);
-                    Assert.Contains("license", result.Message);
+                    Assert.Contains("license", result.Message.PlainTextMessage);
                     Assert.Empty(result.Warnings);
                 }
             }
@@ -530,8 +530,8 @@ namespace NuGetGallery
                     _currentUser,
                     _isNewPackageRegistration);
 
-                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates, result.Type);
-                Assert.Equal(Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates, result.Message);
+                Assert.Equal(PackageValidationResultType.Invalid, result.Type);
+                Assert.IsType<PackageShouldNotBeSignedUserFixableValidationMessage>(result.Message);
                 Assert.Empty(result.Warnings);
             }
 
@@ -548,8 +548,8 @@ namespace NuGetGallery
                     _currentUser,
                     _isNewPackageRegistration);
 
-                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates, result.Type);
-                Assert.Equal(Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates, result.Message);
+                Assert.Equal(PackageValidationResultType.Invalid, result.Type);
+                Assert.IsType<PackageShouldNotBeSignedUserFixableValidationMessage>(result.Message);
                 Assert.Empty(result.Warnings);
             }
 
@@ -566,8 +566,8 @@ namespace NuGetGallery
                     _currentUser,
                     _isNewPackageRegistration);
 
-                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSignedButCanManageCertificates, result.Type);
-                Assert.Equal(Strings.UploadPackage_PackageIsSignedButMissingCertificate_CurrentUserCanManageCertificates, result.Message);
+                Assert.Equal(PackageValidationResultType.Invalid, result.Type);
+                Assert.IsType<PackageShouldNotBeSignedUserFixableValidationMessage>(result.Message);
                 Assert.Empty(result.Warnings);
             }
 
@@ -589,10 +589,10 @@ namespace NuGetGallery
                     _currentUser,
                     _isNewPackageRegistration);
 
-                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSigned, result.Type);
+                Assert.Equal(PackageValidationResultType.Invalid, result.Type);
                 Assert.Equal(
                     string.Format(Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner, otherUser.Username),
-                    result.Message);
+                    result.Message.PlainTextMessage);
                 Assert.Empty(result.Warnings);
             }
 
@@ -620,10 +620,10 @@ namespace NuGetGallery
                     _currentUser,
                     _isNewPackageRegistration);
 
-                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSigned, result.Type);
+                Assert.Equal(PackageValidationResultType.Invalid, result.Type);
                 Assert.Equal(
                     string.Format(Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner, _owner.Username),
-                    result.Message);
+                    result.Message.PlainTextMessage);
                 Assert.Empty(result.Warnings);
             }
 
@@ -652,10 +652,10 @@ namespace NuGetGallery
                     _currentUser,
                     _isNewPackageRegistration);
 
-                Assert.Equal(PackageValidationResultType.PackageShouldNotBeSigned, result.Type);
+                Assert.Equal(PackageValidationResultType.Invalid, result.Type);
                 Assert.Equal(
                     string.Format(Strings.UploadPackage_PackageIsSignedButMissingCertificate_RequiredSigner, ownerB.Username),
-                    result.Message);
+                    result.Message.PlainTextMessage);
                 Assert.Empty(result.Warnings);
             }
 
@@ -712,7 +712,7 @@ namespace NuGetGallery
                     _isNewPackageRegistration);
 
                 Assert.Equal(PackageValidationResultType.Invalid, result.Type);
-                Assert.Equal(Strings.UploadPackage_PackageIsNotSigned, result.Message);
+                Assert.Equal(Strings.UploadPackage_PackageIsNotSigned, result.Message.PlainTextMessage);
                 Assert.Empty(result.Warnings);
             }
 
@@ -812,8 +812,7 @@ namespace NuGetGallery
                     _isNewPackageRegistration);
 
                 Assert.Equal(PackageValidationResultType.Invalid, result.Type);
-                Assert.Equal(string.Format(Strings.TyposquattingCheckFails, string.Join(",", _typosquattingCheckCollisionIds)), result.Message);
-                Assert.Contains("similar", result.Message);
+                Assert.Equal(string.Format(Strings.TyposquattingCheckFails, string.Join(",", _typosquattingCheckCollisionIds)), result.Message.PlainTextMessage);
                 Assert.Empty(result.Warnings);
             }
         }


### PR DESCRIPTION
Progress on #6545.

I needed a way to enhance the errors and warning produced on a package upload and verify pages to allow passing raw HTML as an error, so I could include links in an error or warning message.

The gist of the change is that validation code now instead of returning errors and warnings as strings returns objects (implementing the `IValidationMessage` interface). Those object provide a way to render the message in either plain text or optional HTML. If object chooses not to provide HTML, its plain text representation is used instead. For API purposes plain text representation is always used. Errors passed through `TempData["Message"]` are also always plain text (that's a bit more global change that I don't want to touch right now).

Errors and warnings were passed as an array of strings in a JSON object to be rendered on client side (either through API, or baked into the page (search for `InProgressPackage`)). This is replaced with passing an object instead that should either have `PlainTextMessage` or `RawHtmlMessage` properties set and will render one of those preferring plain text if both provided. On C# side it is covered by the `JsonValidationMessage` object.

Given the inherent insecurity of pasting raw HTML into the output, some precautions were taken to not allow mindless HTML emitting: the default generic implementation of `IValidationMessage` (`PlainTextOnlyValidationMessage` a simple wrapper to allow fast transition to passing objects instead of strings) only accepts plain text as an input and comments in the `IValidationMessage` strongly discourage the implementation that would allow any HTML in. The `JsonValidationMessage` constructors either accept a string, treating it as a plain text (and JS code will encode it) or accept a `IValidationMessage` from which raw HTML will be taken if provided.

The only non-generic implementation of `IValidationMessage` that is currently provided is `PackageShouldNotBeSignedUserFixableValidationMessage` which does not actually produce any raw HTML, but is used to provide different message when error is shown on a web page than if the error is passed in API response. previously that difference was hardcoded in `PackagesController` and required its own value in `PackageValidationResultType` which was eliminated.