### PR TITLE
Remove unlist checkbox from Manage Deprecation form

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1193,6 +1193,9 @@ img.reserved-indicator-icon {
   width: 65px;
   margin-right: 15px;
 }
+.page-manage-deprecation .deprecation-section .deprecation-subsection .security-detail .security-detail-input .cvss-bold {
+  font-weight: bold;
+}
 .page-manage-deprecation .deprecation-section .deprecation-subsection .security-detail .security-detail-list-item {
   padding: 10px;
 }

--- a/src/Bootstrap/less/theme/page-manage-deprecation.less
+++ b/src/Bootstrap/less/theme/page-manage-deprecation.less
@@ -37,6 +37,10 @@
                         width: 65px;
                         margin-right: 15px;
                     }
+
+                    .cvss-bold {
+                        font-weight: bold;
+                    }
                 }
 
                 .security-detail-list-item {

--- a/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
+++ b/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
@@ -105,8 +105,7 @@ namespace NuGetGallery
             IEnumerable<string> cweIds,
             string alternatePackageId,
             string alternatePackageVersion,
-            string customMessage,
-            bool shouldUnlist)
+            string customMessage)
         {
             var currentUser = GetCurrentUser();
             if (!_featureFlagService.IsManageDeprecationEnabled(GetCurrentUser()))
@@ -248,8 +247,7 @@ namespace NuGetGallery
                 cwes,
                 alternatePackageRegistration,
                 alternatePackage,
-                customMessage,
-                shouldUnlist);
+                customMessage);
 
             return Json(HttpStatusCode.OK);
         }

--- a/src/NuGetGallery/Scripts/gallery/page-manage-deprecation.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-deprecation.js
@@ -462,9 +462,6 @@ function ManageDeprecationViewModel(id, versionDeprecationStateDictionary, defau
     // The custom message to submit with the form.
     this.customMessage = ko.observable('');
 
-    // Whether or not the packages should be unlisted.
-    this.shouldUnlist = ko.observable(true);
-
     this.submitError = ko.observable();
     this.submit = function () {
         self.submitError(null);
@@ -489,8 +486,7 @@ function ManageDeprecationViewModel(id, versionDeprecationStateDictionary, defau
                 cweIds: self.cwes.exportIds(),
                 alternatePackageId: self.alternatePackageId(),
                 alternatePackageVersion: self.alternatePackageVersion(),
-                customMessage: self.customMessage(),
-                shouldUnlist: self.shouldUnlist()
+                customMessage: self.customMessage()
             }),
             success: function () {
                 window.location.href = packageUrl;
@@ -522,7 +518,6 @@ function ManageDeprecationViewModel(id, versionDeprecationStateDictionary, defau
         versionData.AlternatePackageId = self.alternatePackageId();
         versionData.AlternatePackageVersion = self.alternatePackageVersion();
         versionData.CustomMessage = self.customMessage();
-        versionData.ShouldUnlist = self.shouldUnlist();
     };
 
     var loadDeprecationFormState = function (version) {
@@ -549,7 +544,6 @@ function ManageDeprecationViewModel(id, versionDeprecationStateDictionary, defau
         }
 
         self.customMessage(versionData.CustomMessage);
-        self.shouldUnlist(versionData.ShouldUnlist);
     };
 
     // When the chosen versions are changed, remember the contents of the form in case the user navigates back to this version.

--- a/src/NuGetGallery/Services/IPackageDeprecationService.cs
+++ b/src/NuGetGallery/Services/IPackageDeprecationService.cs
@@ -24,8 +24,7 @@ namespace NuGetGallery
             IReadOnlyCollection<Cwe> cwe,
             PackageRegistration alternatePackageRegistration,
             Package alternatePackage,
-            string customMessage,
-            bool shouldUnlist);
+            string customMessage);
 
         /// <summary>
         /// Fetches all <see cref="Cve"/>s with a <see cref="Cve.CveId"/> contained in <paramref name="ids"/>.

--- a/src/NuGetGallery/ViewModels/ManagePackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ManagePackageViewModel.cs
@@ -168,10 +168,6 @@ namespace NuGetGallery
                     }
 
                     CustomMessage = deprecation.CustomMessage;
