### PR TITLE
Fix minor bugs in Deprecation UI found in bug bash

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -589,7 +589,7 @@ img.reserved-indicator-icon {
   border-top: 0;
 }
 .multi-select-dropdown .dropdown-content .dropdown-selector {
-  height: 300px;
+  max-height: 300px;
   overflow: auto;
 }
 .multi-select-dropdown .dropdown-content .dropdown-selector .dropdown-filter {

--- a/src/Bootstrap/less/theme/common-multi-select-dropdown.less
+++ b/src/Bootstrap/less/theme/common-multi-select-dropdown.less
@@ -27,7 +27,7 @@
         border-top: 0px;
 
         .dropdown-selector {
-            height: 300px;
+            max-height: 300px;
             overflow: auto;
             
             .dropdown-filter {

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -222,6 +222,12 @@
             return false;
         }
 
+        // Elements with tabindex set to a value besides -1 are focusable.
+        var tabIndex = element.attr('tabindex');
+        if (!!tabIndex && tabIndex >= 0) {
+            return true;
+        }
+
         // See https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Interactive_content
         var alwaysInteractiveElements = ['a', 'button', 'details', 'embed', 'iframe', 'keygen', 'label', 'select', 'textarea'];
         var i;
@@ -229,11 +235,6 @@
             if (element.is(alwaysInteractiveElements[i])) {
                 return true;
             }
-        }
-
-        var tabIndex = element.attr('tabindex');
-        if (!!tabIndex && tabIndex >= 0) {
-            return true;
         }
 
         return element.is("audio") && !!element.attr("controls") ||

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -231,6 +231,11 @@
             }
         }
 
+        var tabIndex = element.attr('tabindex');
+        if (!!tabIndex && tabIndex >= 0) {
+            return true;
+        }
+
         return element.is("audio") && !!element.attr("controls") ||
             element.is("img") && !!element.attr("usemap") ||
             element.is("input") && element.attr("type") !== "hidden" ||

--- a/src/NuGetGallery/Scripts/gallery/page-manage-deprecation.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-deprecation.js
@@ -234,7 +234,7 @@ function ManageDeprecationViewModel(id, versionDeprecationStateDictionary, defau
                 // Show a warning if multiple versions are selected and at least one has an existing deprecation
                 // The user should be aware they are replacing existing deprecations
                 // Don't show an alert if a single version is selected because it is clear that the deprecation is being replaced
-                warningMessage = "Some of the package versions you selected have already been deprecated. These versions will have their deprecation information overriden or removed based on your actions.";
+                warningMessage = "Some of the package versions you selected have already been deprecated. All selected versions will have their deprecation information overridden or removed when you submit this form.";
             }
         } else if (hasVersionsWithExistingDeprecationState) {
             // Show a warning if no reasons are selected and at least one selected version has an existing deprecation
@@ -572,5 +572,10 @@ function ManageDeprecationViewModel(id, versionDeprecationStateDictionary, defau
     // Load the state for the default version.
     loadDeprecationFormState(defaultVersion);
 
-    ko.applyBindings(this, $(".page-manage-deprecation")[0]);
+    var section = $(".page-manage-deprecation")[0];
+    // Only apply bindings if the form exists.
+    // In certain situations (the package is locked, user doesn't have permissions, etc) we do not render the form.
+    if (section) {
+        ko.applyBindings(this, section);
+    }
 }

--- a/src/NuGetGallery/Views/Packages/Manage.cshtml
+++ b/src/NuGetGallery/Views/Packages/Manage.cshtml
@@ -5,6 +5,8 @@
     ViewBag.MdPageColumns = GalleryConstants.ColumnsFormMd;
 }
 
+@Html.Partial("_MultiSelectDropdown")
+
 <section role="main" class="container main-container">
     @ViewHelpers.AjaxAntiForgeryToken(Html)
     <div class="row">
@@ -15,6 +17,15 @@
                     Model,
                     "Manage",
                     linkIdOnly: true))
+
+            @if (Model.IsLocked)
+            {
+                @ViewHelpers.AlertDanger(
+                    @<text>
+                        Package '@Model.Id' has been locked. Please contact 
+                        <a href="mailto:support@nuget.org?subject=@HttpUtility.UrlPathEncode(string.Format("Requesting support for a locked package - '{0}'", Model.Id))">support@nuget.org</a>
+                    </text>)
+            }
 
             @ViewHelpers.Section(
                 this,
@@ -103,7 +114,7 @@
                 var state = versionListedState[version];
                 // Update the listed checkbox to match the state of the package.
                 var listed = state.Listed;
-                $(".page-delete-package input#Listed")[0].checked = listed;
+                $(".page-delete-package input#Listed").prop('checked', listed);
                 // Update the text stating the download count on the delete form.
                 var downloadCount = state.DownloadCount;
                 $(".page-delete-package #downloadCount").text(downloadCount);

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
@@ -32,7 +32,7 @@
 <div class="deprecation-container">
     <div class="icon-text alert alert-warning">
         <div id="show-deprecation-content-container" class="deprecation-expander" tabindex="0" data-toggle="collapse" data-target="#deprecation-content-container" aria-expanded="false" aria-controls="deprecation-content-container" aria-labelledby="deprecation-container-label">
-            <div class="deprecation-expander">
+            <div class="deprecation-expander" role="button">
                 <div class="deprecation-expander-container">
                     <i class="deprecation-expander-icon ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
 
@@ -93,14 +93,12 @@
                 }
 
                 <b>Suggested Alternatives</b>
