### PR TITLE
License expression display in Gallery

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.ServiceRuntime;
 using NuGet.Services.Entities;
 using NuGet.Services.KeyVault;
+using NuGet.Services.Licenses;
 using NuGet.Services.Logging;
 using NuGet.Services.Messaging;
 using NuGet.Services.Messaging.Email;
@@ -343,6 +344,18 @@ namespace NuGetGallery
 
             builder.RegisterType<GalleryContentFileMetadataService>()
                 .As<IContentFileMetadataService>()
+                .InstancePerLifetimeScope();
+
+            builder.RegisterType<LicenseExpressionSplitter>()
+                .As<ILicenseExpressionSplitter>()
+                .InstancePerLifetimeScope();
+
+            builder.RegisterType<LicenseExpressionParser>()
+                .As<ILicenseExpressionParser>()
+                .InstancePerLifetimeScope();
+
+            builder.RegisterType<LicenseExpressionSegmentator>()
+                .As<ILicenseExpressionSegmentator>()
                 .InstancePerLifetimeScope();
 
             RegisterMessagingService(builder, configuration);

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -16,6 +16,7 @@ using System.Web.Caching;
 using System.Web.Mvc;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
+using NuGet.Services.Licenses;
 using NuGet.Services.Messaging.Email;
 using NuGet.Versioning;
 using NuGetGallery.Areas.Admin;
@@ -96,6 +97,7 @@ namespace NuGetGallery
         private readonly IDiagnosticsSource _trace;
         private readonly IFlatContainerService _flatContainerService;
         private readonly ICoreLicenseFileService _coreLicenseFileService;
+        private readonly ILicenseExpressionSplitter _licenseExpressionSplitter;
 
         public PackagesController(
             IPackageService packageService,
@@ -122,7 +124,8 @@ namespace NuGetGallery
             ISymbolPackageUploadService symbolPackageUploadService,
             IDiagnosticsService diagnosticsService,
             IFlatContainerService flatContainerService,
-            ICoreLicenseFileService coreLicenseFileService)
+            ICoreLicenseFileService coreLicenseFileService,
+            ILicenseExpressionSplitter licenseExpressionSplitter)
         {
             _packageService = packageService;
             _uploadFileService = uploadFileService;
@@ -149,6 +152,7 @@ namespace NuGetGallery
             _trace = diagnosticsService?.SafeGetSource(nameof(PackagesController)) ?? throw new ArgumentNullException(nameof(diagnosticsService));
             _flatContainerService = flatContainerService;
             _coreLicenseFileService = coreLicenseFileService ?? throw new ArgumentNullException(nameof(coreLicenseFileService));
+            _licenseExpressionSplitter = licenseExpressionSplitter ?? throw new ArgumentNullException(nameof(licenseExpressionSplitter));
         }
 
         [HttpGet]
@@ -623,6 +627,21 @@ namespace NuGetGallery
             model.IsCertificatesUIEnabled = _contentObjectService.CertificatesConfiguration?.IsUIEnabledForUser(currentUser) ?? false;
 
             model.ReadMeHtml = await _readMeService.GetReadMeHtmlAsync(package);
+
+            if (!string.IsNullOrWhiteSpace(package.LicenseExpression))
+            {
+                try
+                {
+                    model.LicenseExpressionSegments = _licenseExpressionSplitter.SplitExpression(package.LicenseExpression);
+                }
+                catch (Exception ex)
+                {
+                    // Any exception thrown while trying to render license expression beautifully
+                    // is not severe enough to break the client experience, view will fall back to
+                    // display license url.
+                    _telemetryService.TraceException(ex);
+                }
+            }
 
             var externalSearchService = _searchService as ExternalSearchService;
             if (_searchService.ContainsAllVersions && externalSearchService != null)

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2049,6 +2049,9 @@
     <PackageReference Include="Markdig.Signed">
       <Version>0.15.4</Version>
     </PackageReference>
+    <PackageReference Include="NuGet.Services.Licenses">
+      <Version>2.41.0-agr-licenses-2294033</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
     </PackageReference>

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Services.Entities;
+using NuGet.Services.Licenses;
 using NuGet.Services.Validation.Issues;
 using NuGet.Versioning;
 
@@ -130,6 +131,7 @@ namespace NuGetGallery
         public string LicenseUrl { get; set; }
         public IEnumerable<string> LicenseNames { get; set; }
         public string LicenseExpression { get; set; }
+        public IReadOnlyCollection<CompositeLicenseExpressionSegment> LicenseExpressionSegments { get; set; }
         public EmbeddedLicenseFileType EmbeddedLicenseType { get; set; }
 
         private IDictionary<User, string> _pushedByCache = new Dictionary<User, string>();

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -155,9 +155,9 @@
     </div>
 }
 
-@helper MakeLicenseLink(CompositeLicenseExpressionSegment segment) {<a href="@segment.Value">@segment.Value</a>}
+@* The following two helpers must be on a single line each so no extra whitespace is introduced in the expression when rendered. *@
+@helper MakeLicenseLink(CompositeLicenseExpressionSegment segment) {<a href="@LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(segment.Value)">@segment.Value</a>}
 @helper MakeLicenseSpan(CompositeLicenseExpressionSegment segment) {<span>@segment.Value</span>}
