### PR TITLE
Upper bound individual retries, move configurations in web config.

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -744,9 +744,14 @@ namespace NuGetGallery
                     .AddHttpMessageHandler<TracingHttpHandler>()
                     .AddHttpMessageHandler<CorrelatingHttpClientHandler>()
                     .AddPolicyHandler(SearchClientPolicies.SearchClientFallBackCircuitBreakerPolicy(logger, searchClient.name, telemetryService))
-                    .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryPolicy(configuration.Current.WaitAndRetryCount, configuration.Current.WaitAndRetryIntervalInMilliseconds, logger, searchClient.name, telemetryService))
+                    .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryPolicy(
+                            configuration.Current.SearchCircuitBreakerWaitAndRetryCount,
+                            configuration.Current.SearchCircuitBreakerWaitAndRetryIntervalInMilliseconds,
+                            logger,
+                            searchClient.name,
+                            telemetryService))
                     .AddPolicyHandler(SearchClientPolicies.SearchClientCircuitBreakerPolicy(
-                            configuration.Current.CircuitBreakerBreakAfterCount,
+                            configuration.Current.SearchCircuitBreakerBreakAfterCount,
                             TimeSpan.FromSeconds(configuration.Current.SearchCircuitBreakerDelayInSeconds),
                             logger,
                             searchClient.name,

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -744,9 +744,9 @@ namespace NuGetGallery
                     .AddHttpMessageHandler<TracingHttpHandler>()
                     .AddHttpMessageHandler<CorrelatingHttpClientHandler>()
                     .AddPolicyHandler(SearchClientPolicies.SearchClientFallBackCircuitBreakerPolicy(logger, searchClient.name, telemetryService))
-                    .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryForeverPolicy(logger, searchClient.name, telemetryService))
+                    .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryPolicy(configuration.Current.WaitAndRetryCount, configuration.Current.WaitAndRetryIntervalInMilliseconds, logger, searchClient.name, telemetryService))
                     .AddPolicyHandler(SearchClientPolicies.SearchClientCircuitBreakerPolicy(
-                            SearchClientConfiguration.SearchRetryCount,
+                            configuration.Current.CircuitBreakerBreakAfterCount,
                             TimeSpan.FromSeconds(configuration.Current.SearchCircuitBreakerDelayInSeconds),
                             logger,
                             searchClient.name,

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -378,6 +378,20 @@ namespace NuGetGallery.Configuration
         /// </summary>
         public Uri SearchServiceUriSecondary { get; set; }
 
+        [DefaultValue(600)]
         public int SearchCircuitBreakerDelayInSeconds { get; set; }
+
+        // The default value was chosen to have searchRetryCount*retryInterval to be close to 1 second in order to keep the user still engaged.
+        // https://www.nngroup.com/articles/website-response-times/
+        [DefaultValue(500)]
+        public int WaitAndRetryIntervalInMilliseconds { get; set; }
+
+        [DefaultValue(3)]
+        public int WaitAndRetryCount { get; set; }
+
+        // Default value was chosen using the AI data.
+        // It is the average of the search request count per second during the last 90 days.
+        [DefaultValue(200)]
+        public int CircuitBreakerBreakAfterCount { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -384,14 +384,14 @@ namespace NuGetGallery.Configuration
         // The default value was chosen to have searchRetryCount*retryInterval to be close to 1 second in order to keep the user still engaged.
         // https://www.nngroup.com/articles/website-response-times/
         [DefaultValue(500)]
-        public int WaitAndRetryIntervalInMilliseconds { get; set; }
+        public int SearchCircuitBreakerWaitAndRetryIntervalInMilliseconds { get; set; }
 
         [DefaultValue(3)]
-        public int WaitAndRetryCount { get; set; }
+        public int SearchCircuitBreakerWaitAndRetryCount { get; set; }
 
         // Default value was chosen using the AI data.
         // It is the average of the search request count per second during the last 90 days.
         [DefaultValue(200)]
-        public int CircuitBreakerBreakAfterCount { get; set; }
+        public int SearchCircuitBreakerBreakAfterCount { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -409,16 +409,16 @@ namespace NuGetGallery.Configuration
         /// <summary>
         /// The wait time in milliseconds for the WaitAndRetry policy.
         /// </summary>
-        int WaitAndRetryIntervalInMilliseconds { get; set; }
+        int SearchCircuitBreakerWaitAndRetryIntervalInMilliseconds { get; set; }
 
         /// <summary>
-        /// A request will fail after this number of retries.
+        /// A request will fail after this number of retries. In total a request will fail after this number of retries + 1.
         /// </summary>
-        int WaitAndRetryCount { get; set; }
+        int SearchCircuitBreakerWaitAndRetryCount { get; set; }
 
         /// <summary>
         /// CircuitBreaker will open after this number of consecutive failed requests.
         /// </summary>
-        int CircuitBreakerBreakAfterCount { get; set; }
+        int SearchCircuitBreakerBreakAfterCount { get; set; }
     }
 }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -405,5 +405,20 @@ namespace NuGetGallery.Configuration
         /// The time in seconds for the circuit breaker delay. (The time the circuit breaker will stay in open state)
         /// </summary>
         int SearchCircuitBreakerDelayInSeconds { get; set; }
+
+        /// <summary>
+        /// The wait time in milliseconds for the WaitAndRetry policy.
+        /// </summary>
+        int WaitAndRetryIntervalInMilliseconds { get; set; }
+
+        /// <summary>
+        /// A request will fail after this number of retries.
+        /// </summary>
+        int WaitAndRetryCount { get; set; }
+
+        /// <summary>
+        /// CircuitBreaker will open after this number of consecutive failed requests.
+        /// </summary>
+        int CircuitBreakerBreakAfterCount { get; set; }
     }
 }

