### PR TITLE
PackagesController methods should handle SemVer2 and missing packages properly

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1292,7 +1292,7 @@ namespace NuGetGallery
         [RequiresAccountConfirmation("manage a package")]
         public virtual async Task<ActionResult> Manage(string id, string version = null)
         {
-            var package = _packageService.FindPackageByIdAndVersion(id, version);
+            var package = _packageService.FindPackageByIdAndVersion(id, version, SemVerLevelKey.SemVer2);
             if (package == null)
             {
                 return HttpNotFound();
@@ -1318,7 +1318,7 @@ namespace NuGetGallery
         [RequiresAccountConfirmation("delete a symbols package")]
         public virtual ActionResult DeleteSymbols(string id, string version)
         {
-            var package = _packageService.FindPackageByIdAndVersion(id, version);
+            var package = _packageService.FindPackageByIdAndVersion(id, version, SemVerLevelKey.SemVer2);
             if (package == null)
             {
                 return HttpNotFound();
@@ -1360,7 +1360,7 @@ namespace NuGetGallery
         [RequiresAccountConfirmation("reflow a package")]
         public virtual async Task<ActionResult> Reflow(string id, string version)
         {
-            var package = _packageService.FindPackageByIdAndVersion(id, version);
+            var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
 
             if (package == null)
             {
@@ -1395,7 +1395,7 @@ namespace NuGetGallery
         [RequiresAccountConfirmation("revalidate a package")]
         public virtual async Task<ActionResult> Revalidate(string id, string version)
         {
-            var package = _packageService.FindPackageByIdAndVersion(id, version);
+            var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
 
             if (package == null)
             {
@@ -1423,7 +1423,7 @@ namespace NuGetGallery
         [RequiresAccountConfirmation("revalidate a symbols package")]
         public virtual async Task<ActionResult> RevalidateSymbols(string id, string version)
         {
-            var package = _packageService.FindPackageByIdAndVersion(id, version);
+            var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
 
             if (package == null)
             {
@@ -1629,7 +1629,7 @@ namespace NuGetGallery
         [RequiresAccountConfirmation("edit a package")]
         public virtual async Task<JsonResult> Edit(string id, string version, VerifyPackageRequest formData, string returnUrl)
         {
-            var package = _packageService.FindPackageByIdAndVersion(id, version);
+            var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
             if (package == null)
             {
                 return Json(HttpStatusCode.NotFound, new[] { new JsonValidationMessage(string.Format(Strings.PackageWithIdAndVersionNotFound, id, version)) });

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1758,7 +1758,7 @@ namespace NuGetGallery
                 _packageRegistration.Owners.Add(owner);
 
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
-                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.Unknown, true))
+                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.SemVer2, true))
                     .Returns(_package).Verifiable();
 
                 var controller = CreateController(
@@ -1816,7 +1816,7 @@ namespace NuGetGallery
                 _packageRegistration.Owners.Add(owner);
 
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
-                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.Unknown, true))
+                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.SemVer2, true))
                     .Returns(_package).Verifiable();
 
                 var controller = CreateController(
@@ -1864,7 +1864,7 @@ namespace NuGetGallery
                 _packageRegistration.IsLocked = true;
 
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
-                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.Unknown, true))
+                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.SemVer2, true))
                     .Returns(_package).Verifiable();
 
                 var controller = CreateController(
@@ -1894,7 +1894,7 @@ namespace NuGetGallery
                 _package.HasReadMe = true;
 
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
-                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.Unknown, true))
+                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.SemVer2, true))
                     .Returns(_package).Verifiable();
 
                 var readMe = "markdown";
@@ -1933,7 +1933,7 @@ namespace NuGetGallery
                 _package.HasReadMe = false;
 
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
-                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.Unknown, true))
+                packageService.Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.SemVer2, true))
                     .Returns(_package).Verifiable();
                 
                 var readMeService = new Mock<IReadMeService>(MockBehavior.Strict);
@@ -2112,7 +2112,7 @@ namespace NuGetGallery
                 };
 
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
-                packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0.0", SemVerLevelKey.Unknown, true))
+                packageService.Setup(svc => svc.FindPackageByIdAndVersion("Foo", "1.0.0", SemVerLevelKey.SemVer2, true))
                     .Returns(package);
 
                 var controller = CreateController(GetConfigurationService(), packageService: packageService);
