### PR TITLE
Hotfix: Deprecation UI should be hidden when feature flag is disabled

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -748,6 +748,7 @@ namespace NuGetGallery
             model.SymbolsPackageValidationIssues = _validationService.GetLatestPackageValidationIssues(model.LatestSymbolsPackage);
             model.IsCertificatesUIEnabled = _contentObjectService.CertificatesConfiguration?.IsUIEnabledForUser(currentUser) ?? false;
             model.IsAtomFeedEnabled = _featureFlagService.IsPackagesAtomFeedEnabled();
+            model.IsPackageDeprecationEnabled = _featureFlagService.IsManageDeprecationEnabled(currentUser);
 
             model.ReadMeHtml = await _readMeService.GetReadMeHtmlAsync(package);
 

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -19,6 +19,9 @@ $(function () {
             container.removeAttr(expanderAttributes[i]);
         }
 
+        // The expander should not be clickable when it doesn't have content
+        container.find('.deprecation-expander').removeAttr('role');
+
         $('#deprecation-expander-icon-right').hide();
     }
 

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -143,6 +143,7 @@ namespace NuGetGallery
         public bool HasSemVer2Dependency { get; }
         public bool IsDotnetToolPackageType { get; set; }
         public bool IsAtomFeedEnabled { get; set; }
+        public bool IsPackageDeprecationEnabled { get; set; }
 
         public bool HasNewerPrerelease
         {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -255,7 +255,7 @@
                 )
             }
 
-            @if (Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+            @if (Model.IsPackageDeprecationEnabled && Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
             {
                 @Html.Partial("_DisplayPackageDeprecation")
             }
@@ -572,7 +572,7 @@
                                     </td>
 
                                     <td class="package-icon-cell">
-                                        @if (packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                                        @if (Model.IsPackageDeprecationEnabled && packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
                                         {
                                             var deprecationTitle = packageVersion.Version;
                                             var isVulnerable = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.Vulnerable);

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1076,6 +1076,61 @@ namespace NuGetGallery
                 deprecationService.Verify();
             }
 
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public async Task ShowsDeprecationIfEnabled(bool isDeprecationEnabled)
+            {
+                var featureFlagService = new Mock<IFeatureFlagService>();
+                var packageService = new Mock<IPackageService>();
+                var deprecationService = new Mock<IPackageDeprecationService>();
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService,
+                    featureFlagService: featureFlagService,
+                    deprecationService: deprecationService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var id = "Foo";
+                var package = new Package()
+                {
+                    PackageRegistration = new PackageRegistration()
+                    {
+                        Id = id,
+                        Owners = new List<User>()
+                    },
+                    Version = "01.1.01",
+                    NormalizedVersion = "1.1.1",
+                    Title = "A test package!"
+                };
+
+                var packages = new[] { package };
+                packageService
+                    .Setup(p => p.FindPackagesById(id, PackageDeprecationFieldsToInclude.Deprecation))
+                    .Returns(packages);
+
+                packageService
+                    .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
+                    .Returns(package);
+
+                featureFlagService
+                    .Setup(x => x.IsManageDeprecationEnabled(TestUtility.FakeUser))
+                    .Returns(isDeprecationEnabled);
+
+                deprecationService
+                    .Setup(x => x.GetDeprecationByPackage(package))
+                    .Verifiable();
+
+                // Arrange and Act
+                var result = await controller.DisplayPackage(id, version: null);
+
+                // Assert
+                var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
+                Assert.Equal(isDeprecationEnabled, model.IsPackageDeprecationEnabled);
+
+                deprecationService.Verify();
+            }
+
             [Fact]
             public async Task SplitsLicenseExpressionWhenProvided()
             {


### PR DESCRIPTION
(also fixed a minor bug with the deprecation expander being clickable when it's empty)