### PR TITLE
Hotfix: Wrap HealthProbe endpoint in a Razor view

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -280,7 +280,7 @@ namespace NuGetGallery
         [ActionName("HealthProbeApi")]
         public ActionResult HealthProbe()
         {
-            return new HttpStatusCodeWithBodyResult(HttpStatusCode.OK, "Gallery is Available");
+            return View();
         }
 
         [HttpGet]

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1964,6 +1964,7 @@
     <Content Include="Views\Packages\_ManageDeprecation.cshtml" />
     <Content Include="Views\Shared\_MultiSelectDropdown.cshtml" />
     <Content Include="Views\Packages\_DisplayPackageDeprecation.cshtml" />
+    <Content Include="Views\Api\HealthProbeApi.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/src/NuGetGallery/Views/Api/HealthProbeApi.cshtml
+++ b/src/NuGetGallery/Views/Api/HealthProbeApi.cshtml
@@ -1,0 +1,12 @@
+﻿<section role="main" class="container main-container">
+    <div class="row">
+        <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
+            <h1>
+                Health Probe
+            </h1>
+            <p>
+                Gallery is available.
+            </p>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
Applying the HealthProbe changes as part of https://github.com/NuGet/NuGetGallery/pull/7198 as a hotfix.