### PR TITLE
Restructure PackageService to better support endpoints requiring all versions of an ID

### DIFF
--- a/src/NuGetGallery.Core/Services/CorePackageService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageService.cs
@@ -285,15 +285,26 @@ namespace NuGetGallery
             }
         }
 
-        protected IQueryable<Package> GetPackagesByIdQueryable(string id)
+        protected IQueryable<Package> GetPackagesByIdQueryable(string id, bool withDeprecations = false)
         {
-            return _packageRepository
+            var packages = _packageRepository
                 .GetAll()
                 .Include(p => p.LicenseReports)
                 .Include(p => p.PackageRegistration)
                 .Include(p => p.User)
                 .Include(p => p.SymbolPackages)
                 .Where(p => p.PackageRegistration.Id == id);
+
+            if (withDeprecations)
+            {
+                packages = packages
+                    .Include(p => p.Deprecations.Select(d => d.AlternatePackage.PackageRegistration))
+                    .Include(p => p.Deprecations.Select(d => d.AlternatePackageRegistration))
+                    .Include(p => p.Deprecations.Select(d => d.Cves))
+                    .Include(p => p.Deprecations.Select(d => d.Cwes));
+            }
+
+            return packages;
         }
 
         private static Package FindPackage(IQueryable<Package> packages, Func<IQueryable<Package>, IQueryable<Package>> predicate = null)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -688,6 +688,7 @@ namespace NuGetGallery
             model.PackageValidationIssues = _validationService.GetLatestPackageValidationIssues(package);
             model.SymbolsPackageValidationIssues = _validationService.GetLatestPackageValidationIssues(model.LatestSymbolsPackage);
             model.IsCertificatesUIEnabled = _contentObjectService.CertificatesConfiguration?.IsUIEnabledForUser(currentUser) ?? false;
+            model.IsAtomFeedEnabled = _featureFlagService.IsPackagesAtomFeedEnabled();
 
             model.ReadMeHtml = await _readMeService.GetReadMeHtmlAsync(package);
 

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -17,6 +17,8 @@ namespace NuGetGallery
     /// </summary>
     public interface IPackageService : ICorePackageService
     {
+        IReadOnlyCollection<Package> FindPackagesById(string id, bool withDeprecations = false);
+
         /// <summary>
         /// Gets the package with the given ID and version when exists;
         /// otherwise gets the latest package version for the given package ID matching the provided constraints.
@@ -26,9 +28,16 @@ namespace NuGetGallery
         /// <param name="semVerLevelKey">The SemVer-level key that determines the SemVer filter to be applied.</param>
         /// <param name="allowPrerelease"><c>True</c> indicating pre-release packages are allowed, otherwise <c>false</c>.</param>
         /// <returns></returns>
-        Package FindPackageByIdAndVersion(string id, string version, int? semVerLevelKey = null, bool allowPrerelease = true);
+        Package FindPackageByIdAndVersion(
+            string id,
+            string version,
+            int? semVerLevelKey = null,
+            bool allowPrerelease = true);
 
-        Package FindAbsoluteLatestPackageById(string id, int? semVerLevelKey);
+        Package FilterLatestPackage(
+            IReadOnlyCollection<Package> packages,
+            int? semVerLevelKey = SemVerLevelKey.SemVer2,
+            bool allowPrerelease = true);
 
         IEnumerable<Package> FindPackagesByOwner(User user, bool includeUnlisted, bool includeVersions = false);
 

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -17,6 +17,10 @@ namespace NuGetGallery
     /// </summary>
     public interface IPackageService : ICorePackageService
     {
+        /// <summary>
+        /// Returns all packages with an <see cref="Package.Id"/> of <paramref name="id"/>.
+        /// Includes deprecation entities if <paramref name="withDeprecations"/> is true.
+        /// </summary>
         IReadOnlyCollection<Package> FindPackagesById(string id, bool withDeprecations = false);
 
         /// <summary>

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -288,7 +288,6 @@ namespace NuGetGallery
                 .Include(p => p.PackageRegistration)
                 .Include(p => p.PackageRegistration.Owners)
                 .Include(p => p.PackageRegistration.RequiredSigners)
-                .Include(p => p.Deprecations)
                 .ToList();
         }
 

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -193,7 +193,7 @@ namespace NuGetGallery
                 allowPrerelease);
         }
 
-        private Package FilterLatestPackageHelper(
+        private static Package FilterLatestPackageHelper(
             IReadOnlyCollection<Package> packages,
             int? semVerLevelKey,
             bool allowPrerelease)

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -188,7 +188,7 @@ namespace NuGetGallery
         {
             return FilterLatestPackageHelper(
                 // Filter out prereleases in the list if prereleases are not allowed.
-                packages.Where(p => allowPrerelease || !p.IsPrerelease).ToList(),
+                packages?.Where(p => allowPrerelease || !p.IsPrerelease).ToList(),
                 semVerLevelKey,
                 allowPrerelease);
         }
@@ -198,6 +198,11 @@ namespace NuGetGallery
             int? semVerLevelKey,
             bool allowPrerelease)
         {
+            if (packages == null)
+            {
+                throw new ArgumentNullException(nameof(packages));
+            }
+
             Package package = null;
 
             // Fallback behavior: collect the latest version.

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -175,7 +175,7 @@ namespace NuGetGallery
 
                 var packageVersions = packagesQuery.ToList();
 
-                package = FilterLatestPackage(packageVersions, semVerLevelKey);
+                package = FilterLatestPackageHelper(packageVersions, semVerLevelKey, allowPrerelease);
             }
 
             return package;