-                <p>
-                    Consider using <a href="@alternateUrl">@alternateText</a> instead of this package.
-                </p>
+                <p><a href="@alternateUrl">@alternateText</a></p>
             }
 
             @if (!string.IsNullOrEmpty(Model.CustomMessage))
             {
-                <b>Package owner message</b>
+                <b>Additional Details</b>
                 <p>@Model.CustomMessage</p>
             }
         </div>

--- a/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
@@ -1,26 +1,25 @@
 ﻿@model ManagePackageViewModel
 
 <div class="page-manage-deprecation">
-    <span>Deprecating a package will warn all consumers of the package who use it in their projects.</span>
-
     @if (!Model.VersionSelectList.Any())
     {
-        @ViewHelpers.AlertInfo(
-                @<text>
-                    <span>There are no versions that can be deprecated.</span>
-                </text>)
+        @ViewHelpers.AlertInfo(@<text>There are no versions that can be deprecated.</text>)
     }
     else if (!Model.CanDeprecate)
     {
-        @ViewHelpers.AlertWarning(@<text>You do not have permission to deprecate this package.</text>)
+        @ViewHelpers.AlertDanger(@<text>You do not have permission to deprecate this package.</text>)
+    }
+    else if (Model.IsLocked)
+    {
+        @ViewHelpers.AlertDanger(@<text>Locked packages cannot be deprecated.</text>)
     }
     else
     {
+        <span>Deprecating a package will warn all consumers of the package who use it in their projects.</span>
+
         <div data-bind="template: { name: 'add-deprecation-template' }"></div>
     }
 </div>
-
-@Html.Partial("_MultiSelectDropdown")
 
 <script type="text/html" id="add-deprecation-template">
     <div class="deprecation-section form-group">
@@ -150,7 +149,7 @@
             <div class="security-detail-list-item alert-info">
                 <div class="security-detail-list-item-header">
                     <div>
-                        <a data-bind="text: id, attr: { href: $parent.getUrlFromId(id) }, css: { 'security-detail-list-item-existing': fromAutocomplete, 'security-detail-list-item-missing': !fromAutocomplete }"></a>
+                        <a data-bind="text: id, attr: { href: $parent.getUrlFromId(id) }, css: { 'security-detail-list-item-existing': fromAutocomplete, 'security-detail-list-item-missing': !fromAutocomplete }" target="_blank"></a>
                         <span data-bind="visible: name || !fromAutocomplete">
                             &nbsp;-&nbsp;
                             <span data-bind="visible: name, text: name"></span>

--- a/src/NuGetGallery/Views/Packages/_ManageDocumentation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageDocumentation.cshtml
@@ -30,8 +30,7 @@
             @ViewHelpers.AlertDanger(
                 @<text>
                     <span>
-                        Package '@Model.Id' has been locked. This means you cannot publish a new version or change the listing status of a published package version. Please contact
-                        <a href="mailto:support@nuget.org?subject=@HttpUtility.UrlPathEncode(string.Format("Requesting support for a locked package - '{0}'", Model.Id))">support@nuget.org</a>.
+                        You cannot update the documentation of a locked package.
                     </span>
                 </text>)
         </div>

--- a/src/NuGetGallery/Views/Packages/_ManageListing.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageListing.cshtml
@@ -10,35 +10,16 @@
 
     @if (!Model.VersionSelectList.Any())
     {
-        @ViewHelpers.AlertInfo(
-            @<text>
-                <span>There are no versions that can have their listing state changed.</span>
-            </text>)
+        @ViewHelpers.AlertInfo(@<text>There are no versions that can have their listing state changed.</text>)
     }
     else if (Model.IsLocked && !User.IsAdministrator())
     {
         <div class="validation-error-message-list">
-            @ViewHelpers.AlertDanger(
-                @<text>
-                    <span>
-                        Package '@Model.Id' has been locked. This means you cannot publish a new version or change the listing status of a published package version. Please contact
-                        <a href="mailto:support@nuget.org?subject=@HttpUtility.UrlPathEncode(string.Format("Requesting support for a locked package - '{0}'", Model.Id))">support@nuget.org</a>.
-                    </span>
-                </text>)
+            @ViewHelpers.AlertDanger(@<text>You cannot change the listing state of a locked package.</text>)
         </div>
     }
     else
     {
-        if (Model.IsLocked && User.IsAdministrator())
-        {
-            <div class="validation-error-message-list">
-                @ViewHelpers.AlertDanger(
-                    @<text>
-                        <span>Package '@Model.Id' has been locked.</span>
-                    </text>)
-            </div>
-        }
-
         <label for="input-select-version" id="package-version-label">Select version</label>
 
         @Html.DropDownList("version-selection", Model.VersionSelectList,


### PR DESCRIPTION
Some quick bugs found in https://github.com/nuget/engineering/issues/2168

- multi-select dropdown should not be larger than content

![image](https://user-images.githubusercontent.com/18014088/54318245-e6c1f480-45a2-11e9-8318-013b7c9c64c9.png)

- "skip to content" does not tab to the deprecation warning on the package details page (non-focusable elements with `tabIndex` set should be considered `:focusable` and `:tabbable`)

- Fixed page when package is locked or feature flag is disabled

site admin:

![image](https://user-images.githubusercontent.com/18014088/54318340-3e606000-45a3-11e9-8be5-ccaa5630f5e4.png)

owner:

![image](https://user-images.githubusercontent.com/18014088/54318358-4e783f80-45a3-11e9-8e3e-326d592c7f1b.png)

- deprecation warning on package details page should show pointer cursor

- custom message in deprecation warning on package details page should have better text

- alternate package text in deprecation warning on package details page should be shorter

![image](https://user-images.githubusercontent.com/18014088/54318531-df4f1b00-45a3-11e9-93bc-fd2685c35e86.png)
