### PR TITLE
[PROPOSAL] Add "simulate error" endpoints to gallery for testing

### DIFF
--- a/src/NuGetGallery/App_Start/NuGetODataV2CuratedFeedConfig.cs
+++ b/src/NuGetGallery/App_Start/NuGetODataV2CuratedFeedConfig.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Net.Http;
 using System.Web.Http;
 using System.Web.Http.OData.Batch;
 using System.Web.Http.OData.Builder;
@@ -11,6 +12,7 @@ using System.Web.Http.OData.Routing.Conventions;
 using Microsoft.Data.Edm;
 using Microsoft.Data.Edm.Csdl;
 using Microsoft.Data.OData;
+using NuGetGallery.Controllers;
 using NuGetGallery.OData;
 using NuGetGallery.OData.Conventions;
 using NuGetGallery.OData.Routing;
@@ -67,6 +69,9 @@ namespace NuGetGallery
             var findPackagesAction = builder.Action("FindPackagesById");
             findPackagesAction.Parameter<string>("id");
             findPackagesAction.ReturnsCollectionFromEntitySet<V2FeedPackage>("Packages");
+
+            var simulateErrorAction = builder.Action(nameof(ODataV2CuratedFeedController.SimulateError));
+            simulateErrorAction.Parameter<string>("type");
 
             var model = builder.GetEdmModel();
             model.SetEdmVersion(new Version(1, 0));

--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -105,6 +105,11 @@ namespace NuGetGallery
                 new { controller = "Pages", action = "Contributors" });
 
             routes.MapRoute(
+                RouteName.PagesSimulateError,
+                "pages/simulate-error",
+                new { controller = "Pages", action = nameof(PagesController.SimulateError) });
+
+            routes.MapRoute(
                 RouteName.Policies,
                 "policies/{action}",
                 new { controller = "Pages" });
@@ -737,6 +742,11 @@ namespace NuGetGallery
                 RouteName.DownloadNuGetExe,
                 "nuget.exe",
                 new { controller = "Api", action = "GetNuGetExeApi" });
+
+            routes.MapRoute(
+                RouteName.ApiSimulateError,
+                "api/simulate-error",
+                new { controller = "Api", action = nameof(ApiController.SimulateError) });
         }
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -275,6 +275,12 @@ namespace NuGetGallery
             return new HttpStatusCodeWithBodyResult(HttpStatusCode.OK, "Gallery is Available");
         }
 
+        [HttpGet]
+        public virtual ActionResult SimulateError(SimulatedErrorType type = SimulatedErrorType.Exception)
+        {
+            return type.MapToMvcResult();
+        }
+
         [HttpPost]
         [ApiAuthorize]
         [ApiScopeRequired(NuGetScopes.PackagePush, NuGetScopes.PackagePushVersion)]

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.OData;
@@ -67,6 +69,20 @@ namespace NuGetGallery.Controllers
                 .InterceptWith(new NormalizeVersionInterceptor());
 
             return TrackedQueryResult(options, queryable, MaxPageSize, customQuery: true);
+        }
+
+        [HttpGet]
+        [CacheOutput(NoCache = true)]
+        public virtual HttpResponseMessage SimulateError(
+            string curatedFeedName,
+            [FromUri] string type = "Exception")
+        {
+            if (!Enum.TryParse<SimulatedErrorType>(type, out var parsedType))
+            {
+                parsedType = SimulatedErrorType.Exception;
+            }
+
+            return parsedType.MapToWebApiResult();
         }
 
         // /api/v2/curated-feed/curatedFeedName/Packages/$count?semVerLevel=

--- a/src/NuGetGallery/Controllers/PagesController.cs
+++ b/src/NuGetGallery/Controllers/PagesController.cs
@@ -148,5 +148,11 @@ namespace NuGetGallery
             }
             return View();
         }
