### PR TITLE
License file package - License info should appear only after validation job and redirect to correct Url. 

### DIFF
--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -1267,6 +1267,20 @@ namespace NuGetGallery
                 });
         }
 
+        public static string License(this UrlHelper url, string id, string version, bool relativeUrl = true)
+        {
+            return GetActionLink(
+                url,
+                "License",
+                "Packages",
+                relativeUrl,
+                routeValues: new RouteValueDictionary
+                {
+                    { "id", id },
+                    { "version", version }
+                });
+        }
+
         public static string Terms(this UrlHelper url, bool relativeUrl = true)
         {
             if (!String.IsNullOrEmpty(_configuration.Current.ExternalTermsOfUseUrl))

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -62,6 +62,8 @@ namespace NuGetGallery
                 ProjectUrl = projectUrl;
             }
 
+            EmbeddedLicenseType = package.EmbeddedLicenseType;
+
             var licenseExpression = package.LicenseExpression;
             if (!string.IsNullOrWhiteSpace(licenseExpression))
             {
@@ -132,6 +134,7 @@ namespace NuGetGallery
         public string ProjectUrl { get; set; }
         public string LicenseUrl { get; set; }
         public IEnumerable<string> LicenseNames { get; set; }
+        public EmbeddedLicenseFileType EmbeddedLicenseType { get; set; }
 
         private IDictionary<User, string> _pushedByCache = new Dictionary<User, string>();
 

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using NuGet.Services.Entities;
 using NuGet.Services.Validation.Issues;
 using NuGet.Versioning;
-using NuGetGallery.Helpers;
 
 namespace NuGetGallery
 {
@@ -63,13 +62,9 @@ namespace NuGetGallery
             }
 
             EmbeddedLicenseType = package.EmbeddedLicenseType;
+            LicenseExpression = package.LicenseExpression;
 
-            var licenseExpression = package.LicenseExpression;
-            if (!string.IsNullOrWhiteSpace(licenseExpression))
-            {
-                LicenseUrl = LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(licenseExpression);
-            }
-            else if (PackageHelper.TryPrepareUrlForRendering(package.LicenseUrl, out string licenseUrl))
+            if (PackageHelper.TryPrepareUrlForRendering(package.LicenseUrl, out string licenseUrl))
             {
                 LicenseUrl = licenseUrl;
 
@@ -134,6 +129,7 @@ namespace NuGetGallery
         public string ProjectUrl { get; set; }
         public string LicenseUrl { get; set; }
         public IEnumerable<string> LicenseNames { get; set; }
+        public string LicenseExpression { get; set; }
         public EmbeddedLicenseFileType EmbeddedLicenseType { get; set; }
 
         private IDictionary<User, string> _pushedByCache = new Dictionary<User, string>();

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -182,11 +182,14 @@
                         validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
                     </text>
                 )
-                @ViewHelpers.AlertWarning(
+                if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
+                {
+                    @ViewHelpers.AlertWarning(
                     @<text>
                         <strong>The license link will become available once package validation has completed successfully.</strong>
                     </text>
-                )
+                    )
+                }
 
                 if (Model.ValidatingTooLong)
                 {
@@ -281,7 +284,7 @@
                     @ViewHelpers.AlertWarning(
                         @<text>
                             <strong>The symbols for this package have not been indexed yet.</strong> They are not available
-                            for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
+                            for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete. 
                             Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
                         </text>
                      )

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -13,6 +13,16 @@
 
     PackageManagerViewModel[] packageManagers;
 
+    if (!string.IsNullOrWhiteSpace(Model.LicenseExpression))
+    {
+        Model.LicenseUrl = LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(Model.LicenseExpression);
+    }
+
+    if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
+    {
+        Model.LicenseUrl = Url.License(Model.Id, Model.Version);
+    }
+
     if (Model.IsDotnetToolPackageType)
     {
         packageManagers = new PackageManagerViewModel[]
@@ -186,7 +196,7 @@
                 {
                     @ViewHelpers.AlertWarning(
                         @<text>
-                            <strong>The license link will become available once package validation has completed successfully.</strong>
+                            The license link will become available once package validation has completed successfully.
                         </text>
                     )
                 }
@@ -630,7 +640,7 @@
                     {
                         <li>
                             <i class="ms-Icon ms-Icon--Certificate" aria-hidden="true"></i>
-                            <a href="@(Model.EmbeddedLicenseType == EmbeddedLicenseFileType.Absent ? Model.LicenseUrl : Url.License(Model.Id, Model.Version))"
+                            <a href="@Model.LicenseUrl"
                                data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
                                 @if (Model.LicenseNames.AnySafe())
                                 {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -182,6 +182,11 @@
                         validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
                     </text>
                 )
+                @ViewHelpers.AlertWarning(
+                    @<text>
+                        <strong>The license link will become available once package validation has completed successfully.</strong>
+                    </text>
+                )
 
                 if (Model.ValidatingTooLong)
                 {
@@ -276,7 +281,7 @@
                     @ViewHelpers.AlertWarning(
                         @<text>
                             <strong>The symbols for this package have not been indexed yet.</strong> They are not available
-                            for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete. 
+                            for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
                             Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
                         </text>
                      )
@@ -618,19 +623,23 @@
                 }
                 @if (!Model.Deleted && Model.LicenseUrl != null)
                 {
-                    <li>
-                        <i class="ms-Icon ms-Icon--Certificate" aria-hidden="true"></i>
-                        <a href="@Model.LicenseUrl" data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
-                            @if (Model.LicenseNames.AnySafe())
-                            {
-                                @(string.Join(", ", Model.LicenseNames.Select(x => x + " License")))
-                            }
-                            else
-                            {
-                                @:License Info
-                            }
-                        </a>
-                    </li>
+                    if (Model.EmbeddedLicenseType == EmbeddedLicenseFileType.Absent || !Model.Validating)
+                    {
+                        <li>
+                            <i class="ms-Icon ms-Icon--Certificate" aria-hidden="true"></i>
+                            <a href="@(Model.EmbeddedLicenseType == EmbeddedLicenseFileType.Absent ? Model.LicenseUrl : Url.License(Model.Id, Model.Version))"
+                               data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
+                                @if (Model.LicenseNames.AnySafe())
+                                {
+                                    @(string.Join(", ", Model.LicenseNames.Select(x => x + " License")))
+                                }
+                                else
+                                {
+                                    @:License Info
+                                }
+                            </a>
+                        </li>
+                    }
                 }
                 <li>
                     <i class="ms-Icon ms-Icon--Mail" aria-hidden="true"></i>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -185,9 +185,9 @@
                 if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
                 {
                     @ViewHelpers.AlertWarning(
-                    @<text>
-                        <strong>The license link will become available once package validation has completed successfully.</strong>
-                    </text>
+                        @<text>
+                            <strong>The license link will become available once package validation has completed successfully.</strong>
+                        </text>
                     )
                 }
 

--- a/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
@@ -72,6 +72,30 @@ namespace NuGetGallery
             }
         }
 
+        public class TheLicenseMethod
+            : TestContainer
+        {
+            [Theory]
+            [InlineData("https://nuget.org", "TestPackageId", "1.0.0", "/packages/TestPackageId/1.0.0/License", true)]
+            [InlineData("https://nuget.org", "TestPackageId", "1.0.0", "https://nuget.org/packages/TestPackageId/1.0.0/License", false)]
+            [InlineData("https://localhost:66", "AnotherTestPackageId", "3.0.0", "/packages/AnotherTestPackageId/3.0.0/License", true)]
+            [InlineData("https://localhost:66", "AnotherTestPackageId", "3.0.0", "https://localhost:66/packages/AnotherTestPackageId/3.0.0/License", false)]
+            public void ReturnsCorrectLicenseLink(string siteRoot, string packageId, string packageVersion, string expectedUrl, bool relativeUrl)
+            {
+                // Arrange
+                var configurationService = GetConfigurationService();
+                configurationService.Current.SiteRoot = siteRoot;
+
+                var urlHelper = TestUtility.MockUrlHelper(siteRoot);
+
+                // Act
+                var result = urlHelper.License(packageId, packageVersion, relativeUrl);
+
+                // Assert
+                Assert.Equal(expectedUrl, result);
+            }
+        }
+
         public class ThePackageRegistrationTemplateHelperMethod
             : TestContainer
         {


### PR DESCRIPTION
License info link for package with license file should appear only after validation job, and it should redirect to the correct Url in Gallery.
Fix: https://github.com/NuGet/NuGetGallery/issues/6734