### PR TITLE
DisplayPackageViewModel.PackageVersions should not be enumerated multiple times

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -658,14 +658,8 @@ namespace NuGetGallery
             {
                 return HttpNotFound();
             }
-
-            var packageHistory = package
-                .PackageRegistration
-                .Packages
-                .ToList()
-                .OrderByDescending(p => new NuGetVersion(p.Version));
-
-            var model = new DisplayPackageViewModel(package, currentUser, packageHistory);
+            
+            var model = new DisplayPackageViewModel(package, currentUser);
 
             model.ValidatingTooLong = _validationService.IsValidatingTooLong(package);
             model.PackageValidationIssues = _validationService.GetLatestPackageValidationIssues(package);

--- a/src/NuGetGallery/ViewModels/DeletePackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DeletePackageViewModel.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery
     public class DeletePackageViewModel : DisplayPackageViewModel
     {
         public DeletePackageViewModel(Package package, User currentUser, IReadOnlyList<ReportPackageReason> reasons)
-            : base(package, currentUser, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)))
+            : base(package, currentUser)
         {
             DeletePackagesRequest = new DeletePackagesRequest
             {

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery
 {
     public class DisplayPackageViewModel : ListPackageItemViewModel
     {
-        public DisplayPackageViewModel(Package package, User currentUser, IOrderedEnumerable<Package> packageHistory)
+        public DisplayPackageViewModel(Package package, User currentUser)
             : this(package, currentUser, (string)null)
         {
             HasSemVer2Version = NuGetVersion.IsSemVer2;
@@ -23,7 +23,13 @@ namespace NuGetGallery
                 .Any(p => (p.HasUpperBound && p.MaxVersion.IsSemVer2) || (p.HasLowerBound && p.MinVersion.IsSemVer2));
 
             Dependencies = new DependencySetsViewModel(package.Dependencies);
-            PackageVersions = packageHistory.Select(p => new DisplayPackageViewModel(p, currentUser, GetPushedBy(p, currentUser)));
+
+            var packageHistory = package
+                .PackageRegistration
+                .Packages
+                .OrderByDescending(p => new NuGetVersion(p.Version))
+                .ToList();
+            PackageVersions = packageHistory.Select(p => new DisplayPackageViewModel(p, currentUser, GetPushedBy(p, currentUser))).ToList();
 
             PushedBy = GetPushedBy(package, currentUser);
             PackageFileSize = package.PackageFileSize;
@@ -42,7 +48,7 @@ namespace NuGetGallery
             }
         }
 
-        public DisplayPackageViewModel(Package package, User currentUser, string pushedBy)
+        private DisplayPackageViewModel(Package package, User currentUser, string pushedBy)
             : base(package, currentUser)
         {
             Copyright = package.Copyright;

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -87,7 +87,7 @@ namespace NuGetGallery
         public IReadOnlyList<ValidationIssue> PackageValidationIssues { get; set; }
         public IReadOnlyList<ValidationIssue> SymbolsPackageValidationIssues { get; set; }
         public DependencySetsViewModel Dependencies { get; set; }
-        public IEnumerable<DisplayPackageViewModel> PackageVersions { get; set; }
+        public IReadOnlyList<DisplayPackageViewModel> PackageVersions { get; set; }
         public string Copyright { get; set; }
         public string ReadMeHtml { get; set; }
         public DateTime? LastEdited { get; set; }

--- a/src/NuGetGallery/ViewModels/ManagePackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ManagePackageViewModel.cs
@@ -13,10 +13,7 @@ namespace NuGetGallery
     public class ManagePackageViewModel : DisplayPackageViewModel
     {
         public ManagePackageViewModel(Package package, User currentUser, IReadOnlyList<ReportPackageReason> reasons, UrlHelper url, string readMe)
-            : base(
-                  package, 
-                  currentUser, 
-                  package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)))
+            : base(package, currentUser)
         {
             IsCurrentUserAnAdmin = currentUser != null && currentUser.IsAdministrator;
             

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -50,6 +50,11 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0",
                 RepositoryUrl = repoUrl,
                 RepositoryType = repoType,
+                PackageRegistration = new PackageRegistration
+                {
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
             };
 
             var model = new DisplayPackageViewModel(package, null);
@@ -86,7 +91,12 @@ namespace NuGetGallery.ViewModels
             var package = new Package
             {
                 Version = "1.0.0",
-                ProjectUrl = projectUrl
+                ProjectUrl = projectUrl,
+                PackageRegistration = new PackageRegistration
+                {
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
             };
 
             var model = new DisplayPackageViewModel(package, null);
@@ -109,7 +119,12 @@ namespace NuGetGallery.ViewModels
             var package = new Package
             {
                 Version = "1.0.0",
-                LicenseUrl = licenseUrl
+                LicenseUrl = licenseUrl,
+                PackageRegistration = new PackageRegistration
+                {
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
             };
 
             var model = new DisplayPackageViewModel(package, null);
@@ -124,6 +139,11 @@ namespace NuGetGallery.ViewModels
                 LicenseUrl = "https://mylicense.com",
                 Version = "1.0.0",
                 LicenseNames = "l1,l2, l3 ,l4  ,  l5 ",
+                PackageRegistration = new PackageRegistration
+                {
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
             };
 
             var packageViewModel = new DisplayPackageViewModel(package, currentUser: null);

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -52,7 +52,7 @@ namespace NuGetGallery.ViewModels
                 RepositoryType = repoType,
             };
 
-            var model = new DisplayPackageViewModel(package, null, "test");
+            var model = new DisplayPackageViewModel(package, null);
             Assert.Equal(expectedKind, model.RepositoryType);
             Assert.Equal(expectedUrl, model.RepositoryUrl);
         }
@@ -89,7 +89,7 @@ namespace NuGetGallery.ViewModels
                 ProjectUrl = projectUrl
             };
 
-            var model = new DisplayPackageViewModel(package, null, "test");
+            var model = new DisplayPackageViewModel(package, null);
             Assert.Equal(expected, model.ProjectUrl);
         }
 
@@ -112,7 +112,7 @@ namespace NuGetGallery.ViewModels
                 LicenseUrl = licenseUrl
             };
 
-            var model = new DisplayPackageViewModel(package, null, "test");
+            var model = new DisplayPackageViewModel(package, null);
             Assert.Equal(expected, model.LicenseUrl);
         }
 
