### PR TITLE
Only commit once in DeleteAccountService.DeleteAccountAsync

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Controllers/ReservedNamespaceController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/ReservedNamespaceController.cs
@@ -101,7 +101,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         {
             try
             {
-                await _reservedNamespaceService.DeleteOwnerFromReservedNamespaceAsync(prefix.Value, owner, commitAsTransaction:true);
+                await _reservedNamespaceService.DeleteOwnerFromReservedNamespaceAsync(prefix.Value, owner, commitChanges: true);
                 return Json(new { success = true, message = string.Format(Strings.ReservedNamespace_OwnerRemoved, owner, prefix.Value) });
             }
             catch (Exception ex) when (ex is InvalidOperationException || ex is ArgumentException)

--- a/src/NuGetGallery/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery/Authentication/AuthenticationService.cs
@@ -599,12 +599,16 @@ namespace NuGetGallery.Authentication
             return credentialViewModel;
         }
 
-        public virtual async Task RemoveCredential(User user, Credential cred)
+        public virtual async Task RemoveCredential(User user, Credential cred, bool commitChanges = true)
         {
             await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.RemoveCredential, cred));
             user.Credentials.Remove(cred);
             Entities.Credentials.Remove(cred);
-            await Entities.SaveChangesAsync();
+
+            if (commitChanges)
+            {
+                await Entities.SaveChangesAsync();
+            }
         }
 
         public virtual async Task EditCredentialScopes(User user, Credential cred, ICollection<Scope> newScopes)

--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -203,7 +203,7 @@ namespace NuGetGallery
                         return Json(new { success = false, message = "You can't remove the only owner from a package." }, JsonRequestBehavior.AllowGet);
                     }
 
-                    await _packageOwnershipManagementService.RemovePackageOwnerAsync(model.Package, model.CurrentUser, model.User, commitAsTransaction: true);
+                    await _packageOwnershipManagementService.RemovePackageOwnerAsync(model.Package, model.CurrentUser, model.User, commitChanges: true);
 
                     var emailMessage = new PackageOwnerRemovedMessage(_appConfiguration, model.CurrentUser, model.User, model.Package);
                     await _messageService.SendMessageAsync(emailMessage);

--- a/src/NuGetGallery/Controllers/OrganizationsController.cs
+++ b/src/NuGetGallery/Controllers/OrganizationsController.cs
@@ -367,7 +367,7 @@ namespace NuGetGallery
                 return RedirectToAction(nameof(DeleteRequest));
             }
 
-            var result = await DeleteAccountService.DeleteAccountAsync(account, currentUser, commitChanges: true);
+            var result = await DeleteAccountService.DeleteAccountAsync(account, currentUser);
 
             if (result.Success)
             {

--- a/src/NuGetGallery/Controllers/OrganizationsController.cs
+++ b/src/NuGetGallery/Controllers/OrganizationsController.cs
@@ -367,7 +367,7 @@ namespace NuGetGallery
                 return RedirectToAction(nameof(DeleteRequest));
             }
 