+
+        [HttpGet]
+        public virtual ActionResult SimulateError(SimulatedErrorType type = SimulatedErrorType.Exception)
+        {
+            return type.MapToMvcResult();
+        }
     }
 }

--- a/src/NuGetGallery/Extensions/SimulatedErrorTypeExtensions.cs
+++ b/src/NuGetGallery/Extensions/SimulatedErrorTypeExtensions.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Web;
+using System.Web.Http;
+using System.Web.Mvc;
+
+namespace NuGetGallery
+{
+    public static class SimulatedErrorTypeExtensions
+    {
+        public static HttpResponseMessage MapToWebApiResult(this SimulatedErrorType type)
+        {
+            var message = type.GetMessage();
+            switch (type)
+            {
+                case SimulatedErrorType.Result400:
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        ReasonPhrase = message,
+                    };
+                case SimulatedErrorType.Result404:
+                    return new HttpResponseMessage(HttpStatusCode.NotFound)
+                    {
+                        ReasonPhrase = message,
+                    };
+                case SimulatedErrorType.Result500:
+                    return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                    {
+                        ReasonPhrase = message,
+                    };
+                case SimulatedErrorType.Result503:
+                    return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                    {
+                        ReasonPhrase = message,
+                    };
+                default:
+                    throw type.MapToException();
+            }
+        }
+
+        public static ActionResult MapToMvcResult(this SimulatedErrorType type)
+        {
+            var message = type.GetMessage();
+            switch (type)
+            {
+                case SimulatedErrorType.Result400:
+                    return new HttpStatusCodeResult(HttpStatusCode.BadRequest, message);
+                case SimulatedErrorType.Result404:
+                    return new HttpStatusCodeResult(HttpStatusCode.NotFound, message);
+                case SimulatedErrorType.Result500:
+                    return new HttpStatusCodeResult(HttpStatusCode.InternalServerError, message);
+                case SimulatedErrorType.Result503:
+                    return new HttpStatusCodeResult(HttpStatusCode.ServiceUnavailable, message);
+                default:
+                    throw type.MapToException();
+            }
+        }
+        public static string GetMessage(this SimulatedErrorType type)
+        {
+            return $"{nameof(SimulatedErrorType)} {type}";
+        }
+
+        public static Exception MapToException(this SimulatedErrorType type)
+        {
+            var message = type.GetMessage();
+            switch (type)
+            {
+                case SimulatedErrorType.HttpException400:
+                    return new HttpException(400, message);
+                case SimulatedErrorType.HttpException404:
+                    return new HttpException(404, message);
+                case SimulatedErrorType.HttpException500:
+                    return new HttpException(500, message);
+                case SimulatedErrorType.HttpException503:
+                    return new HttpException(503, message);
+                case SimulatedErrorType.HttpResponseException400:
+                    return new HttpResponseException(new HttpResponseMessage(HttpStatusCode.BadRequest)
+                    {
+                        ReasonPhrase = message,
+                    });
+                case SimulatedErrorType.HttpResponseException404:
+                    return new HttpResponseException(new HttpResponseMessage(HttpStatusCode.NotFound)
+                    {
+                        ReasonPhrase = message,
+                    });
+                case SimulatedErrorType.HttpResponseException500:
+                    return new HttpResponseException(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                    {
+                        ReasonPhrase = message,
+                    });
+                case SimulatedErrorType.HttpResponseException503:
+                    return new HttpResponseException(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                    {
+                        ReasonPhrase = message,
+                    });
+                case SimulatedErrorType.Exception:
+                    return new Exception(message);
+                case SimulatedErrorType.UserSafeException:
+                    return new UserSafeException(message);
+                case SimulatedErrorType.ReadOnlyMode:
+                    return new ReadOnlyModeException(message);
+                default:
+                    return new Exception("Unknown simulated error type.");
+            }
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -274,6 +274,7 @@
     <Compile Include="Extensions\RouteExtensions.cs" />
     <Compile Include="Extensions\ScopeExtensions.cs" />
     <Compile Include="Extensions\CredentialExtensions.cs" />
+    <Compile Include="Extensions\SimulatedErrorTypeExtensions.cs" />
     <Compile Include="Extensions\UserExtensions.cs" />
     <Compile Include="Filters\ApiScopeRequiredAttribute.cs" />
     <Compile Include="Filters\UIAuthorizeAttribute.cs" />
@@ -417,6 +418,7 @@
     <Compile Include="Migrations\201711021733062_ApiKeyOwnerScope.Designer.cs">
       <DependentUpon>201711021733062_ApiKeyOwnerScope.cs</DependentUpon>
     </Compile>
+    <Compile Include="RequestModels\SimulatedErrorType.cs" />
     <Compile Include="Security\AutomaticOverwriteRequiredSignerPolicy.cs" />
     <Compile Include="Security\ControlRequiredSignerPolicy.cs" />
     <Compile Include="Security\MicrosoftTeamSubscription.cs" />

--- a/src/NuGetGallery/RequestModels/SimulatedErrorType.cs
+++ b/src/NuGetGallery/RequestModels/SimulatedErrorType.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public enum SimulatedErrorType
+    {
+        Result400,
+        Result404,
+        Result500,
+        Result503,
+        HttpException400,
+        HttpException404,
+        HttpException500,
+        HttpException503,
+        HttpResponseException400,
+        HttpResponseException404,
+        HttpResponseException500,
+        HttpResponseException503,
+        Exception,
+        UserSafeException,
+        ReadOnlyMode,
+    }
+}

--- a/src/NuGetGallery/RouteName.cs
+++ b/src/NuGetGallery/RouteName.cs
@@ -100,5 +100,8 @@ namespace NuGetGallery
         public const string GetOrganizationCertificates = "GetOrganizationCertificates";
         public const string SetRequiredSigner = "SetRequiredSigner";
         public const string License = "License";
+        public const string ApiV2CuratedSimulateError = "api-v2curated-simulate-error";
+        public const string PagesSimulateError = "PagesSimulateError";
+        public const string ApiSimulateError = "ApiSimulateError";
     }
 }


