### PR TITLE
Improve implementation of "Skip To Content" link

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -216,21 +216,9 @@
         });
     };
 
-    nuget.isElement = function (element, type) {
-        return element.is(type);
-    };
-
-    nuget.hasAttribute = function (element, attributeName) {
-        var attribute = element.attr(attributeName);
-        return typeof attribute !== typeof undefined && attribute !== false;
-    };
-
     nuget.canElementBeFocused = function (element) {
         element = $(element);
-        var isElement = window.nuget.isElement.bind(this, element);
-        var hasAttribute = window.nuget.hasAttribute.bind(this, element);
-
-        if (!isElement(':visible')) {
+        if (!element.is(':visible')) {
             return false;
         }
 
@@ -238,17 +226,17 @@
         var alwaysInteractiveElements = ['a', 'button', 'details', 'embed', 'iframe', 'keygen', 'label', 'select', 'textarea'];
         var i;
         for (i = 0; i < alwaysInteractiveElements.length; i++) {
-            if (isElement(alwaysInteractiveElements[i])) {
+            if (element.is(alwaysInteractiveElements[i])) {
                 return true;
             }
         }
 
-        return isElement("audio") && hasAttribute("controls") ||
-            isElement("img") && hasAttribute("usemap") ||
-            isElement("input") && element.attr("type") !== "hidden" ||
-            isElement("menu") && element.attr("type") !== "toolbar" ||
-            isElement("object") && hasAttribute("usemap") ||
-            isElement("video") && hasAttribute("controls");
+        return element.is("audio") && !!element.attr("controls") ||
+            element.is("img") && !!element.attr("usemap") ||
+            element.is("input") && element.attr("type") !== "hidden" ||
+            element.is("menu") && element.attr("type") !== "toolbar" ||
+            element.is("object") && !!element.attr("usemap") ||
+            element.is("video") && !!element.attr("controls");
     };
 
     nuget.canElementBeTabbedTo = function (element) {

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -208,27 +208,30 @@
     nuget.configureFileInputButton = function (id) {
         // File input buttons should respond to keyboard events.
         $("#" + id).on("keypress", function (e) {
-            var code = (e.keyCode || e.which);
-            var isInteract = (code == 13 /*enter*/ || code == 32 /*space*/) && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
+            var code = e.keyCode || e.which;
+            var isInteract = (code === 13 /*enter*/ || code === 32 /*space*/) && !e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey;
             if (isInteract) {
                 $(this).click();
             }
         });
-    }
+    };
 
-    nuget.canElementBeTabbedTo = function (element) {
-        var isElement = function (type) {
-            return element.is(type);
-        }
+    nuget.isElement = function (element, type) {
+        return element.is(type);
+    };
 
-        var hasAttribute = function (attributeName) {
-            var attribute = element.attr(attributeName);
-            return typeof attribute !== typeof undefined && attribute !== false;
-        }
+    nuget.hasAttribute = function (element, attributeName) {
+        var attribute = element.attr(attributeName);
+        return typeof attribute !== typeof undefined && attribute !== false;
+    };
 
-        if (hasAttribute("tabindex")) {
-            // Elements that have had their tabindex set to -1 cannot be tabbed to.
-            return element.attr("tabindex") !== "-1";
+    nuget.canElementBeFocused = function (element) {
+        element = $(element);
+        var isElement = window.nuget.isElement.bind(this, element);
+        var hasAttribute = window.nuget.hasAttribute.bind(this, element);
+
+        if (!isElement(':visible')) {
+            return false;
         }
 
         // See https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Interactive_content
@@ -240,40 +243,17 @@
             }
         }
 
-        return ((isElement("audio") && hasAttribute("controls")) ||
-            (isElement("img") && hasAttribute("usemap")) ||
-            (isElement("input") && element.attr("type") !== "hidden") ||
-            (isElement("menu") && element.attr("type") !== "toolbar") ||
-            (isElement("object") && hasAttribute("usemap")) ||
-            (isElement("video") && hasAttribute("controls")));
-    }
+        return isElement("audio") && hasAttribute("controls") ||
+            isElement("img") && hasAttribute("usemap") ||
+            isElement("input") && element.attr("type") !== "hidden" ||
+            isElement("menu") && element.attr("type") !== "toolbar" ||
+            isElement("object") && hasAttribute("usemap") ||
+            isElement("video") && hasAttribute("controls");
+    };
 
-    nuget.getFirstChildThatCanBeTabbedTo = function (element) {
-        if (window.nuget.canElementBeTabbedTo(element)) {
-            return element;
-        }
-
-        // If an element has its tabindex set to -1, none of its children can be tabbed to.
-        if (element.attr("tabindex") === "-1") {
-            return null;
-        }
-
-        var i;
-        var children = element.children();
-        for (i = 0; i < children.length; i++) {
-            var child = children.eq(i);
-            if (window.nuget.canElementBeTabbedTo(child)) {
-                return child;
-            }
-
-            var childChild = window.nuget.getFirstChildThatCanBeTabbedTo(child);
-            if (childChild !== null) {
-                return childChild;
-            }
-        }
-
-        return null;
-    }
+    nuget.canElementBeTabbedTo = function (element) {
+        return window.nuget.canElementBeFocused(element) && $(element).attr('tabindex') !== "-1";
+    };
 
     // Source: https://stackoverflow.com/a/27568129/52749
     // Detects whether SVG is supported in the browser.
@@ -365,7 +345,7 @@
         var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
         if (data instanceof FormData)
         {
-            data.append($tokenKey, $field.val())
+            data.append($tokenKey, $field.val());
         }
         else
         {
@@ -383,9 +363,14 @@
         }
 
         return stringToFormat;
-    }
+    };
 
     window.nuget = nuget;
