### PR TITLE
Add FAQ links to account login error messages

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -659,4 +659,9 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
     {
         return segment.Type == CompositeLicenseExpressionSegmentType.LicenseIdentifier || segment.Type == CompositeLicenseExpressionSegmentType.ExceptionIdentifier;
     }
+
+    public static MvcHtmlString GetExternalUrlAnchorTag(string data, string link)
+    {
+        return MvcHtmlString.Create(UriExtensions.GetExternalUrlAnchorTag(data, link));
+    }
 }

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -500,8 +500,8 @@ namespace NuGetGallery
                 // The identity value contains cookie non-compliant charachters like `<, >`(eg: John Doe <john@doe.com>), and which would be treated 
                 // as an HTML tags, hence these need to be replaced before encoding, the URL characters need to be endcoded.
                 TempData["RawErrorMessage"] = string.Format(Strings.ChangeCredential_Failed,
-                    HttpUtility.UrlEncode(newCredential.Identity.Replace('<', '[').Replace('>', ']')),
-                    HttpUtility.UrlEncode(UriExtensions.GetExternalUrlElement("FAQs page", GalleryConstants.FAQLinks.MSALinkedToAnotherAccount)));
+                    newCredential.Identity.Replace('<', '[').Replace('>', ']'),
+                    UriExtensions.GetExternalUrlElement("FAQs page", GalleryConstants.FAQLinks.MSALinkedToAnotherAccount));
             }
 
             return SafeRedirect(returnUrl);

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -497,7 +497,7 @@ namespace NuGetGallery
             }
             else
             {
-                // The identity value contains cookie non-compliant charachters like `<, >`(eg: John Doe <john@doe.com>), and which would be treated 
+                // The identity value contains cookie non-compliant characters like `<, >`(eg: John Doe <john@doe.com>), and which would be treated 
                 // as an HTML tags, hence these need to be replaced before encoding, the URL characters need to be endcoded.
                 TempData["RawErrorMessage"] = string.Format(Strings.ChangeCredential_Failed,
                     newCredential.Identity.Replace('<', '[').Replace('>', ']'),

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -497,8 +497,11 @@ namespace NuGetGallery
             }
             else
             {
-                // The identity value contains cookie non-compliant characters like `<, >`(eg: John Doe <john@doe.com>), hence these need to be encoded
-                TempData["ErrorMessage"] = string.Format(Strings.ChangeCredential_Failed, HttpUtility.UrlEncode(newCredential.Identity));
+                // The identity value contains cookie non-compliant charachters like `<, >`(eg: John Doe <john@doe.com>), and which would be treated 
+                // as an HTML tags, hence these need to be replaced before encoding, the URL characters need to be endcoded.
+                TempData["RawErrorMessage"] = string.Format(Strings.ChangeCredential_Failed,
+                    HttpUtility.UrlEncode(newCredential.Identity.Replace('<', '[').Replace('>', ']')),
+                    HttpUtility.UrlEncode(UriExtensions.GetExternalUrlElement("FAQs page", GalleryConstants.FAQLinks.MSALinkedToAnotherAccount)));
             }
 
             return SafeRedirect(returnUrl);

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -497,11 +497,11 @@ namespace NuGetGallery
             }
             else
             {
-                // The identity value contains cookie non-compliant characters like `<, >`(eg: John Doe <john@doe.com>), and which would be treated 
-                // as an HTML tags, hence these need to be replaced before encoding, the URL characters need to be endcoded.
+                // The identity value contains cookie non-compliant characters like `<, >`(eg: John Doe <john@doe.com>), 
+                // These need to be replaced so that they are not treated as HTML tags
                 TempData["RawErrorMessage"] = string.Format(Strings.ChangeCredential_Failed,
-                    newCredential.Identity.Replace('<', '[').Replace('>', ']'),
-                    UriExtensions.GetExternalUrlElement("FAQs page", GalleryConstants.FAQLinks.MSALinkedToAnotherAccount));
+                    newCredential.Identity.Replace("<", "&lt;").Replace(">", "&gt;"),
+                    UriExtensions.GetExternalUrlAnchorTag("FAQs page", GalleryConstants.FAQLinks.MSALinkedToAnotherAccount));
             }
 
             return SafeRedirect(returnUrl);