-            var result = await DeleteAccountService.DeleteAccountAsync(account, currentUser, commitAsTransaction: true);
+            var result = await DeleteAccountService.DeleteAccountAsync(account, currentUser, commitChanges: true);
 
             if (result.Success)
             {

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -333,8 +333,7 @@ namespace NuGetGallery
                 // Unconfirmed users can be deleted immediately without creating a support request.
                 DeleteUserAccountStatus accountDeleteStatus = await _deleteAccountService.DeleteAccountAsync(userToBeDeleted: user,
                     userToExecuteTheDelete: user,
-                    orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans,
-                    commitChanges: true);
+                    orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans);
                 if (!accountDeleteStatus.Success)
                 {
                     TempData["RequestFailedMessage"] = Strings.AccountSelfDelete_Fail;
@@ -393,8 +392,7 @@ namespace NuGetGallery
                 var status = await _deleteAccountService.DeleteAccountAsync(
                     userToBeDeleted: user,
                     userToExecuteTheDelete: admin,
-                    orphanPackagePolicy: model.ShouldUnlist ? AccountDeletionOrphanPackagePolicy.UnlistOrphans : AccountDeletionOrphanPackagePolicy.KeepOrphans,
-                    commitChanges: true);
+                    orphanPackagePolicy: model.ShouldUnlist ? AccountDeletionOrphanPackagePolicy.UnlistOrphans : AccountDeletionOrphanPackagePolicy.KeepOrphans);
                 return View("DeleteUserAccountStatus", status);
             }
         }

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -334,7 +334,7 @@ namespace NuGetGallery
                 DeleteUserAccountStatus accountDeleteStatus = await _deleteAccountService.DeleteAccountAsync(userToBeDeleted: user,
                     userToExecuteTheDelete: user,
                     orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans,
-                    commitAsTransaction: true);
+                    commitChanges: true);
                 if (!accountDeleteStatus.Success)
                 {
                     TempData["RequestFailedMessage"] = Strings.AccountSelfDelete_Fail;
@@ -394,7 +394,7 @@ namespace NuGetGallery
                     userToBeDeleted: user,
                     userToExecuteTheDelete: admin,
                     orphanPackagePolicy: model.ShouldUnlist ? AccountDeletionOrphanPackagePolicy.UnlistOrphans : AccountDeletionOrphanPackagePolicy.KeepOrphans,
-                    commitAsTransaction: true);
+                    commitChanges: true);
                 return View("DeleteUserAccountStatus", status);
             }
         }

--- a/src/NuGetGallery/Security/ISecurityPolicyService.cs
+++ b/src/NuGetGallery/Security/ISecurityPolicyService.cs
@@ -41,12 +41,12 @@ namespace NuGetGallery.Security
         /// <summary>
         /// Unsubscribe a user from one or more security policies.
         /// </summary>
-        Task UnsubscribeAsync(User user, string subscriptionName);
+        Task UnsubscribeAsync(User user, string subscriptionName, bool commitChanges = true);
 
         /// <summary>
         /// Unsubscribe a user from one or more security policies.
         /// </summary>
-        Task UnsubscribeAsync(User user, IUserSecurityPolicySubscription subscription);
+        Task UnsubscribeAsync(User user, IUserSecurityPolicySubscription subscription, bool commitChanges = true);
 
         /// <summary>
         /// Evaluate any security policies that may apply to the current context.

--- a/src/NuGetGallery/Security/SecurityPolicyService.cs
+++ b/src/NuGetGallery/Security/SecurityPolicyService.cs
@@ -426,7 +426,7 @@ namespace NuGetGallery.Security
         /// <summary>
         /// Unsubscribe a user from one or more security policies.
         /// </summary>
-        public Task UnsubscribeAsync(User user, string subscriptionName)
+        public Task UnsubscribeAsync(User user, string subscriptionName, bool commitChanges = true)
         {
             if (string.IsNullOrEmpty(subscriptionName))
             {
@@ -439,13 +439,13 @@ namespace NuGetGallery.Security
                 throw new NotSupportedException($"Subscription '{subscriptionName}' not found.");
             }
 
-            return UnsubscribeAsync(user, subscription);
+            return UnsubscribeAsync(user, subscription, commitChanges);
         }
 
         /// <summary>
         /// Unsubscribe a user from one or more security policies.
         /// </summary>
-        public async Task UnsubscribeAsync(User user, IUserSecurityPolicySubscription subscription)
+        public async Task UnsubscribeAsync(User user, IUserSecurityPolicySubscription subscription, bool commitChanges = true)
         {
             if (user == null)
             {
@@ -471,7 +471,10 @@ namespace NuGetGallery.Security
                 await Auditing.SaveAuditRecordAsync(
                     new UserAuditRecord(user, AuditedUserAction.UnsubscribeFromPolicies, subscription.Policies));
 
-                await EntitiesContext.SaveChangesAsync();
+                if (commitChanges)
+                {
+                    await EntitiesContext.SaveChangesAsync();
+                }
 
                 Diagnostics.Information($"User is now unsubscribed from '{subscription.SubscriptionName}'.");
             }

--- a/src/NuGetGallery/Services/IDeleteAccountService.cs
+++ b/src/NuGetGallery/Services/IDeleteAccountService.cs
@@ -21,10 +21,10 @@ namespace NuGetGallery
         /// <param name="userToBeDeleted">The user to be deleted.</param>
         /// <param name="userToExecuteTheDelete">The user deleting the account.</param>
         /// <param name="orphanPackagePolicy">If deleting the account creates any orphaned packages, a <see cref="AccountDeletionOrphanPackagePolicy"/> that describes how those orphans should be handled.</param>
-        /// <param name="commitAsTransaction">Whether or not to commit the changes as a transaction.</param>
+        /// <param name="commitChanges">Whether or not to commit the changes.</param>
         Task<DeleteUserAccountStatus> DeleteAccountAsync(User userToBeDeleted,
             User userToExecuteTheDelete,
-            bool commitAsTransaction,
+            bool commitChanges,
             AccountDeletionOrphanPackagePolicy orphanPackagePolicy = AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans);
     }
 }

