### PR TITLE
Add AccessConditionWrapper.GenerateIfNoneMatchCondition

### DIFF
--- a/src/NuGetGallery.Core/Services/AccessConditionWrapper.cs
+++ b/src/NuGetGallery.Core/Services/AccessConditionWrapper.cs
@@ -31,6 +31,13 @@ namespace NuGetGallery
                 ifMatchETag: AccessCondition.GenerateIfMatchCondition(etag).IfMatchETag);
         }
 
+        public static IAccessCondition GenerateIfNoneMatchCondition(string etag)
+        {
+            return new AccessConditionWrapper(
+                ifNoneMatchETag: AccessCondition.GenerateIfNoneMatchCondition(etag).IfNoneMatchETag,
+                ifMatchETag: null);
+        }
+
         public static IAccessCondition GenerateIfNotExistsCondition()
         {
             return new AccessConditionWrapper(

--- a/tests/NuGetGallery.Core.Facts/Services/AccessConditionWrapperFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/AccessConditionWrapperFacts.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Xunit;
 
 namespace NuGetGallery.Services
@@ -8,17 +9,23 @@ namespace NuGetGallery.Services
     public class AccessConditionWrapperFacts
     {
         [Theory]
-        [InlineData("*")]
-        [InlineData("\"some-etag\"")]
-        [InlineData("no quotes")]
-        [InlineData("")]
-        [InlineData(null)]
+        [MemberData(nameof(ETags))]
         public void GenerateIfMatchCondition(string etag)
         {
             var actual = AccessConditionWrapper.GenerateIfMatchCondition(etag);
 
             Assert.Equal(etag, actual.IfMatchETag);
             Assert.Null(actual.IfNoneMatchETag);
+        }
+
+        [Theory]
+        [MemberData(nameof(ETags))]
+        public void GenerateIfNoneMatchCondition(string etag)
+        {
+            var actual = AccessConditionWrapper.GenerateIfNoneMatchCondition(etag);
+
+            Assert.Null(actual.IfMatchETag);
+            Assert.Equal(etag, actual.IfNoneMatchETag);
         }
 
         [Fact]
@@ -38,5 +45,14 @@ namespace NuGetGallery.Services
             Assert.Null(actual.IfMatchETag);
             Assert.Null(actual.IfNoneMatchETag);
         }
+
+        public static IEnumerable<object[]> ETags => new[]
+        {
+            new object[] { "*" },
+            new object[] { "\"some-etag\"" },
+            new object[] { "no quotes" },
+            new object[] { "" },
+            new object[] { null },
+        };
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6449.

This supports no-oping by specifying `If-None-Match: (previous etag)` and reacting to HTTP 304 Not Modified.