### PR TITLE
[GH Usage] Added analytics

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -105,14 +105,12 @@ $(function () {
         });
     }
 
-    // Emit a Google Analytics event when the user expands or collapses the Dependencies section.
     if (window.nuget.isGaAvailable()) {
+        // Emit a Google Analytics event when the user expands or collapses the Dependencies section.
         $("#dependency-groups").on('hide.bs.collapse show.bs.collapse', function (e) {
             ga('send', 'event', 'dependencies', e.type);
         });
-    }
 
-    if (window.nuget.isGaAvailable()) {
         // Emit a Google Analytics event when the user expands or collapses the GitHub Usage section.
         $("#github-usage").on('hide.bs.collapse show.bs.collapse', function (e) {
             ga('send', 'event', 'github-usage', e.type);

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -111,4 +111,24 @@ $(function () {
             ga('send', 'event', 'dependencies', e.type);
         });
     }
+
+    if (window.nuget.isGaAvailable()) {
+        // Emit a Google Analytics event when the user expands or collapses the GitHub Usage section.
+        $("#github-usage").on('hide.bs.collapse show.bs.collapse', function (e) {
+            ga('send', 'event', 'github-usage', e.type);
+        });
+
+        // Emit a Google Analytics event when the user clicks on a repo link in the GitHub Usage section.
+        $(".btn-gh-repo").on('click', function (e) {
+            let elem = e.delegateTarget.parentElement.parentElement;
+            let linkIndex = 0;
+            while ((elem = elem.previousSibling) != null) {
+                if (elem.nodeName === "DIV") {
+                    linkIndex++;
+                }
+            }
+
+            ga('send', 'event', 'github-usage', 'link-click-' + linkIndex);
+        });
+    }
 });

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -119,16 +119,13 @@ $(function () {
         });
 
         // Emit a Google Analytics event when the user clicks on a repo link in the GitHub Usage section.
-        $(".btn-gh-repo").on('click', function (e) {
-            let elem = e.delegateTarget.parentElement.parentElement;
-            let linkIndex = 0;
-            while ((elem = elem.previousSibling) != null) {
-                if (elem.nodeName === "DIV") {
-                    linkIndex++;
-                }
+        $(".btn-gh-repo").on('click', function (elem) {
+            if (!elem.delegateTarget.dataset.indexNumber) {
+                console.error("indexNumber property doesn't exist!");
+            } else {
+                let linkIndex = elem.delegateTarget.dataset.indexNumber;
+                ga('send', 'event', 'github-usage', 'link-click-' + linkIndex);
             }
-
-            ga('send', 'event', 'github-usage', 'link-click-' + linkIndex);
         });
     }
 });

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -535,16 +535,16 @@
                             @(Model.Id), including the following:
                         </p>
 
-                        @foreach (var dep in Model.GitHubDependenciesInformation.Repos)
+                        @foreach (var item in Model.GitHubDependenciesInformation.Repos.Select((elem, i) => new { Value = elem, Idx = i}))
                         {
                             <div class="row top-buffer">
                                 <div class="col-xs-12">
-                                    <a class="btn btn-gh-repo text-left" href="@dep.Url" target="_blank">
+                                    <a data-index-number="@item.Idx" class="btn btn-gh-repo text-left" href="@item.Value.Url" target="_blank">
                                         <span class="pull-left">
-                                            @(dep.Id)
+                                            @(item.Value.Id)
                                         </span>
                                         <span class="badge pull-right badge-gh-repo">
-                                            @(dep.Stars.ToKiloFormat()) <i class="ms-Icon ms-Icon--FavoriteStarFill star-gh-repo" aria-hidden="true"></i>
+                                            @(item.Value.Stars.ToKiloFormat()) <i class="ms-Icon ms-Icon--FavoriteStarFill star-gh-repo" aria-hidden="true"></i>
                                         </span>
                                     </a>
                                 </div>


### PR DESCRIPTION
This PR adds analytics for the GitHub Usage section. 
The 2 metrics are:
- Clicks on the GitHub Usage section (show/hide)
- Clicks on the GitHub repo links (which index was clicked/how many total clicks)