--- a/src/NuGetGallery/Infrastructure/Lucene/SearchClientConfiguration.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/SearchClientConfiguration.cs
@@ -7,8 +7,5 @@ namespace NuGetGallery.Infrastructure.Search
     {
         public static string SearchPrimaryInstance = "SearchPrimary";
         public static string SearchSecondaryInstance = "SearchSecondary";
-        public static int SearchRetryCount = 3;
-        // Try to have searchRetryCount*retryInterval to be close to 1 second in order to keep the user still engaged. https://www.nngroup.com/articles/website-response-times/
-        public static int WaitAndRetryDefaultIntervalInMilliseconds = 500;
     }
 }

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -138,6 +138,9 @@
     <add key="Gallery.SearchServiceUriPrimary" value=""/>
     <add key="Gallery.SearchServiceUriSecondary" value=""/>
     <add key="Gallery.SearchCircuitBreakerDelayInSeconds" value="600"/>
+    <add key="Gallery.WaitAndRetryIntervalInMilliseconds" value="500"/>
+    <add key="Gallery.WaitAndRetryCount" value="3"/>
+    <add key="Gallery.CircuitBreakerBreakAfterCount" value="200"/>
     <add key="Gallery.Brand" value="NuGet Gallery"/>
     <add key="Gallery.GalleryOwner" value="NuGet Gallery &lt;support@nuget.org&gt;"/>
     <add key="Gallery.GalleryNoReplyAddress" value="NuGet Gallery &lt;noreply@nuget.org&gt;"/>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -138,9 +138,9 @@
     <add key="Gallery.SearchServiceUriPrimary" value=""/>
     <add key="Gallery.SearchServiceUriSecondary" value=""/>
     <add key="Gallery.SearchCircuitBreakerDelayInSeconds" value="600"/>