--- a/src/NuGetGallery/Services/IDeleteAccountService.cs
+++ b/src/NuGetGallery/Services/IDeleteAccountService.cs
@@ -21,10 +21,8 @@ namespace NuGetGallery
         /// <param name="userToBeDeleted">The user to be deleted.</param>
         /// <param name="userToExecuteTheDelete">The user deleting the account.</param>
         /// <param name="orphanPackagePolicy">If deleting the account creates any orphaned packages, a <see cref="AccountDeletionOrphanPackagePolicy"/> that describes how those orphans should be handled.</param>
-        /// <param name="commitChanges">Whether or not to commit the changes.</param>
         Task<DeleteUserAccountStatus> DeleteAccountAsync(User userToBeDeleted,
             User userToExecuteTheDelete,
-            bool commitChanges,
             AccountDeletionOrphanPackagePolicy orphanPackagePolicy = AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans);
     }
 }

--- a/src/NuGetGallery/Services/IPackageOwnershipManagementService.cs
+++ b/src/NuGetGallery/Services/IPackageOwnershipManagementService.cs
@@ -35,8 +35,8 @@ namespace NuGetGallery
         /// <param name="packageRegistration">The package registration that is intended to get ownership.</param>
         /// <param name="requestingUser">The user requesting to remove an owner from the package.</param>
         /// <param name="userToBeRemoved">The user to remove as an owner from the package.</param>
-        /// <param name="commitAsTransaction">If the data is commited under a transaction.</param>
-        Task RemovePackageOwnerAsync(PackageRegistration packageRegistration, User requestingUser, User userToBeRemoved, bool commitAsTransaction);
+        /// <param name="commitChanges">Whether or not to commit the changes.</param>
+        Task RemovePackageOwnerAsync(PackageRegistration packageRegistration, User requestingUser, User userToBeRemoved, bool commitChanges);
 
         /// <summary>
         /// Remove the pending ownership request.

--- a/src/NuGetGallery/Services/IReservedNamespaceService.cs
+++ b/src/NuGetGallery/Services/IReservedNamespaceService.cs
@@ -42,9 +42,9 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="prefix">The reserved namespace to modify</param>
         /// <param name="username">The user to remove the ownership for the namespace</param>
-        /// <param name="commitAsTransaction">True if the changes will be commited as a single transaction.</param>
+        /// <param name="commitChanges">Whether or not to commit the changes.</param>
         /// <returns>Awaitable Task</returns>
-        Task DeleteOwnerFromReservedNamespaceAsync(string prefix, string username, bool commitAsTransaction);
+        Task DeleteOwnerFromReservedNamespaceAsync(string prefix, string username, bool commitChanges);
 
         /// <summary>
         /// Add the specified package registration to the reserved namespace. It is the caller's reponsibility to

--- a/src/NuGetGallery/Services/ReservedNamespaceService.cs
+++ b/src/NuGetGallery/Services/ReservedNamespaceService.cs
@@ -180,7 +180,7 @@ namespace NuGetGallery
             }
         }
 
