### PR TITLE
Limit release notes field to 35000 characters

### DIFF
--- a/src/NuGetGallery/Helpers/PackageHelper.cs
+++ b/src/NuGetGallery/Helpers/PackageHelper.cs
@@ -109,6 +109,10 @@ namespace NuGetGallery
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Summary", "4000");
             }
+            if (packageMetadata.ReleaseNotes != null && packageMetadata.ReleaseNotes.Length > 35000)
+            {
+                throw new EntityException(Strings.NuGetPackagePropertyTooLong, "ReleaseNotes", "35000");
+            }
             if (packageMetadata.Tags != null && packageMetadata.Tags.Length > 4000)
             {
                 throw new EntityException(Strings.NuGetPackagePropertyTooLong, "Tags", "4000");

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -544,6 +544,17 @@ namespace NuGetGallery
             }
 
             [Fact]
+            private async Task WillThrowIfTheNuGetPackageReleaseNotesIsLongerThan35000()
+            {
+                var service = CreateService();
+                var nugetPackage = PackageServiceUtility.CreateNuGetPackage(releaseNotes: "theReleaseNotes".PadRight(35001, '_'));
+
+                var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
+
+                Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "ReleaseNotes", "35000"), ex.Message);
+            }
+
+            [Fact]
             private async Task WillThrowIfTheVersionIsLongerThan64Characters()
             {
                 var service = CreateService();


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/1953.

35000 was picked by looking at the length of release notes on the most recently pushed package per ID. This number will not break users and protect us until we have further perf/UX information.

```sql
SELECT TOP 10
	pr.Id,
	p.NormalizedVersion,
	LEN(p.ReleaseNotes) AS ReleaseNotesLength,
	pr.LatestCreated,
	pr.TotalDownloadCount,
	p.DownloadCount AS LatestDownloadCount
FROM (
	SELECT pr.[Key], MAX(pr.[Id]) AS [Id], MAX(pr.DownloadCount) AS [TotalDownloadCount], MAX(p.Created) AS [LatestCreated]
	FROM Packages p
	INNER JOIN PackageRegistrations pr ON p.PackageRegistrationKey = pr.[Key]
	WHERE p.Listed = 1
	GROUP BY pr.[Key]
) pr
INNER JOIN Packages p ON p.Created = pr.LatestCreated AND p.PackageRegistrationKey = pr.[Key]
WHERE LEN(p.ReleaseNotes) > 4000
ORDER BY LEN(p.ReleaseNotes) DESC
```


Id | NormalizedVersion | ReleaseNotesLength | LatestCreated | TotalDownloadCount
-- | -- | -- | -- | --
Cuemon.Core.Package | 5.0.2018.310 | 33842 | 11/6/2018 | 5248
Vanara.PInvoke.Kernel32 | 2.0.0 | 32719 | 11/28/2018 | 2098
Cuemon.AspNetCore.Package | 5.0.2018.310 | 25999 | 11/6/2018 | 2872
CanJS.AMD | 2.1.3 | 20231 | 11/5/2014 | 4983
Cuemon.Core | 5.0.2018.310 | 18315 | 11/6/2018 | 2576
SpiseMisu.SemanticVersioning | 1.0.0 | 17988 | 12/16/2016 | 203
HangFire | 1.6.21 | 17346 | 11/1/2018 | 2728638
AnalyzeRe.Client | 1.37.6902.39691 | 17043 | 11/25/2018 | 37691
Cuemon.AspNetCore.Mvc | 5.0.2018.256 | 16182 | 10/30/2018 | 593
StudioShell.Provider | 1.6.4 | 14975 | 3/28/2014 | 1960