-    <add key="Gallery.WaitAndRetryIntervalInMilliseconds" value="500"/>
-    <add key="Gallery.WaitAndRetryCount" value="3"/>
-    <add key="Gallery.CircuitBreakerBreakAfterCount" value="200"/>
+    <add key="Gallery.SearchCircuitBreakerWaitAndRetryIntervalInMilliseconds" value="500"/>
+    <add key="Gallery.SearchCircuitBreakerWaitAndRetryCount" value="3"/>
+    <add key="Gallery.SearchCircuitBreakerBreakAfterCount" value="200"/>
     <add key="Gallery.Brand" value="NuGet Gallery"/>
     <add key="Gallery.GalleryOwner" value="NuGet Gallery &lt;support@nuget.org&gt;"/>
     <add key="Gallery.GalleryNoReplyAddress" value="NuGet Gallery &lt;noreply@nuget.org&gt;"/>

--- a/tests/NuGetGallery.Facts/Infrastructure/Lucene/SearchPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Lucene/SearchPolicyFacts.cs
@@ -31,7 +31,7 @@ namespace NuGetGallery.Infrastructure.Search
         private static LoggerFor_TestSearchHttpClient _loggerFor_InvalidTestSearchHttpClientWithShortCircuitBreakDelay;
         private static LoggerFor_TestSearchHttpClient _loggerFor_ValidTestSearchHttpClient;
         private static string _nameFor_InvalidTestSearchHttpClientWithLongCircuitBreakDelay = "InvalidTestSearchHttpClientWithLongCircuitBreakDelay";
-        private static string _nameFor_InvalidTestSearchHttpClientWithShortCircuitBreakDelay = "InvalidTestSearchHttpClientWithSWhortCircuitBreakDelay";
+        private static string _nameFor_InvalidTestSearchHttpClientWithShortCircuitBreakDelay = "InvalidTestSearchHttpClientWithShortCircuitBreakDelay";
         private static string _nameFor_ValidTestSearchHttpClient = "ValidTestSearchHttpClient";
         private static readonly string _longInvalidAddress = "https://api-v2v3search-long.nuget.org";
         private static readonly string _shortInvalidAddress = "https://api-v2v3search-short.nuget.org";

