### PR TITLE
Fix for the Gallery unable to find license file if paths with backslashes are used

### DIFF
--- a/src/NuGetGallery.Core/Services/CoreLicenseFileService.cs
+++ b/src/NuGetGallery.Core/Services/CoreLicenseFileService.cs
@@ -72,7 +72,7 @@ namespace NuGetGallery
                     throw new InvalidOperationException("No license file specified in the nuspec");
                 }
 
-                var filename = packageMetadata.LicenseMetadata.License;
+                var filename = FileNameHelper.GetZipEntryPath(packageMetadata.LicenseMetadata.License);
                 var licenseFileEntry = packageArchiveReader.GetEntry(filename); // throws on non-existent file
                 using (var licenseFileStream = licenseFileEntry.Open())
                 {

--- a/src/NuGetGallery.Core/Services/FIleNameHelper.cs
+++ b/src/NuGetGallery.Core/Services/FIleNameHelper.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using NuGet.Services.Entities;
 
 namespace NuGetGallery
@@ -56,6 +57,26 @@ namespace NuGetGallery
                 id.ToLowerInvariant(),
                 version.ToLowerInvariant(),
                 extension);
+        }
+
+        /// <summary>
+        /// Enforces the correct file separators for passing paths to work with zip file entries.
+        /// </summary>
+        /// <remarks>
+        /// When client packs the nupkg, it enforces all zip file entries to use forward slashes.
+        /// At the same time, paths in nuspec can contain backslashes. This method fixes the separators
+        /// so those paths can be used to retrieve files from zip archive.
+        /// </remarks>
+        /// <param name="fileName">File name to fix.</param>
+        /// <returns>File path with proper path separators.</returns>
+        public static string GetZipEntryPath(string filePath)
+        {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            return filePath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
     }
 }

--- a/src/NuGetGallery.Core/Services/FIleNameHelper.cs
+++ b/src/NuGetGallery.Core/Services/FIleNameHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using NuGet.Common;
 using NuGet.Services.Entities;
 
 namespace NuGetGallery
@@ -63,9 +64,11 @@ namespace NuGetGallery
         /// Enforces the correct file separators for passing paths to work with zip file entries.
         /// </summary>
         /// <remarks>
-        /// When client packs the nupkg, it enforces all zip file entries to use forward slashes.
-        /// At the same time, paths in nuspec can contain backslashes. This method fixes the separators
-        /// so those paths can be used to retrieve files from zip archive.
+        /// When client packs the nupkg, it enforces all zip file entries to use forward slashes 
+        /// and relative paths.
+        /// At the same time, paths in nuspec can contain backslashes and start with dot. This
+        /// method fixes the separators so those paths can be used to retrieve files from zip
+        /// archive.
         /// </remarks>
         /// <param name="fileName">File name to fix.</param>
         /// <returns>File path with proper path separators.</returns>
@@ -76,7 +79,7 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(filePath));
             }
 
-            return filePath.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return PathUtility.StripLeadingDirectorySeparators(filePath);
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Services/CoreLicenseFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CoreLicenseFileServiceFacts.cs
@@ -164,13 +164,15 @@ namespace NuGetGallery.Services
                 Assert.Contains(LicenseFileName, ex.Message); // current implementation of the client does not properly set the FileName property
             }
 
