### PR TITLE
Fix latest download count, re: issue #6741

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -748,11 +748,18 @@
                     <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
                     @Model.TotalDownloadCount.ToNuGetNumberString() total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
                 </li>
-                <li>
-                    <i class="ms-Icon ms-Icon--Giftbox" aria-hidden="true"></i>
-                    @Model.PackageVersions.First().DownloadCount.ToNuGetNumberString() @(Model.PackageVersions.First().DownloadCount == 1 ? "download" : "downloads")
-                    of latest version
-                </li>
+                @{
+                    var latestListedPackage = Model.PackageVersions.FirstOrDefault(p => p.Listed);
+
+                    if (latestListedPackage != null)
+                    {
+                        <li>
+                            <i class="ms-Icon ms-Icon--Giftbox" aria-hidden="true"></i>
+                            @latestListedPackage.DownloadCount.ToNuGetNumberString() @(latestListedPackage.DownloadCount == 1 ? "download" : "downloads")
+                            of latest version
+                        </li>
+                    }
+                }
                 <li>
                     <i class="ms-Icon ms-Icon--Financial" aria-hidden="true"></i>
                     @Model.DownloadsPerDayLabel @(Model.DownloadsPerDayLabel == "1" || Model.DownloadsPerDayLabel == "<1" ? "download" : "downloads")

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -751,7 +751,7 @@
                 <li>
                     <i class="ms-Icon ms-Icon--Giftbox" aria-hidden="true"></i>
                     @Model.DownloadCount.ToNuGetNumberString() @(Model.DownloadCount == 1 ? "download" : "downloads")
-                    of latest version
+                    of current version
                 </li>
                 <li>
                     <i class="ms-Icon ms-Icon--Financial" aria-hidden="true"></i>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -748,18 +748,11 @@
                     <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
                     @Model.TotalDownloadCount.ToNuGetNumberString() total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
                 </li>
-                @{
-                    var latestListedPackage = Model.PackageVersions.FirstOrDefault(p => p.Listed);
-
-                    if (latestListedPackage != null)
-                    {
-                        <li>
-                            <i class="ms-Icon ms-Icon--Giftbox" aria-hidden="true"></i>
-                            @latestListedPackage.DownloadCount.ToNuGetNumberString() @(latestListedPackage.DownloadCount == 1 ? "download" : "downloads")
-                            of latest version
-                        </li>
-                    }
-                }
+                <li>
+                    <i class="ms-Icon ms-Icon--Giftbox" aria-hidden="true"></i>
+                    @Model.DownloadCount.ToNuGetNumberString() @(Model.DownloadCount == 1 ? "download" : "downloads")
+                    of latest version
+                </li>
                 <li>
                     <i class="ms-Icon ms-Icon--Financial" aria-hidden="true"></i>
                     @Model.DownloadsPerDayLabel @(Model.DownloadsPerDayLabel == "1" || Model.DownloadsPerDayLabel == "<1" ? "download" : "downloads")


### PR DESCRIPTION
Updated fix for issue #6741 from PR #6742.

Displays the latest listed package download count, or no package download count if there are no listed packages.
