### PR TITLE
Open license page for anyone. 

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -735,7 +735,6 @@ namespace NuGetGallery
         }
 
         [HttpGet]
-        [UIAuthorize]
         public virtual async Task<ActionResult> License(string id, string version)
         {
             var package = _packageService.FindPackageByIdAndVersionStrict(id, version);


### PR DESCRIPTION
Customers should check the license page without login. 
Fix: https://github.com/NuGet/Engineering/issues/2134