### PR TITLE
Upload license expression redirect url logic

### DIFF
--- a/src/NuGetGallery/Helpers/LicenseExpressionRedirectUrlHelper.cs
+++ b/src/NuGetGallery/Helpers/LicenseExpressionRedirectUrlHelper.cs
@@ -8,6 +8,7 @@ namespace NuGetGallery.Helpers
     public static class LicenseExpressionRedirectUrlHelper
     {
         private const string LicenseExpressionDeprecationUrlFormat = "https://licenses.nuget.org/{0}";
+
         public static string GetLicenseExpressionRedirectUrl(string licenseExpression)
         {
             return new Uri(string.Format(LicenseExpressionDeprecationUrlFormat, licenseExpression)).AbsoluteUri;

--- a/src/NuGetGallery/Helpers/LicenseExpressionRedirectUrlHelper.cs
+++ b/src/NuGetGallery/Helpers/LicenseExpressionRedirectUrlHelper.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery.Helpers
+{
+    public static class LicenseExpressionRedirectUrlHelper
+    {
+        private const string LicenseExpressionDeprecationUrlFormat = "https://licenses.nuget.org/{0}";
+        public static string GetLicenseExpressionRedirectUrl(string licenseExpression)
+        {
+            return new Uri(string.Format(LicenseExpressionDeprecationUrlFormat, licenseExpression)).AbsoluteUri;
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -284,6 +284,7 @@
     <Compile Include="GalleryConstants.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Helpers\GravatarHelper.cs" />
+    <Compile Include="Helpers\LicenseExpressionRedirectUrlHelper.cs" />
     <Compile Include="Helpers\ObfuscationHelper.cs" />
     <Compile Include="Helpers\TextHelper.cs" />
     <Compile Include="Helpers\ZipArchiveHelpers.cs" />

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -22,8 +22,6 @@ namespace NuGetGallery
 {
     public class PackageUploadService : IPackageUploadService
     {
-        private const string LicenseExpressionDeprecationUrlFormat = "https://licenses.nuget.org/{0}";
-
         private static readonly IReadOnlyCollection<string> AllowedLicenseFileExtensions = new HashSet<string>
         {
             "",
@@ -374,7 +372,7 @@ namespace NuGetGallery
 
             if (LicenseType.Expression == licenseMetadata.Type)
             {
-                return new Uri(string.Format(LicenseExpressionDeprecationUrlFormat, licenseMetadata.License)).AbsoluteUri;
+                return LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(licenseMetadata.License);
             }
 
             throw new InvalidOperationException($"Unsupported license metadata type: {licenseMetadata.Type}");

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -65,10 +65,11 @@ namespace NuGetGallery
             }
 
             var licenseExpression = package.LicenseExpression;
-            if (!string.IsNullOrEmpty(licenseExpression))
+            if (!String.IsNullOrWhiteSpace(licenseExpression))
             {
                 LicenseUrl = LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(licenseExpression);
-            } else if (PackageHelper.TryPrepareUrlForRendering(package.LicenseUrl, out string licenseUrl))
+            }
+            else if (PackageHelper.TryPrepareUrlForRendering(package.LicenseUrl, out string licenseUrl))
             {
                 LicenseUrl = licenseUrl;
 
@@ -79,6 +80,7 @@ namespace NuGetGallery
                 }
             }
         }
+
         public bool ValidatingTooLong { get; set; }
         public IReadOnlyList<ValidationIssue> PackageValidationIssues { get; set; }
         public IReadOnlyList<ValidationIssue> SymbolsPackageValidationIssues { get; set; }

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using NuGet.Services.Entities;
 using NuGet.Services.Validation.Issues;
 using NuGet.Versioning;
+using NuGetGallery.Helpers;
 
 namespace NuGetGallery
 {
@@ -63,7 +64,11 @@ namespace NuGetGallery
                 ProjectUrl = projectUrl;
             }
 
-            if (PackageHelper.TryPrepareUrlForRendering(package.LicenseUrl, out string licenseUrl))
+            var licenseExpression = package.LicenseExpression;
+            if (!string.IsNullOrEmpty(licenseExpression))
+            {
+                LicenseUrl = LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(licenseExpression);
+            } else if (PackageHelper.TryPrepareUrlForRendering(package.LicenseUrl, out string licenseUrl))
             {
                 LicenseUrl = licenseUrl;
 
@@ -74,7 +79,6 @@ namespace NuGetGallery
                 }
             }
         }
-
         public bool ValidatingTooLong { get; set; }
         public IReadOnlyList<ValidationIssue> PackageValidationIssues { get; set; }
         public IReadOnlyList<ValidationIssue> SymbolsPackageValidationIssues { get; set; }


### PR DESCRIPTION
Given valid license expression, we want that the "License Info" link in package page redirects to the license content page at "licenses.nuget.org".
Fix:  https://github.com/NuGet/Engineering/issues/1855