### PR TITLE
Fix for broken package delete

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -25,21 +25,24 @@ namespace NuGetGallery
 
         public const string DefaultCacheControl = "max-age=120";
 
-        public const string UserCertificatesFolderName = "user-certificates";
-        public const string ContentFolderName = "content";
-        public const string DownloadsFolderName = "downloads";
-        public const string PackageBackupsFolderName = "package-backups";
-        public const string PackageReadMesFolderName = "readmes";
-        public const string PackagesFolderName = "packages";
-        public const string PackagesContentFolderName = "packages-content";
-        public const string UploadsFolderName = "uploads";
-        public const string ValidationFolderName = "validation";
-        public const string RevalidationFolderName = "revalidation";
-        public const string StatusFolderName = "status";
+        public static class Folders
+        {
+            public const string UserCertificatesFolderName = "user-certificates";
+            public const string ContentFolderName = "content";
+            public const string DownloadsFolderName = "downloads";
+            public const string PackageBackupsFolderName = "package-backups";
+            public const string PackageReadMesFolderName = "readmes";
+            public const string PackagesFolderName = "packages";
+            public const string PackagesContentFolderName = "packages-content";
+            public const string UploadsFolderName = "uploads";
+            public const string ValidationFolderName = "validation";
+            public const string RevalidationFolderName = "revalidation";
+            public const string StatusFolderName = "status";
+            public const string SymbolPackagesFolderName = "symbol-packages";
+            public const string SymbolPackageBackupsFolderName = "symbol-package-backups";
+        }
 
-        public const string SymbolPackagesFolderName = "symbol-packages";
         public const string NuGetSymbolPackageFileExtension = ".snupkg";
-        public const string SymbolPackageBackupsFolderName = "symbol-package-backups";
 
         public const string UploadTracingKeyHeaderName = "upload-id";
 

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -43,6 +43,7 @@ namespace NuGetGallery
             CoreConstants.UserCertificatesFolderName,
             CoreConstants.RevalidationFolderName,
             CoreConstants.StatusFolderName,
+            CoreConstants.PackagesContentFolderName,
         };
 
         protected readonly ICloudBlobClient _client;

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -28,22 +28,22 @@ namespace NuGetGallery
         private static readonly TimeSpan CopyPollFrequency = TimeSpan.FromMilliseconds(500);
 
         private static readonly HashSet<string> KnownPublicFolders = new HashSet<string> {
-            CoreConstants.PackagesFolderName,
-            CoreConstants.PackageBackupsFolderName,
-            CoreConstants.DownloadsFolderName,
-            CoreConstants.SymbolPackagesFolderName,
-            CoreConstants.SymbolPackageBackupsFolderName
+            CoreConstants.Folders.PackagesFolderName,
+            CoreConstants.Folders.PackageBackupsFolderName,
+            CoreConstants.Folders.DownloadsFolderName,
+            CoreConstants.Folders.SymbolPackagesFolderName,
+            CoreConstants.Folders.SymbolPackageBackupsFolderName
         };
 
         private static readonly HashSet<string> KnownPrivateFolders = new HashSet<string> {
-            CoreConstants.ContentFolderName,
-            CoreConstants.UploadsFolderName,
-            CoreConstants.PackageReadMesFolderName,
-            CoreConstants.ValidationFolderName,
-            CoreConstants.UserCertificatesFolderName,
-            CoreConstants.RevalidationFolderName,
-            CoreConstants.StatusFolderName,
-            CoreConstants.PackagesContentFolderName,
+            CoreConstants.Folders.ContentFolderName,
+            CoreConstants.Folders.UploadsFolderName,
+            CoreConstants.Folders.PackageReadMesFolderName,
+            CoreConstants.Folders.ValidationFolderName,
+            CoreConstants.Folders.UserCertificatesFolderName,
+            CoreConstants.Folders.RevalidationFolderName,
+            CoreConstants.Folders.StatusFolderName,
+            CoreConstants.Folders.PackagesContentFolderName,
         };
 
         protected readonly ICloudBlobClient _client;
