### PR TITLE
Deprecation - CVEs, CWEs, and CVSS should not be submitted with the form if unchecked

### DIFF
--- a/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
@@ -48,7 +48,7 @@
             <div class="deprecation-section-header">
                 <b>Provide additional security details</b>
             </div>
-            <div data-bind="template: { name: 'deprecation-security-detail-list-input-template', data: cves }"></div>
+            <div data-bind="template: { name: 'deprecation-security-detail-list-input-template', data: chosenCves }"></div>
             <div class="security-detail panel panel-default">
                 <div>
                     <label>
@@ -62,7 +62,7 @@
                     <span data-bind="text: cvssRatingLabel, css: { 'text-danger': cvssRatingIsInvalid, 'cvss-bold': !cvssRatingIsInvalid() }"></span>
                 </div>
             </div>
-            <div data-bind="template: { name: 'deprecation-security-detail-list-input-template', data: cwes }"></div>
+            <div data-bind="template: { name: 'deprecation-security-detail-list-input-template', data: chosenCwes }"></div>
         </div>
         <div class="form-group unbolded-label">
             <label>


### PR DESCRIPTION
Found during https://github.com/NuGet/Engineering/issues/2168

Currently, if you enter in CVEs, CWEs, or a CVSS rating and then uncheck "is vulnerable", the CVEs, CWEs, and CVSS you entered will be submitted with the form (even though the package is not marked vulnerable). This fixes the issue.