-            [Fact]
-            public async Task SavesLicenseFile()
+            [Theory]
+            [InlineData("license.txt")]
+            [InlineData("foo\\bar.txt")]
+            [InlineData("foo/bar.txt")]
+            public async Task SavesLicenseFile(string licenseFilenName)
             {
                 var fileStorageSvc = new Mock<ICoreFileStorageService>();
                 var service = CreateService(fileStorageSvc);
-                const string LicenseFileName = "license.txt";
-                var packageStream = GeneratePackageAsync(LicenseFileName);
+                var packageStream = GeneratePackageAsync(licenseFilenName);
                 var package = PackageServiceUtility.CreateTestPackage();
                 package.EmbeddedLicenseType = EmbeddedLicenseFileType.PlainText;
                 var savedLicenseBytes = new byte[LicenseFileContents.Length];

--- a/tests/NuGetGallery.Core.Facts/TestUtils/TestPackage.cs
+++ b/tests/NuGetGallery.Core.Facts/TestUtils/TestPackage.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using ClientPackageType = NuGet.Packaging.Core.PackageType;
@@ -213,7 +214,7 @@ namespace NuGetGallery
                 if (licenseFileContents != null && licenseFilename != null)
                 {
                     // enforce directory separators the same way as the client (see PackageArchiveReader.GetStream)
-                    licenseFilename = licenseFilename.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                    licenseFilename = PathUtility.StripLeadingDirectorySeparators(licenseFilename);
                     var licenseEntry = packageArchive.CreateEntry(licenseFilename, CompressionLevel.Fastest);
                     using (var licenseStream = licenseEntry.Open())
                     {

--- a/tests/NuGetGallery.Core.Facts/TestUtils/TestPackage.cs
+++ b/tests/NuGetGallery.Core.Facts/TestUtils/TestPackage.cs
@@ -212,6 +212,8 @@ namespace NuGetGallery
 
                 if (licenseFileContents != null && licenseFilename != null)
                 {
+                    // enforce directory separators the same way as the client (see PackageArchiveReader.GetStream)
+                    licenseFilename = licenseFilename.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                     var licenseEntry = packageArchive.CreateEntry(licenseFilename, CompressionLevel.Fastest);
                     using (var licenseStream = licenseEntry.Open())
                     {

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -1046,6 +1046,26 @@ namespace NuGetGallery
                 Assert.Empty(result.Warnings);
             }
 
+            [Theory]
+            [InlineData("license/something.txt")]
+            [InlineData("license\\something.txt")]
+            public async Task AcceptsLicenseFileInSubdirectories(string licensePath)
+            {
+                _nuGetPackage = GeneratePackageWithLicense(
+                    licenseFilename: licensePath,
+                    licenseUrl: new Uri(LicenseDeprecationUrl),
+                    licenseFileContents: "some license");
+
+                var result = await _target.ValidateBeforeGeneratePackageAsync(
+                    _nuGetPackage.Object,
+                    GetPackageMetadata(_nuGetPackage));
+
+                Assert.Equal(PackageValidationResultType.Accepted, result.Type);
+                Assert.Null(result.Message);
+                Assert.Empty(result.Warnings);
+            }
+
+
             /// <summary>
             /// A (quite ineffective) method to search for a sequence in an array
             /// </summary>

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -14,6 +14,7 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Services.Entities;
 using NuGetGallery.Configuration;
+using NuGetGallery.Diagnostics;
 using NuGetGallery.Packaging;
 using NuGetGallery.TestUtils;
 using Xunit;
@@ -63,6 +64,10 @@ namespace NuGetGallery
 
             validationService = validationService ?? new Mock<IValidationService>();
             config = config ?? new Mock<IAppConfiguration>();
+            var diagnosticsService = new Mock<IDiagnosticsService>();
+            diagnosticsService
+                .Setup(ds => ds.GetSource(It.IsAny<string>()))
+                .Returns(Mock.Of<IDiagnosticsSource>());
 
             var packageUploadService = new Mock<PackageUploadService>(
                 packageService.Object,
@@ -73,7 +78,8 @@ namespace NuGetGallery
                 config.Object,
                 new Mock<ITyposquattingService>().Object,
                 Mock.Of<ITelemetryService>(),
-                Mock.Of<ICoreLicenseFileService>());
+                Mock.Of<ICoreLicenseFileService>(),
+                diagnosticsService.Object);
 
             return packageUploadService.Object;
         }
@@ -1048,7 +1054,9 @@ namespace NuGetGallery
 
             [Theory]
             [InlineData("license/something.txt")]
-            [InlineData("license\\something.txt")]
+            [InlineData("license\\anotherthing.txt")]
+            [InlineData(".\\license\\morething.txt")]
+            [InlineData("./license/lessthing.txt")]
             public async Task AcceptsLicenseFileInSubdirectories(string licensePath)
             {
                 _nuGetPackage = GeneratePackageWithLicense(
@@ -1797,7 +1805,7 @@ namespace NuGetGallery
             protected readonly Mock<ITyposquattingService> _typosquattingService;
             protected readonly Mock<ITelemetryService> _telemetryService;
             protected readonly Mock<ICoreLicenseFileService> _licenseFileService;
-
+            protected readonly Mock<IDiagnosticsService> _diagnosticsService;
             protected Package _package;
             protected Stream _packageFile;
             protected ArgumentException _unexpectedException;
@@ -1832,6 +1840,11 @@ namespace NuGetGallery
                 _conflictException = new FileAlreadyExistsException("Conflict!");
                 _token = CancellationToken.None;
                 _licenseFileService = new Mock<ICoreLicenseFileService>();
+                _diagnosticsService = new Mock<IDiagnosticsService>();
+
+                _diagnosticsService
+                    .Setup(ds => ds.GetSource(It.IsAny<string>()))
+                    .Returns(Mock.Of<IDiagnosticsSource>());
 
                 _target = new PackageUploadService(
                     _packageService.Object,
@@ -1842,7 +1855,8 @@ namespace NuGetGallery
                     _config.Object,
                     _typosquattingService.Object,
                     _telemetryService.Object,
-                    _licenseFileService.Object);
+                    _licenseFileService.Object,
+                    _diagnosticsService.Object);
             }
 
             protected static Mock<TestPackageReader> GeneratePackage(


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/6737.

Per zip file format [specification](http://www.pkware.com/documents/casestudies/APPNOTE.TXT) (4.4.17.1), only forward slashes can be used in paths inside zip file, but paths in nuspec can contain both forward and back slashes. So added code that fixes the paths before they are passed into `PackageArchiveReader`.

On the other hand, `ZipArchive` implementation in .net does not enforce forward slashes and allows to create zip files with backslashes in paths, so alternative pack implementations might exist that produce technically invalid zip files, not sure we want to support those though.