--- a/src/NuGetGallery/GalleryConstants.cs
+++ b/src/NuGetGallery/GalleryConstants.cs
@@ -132,8 +132,13 @@ namespace NuGetGallery
 
         public static class FAQLinks
         {
-            public const string MSALinkedToAnotherAccount = "https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#microsoft-account-is-linked-with-another-nugetorg-account";
-            public const string EmailLinkedToAnotherMSAAccount = "https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#signing-in-with-microsoft-account-shows-me-my-email-is-linked-to-another-microsoft-account";
+            public const string NuGetFAQ = "https://aka.ms/nuget-faq";
+            public const string MSALinkedToAnotherAccount = "https://aka.ms/nuget-faq-msa-linked-another-account";
+            public const string EmailLinkedToAnotherMSAAccount = "https://aka.ms/nuget-faq-email-linked-another-msa";
+            public const string NuGetAccountManagement = "https://aka.ms/nuget-faq-account-management";
+            public const string NuGetChangeUsername = "https://aka.ms/nuget-faq-change-username";
+            public const string NuGetDeleteAccount = "https://aka.ms/nuget-faq-delete-account";
+            public const string TransformToOrganization = "https://aka.ms/nuget-faq-transform-org";
         }
     }
 }

--- a/src/NuGetGallery/GalleryConstants.cs
+++ b/src/NuGetGallery/GalleryConstants.cs
@@ -129,5 +129,11 @@ namespace NuGetGallery
             public const string ClientVersion = "ClientVersion";
             public const string Operation = "Operation";
         }
+
+        public static class FAQLinks
+        {
+            public const string MSALinkedToAnotherAccount = "https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#microsoft-account-is-linked-with-another-nugetorg-account";
+            public const string EmailLinkedToAnotherMSAAccount = "https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#signing-in-with-microsoft-account-shows-me-my-email-is-linked-to-another-microsoft-account";
+        }
     }
 }

--- a/src/NuGetGallery/Helpers/UriExtensions.cs
+++ b/src/NuGetGallery/Helpers/UriExtensions.cs
@@ -9,6 +9,8 @@ namespace NuGetGallery
 {
     public static class UriExtensions
     {
+        private static string ExternalLinkAnchorTagFormat = $"<a href=\"{{1}}\" target=\"_blank\">{{0}}</a>";
+
         public static bool IsHttpsProtocol(this Uri uri)
         {
             return uri.Scheme == Uri.UriSchemeHttps;
@@ -80,6 +82,11 @@ namespace NuGetGallery
 
             builder.Query = query.ToString();
             return builder.Uri.PathAndQuery;
+        }
+
+        public static string GetExternalUrlElement(string data, string link)
+        {
+            return string.Format(ExternalLinkAnchorTagFormat, data, link);
         }
     }
 }

--- a/src/NuGetGallery/Helpers/UriExtensions.cs
+++ b/src/NuGetGallery/Helpers/UriExtensions.cs
@@ -84,7 +84,7 @@ namespace NuGetGallery
             return builder.Uri.PathAndQuery;
         }
 
-        public static string GetExternalUrlElement(string data, string link)
+        public static string GetExternalUrlAnchorTag(string data, string link)
         {
             return string.Format(ExternalLinkAnchorTagFormat, data, link);
         }

--- a/src/NuGetGallery/Infrastructure/CookieTempDataProvider.cs
+++ b/src/NuGetGallery/Infrastructure/CookieTempDataProvider.cs
@@ -97,7 +97,7 @@ namespace NuGetGallery
                         continue;
                     }
 
-                    cookie[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                    cookie[item.Key] = HttpUtility.UrlEncode(Convert.ToString(item.Value, CultureInfo.InvariantCulture));
                 }
                 _httpContext.Response.Cookies.Add(cookie);
             }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -596,7 +596,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to update the Microsoft account with &apos;{0}&apos;. This could happen if it is already linked to another NuGet account. Contact support for more information..
