### PR TITLE
[SxS 1] Add initial infrastructure for search side-by-side (SxS) page

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -15,6 +15,12 @@
       "SiteAdmins": true,
       "Accounts": [],
       "Domains": []
+    },
+    "NuGetGallery.SearchSideBySide": {
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
     }
   }
 }

--- a/src/NuGetGallery/Infrastructure/Mail/Messages/SearchSideBySideMessage.cs
+++ b/src/NuGetGallery/Infrastructure/Mail/Messages/SearchSideBySideMessage.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Mail;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+using NuGet.Services.Messaging.Email;
+
+namespace NuGetGallery.Infrastructure.Mail.Messages
+{
+    public class SearchSideBySideMessage : MarkdownEmailBuilder
+    {
+        private readonly IMessageServiceConfiguration _configuration;
+        private readonly SearchSideBySideViewModel _model;
+        private readonly string _searchUrl;
+
+        public SearchSideBySideMessage(
+            IMessageServiceConfiguration configuration,
+            SearchSideBySideViewModel model,
+            string searchUrl)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _model = model ?? throw new ArgumentNullException(nameof(model));
+            _searchUrl = searchUrl ?? throw new ArgumentNullException(nameof(searchUrl));
+        }
+
+        public override MailAddress Sender => _configuration.GalleryNoReplyAddress;
+
+        public override IEmailRecipients GetRecipients()
+        {
+            MailAddress[] replyTo = null;
+            if (!string.IsNullOrWhiteSpace(_model.EmailAddress)
+                && Regex.IsMatch(
+                    _model.EmailAddress.Trim(),
+                    GalleryConstants.EmailValidationRegex,
+                    RegexOptions.None,
+                    GalleryConstants.EmailValidationRegexTimeout))
+            {
+                replyTo = new[] { new MailAddress(_model.EmailAddress.Trim()) };
+            }
+
+            return new EmailRecipients(
+                new[] { _configuration.GalleryOwner },
+                cc: null,
+                bcc: null,
+                replyTo: replyTo);
+        }
+
+        public override string GetSubject() => $"[{_configuration.GalleryOwner.DisplayName}] Search Feedback";
+
+        protected override string GetMarkdownBody()
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine("The following feedback has come from the search side-by-side page.");
+            sb.AppendLine();
+
+            var encodedSearchTerm = HttpUtility.HtmlEncode(_model.SearchTerm.Trim());
+            sb.AppendFormat("**Search Query:** [{0}]({1})", encodedSearchTerm, _searchUrl);
+            sb.AppendLine();
+            sb.AppendLine();
+
+            Append(sb, "Old Hits:", _model.OldHits);
+            Append(sb, "New Hits:", _model.NewHits);
+
+            Append(sb, SearchSideBySideViewModel.BetterSideLabel, _model.BetterSide);
+            Append(sb, SearchSideBySideViewModel.MostRelevantPackageLabel, _model.MostRelevantPackage);
+            Append(sb, SearchSideBySideViewModel.ExpectedPackagesLabel, _model.ExpectedPackages);
+            Append(sb, SearchSideBySideViewModel.CommentsLabel, _model.Comments, extraLine: true);
+            Append(sb, "Email:", _model.EmailAddress);
+
+            return sb.ToString();
+        }
+
+        private void Append(
+            StringBuilder sb,
+            string label,
+            object value,
+            bool extraLine = false)
+        {
+            Append(sb, label, value?.ToString(), extraLine);
+        }
+
+        private void Append(
+            StringBuilder sb,
+            string label,
+            string value,
+            bool extraLine = false)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                sb.AppendFormat("**{0}**", label);
+
+                if (extraLine)
+                {
+                    sb.AppendLine();
+                }
+                else
+                {
+                    sb.Append(" ");
+                }
+
+                sb.AppendLine(HttpUtility.HtmlEncode(value.Trim()));
+                sb.AppendLine();
+            }
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Infrastructure\Lucene\Models\SearchResults.cs" />
     <Compile Include="Infrastructure\Lucene\Models\SortOrder.cs" />
     <Compile Include="Infrastructure\Lucene\ServiceResponse.cs" />
