### PR TITLE
Hotfix: ManageDeprecation is not enabled for logged out users

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -748,7 +748,7 @@ namespace NuGetGallery
             model.SymbolsPackageValidationIssues = _validationService.GetLatestPackageValidationIssues(model.LatestSymbolsPackage);
             model.IsCertificatesUIEnabled = _contentObjectService.CertificatesConfiguration?.IsUIEnabledForUser(currentUser) ?? false;
             model.IsAtomFeedEnabled = _featureFlagService.IsPackagesAtomFeedEnabled();
-            model.IsPackageDeprecationEnabled = _featureFlagService.IsManageDeprecationEnabled(currentUser);
+            model.IsPackageDeprecationEnabled = currentUser != null && _featureFlagService.IsManageDeprecationEnabled(currentUser);
 
             model.ReadMeHtml = await _readMeService.GetReadMeHtmlAsync(package);
 

--- a/src/NuGetGallery/Services/FeatureFlagService.cs
+++ b/src/NuGetGallery/Services/FeatureFlagService.cs
@@ -45,11 +45,6 @@ namespace NuGetGallery
 
         public bool IsManageDeprecationEnabled(User user)
         {
-            if (user == null)
-            {
-                return false;
-            }
-
             return _client.IsEnabled(ManageDeprecationFeatureName, user, defaultValue: false);
         }
 

--- a/src/NuGetGallery/Services/FeatureFlagService.cs
+++ b/src/NuGetGallery/Services/FeatureFlagService.cs
@@ -45,6 +45,11 @@ namespace NuGetGallery
 
         public bool IsManageDeprecationEnabled(User user)
         {
+            if (user == null)
+            {
+                return false;
+            }
+
             return _client.IsEnabled(ManageDeprecationFeatureName, user, defaultValue: false);
         }
 


### PR DESCRIPTION
Unfortunately, https://github.com/NuGet/NuGetGallery/pull/7016 throws when the user is null (e.g. logged out)

This is a temporary fix--https://github.com/NuGet/ServerCommon/pull/290 is the long-term fix