### PR TITLE
Add feature flag for deprecating a package with many versions

### DIFF
--- a/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
+++ b/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
@@ -81,12 +81,6 @@ namespace NuGetGallery
                 status |= PackageDeprecationStatus.Other;
             }
 
-            var currentUser = GetCurrentUser();
-            if (!_featureFlagService.IsManageDeprecationEnabled(GetCurrentUser()))
-            {
-                return DeprecateErrorResponse(HttpStatusCode.Forbidden, Strings.DeprecatePackage_Forbidden);
-            }
-
             if (versions == null || !versions.Any())
             {
                 return DeprecateErrorResponse(HttpStatusCode.BadRequest, Strings.DeprecatePackage_NoVersions);
@@ -100,6 +94,12 @@ namespace NuGetGallery
                 return DeprecateErrorResponse(
                     HttpStatusCode.NotFound,
                     string.Format(Strings.DeprecatePackage_MissingRegistration, id));
+            }
+
+            var currentUser = GetCurrentUser();
+            if (!_featureFlagService.IsManageDeprecationEnabled(GetCurrentUser(), registration))
+            {
+                return DeprecateErrorResponse(HttpStatusCode.Forbidden, Strings.DeprecatePackage_Forbidden);
             }
 
             if (ActionsRequiringPermissions.DeprecatePackage.CheckPermissionsOnBehalfOfAnyAccount(currentUser, registration) != PermissionsCheckResult.Allowed)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -751,7 +751,7 @@ namespace NuGetGallery
             model.SymbolsPackageValidationIssues = _validationService.GetLatestPackageValidationIssues(model.LatestSymbolsPackage);
             model.IsCertificatesUIEnabled = _contentObjectService.CertificatesConfiguration?.IsUIEnabledForUser(currentUser) ?? false;
             model.IsAtomFeedEnabled = _featureFlagService.IsPackagesAtomFeedEnabled();