+    <Compile Include="Infrastructure\Mail\Messages\SearchSideBySideMessage.cs" />
     <Compile Include="Migrations\201903020136235_CvesCanBeEmpty.cs" />
     <Compile Include="Migrations\201903020136235_CvesCanBeEmpty.Designer.cs">
       <DependentUpon>201903020136235_CvesCanBeEmpty.cs</DependentUpon>
@@ -767,6 +768,7 @@
     <Compile Include="ViewModels\HandleOrganizationMembershipRequestModel.cs" />
     <Compile Include="ViewModels\ListPackageItemRequiredSignerViewModel.cs" />
     <Compile Include="ViewModels\ManagePackageViewModel.cs" />
+    <Compile Include="ViewModels\SearchSideBySideViewModel.cs" />
     <Compile Include="ViewModels\SignerViewModel.cs" />
     <Compile Include="WebRole.cs" />
     <Compile Include="Areas\Admin\AdminAreaRegistration.cs" />

--- a/src/NuGetGallery/Services/FeatureFlagService.cs
+++ b/src/NuGetGallery/Services/FeatureFlagService.cs
@@ -16,6 +16,7 @@ namespace NuGetGallery
         private const string TyposquattingFeatureName = GalleryPrefix + "Typosquatting";
         private const string TyposquattingFlightName = GalleryPrefix + "TyposquattingFlight";
         private const string EmbeddedIconFlightName = GalleryPrefix + "EmbeddedIcons";
+        private const string SearchSideBySideFlightName = GalleryPrefix + "SearchSideBySide";
 
         private const string PackagesAtomFeedFeatureName = GalleryPrefix + "PackagesAtomFeed";
 
@@ -62,6 +63,11 @@ namespace NuGetGallery
         public bool IsSearchCircuitBreakerEnabled()
         {
             return _client.IsEnabled(SearchCircuitBreakerFeatureName, defaultValue: false);
+        }
+
+        public bool IsSearchSideBySideEnabled(User user)
+        {
+            return _client.IsEnabled(SearchSideBySideFlightName, user, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery/Services/IFeatureFlagService.cs
+++ b/src/NuGetGallery/Services/IFeatureFlagService.cs
@@ -47,5 +47,10 @@ namespace NuGetGallery
         /// Whether the user is allowed to publish packages with an embedded icon.
         /// </summary>
         bool AreEmbeddedIconsEnabled(User user);
+
+        /// <summary>
+        /// Whether the user is able to access the search side-by-side experiment.
+        /// </summary>
+        bool IsSearchSideBySideEnabled(User user);
     }
 }

--- a/src/NuGetGallery/Services/ITelemetryService.cs
+++ b/src/NuGetGallery/Services/ITelemetryService.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
 using System.Security.Principal;
 using NuGet.Services.Entities;
@@ -293,5 +292,41 @@ namespace NuGetGallery
         /// <param name="uri">The request uri.</param>
         /// <param name="circuitBreakerStatus">The CircuitBreakerStatus at the time of the Retry action.</param>
         void TrackMetricForSearchOnRetry(string searchName, Exception exception, string correlationId, string uri, string circuitBreakerStatus);
