### PR TITLE
Targeted block for invalidly URL encoded license URLs for license expressions

### DIFF
--- a/src/NuGetGallery/Helpers/LicenseExpressionRedirectUrlHelper.cs
+++ b/src/NuGetGallery/Helpers/LicenseExpressionRedirectUrlHelper.cs
@@ -7,7 +7,8 @@ namespace NuGetGallery.Helpers
 {
     public static class LicenseExpressionRedirectUrlHelper
     {
-        public const string LicenseExpressionDeprecationUrlFormat = "https://licenses.nuget.org/{0}";
+        public const string LicenseExpressionHostname = "licenses.nuget.org";
+        public const string LicenseExpressionDeprecationUrlFormat = "https://" + LicenseExpressionHostname + "/{0}";
 
         public static string GetLicenseExpressionRedirectUrl(string licenseExpression)
         {

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -427,6 +427,7 @@
     <Compile Include="Services\ActionsRequiringPermissions.cs" />
     <Compile Include="Services\AsynchronousPackageValidationInitiator.cs" />
     <Compile Include="Infrastructure\Mail\BackgroundMarkdownMessageService.cs" />
+    <Compile Include="Services\InvalidLicenseUrlValidationMessage.cs" />
     <Compile Include="Services\InvalidUrlEncodingForLicenseUrlValidationMessage.cs" />
     <Compile Include="Services\ISymbolPackageUploadService.cs" />
     <Compile Include="Services\ISymbolPackageFileService.cs" />

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -427,6 +427,7 @@
     <Compile Include="Services\ActionsRequiringPermissions.cs" />
     <Compile Include="Services\AsynchronousPackageValidationInitiator.cs" />
     <Compile Include="Infrastructure\Mail\BackgroundMarkdownMessageService.cs" />
+    <Compile Include="Services\InvalidUrlEncodingForLicenseUrlValidationMessage.cs" />
     <Compile Include="Services\ISymbolPackageUploadService.cs" />
     <Compile Include="Services\ISymbolPackageFileService.cs" />
     <Compile Include="Services\ITyposquattingCheckListCacheService.cs" />

--- a/src/NuGetGallery/Services/InvalidLicenseUrlValidationMessage.cs
+++ b/src/NuGetGallery/Services/InvalidLicenseUrlValidationMessage.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// The error message to be used when package contains license expression, but
+    /// its license URL points to a wrong location
+    /// </summary>
+    public class InvalidLicenseUrlValidationMessage : IValidationMessage
+    {
+        private string DetailsLink => $"<a href=\"https://aka.ms/invalidNuGetLicenseUrl\">{Strings.UploadPackage_LearnMore}</a>.";
+        private string DetailsPlainText => "https://aka.ms/invalidNuGetLicenseUrl";
+
+        private readonly string _baseMessage;
+
+        public InvalidLicenseUrlValidationMessage(string baseMessage)
+        {
+            _baseMessage = baseMessage ?? throw new ArgumentNullException(nameof(baseMessage));
+        }
+
+        public string PlainTextMessage => _baseMessage + " " + DetailsPlainText;
+
+        public bool HasRawHtmlRepresentation => true;
+
+        public string RawHtmlMessage => _baseMessage + " " + DetailsLink;
+
+    }
+}

--- a/src/NuGetGallery/Services/InvalidUrlEncodingForLicenseUrlValidationMessage.cs
+++ b/src/NuGetGallery/Services/InvalidUrlEncodingForLicenseUrlValidationMessage.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 namespace NuGetGallery
 {
     /// <summary>
@@ -14,8 +9,8 @@ namespace NuGetGallery
     /// </summary>
     public class InvalidUrlEncodingForLicenseUrlValidationMessage : IValidationMessage
     {
-        private string DetailsLink => $"<a href=\"https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5036\">{Strings.UploadPackage_LearnMore}</a>.";
-        private string DetailsPlainText => "(NU5036; https://aka.ms/malformedNuGetLicenseUrl)";
+        private string DetailsLink => $"<a href=\"https://aka.ms/malformedNuGetLicenseUrl\">{Strings.UploadPackage_LearnMore}</a>.";
+        private string DetailsPlainText => "https://aka.ms/malformedNuGetLicenseUrl";
 
         private string BaseMessage => Strings.UploadPackage_MalformedLicenseUrl;
 
@@ -23,6 +18,6 @@ namespace NuGetGallery
 
         public bool HasRawHtmlRepresentation => true;
 
-        public string RawHtmlMessage => PlainTextMessage + " " + DetailsLink;
+        public string RawHtmlMessage => BaseMessage + " " + DetailsLink;
     }
 }

--- a/src/NuGetGallery/Services/InvalidUrlEncodingForLicenseUrlValidationMessage.cs
+++ b/src/NuGetGallery/Services/InvalidUrlEncodingForLicenseUrlValidationMessage.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// The error message to be used when we detect an invalid URL encoding used for a license URL.
+    /// Specifically, if we see that spaces are encoded as pluses instead of %20
+    /// </summary>
+    public class InvalidUrlEncodingForLicenseUrlValidationMessage : IValidationMessage
+    {
+        private string DetailsLink => $"<a href=\"https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5036\">{Strings.UploadPackage_LearnMore}</a>.";
+        private string DetailsPlainText => "(NU5026; https://aka.ms/malformedNuGetLicenseUrl)";
+
+        private string BaseMessage => Strings.UploadPackage_MalformedLicenseUrl;
+
+        public string PlainTextMessage => BaseMessage + " " + DetailsPlainText;
+
+        public bool HasRawHtmlRepresentation => true;
+
+        public string RawHtmlMessage => PlainTextMessage + " " + DetailsLink;
+    }
+}

--- a/src/NuGetGallery/Services/InvalidUrlEncodingForLicenseUrlValidationMessage.cs
+++ b/src/NuGetGallery/Services/InvalidUrlEncodingForLicenseUrlValidationMessage.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
     public class InvalidUrlEncodingForLicenseUrlValidationMessage : IValidationMessage
     {
         private string DetailsLink => $"<a href=\"https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5036\">{Strings.UploadPackage_LearnMore}</a>.";
-        private string DetailsPlainText => "(NU5026; https://aka.ms/malformedNuGetLicenseUrl)";
+        private string DetailsPlainText => "(NU5036; https://aka.ms/malformedNuGetLicenseUrl)";
 
         private string BaseMessage => Strings.UploadPackage_MalformedLicenseUrl;
 

--- a/src/NuGetGallery/Services/LicenseUrlDeprecationValidationMessage.cs
+++ b/src/NuGetGallery/Services/LicenseUrlDeprecationValidationMessage.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
     /// </summary>
     public class LicenseUrlDeprecationValidationMessage : IValidationMessage
     {
-        private string DeprecationLink => $"<a href=\"{GalleryConstants.LicenseDeprecationUrl}\">{Strings.UploadPackage_LearnMore}.</a>";
+        private string DeprecationLink => $"<a href=\"{GalleryConstants.LicenseDeprecationUrl}\">{Strings.UploadPackage_LearnMore}</a>.";
 
         private readonly string _baseMessage;
         

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -227,15 +227,15 @@ namespace NuGetGallery
                 
                 if (licenseMetadata.Type == LicenseType.File)
                 {
-                    warnings.Add(
-                        new PlainTextOnlyValidationMessage(
-                            string.Format(Strings.UploadPackage_DeprecationUrlSuggestedForLicenseFiles, licenseDeprecationUrl)));
+                    return PackageValidationResult.Invalid(
+                        new InvalidLicenseUrlValidationMessage(
+                            string.Format(Strings.UploadPackage_DeprecationUrlRequiredForLicenseFiles, licenseDeprecationUrl)));
                 }
                 else if (licenseMetadata.Type == LicenseType.Expression)
                 {
-                    warnings.Add(
-                        new PlainTextOnlyValidationMessage(
-                            string.Format(Strings.UploadPackage_DeprecationUrlSuggestedForLicenseExpressions, licenseDeprecationUrl)));
+                    return PackageValidationResult.Invalid(
+                        new InvalidLicenseUrlValidationMessage(
+                            string.Format(Strings.UploadPackage_DeprecationUrlRequiredForLicenseExpressions, licenseDeprecationUrl)));
                 }
             }
 

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -171,7 +171,6 @@ namespace NuGetGallery
             var licenseUrl = nuspecReader.GetLicenseUrl();
             var licenseMetadata = nuspecReader.GetLicenseMetadata();
             var licenseDeprecationUrl = GetExpectedLicenseUrl(licenseMetadata);
-            var alternativeDeprecationUrl = GetExpectedAlternativeUrl(licenseMetadata);
 
             if (licenseMetadata == null)
             {
@@ -219,8 +218,13 @@ namespace NuGetGallery
                         string.Join(" ", licenseMetadata.WarningsAndErrors)));
             }
 
