### PR TITLE
Allow published symbols to be downloaded after re-upload failures and Blog updates

### DIFF
--- a/src/NuGet.Services.Entities/Extensions/PackageExtensions.cs
+++ b/src/NuGet.Services.Entities/Extensions/PackageExtensions.cs
@@ -14,10 +14,7 @@ namespace NuGet.Services.Entities
         /// <returns>The latest symbol package if present, null otherwise</returns>
         public static SymbolPackage LatestSymbolPackage(this Package package)
         {
-            return package
-                .SymbolPackages?
-                .OrderByDescending(sp => sp.Created)
-                .FirstOrDefault();
+            return package.GetSymbolsPackagesInReverseOrder()?.FirstOrDefault();
         }
 
         /// <summary>
@@ -25,12 +22,14 @@ namespace NuGet.Services.Entities
         /// </summary>
         /// <param name="package"><see cref="Package"/> for which latest symbol package is to be retrieved.</param>
         /// <returns>The last available symbol package if present, null otherwise</returns>
-        public static SymbolPackage LastAvailableSymbolPackage(this Package package)
+        public static SymbolPackage LatestAvailableSymbolPackage(this Package package)
         {
-            return package
-                .SymbolPackages?
-                .OrderByDescending(sp => sp.Created)
-                .FirstOrDefault(sp => sp.StatusKey == PackageStatus.Available);
+            return package.GetSymbolsPackagesInReverseOrder()?.FirstOrDefault(sp => sp.StatusKey == PackageStatus.Available);
+        }
+
+        public static IOrderedEnumerable<SymbolPackage> GetSymbolsPackagesInReverseOrder(this Package package)
+        {
+            return package.SymbolPackages?.OrderByDescending(sp => sp.Created);
         }
 
         /// <summary>

--- a/src/NuGet.Services.Entities/Extensions/PackageExtensions.cs
+++ b/src/NuGet.Services.Entities/Extensions/PackageExtensions.cs
@@ -27,7 +27,7 @@ namespace NuGet.Services.Entities
             return package.GetSymbolsPackagesInReverseOrder()?.FirstOrDefault(sp => sp.StatusKey == PackageStatus.Available);
         }
 
-        public static IOrderedEnumerable<SymbolPackage> GetSymbolsPackagesInReverseOrder(this Package package)
+        private static IOrderedEnumerable<SymbolPackage> GetSymbolsPackagesInReverseOrder(this Package package)
         {
             return package.SymbolPackages?.OrderByDescending(sp => sp.Created);
         }

--- a/src/NuGet.Services.Entities/Extensions/PackageExtensions.cs
+++ b/src/NuGet.Services.Entities/Extensions/PackageExtensions.cs
@@ -21,6 +21,19 @@ namespace NuGet.Services.Entities
         }
 
         /// <summary>
+        /// Get the last successfully uploaded symbols package for the given package.
+        /// </summary>
+        /// <param name="package"><see cref="Package"/> for which latest symbol package is to be retrieved.</param>
+        /// <returns>The last available symbol package if present, null otherwise</returns>
+        public static SymbolPackage LastAvailableSymbolPackage(this Package package)
+        {
+            return package
+                .SymbolPackages?
+                .OrderByDescending(sp => sp.Created)
+                .FirstOrDefault(sp => sp.StatusKey == PackageStatus.Available);
+        }
+
+        /// <summary>
         /// Returns true if there exists a symbol package which is latest and is in
         /// available state, false otherwise.
         /// </summary>

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -194,6 +194,11 @@ namespace NuGetGallery
                     if (isSymbolPackage)
                     {
                         package = PackageService.FindPackageByIdAndVersionStrict(id, version);
+
+                        if (package == null)
+                        {
+                            return new HttpStatusCodeWithBodyResult(HttpStatusCode.NotFound, string.Format(CultureInfo.CurrentCulture, Strings.PackageWithIdAndVersionNotFound, id, version));
+                        }
                     }
                 }
                 else