@@ -185,6 +185,17 @@ namespace NuGetGallery
             IReadOnlyCollection<Package> packages,
             int? semVerLevelKey = SemVerLevelKey.SemVer2,
             bool allowPrerelease = true)
+        {
+            return FilterLatestPackageHelper(
+                packages.Where(p => allowPrerelease || p.IsPrerelease).ToList(),
+                semVerLevelKey,
+                allowPrerelease);
+        }
+
+        private Package FilterLatestPackageHelper(
+            IReadOnlyCollection<Package> packages,
+            int? semVerLevelKey,
+            bool allowPrerelease)
         {
             Package package = null;
 
@@ -215,8 +226,8 @@ namespace NuGetGallery
                 }
             }
 
-            // If we couldn't find a package marked as latest, then
-            // return the most recent one (prerelease ones were already filtered out if appropriate...)
+            // If we couldn't find a package marked as latest, then return the most recent one.
+            // Prereleases were already filtered out if appropriate.
             if (package == null)
             {
                 package = packages.OrderByDescending(p => p.Version).FirstOrDefault();

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -187,7 +187,8 @@ namespace NuGetGallery
             bool allowPrerelease = true)
         {
             return FilterLatestPackageHelper(
-                packages.Where(p => allowPrerelease || p.IsPrerelease).ToList(),
+                // Filter out prereleases in the list if prereleases are not allowed.
+                packages.Where(p => allowPrerelease || !p.IsPrerelease).ToList(),
                 semVerLevelKey,
                 allowPrerelease);
         }

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -135,6 +135,11 @@ namespace NuGetGallery
                 .SingleOrDefault(pr => pr.Id == packageId);
         }
 
+        public virtual IReadOnlyCollection<Package> FindPackagesById(string id, bool withDeprecations = false)
+        {
+            return GetPackagesByIdQueryable(id, withDeprecations).ToList();
+        }
+
         public virtual Package FindPackageByIdAndVersion(
             string id,
             string version,
@@ -170,62 +175,51 @@ namespace NuGetGallery
 
                 var packageVersions = packagesQuery.ToList();
 
-                // Fallback behavior: collect the latest version.
-                // Check SemVer-level and allow-prerelease constraints.
-                if (semVerLevelKey == SemVerLevelKey.SemVer2)
-                {
-                    package = packageVersions.FirstOrDefault(p => p.IsLatestStableSemVer2);
-
-                    if (package == null && allowPrerelease)
-                    {
-                        package = packageVersions.FirstOrDefault(p => p.IsLatestSemVer2);
-                    }
-                }
-
-                // Fallback behavior: collect the latest version.
-                // If SemVer-level is not defined, 
-                // or SemVer-level = 2.0.0 and no package was marked as SemVer2-latest,
-                // then check for packages marked as non-SemVer2 latest.
-                if (semVerLevelKey == SemVerLevelKey.Unknown
-                    || (semVerLevelKey == SemVerLevelKey.SemVer2 && package == null))
-                {
-                    package = packageVersions.FirstOrDefault(p => p.IsLatestStable);
-
-                    if (package == null && allowPrerelease)
-                    {
-                        package = packageVersions.FirstOrDefault(p => p.IsLatest);
-                    }
-                }
-
-                // If we couldn't find a package marked as latest, then
-                // return the most recent one (prerelease ones were already filtered out if appropriate...)
-                if (package == null)
-                {
-                    package = packageVersions.OrderByDescending(p => p.Version).FirstOrDefault();
-                }
+                package = FilterLatestPackage(packageVersions, semVerLevelKey);
             }
 
             return package;
         }
 
