### PR TITLE
Clean orphan package registration on user delete

### DIFF
--- a/src/NuGetGallery.Services/AccountManagement/DeleteAccountService.cs
+++ b/src/NuGetGallery.Services/AccountManagement/DeleteAccountService.cs
@@ -203,24 +203,24 @@ namespace NuGetGallery
 
         private async Task RemovePackageOwnership(User user, User requestingUser, AccountDeletionOrphanPackagePolicy orphanPackagePolicy)
         {
-            foreach (var packageRegistation in GetPackageRegistrationsOwnedByUser(user))
+            foreach (var packageRegistration in GetPackageRegistrationsOwnedByUser(user))
             {
-                if (_packageService.WillPackageBeOrphanedIfOwnerRemoved(packageRegistation, user))
+                if (_packageService.WillPackageBeOrphanedIfOwnerRemoved(packageRegistration, user))
                 {
                     if (orphanPackagePolicy == AccountDeletionOrphanPackagePolicy.DoNotAllowOrphans)
                     {
-                        throw new InvalidOperationException($"Deleting user '{user.Username}' will make package '{packageRegistation.Id}' an orphan, but no orphans were expected.");
+                        throw new InvalidOperationException($"Deleting user '{user.Username}' will make package '{packageRegistration.Id}' an orphan, but no orphans were expected.");
                     }
                     else if (orphanPackagePolicy == AccountDeletionOrphanPackagePolicy.UnlistOrphans)
                     {
-                        foreach (var package in packageRegistation.Packages)
+                        foreach (var package in packageRegistration.Packages)
                         {
                             await _packageUpdateService.MarkPackageUnlistedAsync(package, commitChanges: false, updateIndex: false);
                         }
                     }
                 }
 
-                await _packageOwnershipManagementService.RemovePackageOwnerAsync(packageRegistation, requestingUser, user, commitChanges: false);
+                await _packageOwnershipManagementService.RemovePackageOwnerAsync(packageRegistration, requestingUser, user, commitChanges: false);
             }
         }
 

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -388,8 +388,8 @@ namespace NuGetGallery
 
         public bool WillPackageBeOrphanedIfOwnerRemoved(PackageRegistration packageRegistration, User ownerToRemove)
         {
-            // If the package was hard deleted it will return false as there is not any package to be orphaned. 
-            if(!packageRegistration.Packages.Any())
+            // If the registration has no packages, no packages will be orphaned if the owner is removed. 
+            if (!packageRegistration.Packages.Any())
             {
                 return false;
             }

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -386,9 +386,14 @@ namespace NuGetGallery
             }
         }
 
-        public bool WillPackageBeOrphanedIfOwnerRemoved(PackageRegistration package, User ownerToRemove)
+        public bool WillPackageBeOrphanedIfOwnerRemoved(PackageRegistration packageRegistration, User ownerToRemove)
         {
-            return WillPackageBeOrphanedIfOwnerRemovedHelper(package.Owners, ownerToRemove);
+            // If the package was hard deleted it will return false as there is not any package to be orphaned. 
+            if(!packageRegistration.Packages.Any())
+            {
+                return false;
+            }
+            return WillPackageBeOrphanedIfOwnerRemovedHelper(packageRegistration.Owners, ownerToRemove);
         }
 
         private bool WillPackageBeOrphanedIfOwnerRemovedHelper(IEnumerable<User> owners, User ownerToRemove)

--- a/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
@@ -389,6 +389,56 @@ namespace NuGetGallery.Services
                 Assert.Contains("An exception was encountered while trying to delete the account 'TestsUser'", result.Description);
             }
 