@@ -231,12 +236,9 @@ namespace NuGetGallery
 
             if (isSymbolPackage)
             {
-                var latestSymbolPackage = package?
-                    .SymbolPackages
-                    .OrderByDescending(sp => sp.Created)
-                    .FirstOrDefault();
+                var lastAvailableSymbolsPackage = package.LastAvailableSymbolPackage();
 
-                if (latestSymbolPackage == null || latestSymbolPackage.StatusKey != PackageStatus.Available)
+                if (lastAvailableSymbolsPackage == null)
                 {
                     return new HttpStatusCodeWithBodyResult(HttpStatusCode.NotFound, string.Format(CultureInfo.CurrentCulture, Strings.SymbolsPackage_PackageNotAvailable, id, version));
                 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -236,9 +236,9 @@ namespace NuGetGallery
 
             if (isSymbolPackage)
             {
-                var lastAvailableSymbolsPackage = package.LatestAvailableSymbolPackage();
+                var latestAvailableSymbolsPackage = package.LatestAvailableSymbolPackage();
 
-                if (lastAvailableSymbolsPackage == null)
+                if (latestAvailableSymbolsPackage == null)
                 {
                     return new HttpStatusCodeWithBodyResult(HttpStatusCode.NotFound, string.Format(CultureInfo.CurrentCulture, Strings.SymbolsPackage_PackageNotAvailable, id, version));
                 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -236,7 +236,7 @@ namespace NuGetGallery
 
             if (isSymbolPackage)
             {
-                var lastAvailableSymbolsPackage = package.LastAvailableSymbolPackage();
+                var lastAvailableSymbolsPackage = package.LatestAvailableSymbolPackage();
 
                 if (lastAvailableSymbolsPackage == null)
                 {

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -35,6 +35,9 @@ namespace NuGetGallery
             PackageFileSize = package.PackageFileSize;
 
             LatestSymbolsPackage = package.LatestSymbolPackage();
+            LastAvailableSymbolsPackage = LatestSymbolsPackage.StatusKey == PackageStatus.Available
+                ? LatestSymbolsPackage
+                : package.LastAvailableSymbolPackage();
 
             if (packageHistory.Any())
             {
@@ -114,6 +117,7 @@ namespace NuGetGallery
         public int TotalDaysSinceCreated { get; private set; }
         public long PackageFileSize { get; private set; }
         public SymbolPackage LatestSymbolsPackage { get; private set; }
+        public SymbolPackage LastAvailableSymbolsPackage { get; private set; }
 
         public bool HasSemVer2Version { get; }
         public bool HasSemVer2Dependency { get; }

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -35,7 +35,7 @@ namespace NuGetGallery
             PackageFileSize = package.PackageFileSize;
 
             LatestSymbolsPackage = package.LatestSymbolPackage();
-            LastAvailableSymbolsPackage = LatestSymbolsPackage.StatusKey == PackageStatus.Available
+            LastAvailableSymbolsPackage = LatestSymbolsPackage != null && LatestSymbolsPackage.StatusKey == PackageStatus.Available
                 ? LatestSymbolsPackage
                 : package.LastAvailableSymbolPackage();
 

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -35,9 +35,9 @@ namespace NuGetGallery
             PackageFileSize = package.PackageFileSize;
 
             LatestSymbolsPackage = package.LatestSymbolPackage();
-            LastAvailableSymbolsPackage = LatestSymbolsPackage != null && LatestSymbolsPackage.StatusKey == PackageStatus.Available
+            LatestAvailableSymbolsPackage = LatestSymbolsPackage != null && LatestSymbolsPackage.StatusKey == PackageStatus.Available
                 ? LatestSymbolsPackage
-                : package.LastAvailableSymbolPackage();
+                : package.LatestAvailableSymbolPackage();
 
             if (packageHistory.Any())
             {
@@ -117,7 +117,7 @@ namespace NuGetGallery
         public int TotalDaysSinceCreated { get; private set; }
         public long PackageFileSize { get; private set; }
         public SymbolPackage LatestSymbolsPackage { get; private set; }
-        public SymbolPackage LastAvailableSymbolsPackage { get; private set; }
+        public SymbolPackage LatestAvailableSymbolsPackage { get; private set; }
 
         public bool HasSemVer2Version { get; }
         public bool HasSemVer2Dependency { get; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -9,7 +9,7 @@
 
     var absolutePackageUrl = Url.Absolute(Url.Package(Model.Id));
 
-    var hasSymbolsPackageAvailable = Model.LastAvailableSymbolsPackage != null;
+    var hasSymbolsPackageAvailable = Model.LatestAvailableSymbolsPackage != null;
     var showSymbolsPackageStatus = Model.LatestSymbolsPackage != null && Model.LatestSymbolsPackage.StatusKey != PackageStatus.Available;
 
     PackageManagerViewModel[] packageManagers;
@@ -161,6 +161,15 @@
                 break;
         }
     </div>
+}
+
+@helper AppendAvailableSymbolsMessage(bool hasSymbolsPackageAvailable)
+{
+    if(hasSymbolsPackageAvailable)
+    {
+        <br /><br />
+        <text><b>Please note:</b> The last successfully published symbols package is still available for debugging and download.</text>
+    }
 }
 
 @* The following two helpers must be on a single line each so no extra whitespace is introduced in the expression when rendered. *@
@@ -324,11 +333,7 @@
                             for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete. 
                             Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
 
-                            @if(hasSymbolsPackageAvailable)
-                            {
-                                <br /><br />
-                                <text><b>Please note:</b> The last successfully published symbols package is still available for debugging and download.</text>
-                            }
+                        @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
                         </text>
                      )
                 }
@@ -353,11 +358,7 @@
                             <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
                         }
 
-                        @if(hasSymbolsPackageAvailable)
-                        {
-                            <br /><br />
-                            <text><b>Please note:</b> The last successfully published symbols package is still available for debugging and download.</text>
-                        }
+                        @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
                     </text>)
                 }
             }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -9,7 +9,7 @@
 
     var absolutePackageUrl = Url.Absolute(Url.Package(Model.Id));
 
-    var hasSymbolsPackageAvailable = Model.LatestSymbolsPackage != null && Model.LatestSymbolsPackage.StatusKey == PackageStatus.Available;
+    var hasSymbolsPackageAvailable = Model.LastAvailableSymbolsPackage != null;
     var showSymbolsPackageStatus = Model.LatestSymbolsPackage != null && Model.LatestSymbolsPackage.StatusKey != PackageStatus.Available;
 
     PackageManagerViewModel[] packageManagers;
@@ -323,6 +323,12 @@
                             <strong>The symbols for this package have not been indexed yet.</strong> They are not available
                             for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete. 
                             Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
+
+                            @if(hasSymbolsPackageAvailable)
+                            {
+                                <br /><br />
+                                <text><b>Please note:</b> The last successfully published symbols package is still available for debugging and download.</text>
+                            }
                         </text>
                      )
                 }