@@ -126,7 +126,7 @@ namespace NuGetGallery.ViewModels
                 LicenseNames = "l1,l2, l3 ,l4  ,  l5 ",
             };
 
-            var packageViewModel = new DisplayPackageViewModel(package, currentUser: null, pushedBy: "test");
+            var packageViewModel = new DisplayPackageViewModel(package, currentUser: null);
             Assert.Equal(new string[] { "l1", "l2", "l3", "l4", "l5" }, packageViewModel.LicenseNames);
         }
 
@@ -155,7 +155,7 @@ namespace NuGetGallery.ViewModels
                     new Package { Version = "1.0.10", PackageRegistration = package.PackageRegistration }
                 };
 
-            var packageVersions = new DisplayPackageViewModel(package, null, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)))
+            var packageVersions = new DisplayPackageViewModel(package, null)
                 .PackageVersions.ToList();
 
             // Descending
@@ -207,7 +207,7 @@ namespace NuGetGallery.ViewModels
                 });
             }
 
-            var viewModel = new DisplayPackageViewModel(package, null, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)));
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Descending
             Assert.NotNull(viewModel.LatestSymbolsPackage);
@@ -245,7 +245,7 @@ namespace NuGetGallery.ViewModels
 
             package.SymbolPackages = symbolPackageList;
 
-            var viewModel = new DisplayPackageViewModel(package, null, packageHistory: Enumerable.Empty<Package>().OrderBy(x => 1));
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             Assert.Equal(symbolPackageList[0], viewModel.LatestSymbolsPackage);
         }
@@ -282,10 +282,8 @@ namespace NuGetGallery.ViewModels
                     new Package { Version = "2.0.1", PackageRegistration = packageRegistration, DownloadCount = 140, Created = utcNow.AddDays(-3) }
                 };
 
-            var packageHistory = packageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version));
-
             // Act
-            var viewModel = new DisplayPackageViewModel(package, null, packageHistory);
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Assert
             Assert.Equal(daysSinceFirstPackageCreated, viewModel.TotalDaysSinceCreated);
@@ -314,7 +312,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package };
 
