### PR TITLE
Fix for "Resend confirmation email" button to use the correct email address

### DIFF
--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -111,10 +111,10 @@ namespace NuGetGallery
                 return new HttpStatusCodeResult(HttpStatusCode.Forbidden, Strings.Unauthorized);
             }
 
-            var alreadyConfirmed = account.UnconfirmedEmailAddress == null;
+            var hasUnconfirmedEmailAddress = account.UnconfirmedEmailAddress == null;
 
             ConfirmationViewModel model;
-            if (!alreadyConfirmed)
+            if (!hasUnconfirmedEmailAddress)
             {
                 if (account.EmailAddress == null)
                 {

--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -111,10 +111,10 @@ namespace NuGetGallery
                 return new HttpStatusCodeResult(HttpStatusCode.Forbidden, Strings.Unauthorized);
             }
 
-            var hasUnconfirmedEmailAddress = account.UnconfirmedEmailAddress == null;
+            var hasUnconfirmedEmailAddress = account.UnconfirmedEmailAddress != null;
 
             ConfirmationViewModel model;
-            if (!hasUnconfirmedEmailAddress)
+            if (hasUnconfirmedEmailAddress)
             {
                 if (account.EmailAddress == null)
                 {

--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -116,7 +116,14 @@ namespace NuGetGallery
             ConfirmationViewModel model;
             if (!alreadyConfirmed)
             {
-                await SendNewAccountEmailAsync(account);
+                if (account.EmailAddress == null)
+                {
+                    await SendNewAccountEmailAsync(account);
+                }
+                else
+                {
+                    await SendEmailChangedConfirmationNoticeAsync(account);
+                }
 
                 model = new ConfirmationViewModel(account)
                 {

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -273,6 +273,24 @@ namespace NuGetGallery
                 Assert.NotNull(result);
                 Assert.Equal((int)HttpStatusCode.Forbidden, result.StatusCode);
             }
+
+            [Fact]
+            public async Task ResendsProperConfirmationEmail()
+            {
+                // Arrange
+                var controller = GetController();
+                var account = GetAccount(controller);
+
+                account.EmailAddress = "foo@bar.test";
+                account.UnconfirmedEmailAddress = "baz@bar.test";
+
+                // Act
+                var result = await InvokeConfirmationRequiredPostAsync(controller, account, _getFakesOrganizationAdmin) as HttpStatusCodeResult;
+
+                // Assert
+                GetMock<IMessageService>()
+                    .Verify(ms => ms.SendMessageAsync(It.IsAny<EmailChangeConfirmationMessage>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
+            }
         }
 
         public class TheConfirmAction : TheConfirmBaseAction

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -275,6 +275,26 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public async Task SendsProperNewAccountMessage()
+            {
+                // Arrange
+                var controller = GetController();
+                var account = GetAccount(controller);
+
+                account.EmailAddress = null;
+                account.UnconfirmedEmailAddress = "baz@bar.test";
+
+                // Act
+                var result = await InvokeConfirmationRequiredPostAsync(controller, account, _getFakesOrganizationAdmin) as HttpStatusCodeResult;
+
+                // Assert
+                GetMock<IMessageService>()
+                    .Verify(ms => ms.SendMessageAsync(It.IsAny<EmailChangeConfirmationMessage>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
+                GetMock<IMessageService>()
+                    .Verify(ms => ms.SendMessageAsync(It.IsAny<NewAccountMessage>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
+            }
+
+            [Fact]
             public async Task ResendsProperConfirmationEmail()
             {
                 // Arrange
@@ -290,6 +310,8 @@ namespace NuGetGallery
                 // Assert
                 GetMock<IMessageService>()
                     .Verify(ms => ms.SendMessageAsync(It.IsAny<EmailChangeConfirmationMessage>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once);
+                GetMock<IMessageService>()
+                    .Verify(ms => ms.SendMessageAsync(It.IsAny<NewAccountMessage>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
             }
         }
 


### PR DESCRIPTION
Attempt to address https://github.com/NuGet/Engineering/issues/2512