-        public async Task DeleteOwnerFromReservedNamespaceAsync(string prefix, string username, bool commitAsTransaction = true)
+        public async Task DeleteOwnerFromReservedNamespaceAsync(string prefix, string username, bool commitChanges = true)
         {
             if (string.IsNullOrWhiteSpace(prefix))
             {
@@ -195,7 +195,7 @@ namespace NuGetGallery
                    ?? throw new InvalidOperationException(string.Format(
                        CultureInfo.CurrentCulture, Strings.ReservedNamespace_NamespaceNotFound, prefix));
             List<PackageRegistration> packageRegistrationsToMarkUnverified;
-            if (commitAsTransaction)
+            if (commitChanges)
             {
                 using (var strategy = new SuspendDbExecutionStrategy())
                 using (var transaction = EntitiesContext.GetDatabase().BeginTransaction())
@@ -206,13 +206,14 @@ namespace NuGetGallery
             }
             else
             {
-                packageRegistrationsToMarkUnverified = await DeleteOwnerFromReservedNamespaceImplAsync(prefix, username, namespaceToModify);
+                packageRegistrationsToMarkUnverified = await DeleteOwnerFromReservedNamespaceImplAsync(prefix, username, namespaceToModify, commitChanges: false);
             }
+
             await AuditingService.SaveAuditRecordAsync(
                   new ReservedNamespaceAuditRecord(namespaceToModify, AuditedReservedNamespaceAction.RemoveOwner, username, packageRegistrationsToMarkUnverified));
         }
 
-        private async Task<List<PackageRegistration>> DeleteOwnerFromReservedNamespaceImplAsync(string prefix, string username, ReservedNamespace namespaceToModify)
+        private async Task<List<PackageRegistration>> DeleteOwnerFromReservedNamespaceImplAsync(string prefix, string username, ReservedNamespace namespaceToModify, bool commitChanges = true)
         {
             var userToRemove = UserService.FindByUsername(username)
                 ?? throw new InvalidOperationException(string.Format(
@@ -248,7 +249,10 @@ namespace NuGetGallery
                 await PackageService.UpdatePackageVerifiedStatusAsync(packageRegistrationsToMarkUnverified, isVerified: false);
             }
             
-            await ReservedNamespaceRepository.CommitChangesAsync();
+            if (commitChanges)
+            {
+                await ReservedNamespaceRepository.CommitChangesAsync();
+            }
 
             return packageRegistrationsToMarkUnverified;
         }

--- a/src/NuGetGallery/Services/ReservedNamespaceService.cs
+++ b/src/NuGetGallery/Services/ReservedNamespaceService.cs
@@ -246,7 +246,7 @@ namespace NuGetGallery
                 packageRegistrationsToMarkUnverified
                     .ForEach(pr => namespaceToModify.PackageRegistrations.Remove(pr));
 
-                await PackageService.UpdatePackageVerifiedStatusAsync(packageRegistrationsToMarkUnverified, isVerified: false);
+                await PackageService.UpdatePackageVerifiedStatusAsync(packageRegistrationsToMarkUnverified, isVerified: false, commitChanges: false);
             }
             
             if (commitChanges)

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -2107,8 +2107,8 @@ namespace NuGetGallery
                     .Returns(Task.CompletedTask);
 
                 controller.MockAuthenticationService
-                    .Setup(s => s.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>()))
-                    .Callback<User, Credential>((u, c) => u.Credentials.Remove(c))
+                    .Setup(s => s.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>(), true))
+                    .Callback<User, Credential, bool>((u, c, cc) => u.Credentials.Remove(c))
                     .Returns(Task.CompletedTask);
 
                 var id = package?.PackageRegistration?.Id ?? PackageId;
@@ -2265,7 +2265,7 @@ namespace NuGetGallery
                     HttpStatusCode.NotFound,
                     String.Format(CultureInfo.CurrentCulture, Strings.PackageWithIdAndVersionNotFound, PackageId, PackageVersion));
 