+
+        /// <summary>
+        /// Tracks that some feedback was left on the search side-by-side page.
+        /// </summary>
+        /// <param name="searchTerm">The search term used.</param>
+        /// <param name="oldHits">The total count of old results.</param>
+        /// <param name="newHits">The total count of new results.</param>
+        /// <param name="betterSide">Which side was better.</param>
+        /// <param name="mostRelevantPackage">The most relevant package.</param>
+        /// <param name="expectedPackages">The expected packages.</param>
+        /// <param name="hasComments">Whether or not comments were provided.</param>
+        /// <param name="hasEmailAddress">Whether or not an email address was provided.</param>
+        void TrackSearchSideBySideFeedback(
+            string searchTerm,
+            int oldHits,
+            int newHits,
+            string betterSide,
+            string mostRelevantPackage,
+            string expectedPackages,
+            bool hasComments,
+            bool hasEmailAddress);
+
+        /// <summary>
+        /// Track a search request made on the search side-by-side page.
+        /// </summary>
+        /// <param name="searchTerm">The search term used.</param>
+        /// <param name="oldSuccess">Whether or not the old query succeeded.</param>
+        /// <param name="oldHits">The total count of old results.</param>
+        /// <param name="oldSuccess">Whether or not the old query succeeded.</param>
+        /// <param name="newHits">The total count of new results.</param>
+        void TrackSearchSideBySide(
+            string searchTerm,
+            bool oldSuccess,
+            int oldHits,
+            bool newSuccess,
+            int newHits);
     }
 }

--- a/src/NuGetGallery/Services/SearchResults.cs
+++ b/src/NuGetGallery/Services/SearchResults.cs
@@ -40,7 +40,7 @@ namespace NuGetGallery
 
         public static bool IsSuccessful(SearchResults searchResults)
         {
-            return searchResults.ResponseMessage?.IsSuccessStatusCode ?? true ;
+            return searchResults.ResponseMessage?.IsSuccessStatusCode ?? true;
         }
     }
 }

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Security.Principal;
 using System.Web;
@@ -75,6 +74,8 @@ namespace NuGetGallery
             public const string SearchCircuitBreakerOnBreak = "SearchCircuitBreakerOnBreak";
             public const string SearchCircuitBreakerOnReset = "SearchCircuitBreakerOnReset";
             public const string SearchOnRetry = "SearchOnRetry";
+            public const string SearchSideBySideFeedback = "SearchSideBySideFeedback";
+            public const string SearchSideBySide = "SearchSideBySide";
         }
 
         private IDiagnosticsSource _diagnosticsSource;
@@ -175,6 +176,18 @@ namespace NuGetGallery
         public const string SearchName = "SearchName";
         public const string SearchPollyCorrelationId = "SearchPollyCorrelationId";
         public const string SearchCircuitBreakerStatus = "SearchCircuitBreakerStatus";
+
+        // Search side-by-side properties
+        public const string SearchTerm = "SearchTerm";
+        public const string OldHits = "OldHits";
+        public const string OldSuccess = "OldSuccess";
+        public const string NewHits = "NewHits";
+        public const string NewSuccess = "NewSuccess";
+        public const string BetterSide = "BetterSide";
+        public const string MostRelevantPackage = "MostRelevantPackage";
+        public const string ExpectedPackages = "ExpectedPackages";
+        public const string HasComments = "HasComments";
+        public const string HasEmailAddress = "HasEmailAddress";
 
         public TelemetryService(IDiagnosticsService diagnosticsService, ITelemetryClient telemetryClient = null)
         {
@@ -835,6 +848,45 @@ namespace NuGetGallery
                 properties.Add(SearchCircuitBreakerStatus, circuitBreakerStatus);
             });
         }
