### PR TITLE
Sending validation request right before committing changes to DB

### DIFF
--- a/src/NuGetGallery/Services/IPackageValidationInitiator.cs
+++ b/src/NuGetGallery/Services/IPackageValidationInitiator.cs
@@ -15,12 +15,14 @@ namespace NuGetGallery
         /// <summary>
         /// Returns the package status that package should go into when validation is started.
         /// Async validations typically return <see cref="PackageStatus.Validating"/>.
-        /// Sync, non-blocking or no validaiton typically return <see cref="PackageStatus.Available"/>.
+        /// Sync, non-blocking or no validation typically return <see cref="PackageStatus.Available"/>.
         /// Caller still must call <see cref="IPackageValidationInitiator{TPackageEntity}.StartValidationAsync(TPackageEntity)"/>
         /// to start the actual validation.
         /// </summary>
         /// <param name="package">The <see cref="TPackageEntity"/> to get future validation status for.</param>
-        /// <returns></returns>
+        /// <returns>The new package status assuming the validation will be started later.</returns>
+        /// <remarks>This method validates the argument the same way <see cref="StartValidationAsync(TPackageEntity)"/> does
+        /// and will throw on invalid input allowing to fail earlier, before expensive operations are performed.</remarks>
         PackageStatus GetPackageStatus(TPackageEntity package);
 
         /// <summary>