-                controller.MockAuthenticationService.Verify(s => s.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>()),
+                controller.MockAuthenticationService.Verify(s => s.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>(), true),
                     CredentialTypes.IsPackageVerificationApiKey(credentialType) ? Times.Once() : Times.Never());
 
                 controller.MockTelemetryService.Verify(x => x.TrackVerifyPackageKeyEvent(PackageId, PackageVersion,
@@ -2333,7 +2333,7 @@ namespace NuGetGallery
                     expectedStatusCode,
                     description);
 
-                controller.MockAuthenticationService.Verify(s => s.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>()),
+                controller.MockAuthenticationService.Verify(s => s.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>(), true),
                     CredentialTypes.IsPackageVerificationApiKey(credentialType) ? Times.Once() : Times.Never());
 
                 controller.MockTelemetryService.Verify(x => x.TrackVerifyPackageKeyEvent(PackageId, PackageVersion,
@@ -2369,7 +2369,7 @@ namespace NuGetGallery
                 // Assert
                 ResultAssert.IsEmpty(result);
 
-                controller.MockAuthenticationService.Verify(s => s.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>()), isRemoved ? Times.Once() : Times.Never());
+                controller.MockAuthenticationService.Verify(s => s.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>(), true), isRemoved ? Times.Once() : Times.Never());
 
                 controller.MockTelemetryService.Verify(x => x.TrackVerifyPackageKeyEvent(PackageId, PackageVersion,
                     It.IsAny<User>(), controller.OwinContext.Request.User.Identity, 200), Times.Once);

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -395,7 +395,7 @@ namespace NuGetGallery.Controllers
                     .Verify(x => x.CreateSessionAsync(controller.OwinContext, authUser, false));
 
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.RemoveCredential(user, passwordCredential));
+                    .Verify(x => x.RemoveCredential(user, passwordCredential, true));
 
                 GetMock<IMessageService>()
                     .Verify(x => x.SendMessageAsync(It.IsAny<CredentialAddedMessage>(), false, false));
@@ -1341,7 +1341,7 @@ namespace NuGetGallery.Controllers
                     .Verifiable();
 
                 serviceMock
-                    .Setup(x => x.RemoveCredential(user, passwordCred))
+                    .Setup(x => x.RemoveCredential(user, passwordCred, true))
                     .Completes()
                     .Verifiable();
 
@@ -1567,7 +1567,7 @@ namespace NuGetGallery.Controllers
                     });
 
                 GetMock<AuthenticationService>()
-                    .Setup(x => x.RemoveCredential(user, passwordCred))
+                    .Setup(x => x.RemoveCredential(user, passwordCred, true))
                     .Completes()
                     .Verifiable();
 
@@ -1590,7 +1590,7 @@ namespace NuGetGallery.Controllers
                 // Assert
                 ResultAssert.IsSafeRedirectTo(result, "theReturnUrl");
                 GetMock<AuthenticationService>()
-                    .Verify(x => x.RemoveCredential(user, passwordCred), discontinuedLogin ? Times.Once() : Times.Never());
+                    .Verify(x => x.RemoveCredential(user, passwordCred, true), discontinuedLogin ? Times.Once() : Times.Never());
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -1438,7 +1438,7 @@ namespace NuGetGallery
                 testOrganization.Members.Remove(fakes.OrganizationCollaborator.Organizations.Single());
 
                 GetMock<IDeleteAccountService>()
-                    .Setup(x => x.DeleteAccountAsync(testOrganization, currentUser, true, AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans))
+                    .Setup(x => x.DeleteAccountAsync(testOrganization, currentUser, AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans))
                     .Returns(Task.FromResult(new DeleteUserAccountStatus { Success = false }));
 
                 // Act & Assert
@@ -1461,7 +1461,7 @@ namespace NuGetGallery
                 testOrganization.Members.Remove(fakes.OrganizationCollaborator.Organizations.Single());
 
                 GetMock<IDeleteAccountService>()
-                    .Setup(x => x.DeleteAccountAsync(testOrganization, currentUser, true, AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans))
+                    .Setup(x => x.DeleteAccountAsync(testOrganization, currentUser, AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans))
                     .Returns(Task.FromResult(new DeleteUserAccountStatus { Success = true }));
 
                 // Act

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -2473,7 +2473,7 @@ namespace NuGetGallery
                     .Returns(testUser);
 
                 GetMock<IDeleteAccountService>()
