### PR TITLE
Remove flaky download count assertion

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
@@ -576,37 +576,6 @@ namespace NuGetGallery.FunctionalTests
         }
 
         /// <summary>
-        /// Returns the download count of the given package as a formatted string as it would appear in the gallery UI.
-        /// </summary>
-        public static string GetFormattedDownLoadStatistics(string packageId)
-        {
-            var formattedCount = GetDownLoadStatistics(packageId).ToString("N1", CultureInfo.InvariantCulture);
-            if (formattedCount.EndsWith(".0"))
-                formattedCount = formattedCount.Remove(formattedCount.Length - 2);
-            return formattedCount;
-        }
-
-        /// <summary>
-        /// Returns the download count of the given package.
-        /// </summary>
-        public static int GetDownLoadStatistics(string packageId)
-        {
-            var repo = PackageRepositoryFactory.Default.CreateRepository(SourceUrl);
-            var package = repo.FindPackage(packageId);
-            return package.DownloadCount;
-        }
-
-        /// <summary>
-        /// Returns the download count of the specific version of the package.
-        /// </summary>
-        public static int GetDownLoadStatisticsForPackageVersion(string packageId, string packageVersion)
-        {
-            var repo = PackageRepositoryFactory.Default.CreateRepository(SourceUrl);
-            var package = repo.FindPackage(packageId, new NuGet.SemanticVersion(packageVersion));
-            return package.DownloadCount;
-        }
-
-        /// <summary>
         /// Searchs the gallery to get the packages matching the specific search term and returns their count.
         /// </summary>
         public static int GetPackageCountForSearchTerm(string searchQuery)

--- a/tests/NuGetGallery.WebUITests.P1/BasicPages/PackagesPageTest.cs
+++ b/tests/NuGetGallery.WebUITests.P1/BasicPages/PackagesPageTest.cs
@@ -29,10 +29,6 @@ namespace NuGetGallery.FunctionalTests.WebUITests.BasicPages
             var packageTitleValidationRule = AssertAndValidationHelper.GetValidationRuleForFindText(packageId + " " + ClientSdkHelper.GetLatestStableVersion(packageId));
             packagePageRequest.ValidateResponse += packageTitleValidationRule.Validate;
 
-            // Rule to check that the download count is present in the response.
-            var downloadCountValidationRule = AssertAndValidationHelper.GetValidationRuleForFindText(ClientSdkHelper.GetFormattedDownLoadStatistics(packageId));
-            packagePageRequest.ValidateResponse += downloadCountValidationRule.Validate;
-
             yield return packagePageRequest;
         }
     }


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/1952.

This is broken since stats don't sync between search and gallery simultaneously. 