### PR TITLE
Site admins can see email address on profile page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1265,6 +1265,9 @@ img.reserved-indicator-icon {
 .page-profile .profile-details .statistics .statistic .description {
   font-size: 24px;
 }
+.page-profile .profile-details .additional-info {
+  margin-top: 20px;
+}
 .page-report-abuse .report-form #alreadycontactedowner-label {
   display: inline;
 }

--- a/src/Bootstrap/less/theme/page-profile.less
+++ b/src/Bootstrap/less/theme/page-profile.less
@@ -52,5 +52,9 @@
         }
       }
     }
+
+    .additional-info {      
+      margin-top: (@padding-large-vertical * 2);
+    }
   }
 }

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -23,6 +23,20 @@
                     <div class="description">Total @(Model.TotalPackageDownloadCount == 1 ? "download" : "downloads") of packages</div>
                 </div>
             </div>
+            @if (User.IsAdministrator())
+            {
+                <div class="additional-info">
+                    <dl>
+                        <dt>Email Address:</dt>
+                        <dd>@Model.EmailAddress</dd>
+                        @if (Model.UnconfirmedEmailAddress != null)
+                        {
+                            <dt>Unconfirmed Email Address:</dt>
+                            <dd>@Model.UnconfirmedEmailAddress</dd>
+                        }
+                    </dl>
+                </div>
+            }
         </aside>
         <article class="col-md-9 col-md-pull-3">
             <div class="profile-title">


### PR DESCRIPTION
This is currently already possible with the database admin view, but this makes it much more convenient. If the user is not a site admin, this information will remain private -- as it should be!

Address https://github.com/NuGet/Engineering/issues/609.

Looks like this:
![image](https://user-images.githubusercontent.com/94054/53432667-c9d4d100-39a7-11e9-8290-e362427b6ebd.png)