### PR TITLE
Need to fetch the license file from Dev0 rather than Devlegacy for DEV. 

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -795,7 +795,7 @@ namespace NuGetGallery
 
                 var registration = builder.RegisterType(dependent.ImplementationType)
                     .WithParameter(new ResolvedParameter(
-                       (pi, ctx) => pi.ParameterType == typeof(IFileStorageService),
+                       (pi, ctx) => pi.ParameterType.IsAssignableFrom(typeof(IFileStorageService)),
                        (pi, ctx) => ctx.ResolveKeyed<IFileStorageService>(dependent.BindingKey)))
                     .AsSelf()
                     .As(dependent.InterfaceType);

--- a/src/NuGetGallery/App_Start/StorageDependent.cs
+++ b/src/NuGetGallery/App_Start/StorageDependent.cs
@@ -93,7 +93,7 @@ namespace NuGetGallery
                 Create<UploadFileService, IUploadFileService>(configuration.AzureStorage_Uploads_ConnectionString, isSingleInstance: false),
                 Create<RevalidationStateService, IRevalidationStateService>(configuration.AzureStorage_Revalidation_ConnectionString, isSingleInstance: false),
                 Create<FeatureFlagFileStorageService, IFeatureFlagStorageService>(configuration.AzureStorage_Content_ConnectionString, isSingleInstance: true),
-                Create<CoreLicenseFileService, ICoreLicenseFileService>(configuration.AzureStorage_Flatcontainer_ConnectionString, isSingleInstance: false)
+                Create<CoreLicenseFileService, ICoreLicenseFileService>(configuration.AzureStorage_FlatContainer_ConnectionString, isSingleInstance: false)
             };
 
             var connectionStringToBindingKey = dependents

--- a/src/NuGetGallery/App_Start/StorageDependent.cs
+++ b/src/NuGetGallery/App_Start/StorageDependent.cs
@@ -91,9 +91,9 @@ namespace NuGetGallery
                 Create<PackageFileService, IPackageFileService>(configuration.AzureStorage_Packages_ConnectionString, isSingleInstance: false),
                 Create<SymbolPackageFileService, ISymbolPackageFileService>(configuration.AzureStorage_Packages_ConnectionString, isSingleInstance: false),
                 Create<UploadFileService, IUploadFileService>(configuration.AzureStorage_Uploads_ConnectionString, isSingleInstance: false),
-                Create<CoreLicenseFileService, ICoreLicenseFileService>(configuration.AzureStorage_Packages_ConnectionString, isSingleInstance: false),
                 Create<RevalidationStateService, IRevalidationStateService>(configuration.AzureStorage_Revalidation_ConnectionString, isSingleInstance: false),
-                Create<FeatureFlagFileStorageService, IFeatureFlagStorageService>(configuration.AzureStorage_Content_ConnectionString, isSingleInstance: true)
+                Create<FeatureFlagFileStorageService, IFeatureFlagStorageService>(configuration.AzureStorage_Content_ConnectionString, isSingleInstance: true),
+                Create<CoreLicenseFileService, ICoreLicenseFileService>(configuration.AzureStorage_Flatcontainer_ConnectionString, isSingleInstance: false)
             };
 
             var connectionStringToBindingKey = dependents

--- a/src/NuGetGallery/App_Start/StorageDependent.cs
+++ b/src/NuGetGallery/App_Start/StorageDependent.cs
@@ -91,9 +91,9 @@ namespace NuGetGallery
                 Create<PackageFileService, IPackageFileService>(configuration.AzureStorage_Packages_ConnectionString, isSingleInstance: false),
                 Create<SymbolPackageFileService, ISymbolPackageFileService>(configuration.AzureStorage_Packages_ConnectionString, isSingleInstance: false),
                 Create<UploadFileService, IUploadFileService>(configuration.AzureStorage_Uploads_ConnectionString, isSingleInstance: false),
+                Create<CoreLicenseFileService, ICoreLicenseFileService>(configuration.AzureStorage_FlatContainer_ConnectionString, isSingleInstance: false),
                 Create<RevalidationStateService, IRevalidationStateService>(configuration.AzureStorage_Revalidation_ConnectionString, isSingleInstance: false),