@@ -576,29 +576,29 @@ namespace NuGetGallery
         {
             switch (folderName)
             {
-                case CoreConstants.PackagesFolderName:
-                case CoreConstants.PackageBackupsFolderName:
-                case CoreConstants.UploadsFolderName:
-                case CoreConstants.ValidationFolderName:
-                case CoreConstants.SymbolPackagesFolderName:
-                case CoreConstants.SymbolPackageBackupsFolderName:
+                case CoreConstants.Folders.PackagesFolderName:
+                case CoreConstants.Folders.PackageBackupsFolderName:
+                case CoreConstants.Folders.UploadsFolderName:
+                case CoreConstants.Folders.ValidationFolderName:
+                case CoreConstants.Folders.SymbolPackagesFolderName:
+                case CoreConstants.Folders.SymbolPackageBackupsFolderName:
                     return CoreConstants.PackageContentType;
 
-                case CoreConstants.DownloadsFolderName:
+                case CoreConstants.Folders.DownloadsFolderName:
                     return CoreConstants.OctetStreamContentType;
 
-                case CoreConstants.PackageReadMesFolderName:
+                case CoreConstants.Folders.PackageReadMesFolderName:
                     return CoreConstants.TextContentType;
 
-                case CoreConstants.ContentFolderName:
-                case CoreConstants.RevalidationFolderName:
-                case CoreConstants.StatusFolderName:
+                case CoreConstants.Folders.ContentFolderName:
+                case CoreConstants.Folders.RevalidationFolderName:
+                case CoreConstants.Folders.StatusFolderName:
                     return CoreConstants.JsonContentType;
 
-                case CoreConstants.UserCertificatesFolderName:
+                case CoreConstants.Folders.UserCertificatesFolderName:
                     return CoreConstants.CertificateContentType;
 
-                case CoreConstants.PackagesContentFolderName:
+                case CoreConstants.Folders.PackagesContentFolderName:
                     return CoreConstants.OctetStreamContentType;
 
                 default:
@@ -611,8 +611,8 @@ namespace NuGetGallery
         {
             switch (folderName)
             {
-                case CoreConstants.PackagesFolderName:
-                case CoreConstants.SymbolPackagesFolderName:
+                case CoreConstants.Folders.PackagesFolderName:
+                case CoreConstants.Folders.SymbolPackagesFolderName:
                     return CoreConstants.DefaultCacheControl;
 
                 default:
@@ -624,21 +624,21 @@ namespace NuGetGallery
         {
             switch (folderName)
             {
-                case CoreConstants.PackagesFolderName:
-                case CoreConstants.SymbolPackagesFolderName:
-                case CoreConstants.ValidationFolderName:
+                case CoreConstants.Folders.PackagesFolderName:
+                case CoreConstants.Folders.SymbolPackagesFolderName:
+                case CoreConstants.Folders.ValidationFolderName:
                     return CoreConstants.DefaultCacheControl;
 
-                case CoreConstants.PackageBackupsFolderName:
-                case CoreConstants.UploadsFolderName:
-                case CoreConstants.SymbolPackageBackupsFolderName:
-                case CoreConstants.DownloadsFolderName:
-                case CoreConstants.PackageReadMesFolderName:
-                case CoreConstants.ContentFolderName:
-                case CoreConstants.RevalidationFolderName:
-                case CoreConstants.StatusFolderName:
-                case CoreConstants.UserCertificatesFolderName:
-                case CoreConstants.PackagesContentFolderName:
+                case CoreConstants.Folders.PackageBackupsFolderName:
+                case CoreConstants.Folders.UploadsFolderName:
+                case CoreConstants.Folders.SymbolPackageBackupsFolderName:
+                case CoreConstants.Folders.DownloadsFolderName:
+                case CoreConstants.Folders.PackageReadMesFolderName:
+                case CoreConstants.Folders.ContentFolderName:
+                case CoreConstants.Folders.RevalidationFolderName:
+                case CoreConstants.Folders.StatusFolderName:
+                case CoreConstants.Folders.UserCertificatesFolderName:
+                case CoreConstants.Folders.PackagesContentFolderName:
                     return null;
 
                 default:

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -626,7 +626,6 @@ namespace NuGetGallery
             {
                 case CoreConstants.PackagesFolderName:
                 case CoreConstants.SymbolPackagesFolderName:
-                case CoreConstants.PackagesContentFolderName:
                 case CoreConstants.ValidationFolderName:
                     return CoreConstants.DefaultCacheControl;
 
@@ -639,6 +638,7 @@ namespace NuGetGallery
                 case CoreConstants.RevalidationFolderName:
                 case CoreConstants.StatusFolderName:
                 case CoreConstants.UserCertificatesFolderName:
+                case CoreConstants.PackagesContentFolderName:
                     return null;
 
                 default:

--- a/src/NuGetGallery.Core/Services/PackageFileServiceMetadata.cs
+++ b/src/NuGetGallery.Core/Services/PackageFileServiceMetadata.cs
@@ -5,9 +5,9 @@ namespace NuGetGallery
 {
     public class PackageFileMetadataService : IFileMetadataService
     {
-        public string FileFolderName => CoreConstants.PackagesFolderName;
+        public string FileFolderName => CoreConstants.Folders.PackagesFolderName;
 
-        public string PackageContentFolderName => CoreConstants.PackagesContentFolderName;
+        public string PackageContentFolderName => CoreConstants.Folders.PackagesContentFolderName;
 
         public string PackageContentPathTemplate => CoreConstants.PackageContentFileSavePathTemplate;
 
@@ -15,9 +15,9 @@ namespace NuGetGallery
 
         public string FileExtension => CoreConstants.NuGetPackageFileExtension;
 
-        public string ValidationFolderName => CoreConstants.ValidationFolderName;
+        public string ValidationFolderName => CoreConstants.Folders.ValidationFolderName;
 
-        public string FileBackupsFolderName => CoreConstants.PackageBackupsFolderName;
+        public string FileBackupsFolderName => CoreConstants.Folders.PackageBackupsFolderName;
 
         public string FileBackupSavePathTemplate => CoreConstants.PackageFileBackupSavePathTemplate;
     }

--- a/src/NuGetGallery.Core/Services/RevalidationStateService.cs
+++ b/src/NuGetGallery.Core/Services/RevalidationStateService.cs
@@ -67,7 +67,7 @@ namespace NuGetGallery
                     jsonWriter.Flush();
                     stream.Position = 0;
 
-                    await _storage.SaveFileAsync(CoreConstants.RevalidationFolderName, StateFileName, stream, accessCondition);
+                    await _storage.SaveFileAsync(CoreConstants.Folders.RevalidationFolderName, StateFileName, stream, accessCondition);
                 }
 
                 return state;
@@ -80,11 +80,11 @@ namespace NuGetGallery
 
         private async Task<InternalState> GetInternalStateAsync()
         {
-            var fileReference = await _storage.GetFileReferenceAsync(CoreConstants.RevalidationFolderName, StateFileName);
+            var fileReference = await _storage.GetFileReferenceAsync(CoreConstants.Folders.RevalidationFolderName, StateFileName);
 
             if (fileReference == null)
             {
-                throw new InvalidOperationException($"Could not find file '{StateFileName}' in folder '{CoreConstants.RevalidationFolderName}'");
+                throw new InvalidOperationException($"Could not find file '{StateFileName}' in folder '{CoreConstants.Folders.RevalidationFolderName}'");
             }
 
             using (var fileStream = fileReference.OpenRead())
@@ -95,7 +95,7 @@ namespace NuGetGallery
 
                 if (state == null)
                 {
-                    throw new InvalidOperationException($"State blob '{StateFileName}' in folder '{CoreConstants.RevalidationFolderName}' is malformed");
+                    throw new InvalidOperationException($"State blob '{StateFileName}' in folder '{CoreConstants.Folders.RevalidationFolderName}' is malformed");
                 }
 
                 return new InternalState(fileReference, state);

--- a/src/NuGetGallery.Core/Services/SymbolPackageFileServiceMetadata.cs
+++ b/src/NuGetGallery.Core/Services/SymbolPackageFileServiceMetadata.cs
@@ -7,7 +7,7 @@ namespace NuGetGallery
 {
     public class SymbolPackageFileMetadataService : IFileMetadataService
     {
-        public string FileFolderName => CoreConstants.SymbolPackagesFolderName;
+        public string FileFolderName => CoreConstants.Folders.SymbolPackagesFolderName;
 
         public string PackageContentFolderName => throw new NotImplementedException();
         public string PackageContentPathTemplate => throw new NotImplementedException();
@@ -16,9 +16,9 @@ namespace NuGetGallery
 
         public string FileExtension => CoreConstants.NuGetSymbolPackageFileExtension;
 
-        public string ValidationFolderName => CoreConstants.ValidationFolderName;
+        public string ValidationFolderName => CoreConstants.Folders.ValidationFolderName;
 
-        public string FileBackupsFolderName => CoreConstants.SymbolPackageBackupsFolderName;
+        public string FileBackupsFolderName => CoreConstants.Folders.SymbolPackageBackupsFolderName;
 
         public string FileBackupSavePathTemplate => CoreConstants.PackageFileBackupSavePathTemplate;
     }

--- a/src/NuGetGallery/Services/CertificateService.cs
+++ b/src/NuGetGallery/Services/CertificateService.cs
@@ -172,7 +172,7 @@ namespace NuGetGallery
             try
             {
                 await _fileStorageService.SaveFileAsync(
-                    CoreConstants.UserCertificatesFolderName,
+                    CoreConstants.Folders.UserCertificatesFolderName,
                     filePath,
                     certificateFile.Stream,
                     overwrite: false);

--- a/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
+++ b/src/NuGetGallery/Services/CloudBlobFileStorageService.cs
@@ -97,7 +97,7 @@ namespace NuGetGallery
 
         public async Task<bool> IsAvailableAsync()
         {
-            var container = await GetContainerAsync(CoreConstants.PackagesFolderName);
+            var container = await GetContainerAsync(CoreConstants.Folders.PackagesFolderName);
             return await container.ExistsAsync();
         }
     }

--- a/src/NuGetGallery/Services/ContentService.cs
+++ b/src/NuGetGallery/Services/ContentService.cs
@@ -124,7 +124,7 @@ namespace NuGetGallery
             using (Trace.Activity("Downloading Content Item: " + fileName))
             {
                 IFileReference reference = await FileStorage.GetFileReferenceAsync(
-                    CoreConstants.ContentFolderName,
+                    CoreConstants.Folders.ContentFolderName,
                     fileName,
                     ifNoneMatch: cachedItem?.ContentId);
 

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -290,11 +290,11 @@ namespace NuGetGallery
         {
             switch (folderName)
             {
-                case CoreConstants.PackagesFolderName:
-                case CoreConstants.SymbolPackagesFolderName:
+                case CoreConstants.Folders.PackagesFolderName:
+                case CoreConstants.Folders.SymbolPackagesFolderName:
                     return CoreConstants.PackageContentType;
 
-                case CoreConstants.DownloadsFolderName:
+                case CoreConstants.Folders.DownloadsFolderName:
                     return CoreConstants.OctetStreamContentType;
 
                 default:

--- a/src/NuGetGallery/Services/PackageFileService.cs
+++ b/src/NuGetGallery/Services/PackageFileService.cs
@@ -28,13 +28,13 @@ namespace NuGetGallery
         public Task<ActionResult> CreateDownloadPackageActionResultAsync(Uri requestUrl, Package package)
         {
             var fileName = BuildFileName(package, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetPackageFileExtension);
-            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.PackagesFolderName, fileName);
+            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.PackagesFolderName, fileName);
         }
 
         public Task<ActionResult> CreateDownloadPackageActionResultAsync(Uri requestUrl, string id, string version)
         {
             var fileName = BuildFileName(id, version, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetPackageFileExtension);
-            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.PackagesFolderName, fileName);
+            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.PackagesFolderName, fileName);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace NuGetGallery
             
             var fileName = BuildFileName(package, ReadMeFilePathTemplateActive, GalleryConstants.MarkdownFileExtension);
 
-            return _fileStorageService.DeleteFileAsync(CoreConstants.PackageReadMesFolderName, fileName);
+            return _fileStorageService.DeleteFileAsync(CoreConstants.Folders.PackageReadMesFolderName, fileName);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace NuGetGallery
 
             using (var readMeMdStream = new MemoryStream(Encoding.UTF8.GetBytes(readMeMd)))
             {
-                await _fileStorageService.SaveFileAsync(CoreConstants.PackageReadMesFolderName, fileName, readMeMdStream, overwrite: true);
+                await _fileStorageService.SaveFileAsync(CoreConstants.Folders.PackageReadMesFolderName, fileName, readMeMdStream, overwrite: true);
             }
         }
 
@@ -86,7 +86,7 @@ namespace NuGetGallery
             
             var fileName = BuildFileName(package, ReadMeFilePathTemplateActive, GalleryConstants.MarkdownFileExtension);
 
-            using (var readMeMdStream = await _fileStorageService.GetFileAsync(CoreConstants.PackageReadMesFolderName, fileName))
+            using (var readMeMdStream = await _fileStorageService.GetFileAsync(CoreConstants.Folders.PackageReadMesFolderName, fileName))
             {
                 // Note that fileStorageService implementations return null if not found.
                 if (readMeMdStream != null)

--- a/src/NuGetGallery/Services/SymbolPackageFileService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageFileService.cs
@@ -21,13 +21,13 @@ namespace NuGetGallery
         public Task<ActionResult> CreateDownloadSymbolPackageActionResultAsync(Uri requestUrl, SymbolPackage symbolPackage)
         {
             var fileName = BuildFileName(symbolPackage.Package, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetSymbolPackageFileExtension);
-            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.SymbolPackagesFolderName, fileName);
+            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.SymbolPackagesFolderName, fileName);
         }
 
         public Task<ActionResult> CreateDownloadSymbolPackageActionResultAsync(Uri requestUrl, string id, string version)
         {
             var fileName = BuildFileName(id, version, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetSymbolPackageFileExtension);
-            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.SymbolPackagesFolderName, fileName);
+            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.SymbolPackagesFolderName, fileName);
         }
     }
 }

--- a/src/NuGetGallery/Services/UploadFileService.cs
+++ b/src/NuGetGallery/Services/UploadFileService.cs
@@ -25,7 +25,7 @@ namespace NuGetGallery
 
             var uploadFileName = BuildFileName(userKey);
 
-            return _fileStorageService.DeleteFileAsync(CoreConstants.UploadsFolderName, uploadFileName);
+            return _fileStorageService.DeleteFileAsync(CoreConstants.Folders.UploadsFolderName, uploadFileName);
         }
 
         public Task<Stream> GetUploadFileAsync(int userKey)
@@ -54,7 +54,7 @@ namespace NuGetGallery
             packageFileStream.Position = 0;
 
             var uploadFileName = BuildFileName(userKey);
-            return _fileStorageService.SaveFileAsync(CoreConstants.UploadsFolderName, uploadFileName, packageFileStream);
+            return _fileStorageService.SaveFileAsync(CoreConstants.Folders.UploadsFolderName, uploadFileName, packageFileStream);
         }
 
         private static string BuildFileName(int userKey)
@@ -66,7 +66,7 @@ namespace NuGetGallery
         private async Task<Stream> GetUploadFileAsyncCore(int userKey)
         {
             var uploadFileName = BuildFileName(userKey);
-            return await _fileStorageService.GetFileAsync(CoreConstants.UploadsFolderName, uploadFileName);
+            return await _fileStorageService.GetFileAsync(CoreConstants.Folders.UploadsFolderName, uploadFileName);
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -48,16 +48,19 @@ namespace NuGetGallery
             {
                 var folderNames = new List<object[]>
                 {
-                    new object[] { CoreConstants.ContentFolderName, false, CoreConstants.JsonContentType, },
-                    new object[] { CoreConstants.DownloadsFolderName, true, CoreConstants.OctetStreamContentType },
-                    new object[] { CoreConstants.PackageBackupsFolderName, true, CoreConstants.PackageContentType },
-                    new object[] { CoreConstants.PackageReadMesFolderName, false, CoreConstants.TextContentType },
-                    new object[] { CoreConstants.PackagesFolderName, true, CoreConstants.PackageContentType },
-                    new object[] { CoreConstants.SymbolPackagesFolderName, true, CoreConstants.PackageContentType },
-                    new object[] { CoreConstants.UploadsFolderName, false, CoreConstants.PackageContentType },
-                    new object[] { CoreConstants.UserCertificatesFolderName, false, CoreConstants.CertificateContentType },
-                    new object[] { CoreConstants.ValidationFolderName, false, CoreConstants.PackageContentType },
-                    new object[] { CoreConstants.PackagesContentFolderName, false, CoreConstants.OctetStreamContentType },
+                    new object[] { CoreConstants.Folders.ContentFolderName, false, CoreConstants.JsonContentType, },
+                    new object[] { CoreConstants.Folders.DownloadsFolderName, true, CoreConstants.OctetStreamContentType },
+                    new object[] { CoreConstants.Folders.PackageBackupsFolderName, true, CoreConstants.PackageContentType },
+                    new object[] { CoreConstants.Folders.PackageReadMesFolderName, false, CoreConstants.TextContentType },
+                    new object[] { CoreConstants.Folders.PackagesFolderName, true, CoreConstants.PackageContentType },
+                    new object[] { CoreConstants.Folders.SymbolPackagesFolderName, true, CoreConstants.PackageContentType },
+                    new object[] { CoreConstants.Folders.SymbolPackageBackupsFolderName, true, CoreConstants.PackageContentType },
+                    new object[] { CoreConstants.Folders.UploadsFolderName, false, CoreConstants.PackageContentType },
+                    new object[] { CoreConstants.Folders.UserCertificatesFolderName, false, CoreConstants.CertificateContentType },
+                    new object[] { CoreConstants.Folders.ValidationFolderName, false, CoreConstants.PackageContentType },
+                    new object[] { CoreConstants.Folders.PackagesContentFolderName, false, CoreConstants.OctetStreamContentType },
+                    new object[] { CoreConstants.Folders.RevalidationFolderName, false, CoreConstants.JsonContentType },
+                    new object[] { CoreConstants.Folders.StatusFolderName, false, CoreConstants.JsonContentType },
                 };
 
                 if (!IncludePermissions && !IncludeContentTypes)
@@ -183,7 +186,7 @@ namespace NuGetGallery
                 fakeBlob.Setup(x => x.Uri).Returns(new Uri("http://theUri"));
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 
-                await service.DeleteFileAsync(CoreConstants.PackagesFolderName, "theFileName");
+                await service.DeleteFileAsync(CoreConstants.Folders.PackagesFolderName, "theFileName");
 
                 fakeBlob.Verify();
             }
@@ -423,7 +426,7 @@ namespace NuGetGallery
                 fakeBlob.Setup(x => x.Uri).Returns(new Uri("http://theUri"));
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 
-                await service.SaveFileAsync(CoreConstants.PackagesFolderName, "theFileName", new MemoryStream());
+                await service.SaveFileAsync(CoreConstants.Folders.PackagesFolderName, "theFileName", new MemoryStream());
 
                 fakeBlob.Verify();
             }
@@ -448,7 +451,7 @@ namespace NuGetGallery
                 fakeBlob.Setup(x => x.Uri).Returns(new Uri("http://theUri"));
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 
-                await Assert.ThrowsAsync<FileAlreadyExistsException>(async () => await service.SaveFileAsync(CoreConstants.PackagesFolderName, "theFileName", new MemoryStream(), overwrite: false));
+                await Assert.ThrowsAsync<FileAlreadyExistsException>(async () => await service.SaveFileAsync(CoreConstants.Folders.PackagesFolderName, "theFileName", new MemoryStream(), overwrite: false));
 
                 fakeBlob.Verify();
             }
