### PR TITLE
Unlisting a package when deprecating it should update LastEdited

### DIFF
--- a/src/NuGetGallery/Services/PackageDeprecationService.cs
+++ b/src/NuGetGallery/Services/PackageDeprecationService.cs
@@ -123,6 +123,7 @@ namespace NuGetGallery
 
             await _deprecationRepository.CommitChangesAsync();
 
+            // Update the indexing of the packages we updated the deprecation information of.
             foreach (var package in packages)
             {
                 _indexingService.UpdatePackage(package);

--- a/src/NuGetGallery/Services/PackageDeprecationService.cs
+++ b/src/NuGetGallery/Services/PackageDeprecationService.cs
@@ -102,6 +102,7 @@ namespace NuGetGallery
                     if (shouldUnlist)
                     {
                         package.Listed = false;
+                        package.LastEdited = DateTime.UtcNow;
                     }
                 }
             }

--- a/src/NuGetGallery/Services/PackageDeprecationService.cs
+++ b/src/NuGetGallery/Services/PackageDeprecationService.cs
@@ -107,7 +107,7 @@ namespace NuGetGallery
 
                     if (shouldUnlist)
                     {
-                        await _packageService.MarkPackageUnlistedAsync(package, false);
+                        await _packageService.MarkPackageUnlistedAsync(package, commitChanges: false);
                     }
                 }
             }

--- a/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
@@ -77,8 +77,10 @@ namespace NuGetGallery.Services
                         false));
             }
 
-            [Fact]
-            public async Task DeletesExistingDeprecationsIfStatusNotDeprecated()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public async Task DeletesExistingDeprecationsIfStatusNotDeprecated(bool shouldUnlist)
             {
                 // Arrange
                 var packageWithDeprecation1 = new Package
@@ -114,6 +116,20 @@ namespace NuGetGallery.Services
                     .Completes()
                     .Verifiable();
 
+                var packageService = GetMock<IPackageService>();
+                var indexingService = GetMock<IIndexingService>();
+                foreach (var package in packages)
+                {
+                    // When deleting deprecations, packages should not be unlisted because the option is hidden in the UI.
+                    packageService
+                        .Setup(x => x.MarkPackageUnlistedAsync(package, false))
+                        .Throws<InvalidOperationException>();
+
+                    indexingService
+                        .Setup(x => x.UpdatePackage(package))
+                        .Verifiable();
+                }
+
                 var service = Get<PackageDeprecationService>();
 
                 // Act
@@ -126,10 +142,11 @@ namespace NuGetGallery.Services
                     null,
                     null,
                     null,
-                    false);
+                    shouldUnlist);
 
                 // Assert
                 deprecationRepository.Verify();
