### PR TITLE
Remove ‘deprecated’ text from the username/password login page

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -115,7 +115,7 @@
 {
     @AlertWarning(
     @<text>
-        NuGet.org password login is deprecated. Please use a Microsoft account to sign into NuGet gallery.
+        NuGet.org password login is no longer supported. Please use a Microsoft account to sign into NuGet gallery.
     </text>
     )
 }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -856,7 +856,7 @@ namespace NuGetGallery {
         ///
         ///[{0}]({0})
         ///
-        ///Note that NuGet.org password login is deprecated. Please use Microsoft account to sign into {1}.
+        ///Note that NuGet.org password login is no longer supported. Please use Microsoft account to sign into {1}.
         ///
         ///Thanks,
         ///The {1} Team.
@@ -884,7 +884,7 @@ namespace NuGetGallery {
         ///
         ///[{0}]({0})
         ///
-        ///Note that NuGet.org password login is deprecated. Please use Microsoft account to sign into {1}.
+        ///Note that NuGet.org password login is no longer supported. Please use Microsoft account to sign into {1}.
         ///
         ///Thanks,
         ///The {1} Team.

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -981,7 +981,7 @@ Click the following link within the next hour to reset your password:
 
 [{0}]({0})
 
-Note that NuGet.org password login is deprecated. Please use Microsoft account to sign into {1}.
+Note that NuGet.org password login is no longer supported. Please use Microsoft account to sign into {1}.
 
 Thanks,
 The {1} Team</value>
@@ -994,7 +994,7 @@ Click the following link within the next hour to set your password:
 
 [{0}]({0})
 
-Note that NuGet.org password login is deprecated. Please use Microsoft account to sign into {1}.
+Note that NuGet.org password login is no longer supported. Please use Microsoft account to sign into {1}.
 
 Thanks,
 The {1} Team</value>

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -214,11 +214,11 @@
                 <div class="@ViewHelpers.GetColumnClasses(ViewBag)" role="alert" aria-live="assertive">
                     @if (User.HasExternalLogin()) 
                     {
-                        @ViewHelpers.AlertWarning(@<text>NuGet.org password login is deprecated. Go to <a href="@Url.AccountSettings()">Account Settings</a> to disable your password login and use Microsoft account to sign in to the @(this.Config.Current.Brand).</text>)
+                        @ViewHelpers.AlertWarning(@<text>NuGet.org password login is no longer supported. Go to <a href="@Url.AccountSettings()">Account Settings</a> to disable your password login and use Microsoft account to sign in to the @(this.Config.Current.Brand).</text>)
                     }
                     else
                     {
-                        @ViewHelpers.AlertWarning(@<text>NuGet.org password login is deprecated. Go to <a href="@Url.AccountSettings()">Account Settings</a> and link a Microsoft account to sign in to the @(this.Config.Current.Brand).</text>)
+                        @ViewHelpers.AlertWarning(@<text>NuGet.org password login is no longer supported. Go to <a href="@Url.AccountSettings()">Account Settings</a> and link a Microsoft account to sign in to the @(this.Config.Current.Brand).</text>)
                     }
                 </div>
             </div>


### PR DESCRIPTION
Fixes #6722