@@ -471,7 +474,7 @@ namespace NuGetGallery
                 var fakePackageFile = new MemoryStream();
                 fakeBlob.Setup(x => x.UploadFromStreamAsync(fakePackageFile, true)).Returns(Task.FromResult(0)).Verifiable();
 
-                await service.SaveFileAsync(CoreConstants.PackagesFolderName, "theFileName", fakePackageFile);
+                await service.SaveFileAsync(CoreConstants.Folders.PackagesFolderName, "theFileName", fakePackageFile);
 
                 fakeBlob.Verify();
             }
@@ -537,9 +540,9 @@ namespace NuGetGallery
 
                 fakeBlob.Verify();
 
-                if (folderName == CoreConstants.PackagesFolderName 
-                    || folderName == CoreConstants.SymbolPackagesFolderName
-                    || folderName == CoreConstants.ValidationFolderName)
+                if (folderName == CoreConstants.Folders.PackagesFolderName 
+                    || folderName == CoreConstants.Folders.SymbolPackagesFolderName
+                    || folderName == CoreConstants.Folders.ValidationFolderName)
                 {
                     Assert.Equal(CoreConstants.DefaultCacheControl, fakeBlob.Object.Properties.CacheControl);
                 }
@@ -607,7 +610,7 @@ namespace NuGetGallery
 
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 
-                await service.SaveFileAsync(CoreConstants.PackagesFolderName, "theFileName", new MemoryStream(), condition);
+                await service.SaveFileAsync(CoreConstants.Folders.PackagesFolderName, "theFileName", new MemoryStream(), condition);
 
                 fakeBlob.Verify(
                     b => b.UploadFromStreamAsync(
@@ -670,7 +673,7 @@ namespace NuGetGallery
 
                 await Assert.ThrowsAsync<FileAlreadyExistsException>(
                     () => service.SaveFileAsync(
-                        CoreConstants.PackagesFolderName,
+                        CoreConstants.Folders.PackagesFolderName,
                         "theFileName",
                         new MemoryStream(),
                         AccessConditionWrapper.GenerateIfNotExistsCondition()));
@@ -762,8 +765,8 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(CoreConstants.ValidationFolderName, "http://example.com/" + CoreConstants.ValidationFolderName + "/" + fileName + signature)]
-            [InlineData(CoreConstants.PackagesFolderName, "http://example.com/" + CoreConstants.PackagesFolderName + "/" + fileName + signature)]
+            [InlineData(CoreConstants.Folders.ValidationFolderName, "http://example.com/" + CoreConstants.Folders.ValidationFolderName + "/" + fileName + signature)]
+            [InlineData(CoreConstants.Folders.PackagesFolderName, "http://example.com/" + CoreConstants.Folders.PackagesFolderName + "/" + fileName + signature)]
             public async Task WillAlwaysUseSasTokenDependingOnContainerAvailability(string containerName, string expectedUri)
             {
                 var setupResult = Setup(containerName, fileName);
@@ -788,7 +791,7 @@ namespace NuGetGallery
             [Fact]
             public async Task WillPassTheEndOfAccessTimestampFurther()
             {
-                const string folderName = CoreConstants.ValidationFolderName;
+                const string folderName = CoreConstants.Folders.ValidationFolderName;
                 const string fileName = "theFileName";
                 const string signature = "?secret=42";
                 DateTimeOffset endOfAccess = DateTimeOffset.Now.AddHours(3);
@@ -876,8 +879,8 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(CoreConstants.ValidationFolderName, "http://example.com/" + CoreConstants.ValidationFolderName + "/" + fileName + signature)]
-            [InlineData(CoreConstants.PackagesFolderName, "http://example.com/" + CoreConstants.PackagesFolderName + "/" + fileName)]
+            [InlineData(CoreConstants.Folders.ValidationFolderName, "http://example.com/" + CoreConstants.Folders.ValidationFolderName + "/" + fileName + signature)]
+            [InlineData(CoreConstants.Folders.PackagesFolderName, "http://example.com/" + CoreConstants.Folders.PackagesFolderName + "/" + fileName)]
             public async Task WillUseSasTokenDependingOnContainerAvailability(string containerName, string expectedUri)
             {
                 var setupResult = Setup(containerName, fileName);
@@ -900,14 +903,14 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.GetFileReadUriAsync(CoreConstants.ValidationFolderName, fileName, null));
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.GetFileReadUriAsync(CoreConstants.Folders.ValidationFolderName, fileName, null));
                 Assert.Equal("endOfAccess", ex.ParamName);
             }
 
             [Fact]
             public async Task WillNotThrowIfNoEndOfAccessSpecifiedForPublicContainer()
             {
-                const string packagesFolderName = CoreConstants.PackagesFolderName;
+                const string packagesFolderName = CoreConstants.Folders.PackagesFolderName;
                 var setupResult = Setup(packagesFolderName, fileName);
                 var service = CreateService(setupResult.Item1);
 
@@ -919,7 +922,7 @@ namespace NuGetGallery
             [Fact]
             public async Task WillPassTheEndOfAccessTimestampFurther()
             {
-                const string folderName = CoreConstants.ValidationFolderName;
+                const string folderName = CoreConstants.Folders.ValidationFolderName;
                 const string signature = "?secret=42";
                 DateTimeOffset endOfAccess = DateTimeOffset.Now.AddHours(3);
                 var setupResult = Setup(folderName, fileName);
@@ -1069,8 +1072,8 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(CoreConstants.PackagesFolderName)]
-            [InlineData(CoreConstants.SymbolPackagesFolderName)]
+            [InlineData(CoreConstants.Folders.PackagesFolderName)]
+            [InlineData(CoreConstants.Folders.SymbolPackagesFolderName)]
             public async Task WillCopyAndSetCacheControlOnCopyForFolder(string folderName)
             {
                 // Arrange
@@ -1399,7 +1402,7 @@ namespace NuGetGallery
                     .Returns(Task.FromResult(0));
 
                 await _service.SetMetadataAsync(
-                    folderName: CoreConstants.PackagesFolderName,
+                    folderName: CoreConstants.Folders.PackagesFolderName,
                     fileName: "a",
                     updateMetadataAsync: async (lazyStream, metadata) =>
                     {
@@ -1424,7 +1427,7 @@ namespace NuGetGallery
                     .Returns(new Dictionary<string, string>());
 
                 await _service.SetMetadataAsync(
-                    folderName: CoreConstants.PackagesFolderName,
+                    folderName: CoreConstants.Folders.PackagesFolderName,
                     fileName: "a",
                     updateMetadataAsync: (lazyStream, metadata) =>
                     {
@@ -1447,7 +1450,7 @@ namespace NuGetGallery
                     .Returns(Task.FromResult(0));
 
                 await _service.SetMetadataAsync(
-                    folderName: CoreConstants.PackagesFolderName,
+                    folderName: CoreConstants.Folders.PackagesFolderName,
                     fileName: "a",
                     updateMetadataAsync: (lazyStream, metadata) =>
                     {
@@ -1496,7 +1499,7 @@ namespace NuGetGallery
                 _blob.SetupGet(x => x.ETag).Returns(_etag);
 
                 // Act 
-                var etagValue = await _service.GetETagOrNullAsync(folderName: CoreConstants.PackagesFolderName, fileName: "a");
+                var etagValue = await _service.GetETagOrNullAsync(folderName: CoreConstants.Folders.PackagesFolderName, fileName: "a");
 
                 // Assert 
                 Assert.Equal(_etag, etagValue);
@@ -1510,7 +1513,7 @@ namespace NuGetGallery
                 _blob.Setup(x => x.FetchAttributesAsync()).ThrowsAsync(new StorageException("Boo"));
 
                 // Act 
-                var etagValue = await _service.GetETagOrNullAsync(folderName: CoreConstants.PackagesFolderName, fileName: "a");
+                var etagValue = await _service.GetETagOrNullAsync(folderName: CoreConstants.Folders.PackagesFolderName, fileName: "a");
 
                 // Assert 
                 Assert.Null(etagValue);

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -57,7 +57,7 @@ namespace NuGetGallery
                     new object[] { CoreConstants.UploadsFolderName, false, CoreConstants.PackageContentType },
                     new object[] { CoreConstants.UserCertificatesFolderName, false, CoreConstants.CertificateContentType },
                     new object[] { CoreConstants.ValidationFolderName, false, CoreConstants.PackageContentType },
-                    new object[] { CoreConstants.PackagesContentFolderName, false, CoreConstants.TextContentType },
+                    new object[] { CoreConstants.PackagesContentFolderName, false, CoreConstants.OctetStreamContentType },
                 };
 
                 if (!IncludePermissions && !IncludeContentTypes)

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -56,7 +56,8 @@ namespace NuGetGallery
                     new object[] { CoreConstants.SymbolPackagesFolderName, true, CoreConstants.PackageContentType },
                     new object[] { CoreConstants.UploadsFolderName, false, CoreConstants.PackageContentType },
                     new object[] { CoreConstants.UserCertificatesFolderName, false, CoreConstants.CertificateContentType },
-                    new object[] { CoreConstants.ValidationFolderName, false, CoreConstants.PackageContentType }
+                    new object[] { CoreConstants.ValidationFolderName, false, CoreConstants.PackageContentType },
+                    new object[] { CoreConstants.PackagesContentFolderName, false, CoreConstants.TextContentType },
                 };
 
                 if (!IncludePermissions && !IncludeContentTypes)

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceFacts.cs
@@ -86,6 +86,24 @@ namespace NuGetGallery
             }
         }
 
+        [Fact]
+        public void FolderNameDataContainsAllFolders()
+        {
+            var folderNameFields = typeof(CoreConstants.Folders)
+                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                .Where(f => f.IsLiteral && !f.IsInitOnly).ToList();
+
+            var folderNames = new FolderNamesDataAttribute().GetData(null).Select(a => (string)a[0]).ToList();
+
+            Assert.Equal(folderNameFields.Count, folderNames.Count);
+
+            foreach (var folderNameField in folderNameFields)
+            {
+                var folderName = (string)folderNameField.GetRawConstantValue();
+                Assert.Contains(folderName, folderNames);
+            }
+        }
+
         public class TheCtor
         {
             [Theory]

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceIntegrationTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobCoreFileStorageServiceIntegrationTests.cs
@@ -62,7 +62,7 @@ namespace NuGetGallery
         public async Task ReturnsCurrentETagForIfMatch()
         {
             // Arrange
-            var folderName = CoreConstants.ValidationFolderName;
+            var folderName = CoreConstants.Folders.ValidationFolderName;
             var fileName = _prefixA;
             await _targetA.SaveFileAsync(folderName, fileName, new MemoryStream(new byte[0]));
             var initialReference = await _targetA.GetFileReferenceAsync(folderName, fileName);
@@ -81,7 +81,7 @@ namespace NuGetGallery
         public async Task ReturnsNullForMissingBlob()
         {
             // Arrange
-            var folderName = CoreConstants.ValidationFolderName;
+            var folderName = CoreConstants.Folders.ValidationFolderName;
             var fileName = _prefixA;
 
             // Act
@@ -95,7 +95,7 @@ namespace NuGetGallery
         public async Task ReturnsTheETagMatchingTheContent()
         {
             // Arrange
-            var folderName = CoreConstants.ValidationFolderName;
+            var folderName = CoreConstants.Folders.ValidationFolderName;
             var fileName = _prefixA;
             var contentToETag = new ConcurrentDictionary<string, string>();
             var iterations = 20;
@@ -154,7 +154,7 @@ namespace NuGetGallery
         public async Task CanReadAndDeleteBlobUsingPrivilegedFileUri()
         {
             // Arrange
-            var folderName = CoreConstants.ValidationFolderName;
+            var folderName = CoreConstants.Folders.ValidationFolderName;
             var fileName = _prefixA;
             var expectedContent = "Hello, world.";
 
@@ -206,11 +206,11 @@ namespace NuGetGallery
         public async Task DoesNotCopyWhenSourceAndDestinationHaveSameHash()
         {
             // Arrange
-            var srcFolderName = CoreConstants.ValidationFolderName;
+            var srcFolderName = CoreConstants.Folders.ValidationFolderName;
             var srcFileName = $"{_prefixA}/src";
             var srcContent = "Hello, world.";
 
-            var destFolderName = CoreConstants.PackagesFolderName;
+            var destFolderName = CoreConstants.Folders.PackagesFolderName;
             var destFileName = $"{_prefixB}/dest";
 
             await _targetA.SaveFileAsync(
@@ -252,11 +252,11 @@ namespace NuGetGallery
         public async Task CopiesWhenDestinationHasNotHashButContentsAreTheSame()
         {
             // Arrange
-            var srcFolderName = CoreConstants.ValidationFolderName;
+            var srcFolderName = CoreConstants.Folders.ValidationFolderName;
             var srcFileName = $"{_prefixA}/src";
             var srcContent = "Hello, world.";
 
-            var destFolderName = CoreConstants.PackagesFolderName;
+            var destFolderName = CoreConstants.Folders.PackagesFolderName;
             var destFileName = $"{_prefixB}/dest";
 
             await _targetA.SaveFileAsync(
@@ -317,11 +317,11 @@ namespace NuGetGallery
             CloudBlobCoreFileStorageService destService)
         {
             // Arrange
-            var srcFolderName = CoreConstants.ValidationFolderName;
+            var srcFolderName = CoreConstants.Folders.ValidationFolderName;
             var srcFileName = $"{srcPrefix}/src";
             var srcContent = "Hello, world.";
 
-            var destFolderName = CoreConstants.PackagesFolderName;
+            var destFolderName = CoreConstants.Folders.PackagesFolderName;
             var destFileName = $"{destPrefix}/dest";
 
             await srcService.SaveFileAsync(

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -108,7 +108,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<ICoreFileStorageService>();
                 var service = CreateService(fileStorageService: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.SaveFileAsync(CoreConstants.PackagesFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => !b)))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(CoreConstants.Folders.PackagesFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => !b)))
                     .Completes()
                     .Verifiable();
 
@@ -633,7 +633,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<ICoreFileStorageService>();
                 var service = CreateService(fileStorageService: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.SaveFileAsync(CoreConstants.PackageBackupsFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => b)))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(CoreConstants.Folders.PackageBackupsFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => b)))
                     .Completes()
                     .Verifiable();
 
@@ -819,7 +819,7 @@ namespace NuGetGallery
                 var packageRegistration = new PackageRegistration { Id = "theId" };
                 var package = new Package { PackageRegistration = packageRegistration, NormalizedVersion = null, Version = "01.01.01", EmbeddedLicenseType = licenseFileType };
 
-                fileStorageSvc.Setup(x => x.SaveFileAsync(CoreConstants.PackagesContentFolderName, BuildLicenseFileName("theId", "1.1.1"), expectedContentType, It.IsAny<Stream>(), true))
+                fileStorageSvc.Setup(x => x.SaveFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildLicenseFileName("theId", "1.1.1"), expectedContentType, It.IsAny<Stream>(), true))
                     .Completes()
                     .Verifiable();
 
@@ -898,7 +898,7 @@ namespace NuGetGallery
                 await service.DownloadLicenseFileAsync(package);
 
                 fileStorageSvc
-                    .Verify(fss => fss.GetFileAsync(CoreConstants.PackagesContentFolderName, BuildLicenseFileName("theId", "1.1.1")),
+                    .Verify(fss => fss.GetFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildLicenseFileName("theId", "1.1.1")),
                         Times.Once);
                 fileStorageSvc
                     .Verify(fss => fss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()),
@@ -949,7 +949,7 @@ namespace NuGetGallery
                 await service.DeleteLicenseFileAsync("theId", "01.02.03");
 
                 fileStorageSvc
-                    .Verify(fss => fss.DeleteFileAsync(CoreConstants.PackagesContentFolderName, BuildLicenseFileName("theId", "1.2.3")), Times.Once);
+                    .Verify(fss => fss.DeleteFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildLicenseFileName("theId", "1.2.3")), Times.Once);
                 fileStorageSvc
                     .Verify(fss => fss.DeleteFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             }

--- a/tests/NuGetGallery.Core.Facts/Services/RevalidationStateServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/RevalidationStateServiceFacts.cs
@@ -20,7 +20,7 @@ namespace NuGetGallery.Services
             public async Task ThrowsIfFileDoesNotExist()
             {
                 _storage
-                    .Setup(s => s.GetFileReferenceAsync(CoreConstants.RevalidationFolderName, "state.json", null))
+                    .Setup(s => s.GetFileReferenceAsync(CoreConstants.Folders.RevalidationFolderName, "state.json", null))
                     .ReturnsAsync((string folder, string file, bool ifNoneMatch) => null);
 
                 var e = await Assert.ThrowsAsync<InvalidOperationException>(() => _target.GetStateAsync());
@@ -247,7 +247,7 @@ namespace NuGetGallery.Services
                 var fileReference = new TestableFileReference(stream, writer, contentId);
 
                 _storage
-                    .Setup(s => s.GetFileReferenceAsync(CoreConstants.RevalidationFolderName, "state.json", null))
+                    .Setup(s => s.GetFileReferenceAsync(CoreConstants.Folders.RevalidationFolderName, "state.json", null))
                     .ReturnsAsync((string folder, string file, bool ifNoneMatch) => fileReference);
 
                 if (storageExceptionCode.HasValue)

--- a/tests/NuGetGallery.Facts/Services/CertificateServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CertificateServiceFacts.cs
@@ -209,7 +209,7 @@ namespace NuGetGallery.Services
                 .Returns(Task.CompletedTask);
             _fileStorageService.Setup(
                 x => x.SaveFileAsync(
-                    It.Is<string>(folderName => folderName == CoreConstants.UserCertificatesFolderName),
+                    It.Is<string>(folderName => folderName == CoreConstants.Folders.UserCertificatesFolderName),
                     It.Is<string>(fileName => fileName == $"SHA-256/{_sha256Thumbprint}.cer"),
                     It.IsNotNull<Stream>(),
                     It.Is<bool>(overwrite => overwrite == false)))

--- a/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
@@ -59,8 +59,8 @@ namespace NuGetGallery
             {
                 var folderNames = new List<object[]>
                     {
-                        new object[] { CoreConstants.PackagesFolderName, true },
-                        new object[] { CoreConstants.UploadsFolderName, false }
+                        new object[] { CoreConstants.Folders.PackagesFolderName, true },
+                        new object[] { CoreConstants.Folders.UploadsFolderName, false }
                     };
 
                 if (!IncludePermissions)
@@ -124,7 +124,7 @@ namespace NuGetGallery
                 fakeBlob.Setup(x => x.Uri).Returns(new Uri(requestUri.Scheme + "://theUri"));
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 
-                var result = await service.CreateDownloadFileActionResultAsync(requestUri, CoreConstants.PackagesFolderName, "theFileName") as RedirectResult;
+                var result = await service.CreateDownloadFileActionResultAsync(requestUri, CoreConstants.Folders.PackagesFolderName, "theFileName") as RedirectResult;
 
                 Assert.NotNull(result);
                 Assert.Equal(scheme + "theuri/", result.Url);
@@ -146,7 +146,7 @@ namespace NuGetGallery
                 fakeBlob.Setup(x => x.Uri).Returns(new Uri(blobUrl));
                 var service = CreateService(fakeBlobClient: fakeBlobClient);
 
-                var result = await service.CreateDownloadFileActionResultAsync(new Uri(requestUrl), CoreConstants.PackagesFolderName, "theFileName") as RedirectResult;
+                var result = await service.CreateDownloadFileActionResultAsync(new Uri(requestUrl), CoreConstants.Folders.PackagesFolderName, "theFileName") as RedirectResult;
                 var redirectUrl = new Uri(result.Url);
                 Assert.Equal(expectedPort, redirectUrl.Port);
             }
@@ -168,7 +168,7 @@ namespace NuGetGallery
 
                 var result = await service.CreateDownloadFileActionResultAsync(
                     new Uri(HttpsRequestUrlString), 
-                    CoreConstants.PackagesFolderName, 
+                    CoreConstants.Folders.PackagesFolderName, 
                     "theFileName") as RedirectResult;
                 fakePolicy.Verify();
             }
@@ -191,7 +191,7 @@ namespace NuGetGallery
                 await Assert.ThrowsAsync<InvalidOperationException>(
                     () => service.CreateDownloadFileActionResultAsync(
                         new Uri(HttpsRequestUrlString), 
-                        CoreConstants.PackagesFolderName, "theFileName")
+                        CoreConstants.Folders.PackagesFolderName, "theFileName")
                     );
             }
         }

--- a/tests/NuGetGallery.Facts/Services/ContentServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ContentServiceFacts.cs
@@ -96,7 +96,7 @@ namespace NuGetGallery.Services
                 Assert.Equal(CachedContent, actual.ToString());
                 contentService.MockFileStorage
                               .Verify(
-                                fs => fs.GetFileReferenceAsync(CoreConstants.ContentFolderName, "TestContentItem.md", It.IsAny<string>()),
+                                fs => fs.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, "TestContentItem.md", It.IsAny<string>()),
                                 Times.Never());
             }
 
@@ -118,7 +118,7 @@ namespace NuGetGallery.Services
                 // Assert
                 Assert.Equal(CachedContent, actual.ToString());
                 contentService.MockFileStorage
-                              .Verify(fs => fs.GetFileReferenceAsync(CoreConstants.ContentFolderName, "TestContentItem.md", cachedContentId));
+                              .Verify(fs => fs.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, "TestContentItem.md", cachedContentId));
                 Assert.Equal(0, file.OpenCount); // Make sure we never tried to open the file.
                 
                 var updatedCache = contentService.GetCached("TestContentItem");
