### PR TITLE
Use JsonConvert for API keys list

### DIFF
--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -1,4 +1,5 @@
-﻿@model ApiKeyListViewModel
+﻿@using Newtonsoft.Json
+@model ApiKeyListViewModel
 @using NuGetGallery.Authentication
 @{
     ViewBag.Title = "API Keys";
@@ -463,7 +464,7 @@
 
 @section bottomScripts {
     <script type="text/javascript">
-        var initialData = @Html.Raw(Json.Encode(new
+        var initialData = @Html.Raw(JsonConvert.SerializeObject(new
                      {
                          ApiKeys = Model.ApiKeys,
                          PackageOwners = Model.PackageOwners,


### PR DESCRIPTION
https://github.com/nuget/nugetgallery/issues/7032

This bug prevents me from creating new API keys on my DEV account so I decided to fix it.
It also affects DEV's NuGetTestAccount.