### PR TITLE
DeleteAccountService should clean up Package.User and PackageDeprecation.DeprecatedBy

### DIFF
--- a/src/NuGet.Services.Entities/Package.cs
+++ b/src/NuGet.Services.Entities/Package.cs
@@ -217,9 +217,11 @@ namespace NuGet.Services.Entities
         public string MinClientVersion { get; set; }
 
         /// <summary>
-        /// The logged in user when this package version was created.
-        /// NULL for older packages.
+        /// The user that uploaded this package or <c>null</c> if the user was deleted.
         /// </summary>
+        /// <remarks>
+        /// Packages uploaded before this field was added have <c>null</c>.
+        /// </remarks>
         public User User { get; set; }
         public int? UserKey { get; set; }
 

--- a/src/NuGet.Services.Entities/PackageDeprecation.cs
+++ b/src/NuGet.Services.Entities/PackageDeprecation.cs
@@ -72,6 +72,9 @@ namespace NuGet.Services.Entities
         /// <summary>
         /// Gets or sets the user that executed the package deprecation.
         /// </summary>
+        /// <remarks>
+        /// This field will be <c>null</c> if the user that deprecated the package has been deleted.
+        /// </remarks>
         public virtual User DeprecatedByUser { get; set; }
 
         /// <summary>

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -49,6 +49,7 @@ namespace NuGetGallery
         }
 
         public bool ReadOnly { get; private set; }
+        public DbSet<Package> Packages { get; set; }
         public DbSet<PackageRegistration> PackageRegistrations { get; set; }
         public DbSet<Credential> Credentials { get; set; }
         public DbSet<Scope> Scopes { get; set; }