@@ -146,7 +146,7 @@ namespace NuGetGallery.Services
                 // Assert
                 Assert.Equal(RenderedNewContent, actual.ToString());
                 contentService.MockFileStorage
-                              .Verify(fs => fs.GetFileReferenceAsync(CoreConstants.ContentFolderName, "TestContentItem.md", cachedContentId));
+                              .Verify(fs => fs.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, "TestContentItem.md", cachedContentId));
                 Assert.Equal(1, file.OpenCount); // Make sure we never tried to open the file.
 
                 var updatedCache = contentService.GetCached("TestContentItem");
@@ -230,7 +230,7 @@ namespace NuGetGallery.Services
                 Assert.Equal(CachedContent, actual.ToString());
                 contentService.MockFileStorage
                               .Verify(
-                                fs => fs.GetFileReferenceAsync(CoreConstants.ContentFolderName, "TestContentItem.md", It.IsAny<string>()),
+                                fs => fs.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, "TestContentItem.md", It.IsAny<string>()),
                                 Times.Never());
             }
 
@@ -252,7 +252,7 @@ namespace NuGetGallery.Services
                 // Assert
                 Assert.Equal(CachedContent, actual.ToString());
                 contentService.MockFileStorage
-                              .Verify(fs => fs.GetFileReferenceAsync(CoreConstants.ContentFolderName, "TestContentItem.md", cachedContentId));
+                              .Verify(fs => fs.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, "TestContentItem.md", cachedContentId));
                 Assert.Equal(0, file.OpenCount); // Make sure we never tried to open the file.
 
                 var updatedCache = contentService.GetCached("TestContentItem");