-
-                    // It doesn't make sense to unlist packages that are already unlisted.
-                    // Additionally, if a package was not unlisted when it was deprecated, we shouldn't unlist it when its deprecation information is updated.
-                    ShouldUnlist = package.Listed && deprecation.Status == PackageDeprecationStatus.NotDeprecated;
                 }
             }
 
@@ -185,7 +181,6 @@ namespace NuGetGallery
             public string AlternatePackageId { get; }
             public string AlternatePackageVersion { get; }
             public string CustomMessage { get; }
-            public bool ShouldUnlist { get; }
 
             /// <remarks>
             /// Ideally, the fields of this class would be pascal-case.

--- a/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
@@ -98,12 +98,6 @@
             <label for="customMessage" class="deprecation-section-header">Provide custom message</label>
             <textarea id="customMessage" name="customMessage" class="form-control full-line" data-bind="textInput: customMessage" rows="2"></textarea>
         </div>
-        <div class="deprecation-section form-group">
-            <label>
-                <input type="checkbox" value="true" data-bind="checked: shouldUnlist" />
-                Unlist this package from search results
-            </label>
-        </div>
     </div>
 
     <div data-bind="visible: submitError">

--- a/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
@@ -59,7 +59,7 @@
                 </div>
                 <div class="security-detail-input">
                     <input id="selectedCvssRating" class="form-control cvss-input" name="selectedCvssRating" type="text" placeholder="0.0" size="4" maxlength="4" data-bind="textInput: selectedCvssRating, disable: !hasCvss()" />
-                    <span class="text-" data-bind="text: cvssRatingLabel, css: { 'text-danger': cvssRatingIsInvalid, 'cvss-bold': !cvssRatingIsInvalid() }"></span>
+                    <span data-bind="text: cvssRatingLabel, css: { 'text-danger': cvssRatingIsInvalid, 'cvss-bold': !cvssRatingIsInvalid() }"></span>
                 </div>
             </div>
             <div data-bind="template: { name: 'deprecation-security-detail-list-input-template', data: cwes }"></div>

--- a/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
@@ -59,7 +59,7 @@
                 </div>
                 <div class="security-detail-input">
                     <input id="selectedCvssRating" class="form-control cvss-input" name="selectedCvssRating" type="text" placeholder="0.0" size="4" maxlength="4" data-bind="textInput: selectedCvssRating, disable: !hasCvss()" />
-                    <span data-bind="text: cvssRatingLabel, css: { 'text-danger': cvssRatingIsInvalid }"></span>
+                    <span class="text-" data-bind="text: cvssRatingLabel, css: { 'text-danger': cvssRatingIsInvalid, 'cvss-bold': !cvssRatingIsInvalid() }"></span>
                 </div>
             </div>
             <div data-bind="template: { name: 'deprecation-security-detail-list-input-template', data: cwes }"></div>