+
+        public void TrackSearchSideBySideFeedback(
+            string searchTerm,
+            int oldHits,
+            int newHits,
+            string betterSide,
+            string mostRelevantPackage,
+            string expectedPackages,
+            bool hasComments,
+            bool hasEmailAddress)
+        {
+            TrackMetric(Events.SearchSideBySideFeedback, 1, properties => {
+                properties.Add(SearchTerm, searchTerm);
+                properties.Add(OldHits, oldHits.ToString());
+                properties.Add(NewHits, newHits.ToString());
+                properties.Add(BetterSide, betterSide);
+                properties.Add(MostRelevantPackage, mostRelevantPackage);
+                properties.Add(ExpectedPackages, expectedPackages);
+                properties.Add(HasComments, hasComments.ToString());
+                properties.Add(HasEmailAddress, hasEmailAddress.ToString());
+            });
+        }
+
+        public void TrackSearchSideBySide(
+            string searchTerm,
+            bool oldSuccess,
+            int oldHits,
+            bool newSuccess,
+            int newHits)
+        {
+            TrackMetric(Events.SearchSideBySide, 1, properties => {
+                properties.Add(SearchTerm, searchTerm);
+                properties.Add(OldSuccess, oldSuccess.ToString());
+                properties.Add(OldHits, oldHits.ToString());
+                properties.Add(NewSuccess, newSuccess.ToString());
+                properties.Add(NewHits, newHits.ToString());
+            });
+        }
+
         /// <summary>
         /// We use <see cref="ITelemetryClient.TrackMetric(string, double, IDictionary{string, string})"/> instead of
         /// <see cref="ITelemetryClient.TrackEvent(string, IDictionary{string, string}, IDictionary{string, double})"/>

--- a/src/NuGetGallery/ViewModels/SearchSideBySideViewModel.cs
+++ b/src/NuGetGallery/ViewModels/SearchSideBySideViewModel.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace NuGetGallery
+{
+    public class SearchSideBySideViewModel
+    {
+        public const string BetterSideLabel = "Which results are better?";
+        public const string MostRelevantPackageLabel = "What was the most relevant package?";
+        public const string ExpectedPackagesLabel = "Name at least one package you were expecting to see.";
+        public const string CommentsLabel = "Comments:";
+        public const string EmailLabel = "Email (optional, provide only if you want us to be able to follow up):";
+
+        public string SearchTerm { get; set; } = string.Empty;
+
+        public bool OldSuccess { get; set; }
+        public int OldHits { get; set; }
+        public IReadOnlyList<ListPackageItemViewModel> OldItems { get; set; } = new List<ListPackageItemViewModel>();
+
+        public bool NewSuccess { get; set; }
+        public int NewHits { get; set; }
+        public IReadOnlyList<ListPackageItemViewModel> NewItems { get; set; } = new List<ListPackageItemViewModel>();
+
+        [Display(Name = BetterSideLabel)]
+        public string BetterSide { get; set; }
+
+        [Display(Name = MostRelevantPackageLabel)]
+        public string MostRelevantPackage { get; set; }
+
+        [Display(Name = ExpectedPackagesLabel)]
+        public string ExpectedPackages { get; set; }
+
+        [Display(Name = CommentsLabel)]
+        public string Comments { get; set; }
+
+        [Display(Name = EmailLabel)]
+        public string EmailAddress { get; set; }
+    }
+}

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -33,11 +33,11 @@
     <add key="Gallery.AzureStorage.Packages.ConnectionString" value=""/>
     <add key="Gallery.AzureStorage.Statistics.ConnectionString" value=""/>
     <add key="Gallery.AzureStorage.Uploads.ConnectionString" value=""/>
-    <add key="Gallery.AzureStorage.Revalidation.ConnectionString" value="" />
+    <add key="Gallery.AzureStorage.Revalidation.ConnectionString" value=""/>
     <!-- The various Azure Storage connection strings to use. If the Gallery.StorageType is AzureStorage, all must be defined. -->
     <add key="Gallery.AzureStorageReadAccessGeoRedundant" value="false"/>
     <!-- If the storage account has to fall-back to a secondary (when Read Access Geo Redundant is enabled in Azure storage), change Gallery.AzureStorageReadAccessGeoRedundant to true -->
-    <add key="Gallery.FeatureFlagsRefreshInterval" value="00:01:00" />
+    <add key="Gallery.FeatureFlagsRefreshInterval" value="00:01:00"/>
     <add key="Gallery.AdminPanelDatabaseAccessEnabled" value="false"/>
     <add key="Gallery.AsynchronousPackageValidationEnabled" value="false"/>
     <add key="Gallery.BlockingAsynchronousPackageValidationEnabled" value="false"/>