@@ -280,7 +280,7 @@ namespace NuGetGallery.Services
                 // Assert
                 Assert.Equal(RenderedNewContent, actual.ToString());
                 contentService.MockFileStorage
-                              .Verify(fs => fs.GetFileReferenceAsync(CoreConstants.ContentFolderName, "TestContentItem.md", cachedContentId));
+                              .Verify(fs => fs.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, "TestContentItem.md", cachedContentId));
                 Assert.Equal(1, file.OpenCount); // Make sure we never tried to open the file.
 
                 var updatedCache = contentService.GetCached("TestContentItem");
@@ -320,10 +320,10 @@ namespace NuGetGallery.Services
             public void SetFile(string filename, string cachedContentId, IFileReference file)
             {
                 MockFileStorage
-                    .Setup(fs => fs.GetFileReferenceAsync(CoreConstants.ContentFolderName, filename, cachedContentId))
+                    .Setup(fs => fs.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, filename, cachedContentId))
                     .Returns(Task.FromResult<IFileReference>(file));
                 MockFileStorage
-                    .Setup(fs => fs.GetFileReferenceAsync(CoreConstants.ContentFolderName, It.Is<string>(s => !s.Equals(filename)), It.IsAny<string>()))
+                    .Setup(fs => fs.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, It.Is<string>(s => !s.Equals(filename)), It.IsAny<string>()))
                     .Returns(Task.FromResult<IFileReference>(null));
             }
 

