### PR TITLE
Add functional tests for the packages Atom feed

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/AtomFeed/AtomFeedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/AtomFeed/AtomFeedTests.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.ServiceModel.Syndication;
+using System.Threading.Tasks;
+using System.Xml;
+using NuGet.Versioning;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetGallery.FunctionalTests.AtomFeed
+{
+    public class AtomFeedTests : GalleryTestBase
+    {
+        public AtomFeedTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        [Priority(2)]
+        [Category("P2Tests")]
+        public async Task IsParsableForAvailablePackage()
+        {
+            // Arrange
+            var feedUrl = new Uri(new Uri(UrlHelper.BaseUrl), $"/packages/{Constants.TestPackageId}/atom.xml");
+
+            // Act
+            using (var httpClient = new HttpClient())
+            using (var response = await httpClient.GetAsync(feedUrl))
+            {
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                var contentType = Assert.Single(response.Content.Headers.GetValues("Content-Type"));
+                Assert.Equal("application/atom+xml; charset=utf-8", contentType);
+
+                var feed = await ReadFeedAsync(response);
+                Assert.Contains(Constants.TestPackageId, feed.Title.Text);
+                Assert.NotEmpty(feed.Items);
+                foreach (var item in feed.Items)
+                {
+                    Assert.Contains(Constants.TestPackageId, item.Title.Text);
+                }
+            }
+        }
+
+        [Theory]
+        [Priority(2)]
+        [Category("P2Tests")]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task ObservesPrerelParameter(bool prerel)
+        {
+            // Arrange
+            var feedUrl = new Uri(new Uri(UrlHelper.BaseUrl), $"/packages/Newtonsoft.Json/atom.xml?prerel={prerel}");
+
+            // Act
+            using (var httpClient = new HttpClient())
+            using (var response = await httpClient.GetAsync(feedUrl))
+            {
+                // Assert
+                var feed = await ReadFeedAsync(response);
+                foreach (var item in feed.Items)
+                {
+                    var version = item.Title.Text.Split(' ').Last();
+                    Assert.True(NuGetVersion.TryParse(version, out var parsedVersion), $"The version '{version}' is not parsable.");
+                    if (!prerel)
+                    {
+                        Assert.False(parsedVersion.IsPrerelease, $"The version '{version}' should not be included since it is prerelease.");
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        [Priority(2)]
+        [Category("P2Tests")]
+        public async Task DefaultsToIncludingPrerel()
+        {
+            // Arrange
+            var feedUrl = new Uri(new Uri(UrlHelper.BaseUrl), $"/packages/Newtonsoft.Json/atom.xml");
+
+            // Act
+            using (var httpClient = new HttpClient())
+            using (var response = await httpClient.GetAsync(feedUrl))
+            {
+                // Assert
+                var feed = await ReadFeedAsync(response);
+                var prerelCount = 0;
+                foreach (var item in feed.Items)
+                {
+                    var version = item.Title.Text.Split(' ').Last();
+                    Assert.True(NuGetVersion.TryParse(version, out var parsedVersion), $"The version '{version}' is not parsable.");
+                    if (parsedVersion.IsPrerelease)
+                    {
+                        prerelCount++;
+                    }
+                }
+
+                Assert.InRange(prerelCount, 1, feed.Items.Count());
+            }
+        }
+
+        [Fact]
+        [Priority(2)]
+        [Category("P2Tests")]
+        public async Task DoesNotExistForPackageThatDoesNotExist()
+        {
+            // Arrange
+            // This package ID can never exist since an ID can't have two hyphens next to each other.
+            var feedUrl = new Uri(new Uri(UrlHelper.BaseUrl), $"/packages/Base--TestPackage/atom.xml");
+
+            // Act
+            using (var httpClient = new HttpClient())
+            using (var response = await httpClient.GetAsync(feedUrl))
+            {
+                // Assert
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+                var contentType = Assert.Single(response.Content.Headers.GetValues("Content-Type"));
+                Assert.Equal("text/html; charset=utf-8", contentType);
+            }
+        }
+
+        private static async Task<SyndicationFeed> ReadFeedAsync(HttpResponseMessage response)
+        {
+            var formatter = new Atom10FeedFormatter();
+            using (var stream = await response.Content.ReadAsStreamAsync())
+            using (var xmlReader = XmlReader.Create(stream, new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Ignore,
+            }))
+            {
+                formatter.ReadFrom(xmlReader);
+            }
+
+            return formatter.Feed;
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -61,6 +61,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
@@ -81,6 +82,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AtomFeed\AtomFeedTests.cs" />
     <Compile Include="Commandline\NuGetCommandLineTests.cs" />
     <Compile Include="Commandline\NuGetCoreTests.cs" />
     <Compile Include="ODataFeeds\CuratedFeedTest.cs" />


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6898.

Many of our other functional tests use Newtonsoft.Json as a pre-existing package. Technically this should probably be an explicit test package but this is out of scope. The benefit of using an pre-existing package is that the run time of the functional test is very low.