@@ -2132,7 +2132,7 @@ namespace NuGetGallery
 
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
                 packageService
-                    .Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.Unknown, true))
+                    .Setup(svc => svc.FindPackageByIdAndVersion(_packageId, _package.Version, SemVerLevelKey.SemVer2, true))
                     .Returns(_package).Verifiable();
 
                 controller = CreateController(
@@ -2626,7 +2626,7 @@ namespace NuGetGallery
                 package.PackageRegistration.Owners.Add(owner);
 
                 var packageService = new Mock<IPackageService>();
-                packageService.Setup(s => s.FindPackageByIdAndVersion(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<bool>()))
+                packageService.Setup(s => s.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns(package);
                 packageService.Setup(s => s.FindPackageRegistrationById(It.IsAny<string>()))
                     .Returns(package.PackageRegistration);
@@ -6496,11 +6496,9 @@ namespace NuGetGallery
 
                 _packageService = new Mock<IPackageService>();
                 _packageService
-                    .Setup(svc => svc.FindPackageByIdAndVersion(
+                    .Setup(svc => svc.FindPackageByIdAndVersionStrict(
                         It.IsAny<string>(),
-                        It.IsAny<string>(),
-                        It.IsAny<int?>(),
-                        It.IsAny<bool>()))
+                        It.IsAny<string>()))
                     .Returns(_package);
 
                 _validationService = new Mock<IValidationService>();
@@ -6546,11 +6544,9 @@ namespace NuGetGallery
             {
                 // Arrange
                 _packageService
-                    .Setup(svc => svc.FindPackageByIdAndVersion(
+                    .Setup(svc => svc.FindPackageByIdAndVersionStrict(
                         It.IsAny<string>(),
-                        It.IsAny<string>(),
-                        It.IsAny<int?>(),
-                        It.IsAny<bool>()))
+                        It.IsAny<string>()))
                     .Returns<Package>(null);
 
                 // Act
@@ -6588,11 +6584,9 @@ namespace NuGetGallery
 
                 _packageService = new Mock<IPackageService>();
                 _packageService
-                    .Setup(svc => svc.FindPackageByIdAndVersion(
+                    .Setup(svc => svc.FindPackageByIdAndVersionStrict(
                         It.IsAny<string>(),
-                        It.IsAny<string>(),
-                        It.IsAny<int?>(),
-                        It.IsAny<bool>()))
+                        It.IsAny<string>()))
                     .Returns(_package);
 
                 _validationService = new Mock<IValidationService>();
@@ -6642,11 +6636,9 @@ namespace NuGetGallery
             {
                 // Arrange
                 _packageService
-                    .Setup(svc => svc.FindPackageByIdAndVersion(
+                    .Setup(svc => svc.FindPackageByIdAndVersionStrict(
                         It.IsAny<string>(),
-                        It.IsAny<string>(),
-                        It.IsAny<int?>(),
-                        It.IsAny<bool>()))
+                        It.IsAny<string>()))
                     .Returns<Package>(null);
 
                 // Act


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6843

For some context, `FindPackageByIdAndVersion` is intended to be used when the consumer wants a package, but if the package does not exist, wants the latest version instead. If the consumer REQUIRES the exact package they are asking for, they should use `FindPackageByIdAndVersionStrict` instead.

Unfortunately, our endpoints here are not using these methods properly, and I've fixed two classes of issues here, including the issue above.

1. `FindPackageByIdAndVersion` only returns the latest semver 2.0 package if `SemVer2` is passed in. It defaults to returning only semver 1 packages. The gallery is a semver 2 client, and should always show semver 2 packages in its UI. Unfortunately, several of our `PackagesController` endpoints were not passing in `SemVer2`, so they do not properly show semver 2.0 packages in some cases. For example, for the manage package page, if the version in the URL does not exist, the page will default to the latest semver 1 package instead of the latest semver 2 package.

2. Sometimes, we were using `FindPackageByIdAndVersion` instead of `FindPackageByIdAndVersionStrict` when the latter is the clear intent. For example, if you are on the display package page for a package that was deleted and click reflow, the page will reflow the latest semver 1 package instead of the package you were intending to reflow.