--- a/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
@@ -10,6 +10,7 @@ namespace NuGetGallery
     public interface IEntitiesContext
     {
         DbSet<Certificate> Certificates { get; set; }
+        DbSet<Package> Packages { get; set; }
         DbSet<PackageRegistration> PackageRegistrations { get; set; }
         DbSet<Credential> Credentials { get; set; }
         DbSet<Scope> Scopes { get; set; }

--- a/src/NuGetGallery/Services/DeleteAccountService.cs
+++ b/src/NuGetGallery/Services/DeleteAccountService.cs
@@ -106,13 +106,14 @@ namespace NuGetGallery
         private async Task DeleteAccountImplAsync(User userToBeDeleted, User userToExecuteTheDelete, AccountDeletionOrphanPackagePolicy orphanPackagePolicy, bool commitChanges = true)
         {
             await RemoveReservedNamespaces(userToBeDeleted);
-            RemovePackagePushedBy(userToBeDeleted);
-            RemovePackageDeprecatedBy(userToBeDeleted);
             await RemovePackageOwnership(userToBeDeleted, userToExecuteTheDelete, orphanPackagePolicy);
             await RemoveMemberships(userToBeDeleted, userToExecuteTheDelete, orphanPackagePolicy);
             await RemoveSecurityPolicies(userToBeDeleted);
             await RemoveUserCredentials(userToBeDeleted);
             await RemovePackageOwnershipRequests(userToBeDeleted);
+
+            RemovePackagePushedBy(userToBeDeleted);
+            RemovePackageDeprecatedBy(userToBeDeleted);
 
             var organizationToBeDeleted = userToBeDeleted as Organization;
             if (organizationToBeDeleted != null)
@@ -215,7 +216,10 @@ namespace NuGetGallery
 
         private void RemovePackagePushedBy(User user)
         {
-            foreach (var package in _entitiesContext.Packages.Where(p => p.UserKey == user.Key).ToList())
+            foreach (var package in _entitiesContext
+                .Packages
+                .Where(p => p.UserKey == user.Key)
+                .ToList())
             {
                 package.User = null;
             }

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -369,12 +369,6 @@ namespace NuGetGallery
             // To support the delete account scenario, the admin can delete the last owner of a package.
             package.Owners.Remove(user);
 
-            // If the package's required signer is the user, remove them.
-            if (package.RequiredSigners.Any(s => s.MatchesUser(user)))
-            {
-                await SetRequiredSignerAsync(package, null, false);
-            }
-
             if (commitChanges)
             {
                 await _packageRepository.CommitChangesAsync();

--- a/src/NuGetGallery/Services/PackageService.cs
+++ b/src/NuGetGallery/Services/PackageService.cs
@@ -368,6 +368,13 @@ namespace NuGetGallery
         {
             // To support the delete account scenario, the admin can delete the last owner of a package.
             package.Owners.Remove(user);
+
+            // If the package's required signer is the user, remove them.
+            if (package.RequiredSigners.Any(s => s.MatchesUser(user)))
+            {
+                await SetRequiredSignerAsync(package, null, false);
+            }
+
             if (commitChanges)
             {
                 await _packageRepository.CommitChangesAsync();

--- a/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
@@ -128,7 +128,6 @@ namespace NuGetGallery.Services
                 if (orphanPolicy == AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans && isPackageOrphaned)
                 {
                     Assert.True(registration.Owners.Any(o => o.MatchesUser(testUser)));
-                    Assert.True(registration.RequiredSigners.Any(o => o.MatchesUser(testUser)));
                     Assert.NotEmpty(testUser.SecurityPolicies);
                     Assert.True(registration.Packages.Single().Listed);
                     Assert.NotNull(testUser.EmailAddress);
@@ -146,7 +145,6 @@ namespace NuGetGallery.Services
                 else
                 {
                     Assert.False(registration.Owners.Any(o => o.MatchesUser(testUser)));
-                    Assert.Empty(registration.RequiredSigners);
                     Assert.Empty(testUser.SecurityPolicies);
                     Assert.Equal(
                         orphanPolicy == AccountDeletionOrphanPackagePolicy.UnlistOrphans && isPackageOrphaned,
@@ -240,7 +238,6 @@ namespace NuGetGallery.Services
 
                 PackageRegistration registration = new PackageRegistration();
                 registration.Owners.Add(organization);
-                registration.RequiredSigners.Add(organization);
 
                 Package p = new Package()
                 {
@@ -265,7 +262,6 @@ namespace NuGetGallery.Services
                     Assert.False(status.Success);
                     Assert.Equal(organization.Confirmed, organization.EmailAddress != null);
                     Assert.True(registration.Owners.Any(o => o.MatchesUser(organization)));
-                    Assert.True(registration.RequiredSigners.Any(o => o.MatchesUser(organization)));
                     Assert.NotEmpty(organization.SecurityPolicies);
                     Assert.NotNull(testableService.PackagePushedByUser.User);
                     Assert.NotNull(testableService.DeprecationDeprecatedByUser.DeprecatedByUser);
@@ -283,7 +279,6 @@ namespace NuGetGallery.Services
                         orphanPolicy == AccountDeletionOrphanPackagePolicy.UnlistOrphans && isPackageOrphaned,
                         !registration.Packages.Single().Listed);
                     Assert.False(registration.Owners.Any(o => o.MatchesUser(organization)));
-                    Assert.Empty(registration.RequiredSigners);
                     Assert.Empty(organization.SecurityPolicies);
                     Assert.Null(testableService.PackagePushedByUser.User);
                     Assert.Null(testableService.DeprecationDeprecatedByUser.DeprecatedByUser);
@@ -323,7 +318,6 @@ namespace NuGetGallery.Services
 
                 PackageRegistration registration = new PackageRegistration();
                 registration.Owners.Add(organization);
-                registration.RequiredSigners.Add(organization);
 
                 Package p = new Package()
                 {
@@ -346,8 +340,6 @@ namespace NuGetGallery.Services
                 Assert.True(status.Success);
                 Assert.Null(testableService.User);
                 Assert.Empty(registration.Owners);
-                Assert.Empty(registration.RequiredSigners);
-                Assert.Empty(registration.RequiredSigners);
                 Assert.Empty(organization.SecurityPolicies);
                 Assert.Empty(organization.ReservedNamespaces);
                 Assert.Null(testableService.PackagePushedByUser.User);
@@ -406,7 +398,6 @@ namespace NuGetGallery.Services
 
                 registration = new PackageRegistration();
                 registration.Owners.Add(testUser);
-                registration.RequiredSigners.Add(testUser);
 
                 var p = new Package()
                 {
@@ -789,7 +780,6 @@ namespace NuGetGallery.Services
                         {
                             _userPackagesRegistration.Owners.Remove(_user);
                             _userPackagesRegistration.ReservedNamespaces.Remove(_reservedNamespace);
-                            _userPackagesRegistration.RequiredSigners.Clear();
                         });
 
                     packageOwnershipManagementService.Setup(m => m.GetPackageOwnershipRequests(null, null, _user))

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1985,45 +1985,29 @@ namespace NuGetGallery
 
         public class TheRemovePackageOwnerMethod
         {
-            [Theory]
-            [InlineData(false)]
-            [InlineData(true)]
-            public async Task WillRemoveOneOfManyOwners(bool isRequiredSigner)
+            [Fact]
+            public async Task WillRemoveOneOfManyOwners()
             {
                 var service = CreateService();
                 var owner1 = new User { Key = 1, Username = "Owner1" };
                 var owner2 = new User { Key = 2, Username = "Owner2" };
                 var package = new PackageRegistration { Owners = new List<User> { owner1, owner2 } };
 
-                if (isRequiredSigner)
-                {
-                    package.RequiredSigners.Add(owner1);
-                }
-
                 await service.RemovePackageOwnerAsync(package, owner1);
 
                 Assert.DoesNotContain(owner1, package.Owners);
-                Assert.DoesNotContain(owner1, package.RequiredSigners);
             }
 
-            [Theory]
-            [InlineData(false)]
-            [InlineData(true)]
-            public async Task WillRemoveLastOwner(bool isRequiredSigner)
+            [Fact]
+            public async Task WillRemoveLastOwner()
             {
                 var service = CreateService();
                 var singleOwner = new User { Key = 1, Username = "Owner" };
                 var package = new PackageRegistration { Owners = new List<User> { singleOwner } };
 
-                if (isRequiredSigner)
-                {
-                    package.RequiredSigners.Add(singleOwner);
-                }
-
                 await service.RemovePackageOwnerAsync(package, singleOwner);
 
                 Assert.DoesNotContain(singleOwner, package.Owners);
-                Assert.DoesNotContain(singleOwner, package.RequiredSigners);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1985,29 +1985,45 @@ namespace NuGetGallery
 
         public class TheRemovePackageOwnerMethod
         {
-            [Fact]
-            public async Task RemovesPackageOwner()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public async Task WillRemoveOneOfManyOwners(bool isRequiredSigner)
             {
                 var service = CreateService();
                 var owner1 = new User { Key = 1, Username = "Owner1" };
                 var owner2 = new User { Key = 2, Username = "Owner2" };
                 var package = new PackageRegistration { Owners = new List<User> { owner1, owner2 } };
 
+                if (isRequiredSigner)
+                {
+                    package.RequiredSigners.Add(owner1);
+                }
+
                 await service.RemovePackageOwnerAsync(package, owner1);
 
                 Assert.DoesNotContain(owner1, package.Owners);
+                Assert.DoesNotContain(owner1, package.RequiredSigners);
             }
 
-            [Fact]
-            public async Task WontRemoveLastOwner()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public async Task WillRemoveLastOwner(bool isRequiredSigner)
             {
                 var service = CreateService();
                 var singleOwner = new User { Key = 1, Username = "Owner" };
                 var package = new PackageRegistration { Owners = new List<User> { singleOwner } };
 
+                if (isRequiredSigner)
+                {
+                    package.RequiredSigners.Add(singleOwner);
+                }
+
                 await service.RemovePackageOwnerAsync(package, singleOwner);
 
                 Assert.DoesNotContain(singleOwner, package.Owners);
+                Assert.DoesNotContain(singleOwner, package.RequiredSigners);
             }
         }
 


### PR DESCRIPTION
https://github.com/nuget/engineering/issues/2358

These relationships aren't being cleaned up.

We also aren't cleaning up `AccountDelete.DeletedBy` and `PackageDelete.DeletedBy`, but I'm not doing them as part of this change as fixing them will require a DB migration.