+        ///   Looks up a localized string similar to Failed to update the Microsoft account with &apos;{0}&apos;. This could happen if it is already linked to another NuGet account. See {1} for more details..
         /// </summary>
         public static string ChangeCredential_Failed {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -697,7 +697,7 @@ For more information, please contact '{2}'.</value>
 If you would like to update the linked Microsoft account you can do so from the account settings page.</value>
   </data>
   <data name="ChangeCredential_Failed" xml:space="preserve">
-    <value>Failed to update the Microsoft account with '{0}'. This could happen if it is already linked to another NuGet account. Contact support for more information.</value>
+    <value>Failed to update the Microsoft account with '{0}'. This could happen if it is already linked to another NuGet account. See {1} for more details.</value>
   </data>
   <data name="ChangeCredential_NotAllowed" xml:space="preserve">
     <value>The change of Azure active directory account is not allowed by your organization(s): {0}. Please leave these organization(s) to change your login.</value>

--- a/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
+++ b/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
@@ -39,7 +39,7 @@
                                 The account with the email @Model.SignIn.UserNameOrEmail is linked to another Microsoft account.
                             </p>
                             <p class="text-center">
-                                Please refer to the <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#signing-in-with-microsoft-account-shows-me-my-email-is-linked-to-another-microsoft-account" target="_blank"> FAQs page</a>
+                                Please refer to the <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#signing-in-with-microsoft-account-shows-me-my-email-is-linked-to-another-microsoft-account" target="_blank">FAQs page</a>
                                 for steps to resolve this issue.
                             </p>
                             break;

--- a/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
+++ b/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
@@ -39,7 +39,7 @@
                                 The account with the email @Model.SignIn.UserNameOrEmail is linked to another Microsoft account.
                             </p>
                             <p class="text-center">
-                                Please refer to the <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#signing-in-with-microsoft-account-shows-me-my-email-is-linked-to-another-microsoft-account" target="_blank">FAQs page</a>
+                                Please refer to the  @(ViewHelpers.GetExternalUrlAnchorTag("FAQs page", GalleryConstants.FAQLinks.EmailLinkedToAnotherMSAAccount))
                                 for steps to resolve this issue.
                             </p>
                             break;

--- a/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
+++ b/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
@@ -39,7 +39,8 @@
                                 The account with the email @Model.SignIn.UserNameOrEmail is linked to another Microsoft account.
                             </p>
                             <p class="text-center">
-                                If you would like to update the linked Microsoft account you can do so from the account settings page.
+                                Please refer to the <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#signing-in-with-microsoft-account-shows-me-my-email-is-linked-to-another-microsoft-account" target="_blank"> FAQs page</a>
+                                for steps to resolve this issue.
                             </p>
                             break;
                         case AssociateExternalAccountViewModel.ExistingUserLinkingErrorType.AccountIsOrganization:
@@ -49,17 +50,21 @@
                             <p class="text-center">
                                 If you would like to manage the organization account, you must sign in as one of its admins.
                             </p>
+
+                            <p class="text-center">
+                                Please <a href="mailto:@Config.Current.GalleryOwner.Address">contact support</a> if you need more assistance.
+                            </p>
                             break;
                         default:
                             <p class="text-center">
                                 An unknown error occurred.
                             </p>
+
+                            <p class="text-center">
+                                Please <a href="mailto:@Config.Current.GalleryOwner.Address">contact support</a> if you need more assistance.
+                            </p>
                             break;
                     }
-
-                    <p class="text-center">
-                        Please <a href="mailto:@Config.Current.GalleryOwner.Address">contact support</a> if you need more assistance.
-                    </p>
                 }
             </div>
         </div>

--- a/src/NuGetGallery/Views/Pages/Contact.cshtml
+++ b/src/NuGetGallery/Views/Pages/Contact.cshtml
@@ -14,15 +14,15 @@
     </div>
     <div class="row">
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
-            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Having problems using a specific package?</h2>
+            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Having problems using a specific package on nuget.org?</h2>
             <p>
