### PR TITLE
Cleaning up upload container on failed sync validation

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -549,7 +549,6 @@ namespace NuGetGallery
             try
             {
                 packageContentData = await ValidateAndProcessPackageContents(currentUser, isSymbolsPackageUpload);
-
             }
             catch (Exception)
             {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -545,20 +545,70 @@ namespace NuGetGallery
             bool isSymbolsPackageUpload,
             bool hasExistingSymbolsPackageAvailable)
         {
+            var packageContentData = await ValidateAndProcessPackageContents(currentUser, isSymbolsPackageUpload);
+
+            if (packageContentData.ErrorResult != null)
+            {
+                await _uploadFileService.DeleteUploadFileAsync(currentUser.Key);
+                return packageContentData.ErrorResult;
+            }
+
+            var model = new VerifyPackageRequest(packageMetadata, accountsAllowedOnBehalfOf, existingPackageRegistration);
+            model.IsSymbolsPackage = isSymbolsPackageUpload;
+            model.HasExistingAvailableSymbols = hasExistingSymbolsPackageAvailable;
+            model.Warnings.AddRange(packageContentData.Warnings.Select(w => new JsonValidationMessage(w)));
+            model.LicenseFileContents = packageContentData.LicenseFileContents;
+            model.LicenseExpressionSegments = packageContentData.LicenseExpressionSegments;
+            return Json(model);
+        }
+
+        private class PackageContentData
+        {
+            public PackageContentData(
+                JsonResult errorResult)
+            {
+                ErrorResult = errorResult;
+            }
+
+            public PackageContentData(
+                PackageMetadata packageMetadata,
+                IReadOnlyList<IValidationMessage> warnings,
+                string licenseFileContents,
+                IReadOnlyCollection<CompositeLicenseExpressionSegmentViewModel> licenseExpressionSegments)
+            {
+                PackageMetadata = packageMetadata;
+                Warnings = warnings;
+                LicenseFileContents = licenseFileContents;
+                LicenseExpressionSegments = licenseExpressionSegments;
+            }
+
+            public JsonResult ErrorResult { get; }
+            public PackageMetadata PackageMetadata { get; }
+            public IReadOnlyList<IValidationMessage> Warnings { get; }
+            public string LicenseFileContents { get; }
+            public IReadOnlyCollection<CompositeLicenseExpressionSegmentViewModel> LicenseExpressionSegments { get; }
+        }
+
+        private async Task<PackageContentData> ValidateAndProcessPackageContents(User currentUser, bool isSymbolsPackageUpload)
+        {
             IReadOnlyList<IValidationMessage> warnings = new List<IValidationMessage>();
             string licenseFileContents = null;
             IReadOnlyCollection<CompositeLicenseExpressionSegmentViewModel> licenseExpressionSegments = null;
+            PackageMetadata packageMetadata = null;
+
             using (Stream uploadedFile = await _uploadFileService.GetUploadFileAsync(currentUser.Key))
             {
                 if (uploadedFile == null)
                 {
-                    return Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(Strings.UploadFileIsRequired) });
+                    return new PackageContentData(
+                        Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(Strings.UploadFileIsRequired) }));
                 }
 
                 var packageArchiveReader = await SafeCreatePackage(currentUser, uploadedFile);
                 if (packageArchiveReader == null)
                 {
-                    return Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(Strings.UploadFileIsRequired) });
+                    return new PackageContentData(
+                        Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(Strings.UploadFileIsRequired) }));
                 }
 
                 try
@@ -571,7 +621,8 @@ namespace NuGetGallery
                 {
                     _telemetryService.TraceException(ex);
 
-                    return Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(ex.GetUserSafeMessage()) });
+                    return new PackageContentData(
+                        Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(ex.GetUserSafeMessage()) }));
                 }
 
                 if (!isSymbolsPackageUpload)
@@ -580,7 +631,7 @@ namespace NuGetGallery
                     var validationJsonResult = GetJsonResultOrNull(validationResult);
                     if (validationJsonResult != null)
                     {
-                        return validationJsonResult;
+                        return new PackageContentData(validationJsonResult);
                     }
 
                     warnings = validationResult.Warnings;