--- a/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
@@ -289,7 +289,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    "id", null, false, false, false, null, null, null, null, null, null, false);
+                    "id", null, false, false, false, null, null, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(controller, result, HttpStatusCode.Forbidden, Strings.DeprecatePackage_Forbidden);
@@ -317,7 +317,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    "id", versions, false, false, false, null, null, null, null, null, null, false);
+                    "id", versions, false, false, false, null, null, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(controller, result, HttpStatusCode.BadRequest, Strings.DeprecatePackage_NoVersions);
@@ -357,7 +357,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    "id", new[] { "1.0.0" }, false, false, false, new[] { "CVE-2019-1111", invalidId }, null, null, null, null, null, false);
+                    "id", new[] { "1.0.0" }, false, false, false, new[] { "CVE-2019-1111", invalidId }, null, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(
@@ -387,7 +387,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    "id", new[] { "1.0.0" }, false, false, false, null, null, new[] { "CWE-1", invalidId }, null, null, null, false);
+                    "id", new[] { "1.0.0" }, false, false, false, null, null, new[] { "CWE-1", invalidId }, null, null, null);
 
                 // Assert
                 AssertErrorResponse(
@@ -417,7 +417,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    "id", new[] { "1.0.0" }, false, false, false, null, cvss, null, null, null, null, false);
+                    "id", new[] { "1.0.0" }, false, false, false, null, cvss, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(controller, result, HttpStatusCode.BadRequest, Strings.DeprecatePackage_InvalidCvss);
@@ -449,7 +449,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    id, new[] { "1.0.0" }, false, false, false, null, null, null, null, null, null, false);
+                    id, new[] { "1.0.0" }, false, false, false, null, null, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(controller, result, HttpStatusCode.NotFound, string.Format(Strings.DeprecatePackage_MissingRegistration, id));
@@ -511,7 +511,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    id, new[] { "1.0.0" }, false, false, false, null, null, null, null, null, null, false);
+                    id, new[] { "1.0.0" }, false, false, false, null, null, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(controller, result, HttpStatusCode.Forbidden, Strings.DeprecatePackage_Forbidden);
@@ -586,7 +586,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    id, new[] { "1.0.0" }, false, false, false, null, null, null, null, null, null, false);
+                    id, new[] { "1.0.0" }, false, false, false, null, null, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(
@@ -640,7 +640,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    id, new[] { "1.0.0" }, false, false, false, null, null, null, alternatePackageId, null, null, false);
+                    id, new[] { "1.0.0" }, false, false, false, null, null, null, alternatePackageId, null, null);
 
                 // Assert
                 AssertErrorResponse(
@@ -695,7 +695,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    id, new[] { "1.0.0" }, false, false, false, null, null, null, alternatePackageId, alternatePackageVersion, null, false);
+                    id, new[] { "1.0.0" }, false, false, false, null, null, null, alternatePackageId, alternatePackageVersion, null);
 
                 // Assert
                 AssertErrorResponse(
@@ -744,7 +744,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    id, new[] { "1.0.0" }, false, false, false, null, null, null, null, null, null, false);
+                    id, new[] { "1.0.0" }, false, false, false, null, null, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(
@@ -793,7 +793,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    id, new[] { package.NormalizedVersion, "1.0.0" }, false, false, false, null, null, null, null, null, null, false);
+                    id, new[] { package.NormalizedVersion, "1.0.0" }, false, false, false, null, null, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(
@@ -855,7 +855,7 @@ namespace NuGetGallery.Controllers
 
                 // Act
                 var result = await controller.Deprecate(
-                    id, new[] { package.NormalizedVersion }, false, false, false, null, null, null, null, null, null, false);
+                    id, new[] { package.NormalizedVersion }, false, false, false, null, null, null, null, null, null);
 
                 // Assert
                 AssertErrorResponse(
@@ -916,7 +916,6 @@ namespace NuGetGallery.Controllers
                     Owner_Data,
                     PackageDeprecationStates_Data,
                     MemberDataHelper.EnumDataSet<ReturnsSuccessful_AlternatePackage_State>(),
-                    MemberDataHelper.BooleanDataSet(),
                     MemberDataHelper.BooleanDataSet()).ToList();
 
             [Theory]
@@ -929,8 +928,7 @@ namespace NuGetGallery.Controllers
                 bool isOther, 
                 PackageDeprecationStatus expectedStatus, 
                 ReturnsSuccessful_AlternatePackage_State alternatePackageState, 
-                bool hasAdditionalData,
-                bool shouldUnlist)
+                bool hasAdditionalData)
             {
                 // Arrange
                 var id = "id";
@@ -1029,8 +1027,7 @@ namespace NuGetGallery.Controllers
                         cwes,
                         alternatePackageState == ReturnsSuccessful_AlternatePackage_State.Registration ? alternatePackageRegistration : null,
                         alternatePackageState == ReturnsSuccessful_AlternatePackage_State.Package ? alternatePackage : null,
-                        customMessage,
-                        shouldUnlist))
+                        customMessage))
                     .Completes()
                     .Verifiable();
                     
@@ -1049,8 +1046,7 @@ namespace NuGetGallery.Controllers
                     cweIds,
                     alternatePackageId, 
                     alternatePackageVersion, 
-                    customMessage, 
-                    shouldUnlist);
+                    customMessage);
 
                 // Assert
                 AssertSuccessResponse(controller);

--- a/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
@@ -33,8 +33,7 @@ namespace NuGetGallery.Services
                         new Cwe[0],
                         null,
                         null,
-                        null,
-                        false));
+                        null));
             }
 
             [Fact]