-                    .Setup(stub => stub.DeleteAccountAsync(testUser, It.IsAny<User>(), It.IsAny<bool>(), It.IsAny<AccountDeletionOrphanPackagePolicy>()))
+                    .Setup(stub => stub.DeleteAccountAsync(testUser, It.IsAny<User>(), It.IsAny<AccountDeletionOrphanPackagePolicy>()))
                     .Returns(value: Task.FromResult(new DeleteUserAccountStatus()
                     {
                         AccountName = userName,

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -1348,7 +1348,7 @@ namespace NuGetGallery
                     .CreateExternalCredential("MicrosoftAccount", "blorg", "bloog"));
 
                 GetMock<AuthenticationService>()
-                    .Setup(a => a.RemoveCredential(user, cred))
+                    .Setup(a => a.RemoveCredential(user, cred, true))
                     .Completes()
                     .Verifiable();
                 var messageService = GetMock<IMessageService>();
@@ -1565,7 +1565,7 @@ namespace NuGetGallery
                     credentialBuilder.CreateExternalCredential("MicrosoftAccount", "blorg", "bloog"));
 
                 GetMock<AuthenticationService>()
-                    .Setup(a => a.RemoveCredential(user, cred))
+                    .Setup(a => a.RemoveCredential(user, cred, true))
                     .Completes()
                     .Verifiable();
 
@@ -1677,7 +1677,7 @@ namespace NuGetGallery
                     credentialBuilder.CreatePasswordCredential("password"));
 
                 GetMock<AuthenticationService>()
-                    .Setup(a => a.RemoveCredential(user, cred))
+                    .Setup(a => a.RemoveCredential(user, cred, true))
                     .Completes()
                     .Verifiable();
 
@@ -1952,8 +1952,8 @@ namespace NuGetGallery
                     .Verifiable();
 
                 GetMock<AuthenticationService>()
-                    .Setup(a => a.RemoveCredential(user, cred))
-                     .Callback<User, Credential>((u, c) => u.Credentials.Remove(c))
+                    .Setup(a => a.RemoveCredential(user, cred, true))
+                     .Callback<User, Credential, bool>((u, c, cc) => u.Credentials.Remove(c))
                     .Completes()
                     .Verifiable();
 
@@ -2056,7 +2056,7 @@ namespace NuGetGallery
 
                 var authenticationService = GetMock<AuthenticationService>();
                 authenticationService
-                    .Setup(x => x.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>()))
+                    .Setup(x => x.RemoveCredential(It.IsAny<User>(), It.IsAny<Credential>(), true))
                     .Verifiable();
 
                 var controller = GetController<UsersController>();

--- a/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
@@ -38,7 +38,6 @@ namespace NuGetGallery.Services
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deleteAccountService.DeleteAccountAsync(
                     null, 
                     new User("AdminUser") { Key = Key++ },
-                    commitChanges: false,
                     orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans));
             }
 
@@ -57,7 +56,6 @@ namespace NuGetGallery.Services
                 await Assert.ThrowsAsync<ArgumentNullException>(() => deleteAccountService.DeleteAccountAsync(
                     new User("TestUser") { Key = Key++ },
                     null,
-                    commitChanges: false,
                     orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans));
             }
 
@@ -77,11 +75,10 @@ namespace NuGetGallery.Services
                 var deleteAccountService = testableService.GetDeleteAccountService(isPackageOrphaned);
 
                 // Act
-                var result = await deleteAccountService.
-                    DeleteAccountAsync(userToBeDeleted: testUser,
-                                                userToExecuteTheDelete: testUser,
-                                                commitChanges: false,
-                                                orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans);
+                var result = await deleteAccountService.DeleteAccountAsync(
+                    userToBeDeleted: testUser,
+                    userToExecuteTheDelete: testUser,
+                    orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans);
                 string expected = $"The account '{testUser.Username}' was already deleted. No action was performed.";
                 Assert.Equal(expected, result.Description);
             }
@@ -122,11 +119,10 @@ namespace NuGetGallery.Services
                 var deleteAccountService = testableService.GetDeleteAccountService(isPackageOrphaned);
 
                 // Act
-                await deleteAccountService.
-                    DeleteAccountAsync(userToBeDeleted: testUser,
-                        userToExecuteTheDelete: testUser,
-                        commitChanges: false,
-                        orphanPackagePolicy: orphanPolicy);
+                await deleteAccountService.DeleteAccountAsync(
+                    userToBeDeleted: testUser,
+                    userToExecuteTheDelete: testUser,
+                    orphanPackagePolicy: orphanPolicy);
 
 
                 if (orphanPolicy == AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans && isPackageOrphaned)
@@ -198,10 +194,10 @@ namespace NuGetGallery.Services
                 var deleteAccountService = testableService.GetDeleteAccountService(isPackageOrphaned);
 
                 //Act
