### PR TITLE
Fix DisplayPackage Perf regression

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1221,17 +1221,20 @@ namespace NuGetGallery
             }
 
             var model = new DeletePackageViewModel(package, currentUser, DeleteReasons);
+            var packageViewModelsForAllAvailableSymbolsPackage = package
+                .PackageRegistration
+                .Packages
+                .Where(p => p.PackageStatusKey != PackageStatus.Deleted)
+                .Select(p => p.LatestSymbolPackage())
+                .Where(sp => sp != null && sp.StatusKey == PackageStatus.Available)
+                .Select(sp => new PackageViewModel(sp.Package));
 
             model.VersionSelectList = new SelectList(
-                model
-                .PackageVersions
-                .Where(p => !p.Deleted
-                    && p.LatestSymbolsPackage != null
-                    && p.LatestSymbolsPackage.StatusKey == PackageStatus.Available)
-                .Select(p => new
+                packageViewModelsForAllAvailableSymbolsPackage
+                .Select(pvm => new
                 {
-                    text = p.NuGetVersion.ToFullString() + (p.LatestVersionSemVer2 ? " (Latest)" : string.Empty),
-                    url = Url.DeleteSymbolsPackage(p)
+                    text = pvm.NuGetVersion.ToFullString() + (pvm.LatestVersionSemVer2 ? " (Latest)" : string.Empty),
+                    url = Url.DeleteSymbolsPackage(pvm)
                 }), "url", "text", Url.DeleteSymbolsPackage(model));
 
             return View(model);

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1221,6 +1221,12 @@ namespace NuGetGallery
             }
 
             var model = new DeletePackageViewModel(package, currentUser, DeleteReasons);
+
+            // Fetch all the available symbols package for all the versions from the 
+            // database since the DisplayPackageViewModel(base class for DeletePackageViewModel) does not
+            // set the `LatestSymbolsPackage` data on the model(since it is an unnecessary and expensive db
+            // query). It is fine to do this here when invoking delete page. Note: this could also potentially 
+            // cause unbounded(high number) db calls based on the number of versions associated with a package.
             var packageViewModelsForAllAvailableSymbolsPackage = package
                 .PackageRegistration
                 .Packages

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -55,8 +55,6 @@ namespace NuGetGallery
 
             PushedBy = pushedBy;
 
-            LatestSymbolsPackage = package.LatestSymbolPackage();
-
             InitializeRepositoryMetadata(package.RepositoryUrl, package.RepositoryType);
 
             if (PackageHelper.TryPrepareUrlForRendering(package.ProjectUrl, out string projectUrl))
@@ -65,7 +63,7 @@ namespace NuGetGallery
             }
 
             var licenseExpression = package.LicenseExpression;
-            if (!String.IsNullOrWhiteSpace(licenseExpression))
+            if (!string.IsNullOrWhiteSpace(licenseExpression))
             {
                 LicenseUrl = LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(licenseExpression);
             }

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -168,6 +168,55 @@ namespace NuGetGallery.ViewModels
         }
 
         [Fact]
+        public void TheCtorDoesNotPopulateLatestSymbolsPackageForHistory()
+        {
+            var package = new Package
+            {
+                Version = "1.0.0",
+                Dependencies = Enumerable.Empty<PackageDependency>().ToList(),
+                PackageRegistration = new PackageRegistration
+                {
+                    Owners = Enumerable.Empty<User>().ToList(),
+                }
+            };
+
+            package.SymbolPackages.Add(new SymbolPackage()
+            {
+                Package = package,
+                StatusKey = PackageStatus.Available
+            });
+
+            package.PackageRegistration.Packages = new[]
+                {
+                    new Package { Version = "1.0.0-alpha2", PackageRegistration = package.PackageRegistration },
+                    new Package { Version = "1.0.0", PackageRegistration = package.PackageRegistration },
+                    new Package { Version = "1.0.0-alpha", PackageRegistration = package.PackageRegistration },
+                    new Package { Version = "1.0.0-beta", PackageRegistration = package.PackageRegistration },
+                    new Package { Version = "1.0.2-beta", PackageRegistration = package.PackageRegistration },
+                    new Package { Version = "1.0.2", PackageRegistration = package.PackageRegistration },
+                    new Package { Version = "1.0.10", PackageRegistration = package.PackageRegistration }
+                };
+
+            foreach (var packageVersion in package.PackageRegistration.Packages)
+            {
+                packageVersion.SymbolPackages.Add(new SymbolPackage()
+                {
+                    Package = packageVersion,
+                    StatusKey = PackageStatus.Available
+                });
+            }
+
+            var viewModel = new DisplayPackageViewModel(package, null, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)));
+
+            // Descending
+            Assert.NotNull(viewModel.LatestSymbolsPackage);
+            foreach (var version in viewModel.PackageVersions)
+            {
+                Assert.Null(version.LatestSymbolsPackage);
+            }
+        }
+
+        [Fact]
         public void TheCtorReturnsLatestSymbolPackageByDateCreated()
         {
             var package = new Package


### PR DESCRIPTION
Addresses #6650 

The fix is basically to avoid setting the `LatestSymbolPackage` on all the package versions, and only set on the main package for the display view. The perf gain would be reduced dependency calls. I verified this locally and was able to see the reduced dependency calls. I will analyze the performance over the week after merging and deploying this change in DEV.

The problem is we are reusing the same view model for two different views(which happen to be on the same page), details view and package versions history. Ideally we should have a completely different view model for the package versions list(history) which should only have the required data populated rather than using same `DisplayPackageViewModel`. However, that is overall a bigger change that I do not want to address in this PR.