### PR TITLE
Update ServerCommon version to pull in latest validation DB migration

### DIFF
--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -96,10 +96,10 @@
       <Version>4.1.0-master-2602271</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -109,7 +109,7 @@
       <Version>4.1.0-master-2602271</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -223,19 +223,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -125,7 +125,7 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.46.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime">
       <Version>4.3.1</Version>

--- a/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
@@ -42,7 +42,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         {
             var groups = validationSets
                 .Where(x => x.ValidatingType == validatingType)
-                .OrderBy(x => x.PackageId)
+                .OrderBy(x => x.PackageId, StringComparer.OrdinalIgnoreCase)
                 .ThenByDescending(x => NuGetVersion.Parse(x.PackageNormalizedVersion))
                 .ThenByDescending(x => x.PackageKey)
                 .ThenByDescending(x => x.Created)
@@ -53,10 +53,8 @@ namespace NuGetGallery.Areas.Admin.Controllers
             {
                 foreach (var set in group)
                 {
-                    // Put completed validations first then put new validations on top.
                     set.PackageValidations = set.PackageValidations
-                        .OrderByDescending(x => x.ValidationStatus)
-                        .ThenByDescending(x => x.ValidationStatusTimestamp)
+                        .OrderBy(x => x.Started)
                         .ToList();
                 }
                 var deletedStatus = _validationAdminService.GetDeletedStatus(group.Key, validatingType);

--- a/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
@@ -87,7 +87,23 @@
                         <b>Created:</b> @ShowTimestamp(set.Created)<br />
                         @if (set.Created != set.Updated)
                         {
-                            <b>Updated:</b> @ShowTimestamp(set.Updated)
+                            <b>Updated:</b> @ShowTimestamp(set.Updated)<br />
+                        }
+                        <b>Status:</b>
+                        @switch (set.ValidationSetStatus)
+                        {
+                            case ValidationSetStatus.Unknown:
+                                @:Unknown
+                                break;
+                            case ValidationSetStatus.InProgress:
+                                @:In progress
+                                break;
+                            case ValidationSetStatus.Completed:
+                                @:Complete
+                                break;
+                            default:
+                                @(set.ValidationSetStatus)
+                                break;
                         }
                     </p>
 

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2123,7 +2123,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
@@ -2347,16 +2347,16 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>


### PR DESCRIPTION
The new DB migration in validation DB adds a status column to validation sets. Also, polish the validation page a little bit.

Progress on https://github.com/NuGet/NuGetGallery/issues/7185.