### PR TITLE
Mark 405 response code as "success" for AI

### DIFF
--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -92,6 +92,7 @@ namespace NuGetGallery
 
                     processor.SuccessfulResponseCodes.Add(400);
                     processor.SuccessfulResponseCodes.Add(404);
+                    processor.SuccessfulResponseCodes.Add(405);
 
                     return processor;
                 });


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6651

Wasn't able to find any unit tests that verify that our `RequestTelemetryProcessor` considers 400, 404, and 405 successful, but I verified locally that they are.