@@ -345,6 +351,12 @@
                         else
                         {
                             <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
+                        }
+
+                        @if(hasSymbolsPackageAvailable)
+                        {
+                            <br /><br />
+                            <text><b>Please note:</b> The last successfully published symbols package is still available for debugging and download.</text>
                         }
                     </text>)
                 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -314,7 +314,7 @@
                 @ViewHelpers.AlertIsSemVer2Package(Model.HasSemVer2Version, Model.HasSemVer2Dependency)
             }
 
-            @if (showSymbolsPackageStatus)
+            @if (Model.CanDisplayPrivateMetadata && showSymbolsPackageStatus)
             {
                 if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.Validating)
                 {

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -35,10 +35,10 @@
     </div>
 }
 
-@helper DisplayNavigationItem(string tab, string url, bool bold = false, string title = null, bool newWindow = false)
+@helper DisplayNavigationItem(string tab, string url, bool bold = false, string title = null)
 {
     <li class="@(ViewBag.Tab == tab ? "active" : string.Empty)" role="presentation">
-        <a role="tab" target= "@(newWindow ? "_blank" : "")" aria-selected="@(ViewBag.Tab == tab ? "true" : "false")" href="@url" title="@title">
+        <a role="tab" aria-selected="@(ViewBag.Tab == tab ? "true" : "false")" href="@url" title="@title">
             @if (bold)
             {
                 @:<b>
@@ -88,7 +88,7 @@
                         }
                         @DisplayNavigationItem("Documentation", "https://docs.microsoft.com/en-us/nuget/what-is-nuget")
                         @DisplayNavigationItem("Downloads", Url.Downloads())
-                        @DisplayNavigationItem("Blog", "https://devblogs.microsoft.com/nuget/", newWindow: true)
+                        @DisplayNavigationItem("Blog", "https://devblogs.microsoft.com/nuget/")
                     </ul>
                     @if (ShowAuthInHeader)
                     {

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -35,10 +35,10 @@
     </div>
 }
 
-@helper DisplayNavigationItem(string tab, string url, bool bold = false, string title = null)
+@helper DisplayNavigationItem(string tab, string url, bool bold = false, string title = null, bool newWindow = false)
 {
     <li class="@(ViewBag.Tab == tab ? "active" : string.Empty)" role="presentation">
-        <a role="tab" aria-selected="@(ViewBag.Tab == tab ? "true" : "false")" href="@url" title="@title">
+        <a role="tab" target= "@(newWindow ? "_blank" : "")" aria-selected="@(ViewBag.Tab == tab ? "true" : "false")" href="@url" title="@title">
             @if (bold)
             {
                 @:<b>
@@ -86,9 +86,9 @@
                         {
                             @DisplayNavigationItem("Admin", Url.Admin())
                         }
-                        @DisplayNavigationItem("Documentation", "https://docs.microsoft.com/en-us/nuget/what-is-nuget")
+                        @DisplayNavigationItem("Documentation", "https://docs.microsoft.com/en-us/nuget/what-is-nuget", newWindow: true)
                         @DisplayNavigationItem("Downloads", Url.Downloads())
-                        @DisplayNavigationItem("Blog", "https://blog.nuget.org/")
+                        @DisplayNavigationItem("Blog", "https://devblogs.microsoft.com/nuget/", newWindow: true)
                     </ul>
                     @if (ShowAuthInHeader)
                     {

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -86,7 +86,7 @@
                         {
                             @DisplayNavigationItem("Admin", Url.Admin())
                         }
-                        @DisplayNavigationItem("Documentation", "https://docs.microsoft.com/en-us/nuget/what-is-nuget", newWindow: true)
+                        @DisplayNavigationItem("Documentation", "https://docs.microsoft.com/en-us/nuget/what-is-nuget")
                         @DisplayNavigationItem("Downloads", Url.Downloads())
                         @DisplayNavigationItem("Blog", "https://devblogs.microsoft.com/nuget/", newWindow: true)
                     </ul>

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -1723,7 +1723,7 @@ namespace NuGetGallery
             [InlineData(PackageStatus.Deleted)]
             [InlineData(PackageStatus.FailedValidation)]
             [InlineData(PackageStatus.Validating)]
-            public async Task GetPackageReturns404ForNotAvailableLatestSymbolPackage(PackageStatus status)
+            public async Task GetPackageReturnsLastAvailableSymbolPackage(PackageStatus status)
             {
                 // Arrange
                 const string packageId = "Baz";
@@ -1750,12 +1750,17 @@ namespace NuGetGallery
                 controller.MockPackageService
                     .Setup(x => x.FindPackageByIdAndVersionStrict(packageId, packageVersion))
                     .Returns(package).Verifiable();
+                controller.MockSymbolPackageFileService
+                    .Setup(x => x.CreateDownloadSymbolPackageActionResultAsync(It.IsAny<Uri>(), packageId, packageVersion))
+                    .Returns(Task.FromResult<ActionResult>(new HttpStatusCodeWithBodyResult(HttpStatusCode.OK, "Test package")))
+                    .Verifiable();
 
                 // Act
                 var result = (HttpStatusCodeWithBodyResult)await controller.GetPackageInternal(packageId, packageVersion, isSymbolPackage: true);
 
                 // Assert
-                Assert.Equal((int)HttpStatusCode.NotFound, result.StatusCode);
+                Assert.Equal((int)HttpStatusCode.OK, result.StatusCode);
+                controller.MockSymbolPackageFileService.Verify();
             }
 
             [Theory]


### PR DESCRIPTION
Allow the pre-published symbols to be downloaded after newer symbols are being published/failed validation.

See https://github.com/NuGet/NuGetGallery/issues/7222#issuecomment-499686460 snapshots

Also, updated the link for "Blog" header to point to new blogs pages.