### PR DESCRIPTION
This proposal is in regards to issue https://github.com/NuGet/NuGetGallery/issues/6601. We have seen strange behavior when it comes to how exceptions and non-success status codes are dealt with in the gallery. Right now we have very high Application Insights noise around HTTP 500s since some HTTP 400s get mapped to HTTP 500. This is bad since it is potentially hiding really HTTP 500s that we need to handle.

Also, we have certain experiences built around error cases. For example, in descending order of importance:

1. **Critical:** HTTP 400 reason phrase is used by to pass an error message to client. If these reason phrase or status stops working as expected, `nuget.exe push` experience is significantly degraded.
1. **Important:** Non-HTML response when `api/v2/Packages(Id='...',Version='...')` returns 404. This is contract. Returning our pretty HTML page here has unknown impact on clients.
1. **Nice to have:** pretty 400, 404, and 500 error pages on the website.

My proposal is to introduce three "simulate error" endpoints and add functional tests that assert these intended error behaviors and more, so that we can be sensitive to any unintended change. The reason I added three is because we have three different categories of controllers with regards to error handling:

1. MVC controllers that don't override `OnException`. I added an endpoint to `PagesController` but this behavior should be consistent across all of our non-OData controllers except `ApiController`.

1. MVC controllers that do override `OnException`. Right now this is just `ApiController`.

1. Web API controllers. These are the OData controllers. I added the endpoint to the curated feed controller to minimize visibility.

This PR just adds the endpoints. I will add the functional tests later.

I am comfortable with these endpoints being on all environments and think it's actually important that we run these tests on all environments since other configurations or APIM can be different from environment to environment. Essentially we have a pretty complex sandwich of stuff that we don't own in front of our app code so functional tests are important.