### PR TITLE
Hotfix: Hotfix: Don't attempt to send emails if they have no recipients

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -203,7 +203,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.36.0-master-2190850</Version>
+      <Version>2.36.0-sb-noemailrecipients-2192794</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>


### PR DESCRIPTION
The package pulled in via the other PR included changes in `NuGet.Services.Entity` that did not have a corresponding DB migration. This caused the change to fail.

This pulls in a package from [a private branch](https://github.com/NuGet/ServerCommon/compare/master...sb-noemailrecipients) that is based off `master` `ServerCommon` BEFORE the `NuGet.Services.Entity` changes.

