### PR TITLE
Mark deprecated versions in Display Package page's version history

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -866,6 +866,9 @@ img.reserved-indicator-icon {
 .page-package-details h1 {
   margin-bottom: 0;
 }
+.page-package-details tr {
+  border-bottom: 1px solid lightgray;
+}
 .page-package-details .package-title {
   margin-bottom: 24px;
 }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -926,13 +926,13 @@ img.reserved-indicator-icon {
 
   overflow-wrap: break-word;
 }
-.page-package-details .package-details-main .package-info-cell {
+.page-package-details .package-details-main .signature-info-cell {
   max-width: 1em;
   padding-right: 0;
   padding-left: 0;
   cursor: default;
 }
-.page-package-details .package-details-main .package-info-cell .package-info {
+.page-package-details .package-details-main .signature-info-cell .signature-info {
   padding-left: 6px;
 }
 .page-package-details .package-details-info .ms-Icon-ul li {

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1016,6 +1016,9 @@ img.reserved-indicator-icon {
   width: 100%;
   margin: 0;
 }
+.page-package-details #version-history .deprecated {
+  text-decoration: line-through;
+}
 .page-downloads .list-tools li {
   margin-top: 20px;
 }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -926,13 +926,13 @@ img.reserved-indicator-icon {
 
   overflow-wrap: break-word;
 }
-.page-package-details .package-details-main .signature-info-cell {
+.page-package-details .package-details-main .package-info-cell {
   max-width: 1em;
   padding-right: 0;
   padding-left: 0;
   cursor: default;
 }
-.page-package-details .package-details-main .signature-info-cell .signature-info {
+.page-package-details .package-details-main .package-info-cell .package-info {
   padding-left: 6px;
 }
 .page-package-details .package-details-info .ms-Icon-ul li {

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1016,9 +1016,6 @@ img.reserved-indicator-icon {
   width: 100%;
   margin: 0;
 }
-.page-package-details #version-history .deprecated {
-  text-decoration: line-through;
-}
 .page-downloads .list-tools li {
   margin-top: 20px;
 }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -926,13 +926,14 @@ img.reserved-indicator-icon {
 
   overflow-wrap: break-word;
 }
-.page-package-details .package-details-main .signature-info-cell {
-  max-width: 1em;
+.page-package-details .package-details-main .package-icon-cell {
   padding-right: 0;
   padding-left: 0;
+  text-align: right;
   cursor: default;
 }
-.page-package-details .package-details-main .signature-info-cell .signature-info {
+.page-package-details .package-details-main .package-icon-cell .package-icon {
+  padding-right: 6px;
   padding-left: 6px;
 }
 .page-package-details .package-details-info .ms-Icon-ul li {

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -67,14 +67,15 @@
   .package-details-main {
     .break-word;
 
-    .signature-info-cell {
+    .package-icon-cell {
       cursor: default;
-      max-width: 1em;
       padding-left: 0;
       padding-right: 0;
+      text-align: right;
 
-      .signature-info {
+      .package-icon {
         padding-left: 6px;
+        padding-right: 6px;
       }
     }
   }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -7,6 +7,10 @@
     margin-bottom: 0;
   }
 
+  tr {
+    border-bottom: 1px solid lightgray;
+  }
+
   .package-title {
     margin-bottom: 24px;
 

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -187,10 +187,4 @@
       }
     }
   }
-
-  #version-history {
-    .deprecated {
-      text-decoration: line-through;
-    }
-  }
 }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -67,13 +67,13 @@
   .package-details-main {
     .break-word;
 
-    .signature-info-cell {
+    .package-info-cell {
       cursor: default;
       max-width: 1em;
       padding-left: 0;
       padding-right: 0;
 
-      .signature-info {
+      .package-info {
         padding-left: 6px;
       }
     }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -67,13 +67,13 @@
   .package-details-main {
     .break-word;
 
-    .package-info-cell {
+    .signature-info-cell {
       cursor: default;
       max-width: 1em;
       padding-left: 0;
       padding-right: 0;
 
-      .package-info {
+      .signature-info {
         padding-left: 6px;
       }
     }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -187,4 +187,10 @@
       }
     }
   }
+
+  #version-history {
+    .deprecated {
+      text-decoration: line-through;
+    }
+  }
 }

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Services\IFileMetadataService.cs" />
     <Compile Include="Services\IRevalidationStateService.cs" />
     <Compile Include="Services\ISimpleCloudBlob.cs" />
+    <Compile Include="Services\PackageDeprecationFieldsToInclude.cs" />
     <Compile Include="Services\SymbolPackageFileServiceMetadata.cs" />
     <Compile Include="Services\PackageFileServiceMetadata.cs" />
     <Compile Include="Services\RevalidationState.cs" />

--- a/src/NuGetGallery.Core/Services/CorePackageService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageService.cs
@@ -285,7 +285,9 @@ namespace NuGetGallery
             }
         }
 
-        protected IQueryable<Package> GetPackagesByIdQueryable(string id, bool withDeprecations = false)
+        protected IQueryable<Package> GetPackagesByIdQueryable(
+            string id, 
+            PackageDeprecationFieldsToInclude deprecationFields = PackageDeprecationFieldsToInclude.None)
         {
             var packages = _packageRepository
                 .GetAll()
@@ -295,7 +297,12 @@ namespace NuGetGallery
                 .Include(p => p.SymbolPackages)
                 .Where(p => p.PackageRegistration.Id == id);
 
-            if (withDeprecations)
+            if (deprecationFields == PackageDeprecationFieldsToInclude.Deprecation)
+            {
+                packages = packages
+                    .Include(p => p.Deprecations);
+            }
+            else if (deprecationFields == PackageDeprecationFieldsToInclude.DeprecationAndRelationships)
             {
                 packages = packages
                     .Include(p => p.Deprecations.Select(d => d.AlternatePackage.PackageRegistration))

--- a/src/NuGetGallery.Core/Services/PackageDeprecationFieldsToInclude.cs
+++ b/src/NuGetGallery.Core/Services/PackageDeprecationFieldsToInclude.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public enum PackageDeprecationFieldsToInclude
+    {
+        None,
+        Deprecation,
+        DeprecationAndRelationships
+    }
+}

--- a/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
+++ b/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
@@ -145,7 +145,7 @@ namespace NuGetGallery
                 return DeprecateErrorResponse(HttpStatusCode.BadRequest, Strings.DeprecatePackage_InvalidCvss);
             }
 
-            var packages = _packageService.FindPackagesById(id, withDeprecations: true);
+            var packages = _packageService.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships);
             var registration = packages.FirstOrDefault()?.PackageRegistration;
             if (registration == null)
             {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -710,7 +710,7 @@ namespace NuGetGallery
 
             Package package = null;
             // Load all packages with the ID.
-            var packages = _packageService.FindPackagesById(id);
+            var packages = _packageService.FindPackagesById(id, PackageDeprecationFieldsToInclude.Deprecation);
             if (version != null)
             {
                 if (version.Equals(GalleryConstants.AbsoluteLatestUrlString, StringComparison.InvariantCultureIgnoreCase))
@@ -1456,7 +1456,8 @@ namespace NuGetGallery
             Package package = null;
 
             // Load all versions of the package.
-            var packages = _packageService.FindPackagesById(id, withDeprecations: true);
+            var packages = _packageService.FindPackagesById(
+                id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships);
             if (version != null)
             {
                 // Try to find the exact version if it was specified.

--- a/src/NuGetGallery/Services/IPackageService.cs
+++ b/src/NuGetGallery/Services/IPackageService.cs
@@ -19,9 +19,11 @@ namespace NuGetGallery
     {
         /// <summary>
         /// Returns all packages with an <see cref="Package.Id"/> of <paramref name="id"/>.
-        /// Includes deprecation entities if <paramref name="withDeprecations"/> is true.
+        /// Includes deprecation fields based on <paramref name="deprecationFields"/>.
         /// </summary>
-        IReadOnlyCollection<Package> FindPackagesById(string id, bool withDeprecations = false);
+        IReadOnlyCollection<Package> FindPackagesById(
+            string id, 
+            PackageDeprecationFieldsToInclude deprecationFields = PackageDeprecationFieldsToInclude.None);
 
         /// <summary>
         /// Gets the package with the given ID and version when exists;

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -135,9 +135,11 @@ namespace NuGetGallery
                 .SingleOrDefault(pr => pr.Id == packageId);
         }
 
-        public virtual IReadOnlyCollection<Package> FindPackagesById(string id, bool withDeprecations = false)
+        public virtual IReadOnlyCollection<Package> FindPackagesById(
+            string id, 
+            PackageDeprecationFieldsToInclude deprecationFields = PackageDeprecationFieldsToInclude.None)
         {
-            return GetPackagesByIdQueryable(id, withDeprecations).ToList();
+            return GetPackagesByIdQueryable(id, deprecationFields).ToList();
         }
 
         public virtual Package FindPackageByIdAndVersion(

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -46,7 +46,7 @@ namespace NuGetGallery
                 DownloadsPerDayLabel = DownloadsPerDay < 1 ? "<1" : DownloadsPerDay.ToNuGetNumberString();
                 IsDotnetToolPackageType = package.PackageTypes.Any(e => e.Name.Equals("DotnetTool", StringComparison.OrdinalIgnoreCase));
             }
-            
+
             if (deprecation != null)
             {
                 CveIds = deprecation.Cves?.Select(c => c.CveId).ToList();

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -46,11 +46,9 @@ namespace NuGetGallery
                 DownloadsPerDayLabel = DownloadsPerDay < 1 ? "<1" : DownloadsPerDay.ToNuGetNumberString();
                 IsDotnetToolPackageType = package.PackageTypes.Any(e => e.Name.Equals("DotnetTool", StringComparison.OrdinalIgnoreCase));
             }
-
+            
             if (deprecation != null)
             {
-                DeprecationStatus = deprecation.Status;
-
                 CveIds = deprecation.Cves?.Select(c => c.CveId).ToList();
                 CweIds = deprecation.Cwes?.Select(c => c.CweId).ToList();
 
@@ -123,6 +121,9 @@ namespace NuGetGallery
                     LicenseNames = licenseNames.Split(',').Select(l => l.Trim());
                 }
             }
+
+            DeprecationStatus = package.Deprecations.SingleOrDefault()?.Status 
+                ?? PackageDeprecationStatus.NotDeprecated;
         }
 
         public bool ValidatingTooLong { get; set; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -529,15 +529,18 @@
                                 rowCount++;
                                 @VersionListDivider(rowCount, versionsExpanded)
                                 <tr class="@(packageVersion.IsCurrent(Model) ? "bg-info" : null)">
-                                    <td class="signature-info-cell">
-                                        @if (Model.IsCertificatesUIEnabled && !string.IsNullOrEmpty(packageVersion.SignatureInformation))
+                                    <td class="package-info-cell">
+                                        @if (packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
                                         {
-                                            <i class="ms-Icon ms-Icon--Ribbon signature-info" title="@packageVersion.SignatureInformation"></i>
+                                            <i class="ms-Icon ms-Icon--Warning package-info" title="Deprecated"></i>
+                                        }
+                                        else if (Model.IsCertificatesUIEnabled && !string.IsNullOrEmpty(packageVersion.SignatureInformation))
+                                        {
+                                            <i class="ms-Icon ms-Icon--Ribbon package-info" title="@packageVersion.SignatureInformation"></i>
                                         }
                                     </td>
                                     <td>
-                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion" 
-                                           class="@(packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated ? "text-danger" : "")">
+                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion">
                                             @packageVersion.Version.Abbreviate(30)
                                         </a>
                                     </td>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -537,7 +537,7 @@
                                     </td>
                                     <td>
                                         <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion" 
-                                           class="@(packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated ? "deprecated" : "")">
+                                           class="@(packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated ? "text-danger" : "")">
                                             @packageVersion.Version.Abbreviate(30)
                                         </a>
                                     </td>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -553,7 +553,7 @@
 
                                         <td>
                                             @if (packageStatusSummary == PackageStatusSummary.Listed ||
-                                                packageStatusSummary == PackageStatusSummary.Unlisted)
+                                                 packageStatusSummary == PackageStatusSummary.Unlisted)
                                             {
                                                 <a href="@Url.ManagePackage(packageVersion)">@NuGetGallery.Helpers.EnumHelper.GetDescription(packageStatusSummary)</a>
                                             }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -529,18 +529,15 @@
                                 rowCount++;
                                 @VersionListDivider(rowCount, versionsExpanded)
                                 <tr class="@(packageVersion.IsCurrent(Model) ? "bg-info" : null)">
-                                    <td class="package-info-cell">
-                                        @if (packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                                    <td class="signature-info-cell">
+                                        @if (Model.IsCertificatesUIEnabled && !string.IsNullOrEmpty(packageVersion.SignatureInformation))
                                         {
-                                            <i class="ms-Icon ms-Icon--Warning package-info" title="Deprecated"></i>
-                                        }
-                                        else if (Model.IsCertificatesUIEnabled && !string.IsNullOrEmpty(packageVersion.SignatureInformation))
-                                        {
-                                            <i class="ms-Icon ms-Icon--Ribbon package-info" title="@packageVersion.SignatureInformation"></i>
+                                            <i class="ms-Icon ms-Icon--Ribbon signature-info" title="@packageVersion.SignatureInformation"></i>
                                         }
                                     </td>
                                     <td>
-                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion">
+                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion" 
+                                           class="@(packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated ? "text-danger" : "")">
                                             @packageVersion.Version.Abbreviate(30)
                                         </a>
                                     </td>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -536,7 +536,8 @@
                                         }
                                     </td>
                                     <td>
-                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion">
+                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion" 
+                                           class="@(packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated ? "deprecated" : "")">
                                             @packageVersion.Version.Abbreviate(30)
                                         </a>
                                     </td>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -504,13 +504,14 @@
                 <table class="table borderless">
                     <thead>
                         <tr>
-                            <th colspan="2">Version</th>
+                            <th>Version</th>
                             <th>Downloads</th>
                             <th>Last updated</th>
                             @if (Model.CanDisplayPrivateMetadata)
                             {
                                 <th>Status</th>
                             }
+                            <th colspan="2"></th>
                         </tr>
                     </thead>
                     <tbody class="no-border">
@@ -529,15 +530,8 @@
                                 rowCount++;
                                 @VersionListDivider(rowCount, versionsExpanded)
                                 <tr class="@(packageVersion.IsCurrent(Model) ? "bg-info" : null)">
-                                    <td class="signature-info-cell">
-                                        @if (Model.IsCertificatesUIEnabled && !string.IsNullOrEmpty(packageVersion.SignatureInformation))
-                                        {
-                                            <i class="ms-Icon ms-Icon--Ribbon signature-info" title="@packageVersion.SignatureInformation"></i>
-                                        }
-                                    </td>
                                     <td>
-                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion" 
-                                           class="@(packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated ? "text-danger" : "")">
+                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion">
                                             @packageVersion.Version.Abbreviate(30)
                                         </a>
                                     </td>
@@ -557,20 +551,32 @@
                                     {
                                         var packageStatusSummary = packageVersion.PackageStatusSummary;
 
-                                        if (packageStatusSummary == PackageStatusSummary.Listed ||
-                                            packageStatusSummary == PackageStatusSummary.Unlisted)
-                                        {
-                                            <td>
+                                        <td>
+                                            @if (packageStatusSummary == PackageStatusSummary.Listed ||
+                                                packageStatusSummary == PackageStatusSummary.Unlisted)
+                                            {
                                                 <a href="@Url.ManagePackage(packageVersion)">@NuGetGallery.Helpers.EnumHelper.GetDescription(packageStatusSummary)</a>
-                                            </td>
-                                        }
-                                        else
-                                        {
-                                            <td>
+                                            }
+                                            else
+                                            {
                                                 @NuGetGallery.Helpers.EnumHelper.GetDescription(packageStatusSummary)
-                                            </td>
-                                        }
+                                            }
+                                        </td>
                                     }
+
+                                    <td class="package-icon-cell">
+                                        @if (Model.IsCertificatesUIEnabled && !string.IsNullOrEmpty(packageVersion.SignatureInformation))
+                                        {
+                                            <i class="ms-Icon ms-Icon--Ribbon package-icon" title="@packageVersion.SignatureInformation"></i>
+                                        }
+                                    </td>
+
+                                    <td class="package-icon-cell">
+                                        @if (packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                                        {
+                                            <i class="ms-Icon ms-Icon--Warning package-icon" title="@packageVersion.Version is deprecated"></i>
+                                        }
+                                    </td>
                                 </tr>
                             }
                             else if (packageVersion.Deleted && packageVersion.CanDisplayPrivateMetadata)
@@ -578,8 +584,8 @@
                                 rowCount++;
                                 @VersionListDivider(rowCount, versionsExpanded)
                                 <tr class="deleted">
-                                    <td class="version" colspan="2">
-                                        @packageVersion.Version (deleted)
+                                    <td class="version">
+                                        @packageVersion.Version
                                     </td>
                                     <td>
                                         @packageVersion.DownloadCount
@@ -587,7 +593,10 @@
                                     <td>
                                         <span data-datetime="@packageVersion.LastUpdated.ToString("O")">@packageVersion.LastUpdated.ToNuGetShortDateString()</span>
                                     </td>
-                                    <td></td>
+                                    <td>
+                                        Deleted
+                                    </td>
+                                    <td colspan="2"></td>
                                 </tr>
                             }
                         }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -574,7 +574,30 @@
                                     <td class="package-icon-cell">
                                         @if (packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
                                         {
-                                            <i class="ms-Icon ms-Icon--Warning package-icon" title="@packageVersion.Version is deprecated"></i>
+                                            var deprecationTitle = packageVersion.Version;
+                                            var isVulnerable = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.Vulnerable);
+                                            var isLegacy = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.Legacy);
+                                            if (isVulnerable)
+                                            {
+                                                deprecationTitle += " is deprecated because it has vulnerabilities";
+
+                                                if (isLegacy)
+                                                {
+                                                    deprecationTitle += " and is legacy and is no longer maintained";
+                                                }
+
+                                                deprecationTitle += ".";
+                                            }
+                                            else if (isLegacy)
+                                            {
+                                                deprecationTitle += " is deprecated because it is legacy and is no longer maintained.";
+                                            }
+                                            else
+                                            {
+                                                deprecationTitle += " is deprecated.";
+                                            }
+
+                                            <i class="ms-Icon ms-Icon--Warning package-icon" title="@deprecationTitle"></i>
                                         }
                                     </td>
                                 </tr>

--- a/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
@@ -187,7 +187,7 @@ namespace NuGetGallery.Controllers
                 // Arrange
                 var id = "Crested.Gecko";
                 GetMock<IPackageService>()
-                    .Setup(x => x.FindPackagesById(id, false))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.None))
                     .Returns(new Package[0]);
 
                 var controller = GetController<ManageDeprecationJsonApiController>();