+            /// <summary>
+            /// An user that does not own any package but owns a registration will have the registration cleaned after deletion.
+            /// </summary>
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public async Task DeleteUserThatOwnsOrphanRegistartionWillCleanTheRegistartion(bool multipleOwners)
+            {
+                // Arrange
+                PackageRegistration registration = null;
+                var testUser = CreateTestUserWithRegistration(ref registration);
+                var newOwner = new User("newOwner");
+                newOwner.EmailAddress = "newOwner@email.com";
+                if (multipleOwners)
+                {                  
+                    registration.Owners.Add(newOwner);
+                }
+
+                var testableService = new DeleteAccountTestService(testUser, registration);
+                var deleteAccountService = testableService.GetDeleteAccountService(isPackageOrphaned: true);
+
+                // Act
+                await deleteAccountService.DeleteAccountAsync(
+                    userToBeDeleted: testUser,
+                    userToExecuteTheDelete: testUser,
+                    orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans);
+
+                // Assert
+                if(multipleOwners)
+                {
+                    Assert.Contains<User>(newOwner, registration.Owners);
+                    Assert.Equal(1, registration.Owners.Count());
+                }
+                else
+                {
+                    Assert.Empty(registration.Owners);
+                }
+            }
+
+
+            private static User CreateTestUserWithRegistration(ref PackageRegistration registration)
+            {
+                var testUser = new User("TestUser") { Key = Key++ };
+                testUser.EmailAddress = "user@test.com";
+                registration = new PackageRegistration();
+                registration.Id = "TestRegistration";
+                registration.Owners.Add(testUser);
+                return testUser;
+            }
+
             private static User CreateTestUser(ref PackageRegistration registration)
             {
                 var testUser = new User("TestUser") { Key = Key++ };
@@ -756,6 +806,7 @@ namespace NuGetGallery.Services
                 if (_user != null)
                 {
                     packageService.Setup(m => m.FindPackagesByAnyMatchingOwner(_user, true, It.IsAny<bool>())).Returns(_userPackages);
+                    packageService.Setup(m => m.FindPackageRegistrationsByOwner(_user)).Returns(new List<PackageRegistration>() { _userPackagesRegistration }.AsQueryable());
                 }
 
                 packageService

--- a/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
@@ -395,7 +395,7 @@ namespace NuGetGallery.Services
             [Theory]
             [InlineData(true)]
             [InlineData(false)]
-            public async Task DeleteUserThatOwnsOrphanRegistartionWillCleanTheRegistartion(bool multipleOwners)
+            public async Task DeleteUserThatOwnsOrphanRegistrationWillCleanTheRegistration(bool multipleOwners)
             {
                 // Arrange
                 PackageRegistration registration = null;
@@ -417,7 +417,7 @@ namespace NuGetGallery.Services
                     orphanPackagePolicy: AccountDeletionOrphanPackagePolicy.UnlistOrphans);
 
                 // Assert
-                if(multipleOwners)
+                if (multipleOwners)
                 {
                     Assert.Contains<User>(newOwner, registration.Owners);
                     Assert.Equal(1, registration.Owners.Count());
@@ -806,7 +806,12 @@ namespace NuGetGallery.Services
                 if (_user != null)
                 {
                     packageService.Setup(m => m.FindPackagesByAnyMatchingOwner(_user, true, It.IsAny<bool>())).Returns(_userPackages);
-                    packageService.Setup(m => m.FindPackageRegistrationsByOwner(_user)).Returns(new List<PackageRegistration>() { _userPackagesRegistration }.AsQueryable());
+                    var packageRegistraionList = new List<PackageRegistration>();
+                    if(_userPackagesRegistration != null)
+                    {
+                        packageRegistraionList.Add(_userPackagesRegistration);
+                    }
+                    packageService.Setup(m => m.FindPackageRegistrationsByOwner(_user)).Returns(packageRegistraionList.AsQueryable());
                 }
 
                 packageService

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -1906,25 +1906,28 @@ namespace NuGetGallery
                 }
 
                 // Configure package ownership
-                var package = new PackageRegistration() { Key = 4 };
+                var package = new Package();
+                var packageRegistration = new PackageRegistration() { Key = 4 };
+                packageRegistration.Packages.Add(package);
+
                 if (state.HasFlag(OwnershipState.OwnedByUser1))
                 {
-                    package.Owners.Add(user1);
+                    packageRegistration.Owners.Add(user1);
                 }
 
                 if (state.HasFlag(OwnershipState.OwnedByUser2))
                 {
-                    package.Owners.Add(user2);
+                    packageRegistration.Owners.Add(user2);
                 }
 
                 if (state.HasFlag(OwnershipState.OwnedByOrganization1))
                 {
-                    package.Owners.Add(organization1);
+                    packageRegistration.Owners.Add(organization1);
                 }
 
                 if (state.HasFlag(OwnershipState.OwnedByOrganization2))
                 {
-                    package.Owners.Add(organization2);
+                    packageRegistration.Owners.Add(organization2);
                 }
 
                 // Determine expected result and account to delete
@@ -1985,10 +1988,28 @@ namespace NuGetGallery
 
                 // Delete account
                 var service = CreateService();
-                var result = service.WillPackageBeOrphanedIfOwnerRemoved(package, userToDelete);
+                var result = service.WillPackageBeOrphanedIfOwnerRemoved(packageRegistration, userToDelete);
 
                 // Assert expected result
                 Assert.Equal(expectedResult, result);
+            }
+
+            [Fact]
+            public void APackageIdThatHasOnlyARegistrationCannotBeOrphaned()
+            {
+                // Create users to test
+                var user = new User("testUser") { Key = 0 };
+               
+                // Configure package registration ownership
+                var packageRegistration = new PackageRegistration() { Key = 1 };
+                packageRegistration.Owners.Add(user);
+
+                // Delete account
+                var service = CreateService();
+                var result = service.WillPackageBeOrphanedIfOwnerRemoved(packageRegistration, user);
+
+                // Assert expected result
+                Assert.False(result);
             }
 
             private void AddMemberToOrganization(Organization organization, User member)


### PR DESCRIPTION
Remove orphan registrations on user delete. 

Addresses [Deleting a user does not remove their ownership from package registrations without packages](https://github.com/NuGet/NuGetGallery/issues/7197)