-        public virtual Package FindAbsoluteLatestPackageById(string id, int? semVerLevelKey)
+        public virtual Package FilterLatestPackage(
+            IReadOnlyCollection<Package> packages,
+            int? semVerLevelKey = SemVerLevelKey.SemVer2,
+            bool allowPrerelease = true)
         {
-            var packageVersions = GetPackagesByIdQueryable(id);
+            Package package = null;
 
-            Package package;
+            // Fallback behavior: collect the latest version.
+            // Check SemVer-level and allow-prerelease constraints.
             if (semVerLevelKey == SemVerLevelKey.SemVer2)
             {
-                package = packageVersions.FirstOrDefault(p => p.IsLatestSemVer2);
-            }
-            else
-            {
-                package = packageVersions.FirstOrDefault(p => p.IsLatest);
+                package = packages.FirstOrDefault(p => p.IsLatestStableSemVer2);
+
+                if (package == null && allowPrerelease)
+                {
+                    package = packages.FirstOrDefault(p => p.IsLatestSemVer2);
+                }
             }
 
-            // If we couldn't find a package marked as latest, then return the most recent one 
+            // Fallback behavior: collect the latest version.
+            // If SemVer-level is not defined, 
+            // or SemVer-level = 2.0.0 and no package was marked as SemVer2-latest,
+            // then check for packages marked as non-SemVer2 latest.
+            if (semVerLevelKey == SemVerLevelKey.Unknown
+                || (semVerLevelKey == SemVerLevelKey.SemVer2 && package == null))
+            {
+                package = packages.FirstOrDefault(p => p.IsLatestStable);
+
+                if (package == null && allowPrerelease)
+                {
+                    package = packages.FirstOrDefault(p => p.IsLatest);
+                }
+            }
+
+            // If we couldn't find a package marked as latest, then
+            // return the most recent one (prerelease ones were already filtered out if appropriate...)
             if (package == null)
             {
-                package = packageVersions.OrderByDescending(p => p.Version).FirstOrDefault();
+                package = packages.OrderByDescending(p => p.Version).FirstOrDefault();
             }
 
             return package;
@@ -277,11 +271,12 @@ namespace NuGetGallery
                         .ThenByDescending(p => p.Key)
                         .FirstOrDefault());
             }
-            
+
             return packages
                 .Include(p => p.PackageRegistration)
                 .Include(p => p.PackageRegistration.Owners)
                 .Include(p => p.PackageRegistration.RequiredSigners)
+                .Include(p => p.Deprecations)
                 .ToList();
         }
 
@@ -360,7 +355,7 @@ namespace NuGetGallery
                 await _packageRepository.CommitChangesAsync();
             }
         }
-        
+
         public bool WillPackageBeOrphanedIfOwnerRemoved(PackageRegistration package, User ownerToRemove)
         {
             return WillPackageBeOrphanedIfOwnerRemovedHelper(package.Owners, ownerToRemove);

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -757,7 +757,7 @@ namespace NuGetGallery.Controllers
                     var controller = GetController<JsonApiController>();
 
                     // Act
-                    var result = controller.GetPackageOwners("fakeId", "2.0.0");
+                    var result = controller.GetPackageOwners("fakeId");
                     dynamic data = ((JsonResult)result).Data;
 
                     // Assert
@@ -775,7 +775,7 @@ namespace NuGetGallery.Controllers
                     controller.SetCurrentUser(currentUser);
 
                     // Act
-                    var result = controller.GetPackageOwners(fakes.Package.Id, fakes.Package.Packages.First().Version);
+                    var result = controller.GetPackageOwners(fakes.Package.Id);
 
                     // Assert
                     Assert.IsType<HttpUnauthorizedResult>(result);
@@ -808,7 +808,7 @@ namespace NuGetGallery.Controllers
                     var controller = GetController<JsonApiController>();
                     controller.SetCurrentUser(currentUser);
 
-                    var result = controller.GetPackageOwners("FakePackage", "2.0");
+                    var result = controller.GetPackageOwners("FakePackage");
                     return ((JsonResult)result).Data as IEnumerable<PackageOwnersResultViewModel>;
                 }
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1261,7 +1261,6 @@ namespace NuGetGallery
             }
         }
 
-
         public class TheOwnershipRequestMethods : TestContainer
         {
             private int _key = 0;

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -30,6 +30,7 @@ using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Helpers;
+using NuGetGallery.Infrastructure;
 using NuGetGallery.Infrastructure.Mail.Messages;
 using NuGetGallery.Infrastructure.Mail.Requests;
 using NuGetGallery.Packaging;

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -68,7 +68,8 @@ namespace NuGetGallery
             Mock<IContentObjectService> contentObjectService = null,
             Mock<ISymbolPackageUploadService> symbolPackageUploadService = null,
             Mock<ICoreLicenseFileService> coreLicenseFileService = null,
-            Mock<ILicenseExpressionSplitter> licenseExpressionSplitter = null)
+            Mock<ILicenseExpressionSplitter> licenseExpressionSplitter = null,
+            Mock<IFeatureFlagService> featureFlagService = null)
         {
             packageService = packageService ?? new Mock<IPackageService>();
             if (uploadFileService == null)
@@ -180,6 +181,12 @@ namespace NuGetGallery
 
             licenseExpressionSplitter = licenseExpressionSplitter ?? new Mock<ILicenseExpressionSplitter>();
 
+            if (featureFlagService == null)
+            {
+                featureFlagService = new Mock<IFeatureFlagService>();
+                featureFlagService.SetReturnsDefault<bool>(true);
+            }
+
             var diagnosticsService = new Mock<IDiagnosticsService>();
             var controller = new Mock<PackagesController>(
                 packageService.Object,
@@ -206,7 +213,8 @@ namespace NuGetGallery
                 symbolPackageUploadService.Object,
                 diagnosticsService.Object,
                 coreLicenseFileService.Object,
-                licenseExpressionSplitter.Object);
+                licenseExpressionSplitter.Object,
+                featureFlagService.Object);
 
             controller.CallBase = true;
             controller.Object.SetOwinContextOverride(Fakes.CreateOwinContext());
