### PR TITLE
Fix deprecation custom message issues

### DIFF
--- a/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
+++ b/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
@@ -66,9 +66,10 @@ namespace NuGetGallery
                 status |= PackageDeprecationStatus.CriticalBugs;
             }
 
+            var customMessage = request.CustomMessage;
             if (request.IsOther)
             {
-                if (string.IsNullOrWhiteSpace(request.CustomMessage))
+                if (string.IsNullOrWhiteSpace(customMessage))
                 {
                     return DeprecateErrorResponse(HttpStatusCode.BadRequest, Strings.DeprecatePackage_CustomMessageRequired);
                 }
@@ -76,17 +77,14 @@ namespace NuGetGallery
                 status |= PackageDeprecationStatus.Other;
             }
 
-            string customMessage = null;
-            if (request.CustomMessage != null)
+            if (customMessage != null)
             {
-                if (request.CustomMessage.Length > MaxCustomMessageLength)
+                if (customMessage.Length > MaxCustomMessageLength)
                 {
                     return DeprecateErrorResponse(
                         HttpStatusCode.BadRequest,
                         string.Format(Strings.DeprecatePackage_CustomMessageTooLong, MaxCustomMessageLength));
                 }
-
-                customMessage = request.CustomMessage;
             }
 
             if (request.Versions == null || !request.Versions.Any())

--- a/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
+++ b/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using System.Web.Mvc;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
-using NuGetGallery.Auditing;
 using NuGetGallery.Filters;
 
 namespace NuGetGallery
@@ -17,6 +16,8 @@ namespace NuGetGallery
     public partial class ManageDeprecationJsonApiController
         : AppController
     {
+        private const int MaxCustomMessageLength = 4000;
+
         private readonly IPackageService _packageService;
         private readonly IPackageDeprecationService _deprecationService;
         private readonly IFeatureFlagService _featureFlagService;
@@ -79,6 +80,13 @@ namespace NuGetGallery
                 }
 
                 status |= PackageDeprecationStatus.Other;
+            }
+
+            if (customMessage != null && customMessage.Length > MaxCustomMessageLength)
+            {
+                return DeprecateErrorResponse(
+                    HttpStatusCode.BadRequest, 
+                    string.Format(Strings.DeprecatePackage_CustomMessageTooLong, MaxCustomMessageLength));
             }
 
             if (versions == null || !versions.Any())

--- a/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
+++ b/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using System.Web;
 using System.Web.Mvc;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
@@ -18,7 +17,7 @@ namespace NuGetGallery
     public partial class ManageDeprecationJsonApiController
         : AppController
     {
-        private const int MaxCustomMessageLength = 4000;
+        private const int MaxCustomMessageLength = 1000;
 
         private readonly IPackageService _packageService;
         private readonly IPackageDeprecationService _deprecationService;
@@ -87,7 +86,7 @@ namespace NuGetGallery
                         string.Format(Strings.DeprecatePackage_CustomMessageTooLong, MaxCustomMessageLength));
                 }
 
-                customMessage = HttpUtility.HtmlEncode(request.CustomMessage);
+                customMessage = request.CustomMessage;
             }
 
             if (request.Versions == null || !request.Versions.Any())

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -252,6 +252,7 @@
     <Compile Include="Migrations\201905071526573_DevelopmentDependencyMetadata.Designer.cs">
       <DependentUpon>201905071526573_DevelopmentDependencyMetadata.cs</DependentUpon>
     </Compile>
+    <Compile Include="RequestModels\DeprecatePackageRequest.cs" />
     <Compile Include="Services\IPackageDeprecationService.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageIdsQuery.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageVersionsQuery.cs" />

--- a/src/NuGetGallery/RequestModels/DeprecatePackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/DeprecatePackageRequest.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Web.Mvc;
+
+namespace NuGetGallery.RequestModels
+{
+    public class DeprecatePackageRequest
+    {
+        public string Id { get; set; }
+        public IEnumerable<string> Versions { get; set; }
+        public bool IsLegacy { get; set; }
+        public bool HasCriticalBugs { get; set; }
+        public bool IsOther { get; set; }
+        public string AlternatePackageId { get; set; }
+        public string AlternatePackageVersion { get; set; }
+
+        [AllowHtml]
+        public string CustomMessage { get; set; }
+    }
+}

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -776,6 +776,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your custom message is too long. It must be under {0} characters..
+        /// </summary>
+        public static string DeprecatePackage_CustomMessageTooLong {
+            get {
+                return ResourceManager.GetString("DeprecatePackage_CustomMessageTooLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You do not have permission to deprecate this package..
         /// </summary>
         public static string DeprecatePackage_Forbidden {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1121,4 +1121,7 @@ The {1} Team</value>
   <data name="UploadPackage_EmbeddedIconNotAccepted" xml:space="preserve">
     <value>The &lt;icon&gt; element is not currently supported.</value>
   </data>
+  <data name="DeprecatePackage_CustomMessageTooLong" xml:space="preserve">
+    <value>Your custom message is too long. It must be under {0} characters.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
@@ -63,7 +63,7 @@
             @if (!string.IsNullOrEmpty(Model.CustomMessage))
             {
                 <b>Additional Details</b>
-                <p>@Model.CustomMessage</p>
+                <p>@Html.PreFormattedText(Model.CustomMessage)</p>
             }
         </div>
     </div>

--- a/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
@@ -152,7 +152,7 @@ namespace NuGetGallery.Controllers
                 var controller = GetController<ManageDeprecationJsonApiController>();
                 controller.SetCurrentUser(currentUser);
 
-                var customMessage = new string('a', 4001);
+                var customMessage = new string('a', 1001);
 
                 // Act
                 var result = await controller.Deprecate(
@@ -166,7 +166,7 @@ namespace NuGetGallery.Controllers
                     controller,
                     result,
                     HttpStatusCode.BadRequest,
-                    string.Format(Strings.DeprecatePackage_CustomMessageTooLong, 4000));
+                    string.Format(Strings.DeprecatePackage_CustomMessageTooLong, 1000));
             }
 
             public static IEnumerable<object[]> ReturnsNotFoundIfNoPackagesOrRegistrationMissing_Data
@@ -785,7 +785,6 @@ namespace NuGetGallery.Controllers
                 var deprecationService = GetMock<IPackageDeprecationService>();
 
                 var customMessage = hasCustomMessage ? "<message>" : null;
-                var encodedCustomMessage = hasCustomMessage ? "&lt;message&gt;" : null;
 
                 deprecationService
                     .Setup(x => x.UpdateDeprecation(
@@ -793,7 +792,7 @@ namespace NuGetGallery.Controllers
                         expectedStatus,
                         alternatePackageState == ReturnsSuccessful_AlternatePackage_State.Registration ? alternatePackageRegistration : null,
                         alternatePackageState == ReturnsSuccessful_AlternatePackage_State.Package ? alternatePackage : null,
-                        encodedCustomMessage,
+                        customMessage,
                         currentUser))
                     .Completes()
                     .Verifiable();


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/7277
https://github.com/NuGet/NuGetGallery/issues/7278
https://github.com/NuGet/NuGetGallery/issues/7279
https://github.com/NuGet/NuGetGallery/issues/7280
https://github.com/NuGet/NuGetGallery/issues/7281

The bulk of these changes were to move the deprecation request parameters to a model so I can add `[AllowHtml]` to the custom message. Otherwise, the changes were fairly trivial.