### PR TITLE
ManagePackageViewModel should not be dependent on DisplayPackageViewModel

### DIFF
--- a/src/NuGetGallery.Core/NuGetVersionExtensions.cs
+++ b/src/NuGetGallery.Core/NuGetVersionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Text.RegularExpressions;
 using NuGet.Versioning;
 
@@ -20,7 +19,7 @@ namespace NuGetGallery
             return parsed.ToNormalizedString();
         }
 
-        public static string ToFullStringOrFallback(string version, string fallback = "")
+        public static string ToFullString(string version)
         {
             NuGetVersion nugetVersion;
             if (NuGetVersion.TryParse(version, out nugetVersion))
@@ -29,7 +28,7 @@ namespace NuGetGallery
             }
             else
             {
-                return fallback;
+                return version;
             }
         }
     }

--- a/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
+++ b/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
@@ -31,15 +31,15 @@
                 }
 
                 var version = _viewModel.Versions[selectedVersion];
-                var cachedReadMe = version.readMe;
+                var cachedReadMe = version.ReadMe;
                 if (cachedReadMe === null) {
-                    var url = version.getReadMe;
+                    var url = version.GetReadMeUrl;
                     $.ajax({
                         url: url,
                         type: 'GET',
                         statusCode: {
                             200: function (data) {
-                                version.readMe = data;
+                                version.ReadMe = data;
                                 _viewModel.Edit = data;
                                 bindData(_viewModel);
                             },
@@ -89,7 +89,7 @@
                     return;
                 }
 
-                var url = _viewModel.Versions[selectedVersion].submit;
+                var url = _viewModel.Versions[selectedVersion].SubmitUrl;
                 $.ajax({
                     url: url,
                     type: 'POST',

--- a/src/NuGetGallery/ViewModels/ManagePackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ManagePackageViewModel.cs
@@ -42,15 +42,21 @@ namespace NuGetGallery
             VersionReadMeStateDictionary = new Dictionary<string, VersionReadMeState>();
             var submitUrlTemplate = url.PackageVersionActionTemplate("Edit");
             var getReadMeUrlTemplate = url.PackageVersionActionTemplate("GetReadMeMd");
+            string defaultSelectedVersion = null;
             foreach (var versionSelectPackage in versionSelectPackages)
             {
-                var text = NuGetVersionFormatter.Normalize(versionSelectPackage.Version) + (versionSelectPackage.IsLatestStableSemVer2 ? " (Latest)" : string.Empty);
-                var value = versionSelectPackage.Version;
+                var text = NuGetVersionFormatter.ToFullString(versionSelectPackage.Version) + (versionSelectPackage.IsLatestSemVer2 ? " (Latest)" : string.Empty);
+                var value = NuGetVersionFormatter.Normalize(versionSelectPackage.Version);
                 versionSelectListItems.Add(new SelectListItem
                 {
                     Text = text,
                     Value = value
                 });
+
+                if (versionSelectPackage == package)
+                {
+                    defaultSelectedVersion = value;
+                }
 
                 VersionListedStateDictionary.Add(
                     value, 
@@ -69,7 +75,7 @@ namespace NuGetGallery
                 versionSelectListItems,
                 nameof(SelectListItem.Value),
                 nameof(SelectListItem.Text),
-                package.Version);
+                defaultSelectedVersion);
 
             // Update edit model with the readme.md data.
             ReadMe = new EditPackageVersionReadMeRequest();

--- a/src/NuGetGallery/ViewModels/PackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageViewModel.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery
         {
             _package = package ?? throw new ArgumentNullException(nameof(package));
 
-            FullVersion = NuGetVersionFormatter.ToFullStringOrFallback(package.Version, fallback: package.Version);
+            FullVersion = NuGetVersionFormatter.ToFullString(package.Version);
             IsSemVer2 = package.SemVerLevelKey == SemVerLevelKey.SemVer2;
 
             Version = String.IsNullOrEmpty(package.NormalizedVersion) ?

--- a/src/NuGetGallery/Views/Packages/Manage.cshtml
+++ b/src/NuGetGallery/Views/Packages/Manage.cshtml
@@ -59,37 +59,12 @@
         var strings_RemovingSelf = "@Html.Raw(Strings.ManagePackageOwners_RemovingSelf)";
 
         // Set up delete section
-        var versionListedState = @Html.Raw(
-           Json.Encode(
-               Model.VersionSelectList.ToDictionary(
-                   v => v.Value,
-                   v =>
-                   {
-                       var version = Model.PackageVersions.Single(p => p.Version == v.Value);
-                       return new
-                       {
-                           version.Listed,
-                           version.DownloadCount
-                       };
-                   })));
+        var versionListedState = @Html.Raw(Json.Encode(Model.VersionListedStateDictionary));
 
         $(function () {
             // Set up documentation section
-            @{
-                var editTemplate = Url.PackageVersionActionTemplate("Edit");
-                var getReadMeTemplate = Url.PackageVersionActionTemplate("GetReadMeMd");
-            }
-
             var readMeModel = {
-                "Versions": @Html.Raw(Json.Encode(Model.VersionSelectList.ToDictionary(v => v.Value, v => {
-                           var pvmodel = new TrivialPackageVersionModel(Model.Id, v.Value);
-                           return new
-                           {
-                               submit = editTemplate.Resolve(pvmodel),
-                               getReadMe = getReadMeTemplate.Resolve(pvmodel),
-                               readMe = (EditPackageVersionReadMeRequest)null
-                           };
-                       }))),
+                "Versions": @Html.Raw(Json.Encode(Model.VersionReadMeStateDictionary)),
                 "Edit": @Html.Raw(Json.Encode(Model.ReadMe))
             };
 

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1366,10 +1366,10 @@ namespace NuGetGallery
                 var packages = InvokeFindPackagesByOwner(currentUser, includeUnlisted: true).ToList();
 
                 var nugetCatalogReaderPackage = packages.Single(p => p.PackageRegistration.Id == "NuGet.CatalogReader");
-                Assert.Equal("1.5.12+git.78e44a8", NuGetVersionFormatter.ToFullStringOrFallback(nugetCatalogReaderPackage.Version, fallback: nugetCatalogReaderPackage.Version));
+                Assert.Equal("1.5.12+git.78e44a8", NuGetVersionFormatter.ToFullString(nugetCatalogReaderPackage.Version));
 
                 var sleetLibPackage = packages.Single(p => p.PackageRegistration.Id == "SleetLib");
-                Assert.Equal("2.2.24+git.f2a0cb6", NuGetVersionFormatter.ToFullStringOrFallback(sleetLibPackage.Version, fallback: sleetLibPackage.Version));
+                Assert.Equal("2.2.24+git.f2a0cb6", NuGetVersionFormatter.ToFullString(sleetLibPackage.Version));
             }
 
             protected FakeEntitiesContext GetMixedVersioningPackagesContext(User currentUser, User packageOwner)


### PR DESCRIPTION
precursor to https://github.com/NuGet/NuGetGallery/issues/6773

We decided that it was a bad idea to make the `ManagePackageViewModel` dependent on `DisplayPackageViewModel` as it forces `DisplayPackageViewModel` to store all information necessary to build the `ManagePackageViewModel`, which complicates the performance of the page.

`ManagePackageViewModel` will need deprecation information for all versions, but `DisplayPackageViewModel` only needs the selected package's deprecation information.

I have kept the dependency on `ListItemPackageViewModel` because it needs some of the fields on it, and I felt the model was lightweight enough for it not to be a big deal to reuse it.