+
+    jQuery.extend(jQuery.expr[':'], {
+        focusable: window.nuget.canElementBeFocused,
+        tabbable: window.nuget.canElementBeTabbedTo
+    });
 
     initializeJQueryValidator();
 
@@ -454,16 +439,16 @@
         });
 
         $(document).on('keydown', function (e) {
-            var code = (e.keyCode || e.which);
+            var code = e.keyCode || e.which;
             var isValidInputCharacter =
-                ((code >= 48 && code <= 57)           // numbers 0-9
-                    || (code >= 64 && code <= 90)     // letters a-z
-                    || (code >= 96 && code <= 111)    // numpad
-                    || (code >= 186 && code <= 192)   // ; = , - . / `
-                    || (code >= 219 && code <= 222))  // [\ ] '
+                (code >= 48 && code <= 57           // numbers 0-9
+                    || code >= 64 && code <= 90     // letters a-z
+                    || code >= 96 && code <= 111    // numpad
+                    || code >= 186 && code <= 192   // ; = , - . / `
+                    || code >= 219 && code <= 222)  // [\ ] '
                 && !e.altKey && !e.ctrlKey && !e.metaKey;
 
-            if (isValidInputCharacter && document.activeElement == document.body) {
+            if (isValidInputCharacter && document.activeElement === document.body) {
                 var searchbox = $("#search");
                 searchbox.focus();
                 var currInput = searchbox.val();
@@ -475,7 +460,7 @@
         $("#skipToContent").on('click', function () {
             // Focus on the first element that can be tabbed to inside the "skippedToContent" element.
             var skippedToContent = $("#skippedToContent");
-            var firstChildThatCanBeTabbedTo = window.nuget.getFirstChildThatCanBeTabbedTo(skippedToContent.first());
+            var firstChildThatCanBeTabbedTo = skippedToContent.find(':tabbable').first();
             if (firstChildThatCanBeTabbedTo !== null) {
                 firstChildThatCanBeTabbedTo.focus();
             } else {
@@ -486,4 +471,3 @@
         });
     });
 }());
-


### PR DESCRIPTION
When exploring custom keyboard controls for the Deprecation form, I discovered this as a substantially simpler implementation than what I had implemented in https://github.com/NuGet/NuGetGallery/pull/6215.

Basically, instead of having to traverse the DOM manually, I am now leveraging JQuery to do this heavy-lifting for me by defining a "this element can be tabbed to" selector. I also added `focusable` in case we need it.

This also fixes a bug in the previous implementation. If an element has a `tabindex` of `-1`, its children can still be tabbed to. In the previous implementation, children of elements with `tabindex="-1"` were not considered `tabbable`.

I also got rid of all the ESLint issues in the file.