-                If you're having trouble installing a specific package, try contacting the owner of that package first.
-                You can reach them using the "Contact Owners" link on the package details page.
+                If you're having trouble installing or using a specific package, try contacting the owner of that package first.
+                You can reach them using the "Contact Owners" link on the package details page. Please note that nuget.org support cannot offer any assistance with regards to individual package issues.
             </p>
 
-            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Found a bug in NuGet or the website NuGet.org?</h2>
+            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Found a bug in NuGet or the website nuget.org?</h2>
             <p>
-                If you're having trouble with the <strong>NuGet.org Website</strong>,
+                If you're having trouble with the <strong>nuget.org website</strong>,
                 file a bug on the NuGet Gallery <a href="https://github.com/NuGet/NuGetGallery/issues">Issue Tracker</a>.
                 If you're having trouble with the <strong>NuGet client tools</strong> (the Visual Studio extension, NuGet.exe command line tool, .NET CLI restore etc.),
                 file a bug on the NuGet Client <a href="https://github.com/NuGet/Home/issues">Issue Tracker</a>.
@@ -31,25 +31,35 @@
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Is a package violating a license or otherwise abusive?</h2>
             <p>
                 If you feel that a package is violating the license of software you own or is violating our terms of service,
-                use the "Report Abuse" link on the package details page to report it directly to us.
+                use the "Report" link on the package details page to report it directly to us.
             </p>
 
-            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Want to change your NuGet.org username?</h2>
+            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Have trouble logging in to nuget.org with MSA/AAD logins?</h2>
             <p>
-                No need to contact support. Create a new user and transfer ownership of your packages to it.
+                Check out our <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#nugetorg-account-management" target="_blank">nuget.org account management</a> FAQ page for solutions.
             </p>
 
-            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Having issues working with NuGet.org?</h2>
+            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Want to change your nuget.org username?</h2>
+            <p>
+                No need to contact support. Check out the steps for <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#how-do-i-change-my-nugetorg-account-username" target="_blank">changing nuget.org username</a> on the FAQ page for resolution steps.
+            </p>
+
+            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Want to delete your nuget.org account?</h2>
+            <p>
+                No need to contact support. Check out the steps for <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#how-to-delete-my-nugetorg-account" target="_blank">deleting nuget.org account</a> on the FAQ page for resolution steps.
+            </p>
+
+            <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Having issues working with nuget.org?</h2>
             <p>
                 Before reaching out to NuGet support, check out the
-                <a href="https://docs.nuget.org/consume/nuget-faq#managing-packages-in-nuget.org"><abbr title="Frequently Asked Questions">FAQ</abbr></a>.
+                <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq"><abbr title="Frequently Asked Questions">FAQ</abbr></a>.
             </p>
 
             @if (!User.Identity.IsAuthenticated)
             {
                 <h2 class="ms-fontSize-xl ms-fontWeight-semibold">The above doesn't help? @Html.ActionLink("Sign in", "LogOn", new { controller = "Authentication", ReturnUrl = "/policies/Contact" }) to contact Support.</h2>
                 <p>
-                    Need help with your NuGet.org account? Please feel free to <span id="emailUs"></span>.
+                    Need help with your nuget.org account? Please feel free to <span id="emailUs"></span>.
                 </p>
             }
             else

--- a/src/NuGetGallery/Views/Pages/Contact.cshtml
+++ b/src/NuGetGallery/Views/Pages/Contact.cshtml
@@ -16,8 +16,8 @@
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Having problems using a specific package on nuget.org?</h2>
             <p>
-                If you're having trouble installing or using a specific package, try contacting the owner of that package first.
-                You can reach them using the "Contact Owners" link on the package details page. Please note that nuget.org does not offer any assistance for individual package issues.
+                Please note that nuget.org does not offer any assistance for individual package issues. If you're having trouble installing or using a specific package, try contacting the owner of that package first.
+                You can reach them using the "Contact Owners" link on the package details page.
             </p>
 
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Found a bug in NuGet or the website nuget.org?</h2>
@@ -36,23 +36,23 @@
 
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Have trouble logging in to nuget.org with MSA/AAD logins?</h2>
             <p>