@@ -53,8 +52,7 @@ namespace NuGetGallery.Services
                         new Cwe[0],
                         null,
                         null,
-                        null,
-                        false));
+                        null));
             }
 
             [Fact]
@@ -73,14 +71,11 @@ namespace NuGetGallery.Services
                         null,
                         null,
                         null,
-                        null,
-                        false));
+                        null));
             }
 
-            [Theory]
-            [InlineData(false)]
-            [InlineData(true)]
-            public async Task DeletesExistingDeprecationsIfStatusNotDeprecated(bool shouldUnlist)
+            [Fact]
+            public async Task DeletesExistingDeprecationsIfStatusNotDeprecated()
             {
                 // Arrange
                 var packageWithDeprecation1 = new Package
@@ -116,20 +111,6 @@ namespace NuGetGallery.Services
                     .Completes()
                     .Verifiable();
 
-                var packageService = GetMock<IPackageService>();
-                var indexingService = GetMock<IIndexingService>();
-                foreach (var package in packages)
-                {
-                    // When deleting deprecations, packages should not be unlisted because the option is hidden in the UI.
-                    packageService
-                        .Setup(x => x.MarkPackageUnlistedAsync(package, false))
-                        .Throws<InvalidOperationException>();
-
-                    indexingService
-                        .Setup(x => x.UpdatePackage(package))
-                        .Verifiable();
-                }
-
                 var service = Get<PackageDeprecationService>();
 
                 // Act
@@ -141,12 +122,10 @@ namespace NuGetGallery.Services
                     new Cwe[0],
                     null,
                     null,
-                    null,
-                    shouldUnlist);
+                    null);
 
                 // Assert
                 deprecationRepository.Verify();
-                indexingService.Verify();
 
                 foreach (var package in packages)
                 {
@@ -161,11 +140,6 @@ namespace NuGetGallery.Services
             {
                 // Arrange
                 var lastEdited = new DateTime(2019, 3, 4);
-
-                var unlistedPackageWithoutDeprecation = new Package
-                {
-                    LastEdited = lastEdited
-                };
 
                 var packageWithDeprecation1 = new Package
                 {
@@ -221,7 +195,6 @@ namespace NuGetGallery.Services
 
                 var packages = new[]
                 {
-                    unlistedPackageWithoutDeprecation,
                     packageWithDeprecation1,
                     packageWithoutDeprecation1,
                     packageWithDeprecation2,
@@ -242,30 +215,6 @@ namespace NuGetGallery.Services
                     .Setup(x => x.CommitChangesAsync())
                     .Completes()
                     .Verifiable();
-
-                var packageService = GetMock<IPackageService>();
-                var indexingService = GetMock<IIndexingService>();
-                foreach (var package in packages)
-                {
-                    var unlistPackageSetup = packageService
-                        .Setup(x => x.MarkPackageUnlistedAsync(package, false));
-
-                    if (shouldUnlist)
-                    {
-                        unlistPackageSetup
-                            .Completes()
-                            .Verifiable();
-                    }
-                    else
-                    {
-                        unlistPackageSetup
-                            .Throws<InvalidOperationException>();
-                    }
-
-                    indexingService
-                        .Setup(x => x.UpdatePackage(package))
-                        .Verifiable();
-                }
 
                 var service = Get<PackageDeprecationService>();
 
@@ -313,13 +262,10 @@ namespace NuGetGallery.Services
                     cwes,
                     alternatePackageRegistration,
                     alternatePackage,
-                    customMessage,
-                    shouldUnlist);
+                    customMessage);
 
                 // Assert
                 deprecationRepository.Verify();
-                packageService.Verify();
-                indexingService.Verify();
 
                 foreach (var package in packages)
                 {


### PR DESCRIPTION
We have decided to remove the "should unlist" checkbox from the Manage Deprecation form. This PR removes it from the form.

Because this PR was also small, I also made a small UI fix that @anangaur asked for--the CVSS rating in the deprecation form should be bolded.

If we leave "should unlist" in the form, we'd need to do testing on whether or not bulk unlisting works. This is non-trivial and may require large V3 changes.

Additionally, we decided to separate "deprecation" and "listing" in the UI, and having a checkbox that bridges the two is confusing, especially when multiple versions are selected.