@@ -130,6 +130,8 @@
     <!-- Set this values to use a remote search service. This overrides ALL other Lucene-related settings and disables indexing jobs. -->
     <add key="Gallery.SearchServiceUriPrimary" value=""/>
     <add key="Gallery.SearchServiceUriSecondary" value=""/>
+    <add key="Gallery.PreviewSearchServiceUriPrimary" value=""/>
+    <add key="Gallery.PreviewSearchServiceUriSecondary" value=""/>
     <add key="Gallery.SearchCircuitBreakerDelayInSeconds" value="600"/>
     <add key="Gallery.SearchCircuitBreakerWaitAndRetryIntervalInMilliseconds" value="500"/>
     <add key="Gallery.SearchCircuitBreakerWaitAndRetryCount" value="3"/>

--- a/tests/NuGet.Services.DatabaseMigration.Facts/ValidateMigrationsFacts.cs
+++ b/tests/NuGet.Services.DatabaseMigration.Facts/ValidateMigrationsFacts.cs
@@ -73,7 +73,7 @@ namespace NuGet.Services.DatabaseMigration.Facts
             {
                 _migrationJob.CheckIsValidMigration(databaseMigrations, localMigrations);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Assert.True(false);
             }

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/SearchSideBySideMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/SearchSideBySideMessageFacts.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Net.Mail;
+using NuGet.Services.Messaging.Email;
+using Xunit;
+
+namespace NuGetGallery.Infrastructure.Mail.Messages
+{
+    public class SearchSideBySideMessageFacts
+    {
+        public class Sender : Facts
+        {
+            [Fact]
+            public void IsGalleryNoReplyAddress()
+            {
+                var message = CreateMessage();
+
+                Assert.Equal(Configuration.GalleryNoReplyAddress, message.Sender);
+            }
+        }
+
+        public class GetRecipients : Facts
+        {
+            [Fact]
+            public void RecipientIsGalleryOwner()
+            {
+                var message = CreateMessage();
+
+                var recipients = message.GetRecipients();
+
+                Assert.Equal(new[] { Configuration.GalleryOwner }, recipients.To.ToArray());
+            }
+
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("   ")]
+            [InlineData("don't contact me")]
+            public void ReplyToIsNullWithInvalidEmailAddress(string emailAddress)
+            {
+                Model.EmailAddress = emailAddress;
+                var message = CreateMessage();
+
+                var recipients = message.GetRecipients();
+
+                Assert.Empty(recipients.ReplyTo);
+            }
+
+            [Theory]
+            [InlineData("me@example.com", "me@example.com")]
+            [InlineData("   me@example.com  ", "me@example.com")]
+            public void ReplyToIsEmailAddressWithValidEmailAddress(string emailAddress, string expected)
+            {
+                Model.EmailAddress = emailAddress;
+                var message = CreateMessage();
+
+                var recipients = message.GetRecipients();
+
+                Assert.Equal(new[] { new MailAddress(expected) }, recipients.ReplyTo.ToArray());
+            }
+        }
+
+        public class GetSubject : Facts
+        {
+            [Fact]
+            public void IsBasedOnConfiguration()
+            {
+                var message = CreateMessage();
+
+                Assert.Equal($"[{Configuration.GalleryOwner.DisplayName}] Search Feedback", message.GetSubject());
+            }
+        }
+
+        public class GetMarkdownBody : Facts
+        {
+            [Fact]
+            public void HasExpectedBodyWithEmptyModel()
+            {
+                var message = CreateMessage();
+
+                var body = message.GetBody(EmailFormat.Markdown);
+
+                Assert.Equal($@"The following feedback has come from the search side-by-side page.
+
+**Search Query:** [](https://localhost/experiments/search-sxs?q=json)
+
+**Old Hits:** 0
+
+**New Hits:** 0
+
+", body);
+            }
+            [Fact]
+            public void HasExpectedBodyWithFullModel()
+            {
+                Model.BetterSide = "new ";
+                Model.Comments = "  These are some comments.\r\nWith two lines!\r\n";
+                Model.EmailAddress = "  me@example.com  ";
+                Model.ExpectedPackages = "  NuGet.Versioning,  NuGet.Protocol";
+                Model.MostRelevantPackage = "  NuGet.Frameworks   ";
+                Model.OldHits = 23;
+                Model.NewHits = 42;
+                Model.SearchTerm = "nuget";
+                var message = CreateMessage();
+
+                var body = message.GetBody(EmailFormat.Markdown);
+
+                Assert.Equal($@"The following feedback has come from the search side-by-side page.
+
+**Search Query:** [nuget](https://localhost/experiments/search-sxs?q=json)
+
+**Old Hits:** 23
+
+**New Hits:** 42
+
+**Which results are better?** new
+
+**What was the most relevant package?** NuGet.Frameworks
+
+**Name at least one package you were expecting to see.** NuGet.Versioning,  NuGet.Protocol
+
+**Comments:**
+These are some comments.
+With two lines!
+
+**Email:** me@example.com
+
+", body);
+            }
+        }
+
+        public abstract class Facts : MarkdownMessageBuilderFacts
+        {
+            public SearchSideBySideViewModel Model { get; }
+            public string SearchUrl { get; set; }
+
+            public Facts()
+            {
+                Model = new SearchSideBySideViewModel();
+                SearchUrl = "https://localhost/experiments/search-sxs?q=json";
+            }
+
+            public SearchSideBySideMessage CreateMessage()
+            {
+                return new SearchSideBySideMessage(
+                    Configuration,
+                    Model,
+                    SearchUrl);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Infrastructure\Lucene\ResilientSearchServiceFacts.cs" />
     <Compile Include="Infrastructure\Lucene\GallerySearchServiceFacts.cs" />
     <Compile Include="Helpers\StreamHelperFacts.cs" />
+    <Compile Include="Infrastructure\Mail\Messages\SearchSideBySideMessageFacts.cs" />
     <Compile Include="Services\PackageDeprecationServiceFacts.cs" />
     <Compile Include="Services\StatusServiceFacts.cs" />
     <Compile Include="TestData\TestDataResourceUtility.cs" />

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -269,6 +269,14 @@ namespace NuGetGallery
                     yield return new object[] { "SearchOnRetry",
                         (TrackAction)(s => s.TrackMetricForSearchOnRetry("SomeName", exception: null, correlationId: string.Empty, uri: string.Empty, circuitBreakerStatus: string.Empty))
                     };
+
+                    yield return new object[] { "SearchSideBySideFeedback",
+                        (TrackAction)(s => s.TrackSearchSideBySideFeedback("nuget", 1, 2, "new", "nuget.core", null, true, true))
+                    };
+
+                    yield return new object[] { "SearchSideBySide",
+                        (TrackAction)(s => s.TrackSearchSideBySide("nuget", true, 1, true, 2))
+                    };
                 }
             }
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/7152.

- Add feature flag
- Add an email message that will be sent when people leave feedback
  - Email address and comments should not be recorded in AI and therefore take a path like support requests.
- Add telemetry to record SxS search and feedback in AI
  - Just "metadata" not comments or email address
- Minor style issues in existing code (VS was nagging me)

This is what the email looks like:

![image](https://user-images.githubusercontent.com/94054/58123137-09364680-7bc0-11e9-92e2-c099e2b23166.png)


Look at the view model for an idea of the kind of data we are going to pass to the view and get back from the feedback form. Here's a sneak-peak of the UI (PR forthcoming) to help you understand the goal. Please leave UI comments to a future PR.

![image](https://user-images.githubusercontent.com/94054/58122049-9deb7500-7bbd-11e9-95d8-5e02a8109efe.png)