@@ -683,7 +691,7 @@ namespace NuGetGallery
                 // The page should select the first package that is IsLatestSemVer2
                 Assert.Equal(latestPackage.NormalizedVersion, model.Version);
                 Assert.Equal(latestPackage.Title, model.Title);
-                Assert.True(model.LatestVersion);
+                Assert.True(model.LatestVersionSemVer2);
             }
 
             [Fact]
@@ -943,6 +951,315 @@ namespace NuGetGallery
                 public override ValidationIssueCode IssueCode => throw new NotImplementedException();
             }
         }
+
+        public class TheAtomFeedPackageMethod
+            : TestContainer
+        {
+            [Fact]
+            public void GivenANonExistentPackageIt404s()
+            {
+                // Arrange
+                var packageService = new Mock<IPackageService>();
+
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService);
+
+                packageService.Setup(p => p.FindPackageRegistrationById("Foo"))
+                              .ReturnsNull();
+
+                // Act
+                var result = controller.AtomFeed("Foo");
+
+                // Assert
+                ResultAssert.IsNotFound(result);
+            }
+
+            [Fact]
+            public void GivenAExistentPackageWithNoVersionsIt404s()
+            {
+                // Arrange
+                var packageService = new Mock<IPackageService>();
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService);
+
+
+                packageService.Setup(p => p.FindPackageRegistrationById("Foo"))
+                              .Returns(new PackageRegistration());
+
+                // Act
+                var result = controller.AtomFeed("Foo");
+
+                // Assert
+                ResultAssert.IsNotFound(result);
+            }
+
+            [Fact]
+            public void GivenAExistentPackageWithUnlistedAvailablePackagesIt404s()
+            {
+                // Arrange
+                var packageService = new Mock<IPackageService>();
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService);
+
+                var packageRegistration = new PackageRegistration();
+                var package = new Package
+                {
+                    Listed = false,
+                    PackageStatusKey = PackageStatus.Available
+                };
+                packageRegistration.Packages.Add(package);
+
+                packageService.Setup(p => p.FindPackageRegistrationById("Foo"))
+                              .Returns(packageRegistration);
+
+                // Act
+                var result = controller.AtomFeed("Foo");
+
+                // Assert
+                ResultAssert.IsNotFound(result);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void GivenAnExistentPackageTheFeatureFlagHidesTheFeed(bool enabled)
+            {
+                // Arrange
+                var httpContext = new Mock<HttpContextBase>();
+                var packageService = new Mock<IPackageService>();
+                var configurationService = GetConfigurationService();
+                configurationService.Current.Brand = "Test Gallery";
+                var featureFlagService = new Mock<IFeatureFlagService>();
+                featureFlagService
+                    .Setup(x => x.IsPackagesAtomFeedEnabled())
+                    .Returns(enabled);
+
+                var controller = CreateController(
+                    configurationService,
+                    packageService: packageService,
+                    featureFlagService: featureFlagService,
+                    httpContext: httpContext);
+
+                var packageRegistration = new PackageRegistration();
+                packageRegistration.Id = "Foo";
+
+                var onlyVersion = new Package
+                {
+                    Listed = true,
+                    PackageStatusKey = PackageStatus.Available,
+                    NormalizedVersion = "2.0.0",
+                    Version = "2.0.0",
+                    IsPrerelease = true,
+                    PackageRegistration = new PackageRegistration()
+                    {
+                        Id = "Foo"
+                    }
+                };
+                packageRegistration.Packages.Add(onlyVersion);
+
+                packageService.Setup(p => p.FindPackageRegistrationById("Foo"))
+                              .Returns(packageRegistration);
+
+                // Act
+                var result = controller.AtomFeed("Foo");
+
+                // Assert
+                if (enabled)
+                {
+                    Assert.IsType<SyndicationAtomActionResult>(result);
+                }
+                else
+                {
+                    ResultAssert.IsNotFound(result);
+                }
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void GivenAExistentPackagePrereleaseVersionsCanBeFilteredOut(bool includePrerelease)
+            {
+                // Arrange
+                var httpContext = new Mock<HttpContextBase>();
+                var packageService = new Mock<IPackageService>();
+                var configurationService = GetConfigurationService();
+                configurationService.Current.Brand = "Test Gallery";
+
+                var controller = CreateController(
+                    configurationService,
+                    packageService: packageService,
+                    httpContext: httpContext);
+
+                var packageRegistration = new PackageRegistration();
+                packageRegistration.Id = "Foo";
+
+                var onlyVersion = new Package
+                {
+                    Listed = true,
+                    PackageStatusKey = PackageStatus.Available,
+                    NormalizedVersion = "2.0.0-beta",
+                    Version = "2.0.0-beta",
+                    IsPrerelease = true,
+                    PackageRegistration = new PackageRegistration()
+                    {
+                        Id = "Foo"
+                    }
+                };
+                packageRegistration.Packages.Add(onlyVersion);
+
+                packageService.Setup(p => p.FindPackageRegistrationById("Foo"))
+                              .Returns(packageRegistration);
+
+                // Act
+                var result = controller.AtomFeed("Foo", includePrerelease);
+
+                // Assert
+                if (includePrerelease)
+                {
+                    Assert.IsType<SyndicationAtomActionResult>(result);
+                }
+                else
+                {
+                    ResultAssert.IsNotFound(result);
+                }
+            }
+
+            [Fact]
+            public void GivenAExistentPackageWithListedUnavailablePackagesIt404s()
+            {
+                // Arrange
+                var packageService = new Mock<IPackageService>();
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService);
+
+                var packageRegistration = new PackageRegistration();
+                var package = new Package
+                {
+                    Listed = true,
+                    PackageStatusKey = PackageStatus.Validating
+                };
+                packageRegistration.Packages.Add(package);
+
+                packageService.Setup(p => p.FindPackageRegistrationById("Foo"))
+                              .Returns(packageRegistration);
+
+                // Act
+                var result = controller.AtomFeed("Foo");
+
+                // Assert
+                ResultAssert.IsNotFound(result);
+            }
+
+            [Fact]
+            public void GivenAExistentPackageWithListedAvailablePackagesItReturnsSyndicationFeed()
+            {
+                // Arrange
+                var httpContext = new Mock<HttpContextBase>();
+                var packageService = new Mock<IPackageService>();
+                var configurationService = GetConfigurationService();
+                configurationService.Current.Brand = "Test Gallery";
+
+                var controller = CreateController(
+                    configurationService,
+                    packageService: packageService,
+                    httpContext: httpContext);
+
+                var dateTimeNow = DateTime.Now;
+                var dateTimeYesterDay = dateTimeNow.AddDays(-1);
+                var dateTimeTwoDaysAgo = dateTimeNow.AddDays(-2);
+
+                var packageRegistration = new PackageRegistration();
+                packageRegistration.Id = "Foo";
+
+                var oldestPackage = new Package
+                {
+                    Listed = true,
+                    PackageStatusKey = PackageStatus.Available,
+                    NormalizedVersion = "1.0.0",
+                    Version = "1.0.0",
+                    Title = "Foo",
+                    Description = "Test Package",
+                    Created = dateTimeTwoDaysAgo,
+                    PackageRegistration = new PackageRegistration()
+                    {
+                        Id = "Foo"
+                    }
+                };
+                packageRegistration.Packages.Add(oldestPackage);
+
+                var highestVersionPackage = new Package
+                {
+                    Listed = true,
+                    PackageStatusKey = PackageStatus.Available,
+                    NormalizedVersion = "2.0.0-beta",
+                    Version = "2.0.0-beta",
+                    IsPrerelease = true,
+                    Description = "Most recent version: Test Package",
+                    Created = dateTimeYesterDay,
+                    PackageRegistration = new PackageRegistration()
+                    {
+                        Id = "Foo"
+                    }
+                };
+                packageRegistration.Packages.Add(highestVersionPackage);
+
+                var newestPackageButNotHighestVersion = new Package
+                {
+                    Listed = true,
+                    PackageStatusKey = PackageStatus.Available,
+                    NormalizedVersion = "1.1.0",
+                    Version = "1.1.0",
+                    Description = "Fix for older version: Test Package",
+                    Created = dateTimeNow,
+                    PackageRegistration = new PackageRegistration()
+                    {
+                        Id = "Foo"
+                    }
+                };
+                packageRegistration.Packages.Add(newestPackageButNotHighestVersion);
+                packageService.Setup(p => p.FindPackageRegistrationById("Foo"))
+                              .Returns(packageRegistration);
+
+                // Act
+                var result = controller.AtomFeed("Foo");
+                var syndicationResult = result as SyndicationAtomActionResult;
+
+                // Assert
+                Assert.NotNull(syndicationResult);
+
+                Assert.Equal("https://localhost/packages/Foo/", syndicationResult.SyndicationFeed.Id);
+                Assert.Equal("Test Gallery Feed for Foo", syndicationResult.SyndicationFeed.Title.Text);
+                Assert.Equal("Most recent version: Test Package", syndicationResult.SyndicationFeed.Description.Text);
+                Assert.Equal(dateTimeNow, syndicationResult.SyndicationFeed.LastUpdatedTime);
+
+                var syndicationFeedItems = new List<System.ServiceModel.Syndication.SyndicationItem>(syndicationResult.SyndicationFeed.Items);
+
+                Assert.Equal(3, syndicationFeedItems.Count);
+
+                Assert.Equal("https://localhost/packages/Foo/2.0.0-beta", syndicationFeedItems[0].Id);
+                Assert.Equal("Foo 2.0.0-beta", syndicationFeedItems[0].Title.Text);
+                Assert.Equal("Most recent version: Test Package", (syndicationFeedItems[0].Content as System.ServiceModel.Syndication.TextSyndicationContent).Text);
+                Assert.Equal(dateTimeYesterDay, syndicationFeedItems[0].PublishDate);
+                Assert.Equal(dateTimeYesterDay, syndicationFeedItems[0].LastUpdatedTime);
+
+                Assert.Equal("https://localhost/packages/Foo/1.1.0", syndicationFeedItems[1].Id);
+                Assert.Equal("Foo 1.1.0", syndicationFeedItems[1].Title.Text);
+                Assert.Equal("Fix for older version: Test Package", (syndicationFeedItems[1].Content as System.ServiceModel.Syndication.TextSyndicationContent).Text);
+                Assert.Equal(dateTimeNow, syndicationFeedItems[1].PublishDate);
+                Assert.Equal(dateTimeNow, syndicationFeedItems[1].LastUpdatedTime);
+
+                Assert.Equal("https://localhost/packages/Foo/1.0.0", syndicationFeedItems[2].Id);
+                Assert.Equal("Foo 1.0.0", syndicationFeedItems[2].Title.Text);
+                Assert.Equal("Test Package", (syndicationFeedItems[2].Content as System.ServiceModel.Syndication.TextSyndicationContent).Text);
+                Assert.Equal(dateTimeTwoDaysAgo, syndicationFeedItems[2].PublishDate);
+                Assert.Equal(dateTimeTwoDaysAgo, syndicationFeedItems[2].LastUpdatedTime);
+            }
+        }
+
 
         public class TheOwnershipRequestMethods : TestContainer
         {

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -912,6 +912,12 @@ namespace NuGetGallery
                 Assert.Equal("1.0.0b", result.Version);
             }
 
