### PR TITLE
Removed the "RejectPackagesWithLicense" configuration option.

### DIFF
--- a/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
@@ -354,9 +354,6 @@ namespace NuGetGallery.Configuration
         public bool AsynchronousEmailServiceEnabled { get; set; }
 
         [DefaultValue(false)]
-        public bool RejectPackagesWithLicense { get; set; }
-
-        [DefaultValue(false)]
         public bool BlockLegacyLicenseUrl { get; set; }
 
         [DefaultValue(true)]

--- a/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
@@ -371,11 +371,6 @@ namespace NuGetGallery.Configuration
         bool AsynchronousEmailServiceEnabled { get; set; }
 
         /// <summary>
-        /// Flag that indicates whether packages with `license` node in them should be rejected.
-        /// </summary>
-        bool RejectPackagesWithLicense { get; set; }
-
-        /// <summary>
         /// Indicates whether packages that specify the license the "old" way (with a "licenseUrl" node only) should be rejected.
         /// </summary>
         bool BlockLegacyLicenseUrl { get; set; }

--- a/src/NuGetGallery.Services/ServicesStrings.Designer.cs
+++ b/src/NuGetGallery.Services/ServicesStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ServicesStrings {
@@ -2432,15 +2432,6 @@ namespace NuGetGallery {
         public static string UploadPackage_LicenseFileDoesNotExist {
             get {
                 return ResourceManager.GetString("UploadPackage_LicenseFileDoesNotExist", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to License files are not yet supported..
-        /// </summary>
-        public static string UploadPackage_LicenseFilesAreNotAllowed {
-            get {
-                return ResourceManager.GetString("UploadPackage_LicenseFilesAreNotAllowed", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery.Services/ServicesStrings.resx
+++ b/src/NuGetGallery.Services/ServicesStrings.resx
@@ -1053,9 +1053,6 @@ The {1} Team</value>
     <value>Unsupported license type '{0}'.</value>
     <comment>{0} is the license type read from the nuspec</comment>
   </data>
-  <data name="UploadPackage_LicenseFilesAreNotAllowed" xml:space="preserve">
-    <value>License files are not yet supported.</value>
-  </data>
   <data name="UploadPackage_DeprecationUrlRequiredForLicenseExpressions" xml:space="preserve">
     <value>To provide a better experience for older clients when a license expression is specified, &lt;licenseUrl&gt; must be set to '{0}'.</value>
     <comment>{0} is the licenses.nuget.org link with license expression</comment>

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -150,11 +150,6 @@ namespace NuGetGallery
 
             if (licenseElement != null)
             {
-                if (_config.RejectPackagesWithLicense)
-                {
-                    return PackageValidationResult.Invalid(Strings.UploadPackage_NotAcceptingPackagesWithLicense);
-                }
-
                 if (licenseElement.Value.Length > MaxAllowedLicenseNodeValueLength)
                 {
                     return PackageValidationResult.Invalid(Strings.UploadPackage_LicenseNodeValueTooLong);

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2445,15 +2445,6 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to License files are not yet supported..
-        /// </summary>
-        public static string UploadPackage_LicenseFilesAreNotAllowed {
-            get {
-                return ResourceManager.GetString("UploadPackage_LicenseFilesAreNotAllowed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The license file cannot be longer than {0}..
         /// </summary>
         public static string UploadPackage_LicenseFileTooLong {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1053,9 +1053,6 @@ The {1} Team</value>
     <value>Unsupported license type '{0}'.</value>
     <comment>{0} is the license type read from the nuspec</comment>
   </data>
-  <data name="UploadPackage_LicenseFilesAreNotAllowed" xml:space="preserve">
-    <value>License files are not yet supported.</value>
-  </data>
   <data name="UploadPackage_DeprecationUrlRequiredForLicenseExpressions" xml:space="preserve">
     <value>To provide a better experience for older clients when a license expression is specified, &lt;licenseUrl&gt; must be set to '{0}'.</value>
     <comment>{0} is the licenses.nuget.org link with license expression</comment>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -187,7 +187,6 @@
     <add key="PackageDelete.StatisticsUpdateFrequencyInHours" value=""/>
     <add key="PackageDelete.HourLimitWithMaximumDownloads" value=""/>
     <add key="PackageDelete.MaximumDownloadsForPackageVersion" value=""/>
-    <add key="Gallery.RejectPackagesWithLicense" value="false"/>
     <add key="Gallery.BlockLegacyLicenseUrl" value="false"/>
     <add key="Gallery.AllowLicenselessPackages" value="true"/>
   </appSettings>

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -866,58 +866,6 @@ namespace NuGetGallery
                 return new Uri(string.Format("https://licenses.nuget.org/{0}", licenseExpression));
             }
 
-            private static string[] LicenseNodeVariants => new string[]
-            {
-                "<license/>",
-                "<license></license>",
-                "<license> </license>",
-                "<license>ttt</license>",
-                "<license type='file'>fff</license>",
-                "<license type='expression'>ee</license>",
-                "<license type='foobar'>ttt</license>",
-                "<license type='file'><someChildNode /></license>",
-                "<license type='file' version='1.0.0'>fff</license>",
-                "<license type='expression' version='1.0.0'>ee</license>",
-                "<license type='foobar' version='1.0.0'>ttt</license>",
-                "<license type='file' version='1.0.0'><someChildNode /></license>",
-                "<license type='file' version='2.0.0'>fff</license>",
-                "<license type='expression' version='2.0.0'>ee</license>",
-                "<license type='foobar' version='2.0.0'>ttt</license>",
-                "<license type='file' version='2.0.0'><someChildNode /></license>",
-            };
-
-            public static IEnumerable<object[]> RejectsLicensedPackagesWhenConfigured_Input =>
-                from licenseNode in LicenseNodeVariants
-                select new object[] { licenseNode, true, false };
-
-            [Theory]
-            [MemberData(nameof(RejectsLicensedPackagesWhenConfigured_Input))]
-            public async Task RejectsLicensedPackagesWhenConfigured(string licenseNode, bool rejectPackagesWithLicense, bool expectedSuccess)
-            {
-                _config
-                    .SetupGet(x => x.RejectPackagesWithLicense)
-                    .Returns(rejectPackagesWithLicense);
-                _nuGetPackage = GeneratePackageWithUserContent(getCustomNuspecNodes: () => licenseNode);
-
-                var result = await _target.ValidateBeforeGeneratePackageAsync(
-                    _nuGetPackage.Object,
-                    GetPackageMetadata(_nuGetPackage),
-                    _currentUser);
-
-                if (expectedSuccess)
-                {
-                    Assert.Equal(PackageValidationResultType.Accepted, result.Type);
-                    Assert.Null(result.Message);
-                    Assert.Empty(result.Warnings);
-                }
-                else
-                {
-                    Assert.Equal(PackageValidationResultType.Invalid, result.Type);
-                    Assert.Contains("license", result.Message.PlainTextMessage);
-                    Assert.Empty(result.Warnings);
-                }
-            }
-
             [Fact]
             public async Task RejectsLongLicenses()
             {


### PR DESCRIPTION
Addresses #7083 

Don't need it anymore as license implementation is live for quite some time now.
There is an accompanying configuration update PR.