@@ -595,17 +646,12 @@ namespace NuGetGallery
                 {
                     _telemetryService.TraceException(ex);
 
-                    return Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(ex.GetUserSafeMessage()) });
+                    return new PackageContentData(
+                        Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(ex.GetUserSafeMessage()) }));
                 }
             }
 
-            var model = new VerifyPackageRequest(packageMetadata, accountsAllowedOnBehalfOf, existingPackageRegistration);
-            model.IsSymbolsPackage = isSymbolsPackageUpload;
-            model.HasExistingAvailableSymbols = hasExistingSymbolsPackageAvailable;
-            model.Warnings.AddRange(warnings.Select(w => new JsonValidationMessage(w)));
-            model.LicenseFileContents = licenseFileContents;
-            model.LicenseExpressionSegments = licenseExpressionSegments;
-            return Json(model);
+            return new PackageContentData(packageMetadata, warnings, licenseFileContents, licenseExpressionSegments);
         }
 
         private IReadOnlyCollection<CompositeLicenseExpressionSegmentViewModel> GetLicenseExpressionSegmentsOrNull(LicenseMetadata licenseMetadata)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -545,7 +545,17 @@ namespace NuGetGallery
             bool isSymbolsPackageUpload,
             bool hasExistingSymbolsPackageAvailable)
         {
-            var packageContentData = await ValidateAndProcessPackageContents(currentUser, isSymbolsPackageUpload);
+            PackageContentData packageContentData = null;
+            try
+            {
+                packageContentData = await ValidateAndProcessPackageContents(currentUser, isSymbolsPackageUpload);
+
+            }
+            catch (Exception)
+            {
+                await _uploadFileService.DeleteUploadFileAsync(currentUser.Key);
+                throw;
+            }
 
             if (packageContentData.ErrorResult != null)
             {

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -4577,6 +4577,45 @@ namespace NuGetGallery
                 Assert.Equal(expectedMessage, (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
 
+            [Fact]
+            public async Task WillCleanupUploadContainerOnErrorsFoundBeforeGeneratePackage()
+            {
+                var expectedMessage = "Bad package.";
+                var fakeUploadedFile = new Mock<HttpPostedFileBase>();
+                fakeUploadedFile
+                    .Setup(x => x.FileName)
+                    .Returns(PackageId + ".nupkg");
+                Stream fakeFileStream = TestPackage.CreateTestPackageStream(PackageId, PackageVersion);
+                fakeUploadedFile
+                    .Setup(x => x.InputStream)
+                    .Returns(fakeFileStream);
+                var fakeUploadFileService = new Mock<IUploadFileService>();
+                fakeUploadFileService
+                    .Setup(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key))
+                    .Returns(Task.FromResult(0));
+                fakeUploadFileService
+                    .SetupSequence(x => x.GetUploadFileAsync(TestUtility.FakeUser.Key))
+                    .Returns(Task.FromResult<Stream>(null))
+                    .Returns(Task.FromResult(fakeFileStream));
+                fakeUploadFileService
+                    .Setup(x => x.SaveUploadFileAsync(TestUtility.FakeUser.Key, It.IsAny<Stream>())).Returns(Task.FromResult(0));
+
+                var fakePackageUploadService = GetValidPackageUploadService(PackageId, PackageVersion);
+                fakePackageUploadService
+                    .Setup(x => x.ValidateBeforeGeneratePackageAsync(It.IsAny<PackageArchiveReader>(), It.IsAny<PackageMetadata>()))
+                    .ReturnsAsync(PackageValidationResult.Invalid(expectedMessage));
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    uploadFileService: fakeUploadFileService,
+                    packageUploadService: fakePackageUploadService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
+
+                fakeUploadFileService
+                    .Verify(x => x.DeleteUploadFileAsync(TestUtility.FakeUser.Key), Times.Once);
+            }
 
             [Fact]
             public async Task WillShowValidationWarningsFoundBeforeGeneratePackage()


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/6570

Moved package contents processing (opening package, validating metadata, getting the license data) into separate method `ValidateAndProcessPackageContents`. Added code that if that method returns error the package is deleted from the upload container, preventing the situation when Gallery tries to resume package upload for a package that was deemed invalid.