### PR TITLE
Add a feature flag for the atom feed and enable prerelease filtering

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -1,11 +1,14 @@
 {
   "Features": {
-    "NuGetGallery.Typosquatting": "Enabled"
+    "NuGetGallery.Typosquatting": "Enabled",
+    "NuGetGallery.PackagesAtomFeed": "Enabled"
   },
-
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {
-      "All": true
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
     }
   }
 }

--- a/src/NuGetGallery/Services/FeatureFlagService.cs
+++ b/src/NuGetGallery/Services/FeatureFlagService.cs
@@ -16,6 +16,8 @@ namespace NuGetGallery
         private const string TyposquattingFeatureName = GalleryPrefix + "Typosquatting";
         private const string TyposquattingFlightName = GalleryPrefix + "TyposquattingFlight";
 
+        private const string PackagesAtomFeedFeatureName = GalleryPrefix + "PackagesAtomFeed";
+
         private readonly IFeatureFlagClient _client;
 
         public FeatureFlagService(IFeatureFlagClient client)
@@ -31,6 +33,11 @@ namespace NuGetGallery
         public bool IsTyposquattingEnabled(User user)
         {
             return _client.IsEnabled(TyposquattingFlightName, user, defaultValue: false);
+        }
+
+        public bool IsPackagesAtomFeedEnabled()
+        {
+            return _client.IsEnabled(PackagesAtomFeedFeatureName, defaultValue: false);
         }
 
         private bool IsEnabled(string flight, User user, bool defaultValue)

--- a/src/NuGetGallery/Services/IFeatureFlagService.cs
+++ b/src/NuGetGallery/Services/IFeatureFlagService.cs
@@ -21,5 +21,12 @@ namespace NuGetGallery
         /// <param name="user"></param>
         /// <returns></returns>
         bool IsTyposquattingEnabled(User user);
+
+        /// <summary>
+        /// Whether the packages Atom feed is enabled. If true, users can subscribe to new package versions using a
+        /// feed reader on a per package ID basis.
+        /// </summary>
+        /// <returns></returns>
+        bool IsPackagesAtomFeedEnabled();
     }
 }

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -99,6 +99,7 @@ namespace NuGetGallery
         public bool HasSemVer2Version { get; }
         public bool HasSemVer2Dependency { get; }
         public bool IsDotnetToolPackageType { get; set; }
+        public bool IsAtomFeedEnabled { get; set; }
 
         public bool HasNewerPrerelease
         {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -86,7 +86,10 @@
     <meta property="og:determiner" content="a" />
     <meta property="og:image" content="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png"))" />
 
-    <link rel="alternate" type="application/atom+xml" title="Subscribe to @Model.Id updates" href="@Url.PackageAtomFeed(Model.Id)" />
+    @if (Model.IsAtomFeedEnabled)
+    {
+        <link rel="alternate" type="application/atom+xml" title="Subscribe to @Model.Id updates" href="@Url.PackageAtomFeed(Model.Id)" />
+    }
 }
 
 @helper VersionListDivider(int rowCount, bool versionsExpanded)
@@ -862,11 +865,14 @@ foreach (var owner in Model.Owners)
                              src="@Url.Absolute("~/Content/gallery/img/twitter.svg")"
                              @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/twitter-24x24.png")) />
                     </a>
-                    <a href="@Url.PackageAtomFeed(Model.Id)" data-track="atom-feed">
-                        <img width="24" height="24" alt="Use the Atom feed to subscribe to new versions of @Model.Id"
-                             src="@Url.Absolute("~/Content/gallery/img/rss.svg")"
-                             @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/rss-24x24.png")) />
-                    </a>
+                    @if (Model.IsAtomFeedEnabled)
+                    {
+                        <a href="@Url.PackageAtomFeed(Model.Id)" data-track="atom-feed">
+                            <img width="24" height="24" alt="Use the Atom feed to subscribe to new versions of @Model.Id"
+                                 src="@Url.Absolute("~/Content/gallery/img/rss.svg")"
+                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/rss-24x24.png")) />
+                        </a>
+                    }
                 </p>
             }
         </aside>


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/2992

If there is unexpected performance issues, we can use this as an escape hatch. Also plumb through the `prerel` parameter and give it a name consistent with the package search page.