### PR TITLE
Add capability of a preview ISearchService

### DIFF
--- a/src/NuGetGallery/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/AppConfiguration.cs
@@ -355,15 +355,13 @@ namespace NuGetGallery.Configuration
         [DefaultValue(true)]
         public bool AllowLicenselessPackages { get; set; }
 
-        /// <summary>
-        /// The Uri for the Primary Search endpoint
-        /// </summary>
         public Uri SearchServiceUriPrimary { get; set; }
 
-        /// <summary>
-        /// The Uri for the Secondary Search endpoint
-        /// </summary>
         public Uri SearchServiceUriSecondary { get; set; }
+
+        public Uri PreviewSearchServiceUriPrimary { get; set; }
+
+        public Uri PreviewSearchServiceUriSecondary { get; set; }
 
         [DefaultValue(600)]
         public int SearchCircuitBreakerDelayInSeconds { get; set; }

--- a/src/NuGetGallery/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery/Configuration/IAppConfiguration.cs
@@ -382,14 +382,24 @@ namespace NuGetGallery.Configuration
         bool AllowLicenselessPackages { get; set; }
 
         /// <summary>
-        /// The Uri for the Primary Search endpoint
+        /// The URL for the primary search endpoint, for stable behavior.
         /// </summary>
         Uri SearchServiceUriPrimary { get; set; }
 
         /// <summary>
-        /// The Uri for the Secondary Search endpoint
+        /// The URL for the secondary search endpoint, for stable behavior.
         /// </summary>
         Uri SearchServiceUriSecondary { get; set; }
+
+        /// <summary>
+        /// The URL for the primary search endpoint, for preview behavior.
+        /// </summary>
+        Uri PreviewSearchServiceUriPrimary { get; set; }
+
+        /// <summary>
+        /// The URL for the secondary search endpoint, for preview behavior.
+        /// </summary>
+        Uri PreviewSearchServiceUriSecondary { get; set; }
 
         /// <summary>
         /// The time in seconds for the circuit breaker delay. (The time the circuit breaker will stay in open state)

--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json.Linq;
@@ -35,10 +34,6 @@ namespace NuGetGallery.Infrastructure.Search
         }
 
         public bool ContainsAllVersions { get { return true; } }
-
-        public ExternalSearchService()
-        {
-        }
 
         public ExternalSearchService(IAppConfiguration config, IDiagnosticsService diagnostics, ISearchClient searchClient)
         {

--- a/src/NuGetGallery/Infrastructure/Lucene/SearchClientConfiguration.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/SearchClientConfiguration.cs
@@ -3,9 +3,12 @@
 
 namespace NuGetGallery.Infrastructure.Search
 {
-    public class SearchClientConfiguration
+    public static class SearchClientConfiguration
     {
         public static string SearchPrimaryInstance = "SearchPrimary";
         public static string SearchSecondaryInstance = "SearchSecondary";
+
+        public static string PreviewSearchPrimaryInstance = "PreviewSearchPrimary";
+        public static string PreviewSearchSecondaryInstance = "PreviewSearchSecondary";
     }
 }

--- a/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
@@ -15,6 +15,7 @@ using System.Web.Http.Results;
 using Moq;
 using NuGet.Services.Entities;
 using NuGetGallery.Configuration;
+using NuGetGallery.Diagnostics;
 using NuGetGallery.Infrastructure.Search;
 using NuGetGallery.OData;
 using NuGetGallery.OData.QueryFilter;
@@ -554,7 +555,11 @@ namespace NuGetGallery
                     configuration.Setup(c => c.Features).Returns(new FeatureConfiguration() { FriendlyLicenses = true });
                     configuration.Setup(c => c.Current).Returns(new AppConfiguration() { IsODataFilterEnabled = false });
 
-                    var searchService = new Mock<ExternalSearchService>(MockBehavior.Loose);
+                    var searchService = new Mock<ExternalSearchService>(
+                        MockBehavior.Loose,
+                        Mock.Of<IAppConfiguration>(),
+                        Mock.Of<IDiagnosticsService>(),
+                        Mock.Of<ISearchClient>());
                     searchService.CallBase = true;
                     searchService
                         .Setup(x => x.RawSearch(It.IsAny<SearchFilter>()))
@@ -614,7 +619,11 @@ namespace NuGetGallery
                     configuration.Setup(c => c.Current).Returns(new AppConfiguration() { IsODataFilterEnabled = false });
 
                     bool called = false;
-                    var searchService = new Mock<ExternalSearchService>(MockBehavior.Loose);
+                    var searchService = new Mock<ExternalSearchService>(
+                        MockBehavior.Loose,
+                        Mock.Of<IAppConfiguration>(),
+                        Mock.Of<IDiagnosticsService>(),
+                        Mock.Of<ISearchClient>());
                     searchService
                         .Setup(x => x.RawSearch(It.IsAny<SearchFilter>()))
                         .ReturnsAsync(new SearchResults(0, indexTimestampUtc: null));


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/7152.

- Add config for two "preview" search endpoints.
- Add an `ISearchService` instance that hits these preview endpoints
  - This is available with a binding key. The default `ISearchService` has not changed.

This basic infrastructure is for the side-by-side search page and can be adapted for https://github.com/NuGet/NuGetGallery/issues/7166 later.

To do this, I needed to move the DI wire-up of `ISearchService` to Autofac, which has binding key support.