-                Check out our <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#nugetorg-account-management" target="_blank">nuget.org account management</a> FAQ page for solutions.
+                Check out our @(ViewHelpers.GetExternalUrlAnchorTag("nuget.org account management", GalleryConstants.FAQLinks.NuGetAccountManagement)) FAQ page for solutions.
             </p>
 
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Want to change your nuget.org username?</h2>
             <p>
-                No need to contact support. Check out the steps for <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#how-do-i-change-my-nugetorg-account-username" target="_blank">changing nuget.org username</a> on the FAQ page for resolution steps.
+                No need to contact support. Check out the steps for @(ViewHelpers.GetExternalUrlAnchorTag("changing nuget.org username", GalleryConstants.FAQLinks.NuGetChangeUsername)) on the FAQ page for resolution steps.
+
             </p>
 
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Want to delete your nuget.org account?</h2>
             <p>
-                No need to contact support. Check out the steps for <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#how-to-delete-my-nugetorg-account" target="_blank">deleting nuget.org account</a> on the FAQ page for resolution steps.
+                No need to contact support. Check out the steps for @(ViewHelpers.GetExternalUrlAnchorTag("deleting nuget.org account", GalleryConstants.FAQLinks.NuGetDeleteAccount)) on the FAQ page for resolution steps.
             </p>
 
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Having issues working with nuget.org?</h2>
             <p>
-                Before reaching out to NuGet support, check out the
-                <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq"><abbr title="Frequently Asked Questions">FAQ</abbr></a>.
+                Before reaching out to NuGet support, check out the @(ViewHelpers.GetExternalUrlAnchorTag("FAQ", GalleryConstants.FAQLinks.NuGetFAQ)).
             </p>
 
             @if (!User.Identity.IsAuthenticated)

--- a/src/NuGetGallery/Views/Pages/Contact.cshtml
+++ b/src/NuGetGallery/Views/Pages/Contact.cshtml
@@ -17,7 +17,7 @@
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Having problems using a specific package on nuget.org?</h2>
             <p>
                 If you're having trouble installing or using a specific package, try contacting the owner of that package first.
-                You can reach them using the "Contact Owners" link on the package details page. Please note that nuget.org support cannot offer any assistance with regards to individual package issues.
+                You can reach them using the "Contact Owners" link on the package details page. Please note that nuget.org does not offer any assistance for individual package issues.
             </p>
 
             <h2 class="ms-fontSize-xl ms-fontWeight-semibold">Found a bug in NuGet or the website nuget.org?</h2>

--- a/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
+++ b/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
@@ -41,6 +41,7 @@
                     <span>Please link this account to your Microsoft account.</span>
                 }
                 <br /><br />
+                If you wish to convert this account to an <b>organization</b>. Please follow the steps given in our <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#how-to-transform-my-nugetorg-account-to-an-organization" target="_blank">FAQ page.</a>
                 <b>Note:</b> No changes will be made to your account except for the authentication mechanism.
             </div>
             <div class="action-node">

--- a/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
+++ b/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
@@ -41,7 +41,6 @@
                     <span>Please link this account to your Microsoft account.</span>
                 }
                 <br /><br />
-                If you wish to convert this account to an <b>organization</b>. Please follow the steps given in our <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#how-to-transform-my-nugetorg-account-to-an-organization" target="_blank">FAQ page.</a>
                 <b>Note:</b> No changes will be made to your account except for the authentication mechanism.
             </div>
             <div class="action-node">
@@ -51,6 +50,9 @@
                          @(!string.IsNullOrEmpty("~/Content/gallery/img/microsoft-account-24x24.png") ? (IHtmlString)ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/microsoft-account-24x24.png")) : new HtmlString(string.Empty)) />
                     <span>Sign in with Microsoft</span>
                 </button>
+            </div>
+            <div class="transform-text">
+                If you want to transform this account to an <a href="https://docs.microsoft.com/en-us/nuget/reference/organizations-on-nuget-org" target="_blank">organization</a>, please follow the steps on our <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#how-to-transform-my-nugetorg-account-to-an-organization" target="_blank">FAQ page.</a>
             </div>
         }
     </div>

