### PR TITLE
Emit Application Insights metric from browser for search selection

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -304,6 +304,10 @@
         return typeof ga === 'function';
     };
 
+    nuget.isAiAvailable = function () {
+        return typeof window.appInsights === 'object';
+    };
+
     nuget.getDateFormats = function (input) {
         var datetime = moment.utc(input);
 
@@ -405,6 +409,12 @@
     nuget.sendAnalyticsEvent = function (category, action, label, eventValue, options) {
         if (window.nuget.isGaAvailable()) {
             ga('send', 'event', category, action, label, eventValue, options);
+        }
+    };
+
+    nuget.sendAiMetric = function (name, value, properties) {
+        if (window.nuget.isAiAvailable()) {
+            window.appInsights.trackMetric(name, value, 1, value, value, properties);
         }
     };
 

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -80,7 +80,12 @@
 
 @section bottomScripts {
     <script type="text/javascript">
+        // Used to track how long the user waited before clicking a search selection.
+        var pageLoadTime = Date.now();
 
+        // Used to track how many selections were made on this page. Multiple selections can happen if the user opens
+        // a search selection in a new tab, instead of navigating away from this page.
+        var sincePageLoadCount = 0;
         @if (!string.IsNullOrWhiteSpace(Model.SearchTerm) && (Model.PageIndex == 0 || Model.Items.Count() > 0))
         {
             var action = Model.IncludePrerelease ? "search-prerel" : "search-stable";
@@ -88,6 +93,12 @@
             // event to be correlated in Google Analytics.
             <text>
             window.nuget.sendAnalyticsEvent('search-page', '@action', @Html.Raw(Json.Encode(Model.SearchTerm)), @Model.PageIndex);
+            window.nuget.sendAiMetric('BrowserSearchPage', @Model.PageIndex, {
+                SearchTerm: @Html.Raw(Json.Encode(Model.SearchTerm)),
+                IncludePrerelease: '@Model.IncludePrerelease',
+                PageIndex: @Model.PageIndex,
+                TotalCount: @Model.TotalCount
+            });
             </text>
         }
 
@@ -111,7 +122,42 @@
                     queryString
                 ].join('');
                 window.location.href = url;
-            })
+            });
+
+            var emitAiClickEvent = function () {
+                if (!window.nuget.isAiAvailable()) {
+                    return;
+                }
+
+                var $this = $(this);
+                var data = $this.data();
+                if ($this.attr('href') && data.track) {
+                    window.nuget.sendAiMetric('BrowserSearchSelection', data.trackValue, {
+                        SearchTerm: @Html.Raw(Json.Encode(Model.SearchTerm)),
+                        IncludePrerelease: '@Model.IncludePrerelease',
+                        PageIndex: @Model.PageIndex,
+                        TotalCount: @Model.TotalCount,
+                        ClickIndex: data.trackValue,
+                        PackageId: data.packageId,
+                        PackageVersion: data.packageVersion,
+                        UseVersion: data.useVersion,
+                        SincePageLoadMs: Date.now() - pageLoadTime,
+                        SincePageLoadCount: sincePageLoadCount
+                    });
+
+                    sincePageLoadCount++;
+                }
+            };
+            $.each($('a[data-track]'), function () {
+                $(this).mouseup(function (e) {
+                    if (e.which === 2) { // Middle-mouse click
+                        emitAiClickEvent.call(this, e);
+                    }
+                });
+                $(this).click(function (e) {
+                    emitAiClickEvent.call(this, e);
+                });
+            });
         });
     </script>
 }

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -26,7 +26,6 @@
     }
 }
 
-
 <article class="package" role="listitem">
 
     <div class="row">
@@ -42,6 +41,7 @@
                    @if (itemIndex.HasValue)
                    {
                        @:data-track="@eventName" data-track-value="@itemIndex"
+                       @:data-package-id="@Model.Id" data-package-version="@Model.Version" data-use-version="@Model.UseVersion"
                    }
                    >@Html.BreakWord(Model.Id)</a>
 

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -492,10 +492,10 @@
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Services.Contracts" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.50.0.0" newVersion="2.50.0.0"/>
-			</dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.Contracts" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.50.0.0" newVersion="2.50.0.0"/>
+      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Xml.XPath.XDocument" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7287

I will keep it side-by-side with Google Analytics so we can understand if we are missing data. I think this is a better model overall and works great for click events performed within our site.

For outgoing links we would probably need to investigate the beacon API in AI to avoid events dropped during page transition.

Issue https://github.com/NuGet/NuGetGallery/issues/7289 tracks removing GA later.