+            [Fact]
+            public void ThrowsIfPackagesNull()
+            {
+                Assert.Throws<ArgumentNullException>(() => InvokeMethod(null));
+            }
+
             protected virtual Package InvokeMethod(
                 IReadOnlyCollection<Package> packages,
                 int? semVerLevelKey = SemVerLevelKey.SemVer2,

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -826,7 +826,102 @@ namespace NuGetGallery
             }
         }
 
-        public class TheFindPackageByIdAndVersionMethod
+        public class TheFilterLatestPackageMethod
+        {
+            protected const string Id = "theId";
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("2.0.0")]
+            public void ReturnsTheLatestStableVersionIfAvailable(string semVerLevel)
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration { Id = Id };
+                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true, IsLatestStable = true, IsLatestStableSemVer2 = true };
+                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
+
+                // Act
+                var result = InvokeMethod(new[] { package1, package2 }, semVerLevelKey: SemVerLevelKey.ForSemVerLevel(semVerLevel));
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("1.0", result.Version);
+            }
+
+            [Fact]
+            public void ReturnsTheLatestStableSemVer2VersionIfAvailable()
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration { Id = Id };
+                var package0 = new Package { Version = "1.0.0+metadata", PackageRegistration = packageRegistration, Listed = true, IsLatestStableSemVer2 = true };
+                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true, IsLatestStable = true };
+                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
+
+                // Act
+                var result = InvokeMethod(new[] { package0, package1, package2 }, semVerLevelKey: SemVerLevelKey.SemVer2);
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("1.0.0+metadata", result.Version);
+            }
+
+            [Fact]
+            public void ReturnsTheLatestVersionIfNoLatestStableVersionIsAvailable()
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration { Id = Id };
+                var package1 = new Package { Version = "1.0.0b", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
+                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true };
+
+                // Act
+                var result = InvokeMethod(new[] { package1, package2 });
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("1.0.0b", result.Version);
+            }
+
+            [Fact]
+            public void ReturnsNullIfNoLatestStableVersionIsAvailableAndPrereleaseIsDisallowed()
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration { Id = Id };
+                var package1 = new Package { Version = "1.0.0b", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
+                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true };
+
+                // Act
+                var result = InvokeMethod(new[] { package1, package2 }, allowPrerelease: false);
+
+                // Assert
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void ReturnsTheMostRecentVersionIfNoLatestVersionIsAvailable()
+            {
+                // Arrange
+                var packageRegistration = new PackageRegistration { Id = Id };
+                var package1 = new Package { Version = "1.0.0b", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = false };
+                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = false };
+
+                // Act
+                var result = InvokeMethod(new[] { package1, package2 });
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("1.0.0b", result.Version);
+            }
+
+            protected virtual Package InvokeMethod(
+                IReadOnlyCollection<Package> packages,
+                int? semVerLevelKey = SemVerLevelKey.SemVer2,
+                bool allowPrerelease = true)
+            {
+                return CreateService().FilterLatestPackage(packages, semVerLevelKey, allowPrerelease);
+            }
+        }
+
+        public class TheFindPackageByIdAndVersionMethod : TheFilterLatestPackageMethod
         {
             [Fact]
             public void ReturnsTheRequestedPackageVersion()
@@ -838,7 +933,7 @@ namespace NuGetGallery
                             new Exception("This should not be called when the version is specified."));
                     });
 
