### PR TITLE
Aligning ServerCommon versions with NuGet.Jobs

### DIFF
--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -96,10 +96,10 @@
       <Version>4.1.0-master-2602271</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.47.0-master-2652814</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -109,7 +109,7 @@
       <Version>4.1.0-master-2602271</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -223,19 +223,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2158,7 +2158,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
@@ -2382,16 +2382,16 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.46.0</Version>
+      <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>


### PR DESCRIPTION
Related to https://github.com/NuGet/NuGet.Jobs/pull/759.
Bringing in version parity between repos.

Difference between 2.46 and 2.48: https://github.com/NuGet/ServerCommon/compare/a827b73d00bf971c631149461d2afcaa862a9382...172a0f385dec8b90f5efb889d1d6f0996a3f9b0e?expand=1