--- a/src/NuGetGallery/Services/IPackageValidationInitiator.cs
+++ b/src/NuGetGallery/Services/IPackageValidationInitiator.cs
@@ -13,6 +13,17 @@ namespace NuGetGallery
         where TPackageEntity: IPackageEntity
     {
         /// <summary>
+        /// Returns the package status that package should go into when validation is started.
+        /// Async validations typically return <see cref="PackageStatus.Validating"/>.
+        /// Sync, non-blocking or no validaiton typically return <see cref="PackageStatus.Available"/>.
+        /// Caller still must call <see cref="IPackageValidationInitiator{TPackageEntity}.StartValidationAsync(TPackageEntity)"/>
+        /// to start the actual validation.
+        /// </summary>
+        /// <param name="package">The <see cref="TPackageEntity"/> to get future validation status for.</param>
+        /// <returns></returns>
+        PackageStatus GetPackageStatus(TPackageEntity package);
+
+        /// <summary>
         /// Starts the validation for the specified IPackageEntity. The validation can be done asynchronously with respect
         /// to the gallery and therefore may not be complete when the returned <see cref="Task"/> completes. This
         /// pending validation state is indicated by the package having the <see cref="PackageStatus.Validating"/>

--- a/src/NuGetGallery/Services/IValidationService.cs
+++ b/src/NuGetGallery/Services/IValidationService.cs
@@ -16,19 +16,21 @@ namespace NuGetGallery
         /// <summary>
         /// Updates the package with the expected <see cref="PackageStatus"/> that the package will
         /// have after starting the validation.
-        /// The caller must also call <see cref="IValidationService.StartValidationAsync(Package)"/>
+        /// The caller must also call <see cref="StartValidationAsync(Package)"/>
         /// at later time.
         /// </summary>
-        /// <param name="package">package to update</param>
+        /// <param name="package">The package to update</param>
+        /// <remarks>This method only updates the object passed into it, no database commit is performed.</remarks>
         Task UpdatePackageAsync(Package package);
 
         /// <summary>
         /// Updates the symbol package with the expected <see cref="PackageStatus"/> that the package will
         /// have after starting the validation.
-        /// The caller must also call <see cref="IValidationService.StartValidationAsync(Package)"/>
+        /// The caller must also call <see cref="StartValidationAsync(Package)"/>
         /// at later time.
         /// </summary>
-        /// <param name="package">package to update</param>
+        /// <param name="package">The package to update</param>
+        /// <remarks>This method only updates the object passed into it, no database commit is performed.</remarks>
         Task UpdatePackageAsync(SymbolPackage symbolPackage);
 
         /// <summary>
@@ -36,6 +38,7 @@ namespace NuGetGallery
         /// <see cref="Package.PackageStatusKey"/>. The commit to the database is the responsibility of the caller.
         /// </summary>
         /// <param name="package">The package to start validation for.</param>
+        /// <remarks>This method only updates the object passed into it, no database commit is performed.</remarks>
         Task StartValidationAsync(Package package);
 
         /// <summary>
@@ -43,6 +46,7 @@ namespace NuGetGallery
         /// <see cref="Package.PackageStatusKey"/>. The commit to the database is the responsibility of the caller.
         /// </summary>
         /// <param name="symbolPackage">The symbol package to start validation for.</param>
+        /// <remarks>This method only updates the object passed into it, no database commit is performed.</remarks>
         Task StartValidationAsync(SymbolPackage symbolPackage);
 
         /// <summary>

--- a/src/NuGetGallery/Services/IValidationService.cs
+++ b/src/NuGetGallery/Services/IValidationService.cs
@@ -14,6 +14,24 @@ namespace NuGetGallery
     public interface IValidationService
     {
         /// <summary>
+        /// Updates the package with the expected <see cref="PackageStatus"/> that the package will
+        /// have after starting the validation.
+        /// The caller must also call <see cref="IValidationService.StartValidationAsync(Package)"/>
+        /// at later time.
+        /// </summary>
+        /// <param name="package">package to update</param>
+        Task UpdatePackageAsync(Package package);
+
+        /// <summary>
+        /// Updates the symbol package with the expected <see cref="PackageStatus"/> that the package will
+        /// have after starting the validation.
+        /// The caller must also call <see cref="IValidationService.StartValidationAsync(Package)"/>
+        /// at later time.
+        /// </summary>
+        /// <param name="package">package to update</param>
+        Task UpdatePackageAsync(SymbolPackage symbolPackage);
+
+        /// <summary>
         /// Starts the asynchronous validation for the provided new package and puts the package in the correct
         /// <see cref="Package.PackageStatusKey"/>. The commit to the database is the responsibility of the caller.
         /// </summary>

--- a/src/NuGetGallery/Services/ImmediatePackageValidator.cs
+++ b/src/NuGetGallery/Services/ImmediatePackageValidator.cs
@@ -13,6 +13,9 @@ namespace NuGetGallery
     public class ImmediatePackageValidator<TPackageEntity> : IPackageValidationInitiator<TPackageEntity> 
         where TPackageEntity: IPackageEntity
     {
+        public PackageStatus GetPackageStatus(TPackageEntity package)
+            => PackageStatus.Available;
+
         public Task<PackageStatus> StartValidationAsync(TPackageEntity package)
         {
             return Task.FromResult(PackageStatus.Available);

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -674,7 +674,7 @@ namespace NuGetGallery
 
         public async Task<PackageCommitResult> CommitPackageAsync(Package package, Stream packageFile)
         {
-            await _validationService.StartValidationAsync(package);
+            await _validationService.UpdatePackageAsync(package);
 
             if (package.PackageStatusKey != PackageStatus.Available
                 && package.PackageStatusKey != PackageStatus.Validating)
@@ -760,6 +760,8 @@ namespace NuGetGallery
                 ex.Log();
                 return PackageCommitResult.Conflict;
             }
+
+            await _validationService.StartValidationAsync(package);
 
             try
             {

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -761,16 +761,20 @@ namespace NuGetGallery
                 return PackageCommitResult.Conflict;
             }
 
-            await _validationService.StartValidationAsync(package);
-
             try
             {
+                // Sending the validation request after copying to prevent multiple validation requests
+                // sent when several pushes for the same package happen concurrently. Copying the file
+                // resolves the race and only one request will "win" and reach this code.
+                await _validationService.StartValidationAsync(package);
+
                 // commit all changes to database as an atomic transaction
                 await _entitiesContext.SaveChangesAsync();
             }
             catch (Exception ex)
             {
-                // If saving to the DB fails for any reason we need to delete the package we just saved.
+                // If sending the validation request or saving to the DB fails for any reason
+                // we need to delete the package we just saved.
                 if (package.PackageStatusKey == PackageStatus.Validating)
                 {
                     await _packageFileService.DeleteValidationPackageFileAsync(

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -149,7 +149,7 @@ namespace NuGetGallery
             var previousSymbolsPackage = package.LatestSymbolPackage();
             var symbolPackage = _symbolPackageService.CreateSymbolPackage(package, packageStreamMetadata);
 
-            await _validationService.StartValidationAsync(symbolPackage);
+            await _validationService.UpdatePackageAsync(symbolPackage);
 
             if (symbolPackage.StatusKey != PackageStatus.Available
                 && symbolPackage.StatusKey != PackageStatus.Validating)
@@ -205,6 +205,8 @@ namespace NuGetGallery
                     // for saving files, however since it doesn't really affect nuget.org which happen have async validations flow I will leave it as is.
                     await _symbolPackageFileService.SavePackageFileAsync(symbolPackage.Package, symbolPackageFile, overwrite);
                 }
+
+                await _validationService.StartValidationAsync(symbolPackage);
 
                 try
                 {

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -208,6 +208,8 @@ namespace NuGetGallery
 
                 try
                 {
+                    // Sending the validation request right before updating the database, so all file operations
+                    // are complete by that time and all possible conflicts are resolved.
                     await _validationService.StartValidationAsync(symbolPackage);
 
                     // commit all changes to database as an atomic transaction

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -206,10 +206,10 @@ namespace NuGetGallery
                     await _symbolPackageFileService.SavePackageFileAsync(symbolPackage.Package, symbolPackageFile, overwrite);
                 }
 
-                await _validationService.StartValidationAsync(symbolPackage);
-
                 try
                 {
+                    await _validationService.StartValidationAsync(symbolPackage);
+
                     // commit all changes to database as an atomic transaction
                     await _entitiesContext.SaveChangesAsync();
                 }
@@ -217,7 +217,8 @@ namespace NuGetGallery
                 {
                     ex.Log();
 
-                    // If saving to the DB fails for any reason we need to delete the package we just saved.
+                    // If sending the validation request or saving to the DB fails for any reason
+                    // we need to delete the package we just saved.
                     if (symbolPackage.StatusKey == PackageStatus.Validating)
                     {
                         await _symbolPackageFileService.DeleteValidationPackageFileAsync(

--- a/src/NuGetGallery/Services/ValidationService.cs
+++ b/src/NuGetGallery/Services/ValidationService.cs
@@ -50,14 +50,25 @@ namespace NuGetGallery
             }
         }
 
+        public async Task UpdatePackageAsync(Package package)
+        {
+            var packageStatus = _packageValidationInitiator.GetPackageStatus(package);
+
+            await UpdatePackageInternalAsync(package, packageStatus);
+        }
+
+        public async Task UpdatePackageAsync(SymbolPackage symbolPackage)
+        {
+            var symbolPackageStatus = _symbolPackageValidationInitiator.GetPackageStatus(symbolPackage);
+
+            await UpdateSymbolPackageInternalAsync(symbolPackage, symbolPackageStatus);
+        }
+
         public async Task StartValidationAsync(Package package)
         {
             var packageStatus = await _packageValidationInitiator.StartValidationAsync(package);
 
-            await _packageService.UpdatePackageStatusAsync(
-                package,
-                packageStatus,
-                commitChanges: false);
+            await UpdatePackageInternalAsync(package, packageStatus);
         }
 
         public async Task RevalidateAsync(Package package)
@@ -92,6 +103,34 @@ namespace NuGetGallery
             return GetValidationIssues(symbolPackage.Key, symbolPackage.StatusKey, ValidatingType.SymbolPackage);
         }
 
+        public async Task StartValidationAsync(SymbolPackage symbolPackage)
+        {
+            var symbolPackageStatus = await _symbolPackageValidationInitiator.StartValidationAsync(symbolPackage);
+            await UpdateSymbolPackageInternalAsync(symbolPackage, symbolPackageStatus);
+        }
+
+        public async Task RevalidateAsync(SymbolPackage symbolPackage)
+        {
+            await _symbolPackageValidationInitiator.StartValidationAsync(symbolPackage);
+
+            _telemetryService.TrackSymbolPackageRevalidate(symbolPackage.Id, symbolPackage.Version);
+        }
+
+        private async Task UpdatePackageInternalAsync(Package package, PackageStatus packageStatus)
+        {
+            await _packageService.UpdatePackageStatusAsync(
+                package,
+                packageStatus,
+                commitChanges: false);
+        }
+
+        private async Task UpdateSymbolPackageInternalAsync(SymbolPackage symbolPackage, PackageStatus symbolPackageStatus)
+        {
+            await _symbolPackageService.UpdateStatusAsync(symbolPackage,
+                symbolPackageStatus,
+                commitChanges: false);
+        }
+
         private IReadOnlyList<ValidationIssue> GetValidationIssues(int entityKey, PackageStatus status, ValidatingType validatingType)
         {
             IReadOnlyList<ValidationIssue> issues = new ValidationIssue[0];
@@ -117,21 +156,6 @@ namespace NuGetGallery
             }
 
             return issues;
-        }
-
-        public async Task StartValidationAsync(SymbolPackage symbolPackage)
-        {
-            var symbolPackageStatus = await _symbolPackageValidationInitiator.StartValidationAsync(symbolPackage);
-            await _symbolPackageService.UpdateStatusAsync(symbolPackage,
-                symbolPackageStatus,
-                commitChanges: false);
-        }
-
-        public async Task RevalidateAsync(SymbolPackage symbolPackage)
-        {
-            await _symbolPackageValidationInitiator.StartValidationAsync(symbolPackage);
-
-            _telemetryService.TrackSymbolPackageRevalidate(symbolPackage.Id, symbolPackage.Version);
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SymbolPackageUploadServiceFacts.cs
@@ -228,7 +228,7 @@ namespace NuGetGallery
             {
                 var validationService = new Mock<IValidationService>();
                 validationService
-                    .Setup(x => x.StartValidationAsync(It.IsAny<SymbolPackage>()))
+                    .Setup(x => x.UpdatePackageAsync(It.IsAny<SymbolPackage>()))
                     .Returns((SymbolPackage sp) =>
                     {
                         sp.StatusKey = invalidStatus;

--- a/tests/NuGetGallery.Facts/Services/ValidationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ValidationServiceFacts.cs
@@ -52,6 +52,31 @@ namespace NuGetGallery
             }
         }
 
+        public class TheUpdatePackageAsyncMethod : FactsBase
+        {
+            public async Task UpdatesPackageStatus()
+            {
+                // Arrange
+                var packageStatus = PackageStatus.Validating;
+                _package.PackageStatusKey = PackageStatus.Available;
+                _packageInitiator
+                    .Setup(x => x.StartValidationAsync(It.IsAny<Package>()))
+                    .ReturnsAsync(packageStatus);
+
+                // Act
+                await _target.UpdatePackageAsync(_package);
+
+                // Assert
+                _packageService.Verify(
+                    x => x.UpdatePackageStatusAsync(_package, packageStatus, false),
+                    Times.Once);
+
+                /// The implementation should not change the package status on its own. It should depend on 
+                /// <see cref="IPackageService"/> to do this.
+                Assert.Equal(PackageStatus.Available, _package.PackageStatusKey);
+            }
+        }
+
         public class TheStartSymbolsPackageValidationAsyncMethod : FactsBase
         {
             [Fact]
@@ -84,6 +109,31 @@ namespace NuGetGallery
 
                 /// The implementation should not change the package status on its own. It should depend on 
                 /// <see cref="ISymbolPackageService"/> to do this.
+                Assert.Equal(PackageStatus.Available, _symbolPackage.StatusKey);
+            }
+        }
+
+        public class TheUpdateSymbolPackageAsyncMethod : FactsBase
+        {
+            public async Task UpdatesPackageStatus()
+            {
+                // Arrange
+                var packageStatus = PackageStatus.Validating;
+                _symbolPackage.StatusKey = PackageStatus.Available;
+                _symbolInitiator
+                    .Setup(x => x.StartValidationAsync(It.IsAny<SymbolPackage>()))
+                    .ReturnsAsync(packageStatus);
+
+                // Act
+                await _target.UpdatePackageAsync(_symbolPackage);
+
+                // Assert
+                _symbolPackageService.Verify(
+                    x => x.UpdateStatusAsync(_symbolPackage, packageStatus, false),
+                    Times.Once);
+
+                /// The implementation should not change the package status on its own. It should depend on 
+                /// <see cref="IPackageService"/> to do this.
                 Assert.Equal(PackageStatus.Available, _symbolPackage.StatusKey);
             }
         }


### PR DESCRIPTION
Related to #6624 

Targeted fix for the "DuplicatePushesAreRejectedAndNotDeleted" tests causing deadlettering in validation pipeline. Validation request ServiceBus message now sent right before committing changes to DB, which in case of that test means there will be no surge of validation request for the same package.

Since the post validation request package status is used in `PackageUploadService` to determine the course of action, updating the package status was extracted into separate method, so it can be done without sending the validation request. It, of course, introduces an issue that we can forget to call the actual method that sends the message, but the exposure is very limited (one call for regular packages and another one for the symbol packages), and we are likely to notice very soon that validations are not running.