-            if (licenseDeprecationUrl != licenseUrl && (alternativeDeprecationUrl == null || alternativeDeprecationUrl != licenseUrl))
+            if (licenseDeprecationUrl != licenseUrl)
             {
+                if (IsMalformedDeprecationUrl(licenseUrl))
+                {
+                    return PackageValidationResult.Invalid(new InvalidUrlEncodingForLicenseUrlValidationMessage());
+                }
+                
                 if (licenseMetadata.Type == LicenseType.File)
                 {
                     warnings.Add(
@@ -307,6 +311,28 @@ namespace NuGetGallery
             return null;
         }
 
+        private bool IsMalformedDeprecationUrl(string licenseUrl)
+        {
+            // nuget.exe 4.9.0 and its dotnet and msbuild counterparts encode spaces as "+"
+            // when generating legacy license URL, which is bad. We explicitly forbid such
+            // URLs. On the other hand, if license expression does not contain spaces they
+            // generate good URLs which we don't want to reject. This method detects the 
+            // case when spaces are in the expression in a meaningful way.
+
+            if (Uri.TryCreate(licenseUrl, UriKind.Absolute, out var url))
+            {
+                if (url.Host != LicenseExpressionRedirectUrlHelper.LicenseExpressionHostname)
+                {
+                    return false;
+                }
+
+                var invalidUrlBits = new string[] { "+OR+", "+AND+", "+WITH+" };
+                return invalidUrlBits.Any(invalidBit => licenseUrl.IndexOf(invalidBit, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+
+            return false;
+        }
+
         private List<LicenseData> GetLicenseList(NuGetLicenseExpression licenseExpression)
         {
             var licenseList = new List<LicenseData>();
@@ -378,25 +404,6 @@ namespace NuGetGallery
             }
 
             throw new InvalidOperationException($"Unsupported license metadata type: {licenseMetadata.Type}");
-        }
-
-        /// <summary>
-        /// 15.9 client does url encoding with <see cref="WebUtility.UrlEncode(string)"/> which
-        /// replaces spaces with "+". We shouldn't work about it, but we should fix the client,
-        /// too.
-        /// </summary>
-        private static string GetExpectedAlternativeUrl(LicenseMetadata licenseMetadata)
-        {
-            if (licenseMetadata != null && licenseMetadata.Type == LicenseType.Expression)
-            {
-                return new Uri(
-                    string.Format(
-                        LicenseExpressionRedirectUrlHelper.LicenseExpressionDeprecationUrlFormat,
-                        WebUtility.UrlEncode(licenseMetadata.License)))
-                    .AbsoluteUri;
-            }
-
-            return null;
         }
 
         private static bool HasChildElements(XElement xElement)

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {
@@ -2369,6 +2369,15 @@ namespace NuGetGallery {
         public static string UploadPackage_LicenseShouldBeSpecified {
             get {
                 return ResourceManager.GetString("UploadPackage_LicenseShouldBeSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package has malformed license URL..
+        /// </summary>
+        public static string UploadPackage_MalformedLicenseUrl {
+            get {
+                return ResourceManager.GetString("UploadPackage_MalformedLicenseUrl", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2202,20 +2202,20 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To provide better experience for older clients when a license expression is specified, &lt;licenseUrl&gt; should be set to &apos;{0}&apos;..
+        ///   Looks up a localized string similar to To provide a better experience for older clients when a license expression is specified, &lt;licenseUrl&gt; must be set to &apos;{0}&apos;..
         /// </summary>
-        public static string UploadPackage_DeprecationUrlSuggestedForLicenseExpressions {
+        public static string UploadPackage_DeprecationUrlRequiredForLicenseExpressions {
             get {
-                return ResourceManager.GetString("UploadPackage_DeprecationUrlSuggestedForLicenseExpressions", resourceCulture);
+                return ResourceManager.GetString("UploadPackage_DeprecationUrlRequiredForLicenseExpressions", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To provide better experience for older clients when a license file is packaged, &lt;licenseUrl&gt; should be set to &apos;{0}&apos;..
+        ///   Looks up a localized string similar to To provide a better experience for older clients when a license file is packaged, &lt;licenseUrl&gt; must be set to &apos;{0}&apos;..
         /// </summary>
-        public static string UploadPackage_DeprecationUrlSuggestedForLicenseFiles {
+        public static string UploadPackage_DeprecationUrlRequiredForLicenseFiles {
             get {
-                return ResourceManager.GetString("UploadPackage_DeprecationUrlSuggestedForLicenseFiles", resourceCulture);
+                return ResourceManager.GetString("UploadPackage_DeprecationUrlRequiredForLicenseFiles", resourceCulture);
             }
         }
         
@@ -2373,7 +2373,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package has a malformed license URL..
+        ///   Looks up a localized string similar to The package contains a malformed license URL..
         /// </summary>
         public static string UploadPackage_MalformedLicenseUrl {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2373,7 +2373,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package has malformed license URL..
+        ///   Looks up a localized string similar to The package has a malformed license URL..
         /// </summary>
         public static string UploadPackage_MalformedLicenseUrl {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1075,6 +1075,6 @@ The {1} Team</value>
     <comment>{0} is list of the package license ids that are neither OSI nor FSF approved</comment>
   </data>
   <data name="UploadPackage_MalformedLicenseUrl" xml:space="preserve">
-    <value>The package has malformed license URL.</value>
+    <value>The package has a malformed license URL.</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1056,12 +1056,12 @@ The {1} Team</value>
   <data name="UploadPackage_LicenseFilesAreNotAllowed" xml:space="preserve">
     <value>License files are not yet supported.</value>
   </data>
-  <data name="UploadPackage_DeprecationUrlSuggestedForLicenseExpressions" xml:space="preserve">
-    <value>To provide better experience for older clients when a license expression is specified, &lt;licenseUrl&gt; should be set to '{0}'.</value>
+  <data name="UploadPackage_DeprecationUrlRequiredForLicenseExpressions" xml:space="preserve">
+    <value>To provide a better experience for older clients when a license expression is specified, &lt;licenseUrl&gt; must be set to '{0}'.</value>
     <comment>{0} is the licenses.nuget.org link with license expression</comment>
   </data>
-  <data name="UploadPackage_DeprecationUrlSuggestedForLicenseFiles" xml:space="preserve">
-    <value>To provide better experience for older clients when a license file is packaged, &lt;licenseUrl&gt; should be set to '{0}'.</value>
+  <data name="UploadPackage_DeprecationUrlRequiredForLicenseFiles" xml:space="preserve">
+    <value>To provide a better experience for older clients when a license file is packaged, &lt;licenseUrl&gt; must be set to '{0}'.</value>
     <comment>{0} is the deprecation page URL</comment>
   </data>
   <data name="UploadPackage_LearnMore" xml:space="preserve">
@@ -1075,6 +1075,6 @@ The {1} Team</value>
     <comment>{0} is list of the package license ids that are neither OSI nor FSF approved</comment>
   </data>
   <data name="UploadPackage_MalformedLicenseUrl" xml:space="preserve">
-    <value>The package has a malformed license URL.</value>
+    <value>The package contains a malformed license URL.</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1074,4 +1074,7 @@ The {1} Team</value>
     <value>License expression must only contain licenses that are approved by Open Source Initiative or Free Software Foundation. Unsupported licenses: {0}.</value>
     <comment>{0} is list of the package license ids that are neither OSI nor FSF approved</comment>
   </data>
+  <data name="UploadPackage_MalformedLicenseUrl" xml:space="preserve">
+    <value>The package has malformed license URL.</value>
+  </data>
 </root>


### PR DESCRIPTION
#6679