--- a/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
@@ -76,7 +76,7 @@ namespace NuGetGallery
                 var ex = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => service.CreateDownloadFileActionResultAsync(
                         HttpRequestUrl,
-                        CoreConstants.PackagesFolderName,
+                        CoreConstants.Folders.PackagesFolderName,
                         fileName));
 
                 Assert.Equal("fileName", ex.ParamName);
@@ -87,11 +87,11 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.PackagesFolderName, "theFileName") as FilePathResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName") as FilePathResult;
 
                 Assert.NotNull(result);
                 Assert.Equal(
-                    Path.Combine(FakeConfiguredFileStorageDirectory, CoreConstants.PackagesFolderName, "theFileName"),
+                    Path.Combine(FakeConfiguredFileStorageDirectory, CoreConstants.Folders.PackagesFolderName, "theFileName"),
                     result.FileName);
             }
 
@@ -102,7 +102,7 @@ namespace NuGetGallery
                 fakeFileSystemService.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
                 var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.PackagesFolderName, "theFileName") as HttpNotFoundResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName") as HttpNotFoundResult;
 
                 Assert.NotNull(result);
             }
@@ -112,7 +112,7 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.PackagesFolderName, "theFileName") as FilePathResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName") as FilePathResult;
 
                 Assert.NotNull(result);
                 Assert.Equal(CoreConstants.PackageContentType, result.ContentType);
