### PR TITLE
Hotfix copy-sender

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -212,16 +212,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>2.38.0</Version>
+      <Version>2.40.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.38.0</Version>
+      <Version>2.40.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.38.0</Version>
+      <Version>2.40.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.38.0</Version>
+      <Version>2.40.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2218,16 +2218,16 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.38.0</Version>
+      <Version>2.40.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.38.0</Version>
+      <Version>2.40.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.38.0</Version>
+      <Version>2.40.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.38.0</Version>
+      <Version>2.40.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/TestMailSender.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/TestMailSender.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Net.Mail;
+using AnglicanGeek.MarkdownMailer;
+
+namespace NuGetGallery
+{
+    // Normally I don't like hand-written mocks, but this actually seems appropriate - anurse
+    public class TestMailSender : IMailSender
+    {
+        public IList<MailMessage> Sent { get; private set; }
+
+        public TestMailSender()
+        {
+            Sent = new List<MailMessage>();
+        }
+
+        public void Send(MailMessage mailMessage)
+        {
+            Sent.Add(mailMessage);
+        }
+
+        public void Send(MailAddress fromAddress, MailAddress toAddress, string subject, string markdownBody)
+        {
+            Send(new MailMessage(fromAddress, toAddress)
+            {
+                Subject = subject,
+                Body = markdownBody
+            });
+        }
+
+        public void Send(string fromAddress, string toAddress, string subject, string markdownBody)
+        {
+            Send(new MailMessage(fromAddress, toAddress, subject, markdownBody));
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/TestableMarkdownMessageService.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/TestableMarkdownMessageService.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Mail;
+using Moq;
+using NuGetGallery.Authentication;
+using NuGetGallery.Configuration;
+using NuGetGallery.Infrastructure.Mail;
+
+namespace NuGetGallery
+{
+    public class TestableMarkdownMessageService
+        : MarkdownMessageService
+    {
+        public static readonly MailAddress TestGalleryOwner = new MailAddress("joe@example.com", "Joe Shmoe");
+        public static readonly MailAddress TestGalleryNoReplyAddress = new MailAddress("noreply@example.com", "No Reply");
+
+        private TestableMarkdownMessageService(IGalleryConfigurationService configurationService)
+            : base(new TestMailSender(), configurationService.Current, new Mock<ITelemetryService>().Object)
+        {
+            configurationService.Current.GalleryOwner = TestGalleryOwner;
+            configurationService.Current.GalleryNoReplyAddress = TestGalleryNoReplyAddress;
+
+            MockMailSender = (TestMailSender)MailSender;
+        }
+
+        public Mock<AuthenticationService> MockAuthService { get; protected set; }
+        public TestMailSender MockMailSender { get; protected set; }
+
+        public static TestableMarkdownMessageService Create(IGalleryConfigurationService configurationService)
+        {
+            configurationService.Current.SmtpUri = new Uri("smtp://fake.mail.server");
+            return new TestableMarkdownMessageService(configurationService);
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -148,6 +148,8 @@
     <Compile Include="Infrastructure\Mail\Messages\OrganizationTransformRejectedMessageFacts.cs" />
     <Compile Include="Infrastructure\Mail\Messages\OrganizationTransformAcceptedMessageFacts.cs" />
     <Compile Include="Infrastructure\Mail\Messages\OrganizationMemberUpdatedMessageFacts.cs" />
+    <Compile Include="Infrastructure\Mail\TestableMarkdownMessageService.cs" />
+    <Compile Include="Infrastructure\Mail\TestMailSender.cs" />
     <Compile Include="Infrastructure\Mail\TestMessageServiceConfiguration.cs" />
     <Compile Include="Security\ControlRequiredSignerPolicyFacts.cs" />
     <Compile Include="Security\AutomaticallyOverwriteRequiredSignerPolicyFacts.cs" />

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Services\ActionRequiringEntityPermissionsFacts.cs" />
     <Compile Include="Services\CertificatesConfigurationFacts.cs" />
     <Compile Include="Services\CuratedFeedServiceFacts.cs" />
+    <Compile Include="Infrastructure\Mail\MarkdownMessageServiceFacts.cs" />
     <Compile Include="Services\TyposquattingCheckListCacheServiceFacts.cs" />
     <Compile Include="Services\TyposquattingServiceFacts.cs" />
     <Compile Include="Services\CloudDownloadCountServiceFacts.cs" />
@@ -241,7 +242,6 @@
     <Compile Include="Services\ContentServiceFacts.cs" />
     <Compile Include="TestUtils\Infrastructure\FeedServiceHelpers.cs" />
     <Compile Include="Services\FileSystemFileStorageServiceFacts.cs" />
-    <Compile Include="Services\MessageServiceFacts.cs" />
     <Compile Include="Services\ODataRemoveSorterFacts.cs" />
     <Compile Include="Services\PackageFileServiceFacts.cs" />
     <Compile Include="Services\PackageDeleteServiceFacts.cs" />


### PR DESCRIPTION
Whilst at it, refactored the `MarkdownMessageServiceTests` a bit and moved them next to the other email tests. The hotfix is within the ServerCommon dependency upgrade.