+                indexingService.Verify();
 
                 foreach (var package in packages)
                 {
@@ -147,26 +164,22 @@ namespace NuGetGallery.Services
 
                 var unlistedPackageWithoutDeprecation = new Package
                 {
-                    Listed = false,
                     LastEdited = lastEdited
                 };
 
                 var packageWithDeprecation1 = new Package
                 {
-                    Listed = true,
                     Deprecations = new List<PackageDeprecation> { new PackageDeprecation() },
                     LastEdited = lastEdited
                 };
 
                 var packageWithoutDeprecation1 = new Package
                 {
-                    Listed = true,
                     LastEdited = lastEdited
                 };
 
                 var packageWithDeprecation2 = new Package
                 {
-                    Listed = true,
                     LastEdited = lastEdited,
                     Deprecations = new List<PackageDeprecation>
                     {
@@ -185,13 +198,11 @@ namespace NuGetGallery.Services
 
                 var packageWithoutDeprecation2 = new Package
                 {
-                    Listed = true,
                     LastEdited = lastEdited
                 };
 
                 var packageWithDeprecation3 = new Package
                 {
-                    Listed = true,
                     LastEdited = lastEdited,
                     Deprecations = new List<PackageDeprecation>
                     {
@@ -231,6 +242,30 @@ namespace NuGetGallery.Services
                     .Setup(x => x.CommitChangesAsync())
                     .Completes()
                     .Verifiable();
+
+                var packageService = GetMock<IPackageService>();
+                var indexingService = GetMock<IIndexingService>();
+                foreach (var package in packages)
+                {
+                    var unlistPackageSetup = packageService
+                        .Setup(x => x.MarkPackageUnlistedAsync(package, false));
+
+                    if (shouldUnlist)
+                    {
+                        unlistPackageSetup
+                            .Completes()
+                            .Verifiable();
+                    }
+                    else
+                    {
+                        unlistPackageSetup
+                            .Throws<InvalidOperationException>();
+                    }
+
+                    indexingService
+                        .Setup(x => x.UpdatePackage(package))
+                        .Verifiable();
+                }
 
                 var service = Get<PackageDeprecationService>();
 
@@ -283,6 +318,8 @@ namespace NuGetGallery.Services
 
                 // Assert
                 deprecationRepository.Verify();
+                packageService.Verify();
+                indexingService.Verify();
 
                 foreach (var package in packages)
                 {
@@ -294,17 +331,6 @@ namespace NuGetGallery.Services
                     Assert.Equal(alternatePackageRegistration, deprecation.AlternatePackageRegistration);
                     Assert.Equal(alternatePackage, deprecation.AlternatePackage);
                     Assert.Equal(customMessage, deprecation.CustomMessage);
-                    
-                    if (shouldUnlist)
-                    {
-                        Assert.False(package.Listed);
-                        Assert.True(package.LastEdited > lastEdited);
-                    }
-                    else 
-                    {
-                        Assert.Equal(package != unlistedPackageWithoutDeprecation, package.Listed);
-                        Assert.Equal(lastEdited, package.LastEdited);
-                    }
                 }
             }
         }

--- a/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
@@ -143,22 +143,31 @@ namespace NuGetGallery.Services
             public async Task ReplacesExistingDeprecations(bool shouldUnlist)
             {
                 // Arrange
-                var unlistedPackageWithoutDeprecation = new Package();
+                var lastEdited = new DateTime(2019, 3, 4);
+
+                var unlistedPackageWithoutDeprecation = new Package
+                {
+                    Listed = false,
+                    LastEdited = lastEdited
+                };
 
                 var packageWithDeprecation1 = new Package
                 {
                     Listed = true,
-                    Deprecations = new List<PackageDeprecation> { new PackageDeprecation() }
+                    Deprecations = new List<PackageDeprecation> { new PackageDeprecation() },
+                    LastEdited = lastEdited
                 };
 
                 var packageWithoutDeprecation1 = new Package
                 {
                     Listed = true,
+                    LastEdited = lastEdited
                 };
 
                 var packageWithDeprecation2 = new Package
                 {
                     Listed = true,
+                    LastEdited = lastEdited,
                     Deprecations = new List<PackageDeprecation>
                     {
                         new PackageDeprecation
@@ -177,11 +186,13 @@ namespace NuGetGallery.Services
                 var packageWithoutDeprecation2 = new Package
                 {
                     Listed = true,
+                    LastEdited = lastEdited
                 };
 
                 var packageWithDeprecation3 = new Package
                 {
                     Listed = true,
+                    LastEdited = lastEdited,
                     Deprecations = new List<PackageDeprecation>
                     {
                         new PackageDeprecation
@@ -287,10 +298,12 @@ namespace NuGetGallery.Services
                     if (shouldUnlist)
                     {
                         Assert.False(package.Listed);
+                        Assert.True(package.LastEdited > lastEdited);
                     }
-                    else if (package != unlistedPackageWithoutDeprecation)
+                    else 
                     {
-                        Assert.True(package.Listed);
+                        Assert.Equal(package != unlistedPackageWithoutDeprecation, package.Listed);
+                        Assert.Equal(lastEdited, package.LastEdited);
                     }
                 }
             }


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/2082

This is a bug fix for the behavior of the deprecation form on the manage package page. Without setting `LastEdited`, the change is not pushed to V3.

In the future, when deprecation information is pushed to V3 as well, this route should always set `LastEdited`, but right now, because deprecation information is not push to V3, it only needs to update `LastEdited` when we are unlisting.