### PR TITLE
Fixing ToKiloFormat method

### DIFF
--- a/src/NuGetGallery/Extensions/NumberExtensions.cs
+++ b/src/NuGetGallery/Extensions/NumberExtensions.cs
@@ -96,7 +96,7 @@ namespace NuGetGallery
 
             return powers
                 .Where(pow => Math.Abs(Math.Round(number / pow.Value, 3)) >= 1f)
-                .Select(pow => string.Format("{0:F1}{1}", number / pow.Value, pow.Unit))
+                .Select(pow => string.Format(CultureInfo.InvariantCulture, "{0:F1}{1}", number / pow.Value, pow.Unit))
                 .First();
         }
     }


### PR DESCRIPTION
Currently the int.ToKiloFormat() is Culture sensitive. This PR fixes that.

(See [Build #57489](https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=57489))