### PR TITLE
Fix for the package corruption when license file is extracted by Gallery

### DIFF
--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -692,6 +692,21 @@ namespace NuGetGallery
 
         public async Task<PackageCommitResult> CommitPackageAsync(Package package, Stream packageFile)
         {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (packageFile == null)
+            {
+                throw new ArgumentNullException(nameof(packageFile));
+            }
+
+            if (!packageFile.CanSeek)
+            {
+                throw new ArgumentException($"{nameof(packageFile)} argument must be seekable stream", nameof(packageFile));
+            }
+
             await _validationService.UpdatePackageAsync(package);
 
             if (package.PackageStatusKey != PackageStatus.Available
@@ -762,6 +777,7 @@ namespace NuGetGallery
                     }
                     try
                     {
+                        packageFile.Seek(0, SeekOrigin.Begin);
                         await _packageFileService.SavePackageFileAsync(package, packageFile);
                     }
                     catch when (package.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)


### PR DESCRIPTION
Addresses #7147.

The issue was that the `_coreLicenseFileService.ExtractAndSaveLicenseFileAsync` call in `PackageUploadService` left the package stream with `Position` pointing to the middle of the stream, so `_packageFileService.SavePackageFileAsync` saved the package starting from that position.