### PR TITLE
Work around Chromium bug that gives false positives during accessibility pass

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -60,6 +60,7 @@ body h3 {
 .footer .container {
   margin-top: 50px;
   margin-bottom: 50px;
+  background-color: #002440;
 }
 .footer a {
   color: #e3ebf1;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -70,6 +70,10 @@ body {
   .container {
     margin-top: 50px;
     margin-bottom: 50px;
+
+    // This is a workaround for the following bug:
+    // https://github.com/microsoft/accessibility-insights-web/issues/692
+    background-color: @panel-footer-bg;
   }
 
   a {


### PR DESCRIPTION
Related to https://github.com/microsoft/accessibility-insights-web/issues/692
Related to https://bugs.chromium.org/p/chromium/issues/detail?id=647594

This is a workaround suggested by the Accessibility Insights team (the tool formerly known as Keros). This means there is less noise in our accessibility passes using this tool.