### PR TITLE
Use separate model binding classes

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1387,7 +1387,7 @@ namespace NuGetGallery
                 PackageId = id,
                 PackageVersion = package.Version,
                 ProjectUrl = package.ProjectUrl,
-                Owners = package.PackageRegistration.Owners.Where(u => u.EmailAllowed),
+                Owners = package.PackageRegistration.Owners.Where(u => u.EmailAllowed).Select(u => u.Username),
                 CopySender = true,
                 HasOwners = hasOwners
             };
@@ -2141,7 +2141,7 @@ namespace NuGetGallery
             }
         }
 
-        public virtual async Task<JsonResult> VerifySymbolsPackageInternal(
+        protected virtual async Task<JsonResult> VerifySymbolsPackageInternal(
             VerifyPackageRequest formData,
             Stream uploadFile,
             PackageArchiveReader packageArchiveReader,
@@ -2241,7 +2241,7 @@ namespace NuGetGallery
             }
         }
 
-        public virtual async Task<JsonResult> VerifyPackageInternal(
+        protected virtual async Task<JsonResult> VerifyPackageInternal(
             VerifyPackageRequest formData,
             Stream uploadFile,
             PackageArchiveReader packageArchiveReader,

--- a/src/NuGetGallery/ViewModels/ContactOwnersViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ContactOwnersViewModel.cs
@@ -17,7 +17,7 @@ namespace NuGetGallery
 
         public string ProjectUrl { get; set; }
 
-        public IEnumerable<User> Owners { get; set; }
+        public IEnumerable<string> Owners { get; set; }
 
         [Display(Name = "Send me a copy")]
         public bool CopySender { get; set; }

--- a/src/NuGetGallery/Views/Packages/ContactOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/ContactOwners.cshtml
@@ -32,7 +32,7 @@
                         <p>
                             @foreach (var owner in Model.Owners)
                             {
-                                <a href="@Url.User(owner)" title="View @owner.Username's profile" class="ms-font-xl">@owner.Username</a>
+                                <a href="@Url.User(owner)" title="View @owner's profile" class="ms-font-xl">@owner</a>
                             }
                         </p>
                     </div>

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -2161,7 +2161,7 @@ namespace NuGetGallery
 
                 // assert
                 Assert.Equal(2, model.Owners.Count());
-                Assert.Empty(model.Owners.Where(u => u.Username == notAllowedUser));
+                Assert.Empty(model.Owners.Where(u => u == notAllowedUser));
             }
 
             [Fact]


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/2250

Two issues here
- `ContactOwnersViewModel.Owners` uses `User` entity
- `PackagesController.VerifyPackageInternal` and `PackagesController.VerifySymbolsPackageInternal` are `public` so [they can be hit using a REST API](https://www.nuget.org/packages/woah/VerifyPackageInternal?formData=hi&uploadFile=hi&packageArchiveReader=ho&packageMetadata=haah&currentUser=hi&owner=ho)