### PR TITLE
Fix for non-bold labels on preview page

### DIFF
--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -134,7 +134,7 @@
             </div>
 
             <div class="verify-package-field">
-                <div class="verify-package-field-heading">Dependencies</div>
+                <label class="verify-package-field-heading">Dependencies</label>
                 <!-- ko if: $data.Dependencies && Object.keys($data.Dependencies.DependencySets).length > 0 -->
                 <div data-bind="template: {name: 'display-dependencysets', data: { DependencySets: Dependencies.DependencySets, OnlyHasAllFrameworks: Dependencies.OnlyHasAllFrameworks }}"></div>
                 <!-- /ko -->
@@ -188,7 +188,7 @@
 
             <!-- ko if: $data.IconUrl -->
             <div class="verify-package-field row">
-                <div class="verify-package-field-heading col-sm-12">Icon Preview</div>
+                <label class="verify-package-field-heading col-sm-12">Icon Preview</label>
                 <div id="icon-preview-container" class="col-sm-1">
                     <img class="package-icon img-responsive" id="icon-preview" aria-label="The icon of your package" data-bind="attr: { src: $data.IconUrl }" /> <!-- probably need to check this for safety-->
                 </div>
@@ -212,7 +212,7 @@
 
             <!-- ko if: $data.LicenseUrl -->
             <div class="verify-package-field">
-                <div class="verify-package-field-heading">Require License Acceptance</div>
+                <label class="verify-package-field-heading">Require License Acceptance</label>
                 <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.RequiresLicenseAcceptance }}"></div>
             </div>
             <!-- /ko -->


### PR DESCRIPTION
Some of the labels on verify package page are not bold:

![image](https://user-images.githubusercontent.com/102933/50669350-8480be00-0f79-11e9-8f94-19135f93b88e.png)

They were missing the `label` tag. This is the fix.