--- a/tests/NuGetGallery.Facts/Infrastructure/Lucene/SearchPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Lucene/SearchPolicyFacts.cs
@@ -17,7 +17,12 @@ namespace NuGetGallery.Infrastructure.Search
 {
     public class SearchPolicyFacts
     {
-        private static int _retryCount = 2;
+        private static int _waitBetweenRetriesInMilliseconds = 500;
+        private static int _circuitBreakerFailAfter = 2;
+        private static int _retryCount = 10;
+        // set the circuit breker to be larger than the retryCount
+        private static int _circuitBreakerFailAfter_2 = 10;
+        private static int _retryCount_2 = 2;
         private static int _circuitBreakerLongDelaySeconds = 600;
         private static int _circuitBreakerShortDelaySeconds = 1;
         private static ServiceCollection _services = null;
@@ -31,6 +36,9 @@ namespace NuGetGallery.Infrastructure.Search
         private static readonly string _longInvalidAddress = "https://api-v2v3search-long.nuget.org";
         private static readonly string _shortInvalidAddress = "https://api-v2v3search-short.nuget.org";
         private static readonly string _validAddress = "https://api-v2v3search-0.nuget.org";
+        private static readonly string _shortInvalidAddress_2 = "https://api-v2v3search-short-2.nuget.org";
+        private static string _nameFor_InvalidTestSearchHttpClientRetryCountExpires = "InvalidTestSearchHttpClientRetryCountExpires";
+        private static LoggerFor_TestSearchHttpClient _loggerFor_InvalidTestSearchHttpClientRetryCountExpires;
 
         public SearchPolicyFacts()
         {
@@ -163,6 +171,28 @@ namespace NuGetGallery.Infrastructure.Search
             Assert.Equal(HttpStatusCode.OK, r.StatusCode);
         }
 
+        [Fact]
+        public async Task TestWaitAndRetryForInvalidRequests()
+        {
+            var invalidClient = _services.BuildServiceProvider().GetServices<TestSearchHttpClient>().Where(s => s.BaseAddress == new Uri(_shortInvalidAddress_2)).ElementAt(0);
+            var uri = new Uri($"{invalidClient.BaseAddress}query?q=packageid:Newtonsoft.Json version:12.0.1");
+
+            var r = await invalidClient.GetAsync(uri);
+
+            var retryInfo = _loggerFor_InvalidTestSearchHttpClientRetryCountExpires.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
+            var onCircuitBreakerfallBackInfo = _loggerFor_InvalidTestSearchHttpClientRetryCountExpires.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
+            var circuitBreakerWarning = _loggerFor_InvalidTestSearchHttpClientRetryCountExpires.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
+            var onCircuitBreakerReset = _loggerFor_InvalidTestSearchHttpClientRetryCountExpires.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!")).Count();
+            var onCircuitBreakerHalfOpen = _loggerFor_InvalidTestSearchHttpClientRetryCountExpires.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!")).Count();
+
+            Assert.Equal(_retryCount_2, retryInfo);
+            Assert.Equal(1, onCircuitBreakerfallBackInfo);
+            Assert.Equal(0, circuitBreakerWarning);
+            Assert.Equal(0, onCircuitBreakerReset);
+            Assert.Equal(0, onCircuitBreakerHalfOpen);
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, r.StatusCode);
+        }
+
         private static ILogger<ResilientSearchHttpClient> GetLogger()
         {
             var mockConfiguration = new Mock<ILogger<ResilientSearchHttpClient>>();
@@ -178,33 +208,43 @@ namespace NuGetGallery.Infrastructure.Search
             _loggerFor_InvalidTestSearchHttpClientWithLongCircuitBreakDelay = new LoggerFor_TestSearchHttpClient();
             _loggerFor_InvalidTestSearchHttpClientWithShortCircuitBreakDelay = new LoggerFor_TestSearchHttpClient();
             _loggerFor_ValidTestSearchHttpClient = new LoggerFor_TestSearchHttpClient();
+            _loggerFor_InvalidTestSearchHttpClientRetryCountExpires = new LoggerFor_TestSearchHttpClient();
 
             services.AddHttpClient<TestSearchHttpClient>(_nameFor_InvalidTestSearchHttpClientWithLongCircuitBreakDelay, c => c.BaseAddress = new Uri(_longInvalidAddress))
                     .AddPolicyHandler(SearchClientPolicies.SearchClientFallBackCircuitBreakerPolicy(_loggerFor_InvalidTestSearchHttpClientWithLongCircuitBreakDelay, "InvalidTestSearchHttpClientWithLongCircuitBreakDelay", telemetryServiceResolver))
-                    .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryForeverPolicy(_loggerFor_InvalidTestSearchHttpClientWithLongCircuitBreakDelay, "InvalidTestSearchHttpClientWithLongCircuitBreakDelay", telemetryServiceResolver))
+                    .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryPolicy(_retryCount, _waitBetweenRetriesInMilliseconds, _loggerFor_InvalidTestSearchHttpClientWithLongCircuitBreakDelay, "InvalidTestSearchHttpClientWithLongCircuitBreakDelay", telemetryServiceResolver))
                     .AddPolicyHandler(SearchClientPolicies.SearchClientCircuitBreakerPolicy(
-                            _retryCount,
+                            _circuitBreakerFailAfter,
                             TimeSpan.FromSeconds(_circuitBreakerLongDelaySeconds),
                             _loggerFor_InvalidTestSearchHttpClientWithLongCircuitBreakDelay,
                             "InvalidTestSearchHttpClientWithLongCircuitBreakDelay", telemetryServiceResolver));
 
             services.AddHttpClient<TestSearchHttpClient>(_nameFor_InvalidTestSearchHttpClientWithShortCircuitBreakDelay, c => c.BaseAddress = new Uri(_shortInvalidAddress))
                     .AddPolicyHandler(SearchClientPolicies.SearchClientFallBackCircuitBreakerPolicy(_loggerFor_InvalidTestSearchHttpClientWithShortCircuitBreakDelay, "InvalidTestSearchHttpClientWithShortCircuitBreakDelay", telemetryServiceResolver))