-                service.FindPackageByIdAndVersion("theId", "1.0.42");
+                service.FindPackageByIdAndVersion(Id, "1.0.42");
 
                 // Nothing to assert because it's too complicated to test the actual LINQ expression.
                 // What we're testing via the throw above is that it didn't load the registration and get the latest version.
@@ -854,116 +949,17 @@ namespace NuGetGallery
                 Assert.Equal("id", ex.ParamName);
             }
 
-            [Theory]
-            [InlineData(null)]
-            [InlineData("2.0.0")]
-            public void ReturnsTheLatestStableVersionIfAvailable(string semVerLevel)
+            protected override Package InvokeMethod(
+                IReadOnlyCollection<Package> packages, 
+                int? semVerLevelKey = 2, 
+                bool allowPrerelease = true)
             {
-                // Arrange
                 var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true, IsLatestStable = true, IsLatestStableSemVer2 = true };
-                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
-
                 repository
                     .Setup(repo => repo.GetAll())
-                    .Returns(new[] { package1, package2 }.AsQueryable());
+                    .Returns(packages.AsQueryable());
                 var service = CreateService(packageRepository: repository);
-
-                // Act
-                var result = service.FindPackageByIdAndVersion("theId", version: null, semVerLevelKey: SemVerLevelKey.ForSemVerLevel(semVerLevel));
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal("1.0", result.Version);
-            }
-
-            [Fact]
-            public void ReturnsTheLatestStableSemVer2VersionIfAvailable()
-            {
-                // Arrange
-                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package0 = new Package { Version = "1.0.0+metadata", PackageRegistration = packageRegistration, Listed = true, IsLatestStableSemVer2 = true };
-                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true, IsLatestStable = true };
-                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
-
-                repository
-                    .Setup(repo => repo.GetAll())
-                    .Returns(new[] { package0, package1, package2 }.AsQueryable());
-                var service = CreateService(packageRepository: repository);
-
-                // Act
-                var result = service.FindPackageByIdAndVersion("theId", version: null, semVerLevelKey: SemVerLevelKey.SemVer2);
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal("1.0.0+metadata", result.Version);
-            }
-
-            [Fact]
-            public void ReturnsTheLatestVersionIfNoLatestStableVersionIsAvailable()
-            {
-                // Arrange
-                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package1 = new Package { Version = "1.0.0b", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
-                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true };
-
-                repository
-                    .Setup(repo => repo.GetAll())
-                    .Returns(new[] { package1, package2 }.AsQueryable());
-                var service = CreateService(packageRepository: repository);
-
-                // Act
-                var result = service.FindPackageByIdAndVersion("theId", version: null);
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal("1.0.0b", result.Version);
-            }
-
-            [Fact]
-            public void ReturnsNullIfNoLatestStableVersionIsAvailableAndPrereleaseIsDisallowed()
-            {
-                // Arrange
-                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package1 = new Package { Version = "1.0.0b", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
-                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true };
-
-                repository
-                    .Setup(repo => repo.GetAll())
-                    .Returns(new[] { package1, package2 }.AsQueryable());
-                var service = CreateService(packageRepository: repository);
-
-                // Act
-                var result = service.FindPackageByIdAndVersion("theId", version: null, allowPrerelease: false);
-
-                // Assert
-                Assert.Null(result);
-            }
-
-            [Fact]
-            public void ReturnsTheMostRecentVersionIfNoLatestVersionIsAvailable()
-            {
-                // Arrange
-                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package1 = new Package { Version = "1.0.0b", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = false };
-                var package2 = new Package { Version = "1.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = false };
-
-                repository
-                    .Setup(repo => repo.GetAll())
-                    .Returns(new[] { package1, package2 }.AsQueryable());
-                var service = CreateService(packageRepository: repository);
-
-                // Act
-                var result = service.FindPackageByIdAndVersion("theId", null);
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal("1.0.0b", result.Version);
+                return service.FindPackageByIdAndVersion(Id, null, semVerLevelKey, allowPrerelease);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -967,99 +967,6 @@ namespace NuGetGallery
             }
         }
 
