### PR TITLE
Add pending migration test

### DIFF
--- a/src/DatabaseMigrationTools/MigrationTargetDatabaseArgumentNames.cs
+++ b/src/DatabaseMigrationTools/MigrationTargetDatabaseArgumentNames.cs
@@ -3,7 +3,7 @@
 
 namespace NuGetGallery.DatabaseMigrationTools
 {
-    internal static class MigrationTargetDatabaseArgumentNames
+    public static class MigrationTargetDatabaseArgumentNames
     {
         public const string GalleryDatabase = "GalleryDatabase";
         public const string SupportRequestDatabase = "SupportRequestDatabase";

--- a/tests/NuGet.Services.DatabaseMigration.Facts/NuGet.Services.DatabaseMigration.Facts.csproj
+++ b/tests/NuGet.Services.DatabaseMigration.Facts/NuGet.Services.DatabaseMigration.Facts.csproj
@@ -44,9 +44,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DatabaseMigrationFacts.cs" />
+    <Compile Include="PendingMigrationsFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Moq">
+      <Version>4.8.2</Version>
+    </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>
     </PackageReference>
@@ -63,6 +67,10 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\DatabaseMigrationTools\DatabaseMigrationTools.csproj">
+      <Project>{dced7162-a24c-4579-96c8-544bfaf4c305}</Project>
+      <Name>DatabaseMigrationTools</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\NuGet.Services.DatabaseMigration\NuGet.Services.DatabaseMigration.csproj">
       <Project>{f4c8c34f-72a9-4773-a315-8fa3f2d5ce4e}</Project>
       <Name>NuGet.Services.DatabaseMigration</Name>

--- a/tests/NuGet.Services.DatabaseMigration.Facts/PendingMigrationsFacts.cs
+++ b/tests/NuGet.Services.DatabaseMigration.Facts/PendingMigrationsFacts.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity.Migrations.Design;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Jobs;
+using NuGet.Jobs.Configuration;
+using NuGetGallery.DatabaseMigrationTools;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.DatabaseMigration.Facts
+{
+    public class PendingMigrationsFacts : IAsyncLifetime
+    {
+        private string _dbName;
+        private readonly ITestOutputHelper _output;
+
+        public PendingMigrationsFacts(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public Task InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_dbName == null)
+            {
+                return;
+            }
+
+            const string connectionString = @"Data Source=(localdb)\mssqllocaldb; Initial Catalog=master; Integrated Security=True; MultipleActiveResultSets=True";
+            using (var sqlConnection = new SqlConnection(connectionString))
+            {
+                await sqlConnection.OpenAsync();
+                using (var sqlCommand = sqlConnection.CreateCommand())
+                {
+                    sqlCommand.CommandText = $"ALTER DATABASE {_dbName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE {_dbName};";
+                    await sqlCommand.ExecuteNonQueryAsync();
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> TestData
+        {
+            get
+            {
+                var factory = new MigrationContextFactory();
+
+                var currentTimestamp = DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmssFFFFFFF");
+
+                var galleryDbName = $"PendingMigrationsTest{currentTimestamp}Gallery";
+                var gallerySqlConnectionFactory = new Mock<ISqlConnectionFactory<GalleryDbConfiguration>>();
+                gallerySqlConnectionFactory
+                    .Setup(x => x.CreateAsync())
+                    .ReturnsAsync(() => new SqlConnection(
+                        $@"Data Source=(localdb)\mssqllocaldb; Initial Catalog={galleryDbName}; Integrated Security=True; MultipleActiveResultSets=True"));
+
+                var supportRequestsDbName = $"PendingMigrationsTest{currentTimestamp}SupportRequests";
+                var supportRequestsSqlConnectionFactory = new Mock<ISqlConnectionFactory<SupportRequestDbConfiguration>>();
+                supportRequestsSqlConnectionFactory
+                    .Setup(x => x.CreateAsync())
+                    .ReturnsAsync(() => new SqlConnection(
+                        $@"Data Source=(localdb)\mssqllocaldb; Initial Catalog={supportRequestsDbName}; Integrated Security=True; MultipleActiveResultSets=True"));
+
+                var serviceProvider = new Mock<IServiceProvider>();
+
+                serviceProvider
+                    .Setup(x => x.GetService(typeof(ISqlConnectionFactory<GalleryDbConfiguration>)))
+                    .Returns(() => gallerySqlConnectionFactory.Object);
+
+                serviceProvider
+                    .Setup(x => x.GetService(typeof(ISqlConnectionFactory<SupportRequestDbConfiguration>)))
+                    .Returns(() => supportRequestsSqlConnectionFactory.Object);
+
+                yield return new object[] { galleryDbName, MigrationTargetDatabaseArgumentNames.GalleryDatabase, factory, serviceProvider.Object };
+                yield return new object[] { supportRequestsDbName, MigrationTargetDatabaseArgumentNames.SupportRequestDatabase, factory, serviceProvider.Object };
+
+                // Validation DB is not tested here because:
+                // 1) The migrations do no live in this repository so it's a bit late if we find out there are pending changes at this point.
+                // 2) There is a type load exception since a type of name EntitiesConfiguration is already loaded by Gallery DB or Suppport Requests DB.
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public async Task NoPendingMigrations(string dbName, string argumentName, MigrationContextFactory factory, IServiceProvider serviceProvider)
+        {
+            _dbName = dbName;
+
+            var migrationContext = await factory.CreateMigrationContextAsync(argumentName, serviceProvider);
+
+            var dbMigrator = migrationContext.GetDbMigrator();
+            var migrations = dbMigrator.GetLocalMigrations();
+            dbMigrator.Update(migrations.Last());
+
+            var migrationScaffolder = new MigrationScaffolder(dbMigrator.Configuration);
+
+            var migrationName = $"TestMigration{DateTimeOffset.UtcNow:yyyyMMddHHmmssFFFFFFF}";
+            var result = migrationScaffolder.Scaffold(migrationName);
+
+            _output.WriteLine("Migration content:");
+            _output.WriteLine(new string('-', 60));
+            _output.WriteLine(result.UserCode);
+            _output.WriteLine(new string('-', 60));
+
+            Assert.Equal(
+                $@"namespace {dbMigrator.Configuration.MigrationsNamespace}
+{{
+    using System;
+    using System.Data.Entity.Migrations;
+    
+    public partial class {migrationName} : DbMigration
+    {{
+        public override void Up()
+        {{
+        }}
+        
+        public override void Down()
+        {{
+        }}
+    }}
+}}
+", result.UserCode);
+        }
+    }
+}

--- a/tests/NuGet.Services.DatabaseMigration.Facts/Properties/AssemblyInfo.cs
+++ b/tests/NuGet.Services.DatabaseMigration.Facts/Properties/AssemblyInfo.cs
@@ -2,5 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Reflection;
+using Xunit;
 
 [assembly: AssemblyTitle("NuGet.Services.DatabaseMigration.Facts")]
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
This adds a unit test that fails if there are any pending changes in the entity model. It asserts that if someone was to run `Add-Migration`, an empty migration would be added (indicating the latest migration matches the entity model).

Found with https://github.com/NuGet/NuGetGallery/issues/7140.
Addresses https://github.com/NuGet/NuGetGallery/issues/4934.