### PR TITLE
Wrap the Status endpoint in a Razor view

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -265,6 +265,10 @@ namespace NuGetGallery
             return new RedirectResult(NuGetExeUrl, permanent: false);
         }
 
+        /// <remarks>
+        /// This endpoint is used by our traffic manager to determine whether or not this instance is available.
+        /// We are returning a Razor view because it forces this request to wait for Razor to be initialized before becoming available.
+        /// </remarks>
         [HttpGet]
         [ActionName("StatusApi")]
         public virtual async Task<ActionResult> Status()
@@ -279,6 +283,10 @@ namespace NuGetGallery
             return View(status);
         }
 
+        /// <remarks>
+        /// This endpoint is used by our load balancer to determine whether or not this instance is available.
+        /// We are returning a Razor view because it forces this request to wait for Razor to be initialized before becoming available.
+        /// </remarks>
         [HttpGet]
         [ActionName("HealthProbeApi")]
         public ActionResult HealthProbe()

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -13,7 +13,6 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
-using System.Web.UI.WebControls;
 using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging;

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -13,6 +13,7 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
+using System.Web.UI.WebControls;
 using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
@@ -273,7 +274,10 @@ namespace NuGetGallery
             {
                 return new HttpStatusCodeResult(HttpStatusCode.ServiceUnavailable, "Status service is unavailable");
             }
-            return await StatusService.GetStatus();
+
+            var status = await StatusService.GetStatus();
+            Response.StatusCode = (int)(status.GalleryServiceAvailable ? HttpStatusCode.OK : HttpStatusCode.ServiceUnavailable);
+            return View(status);
         }
 
         [HttpGet]

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -743,6 +743,7 @@
     <Compile Include="ViewModels\ManagePackageViewModel.cs" />
     <Compile Include="ViewModels\SearchSideBySideViewModel.cs" />
     <Compile Include="ViewModels\SignerViewModel.cs" />
+    <Compile Include="ViewModels\StatusViewModel.cs" />
     <Compile Include="WebRole.cs" />
     <Compile Include="Areas\Admin\AdminAreaRegistration.cs" />
     <Compile Include="Areas\Admin\Controllers\AdminControllerBase.cs" />
@@ -1932,6 +1933,7 @@
     <Content Include="Views\Packages\_DisplayPackageDeprecation.cshtml" />
     <Content Include="Views\Experiments\SearchSideBySide.cshtml" />
     <Content Include="Views\Api\HealthProbeApi.cshtml" />
+    <Content Include="Views\Api\StatusApi.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/src/NuGetGallery/Services/IStatusService.cs
+++ b/src/NuGetGallery/Services/IStatusService.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
-using System.Web.Mvc;
 
 namespace NuGetGallery
 {
     public interface IStatusService
     {
-        Task<ActionResult> GetStatus();
+        Task<StatusViewModel> GetStatus();
     }
 }

--- a/src/NuGetGallery/ViewModels/StatusViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatusViewModel.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public class StatusViewModel
+    {
+        public StatusViewModel(
+            bool sqlAzureAvailable,
+            bool? storageAvailable)
+        {
+            SqlAzureAvailable = sqlAzureAvailable;
+            StorageAvailable = storageAvailable;
+        }
+
+        public bool GalleryServiceAvailable => SqlAzureAvailable && (StorageAvailable ?? true);
+
+        public bool SqlAzureAvailable { get; }
+        public bool? StorageAvailable { get; }
+    }
+}

--- a/src/NuGetGallery/Views/Api/StatusApi.cshtml
+++ b/src/NuGetGallery/Views/Api/StatusApi.cshtml
@@ -1,0 +1,19 @@
+﻿@model StatusViewModel
+
+@helper AvailabilityString(bool? isAvailable)
+{
+    @((isAvailable ?? true) ? "available" : "unavailable")
+}
+
+<section role="main" class="container main-container">
+    <div class="row">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
+            <h1>
+                Status
+            </h1>
+            <p>
+                NuGet Gallery instance @HostMachine.Name is @AvailabilityString(Model.GalleryServiceAvailable). SQL is @AvailabilityString(Model.SqlAzureAvailable). Storage is @AvailabilityString(Model.StorageAvailable).
+            </p>
+        </div>
+    </div>
+</section>

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -2574,12 +2574,11 @@ namespace NuGetGallery
         public class TheHealthProbeMethod : TestContainer
         {
             [Fact]
-            public void Returns200()
+            public void ReturnsView()
             {
                 var controller = new TestableApiController(GetConfigurationService());
                 var result = controller.HealthProbe();
                 ResultAssert.IsView(result);
-                Assert.Equal((int)HttpStatusCode.OK, controller.Response.StatusCode);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -15,7 +15,6 @@ using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 using Autofac;
-using Microsoft.Ajax.Utilities;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NuGet.Packaging;


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/2493

By wrapping our status response in a Razor view, we now force this endpoint to also wait for Razor initialization as well, which means that this endpoint will no longer return available before the instance is ready to handle Razor requests.

It also adds testing to the `HealthProbe` endpoint, which had the same change made to it as part of a hotfix.