### PR TITLE
Make IEntitiesContext implement IDisposable

### DIFF
--- a/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data.Entity;
 using System.Threading.Tasks;
 using NuGet.Services.Entities;
 
 namespace NuGetGallery
 {
-    public interface IEntitiesContext
+    public interface IEntitiesContext : IDisposable
     {
         DbSet<Certificate> Certificates { get; set; }
         DbSet<Package> Packages { get; set; }

--- a/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
@@ -237,5 +237,9 @@ namespace NuGetGallery
 
             return mockSet.Object;
         }
+
+        public void Dispose()
+        {
+        }
     }
 }


### PR DESCRIPTION
Related to https://github.com/NuGet/NuGet.Services.Metadata/pull/518#discussion_r284468321.

This allows `IEntitiesContext` to be provided by DI and still disposed via a factory pattern.