@@ -250,7 +250,7 @@ namespace NuGetGallery.Controllers
                 };
 
                 GetMock<IPackageService>()
-                    .Setup(x => x.FindPackagesById(id, false))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.None))
                     .Returns(packages);
 
                 var controller = GetController<ManageDeprecationJsonApiController>();
@@ -440,7 +440,7 @@ namespace NuGetGallery.Controllers
 
                 var packageService = GetMock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(id, true))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(packages.ToList())
                     .Verifiable();
 
@@ -502,7 +502,7 @@ namespace NuGetGallery.Controllers
 
                 var packageService = GetMock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(id, true))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(new[] { package })
                     .Verifiable();
 
@@ -577,7 +577,7 @@ namespace NuGetGallery.Controllers
 
                 var packageService = GetMock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(id, true))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(new[] { package })
                     .Verifiable();
 
@@ -625,7 +625,7 @@ namespace NuGetGallery.Controllers
 
                 var packageService = GetMock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(id, true))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(new[] { package })
                     .Verifiable();
 
@@ -679,7 +679,7 @@ namespace NuGetGallery.Controllers
 
                 var packageService = GetMock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(id, true))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(new[] { package })
                     .Verifiable();
 
@@ -735,7 +735,7 @@ namespace NuGetGallery.Controllers
 
                 var packageService = GetMock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(id, true))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(new[] { package })
                     .Verifiable();
 