-        public class TheFindAbsoluteLatestPackageByIdMethod
-        {
-            [Fact]
-            public void ReturnsTheLatestVersionWhenSemVerLevelUnknown()
-            {
-                // Arrange
-                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true, IsLatestStable = true };
-                var package2 = new Package { Version = "2.0.0a", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true };
-
-                repository
-                    .Setup(repo => repo.GetAll())
-                    .Returns(new[] { package1, package2 }.AsQueryable());
-                var service = CreateService(packageRepository: repository);
-
-                // Act
-                var result = service.FindAbsoluteLatestPackageById("theId", SemVerLevelKey.Unknown);
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal("2.0.0a", result.Version);
-            }
-
-            [Fact]
-            public void ReturnsTheLatestVersionWhenSemVerLevel2()
-            {
-                // Arrange
-                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true, IsLatestStable = true };
-                var package2 = new Package { Version = "2.0.0-alpha.1", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, IsLatest = true, SemVerLevelKey = SemVerLevelKey.SemVer2 };
-
-                repository
-                    .Setup(repo => repo.GetAll())
-                    .Returns(new[] { package1, package2 }.AsQueryable());
-                var service = CreateService(packageRepository: repository);
-
-                // Act
-                var result = service.FindAbsoluteLatestPackageById("theId", SemVerLevelKey.SemVer2);
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal("2.0.0-alpha.1", result.Version);
-            }
-
-            [Fact]
-            public void ReturnsTheMostRecentVersionWhenSemVerLevelUnknown()
-            {
-                // Arrange
-                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true };
-                var package2 = new Package { Version = "2.0.0-alpha", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true };
-                var package3 = new Package { Version = "2.0.0", PackageRegistration = packageRegistration, Listed = true, IsLatest = true };
-
-                repository
-                    .Setup(repo => repo.GetAll())
-                    .Returns(new[] { package1, package2, package3 }.AsQueryable());
-                var service = CreateService(packageRepository: repository);
-
-                // Act
-                var result = service.FindAbsoluteLatestPackageById("theId", SemVerLevelKey.Unknown);
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal("2.0.0", result.Version);
-            }
-
-            [Fact]
-            public void ReturnsTheMostRecentVersionWhenSemVerLevel2()
-            {
-                // Arrange
-                var repository = new Mock<IEntityRepository<Package>>(MockBehavior.Strict);
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package1 = new Package { Version = "1.0", PackageRegistration = packageRegistration, Listed = true };
-                var package2 = new Package { Version = "2.0.0-alpha.1", PackageRegistration = packageRegistration, IsPrerelease = true, Listed = true, SemVerLevelKey = SemVerLevelKey.SemVer2 };
-                var package3 = new Package { Version = "2.0.0+metadata", PackageRegistration = packageRegistration, Listed = true, SemVerLevelKey = SemVerLevelKey.SemVer2, IsLatestSemVer2 = true };
-
-                repository
-                    .Setup(repo => repo.GetAll())
-                    .Returns(new[] { package1, package2, package3 }.AsQueryable());
-                var service = CreateService(packageRepository: repository);
-
-                // Act
-                var result = service.FindAbsoluteLatestPackageById("theId", SemVerLevelKey.SemVer2);
-
-                // Assert
-                Assert.NotNull(result);
-                Assert.Equal("2.0.0+metadata", result.Version);
-            }
-        }
-
         public class TheFindPackagesByOwnerMethod : TheFindPackagesByOwnersMethodsBase
         {
             public static IEnumerable<object[]> TestData_RoleVariants
@@ -2226,7 +2133,7 @@ namespace NuGetGallery
 
                     // If we delete the first organization, the package is orphaned unless is it owned a user or it is owned by the second organization and that organization has members.
                     if (state.HasFlag(OwnershipState.OwnedByUser1) ||
-                        state.HasFlag(OwnershipState.OwnedByUser2) || 
+                        state.HasFlag(OwnershipState.OwnedByUser2) ||
                         (state.HasFlag(OwnershipState.OwnedByOrganization2) && (state.HasFlag(OwnershipState.User1InOrganization2) || state.HasFlag(OwnershipState.User2InOrganization2))))
                     {
                         expectedResult = false;
@@ -2301,7 +2208,7 @@ namespace NuGetGallery
                 Assert.True(package.HideLicenseReport);
             }
         }
