### PR TITLE
Limiting the id + version length to 160 characters.

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/PackageHelper.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageHelper.cs
@@ -134,6 +134,11 @@ namespace NuGetGallery
                 throw new EntityException(ServicesStrings.NuGetPackagePropertyTooLong, "Language", "20");
             }
 
+            if (packageMetadata.Id.Length + (packageMetadata.Version?.ToFullString().Length ?? 0) > 160)
+            {
+                throw new EntityException(ServicesStrings.NuGetPackageIdVersionCombinedTooLong, "160");
+            }
+
             // Validate dependencies
             if (packageMetadata.GetDependencyGroups() != null)
             {

--- a/src/NuGetGallery.Services/PackageManagement/PackageHelper.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageHelper.cs
@@ -77,7 +77,7 @@ namespace NuGetGallery
             // TODO: Change this to use DataAnnotations
             if (packageMetadata.Id.Length > NuGet.Services.Entities.Constants.MaxPackageIdLength)
             {
-                throw new EntityException(ServicesStrings.NuGetPackagePropertyTooLong, "Id", NuGet.Services.Entities.Constants.MaxPackageIdLength);
+                throw new EntityException(ServicesStrings.NuGetPackagePropertyTooLong, "ID", NuGet.Services.Entities.Constants.MaxPackageIdLength);
             }
             if (packageMetadata.Authors != null && packageMetadata.Authors.Flatten().Length > 4000)
             {

--- a/src/NuGetGallery.Services/ServicesStrings.Designer.cs
+++ b/src/NuGetGallery.Services/ServicesStrings.Designer.cs
@@ -1229,6 +1229,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A nuget package&apos;s id and version properties combined may not be more than {0} characters long..
+        /// </summary>
+        public static string NuGetPackageIdVersionCombinedTooLong {
+            get {
+                return ResourceManager.GetString("NuGetPackageIdVersionCombinedTooLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A nuget package&apos;s {0} property is required..
         /// </summary>
         public static string NuGetPackagePropertyMissing {

--- a/src/NuGetGallery.Services/ServicesStrings.Designer.cs
+++ b/src/NuGetGallery.Services/ServicesStrings.Designer.cs
@@ -1229,7 +1229,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A nuget package&apos;s id and version properties combined may not be more than {0} characters long..
+        ///   Looks up a localized string similar to A nuget package&apos;s ID and version properties combined may not be more than {0} characters long..
         /// </summary>
         public static string NuGetPackageIdVersionCombinedTooLong {
             get {

--- a/src/NuGetGallery.Services/ServicesStrings.resx
+++ b/src/NuGetGallery.Services/ServicesStrings.resx
@@ -1118,4 +1118,7 @@ The {1} Team</value>
   <data name="UploadPackage_EmbeddedIconNotAccepted" xml:space="preserve">
     <value>The &lt;icon&gt; element is not currently supported.</value>
   </data>
+  <data name="NuGetPackageIdVersionCombinedTooLong" xml:space="preserve">
+    <value>A nuget package's id and version properties combined may not be more than {0} characters long.</value>
+  </data>
 </root>

--- a/src/NuGetGallery.Services/ServicesStrings.resx
+++ b/src/NuGetGallery.Services/ServicesStrings.resx
@@ -1119,6 +1119,6 @@ The {1} Team</value>
     <value>The &lt;icon&gt; element is not currently supported.</value>
   </data>
   <data name="NuGetPackageIdVersionCombinedTooLong" xml:space="preserve">
-    <value>A nuget package's id and version properties combined may not be more than {0} characters long.</value>
+    <value>A nuget package's ID and version properties combined may not be more than {0} characters long.</value>
   </data>
 </root>

--- a/tests/NuGetGallery.Facts/Helpers/PackageHelperTests.cs
+++ b/tests/NuGetGallery.Facts/Helpers/PackageHelperTests.cs
@@ -104,7 +104,7 @@ namespace NuGetGallery.Helpers
                     repositoryMetadata: null);
 
                 var ex = Assert.Throws<EntityException>(() => PackageHelper.ValidateNuGetPackageMetadata(metadata));
-                Assert.Contains("id and version", ex.Message);
+                Assert.Contains("ID and version", ex.Message);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Helpers/PackageHelperTests.cs
+++ b/tests/NuGetGallery.Facts/Helpers/PackageHelperTests.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Packaging;
 using NuGet.Services.Entities;
+using NuGetGallery.Packaging;
 using Xunit;
 
 namespace NuGetGallery.Helpers
@@ -78,6 +82,29 @@ namespace NuGetGallery.Helpers
                 }
 
                 Assert.Equal(expected, PackageHelper.GetSelectListText(package));
+            }
+        }
+
+        public class TheValidateNuGetPackageMetadataMethod
+        {
+            [Fact]
+            public void ChecksIdVersionCombinedLength()
+            {
+                var metadata = new PackageMetadata(
+                    new Dictionary<string, string>
+                    {
+                        { "id", "someidthatis128characterslong.padding.padding.padding.padding.padding.padding.padding.padding.padding.padding.padding.padding.a" },
+                        { "version", "1.2.3-versionthatis64characterslong-padding-padding-padding-pad" },
+                        { "description", "test description" }
+                    },
+                    Enumerable.Empty<PackageDependencyGroup>(),
+                    Enumerable.Empty<FrameworkSpecificGroup>(),
+                    Enumerable.Empty<NuGet.Packaging.Core.PackageType>(),
+                    minClientVersion: null,
+                    repositoryMetadata: null);
+
+                var ex = Assert.Throws<EntityException>(() => PackageHelper.ValidateNuGetPackageMetadata(metadata));
+                Assert.Contains("id and version", ex.Message);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -536,7 +536,7 @@ namespace NuGetGallery
 
                 var ex = await Assert.ThrowsAsync<InvalidPackageException>(async () => await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), owner: null, currentUser: null, isVerified: false));
 
-                Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "Id", NuGet.Services.Entities.Constants.MaxPackageIdLength), ex.Message);
+                Assert.Equal(String.Format(Strings.NuGetPackagePropertyTooLong, "ID", NuGet.Services.Entities.Constants.MaxPackageIdLength), ex.Message);
             }
 
             [Fact]


### PR DESCRIPTION
User friendly mitigation for https://github.com/NuGet/Engineering/issues/2481