--- a/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
+++ b/src/NuGetGallery/Views/Pages/_TransformOrLink.cshtml
@@ -52,7 +52,7 @@
                 </button>
             </div>
             <div class="transform-text">
-                If you want to transform this account to an <a href="https://docs.microsoft.com/en-us/nuget/reference/organizations-on-nuget-org" target="_blank">organization</a>, please follow the steps on our <a href="https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#how-to-transform-my-nugetorg-account-to-an-organization" target="_blank">FAQ page.</a>
+                If you want to transform this account to an @(ViewHelpers.GetExternalUrlAnchorTag("organization", "https://aka.ms/nugetorgs")), please follow the steps on our @(ViewHelpers.GetExternalUrlAnchorTag("FAQ page", GalleryConstants.FAQLinks.TransformToOrganization)).
             </div>
         }
     </div>

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -42,12 +42,12 @@
             @if (bold)
             {
                 @:<b>
-                }
+            }
             <span>@tab</span>
             @if (bold)
             {
-            @:</b>
-        }
+                @:</b>
+            }
         </a>
     </li>
 }

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -5,6 +5,7 @@
         && Request.IsAuthenticated
         && Config.Current.DeprecateNuGetPasswordLogins
         && User.HasPasswordLogin();
+    var rawErrorMessage = TempData.ContainsKey("RawErrorMessage") ? TempData["RawErrorMessage"].ToString() : null;
 }
 
 @if (!string.IsNullOrWhiteSpace(Config.Current.WarningBanner))
@@ -41,12 +42,12 @@
             @if (bold)
             {
                 @:<b>
-            }
+                }
             <span>@tab</span>
             @if (bold)
             {
-                @:</b>
-            }
+            @:</b>
+        }
         </a>
     </li>
 }
@@ -206,13 +207,26 @@
     </div>
 }
 