-                Create<FeatureFlagFileStorageService, IFeatureFlagStorageService>(configuration.AzureStorage_Content_ConnectionString, isSingleInstance: true),
-                Create<CoreLicenseFileService, ICoreLicenseFileService>(configuration.AzureStorage_FlatContainer_ConnectionString, isSingleInstance: false)
+                Create<FeatureFlagFileStorageService, IFeatureFlagStorageService>(configuration.AzureStorage_Content_ConnectionString, isSingleInstance: true)
             };
 
             var connectionStringToBindingKey = dependents

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -53,6 +53,9 @@ namespace NuGetGallery.Configuration
         [DisplayName("AzureStorage.Packages.ConnectionString")]
         public string AzureStorage_Packages_ConnectionString { get; set; }
 
+        [DisplayName("AzureStorage.Flatcontainer.ConnectionString")]
+        public string AzureStorage_Flatcontainer_ConnectionString { get; set; }
+
         [DisplayName("AzureStorage.Statistics.ConnectionString")]
         public string AzureStorage_Statistics_ConnectionString { get; set; }
 

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -53,8 +53,8 @@ namespace NuGetGallery.Configuration
         [DisplayName("AzureStorage.Packages.ConnectionString")]
         public string AzureStorage_Packages_ConnectionString { get; set; }
 
-        [DisplayName("AzureStorage.Flatcontainer.ConnectionString")]
-        public string AzureStorage_Flatcontainer_ConnectionString { get; set; }
+        [DisplayName("AzureStorage.FlatContainer.ConnectionString")]
+        public string AzureStorage_FlatContainer_ConnectionString { get; set; }
 
         [DisplayName("AzureStorage.Statistics.ConnectionString")]
         public string AzureStorage_Statistics_ConnectionString { get; set; }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -66,6 +66,11 @@ namespace NuGetGallery.Configuration
         string AzureStorage_Packages_ConnectionString { get; set; }
 
         /// <summary>
+        /// The Azure Storage connection string used for flatcontainer, after upload.
+        /// </summary>
+        string AzureStorage_Flatcontainer_ConnectionString { get; set; }
+
+        /// <summary>
         /// The Azure Storage connection string used for statistics.
         /// </summary>
         string AzureStorage_Statistics_ConnectionString { get; set; }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -66,9 +66,9 @@ namespace NuGetGallery.Configuration
         string AzureStorage_Packages_ConnectionString { get; set; }
 
         /// <summary>
-        /// The Azure Storage connection string used for flatcontainer, after upload.
+        /// The Azure Storage connection string used for flatContainer, after upload.
         /// </summary>
-        string AzureStorage_Flatcontainer_ConnectionString { get; set; }
+        string AzureStorage_FlatContainer_ConnectionString { get; set; }
 
         /// <summary>
         /// The Azure Storage connection string used for statistics.

--- a/tests/NuGetGallery.Facts/App_Start/StorageDependentFacts.cs
+++ b/tests/NuGetGallery.Facts/App_Start/StorageDependentFacts.cs
@@ -102,6 +102,7 @@ namespace NuGetGallery
             Assert.Equal(typeToConnectionString[typeof(ContentService)], config.AzureStorage_Content_ConnectionString);
             Assert.Equal(typeToConnectionString[typeof(PackageFileService)], config.AzureStorage_Packages_ConnectionString);
             Assert.Equal(typeToConnectionString[typeof(UploadFileService)], config.AzureStorage_Uploads_ConnectionString);
+            Assert.Equal(typeToConnectionString[typeof(CoreLicenseFileService)], config.AzureStorage_FlatContainer_ConnectionString);
         }
 
         [Fact]
@@ -130,6 +131,8 @@ namespace NuGetGallery
             mock.Setup(x => x.AzureStorage_Content_ConnectionString).Returns("Content");
             mock.Setup(x => x.AzureStorage_Packages_ConnectionString).Returns("Packages");
             mock.Setup(x => x.AzureStorage_Uploads_ConnectionString).Returns("Uploads");
+            mock.Setup(x => x.AzureStorage_FlatContainer_ConnectionString).Returns("FlatContainer");
+
             return mock.Object;
         }
     }


### PR DESCRIPTION
For DEV blob storage, we have separate locations as "nugetdev0" and "nugetdevlegacy". V3 job will put the package with license file at "nugetdev0". However, gallery will go to "nugetdevlegacy" to fetch the license file, which is not there. So there is a need to let the gallery get the license file from "nugetdev0" in DEV.
Fix: https://github.com/NuGet/Engineering/issues/2119