### PR TITLE
Improve version list display for deleted packages

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -577,8 +577,9 @@
                                 rowCount++;
                                 @VersionListDivider(rowCount, versionsExpanded)
                                 <tr class="deleted">
-                                    <td class="version" colspan="2">
-                                        @packageVersion.Version (deleted)
+                                    <td class="signature-info-cell"></td>
+                                    <td class="version">
+                                        @packageVersion.Version
                                     </td>
                                     <td>
                                         @packageVersion.DownloadCount
@@ -586,7 +587,9 @@
                                     <td>
                                         <span data-datetime="@packageVersion.LastUpdated.ToString("O")">@packageVersion.LastUpdated.ToNuGetShortDateString()</span>
                                     </td>
-                                    <td></td>
+                                    <td>
+                                        Deleted
+                                    </td>
                                 </tr>
                             }
                         }


### PR DESCRIPTION
Noticed this while working on https://github.com/NuGet/NuGetGallery/pull/6973

The version list display for deleted packages is odd. The signature information column is improperly aligned, and we have "(deleted" in the same column as the version, when there is a status column that we could easily leverage.

New:

![image](https://user-images.githubusercontent.com/18014088/54045931-bb489f80-4187-11e9-8374-c232b706a0ef.png)

with certificate icons

![image](https://user-images.githubusercontent.com/18014088/54047017-c94bef80-418a-11e9-9f4b-ec9972c8e1c1.png)

Old:

![image](https://user-images.githubusercontent.com/18014088/54046066-272b0800-4188-11e9-80a7-6034c8c4b10b.png)

with certificate icons

![image](https://user-images.githubusercontent.com/18014088/54047105-00ba9c00-418b-11e9-9881-4259842764f5.png)
