### PR TITLE
Add tool to upgrade gallery deployments to support SemVer2 feature

### DIFF
--- a/src/GalleryTools/Commands/UpdateIsLatestCommand.cs
+++ b/src/GalleryTools/Commands/UpdateIsLatestCommand.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.Services.Entities;
+using NuGetGallery;
+
+namespace GalleryTools.Commands
+{
+    public static class UpdateIsLatestCommand
+    {
+        public static void Configure(CommandLineApplication config)
+        {
+            config.Description = "Update IsLatest(Stable)(SemVer2) properties of all packages in the target NuGetGallery database. !!Please make sure you have created a back-up of your database first!!";
+            config.HelpOption("-? | -h | --help");
+
+            var connectionstringOption = config.Option(
+                "--connectionstring",
+                "The SQL connectionstring of the target NuGetGallery database.",
+                CommandOptionType.SingleValue);
+
+            config.OnExecute(async () => await Execute(connectionstringOption));
+        }
+
+        private static async Task<int> Execute(
+            CommandOption connectionStringOption)
+        {
+            if (!connectionStringOption.HasValue())
+            {
+                Console.Error.WriteLine($"The {connectionStringOption.Template} option is required.");
+                return 1;
+            }
+
+            Console.Write("Testing database connectivity...");
+
+            using (var sqlConnection = new SqlConnection(connectionStringOption.Value()))
+            {
+                try
+                {
+                    await sqlConnection.OpenAsync();
+                    Console.WriteLine(" OK");
+                }
+                catch (Exception exception)
+                {
+                    Console.WriteLine(" Failed");
+                    Console.Error.WriteLine(exception.Message);
+                    return -1;
+                }
+
+                var entitiesContext = new EntitiesContext(sqlConnection, readOnly: false);
+                var packageRegistrationRepository = new EntityRepository<PackageRegistration>(entitiesContext);
+
+                var packageService = new CorePackageService(
+                    new EntityRepository<Package>(entitiesContext),
+                    packageRegistrationRepository,
+                    new EntityRepository<Certificate>(entitiesContext));
+
+                Console.WriteLine("Retrieving package registrations...");
+                var packageRegistrations = packageRegistrationRepository.GetAll().ToList();
+                Console.WriteLine($"Processing {packageRegistrations.Count} records...");
+
+                double counter = 0;
+                foreach (var packageRegistration in packageRegistrations.OrderBy(pr => pr.Id))
+                {
+                    var pct = 100 * counter++ / packageRegistrations.Count;
+
+                    Console.Write($"  [{pct.ToString("N2")} %] Updating {packageRegistration.Id} ...");
+                    await packageService.UpdateIsLatestAsync(packageRegistration, commitChanges: true);
+                    Console.WriteLine($" OK");
+                }
+            }
+
+            Console.WriteLine("DONE");
+            return 0;
+        }
+    }
+}

--- a/src/GalleryTools/Commands/VerifyApiKeyCommand.cs
+++ b/src/GalleryTools/Commands/VerifyApiKeyCommand.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Services.Entities;
-using NuGetGallery;
 using NuGetGallery.Infrastructure.Authentication;
 
 namespace GalleryTools.Commands

--- a/src/GalleryTools/GalleryTools.csproj
+++ b/src/GalleryTools/GalleryTools.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Commands\BackfillRepositoryMetadataCommand.cs" />
     <Compile Include="Commands\HashCommand.cs" />
     <Compile Include="Commands\ReflowCommand.cs" />
+    <Compile Include="Commands\UpdateIsLatestCommand.cs" />
     <Compile Include="Commands\VerifyApiKeyCommand.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/GalleryTools/Program.cs
+++ b/src/GalleryTools/Program.cs
@@ -18,6 +18,7 @@ namespace GalleryTools
             commandLineApplication.Command("reflow", ReflowCommand.Configure);
             commandLineApplication.Command("fillrepodata", BackfillRepositoryMetadataCommand.Configure);
             commandLineApplication.Command("verifyapikey", VerifyApiKeyCommand.Configure);
+            commandLineApplication.Command("updateIsLatest", UpdateIsLatestCommand.Configure);
 
             try
             {


### PR DESCRIPTION
This adds a command to `GalleryTools.exe` to `updateIsLatest` on a target gallery database.

Main use case:
Properly set `IsLatest(Stable)SemVer2` after running the EF migrations against a gallery database that did not have SemVer2 support yet.

Usage:
```
gallerytools.exe updateIsLatest --connectionstring "value"
```

Screenshot:
![image](https://user-images.githubusercontent.com/880728/49222054-22152a80-f3db-11e8-8fe1-d7ef81a845f6.png)