-            var viewModel = new DisplayPackageViewModel(package, null, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)));
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Act
             var label = viewModel.DownloadsPerDayLabel;
@@ -346,7 +344,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package };
 
-            var viewModel = new DisplayPackageViewModel(package, null, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)));
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Act
             var label = viewModel.DownloadsPerDayLabel;
@@ -394,7 +392,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package, otherPackage };
 
-            var viewModel = new DisplayPackageViewModel(package, null, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)));
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Act
             var hasNewerPrerelease = viewModel.HasNewerPrerelease;
@@ -441,7 +439,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package, otherPackage };
 
-            var viewModel = new DisplayPackageViewModel(package, null, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)));
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Act
             var hasNewerRelease = viewModel.HasNewerRelease;
@@ -480,7 +478,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package, otherPackage };
 
-            var viewModel = new DisplayPackageViewModel(package, null, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)));
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Act
             var hasNewerPrerelease = viewModel.HasNewerPrerelease;
@@ -520,7 +518,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package, otherPackage };
 
-            var viewModel = new DisplayPackageViewModel(package, null, package.PackageRegistration.Packages.OrderByDescending(p => new NuGetVersion(p.Version)));
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Act
             var hasNewerRelease = viewModel.HasNewerRelease;
@@ -536,10 +534,9 @@ namespace NuGetGallery.ViewModels
         {
             // Arrange
             var package = CreateTestPackage("1.0.0", dependencyVersion: versionSpec);
-            var history = package.PackageRegistration.Packages.OrderByDescending(p => p.Version);
 
             // Act
-            var viewModel = new DisplayPackageViewModel(package, null, history);
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Assert
             Assert.False(viewModel.HasSemVer2Dependency);
@@ -553,10 +550,9 @@ namespace NuGetGallery.ViewModels
         {
             // Arrange
             var package = CreateTestPackage("1.0.0", dependencyVersion: versionSpec);
-            var history = package.PackageRegistration.Packages.OrderByDescending(p => p.Version);
 
             // Act
-            var viewModel = new DisplayPackageViewModel(package, null, history);
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Assert
             Assert.True(viewModel.HasSemVer2Dependency);
@@ -570,10 +566,9 @@ namespace NuGetGallery.ViewModels
         {
             // Arrange
             var package = CreateTestPackage("1.0.0", dependencyVersion: versionSpec);
-            var history = package.PackageRegistration.Packages.OrderByDescending(p => p.Version);
 
             // Act
-            var viewModel = new DisplayPackageViewModel(package, null, history);
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Assert
             Assert.False(viewModel.HasSemVer2Dependency);
@@ -587,10 +582,9 @@ namespace NuGetGallery.ViewModels
         {
             // Arrange
             var package = CreateTestPackage(version);
-            var history = package.PackageRegistration.Packages.OrderByDescending(p => p.Version);
 
             // Act
-            var viewModel = new DisplayPackageViewModel(package, null, history);
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Assert
             Assert.False(viewModel.HasSemVer2Version);
@@ -604,10 +598,9 @@ namespace NuGetGallery.ViewModels
         {
             // Arrange
             var package = CreateTestPackage(version);
-            var history = package.PackageRegistration.Packages.OrderByDescending(p => p.Version);
 
             // Act
-            var viewModel = new DisplayPackageViewModel(package, null, history);
+            var viewModel = new DisplayPackageViewModel(package, null);
 
             // Assert
             Assert.True(viewModel.HasSemVer2Version);
@@ -717,7 +710,7 @@ namespace NuGetGallery.ViewModels
             [MemberData(nameof(Data))]
             public void ReturnsExpectedUser(Package package, User currentUser, string expected)
             {
-                var model = new DisplayPackageViewModel(package, currentUser, new[] { package }.OrderByDescending(p => new NuGetVersion(p.Version)));
+                var model = new DisplayPackageViewModel(package, currentUser);
 
                 Assert.Equal(expected, model.PushedBy);
             }


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6845

This PR adds a `ToList` to `DisplayPackageViewModel.PackageVersions`, which prevents it from be enumerated multiple times. Without this change, it is recalculated every time it is called, which is very expensive with many versions.

I also simplified the constructor by getting rid of the `packageHistory` parameter that was continually set to the same expression by all of our app code and by making the other constructor, which was only intended to be used by the other constructor, private.