-        
+
         public class TheSetRequiredSignerAsyncMethodOneParameter : TestContainer
         {
             private readonly User _user1;


### PR DESCRIPTION
precursor to https://github.com/NuGet/NuGetGallery/issues/6773

Both `PackagesController.DisplayPackage` and `PackagesController.Manage` require all versions of a package.

Previously, this was done either implicitly or lazily, specifically:
- if a version isn't specified or is missing, `FindPackageByIdAndVersion` must fetch all versions to calculate the latest one
- if a version was specified and found, the remaining versions would be loaded lazily

This is bad because our perf for these endpoints are relying on a hidden behavior of one of our services, and when this hidden behavior doesn't go our way, lazy loading is **very very very very** slow, and adding the deprecation entities associated with this feature makes it *even* worse.

So, to remedy this
- add `FindPackagesById` to get all packages by ID (with a `withDeprecations` parameter for when deprecation entities are needed)
- move logic from `FindPackageByIdAndVersion` that fetches the latest version from a list of packages and move it into `FilterLatestPackage`
    - `FindPackageByIdAndVersion` now calls `FilterLatestPackage` internally
- make DisplayPackage and Manage call `FindPackagesById` and then `FilterLatestPackage` if an exact version isn't found
- move the code from `FindAbsoluteLatestPackageById` into `DisplayPackage`