@@ -123,7 +123,7 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.SymbolPackagesFolderName, "theFileName") as FilePathResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.SymbolPackagesFolderName, "theFileName") as FilePathResult;
 
                 Assert.NotNull(result);
                 Assert.Equal(CoreConstants.PackageContentType, result.ContentType);
@@ -134,7 +134,7 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.PackagesFolderName, "theFileName") as FilePathResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName") as FilePathResult;
 
                 Assert.NotNull(result);
                 Assert.Equal(
@@ -169,7 +169,7 @@ namespace NuGetGallery
 
                 var ex = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => service.DeleteFileAsync(
-                        CoreConstants.PackagesFolderName,
+                        CoreConstants.Folders.PackagesFolderName,
                         fileName));
 
                 Assert.Equal("fileName", ex.ParamName);
@@ -182,11 +182,11 @@ namespace NuGetGallery
                 fakeFileSystemService.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
                 var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                service.DeleteFileAsync(CoreConstants.PackagesFolderName, "theFileName");
+                service.DeleteFileAsync(CoreConstants.Folders.PackagesFolderName, "theFileName");
 
                 fakeFileSystemService.Verify(
                     x => x.DeleteFile(
-                        Path.Combine(FakeConfiguredFileStorageDirectory, CoreConstants.PackagesFolderName, "theFileName")));
+                        Path.Combine(FakeConfiguredFileStorageDirectory, CoreConstants.Folders.PackagesFolderName, "theFileName")));
             }
 
             [Fact]