-                var status = await deleteAccountService.DeleteAccountAsync(userToBeDeleted: testUser,
-                                                userToExecuteTheDelete: testUser,
-                                                commitChanges: false,
-                                                orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans);
+                var status = await deleteAccountService.DeleteAccountAsync(
+                    userToBeDeleted: testUser,
+                    userToExecuteTheDelete: testUser,
+                    orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans);
 
                 //Assert
                 Assert.True(status.Success);
@@ -251,12 +247,10 @@ namespace NuGetGallery.Services
                 var deleteAccountService = testableService.GetDeleteAccountService(isPackageOrphaned);
 
                 // Act
-                var status = await deleteAccountService.
-                    DeleteAccountAsync(
-                        organization,
-                        member,
-                        commitChanges: false,
-                        orphanPackagePolicy: orphanPolicy);
+                var status = await deleteAccountService.DeleteAccountAsync(
+                    organization,
+                    member,
+                    orphanPackagePolicy: orphanPolicy);
 
                 // Assert
                 if (orphanPolicy == AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans && isPackageOrphaned)
@@ -329,12 +323,10 @@ namespace NuGetGallery.Services
                 var deleteAccountService = testableService.GetDeleteAccountService(isPackageOrphaned);
 
                 // Act
-                var status = await deleteAccountService.
-                    DeleteAccountAsync(
-                        organization,
-                        member,
-                        commitChanges: false,
-                        orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.KeepOrphans);
+                var status = await deleteAccountService.DeleteAccountAsync(
+                    organization,
+                    member,
+                    orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.KeepOrphans);
 
                 // Assert
                 Assert.True(status.Success);
@@ -365,8 +357,7 @@ namespace NuGetGallery.Services
                 // Act
                 var result = await deleteAccountService.DeleteAccountAsync(
                     userToBeDeleted: testUser,
-                    userToExecuteTheDelete: testUser,
-                    commitChanges: false);
+                    userToExecuteTheDelete: testUser);
 
                 // Assert
                 Assert.False(result.Success);
@@ -493,6 +484,7 @@ namespace NuGetGallery.Services
                 _user = user;
                 _user.ReservedNamespaces.Add(_reservedNamespace);
                 _user.Credentials.Add(_credential);
+                _credential.User = _user;
                 _user.SecurityPolicies.Add(_securityPolicy);
                 _userPackagesRegistration = userPackagesRegistration;
                 _userPackages = userPackagesRegistration.Packages;

--- a/tests/NuGetGallery.Facts/Services/ReservedNamespaceServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReservedNamespaceServiceFacts.cs
@@ -745,7 +745,7 @@ namespace NuGetGallery.Services
                 service
                     .MockPackageService
                     .Verify(p => p.UpdatePackageVerifiedStatusAsync(
-                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), true),
+                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), false),
                         Times.Once);
 
                 Assert.False(existingNamespace.Owners.Contains(owner1));
@@ -790,7 +790,7 @@ namespace NuGetGallery.Services
                 service
                     .MockPackageService
                     .Verify(p => p.UpdatePackageVerifiedStatusAsync(
-                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), true),
+                        It.IsAny<IReadOnlyCollection<PackageRegistration>>(), It.IsAny<bool>(), false),
                         Times.Once);
 
                 Assert.False(existingNamespace.Owners.Contains(owner1));


### PR DESCRIPTION
https://github.com/nuget/engineering/issues/2264

`DeleteAccountService.DeleteAccountAsync` was so slow because it calls a lot of other services, most of which internally called `EntitiesContext.SaveChangesAsync`. Because the entire method is wrapped in a transaction, none of these calls are necessary and thus slow down the process substantially. Each call to `EntitiesContext.SaveChangesAsync` forces EF to do a lot of work behind the scenes--even if the transaction isn't going to be committed to the DB yet.

This was fixed by
- passing `commitChanges: false` to services that already supported it
- modifying services so that they allow `commitChanges: false`

We had a couple services with a `commitAsTransaction` parameter, which committed regardless of whether or not it was in a transaction or not. I changed these so that it only committed if it was wrapped in a transaction, because if the caller doesn't want the commit in a transaction, it's likely they don't want the commit anyway.