### PR TITLE
Add deployment ID value to Application Insights telemetry

### DIFF
--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -82,6 +82,7 @@ namespace NuGetGallery
                 TelemetryConfiguration.Active.InstrumentationKey = instrumentationKey;
 
                 // Add enrichers
+                TelemetryConfiguration.Active.TelemetryInitializers.Add(new DeploymentIdTelemetryEnricher());
                 TelemetryConfiguration.Active.TelemetryInitializers.Add(new ClientInformationTelemetryEnricher());
 
                 var telemetryProcessorChainBuilder = TelemetryConfiguration.Active.TelemetryProcessorChainBuilder;

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -568,6 +568,7 @@
     <Compile Include="Services\ValidationService.cs" />
     <Compile Include="Telemetry\ClientInformationTelemetryEnricher.cs" />
     <Compile Include="Telemetry\ClientTelemetryPIIProcessor.cs" />
+    <Compile Include="Telemetry\DeploymentIdTelemetryEnricher.cs" />
     <Compile Include="Telemetry\QuietExceptionLogger.cs" />
     <Compile Include="Infrastructure\Authentication\CredentialValidator.cs" />
     <Compile Include="Infrastructure\Authentication\ICredentialValidator.cs" />

--- a/src/NuGetGallery/Telemetry/DeploymentIdTelemetryEnricher.cs
+++ b/src/NuGetGallery/Telemetry/DeploymentIdTelemetryEnricher.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.WindowsAzure.ServiceRuntime;
+
+namespace NuGetGallery
+{
+    public class DeploymentIdTelemetryEnricher : ITelemetryInitializer
+    {
+        private const string PropertyKey = "CloudDeploymentId";
+
+        private static readonly Lazy<string> LazyDeploymentId = new Lazy<string>(() =>
+        {
+            try
+            {
+                if (RoleEnvironment.IsAvailable)
+                {
+                    return RoleEnvironment.DeploymentId;
+                }
+            }
+            catch
+            {
+                // This likely means the cloud service runtime is not available.
+            }
+
+            return null;
+        });
+
+        internal virtual string DeploymentId => LazyDeploymentId.Value;
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (telemetry == null
+                || DeploymentId == null
+                || telemetry.Context.Properties.ContainsKey(PropertyKey))
+            {
+                return;
+            }
+
+            telemetry.Context.Properties.Add(PropertyKey, DeploymentId);
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Services\PackageDeprecationServiceFacts.cs" />
     <Compile Include="Services\SearchSideBySideServiceFacts.cs" />
     <Compile Include="Services\StatusServiceFacts.cs" />
+    <Compile Include="Telemetry\DeploymentIdTelemetryEnricherFacts.cs" />
     <Compile Include="TestData\TestDataResourceUtility.cs" />
     <Compile Include="UsernameValidationRegex.cs" />
     <Compile Include="Extensions\NumberExtensionsFacts.cs" />

--- a/tests/NuGetGallery.Facts/Telemetry/DeploymentIdTelemetryEnricherFacts.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/DeploymentIdTelemetryEnricherFacts.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Moq;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class DeploymentIdTelemetryEnricherFacts
+    {
+        private const string PropertyKey = "CloudDeploymentId";
+
+        public DeploymentIdTelemetryEnricherFacts()
+        {
+            Telemetry = new Mock<ITelemetry>();
+            Telemetry.Setup(x => x.Context).Returns(new TelemetryContext());
+            Target = new Mock<TestableDeploymentIdTelemetryEnricher>();
+            Target.Object.SetDeploymentId("TheDeploymentId");
+        }
+
+        public Mock<ITelemetry> Telemetry { get; }
+        public Mock<TestableDeploymentIdTelemetryEnricher> Target { get; }
+
+        [Fact]
+        public void DoesNothingWithNullTelemetry()
+        {
+            Target.Object.Initialize(telemetry: null);
+
+            Target.Verify(x => x.DeploymentId, Times.Never);
+            Assert.DoesNotContain(PropertyKey, Telemetry.Object.Context.Properties.Keys);
+        }
+
+        [Fact]
+        public void DoesNothingWhenDeploymentIdIsNull()
+        {
+            Target.Object.SetDeploymentId(null);
+
+            Target.Object.Initialize(Telemetry.Object);
+
+            Target.Verify(x => x.DeploymentId, Times.Never);
+            Assert.DoesNotContain(PropertyKey, Telemetry.Object.Context.Properties.Keys);
+        }
+
+        [Fact]
+        public void DoesNothingWhenDeploymentIdIsAlreadySet()
+        {
+            Telemetry.Object.Context.Properties[PropertyKey] = "something else";
+
+            Target.Object.Initialize(Telemetry.Object);
+
+            Target.Verify(x => x.DeploymentId, Times.Never);
+            Assert.Equal(Telemetry.Object.Context.Properties[PropertyKey], "something else");
+        }
+
+        [Fact]
+        public void SetsDeploymentId()
+        {
+            Target.Object.Initialize(Telemetry.Object);
+
+            Assert.Equal(Telemetry.Object.Context.Properties[PropertyKey], "TheDeploymentId");
+        }
+
+        public class TestableDeploymentIdTelemetryEnricher : DeploymentIdTelemetryEnricher
+        {
+            private string _deploymentId;
+
+            public void SetDeploymentId(string deploymentId)
+            {
+                _deploymentId = deploymentId;
+            }
+
+            internal override string DeploymentId => _deploymentId;
+        }
+    }
+}


### PR DESCRIPTION
This can help us distinguish between USNC-USSC, production-staging slot. This is the same value we see in our internal telemetry system for "tenant".

The actual name of the slot and cloud service resource is not directly available. See:
https://stackoverflow.com/questions/24522781/get-cloud-service-name-in-a-web-role

I am in the process of confirming this on DEV.