### PR TITLE
Server-side performance fixes for Manage Packages page

### DIFF
--- a/src/NuGetGallery/Services/ActionRequiringEntityPermissions.cs
+++ b/src/NuGetGallery/Services/ActionRequiringEntityPermissions.cs
@@ -79,11 +79,9 @@ namespace NuGetGallery
                 possibleAccountsOnBehalfOf.AddRange(currentUser.Organizations.Select(o => o.Organization));
             }
 
-            possibleAccountsOnBehalfOf = possibleAccountsOnBehalfOf.Distinct(new UserEqualityComparer());
-
             var aggregateResult = PermissionsCheckResult.Unknown;
 
-            foreach (var accountOnBehalfOf in possibleAccountsOnBehalfOf)
+            foreach (var accountOnBehalfOf in possibleAccountsOnBehalfOf.Distinct(new UserEqualityComparer()))
             {
                 var result = CheckPermissions(currentUser, accountOnBehalfOf, entity);
                 aggregateResult = ChoosePermissionsCheckResult(aggregateResult, result);

--- a/src/NuGetGallery/Services/ActionRequiringEntityPermissions.cs
+++ b/src/NuGetGallery/Services/ActionRequiringEntityPermissions.cs
@@ -79,7 +79,7 @@ namespace NuGetGallery
                 possibleAccountsOnBehalfOf.AddRange(currentUser.Organizations.Select(o => o.Organization));
             }
 
-            possibleAccountsOnBehalfOf = possibleAccountsOnBehalfOf.Distinct(new UserEqualityComparer()).ToList();
+            possibleAccountsOnBehalfOf = possibleAccountsOnBehalfOf.Distinct(new UserEqualityComparer());
 
             var aggregateResult = PermissionsCheckResult.Unknown;
 


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6755

These fixes drastically improve the performance of the Manage Packages page.

1) Include `RequiredSigners` in the initial request for packages. Previously, the page was making a SQL request for every package in `ListPackageItemRequiredSignerViewModel`.

2) Exit the `ChecksPermissionsOnBehalfOfAnyAccount` call early. `ChecksPermissionsOnBehalfOfAnyAccount` has two implementations-- both return whether or not the action can be done on behalf of any owner, but one returns the list of owners the action can be done on behalf as well. To get the full list of owners the action can be done on behalf of, we were enumerating the full list of possible owners every time, even if we didn't care about which owners the action can be done on behalf of. By exiting the loop early when we don't care about the list, we drastically reduce the number of permissions checks that are done on accounts with many packages or packages with many co-owners.

Tested in against NuGetTestAccount on dev, **the page won't even load without the fixes**. NuGetTestAccount has around 30,000 packages, which is 6 times the number of packages owned by the `Microsoft` account.

With the fixes, I got page load times of:

![image](https://user-images.githubusercontent.com/18014088/49891606-c9428a80-fdfb-11e8-9cd8-fa7288d33b83.png)