-                    .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryForeverPolicy(_loggerFor_InvalidTestSearchHttpClientWithShortCircuitBreakDelay, "InvalidTestSearchHttpClientWithShortCircuitBreakDelay", telemetryServiceResolver))
+                    .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryPolicy(_retryCount, _waitBetweenRetriesInMilliseconds, _loggerFor_InvalidTestSearchHttpClientWithShortCircuitBreakDelay, "InvalidTestSearchHttpClientWithShortCircuitBreakDelay", telemetryServiceResolver))
                     .AddPolicyHandler(SearchClientPolicies.SearchClientCircuitBreakerPolicy(
-                            _retryCount,
+                            _circuitBreakerFailAfter,
                             TimeSpan.FromSeconds(_circuitBreakerShortDelaySeconds),
                             _loggerFor_InvalidTestSearchHttpClientWithShortCircuitBreakDelay,
                             "InvalidTestSearchHttpClientWithShortCircuitBreakDelay", telemetryServiceResolver));
 
             services.AddHttpClient<TestSearchHttpClient>(_nameFor_ValidTestSearchHttpClient, c => c.BaseAddress = new Uri(_validAddress))
-                   .AddPolicyHandler(SearchClientPolicies.SearchClientFallBackCircuitBreakerPolicy(_loggerFor_ValidTestSearchHttpClient, "ValidTestSearchHttpClient", telemetryServiceResolver))
-                   .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryForeverPolicy(_loggerFor_ValidTestSearchHttpClient, "InvalidTestSearchHttpClientWithShortCircuitBreakDelay", telemetryServiceResolver))
+                   .AddPolicyHandler(SearchClientPolicies.SearchClientFallBackCircuitBreakerPolicy(_loggerFor_ValidTestSearchHttpClient, "InvalidTestSearchHttpClientWithShortCircuitBreakDelay", telemetryServiceResolver))
+                   .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryPolicy(_retryCount, _waitBetweenRetriesInMilliseconds, _loggerFor_ValidTestSearchHttpClient, "InvalidTestSearchHttpClientWithShortCircuitBreakDelay", telemetryServiceResolver))
                    .AddPolicyHandler(SearchClientPolicies.SearchClientCircuitBreakerPolicy(
-                           _retryCount,
+                           _circuitBreakerFailAfter,
                            TimeSpan.FromSeconds(_circuitBreakerShortDelaySeconds),
                            _loggerFor_ValidTestSearchHttpClient,
                            "InvalidTestSearchHttpClientWithShortCircuitBreakDelay", telemetryServiceResolver));
+
+            services.AddHttpClient<TestSearchHttpClient>(_nameFor_InvalidTestSearchHttpClientRetryCountExpires, c => c.BaseAddress = new Uri(_shortInvalidAddress_2))
+                   .AddPolicyHandler(SearchClientPolicies.SearchClientFallBackCircuitBreakerPolicy(_loggerFor_InvalidTestSearchHttpClientRetryCountExpires, "InvalidTestSearchHttpClientRetryCountExpires", telemetryServiceResolver))
+                   .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryPolicy(_retryCount_2, _waitBetweenRetriesInMilliseconds, _loggerFor_InvalidTestSearchHttpClientRetryCountExpires, "InvalidTestSearchHttpClientRetryCountExpires", telemetryServiceResolver))
+                   .AddPolicyHandler(SearchClientPolicies.SearchClientCircuitBreakerPolicy(
+                           _circuitBreakerFailAfter_2,
+                           TimeSpan.FromSeconds(_circuitBreakerShortDelaySeconds),
+                           _loggerFor_InvalidTestSearchHttpClientRetryCountExpires,
+                           "InvalidTestSearchHttpClientRetryCountExpires", telemetryServiceResolver));
 
             return services;
         }


### PR DESCRIPTION
Two changes in this PR:
1. Move configurations in web.config.
2. Fix a potential issue with a case like:
- one single query will return 500+
- multiple queries will be fine
The circuit breaker will not be closed and the failing query will keep retrying until timing out. 
With this change only a certain amount of retries will be allowed. 