### PR TITLE
Add functional tests for error cases in gallery

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/ErrorHandling/EndpointType.cs
+++ b/tests/NuGetGallery.FunctionalTests/ErrorHandling/EndpointType.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.FunctionalTests.ErrorHandling
+{
+    /// <summary>
+    /// The possible simulated error endpoints. This is used with <see cref="SimulatedErrorType"/>.
+    /// </summary>
+    public enum EndpointType
+    {
+        Pages,
+        Api,
+        OData,
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/ErrorHandling/ErrorHandlingTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ErrorHandling/ErrorHandlingTests.cs
@@ -1,0 +1,212 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetGallery.FunctionalTests.ErrorHandling
+{
+    public class ErrorHandlingTests : GalleryTestBase, IDisposable
+    {
+        private readonly HttpClientHandler _httpClientHandler;
+        private readonly HttpClient _httpClient;
+
+        public ErrorHandlingTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+            _httpClientHandler = new HttpClientHandler
+            {
+                AllowAutoRedirect = false,
+                UseCookies = false,
+            };
+            _httpClient = new HttpClient(_httpClientHandler);
+        }
+
+        /// <summary>
+        /// Verify the behavior when a corrupted cookie is sent back to the server.
+        /// </summary>
+        [Theory]
+        [InlineData("__Controller::TempData", "Message=You successfully uploaded z̡̜͍̈̍̐̃̊͋́a̜̣͍̬̞̝͉̽ͧ͗l̸̖͕̤̠̹̘͖̃̌ͤg͓̝͓̰̀ͪo͈͌ 1.0.0.")]
+        public async Task RejectedCookie(string name, string value)
+        {
+            // Arrange
+            var relativePath = $"/packages/{Constants.TestPackageId}";
+            var requestUri = GetRequestUri(relativePath);
+            using (var request = new HttpRequestMessage(HttpMethod.Get, requestUri))
+            {
+                request.Headers.TryAddWithoutValidation("Cookie", $"{name}={value}");
+
+                // Act
+                var response = await GetTestResponseAsync(relativePath, request);
+
+                // Assert
+                Validator.SimpleHtml(HttpStatusCode.BadRequest)(response);
+            }
+        }
+
+        /// <summary>
+        /// Verify the behavior when a URL with restricted characters is used.
+        /// </summary>
+        [Theory]
+        [InlineData("/api/v2/lazy/%3E=1.0.5%20%3C1.1")]
+        [InlineData("/api/v2/mysql/*")]
+        [InlineData("/api/v2/comb/%3E=0.0.2")]
+        [InlineData("/.nuGetV3/feed.json:properties")]
+        [InlineData("/.nuGetV3/registration-semver2/serilog/page/0.1.6/1.2.47.json:properties")]
+        public async Task RejectedUrl(string relativePath)
+        {
+            // Arrange & Act
+            var response = await GetTestResponseAsync(relativePath);
+
+            // Assert
+            // Since the HTTP client is configured to not follow redirects, the response we get back is not the
+            // error page itself but instead a redirect to an error page.
+            Validator.Redirect("500")(response);
+        }
+
+        /// <summary>
+        /// Verify simple 404 behavior.
+        /// </summary>
+        [Theory]
+        [InlineData("/api/does-not-exist")]
+        [InlineData("/pages/does-not-exist")]
+        [InlineData("/api/v2/curated-feed/microsoftdotnet/DoesNotExist()")]
+        [InlineData("/does-not-exist")]
+        public async Task PageThatDoesNotExist(string relativePath)
+        {
+            // Arrange & Act
+            var response = await GetTestResponseAsync(relativePath);
+
+            // Assert
+            Validator.PrettyHtml(HttpStatusCode.NotFound)(response);
+        }
+
+        /// <summary>
+        /// Simulate cases where application code throws different sorts of exceptions.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(AllTestData))]
+        public async Task SimulateError(EndpointType endpointType, SimulatedErrorType simulatedErrorType)
+        {
+            // Arrange
+            var request = new SimulatedErrorRequest(endpointType, simulatedErrorType);
+
+            // Act
+            var response = await GetTestResponseAsync(request.GetRelativePath());
+
+            // Assert
+            if (!ExpectedSimulatedErrorResponses.TryGetValue(request, out var validator))
+            {
+                validator = Validator.PrettyInternalServerError();
+            }
+
+            validator(response);
+        }
+
+        /// <summary>
+        /// This enumerates all combinations of <see cref="EndpointType"/> and <see cref="SimulatedErrorRequest"/> for
+        /// testing purposes.
+        /// </summary>
+        public static IEnumerable<object[]> AllTestData
+        {
+            get
+            {
+                foreach (var endpoint in Enum.GetValues(typeof(EndpointType)).Cast<EndpointType>())
+                {
+                    foreach (var type in Enum.GetValues(typeof(SimulatedErrorType)).Cast<SimulatedErrorType>())
+                    {
+                        yield return new object[] { endpoint, type };
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// The expected responses for a <see cref="SimulatedErrorRequest"/>. If a key is not present, the
+        /// <see cref="SimulateError(EndpointType, SimulatedErrorType)"/> test will use the
+        /// <see cref="Validator.PrettyInternalServerError"/> validator.
+        /// </summary>
+        public static IReadOnlyDictionary<SimulatedErrorRequest, Action<TestResponse>> ExpectedSimulatedErrorResponses = new Dictionary<SimulatedErrorRequest, Action<TestResponse>>
+        {
+            { SER(EndpointType.Api, SimulatedErrorType.Exception), Validator.SimpleHtml(HttpStatusCode.InternalServerError, SimulatedErrorType.Exception) },
+            { SER(EndpointType.Api, SimulatedErrorType.HttpException500), Validator.SimpleHtml(HttpStatusCode.InternalServerError, SimulatedErrorType.HttpException500) },
+            { SER(EndpointType.Api, SimulatedErrorType.HttpResponseException400), Validator.SimpleHtmlWithExceptionReasonPhrase() },
+            { SER(EndpointType.Api, SimulatedErrorType.HttpResponseException404), Validator.SimpleHtmlWithExceptionReasonPhrase() },
+            { SER(EndpointType.Api, SimulatedErrorType.HttpResponseException500), Validator.SimpleHtmlWithExceptionReasonPhrase() },
+            { SER(EndpointType.Api, SimulatedErrorType.HttpResponseException503), Validator.SimpleHtmlWithExceptionReasonPhrase() },
+            { SER(EndpointType.Api, SimulatedErrorType.ReadOnlyMode), Validator.SimpleHtml(HttpStatusCode.ServiceUnavailable, SimulatedErrorType.ReadOnlyMode) },
+            { SER(EndpointType.Api, SimulatedErrorType.Result400), Validator.SimpleHtml(HttpStatusCode.BadRequest, SimulatedErrorType.Result400) },
+            { SER(EndpointType.Api, SimulatedErrorType.Result404), Validator.PrettyHtml(HttpStatusCode.NotFound) },
+            { SER(EndpointType.Api, SimulatedErrorType.Result503), Validator.SimpleHtml(HttpStatusCode.ServiceUnavailable, SimulatedErrorType.Result503) },
+            { SER(EndpointType.Api, SimulatedErrorType.UserSafeException), Validator.SimpleHtml(HttpStatusCode.InternalServerError, SimulatedErrorType.UserSafeException) },
+            { SER(EndpointType.OData, SimulatedErrorType.Exception), Validator.Xml() },
+            { SER(EndpointType.OData, SimulatedErrorType.HttpException400), Validator.Xml() },
+            { SER(EndpointType.OData, SimulatedErrorType.HttpException404), Validator.Xml() },
+            { SER(EndpointType.OData, SimulatedErrorType.HttpException500), Validator.Xml() },
+            { SER(EndpointType.OData, SimulatedErrorType.HttpException503), Validator.Xml() },
+            { SER(EndpointType.OData, SimulatedErrorType.HttpResponseException400), Validator.Empty(HttpStatusCode.BadRequest, SimulatedErrorType.HttpResponseException400) },
+            { SER(EndpointType.OData, SimulatedErrorType.HttpResponseException404), Validator.Empty(HttpStatusCode.NotFound, SimulatedErrorType.HttpResponseException404) },
+            { SER(EndpointType.OData, SimulatedErrorType.HttpResponseException500), Validator.Empty(HttpStatusCode.InternalServerError, SimulatedErrorType.HttpResponseException500) },
+            { SER(EndpointType.OData, SimulatedErrorType.HttpResponseException503), Validator.Empty(HttpStatusCode.ServiceUnavailable, SimulatedErrorType.HttpResponseException503) },
+            { SER(EndpointType.OData, SimulatedErrorType.ReadOnlyMode), Validator.Xml() },
+            { SER(EndpointType.OData, SimulatedErrorType.Result400), Validator.Empty(HttpStatusCode.BadRequest, SimulatedErrorType.Result400) },
+            { SER(EndpointType.OData, SimulatedErrorType.Result404), Validator.Empty(HttpStatusCode.NotFound, SimulatedErrorType.Result404) },
+            { SER(EndpointType.OData, SimulatedErrorType.Result500), Validator.Empty(HttpStatusCode.InternalServerError, SimulatedErrorType.Result500) },
+            { SER(EndpointType.OData, SimulatedErrorType.Result503), Validator.Empty(HttpStatusCode.ServiceUnavailable, SimulatedErrorType.Result503) },
+            { SER(EndpointType.OData, SimulatedErrorType.UserSafeException), Validator.Xml() },
+            { SER(EndpointType.Pages, SimulatedErrorType.HttpException400), Validator.Redirect("500") },
+            { SER(EndpointType.Pages, SimulatedErrorType.HttpException404), Validator.Redirect("404") },
+            { SER(EndpointType.Pages, SimulatedErrorType.HttpException503), Validator.Redirect("500") },
+            { SER(EndpointType.Pages, SimulatedErrorType.ReadOnlyMode), Validator.PrettyHtml(HttpStatusCode.ServiceUnavailable) },
+            { SER(EndpointType.Pages, SimulatedErrorType.Result400), Validator.SimpleHtml(HttpStatusCode.BadRequest, SimulatedErrorType.Result400) },
+            { SER(EndpointType.Pages, SimulatedErrorType.Result404), Validator.PrettyHtml(HttpStatusCode.NotFound) },
+            { SER(EndpointType.Pages, SimulatedErrorType.Result503), Validator.SimpleHtml(HttpStatusCode.ServiceUnavailable, SimulatedErrorType.Result503) },
+        };
+
+        /// <summary>
+        /// This is a short-hand for instantiating a <see cref="SimulatedErrorRequest"/>.
+        /// </summary>
+        private static SimulatedErrorRequest SER(EndpointType endpointType, SimulatedErrorType simulatedErrorType)
+        {
+            return new SimulatedErrorRequest(endpointType, simulatedErrorType);
+        }
+
+        private async Task<TestResponse> GetTestResponseAsync(string relativePath, HttpRequestMessage request)
+        {
+            TestOutputHelper.WriteLine($"Request:  {request.Method} {request.RequestUri.AbsoluteUri}");
+            var stopwatch = Stopwatch.StartNew();
+            using (var httpResponseMessage = await _httpClient.SendAsync(request))
+            {
+                var response = await TestResponse.FromHttpResponseMessageAsync(relativePath, httpResponseMessage);
+                TestOutputHelper.WriteLine($"Duration: {stopwatch.ElapsedMilliseconds}ms");
+                TestOutputHelper.WriteLine(response.ToString());
+                return response;
+            }
+        }
+
+        private async Task<TestResponse> GetTestResponseAsync(string relativePath)
+        {
+            using (var request = new HttpRequestMessage(HttpMethod.Get, GetRequestUri(relativePath)))
+            {
+                return await GetTestResponseAsync(relativePath, request);
+            }
+        }
+
+        private Uri GetRequestUri(string relativePath)
+        {
+            return new Uri(new Uri(UrlHelper.BaseUrl), relativePath);
+        }
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+            _httpClientHandler.Dispose();
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/ErrorHandling/SimulatedErrorRequest.cs
+++ b/tests/NuGetGallery.FunctionalTests/ErrorHandling/SimulatedErrorRequest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGetGallery.FunctionalTests.ErrorHandling
+{
+    /// <summary>
+    /// Represents a pair of <see cref="EndpointType"/> and <see cref="SimulatedErrorType"/>. Also contains logic on
+    /// building a relative URL for this pair.
+    /// </summary>
+    public class SimulatedErrorRequest : IEquatable<SimulatedErrorRequest>
+    {
+        public SimulatedErrorRequest(EndpointType endpointType, SimulatedErrorType simulatedErrorType)
+        {
+            EndpointType = endpointType;
+            SimulatedErrorType = simulatedErrorType;
+        }
+
+        public EndpointType EndpointType { get; }
+        public SimulatedErrorType SimulatedErrorType { get; }
+
+        public string GetRelativePath()
+        {
+            string path;
+            switch (EndpointType)
+            {
+                case EndpointType.Pages:
+                    path = "/pages/simulate-error";
+                    break;
+                case EndpointType.Api:
+                    path = "/api/simulate-error";
+                    break;
+                case EndpointType.OData:
+                    path = "/api/v2/curated-feed/microsoftdotnet/SimulateError()";
+                    break;
+                default:
+                    throw new NotImplementedException("The endpoint type is not supported.");
+            }
+
+            return $"{path}?type={SimulatedErrorType}";
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as SimulatedErrorRequest);
+        }
+
+        public bool Equals(SimulatedErrorRequest other)
+        {
+            return other != null
+                && EndpointType == other.EndpointType
+                && SimulatedErrorType == other.SimulatedErrorType;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -73651023;
+            hashCode = hashCode * -1521134295 + EndpointType.GetHashCode();
+            hashCode = hashCode * -1521134295 + SimulatedErrorType.GetHashCode();
+            return hashCode;
+        }
+
+        public override string ToString() => GetRelativePath();
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/ErrorHandling/SimulatedErrorType.cs
+++ b/tests/NuGetGallery.FunctionalTests/ErrorHandling/SimulatedErrorType.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+namespace NuGetGallery.FunctionalTests.ErrorHandling
+{
+    /// <summary>
+    /// Intentionally copied from the NuGetGallery solution to seperate test code from business logic.
+    /// </summary>
+    public enum SimulatedErrorType
+    {
+        Result400,
+        Result404,
+        Result500,
+        Result503,
+        HttpException400,
+        HttpException404,
+        HttpException500,
+        HttpException503,
+        HttpResponseException400,
+        HttpResponseException404,
+        HttpResponseException500,
+        HttpResponseException503,
+        Exception,
+        UserSafeException,
+        ReadOnlyMode,
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/ErrorHandling/TestResponse.cs
+++ b/tests/NuGetGallery.FunctionalTests/ErrorHandling/TestResponse.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGetGallery.FunctionalTests.ErrorHandling
+{
+    /// <summary>
+    /// A simplified version of <see cref="HttpResponseMessage"/> so we don't have to worry about disposal, streams,
+    /// or intepreting some common response bodies.
+    /// </summary>
+    public class TestResponse
+    {
+        private TestResponse(
+            string relativePath,
+            HttpStatusCode statusCode,
+            string reasonPhrase,
+            string contentTypeHeader,
+            string locationHeader,
+            int contentLength,
+            string content)
+        {
+            RelativePath = relativePath ?? throw new ArgumentNullException(nameof(relativePath));
+            StatusCode = statusCode;
+            ReasonPhrase = reasonPhrase ?? throw new ArgumentNullException(nameof(reasonPhrase));
+            ContentTypeHeader = contentTypeHeader;
+            LocationHeader = locationHeader;
+            ContentLength = contentLength;
+            Content = content ?? throw new ArgumentNullException(nameof(content));
+        }
+
+        public static async Task<TestResponse> FromHttpResponseMessageAsync(
+            string relativePath,
+            HttpResponseMessage httpResponseMessage)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            var hasContentType = httpResponseMessage.Content.Headers.TryGetValues("Content-Type", out var contentTypes);
+            var hasLocation = httpResponseMessage.Headers.TryGetValues("Location", out var locations);
+
+            var contentBytes = await httpResponseMessage.Content.ReadAsByteArrayAsync();
+            var contentString = await httpResponseMessage.Content.ReadAsStringAsync();
+
+            var output = new TestResponse(
+                relativePath,
+                httpResponseMessage.StatusCode,
+                httpResponseMessage.ReasonPhrase,
+                hasContentType ? contentTypes.Single() : null,
+                hasLocation ? locations.Single() : null,
+                contentBytes.Length,
+                contentString);
+
+            return output;
+        }
+
+        public string RelativePath { get; }
+        public HttpStatusCode StatusCode { get; }
+        public string ReasonPhrase { get; }
+        public string ContentTypeHeader { get; }
+        public string LocationHeader { get; }
+        public int ContentLength { get; }
+        public string Content { get; }
+
+        public bool IsPrettyHtml => Content.Contains("page-error")
+            && Content.Contains("Oops")
+            && Content.Contains("Get me out of here!");
+
+        public bool IsErrorXml => Content.Contains("<m:message xml:lang=\"en-US\">An error has occurred.</m:message>");
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            sb.Append(nameof(TestResponse));
+            sb.AppendLine(":");
+            Append(sb, "  StatusCode:        ", (int)StatusCode);
+            Append(sb, "  ReasonPhrase:      ", ReasonPhrase);
+            Append(sb, "  ContentTypeHeader: ", ContentTypeHeader);
+            Append(sb, "  LocationHeader:    ", LocationHeader);
+            Append(sb, "  ContentLength:     ", ContentLength);
+            Append(sb, "  IsPrettyHtml:      ", IsPrettyHtml);
+            Append(sb, "  IsErrorXml:        ", IsErrorXml);
+
+            return sb.ToString();
+        }
+
+        private void Append(StringBuilder sb, string label, int value) => Append(sb, label, value, quotes: false);
+        private void Append(StringBuilder sb, string label, bool value) => Append(sb, label, value, quotes: false);
+        private void Append(StringBuilder sb, string label, string value) => Append(sb, label, value, quotes: true);
+
+        private void Append(StringBuilder sb, string label, object value, bool quotes)
+        {
+            sb.Append(label);
+
+            if (value == null)
+            {
+                sb.Append("(none)");
+            }
+            else
+            {
+                if (quotes)
+                {
+                    sb.AppendFormat("'{0}'", value);
+                }
+                else
+                {
+                    sb.Append(value);
+                }
+            }
+
+            sb.AppendLine();
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/ErrorHandling/Validator.cs
+++ b/tests/NuGetGallery.FunctionalTests/ErrorHandling/Validator.cs
@@ -1,0 +1,188 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using Xunit;
+
+namespace NuGetGallery.FunctionalTests.ErrorHandling
+{
+    /// <summary>
+    /// A collection of higher-order functions for validating a <see cref="TestResponse"/>. Note that some of these
+    /// implementations assume that the <see cref="HttpClient"/> that produced the response had redirects turned off.
+    /// For example, the <see cref="Redirect(string)"/> function asserts that the response is a 302 Found. This is not
+    /// exactly what the user experiences because the web browser follows redirects.
+    /// </summary>
+    public static class Validator
+    {
+        private const string GenericExceptionReasonPhrase =
+            "Processing of the HTTP request resulted in an exception. Please see the HTTP response returned by " +
+            "the 'Response' property of this exception for details.";
+
+        /// <summary>
+        /// Asserts the response has no content or content type.
+        /// </summary>
+        public static Action<TestResponse> Empty(HttpStatusCode statusCode, SimulatedErrorType simulatedErrorType)
+        {
+            return response =>
+            {
+                Assert.Equal(statusCode, response.StatusCode);
+                Assert.Equal(GetSimulatedErrorReasonPhrase(simulatedErrorType), response.ReasonPhrase);
+                Assert.Null(response.ContentTypeHeader);
+                Assert.Null(response.LocationHeader);
+                Assert.Equal(0, response.ContentLength);
+                Assert.Empty(response.Content);
+            };
+        }
+
+        /// <summary>
+        /// Asserts the response is a redirect to the specified error page.
+        /// </summary>
+        public static Action<TestResponse> Redirect(string errorPageName)
+        {
+            return response =>
+            {
+                Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+                Assert.Equal(GetDefaultReasonPhrase(HttpStatusCode.Found), response.ReasonPhrase);
+                AssertContentTypeIsHtml(response);
+                Assert.NotNull(response.LocationHeader);
+
+                const string errorsPrefix = "/Errors/";
+                Assert.StartsWith(errorsPrefix, response.LocationHeader);
+
+                var errorNumberAndQueryString = response.LocationHeader.Substring(errorsPrefix.Length);
+                var pieces = errorNumberAndQueryString.Split(new[] { '?' }, 2);
+                Assert.Equal(2, pieces.Length);
+                var actualErrorPageName = pieces[0];
+                var queryString = pieces[1];
+
+                var questionMarkIndex = response.RelativePath.IndexOf('?');
+                var expectedRelativePath = response.RelativePath;
+                if (questionMarkIndex >= 0)
+                {
+                    expectedRelativePath = expectedRelativePath.Substring(0, questionMarkIndex);
+                }
+
+                Assert.Equal($"aspxerrorpath={expectedRelativePath}", queryString);
+                Assert.Contains(errorPageName, actualErrorPageName);
+
+                AssertContentIsNotPrettyHtml(response);
+            };
+        }
+
+        /// <summary>
+        /// Asserts the response is XML.
+        /// </summary>
+        public static Action<TestResponse> Xml()
+        {
+            return response =>
+            {
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+                Assert.Equal(GetDefaultReasonPhrase(HttpStatusCode.InternalServerError), response.ReasonPhrase);
+                AssertContentTypeIsXml(response);
+                Assert.Null(response.LocationHeader);
+                Assert.NotEqual(0, response.ContentLength);
+                Assert.True(response.IsErrorXml, "The content should contain the generic XML error message.");
+            };
+        }
+
+        /// <summary>
+        /// Asserts the response is a simple HTML page with a generic exception message in the reason phrase.
+        /// </summary>
+        public static Action<TestResponse> SimpleHtmlWithExceptionReasonPhrase()
+        {
+            return SimpleHtml(HttpStatusCode.InternalServerError, GenericExceptionReasonPhrase);
+        }
+
+        /// <summary>
+        /// Asserts the response is a simple HTML page with the default reason phrase for the specific status code.
+        /// </summary>
+        public static Action<TestResponse> SimpleHtml(HttpStatusCode statusCode)
+        {
+            return SimpleHtml(statusCode, GetDefaultReasonPhrase(statusCode));
+        }
+
+        /// <summary>
+        /// Asserts the response is a simple HTML page with a reason phrase containing a simulated error type. This
+        /// essentially is the behavior that NuGet client depends on to get error messages from HTTP responses. Error
+        /// messages come back in the HTTP response reason phrase.
+        /// </summary>
+        public static Action<TestResponse> SimpleHtml(HttpStatusCode statusCode, SimulatedErrorType simulatedErrorType)
+        {
+            return SimpleHtml(statusCode, GetSimulatedErrorReasonPhrase(simulatedErrorType));
+        }
+
+        /// <summary>
+        /// Asserts the response is the pretty HTML error page.
+        /// </summary>
+        public static Action<TestResponse> PrettyHtml(HttpStatusCode statusCode)
+        {
+            return response =>
+            {
+                Assert.Equal(statusCode, response.StatusCode);
+                Assert.Equal(GetDefaultReasonPhrase(statusCode), response.ReasonPhrase);
+                AssertContentTypeIsHtml(response);
+                Assert.Null(response.LocationHeader);
+                Assert.NotEqual(0, response.ContentLength);
+                Assert.NotEmpty(response.Content);
+                AssertContentIsPrettyHtml(response);
+            };
+        }
+
+        /// <summary>
+        /// Asserts the response is the pretty HTML error page for HTTP 500 Internal Server Error.
+        /// </summary>
+        public static Action<TestResponse> PrettyInternalServerError()
+        {
+            return PrettyHtml(HttpStatusCode.InternalServerError);
+        }
+
+        private static Action<TestResponse> SimpleHtml(HttpStatusCode statusCode, string reasonPhrase)
+        {
+            return response =>
+            {
+                Assert.Equal(statusCode, response.StatusCode);
+                Assert.Equal(reasonPhrase, response.ReasonPhrase);
+                AssertContentTypeIsHtml(response);
+                Assert.Null(response.LocationHeader);
+                Assert.NotEqual(0, response.ContentLength);
+                Assert.NotEmpty(response.Content);
+                AssertContentIsNotPrettyHtml(response);
+            };
+        }
+
+        private static void AssertContentIsNotPrettyHtml(TestResponse response)
+        {
+            Assert.False(response.IsPrettyHtml, "The content should not be the pretty HTML error page.");
+        }
+
+        private static void AssertContentIsPrettyHtml(TestResponse response)
+        {
+            Assert.True(response.IsPrettyHtml, "The content should be the pretty HTML error page.");
+        }
+
+        private static void AssertContentTypeIsXml(TestResponse response)
+        {
+            Assert.StartsWith("application/xml", response.ContentTypeHeader);
+        }
+
+        private static void AssertContentTypeIsHtml(TestResponse response)
+        {
+            Assert.StartsWith("text/html", response.ContentTypeHeader);
+        }
+
+        private static string GetDefaultReasonPhrase(HttpStatusCode statusCode)
+        {
+            using (var response = new HttpResponseMessage(statusCode))
+            {
+                return response.ReasonPhrase;
+            }
+        }
+
+        private static string GetSimulatedErrorReasonPhrase(SimulatedErrorType simulatedErrorType)
+        {
+            return $"SimulatedErrorType {simulatedErrorType}";
+        }
+    }
+}

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -85,6 +85,12 @@
     <Compile Include="AtomFeed\AtomFeedTests.cs" />
     <Compile Include="Commandline\NuGetCommandLineTests.cs" />
     <Compile Include="Commandline\NuGetCoreTests.cs" />
+    <Compile Include="ErrorHandling\EndpointType.cs" />
+    <Compile Include="ErrorHandling\ErrorHandlingTests.cs" />
+    <Compile Include="ErrorHandling\Validator.cs" />
+    <Compile Include="ErrorHandling\SimulatedErrorRequest.cs" />
+    <Compile Include="ErrorHandling\SimulatedErrorType.cs" />
+    <Compile Include="ErrorHandling\TestResponse.cs" />
     <Compile Include="ODataFeeds\CuratedFeedTest.cs" />
     <Compile Include="ODataFeeds\SearchTest.cs" />
     <Compile Include="ODataFeeds\V2FeedExtendedTests.cs" />


### PR DESCRIPTION
This just adds test coverage of current behavior. Cases asserted:

1. Bad cookie
1. Missing route (simple 404)
1. Nasty URLs that IIS does not like.
1. All possible inputs for the "simulate error" endpoints.

Progress on https://github.com/NuGet/NuGetGallery/issues/6601.