@@ -784,7 +784,7 @@ namespace NuGetGallery.Controllers
 
                 var packageService = GetMock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(id, true))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(new[] { package })
                     .Verifiable();
 
@@ -833,7 +833,7 @@ namespace NuGetGallery.Controllers
 
                 var packageService = GetMock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(id, true))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(new[] { package })
                     .Verifiable();
 
@@ -966,7 +966,7 @@ namespace NuGetGallery.Controllers
 
                 var packageService = GetMock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(id, true))
+                    .Setup(x => x.FindPackagesById(id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(new[] { package, package2, unselectedPackage })
                     .Verifiable();
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -374,7 +374,7 @@ namespace NuGetGallery
                     GetConfigurationService(),
                     packageService: packageService);
 
-                packageService.Setup(p => p.FindPackagesById("Foo", false))
+                packageService.Setup(p => p.FindPackagesById("Foo", PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(new Package[0]);
 
                 // Act
@@ -518,7 +518,7 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, false))
+                    .Setup(p => p.FindPackagesById(id, PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(packages);
 
                 var getDeprecationByPackageSetup = deprecationService
@@ -641,7 +641,7 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, false))
+                    .Setup(p => p.FindPackagesById(id, PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(packages);
 
                 deprecationService
@@ -717,7 +717,7 @@ namespace NuGetGallery
                 };
 
                 packageService
-                    .Setup(p => p.FindPackagesById(id, false))
+                    .Setup(p => p.FindPackagesById(id, PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(new[] { notLatestPackage, latestPackage, latestButNotPackage });
 
                 deprecationService
@@ -770,7 +770,7 @@ namespace NuGetGallery
 
                 var packages = new[] { notLatestPackage };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, false))
+                    .Setup(p => p.FindPackagesById(id, PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(packages);
 
                 packageService
@@ -825,7 +825,7 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById("Foo", false))
+                    .Setup(p => p.FindPackagesById("Foo", PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(packages);
 
                 packageService
@@ -933,7 +933,7 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, false))
+                    .Setup(p => p.FindPackagesById(id, PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(packages);
 
                 packageService
@@ -990,7 +990,7 @@ namespace NuGetGallery
                 };
 
                 var packages = new[] { package };
-                packageService.Setup(p => p.FindPackagesById("Foo", false))
+                packageService.Setup(p => p.FindPackagesById("Foo", PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(packages);
                 packageService.Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
                     .Returns(package);
@@ -1051,7 +1051,7 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, false))
+                    .Setup(p => p.FindPackagesById(id, PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(packages);
 
                 packageService
@@ -1106,7 +1106,7 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, false))
+                    .Setup(p => p.FindPackagesById(id, PackageDeprecationFieldsToInclude.Deprecation))
                     .Returns(packages);
 
                 packageService
@@ -2576,7 +2576,7 @@ namespace NuGetGallery
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
                 var packages = isPackageMissing ? new Package[0] : new[] { Package };
                 packageService
-                    .Setup(p => p.FindPackagesById(PackageRegistration.Id, true))
+                    .Setup(p => p.FindPackagesById(PackageRegistration.Id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(packages)
                     .Verifiable();
 
@@ -2598,7 +2598,7 @@ namespace NuGetGallery
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
                 var packages = new[] { Package };
                 packageService
-                    .Setup(p => p.FindPackagesById(PackageRegistration.Id, true))
+                    .Setup(p => p.FindPackagesById(PackageRegistration.Id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships))
                     .Returns(packages)
                     .Verifiable();
 
@@ -2676,7 +2676,7 @@ namespace NuGetGallery
             {
                 var packageService = new Mock<IPackageService>();
                 packageService
-                    .Setup(x => x.FindPackagesById(_packageRegistration.Id, false))
+                    .Setup(x => x.FindPackagesById(_packageRegistration.Id, PackageDeprecationFieldsToInclude.None))
                     .Returns(new Package[0]);
 
                 var controller = CreateController(
@@ -2819,7 +2819,7 @@ namespace NuGetGallery
             {
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
                 packageService
-                    .Setup(svc => svc.FindPackagesById(_packageId, false))
+                    .Setup(svc => svc.FindPackagesById(_packageId, PackageDeprecationFieldsToInclude.None))
                     .Returns(_packageRegistration.Packages.ToList())
                     .Verifiable();
 
@@ -2839,7 +2839,7 @@ namespace NuGetGallery
                 var packages = _packageRegistration.Packages.ToList();
                 var packageService = new Mock<IPackageService>(MockBehavior.Strict);
                 packageService
-                    .Setup(svc => svc.FindPackagesById(_packageId, false))
+                    .Setup(svc => svc.FindPackagesById(_packageId, PackageDeprecationFieldsToInclude.None))
                     .Returns(packages)
                     .Verifiable();
 

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -789,7 +789,6 @@ namespace NuGetGallery.ViewModels
 
             var deprecation = new PackageDeprecation
             {
-                Status = status,
                 CvssRating = cvss,
                 CustomMessage = "hello"
             };
@@ -852,6 +851,13 @@ namespace NuGetGallery.ViewModels
             }
 
             var package = CreateTestPackage("1.0.0");
+
+            var linkedDeprecation = new PackageDeprecation
+            {
+                Status = status
+            };
+
+            package.Deprecations.Add(linkedDeprecation);
 
             // Act
             var model = new DisplayPackageViewModel(package, null, deprecation);
@@ -917,6 +923,15 @@ namespace NuGetGallery.ViewModels
                 Assert.Null(model.AlternatePackageId);
                 Assert.Null(model.AlternatePackageVersion);
             }
+
+            var versionModel = model.PackageVersions.Single();
+            Assert.Equal(status, versionModel.DeprecationStatus);
+            Assert.Null(versionModel.Severity);
+            Assert.Null(versionModel.CveIds);
+            Assert.Null(versionModel.CweIds);
+            Assert.Null(versionModel.AlternatePackageId);
+            Assert.Null(versionModel.AlternatePackageVersion);
+            Assert.Null(versionModel.CustomMessage);
         }
     }
 }


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6954

Current implementation: icons on right with row border between

Regarding SQL performance, the `DisplayPackage` endpoint now loads the `PackageDeprecation`s associated with each `Package` as well, but not any entities linked to those deprecations (like the CVEs, CWEs, alternate packages, etc). In my testing, this added load seemed entirely insignificant. I am continuing to look into potential impact but I think I'm not sure what else we could do to decrease the risk of impact.

# As owner

![image](https://user-images.githubusercontent.com/18014088/54063906-a63e3180-41c4-11e9-9935-fef6093dfc4a.png)

with certs

![image](https://user-images.githubusercontent.com/18014088/54063723-48f5b080-41c3-11e9-83ea-1184a7ae5cd5.png)

# As non-owner

![image](https://user-images.githubusercontent.com/18014088/54063910-ad653f80-41c4-11e9-9836-aad86bf34582.png)
