### PR TITLE
Hotfix: FeatureFlagClient should return the defaultValue when user is null

### DIFF
--- a/src/NuGetGallery.Core/Features/FeatureFlagClientExtensions.cs
+++ b/src/NuGetGallery.Core/Features/FeatureFlagClientExtensions.cs
@@ -17,7 +17,9 @@ namespace NuGetGallery.Features
         {
             if (user == null)
             {
-                throw new ArgumentNullException(nameof(user));
+                // The current user is null when not logged in.
+                // Return the default value if the user is not logged in.
+                return defaultValue;
             }
 
             return client.IsEnabled(flight, new FlightUser(user), defaultValue);

--- a/tests/NuGetGallery.Core.Facts/Features/FeatureFlagClientExtensionsFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Features/FeatureFlagClientExtensionsFacts.cs
@@ -11,8 +11,10 @@ namespace NuGetGallery.Features
 {
     public class FeatureFlagClientExtensionsFacts
     {
-        [Fact]
-        public void ConvertsUser()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ConvertsUser(bool defaultValueForNull)
         {
             // Arrange
             var client = new Mock<IFeatureFlagClient>();
@@ -37,6 +39,7 @@ namespace NuGetGallery.Features
             // Act
             FeatureFlagClientExtensions.IsEnabled(client.Object, "flightA", user, defaultValue: true);
             FeatureFlagClientExtensions.IsEnabled(client.Object, "flightB", admin, defaultValue: true);
+            var result = FeatureFlagClientExtensions.IsEnabled(client.Object, "flightC", null, defaultValueForNull);
 
             // Assert
             client.Verify(
@@ -56,6 +59,15 @@ namespace NuGetGallery.Features
                         u.EmailAddress == "b@b.com" &&
                         u.IsSiteAdmin == true),
                     true));
+
+            client.Verify(
+                c => c.IsEnabled(
+                    "flightC",
+                    null,
+                    defaultValueForNull),
+                Times.Never());
+
+            Assert.Equal(defaultValueForNull, result);
         }
     }
 }


### PR DESCRIPTION
`FeatureFlagClient` throws if the user is `null`.

Null user means "not logged in", so we should return the default value. This is the same logic the permissions service has.

(Note: https://github.com/NuGet/ServerCommon/blob/master/src/NuGet.Services.FeatureFlags/FeatureFlagClient.cs#L61 throws when `user` is `null`.)