+@if (!string.IsNullOrEmpty(rawErrorMessage))
+{
+    <div class="alert-transient @(ViewBag.HasJumbotron == true ? "alert-transient-jumbotron" : string.Empty)">
+        <div class="container">
+            <div class="row">
+                <div class="@ViewHelpers.GetColumnClasses(ViewBag)" role="alert" aria-live="assertive">
+                    @ViewHelpers.AlertDanger(@<span>@Html.Raw(@rawErrorMessage)</span>)
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 @if (ShowPasswordDeprecationBanner)
 {
     <div class="alert-transient @(ViewBag.HasJumbotron == true ? "alert-transient-jumbotron" : string.Empty)">
         <div class="container">
             <div class="row">
                 <div class="@ViewHelpers.GetColumnClasses(ViewBag)" role="alert" aria-live="assertive">
-                    @if (User.HasExternalLogin()) 
+                    @if (User.HasExternalLogin())
                     {
                         @ViewHelpers.AlertWarning(@<text>NuGet.org password login is no longer supported. Go to <a href="@Url.AccountSettings()">Account Settings</a> to disable your password login and use Microsoft account to sign in to the @(this.Config.Current.Brand).</text>)
                     }

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -1282,7 +1282,7 @@ namespace NuGetGallery.Controllers
 
                 // Assert
                 ResultAssert.IsSafeRedirectTo(result, "theReturnUrl");
-                Assert.Equal(string.Format(Strings.ChangeCredential_Failed, identity), controller.TempData["ErrorMessage"]);
+                Assert.NotNull(controller.TempData["RawErrorMessage"]);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -1261,7 +1261,7 @@ namespace NuGetGallery.Controllers
                 // Arrange
                 GetMock<AuthenticationService>(); // Force a mock to be created
                 var controller = GetController<AuthenticationController>();
-                var identity = "Bloog";
+                var identity = "Bloog <bloog@blorg.com>";
                 var cred = new CredentialBuilder().CreateExternalCredential("MicrosoftAccount", "blorg", identity);
                 var serviceMock = GetMock<AuthenticationService>();
                 serviceMock
@@ -1286,7 +1286,7 @@ namespace NuGetGallery.Controllers
                 var errorMessage = controller.TempData["RawErrorMessage"];
                 var expectedMessage = string.Format(
                     Strings.ChangeCredential_Failed,
-                    identity.Replace("<", "&lgt;").Replace(">", "&gt;"),
+                    identity.Replace("<", "&lt;").Replace(">", "&gt;"),
                     UriExtensions.GetExternalUrlAnchorTag("FAQs page", GalleryConstants.FAQLinks.MSALinkedToAnotherAccount));
 
                 Assert.NotNull(errorMessage);

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -1282,7 +1282,15 @@ namespace NuGetGallery.Controllers
 
                 // Assert
                 ResultAssert.IsSafeRedirectTo(result, "theReturnUrl");
-                Assert.NotNull(controller.TempData["RawErrorMessage"]);
+                
+                var errorMessage = controller.TempData["RawErrorMessage"];
+                var expectedMessage = string.Format(
+                    Strings.ChangeCredential_Failed,
+                    identity.Replace("<", "&lgt;").Replace(">", "&gt;"),
+                    UriExtensions.GetExternalUrlAnchorTag("FAQs page", GalleryConstants.FAQLinks.MSALinkedToAnotherAccount));
+
+                Assert.NotNull(errorMessage);
+                Assert.Equal(expectedMessage, errorMessage);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Infrastructure/CookieTempDataProviderFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/CookieTempDataProviderFacts.cs
@@ -94,7 +94,7 @@ namespace NuGetGallery.Infrastructure
         public class TheSaveTempDataMethod
         {
             [Fact]
-            public void StoresValuesInCookie()
+            public void StoresValuesInCookieInEncodedFormat()
             {
                 var cookies = new HttpCookieCollection();
                 var httpContext = new Mock<HttpContextBase>();
@@ -115,9 +115,9 @@ namespace NuGetGallery.Infrastructure
                 Assert.True(cookies[0].HttpOnly);
                 Assert.True(cookies[0].Secure);
                 Assert.Equal(3, cookies[0].Values.Count);
-                Assert.Equal("Say hello to my little friend", cookies[0]["message"]);
-                Assert.Equal("123", cookies[0]["key2"]);
-                Assert.Equal("dumb&dumber?:;,isit", cookies[0]["key3"]);
+                Assert.Equal(HttpUtility.UrlEncode("Say hello to my little friend"), cookies[0]["message"]);
+                Assert.Equal(HttpUtility.UrlEncode("123"), cookies[0]["key2"]);
+                Assert.Equal(HttpUtility.UrlEncode("dumb&dumber?:;,isit"), cookies[0]["key3"]);
             }
 
             [Fact]


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/6777 https://github.com/NuGet/Engineering/issues/2071 https://github.com/NuGet/Engineering/issues/2066, I ended up dropping the idea that @agr used for validation messages, it is not straight forward to integrate it with `TempData`, main issue being `TempData` is stored in cookies and it can only be stored as strings. The full fledged support would include JSON serialization and Deserialization with cookie support which is a much larger change for addressing this issue. 

This PR introduces a new property `RawErrorMessage` in `TempData` which would be rendered as a RawHtml on the view side. We have to be careful when using this property for showing error messages making sure we do not format user data in this property. It is fine to be used as an absolute links to our documentation.

Also modified the contact page to include links to FAQ for common resolutions

![image](https://user-images.githubusercontent.com/1646506/52673427-9e48e580-2ed5-11e9-95e3-d3bd32e3054f.png)


![image](https://user-images.githubusercontent.com/1646506/52673334-4ad69780-2ed5-11e9-907a-62520826f923.png)

![image](https://user-images.githubusercontent.com/1646506/52676025-86755f80-2edd-11e9-8382-d7a32a3c70ef.png)

Added FAQ links to contact page:

![image](https://user-images.githubusercontent.com/1646506/52678666-4b782980-2ee7-11e9-8b8c-a87efb199fd2.png)
