### PR TITLE
Allow HTML in owner request messages.

### DIFF
--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -103,8 +103,12 @@ namespace NuGetGallery
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<JsonResult> AddPackageOwner(string id, string username, string message)
+        public async Task<JsonResult> AddPackageOwner(AddPackageOwnerViewModel addOwnerData)
         {
+            string id = addOwnerData.Id;
+            string username = addOwnerData.Username;
+            string message = addOwnerData.Message;
+
             if (Regex.IsMatch(username, GalleryConstants.EmailValidationRegex, RegexOptions.None, GalleryConstants.EmailValidationRegexTimeout))
             {
                 return Json(new { success = false, message = Strings.AddOwner_NameIsEmail }, JsonRequestBehavior.AllowGet);

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -748,6 +748,7 @@
     <Compile Include="Telemetry\UserPackageDeleteOutcome.cs" />
     <Compile Include="UrlHelperExtensions.cs" />
     <Compile Include="ViewModels\AddOrganizationViewModel.cs" />
+    <Compile Include="ViewModels\AddPackageOwnerViewModel.cs" />
     <Compile Include="ViewModels\CompositeLicenseExpressionSegmentViewModel.cs" />
     <Compile Include="ViewModels\DeleteOrganizationViewModel.cs" />
     <Compile Include="ViewModels\DeleteUserViewModel.cs" />

--- a/src/NuGetGallery/ViewModels/AddPackageOwnerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/AddPackageOwnerViewModel.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Web.Mvc;
+
+namespace NuGetGallery
+{
+    public class AddPackageOwnerViewModel
+    {
+        public string Id { get; set; }
+        public string Username { get; set; }
+
+        [AllowHtml]
+        public string Message { get; set; }
+    }
+}

--- a/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/JsonApiControllerFacts.cs
@@ -355,9 +355,15 @@ namespace NuGetGallery.Controllers
                             var package = fakes.Package;
                             var controller = GetController<JsonApiController>();
                             controller.SetCurrentUser(currentUser);
+                            AddPackageOwnerViewModel testData = new AddPackageOwnerViewModel
+                            {
+                                Id = package.Id,
+                                Username = usernameToAdd,
+                                Message = "a message"
+                            };
 
                             // Act
-                            var result = await controller.AddPackageOwner(package.Id, usernameToAdd, "a message");
+                            var result = await controller.AddPackageOwner(testData);
                             dynamic data = result.Data;
 
                             // Assert
@@ -444,8 +450,15 @@ namespace NuGetGallery.Controllers
                                         .Verifiable();
                                 }
                             }
+                            AddPackageOwnerViewModel testData = new AddPackageOwnerViewModel
+                            {
+                                Id = fakes.Package.Id,
+                                Username = userToAdd.Username,
+                                Message = "Hello World! Html Encoded <3"
+                            };
 
-                            JsonResult result = await controller.AddPackageOwner(fakes.Package.Id, userToAdd.Username, "Hello World! Html Encoded <3");
+
+                            JsonResult result = await controller.AddPackageOwner(testData);
                             dynamic data = result.Data;
                             PackageOwnersResultViewModel model = data.model;
 
@@ -679,7 +692,14 @@ namespace NuGetGallery.Controllers
 
                 private static async Task<ActionResult> AddPackageOwner(JsonApiController jsonApiController, string packageId, string username)
                 {
-                    return await jsonApiController.AddPackageOwner(packageId, username, "message");
+                    AddPackageOwnerViewModel testData = new AddPackageOwnerViewModel
+                    {
+                        Id = packageId,
+                        Username = username,
+                        Message = "message"
+                    };
+
+                    return await jsonApiController.AddPackageOwner(testData);
                 }
 
                 private static async Task<ActionResult> RemovePackageOwner(JsonApiController jsonApiController, string packageId, string username)


### PR DESCRIPTION
Since we encode the incoming message on our side before we send the message, there is no reason to reject the message from the client based on that alone.

Adds a new object type for the parameters to AddOwners so we can restricted the relaxing of verification to the message field only.