### PR TITLE
Improve deprecation information UI on Display Package page with multiple reasons

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -880,6 +880,7 @@ img.reserved-indicator-icon {
   display: -webkit-flex;
   display: -ms-flexbox;
   display:         flex;
+  width: 100%;
   vertical-align: middle;
 
   -webkit-box-pack: justify;
@@ -887,26 +888,26 @@ img.reserved-indicator-icon {
   -ms-flex-pack: justify;
           justify-content: space-between;
 }
-.page-package-details .deprecation-container .deprecation-expander .deprecation-expander-icon-container {
+.page-package-details .deprecation-container .deprecation-expander .deprecation-expander-container {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display:         flex;
-
-  -webkit-box-align: center;
-  -webkit-align-items: center;
-  -ms-flex-align: center;
-          align-items: center;
 }
-.page-package-details .deprecation-container .deprecation-expander .deprecation-expander-icon-container .deprecation-expander-icon {
+.page-package-details .deprecation-container .deprecation-expander .deprecation-expander-container .deprecation-expander-icon {
   position: unset;
   top: unset;
 }
-.page-package-details .deprecation-container .deprecation-expander .deprecation-expander-info-right {
+.page-package-details .deprecation-container .deprecation-expander .deprecation-expander-container .deprecation-expander-info-right {
   padding-left: 15px;
 }
+.page-package-details .deprecation-container .deprecation-expander .deprecation-expander-container .deprecation-expander-severity-rating {
+  margin-left: 5px;
+}
 .page-package-details .deprecation-container .deprecation-content-container {
+  padding-top: 15px;
   margin-top: 15px;
+  border-top: 1px solid lightgray;
 }
 .page-package-details .deprecation-container .deprecation-content-container p {
   margin-top: 5px;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -24,24 +24,30 @@
       display: flex;
       justify-content: space-between;
       vertical-align: middle;
+      width: 100%;
 
-      .deprecation-expander-icon-container {
+      .deprecation-expander-container {
         display: flex;
-        align-items: center;
-        
+
         .deprecation-expander-icon {
           position: unset;
           top: unset;
         }
-      }
+  
+        .deprecation-expander-info-right {
+          padding-left: 15px;
+        }
 
-      .deprecation-expander-info-right {
-        padding-left: 15px;
+        .deprecation-expander-severity-rating {
+          margin-left: 5px;
+        }
       }
     }
 
     .deprecation-content-container {
       margin-top: 15px;
+      padding-top: 15px;
+      border-top: 1px solid lightgray;
 
       p {
         margin-top: 5px;

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -52,8 +52,28 @@ namespace NuGetGallery
                 DeprecationStatus = deprecation.Status;
 
                 CveIds = deprecation.Cves?.Select(c => c.CveId).ToList();
-                CvssRating = deprecation.CvssRating;
                 CweIds = deprecation.Cwes?.Select(c => c.CweId).ToList();
+
+                if (deprecation.CvssRating.HasValue)
+                {
+                    var cvssRating = deprecation.CvssRating.Value;
+                    if (cvssRating < 4)
+                    {
+                        Severity = "Low";
+                    }
+                    else if (cvssRating < 7)
+                    {
+                        Severity = "Medium";
+                    }
+                    else if (cvssRating < 9)
+                    {
+                        Severity = "High";
+                    }
+                    else
+                    {
+                        Severity = "Critical";
+                    }
+                }
 
                 AlternatePackageId = deprecation.AlternatePackageRegistration?.Id;
 
@@ -165,7 +185,7 @@ namespace NuGetGallery
 
         public PackageDeprecationStatus DeprecationStatus { get; set; }
         public IReadOnlyCollection<string> CveIds { get; set; }
-        public decimal? CvssRating { get; set; }
+        public string Severity { get; set; }
         public IReadOnlyCollection<string> CweIds { get; set; }
         public string AlternatePackageId { get; set; }
         public string AlternatePackageVersion { get; set; }

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
@@ -33,61 +33,62 @@
     <div class="icon-text alert alert-warning">
         <div id="show-deprecation-content-container" class="deprecation-expander" tabindex="0" data-toggle="collapse" data-target="#deprecation-content-container" aria-expanded="false" aria-controls="deprecation-content-container" aria-labelledby="deprecation-container-label">
             <div class="deprecation-expander">
-                <div class="deprecation-expander-icon-container">
+                <div class="deprecation-expander-container">
                     <i class="deprecation-expander-icon ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
+
+                    <div id="deprecation-container-label" class="deprecation-expander-info-right">
+                        @{
+                            var isVulnerable = Model.DeprecationStatus.HasFlag(PackageDeprecationStatus.Vulnerable);
+                            var isLegacy = Model.DeprecationStatus.HasFlag(PackageDeprecationStatus.Legacy);
+                            if (isVulnerable || isLegacy)
+                            {
+                                if (isVulnerable)
+                                {
+                                    @:This package has been deprecated due to <b>vulnerabilities</b>.
+                                }
+
+                                if (isLegacy)
+                                {
+                                    if (isVulnerable)
+                                    {
+                                        <br />
+                                    }
+
+                                    @:This package has been deprecated because it is <b>no longer maintained</b>.
+                                }
+                            }
+                            else
+                            {
+                                @:This package has been deprecated.
+                            }
+                        }
+                    </div>
                 </div>
 
-                @{
-                    var isVulnerable = Model.DeprecationStatus.HasFlag(PackageDeprecationStatus.Vulnerable);
-                    var isLegacy = Model.DeprecationStatus.HasFlag(PackageDeprecationStatus.Legacy);
-                    var deprecationReasonString = string.Empty;
-                    if (isVulnerable || isLegacy)
+                <div class="deprecation-expander-container">
+                    @if (Model.CvssRating.HasValue)
                     {
-                        deprecationReasonString += " because it ";
-                        if (isVulnerable)
+                        string ratingString;
+                        if (Model.CvssRating < 4)
                         {
-                            deprecationReasonString += "has vulnerabilities";
+                            ratingString = "Low";
+                        }
+                        else if (Model.CvssRating < 7)
+                        {
+                            ratingString = "Medium";
+                        }
+                        else if (Model.CvssRating < 9)
+                        {
+                            ratingString = "High";
+                        }
+                        else
+                        {
+                            ratingString = "Critical";
                         }
 
-                        if (isLegacy)
-                        {
-                            if (isVulnerable)
-                            {
-                                deprecationReasonString += " and ";
-                            }
-
-                            deprecationReasonString += "is no longer maintained by its owners";
-                        }
-                    }
-                }
-                <div id="deprecation-container-label" class="deprecation-expander-info-right">This package has been deprecated@(deprecationReasonString).</div>
-            </div>
-
-            <div class="deprecation-expander">
-                @if (Model.CvssRating.HasValue)
-                {
-                    string ratingString;
-                    if (Model.CvssRating < 4)
-                    {
-                        ratingString = "Low";
-                    }
-                    else if (Model.CvssRating < 7)
-                    {
-                        ratingString = "Medium";
-                    }
-                    else if (Model.CvssRating < 9)
-                    {
-                        ratingString = "High";
-                    }
-                    else
-                    {
-                        ratingString = "Critical";
+                        <div class="deprecation-expander-info-right deprecation-expander-container">Severity: <b class="deprecation-expander-severity-rating">@ratingString</b></div>
                     }
 
-                    <div class="deprecation-expander-info-right">CVSS rating: <b>@ratingString</b></div>
-                }
-
-                <div class="deprecation-expander-icon-container">
                     <i id="deprecation-expander-icon-right" class="deprecation-expander-icon deprecation-expander-info-right ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
                 </div>
             </div>

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
@@ -63,27 +63,9 @@
                 </div>
 
                 <div class="deprecation-expander-container">
-                    @if (Model.CvssRating.HasValue)
+                    @if (Model.Severity != null)
                     {
-                        string ratingString;
-                        if (Model.CvssRating < 4)
-                        {
-                            ratingString = "Low";
-                        }
-                        else if (Model.CvssRating < 7)
-                        {
-                            ratingString = "Medium";
-                        }
-                        else if (Model.CvssRating < 9)
-                        {
-                            ratingString = "High";
-                        }
-                        else
-                        {
-                            ratingString = "Critical";
-                        }
-
-                        <div class="deprecation-expander-info-right deprecation-expander-container">Severity: <b class="deprecation-expander-severity-rating">@ratingString</b></div>
+                        <div class="deprecation-expander-info-right deprecation-expander-container">Severity: <b class="deprecation-expander-severity-rating">@Model.Severity</b></div>
                     }
 
                     <i id="deprecation-expander-icon-right" class="deprecation-expander-icon deprecation-expander-info-right ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
@@ -45,16 +45,12 @@
                                 if (isVulnerable)
                                 {
                                     @:This package has been deprecated due to <b>vulnerabilities</b>.
+                                    <br />
+                                    @:This package is also <b>legacy</b> and is no longer maintained.
                                 }
-
-                                if (isLegacy)
+                                else if (isLegacy)
                                 {
-                                    if (isVulnerable)
-                                    {
-                                        <br />
-                                    }
-
-                                    @:This package has been deprecated because it is <b>no longer maintained</b>.
+                                    @:This package has been deprecated because it is <b>legacy</b> and is no longer maintained.
                                 }
                             }
                             else

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
@@ -40,18 +40,19 @@
                         @{
                             var isVulnerable = Model.DeprecationStatus.HasFlag(PackageDeprecationStatus.Vulnerable);
                             var isLegacy = Model.DeprecationStatus.HasFlag(PackageDeprecationStatus.Legacy);
-                            if (isVulnerable || isLegacy)
+                            if (isVulnerable)
                             {
-                                if (isVulnerable)
+                                @:This package has been deprecated due to <b>vulnerabilities</b>.
+
+                                if (isLegacy)
                                 {
-                                    @:This package has been deprecated due to <b>vulnerabilities</b>.
                                     <br />
                                     @:This package is also <b>legacy</b> and is no longer maintained.
                                 }
-                                else if (isLegacy)
-                                {
-                                    @:This package has been deprecated because it is <b>legacy</b> and is no longer maintained.
-                                }
+                            }
+                            else if (isLegacy)
+                            {
+                                @:This package has been deprecated because it is <b>legacy</b> and is no longer maintained.
                             }
                             else
                             {

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -736,9 +736,19 @@ namespace NuGetGallery.ViewModels
             }
         }
 
+        public enum SeverityString_State
+        {
+            None,
+            Low,
+            Medium,
+            High,
+            Critical
+        }
+
         public static IEnumerable<object[]> DeprecationFieldsAreSetAsExpected_Data =
             MemberDataHelper.Combine(
                 MemberDataHelper.FlagEnumDataSet<PackageDeprecationStatus>(),
+                MemberDataHelper.EnumDataSet<SeverityString_State>(),
                 MemberDataHelper.BooleanDataSet(),
                 MemberDataHelper.BooleanDataSet(),
                 MemberDataHelper.BooleanDataSet(),
@@ -748,16 +758,39 @@ namespace NuGetGallery.ViewModels
         [MemberData(nameof(DeprecationFieldsAreSetAsExpected_Data))]
         public void DeprecationFieldsAreSetAsExpected(
             PackageDeprecationStatus status,
+            SeverityString_State severity,
             bool hasCves,
             bool hasCwes,
             bool hasAlternateRegistration,
             bool hasAlternatePackage)
         {
             // Arrange
+            decimal? cvss;
+            switch (severity)
+            {
+                case SeverityString_State.Critical:
+                    cvss = (decimal)9.5;
+                    break;
+                case SeverityString_State.High:
+                    cvss = (decimal)7.5;
+                    break;
+                case SeverityString_State.Medium:
+                    cvss = (decimal)5;
+                    break;
+                case SeverityString_State.Low:
+                    cvss = (decimal)2;
+                    break;
+                case SeverityString_State.None:
+                    cvss = null;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(severity));
+            }
+
             var deprecation = new PackageDeprecation
             {
                 Status = status,
-                CvssRating = (decimal)5.5,
+                CvssRating = cvss,
                 CustomMessage = "hello"
             };
 
@@ -825,8 +858,31 @@ namespace NuGetGallery.ViewModels
 
             // Assert
             Assert.Equal(status, model.DeprecationStatus);
-            Assert.Equal(deprecation.CvssRating, model.CvssRating);
             Assert.Equal(deprecation.CustomMessage, model.CustomMessage);
+
+            string expectedString;
+            switch (severity)
+            {
+                case SeverityString_State.Critical:
+                    expectedString = "Critical";
+                    break;
+                case SeverityString_State.High:
+                    expectedString = "High";
+                    break;
+                case SeverityString_State.Medium:
+                    expectedString = "Medium";
+                    break;
+                case SeverityString_State.Low:
+                    expectedString = "Low";
+                    break;
+                case SeverityString_State.None:
+                    expectedString = null;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(severity));
+            }
+
+            Assert.Equal(expectedString, model.Severity);
 
             if (hasCves)
             {


### PR DESCRIPTION
@anangaur had some additional feedback for https://github.com/nuget/nugetgallery/issues/6774

If you remember before, we merged a single string for the reason text and then had text/icons centered with the reason text. We now have separate text for each reason and text/icons aligned with the top line.

We also changed the text for legacy only.

# Vulnerable and Legacy and Other with CVSS collapsed

![image](https://user-images.githubusercontent.com/18014088/53842076-53aa0e80-3f53-11e9-9207-6e4047b8eacc.png)

# Vulnerable and Legacy and Other with CVSS expanded

![image](https://user-images.githubusercontent.com/18014088/53842087-5a388600-3f53-11e9-985b-b2686e7f2078.png)

# Vulnerable and Legacy with CVSS

![image](https://user-images.githubusercontent.com/18014088/53842065-4c830080-3f53-11e9-85e4-4f3f604c3c83.png)

# Vulnerable and Legacy

![image](https://user-images.githubusercontent.com/18014088/53842043-3b39f400-3f53-11e9-821d-8ec1c9560edf.png)

# Vulnerable and Legacy collapsed

![image](https://user-images.githubusercontent.com/18014088/53841997-1d6c8f00-3f53-11e9-9d0e-f0cfd2402aab.png)

# Vulnerable and Legacy expanded

![image](https://user-images.githubusercontent.com/18014088/53842009-25c4ca00-3f53-11e9-9001-0b62fcc9d567.png)

# Legacy collapsed

![image](https://user-images.githubusercontent.com/18014088/53842236-c1563a80-3f53-11e9-93d4-9b7a08a871c7.png)

# Legacy expanded

![image](https://user-images.githubusercontent.com/18014088/53842249-c7e4b200-3f53-11e9-87b3-19a4693df9ba.png)
