### PR TITLE
Add Google Analytics events for search

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -402,6 +402,12 @@
         });
     };
 
+    nuget.sendAnalyticsEvent = function (category, action, label, eventValue, options) {
+        if (window.nuget.isGaAvailable()) {
+            ga('send', 'event', category, action, label, eventValue, options);
+        }
+    }
+
     window.nuget = nuget;
 
     jQuery.extend(jQuery.expr[':'], {
@@ -445,12 +451,13 @@
             $(this).click(function (e) {
                 var href = $(this).attr('href');
                 var category = $(this).data().track;
+                var trackValue = $(this).data().trackValue;
                 if (window.nuget.isGaAvailable() && href && category) {
                     if (e.altKey || e.ctrlKey || e.metaKey) {
-                        ga('send', 'event', category, 'click', href);
+                        window.nuget.sendAnalyticsEvent(category, 'click', href, trackValue);
                     } else {
                         e.preventDefault();
-                        ga('send', 'event', category, 'click', href, {
+                        window.nuget.sendAnalyticsEvent(category, 'click', href, trackValue, {
                             'transport': 'beacon',
                             'hitCallback': window.nuget.createFunctionWithTimeout(function () {
                                 document.location = href;

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -61,9 +61,13 @@
     }
 
     <div class="list-packages" role="list">
+        @{ var itemIndex = Model.PageIndex * Model.PageSize; }
         @foreach (var package in Model.Items)
         {
-            @Html.Partial("_ListPackage", package)
+            // Only set an item index when there is a search query, for now.
+            var thisItemIndex = string.IsNullOrWhiteSpace(Model.SearchTerm) ? null : (int?) itemIndex;
+            @Html.Partial("_ListPackage", package, new ViewDataDictionary { { "itemIndex", thisItemIndex } })
+            itemIndex++;
         }
     </div>
 
@@ -76,6 +80,17 @@
 
 @section bottomScripts {
     <script type="text/javascript">
+
+        @if (!string.IsNullOrWhiteSpace(Model.SearchTerm) && (Model.PageIndex == 0 || Model.Items.Count() > 0))
+        {
+            var action = Model.IncludePrerelease ? "search-prerel" : "search-stable";
+            // Emit an event representing the search page and the page index. This make it easier for the search selection
+            // event to be correlated in Google Analytics.
+            <text>
+            window.nuget.sendAnalyticsEvent('search-page', '@action', @Html.Raw(Json.Encode(Model.SearchTerm)), @Model.PageIndex);
+            </text>
+        }
+
         $(function () {
             $("#include-prerelease").on('change', function () {
                 var parameters = {};

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -1,4 +1,16 @@
 ﻿@model ListPackageItemViewModel
+@{
+    // This view data will sometimes be null or missing. For example, the profile page uses this partial and should not
+    // emit search selection events.
+    int? itemIndex = null;
+    int parsedItemIndex;
+    if (ViewData.ContainsKey("itemIndex")
+        && int.TryParse(ViewData["itemIndex"].ToStringOrNull(), out parsedItemIndex))
+    {
+        itemIndex = parsedItemIndex;
+    }
+}
+
 
 <article class="package" role="listitem">
 
@@ -10,7 +22,13 @@
         </div>
         <div class="col-sm-11">
             <div class="package-header">
-                <a class="package-title" href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)">@Html.BreakWord(Model.Id)</a>
+                <a class="package-title"
+                   href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)"
+                   @if (itemIndex.HasValue)
+                   {
+                       @:data-track="search-selection" data-track-value="@itemIndex"
+                   }
+                   >@Html.BreakWord(Model.Id)</a>
 
                 @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
                 {


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/6803.

Adds two new events to Google Analytics:

1. `search-selection`. This is emitted when someone clicks a search result. This includes the absolute index of the selection. In other words, with page size 20 and you click the 4th result on the 3rd page, the index will be `(20 * (3 - 1)) + (4 - 1) = 43`.
1. `search-page`. This is emitted when someone navigates to a page of search results. The page index is emitted with this event.

There is parity between these events and the client event where appropriate.

These events are only emitted when there is a search term. Our main search ranking efforts are going into relevancy towards the search query, not to the default page of popular packages. I would rather not add noise to the events related to people not even performing a search.

