### PR TITLE
Add OpenWriteAsync to ISimpleCloudBlob to allow streaming writes

### DIFF
--- a/src/NuGetGallery.Core/Services/CloudBlobWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobWrapper.cs
@@ -54,6 +54,14 @@ namespace NuGetGallery
                 operationContext: null);
         }
 
+        public async Task<Stream> OpenWriteAsync(AccessCondition accessCondition)
+        {
+            return await _blob.OpenWriteAsync(
+                accessCondition: accessCondition,
+                options: null,
+                operationContext: null);
+        }
+
         public async Task DeleteIfExistsAsync()
         {
             await _blob.DeleteIfExistsAsync(

--- a/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
@@ -22,6 +22,7 @@ namespace NuGetGallery
         string ETag { get; }
 
         Task<Stream> OpenReadAsync(AccessCondition accessCondition);
+        Task<Stream> OpenWriteAsync(AccessCondition accessCondition);
 
         Task DeleteIfExistsAsync();
         Task DownloadToStreamAsync(Stream target);


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6475.

This method is the buddy of the already plumbed through `OpenReadAsync`. `StreamWriter` and `JsonTextWriter` can be used on top of this stream to incrementally write to a blob.