-
 
 <section role="main" class="container main-container page-package-details">
     <div class="row">

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1,4 +1,5 @@
-@using NuGet.Services.Validation;
+@using NuGet.Services.Validation
+@using NuGet.Services.Licenses
 
 @model DisplayPackageViewModel
 @{
@@ -66,6 +67,14 @@
                 InstallPackageCommand = string.Format("paket add {0} --version {1}", Model.Id, Model.Version),
             }
         };
+    }
+}
+
+@functions
+{
+    static bool IsLicenseOrException(CompositeLicenseExpressionSegment segment)
+    {
+        return segment.Type == CompositeLicenseExpressionSegmentType.LicenseIdentifier || segment.Type == CompositeLicenseExpressionSegmentType.ExceptionIdentifier;
     }
 }
 
@@ -145,6 +154,10 @@
         }
     </div>
 }
+
+@helper MakeLicenseLink(CompositeLicenseExpressionSegment segment) {<a href="@segment.Value">@segment.Value</a>}
+@helper MakeLicenseSpan(CompositeLicenseExpressionSegment segment) {<span>@segment.Value</span>}
+
 
 <section role="main" class="container main-container page-package-details">
     <div class="row">
@@ -638,8 +651,25 @@
                 {
                     if (Model.EmbeddedLicenseType == EmbeddedLicenseFileType.Absent || !Model.Validating)
                     {
-                        <li>
-                            <i class="ms-Icon ms-Icon--Certificate" aria-hidden="true"></i>
+                    <li>
+                        <i class="ms-Icon ms-Icon--Certificate" aria-hidden="true"></i>
+                        @if (Model.LicenseExpressionSegments.AnySafe())
+                        {
+                            @:License:
+                            foreach (var segment in Model.LicenseExpressionSegments)
+                            {
+                                if (IsLicenseOrException(segment))
+                                {
+                                    @MakeLicenseLink(segment);
+                                }
+                                else
+                                {
+                                    @MakeLicenseSpan(segment);
+                                }
+                            }
+                        }
+                        else
+                        {
                             <a href="@Model.LicenseUrl"
                                data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
                                 @if (Model.LicenseNames.AnySafe())
@@ -651,7 +681,8 @@
                                     @:License Info
                                 }
                             </a>
-                        </li>
+                        }
+                    </li>
                     }
                 }
                 <li>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -156,6 +156,7 @@
 }
 
 @* The following two helpers must be on a single line each so no extra whitespace is introduced in the expression when rendered. *@
+@* Helpers themselves are needed not to introduce that extra whitespce, which happens if they are inlined. *@
 @helper MakeLicenseLink(CompositeLicenseExpressionSegment segment) {<a href="@LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(segment.Value)">@segment.Value</a>}
 @helper MakeLicenseSpan(CompositeLicenseExpressionSegment segment) {<span>@segment.Value</span>}
 

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -2,6 +2,7 @@
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=152368
+
   NOTE: If you debug this on your local machine with IIS 7 then install the URL Rewrite Module
   http://www.iis.net/downloads/microsoft/url-rewrite
   -->

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -2,7 +2,6 @@
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=152368
-
   NOTE: If you debug this on your local machine with IIS 7 then install the URL Rewrite Module
   http://www.iis.net/downloads/microsoft/url-rewrite
   -->

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -16,6 +16,7 @@ using System.Web.Routing;
 using Moq;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
+using NuGet.Services.Licenses;
 using NuGet.Services.Messaging.Email;
 using NuGet.Services.Validation;
 using NuGet.Services.Validation.Issues;
@@ -67,7 +68,8 @@ namespace NuGetGallery
             Mock<IContentObjectService> contentObjectService = null,
             Mock<ISymbolPackageUploadService> symbolPackageUploadService = null,
             Mock<IFlatContainerService> flatContainerService = null,
-            Mock<ICoreLicenseFileService> coreLicenseFileService = null)
+            Mock<ICoreLicenseFileService> coreLicenseFileService = null,
+            Mock<ILicenseExpressionSplitter> licenseExpressionSplitter = null)
         {
             packageService = packageService ?? new Mock<IPackageService>();
             if (uploadFileService == null)
@@ -185,6 +187,8 @@ namespace NuGetGallery
                     .ReturnsAsync(() => new MemoryStream());
             }
 
+            licenseExpressionSplitter = licenseExpressionSplitter ?? new Mock<ILicenseExpressionSplitter>();
+
             var diagnosticsService = new Mock<IDiagnosticsService>();
             var controller = new Mock<PackagesController>(
                 packageService.Object,
@@ -211,7 +215,8 @@ namespace NuGetGallery
                 symbolPackageUploadService.Object,
                 diagnosticsService.Object,
                 flatContainerService.Object,
-                coreLicenseFileService.Object);
+                coreLicenseFileService.Object,
+                licenseExpressionSplitter.Object);
 
             controller.CallBase = true;
             controller.Object.SetOwinContextOverride(Fakes.CreateOwinContext());


### PR DESCRIPTION
Addresses NuGet/NuGetGallery#6721

Will update PR once https://github.com/NuGet/ServerCommon/pull/234 is merged and non-private builds of a new library are available.

![image](https://user-images.githubusercontent.com/102933/50704226-7e3b2200-100b-11e9-960b-2e6cbc8838c1.png)

Worse case:

![image](https://user-images.githubusercontent.com/102933/50704352-eab62100-100b-11e9-886f-d70e75d31c3f.png)

Should we put `<nobr>` (or set up css accordingly) around license names, so they are not split between lines?