-            model.IsPackageDeprecationEnabled = _featureFlagService.IsManageDeprecationEnabled(currentUser);
+            model.IsPackageDeprecationEnabled = _featureFlagService.IsManageDeprecationEnabled(currentUser, package.PackageRegistration);
 
             if(model.IsGitHubUsageEnabled = _featureFlagService.IsGitHubUsageEnabled(currentUser))
             {
@@ -1467,6 +1467,7 @@ namespace NuGetGallery
             // Load all versions of the package.
             var packages = _packageService.FindPackagesById(
                 id, PackageDeprecationFieldsToInclude.DeprecationAndRelationships);
+
             if (version != null)
             {
                 // Try to find the exact version if it was specified.
@@ -1492,7 +1493,7 @@ namespace NuGetGallery
                 ReportMyPackageReasons,
                 Url,
                 await _readMeService.GetReadMeMdAsync(package),
-                _featureFlagService.IsManageDeprecationEnabled(currentUser));
+                _featureFlagService.IsManageDeprecationEnabled(currentUser, package.PackageRegistration));
 
             if (!model.CanEdit && !model.CanManageOwners && !model.CanUnlistOrRelist)
             {

--- a/src/NuGetGallery/Services/FeatureFlagService.cs
+++ b/src/NuGetGallery/Services/FeatureFlagService.cs
@@ -55,10 +55,13 @@ namespace NuGetGallery
 
         public bool IsManageDeprecationEnabled(User user, PackageRegistration registration)
         {
-            var isEnabled = _client.IsEnabled(ManageDeprecationFeatureName, user, defaultValue: false);
-            return registration.Packages.Count() > _manageDeprecationForManyVersionsThreshold
-                ? _client.IsEnabled(ManageDeprecationForManyVersionsFeatureName, user, defaultValue: isEnabled)
-                : isEnabled;
+            if (!_client.IsEnabled(ManageDeprecationFeatureName, user, defaultValue: false))
+            {
+                return false;
+            }
+
+            return registration.Packages.Count() < _manageDeprecationForManyVersionsThreshold 
+                || _client.IsEnabled(ManageDeprecationForManyVersionsFeatureName, user, defaultValue: true);
         }
 
         public bool AreEmbeddedIconsEnabled(User user)

--- a/src/NuGetGallery/Services/IFeatureFlagService.cs
+++ b/src/NuGetGallery/Services/IFeatureFlagService.cs
@@ -33,9 +33,7 @@ namespace NuGetGallery
         /// Whether or not users can manage their package's deprecation state.
         /// If disabled, 
         /// </summary>
-        /// <param name="user"></param>
-        /// <returns></returns>
-        bool IsManageDeprecationEnabled(User user);
+        bool IsManageDeprecationEnabled(User user, PackageRegistration registration);
 
         /// <summary>
         /// Whether the user is allowed to publish packages with an embedded icon.

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -1136,7 +1136,7 @@ namespace NuGetGallery
                     .Returns(package);
 
                 featureFlagService
-                    .Setup(x => x.IsManageDeprecationEnabled(It.IsAny<User>()))
+                    .Setup(x => x.IsManageDeprecationEnabled(It.IsAny<User>(), package.PackageRegistration))
                     .Returns(isDeprecationEnabled);
 
                 deprecationService
@@ -1191,7 +1191,7 @@ namespace NuGetGallery
                     .Returns(package);
 
                 featureFlagService
-                    .Setup(x => x.IsManageDeprecationEnabled(TestUtility.FakeUser))
+                    .Setup(x => x.IsManageDeprecationEnabled(TestUtility.FakeUser, package.PackageRegistration))
                     .Returns(isDeprecationEnabled);
 
                 deprecationService
@@ -2668,7 +2668,7 @@ namespace NuGetGallery
 
                 var featureFlagService = GetMock<IFeatureFlagService>();
                 featureFlagService
-                    .Setup(x => x.IsManageDeprecationEnabled(currentUser))
+                    .Setup(x => x.IsManageDeprecationEnabled(currentUser, PackageRegistration))
                     .Returns(isManageDeprecationEnabled)
                     .Verifiable();
 

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Infrastructure\Lucene\GallerySearchServiceFacts.cs" />
     <Compile Include="Helpers\StreamHelperFacts.cs" />
     <Compile Include="Infrastructure\Mail\Messages\SearchSideBySideMessageFacts.cs" />
+    <Compile Include="Services\FeatureFlagServiceFacts.cs" />
     <Compile Include="Services\PackageDeprecationServiceFacts.cs" />
     <Compile Include="Services\SearchSideBySideServiceFacts.cs" />
     <Compile Include="Services\PackageUpdateServiceFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/FeatureFlagServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FeatureFlagServiceFacts.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Services.Entities;
+using NuGet.Services.FeatureFlags;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class FeatureFlagServiceFacts
+    {
+        public class TheIsManageDeprecationEnabledMethod
+        {
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void WhenManageDeprecationFeatureIsDisabled_ReturnsFalse(bool hasManyVersions)
+            {
+                // Arrange
+                var user = new User();
+                var registration = new PackageRegistration();
+                if (hasManyVersions)
+                {
+                    for (var i = 0; i < 1000; i++)
+                    {
+                        registration.Packages.Add(new Package { Key = i });
+                    }
+                }
+
+                var clientMock = new Mock<IFeatureFlagClient>();
+                clientMock
+                    .Setup(c => c.IsEnabled("NuGetGallery.ManageDeprecation", It.IsAny<IFlightUser>(), false))
+                    .Returns(false);
+
+                var service = new FeatureFlagService(clientMock.Object);
+
+                // Act
+                var result = service.IsManageDeprecationEnabled(user, registration);
+
+                // Assert
+                Assert.False(result);
+            }
+
+            [Fact]
+            public void WhenManageDeprecationFeatureIsEnabledAndFewVersions_ReturnsTrue()
+            {
+                // Arrange
+                var user = new User();
+                var registration = new PackageRegistration();
+
+                var clientMock = new Mock<IFeatureFlagClient>();
+                clientMock
+                    .Setup(c => c.IsEnabled("NuGetGallery.ManageDeprecation", It.IsAny<IFlightUser>(), false))
+                    .Returns(true);
+
+                var service = new FeatureFlagService(clientMock.Object);
+
+                // Act
+                var result = service.IsManageDeprecationEnabled(user, registration);
+
+                // Assert
+                Assert.True(result);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void WhenManageDeprecationFeatureIsEnabledAndManyVersions_ReturnsIfManageDeprecationForManyVersionsIsEnabled(
+                bool isManyVersionsEnabled)
+            {
+                // Arrange
+                var user = new User();
+                var registration = new PackageRegistration();
+                for (var i = 0; i < 1000; i++)
+                {
+                    registration.Packages.Add(new Package { Key = i });
+                }
+
+                var clientMock = new Mock<IFeatureFlagClient>();
+                clientMock
+                    .Setup(c => c.IsEnabled("NuGetGallery.ManageDeprecation", It.IsAny<IFlightUser>(), false))
+                    .Returns(true);
+
+                clientMock
+                    .Setup(c => c.IsEnabled("NuGetGallery.ManageDeprecationMany", It.IsAny<IFlightUser>(), true))
+                    .Returns(isManyVersionsEnabled);
+
+                var service = new FeatureFlagService(clientMock.Object);
+
+                // Act
+                var result = service.IsManageDeprecationEnabled(user, registration);
+
+                // Assert
+                Assert.Equal(isManyVersionsEnabled, result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/nuget/nugetgallery/issues/7159

Basically, if the feature goes haywire, we want to be able to turn it off for packages with many versions while not affecting people with few versions.

Right now I've set the cut-off at 500. I think this is sufficiently low given the performance I've seen on DEV--even doing a bulk update on a thousand versions doesn't seem to have a large effect.

Also, if the existing feature flag is enabled but the "many versions" flag is not configured, I have it returning true. This means that if the existing flag is enabled, we would need to explicitly disable it for many versions to turn it off for many versions. I think this is ideal because it will make it harder for us to not notice when it's turned on for few versions and turned off for many versions.