### PR TITLE
Not saving markdown files with "text/markdown" anymore

### DIFF
--- a/src/NuGetGallery.Core/Services/CoreLicenseFileService.cs
+++ b/src/NuGetGallery.Core/Services/CoreLicenseFileService.cs
@@ -42,13 +42,7 @@ namespace NuGetGallery
 
             var fileName = BuildLicenseFileName(package);
 
-            // Gallery will generally ignore the content type on license files and will use the value from the DB,
-            // but we'll be nice and try to specify correct content type for them.
-            var contentType = package.EmbeddedLicenseType == EmbeddedLicenseFileType.Markdown
-                ? CoreConstants.MarkdownContentType
-                : CoreConstants.TextContentType;
-
-            return _fileStorageService.SaveFileAsync(_metadata.PackageContentFolderName, fileName, contentType, licenseFile, overwrite: true);
+            return _fileStorageService.SaveFileAsync(_metadata.PackageContentFolderName, fileName, CoreConstants.TextContentType, licenseFile, overwrite: true);
         }
 
         public async Task ExtractAndSaveLicenseFileAsync(Package package, Stream packageStream)

--- a/tests/NuGetGallery.Core.Facts/Services/CoreLicenseFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CoreLicenseFileServiceFacts.cs
@@ -93,7 +93,7 @@ namespace NuGetGallery.Services
 
             [Theory]
             [InlineData(EmbeddedLicenseFileType.PlainText, "text/plain")]
-            [InlineData(EmbeddedLicenseFileType.Markdown, "text/markdown")]
+            [InlineData(EmbeddedLicenseFileType.Markdown, "text/plain")]
             public async Task WillUseNormalizedRegularVersionIfNormalizedVersionMissing(EmbeddedLicenseFileType licenseFileType, string expectedContentType)
             {
                 var fileStorageSvc = new Mock<ICoreFileStorageService>();


### PR DESCRIPTION
Internally, we don't care about content type since we store type in DB, I just wanted to be nice and store markdown files with proper content type, unfortunately, at least Edge and Firefox try to save it when pointed to it instead of rendering as plain text, so we'll save as `text/plain` to provide better experience for users of those browsers.

Later, when we stop pointing to a blob directly, but render it inside Gallery, we can put proper content types back.