### PR TITLE
UI should return Forbidden when symbols feature flag is disabled

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -2520,7 +2520,7 @@ namespace NuGetGallery
                     httpStatusCode = HttpStatusCode.Conflict;
                     break;
                 case SymbolPackageValidationResultType.UserNotAllowedToUpload:
-                    httpStatusCode = HttpStatusCode.Unauthorized;
+                    httpStatusCode = HttpStatusCode.Forbidden;
                     break;
                 default:
                     throw new NotImplementedException($"The symbol package validation result type {validationResult.Type} is not supported.");

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -216,7 +216,7 @@
         }
 
         function displayErrors(errors) {
-            if (errors == null || errors.length < 1) {
+            if (!errors || errors.length < 1) {
                 return;
             }
 


### PR DESCRIPTION
Quick fix for https://github.com/NuGet/NuGetGallery/issues/6956 that I encountered previously and while working on https://github.com/nuget/nugetgallery/issues/7154

Basically, because we are returning `401` (unauthorized) in a UI request, MVC automatically redirects the request to the authentication middleware which returns `200` because the user is logged in. As a result, the Javascript on the upload page thinks the request succeeded and shows some weird behavior.

I did not change this for the API symbols push path because I'm not sure of the impact it will have on NuGet clients. I also don't think the authentication middleware redirect happens for API symbols push because API controller methods use different authentication middleware and [we already have another flow that returns unauthorized and does not redirect](https://github.com/NuGet/NuGetGallery/blob/master/src/NuGetGallery/Controllers/ApiController.cs#L993).

I also fixed a minor Javascript lint error.