### PR TITLE
Aligned NuGet.GalleryCore and NuGetGallery references to NuGet.Services.Entities

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -203,7 +203,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>2.32.0-agr-license-2170862</Version>
+      <Version>2.35.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging">
       <Version>2.31.0</Version>


### PR DESCRIPTION
Forgot to update NuGet.GalleryCore package reference after updating the NuGetGallery one.