### PR TITLE
Controller should redirect to licenses.nuget.org with license expression

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -677,6 +677,11 @@ namespace NuGetGallery
                 return HttpNotFound();
             }
 
+            if (!string.IsNullOrWhiteSpace(package.LicenseExpression))
+            {
+                return Redirect(LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(package.LicenseExpression));
+            }
+
             if (package.EmbeddedLicenseType == EmbeddedLicenseFileType.Absent)
             {
                 return HttpNotFound();

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -7138,6 +7138,31 @@ namespace NuGetGallery
                 Assert.IsType<HttpNotFoundResult>(result);
             }
 
+            [Theory]
+            [InlineData("MIT", "https://licenses.nuget.org/MIT")]
+            [InlineData("TestLicenseExpression", "https://licenses.nuget.org/TestLicenseExpression")]
+            public async Task GivenValidPackageWithLicenseExpressionRedirectToLicenseUrl(string licenseExpression, string expectedRedirectUrl)
+            {
+                // arrange
+                var package = new Package
+                {
+                    PackageRegistration = new PackageRegistration { Id = _packageId },
+                    Version = _packageVersion,
+                    LicenseExpression = licenseExpression
+                };
+
+                _packageService.Setup(p => p.FindPackageByIdAndVersionStrict(_packageId, _packageVersion)).Returns(package);
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: _packageService);
+
+                // act
+                var result = await controller.License(_packageId, _packageVersion);
+
+                // assert
+                ResultAssert.IsRedirectTo(result, expectedRedirectUrl);
+            }
+
             [Fact]
             public async Task GivenPackageWithoutLicenseFileReturns404()
             {


### PR DESCRIPTION
Controller should redirect to licenses.nuget.org with license expression.