@@ -198,7 +198,7 @@ namespace NuGetGallery
                 fakeFileSystemService.Setup(x => x.DeleteFile(It.IsAny<string>())).Callback(() => deleteWasInvoked = true);
                 var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                service.DeleteFileAsync(CoreConstants.PackagesFolderName, "theFileName");
+                service.DeleteFileAsync(CoreConstants.Folders.PackagesFolderName, "theFileName");
 
                 Assert.False(deleteWasInvoked);
             }
@@ -230,7 +230,7 @@ namespace NuGetGallery
 
                 var ex = await Assert.ThrowsAsync<ArgumentNullException>(
                     () => service.GetFileAsync(
-                        CoreConstants.PackagesFolderName,
+                        CoreConstants.Folders.PackagesFolderName,
                         fileName));
 
                 Assert.Equal("fileName", ex.ParamName);

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
@@ -47,7 +47,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.DeleteFileAsync(CoreConstants.PackagesFolderName, It.IsAny<string>()))
+                fileStorageSvc.Setup(x => x.DeleteFileAsync(CoreConstants.Folders.PackagesFolderName, It.IsAny<string>()))
                     .Completes()
                     .Verifiable();
 
@@ -126,7 +126,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), CoreConstants.PackagesFolderName, It.IsAny<string>()))
+                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), CoreConstants.Folders.PackagesFolderName, It.IsAny<string>()))
                     .CompletesWithNull()
                     .Verifiable();
 
@@ -213,7 +213,7 @@ namespace NuGetGallery
                 await service.DeleteReadMeMdFileAsync(package);
 
                 // Assert.
-                fileServiceMock.Verify(fs => fs.DeleteFileAsync(CoreConstants.PackageReadMesFolderName, $"active/test/1.0.0.md"), Times.Once);
+                fileServiceMock.Verify(fs => fs.DeleteFileAsync(CoreConstants.Folders.PackageReadMesFolderName, $"active/test/1.0.0.md"), Times.Once);
             }
         }
 
@@ -258,7 +258,7 @@ namespace NuGetGallery
                 await service.SaveReadMeMdFileAsync(package, "<p>Hello World!</p>");
 
                 // Assert.
-                fileServiceMock.Verify(f => f.SaveFileAsync(CoreConstants.PackageReadMesFolderName, "active/foo/1.0.0.md", It.IsAny<Stream>(), true),
+                fileServiceMock.Verify(f => f.SaveFileAsync(CoreConstants.Folders.PackageReadMesFolderName, "active/foo/1.0.0.md", It.IsAny<Stream>(), true),
                     Times.Once);
             }
         }
@@ -302,7 +302,7 @@ namespace NuGetGallery
                     // Assert.
                     Assert.Equal(expectedMd, actualMd);
 
-                    fileServiceMock.Verify(f => f.GetFileAsync(CoreConstants.PackageReadMesFolderName, $"active/foo/1.1.1.md"), Times.Once);
+                    fileServiceMock.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackageReadMesFolderName, $"active/foo/1.1.1.md"), Times.Once);
                 }
             }
 
@@ -331,7 +331,7 @@ namespace NuGetGallery
                 // Assert
                 Assert.Null(result);
 
-                fileServiceMock.Verify(f => f.GetFileAsync(CoreConstants.PackageReadMesFolderName, $"active/foo/1.1.1.md"), Times.Once);
+                fileServiceMock.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackageReadMesFolderName, $"active/foo/1.1.1.md"), Times.Once);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/UploadFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UploadFileServiceFacts.cs
@@ -40,7 +40,7 @@ namespace NuGetGallery
 
                 service.DeleteUploadFileAsync(1);
 
-                fakeFileStorageService.Verify(x => x.DeleteFileAsync(CoreConstants.UploadsFolderName, It.IsAny<string>()));
+                fakeFileStorageService.Verify(x => x.DeleteFileAsync(CoreConstants.Folders.UploadsFolderName, It.IsAny<string>()));
             }
 
             [Fact]
@@ -76,7 +76,7 @@ namespace NuGetGallery
 
                 service.GetUploadFileAsync(1);
 
-                fakeFileStorageService.Verify(x => x.GetFileAsync(CoreConstants.UploadsFolderName, It.IsAny<string>()));
+                fakeFileStorageService.Verify(x => x.GetFileAsync(CoreConstants.Folders.UploadsFolderName, It.IsAny<string>()));
             }
 
             [Fact]
@@ -97,7 +97,7 @@ namespace NuGetGallery
                 var expectedFileName = String.Format(GalleryConstants.UploadFileNameTemplate, 1, CoreConstants.NuGetPackageFileExtension);
                 var fakeFileStorageService = new Mock<IFileStorageService>();
                 var fakeFileStream = new MemoryStream();
-                fakeFileStorageService.Setup(x => x.GetFileAsync(CoreConstants.UploadsFolderName, expectedFileName))
+                fakeFileStorageService.Setup(x => x.GetFileAsync(CoreConstants.Folders.UploadsFolderName, expectedFileName))
                                       .Returns(Task.FromResult<Stream>(fakeFileStream));
                 var service = CreateService(fakeFileStorageService: fakeFileStorageService);
 
@@ -137,7 +137,7 @@ namespace NuGetGallery
 
                 service.SaveUploadFileAsync(1, new MemoryStream());
 
-                fakeFileStorageService.Verify(x => x.SaveFileAsync(CoreConstants.UploadsFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => b)));
+                fakeFileStorageService.Verify(x => x.SaveFileAsync(CoreConstants.Folders.UploadsFolderName, It.IsAny<string>(), It.IsAny<Stream>(), It.Is<bool>(b => b)));
             }
 
             [Fact]


### PR DESCRIPTION
Added new folder to a list of known private folders.
Changed the default cache control to be not set.
Updated tests to include the new folder.

To prevent the issue in the future all folders were moved into their own class and added a test that makes sure `CloudBlobCoreFileStorageServiceFacts` have all of them covered.