### PR TITLE
[A/B Test 1] Add A/B test content file, flight, and telemetry

### DIFF
--- a/src/AccountDeleter/Telemetry/GalleryTelemetryService.cs
+++ b/src/AccountDeleter/Telemetry/GalleryTelemetryService.cs
@@ -17,6 +17,16 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
+        public void TrackABTestEnrollmentInitialized(int schemaVersion, int previewSearchBucket)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void TrackABTestEvaluated(string name, bool isActive, bool isAuthenticated, int testBucket, int testPercentage)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackAccountDeletionCompleted(User deletedUser, User deletedBy, bool success)
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Services/Configuration/ABTestConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/ABTestConfiguration.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace NuGetGallery.Services
+{
+    public class ABTestConfiguration : IABTestConfiguration
+    {
+        public ABTestConfiguration()
+        {
+            PreviewSearchPercentage = 0;
+        }
+
+        [JsonConstructor]
+        public ABTestConfiguration(int previewSearchPercentage)
+        {
+            GuardPercentage(previewSearchPercentage, nameof(previewSearchPercentage));
+
+            PreviewSearchPercentage = previewSearchPercentage;
+        }
+
+        public int PreviewSearchPercentage { get; }
+
+        private static void GuardPercentage(int value, string paramName)
+        {
+            if (value < 0 || value > 100)
+            {
+                throw new ArgumentOutOfRangeException(paramName, "Percentages must be between 0 and 100, inclusive.");
+            }
+        }
+    }
+}

--- a/src/NuGetGallery.Services/Configuration/IABTestConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IABTestConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Services
+{
+    public interface IABTestConfiguration
+    {
+        /// <summary>
+        /// A value between 0 and 100 (inclusive) representing the desired percentage of users the should get the preview search
+        /// experience.
+        /// </summary>
+        int PreviewSearchPercentage { get; }
+    }
+}

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -52,8 +52,10 @@
     <Compile Include="Authentication\IdentityInformation.cs" />
     <Compile Include="Authentication\NuGetScopes.cs" />
     <Compile Include="Authentication\V3Hasher.cs" />
+    <Compile Include="Configuration\ABTestConfiguration.cs" />
     <Compile Include="Configuration\AppConfiguration.cs" />
     <Compile Include="Configuration\CertificatesConfiguration.cs" />
+    <Compile Include="Configuration\IABTestConfiguration.cs" />
     <Compile Include="Configuration\IAppConfiguration.cs" />
     <Compile Include="Configuration\ICertificatesConfiguration.cs" />
     <Compile Include="Configuration\ILoginDiscontinuationConfiguration.cs" />

--- a/src/NuGetGallery.Services/ServicesConstants.cs
+++ b/src/NuGetGallery.Services/ServicesConstants.cs
@@ -40,6 +40,7 @@ namespace NuGetGallery
             public static readonly string SymbolsConfiguration = "Symbols-Configuration";
             public static readonly string TyposquattingConfiguration = "Typosquatting-Configuration";
             public static readonly string NuGetPackagesGitHubDependencies = "GitHubUsage.v1";
+            public static readonly string ABTestConfiguration = "AB-Test-Configuration";
         }
     }
 }

--- a/src/NuGetGallery.Services/Storage/ContentObjectService.cs
+++ b/src/NuGetGallery.Services/Storage/ContentObjectService.cs
@@ -23,13 +23,15 @@ namespace NuGetGallery
             CertificatesConfiguration = new CertificatesConfiguration();
             SymbolsConfiguration = new SymbolsConfiguration();
             TyposquattingConfiguration = new TyposquattingConfiguration();
+            ABTestConfiguration = new ABTestConfiguration();
         }
 
-        public ILoginDiscontinuationConfiguration LoginDiscontinuationConfiguration { get; set; }
-        public ICertificatesConfiguration CertificatesConfiguration { get; set; }
-        public ISymbolsConfiguration SymbolsConfiguration { get; set; }
-        public ITyposquattingConfiguration TyposquattingConfiguration { get; set; }
-        public IGitHubUsageConfiguration GitHubUsageConfiguration { get; set; }
+        public ILoginDiscontinuationConfiguration LoginDiscontinuationConfiguration { get; private set; }
+        public ICertificatesConfiguration CertificatesConfiguration { get; private set; }
+        public ISymbolsConfiguration SymbolsConfiguration { get; private set; }
+        public ITyposquattingConfiguration TyposquattingConfiguration { get; private set; }
+        public IGitHubUsageConfiguration GitHubUsageConfiguration { get; private set; }
+        public IABTestConfiguration ABTestConfiguration { get; private set; }
 
         public async Task Refresh()
         {
@@ -54,6 +56,10 @@ namespace NuGetGallery
                 Array.Empty<RepositoryInformation>();
 
             GitHubUsageConfiguration = new GitHubUsageConfiguration(reposCache);
+
+            ABTestConfiguration =
+               await Refresh<ABTestConfiguration>(ServicesConstants.ContentNames.ABTestConfiguration) ??
+               new ABTestConfiguration();
         }
 
         private async Task<T> Refresh<T>(string contentName)

--- a/src/NuGetGallery.Services/Storage/IContentObjectService.cs
+++ b/src/NuGetGallery.Services/Storage/IContentObjectService.cs
@@ -14,6 +14,7 @@ namespace NuGetGallery
         ISymbolsConfiguration SymbolsConfiguration { get; }
         ITyposquattingConfiguration TyposquattingConfiguration { get; }
         IGitHubUsageConfiguration GitHubUsageConfiguration { get; }
+        IABTestConfiguration ABTestConfiguration { get; }
 
         Task Refresh();
     }

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -335,5 +335,29 @@ namespace NuGetGallery
             int oldHits,
             bool newSuccess,
             int newHits);
+
+        /// <summary>
+        /// Track when an A/B test enrollment is initialized.
+        /// </summary>
+        /// <param name="schemaVersion">The schema version.</param>
+        /// <param name="previewSearchBucket">The bucket for the preview search test.</param>
+        void TrackABTestEnrollmentInitialized(
+            int schemaVersion,
+            int previewSearchBucket);
+
+        /// <summary>
+        /// Track when an A/B test is evaluated.
+        /// </summary>
+        /// <param name="name">The name of the A/B test.</param>
+        /// <param name="isActive">Whether or not the test evaluated to being active.</param>
+        /// <param name="isAuthenticated">Whether or not the user is authenticated.</param>
+        /// <param name="testBucket">The bucket the user is in.</param>
+        /// <param name="testPercentage">The percentage of users in the test.</param>
+        void TrackABTestEvaluated(
+            string name,
+            bool isActive,
+            bool isAuthenticated,
+            int testBucket,
+            int testPercentage);
     }
 }

--- a/src/NuGetGallery/App_Data/Files/Content/AB-Test-Configuration.json
+++ b/src/NuGetGallery/App_Data/Files/Content/AB-Test-Configuration.json
@@ -1,0 +1,3 @@
+{
+    "PreviewSearchPercentage": 0
+}

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -27,6 +27,12 @@
       "SiteAdmins": false,
       "Accounts": [],
       "Domains": []
+    },
+    "NuGetGallery.ABTesting": {
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
     }
   }
 }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1828,6 +1828,7 @@
     <Content Include="Areas\Admin\Views\Features\_AddFeature.cshtml" />
     <Content Include="Areas\Admin\Views\Features\_AddFlight.cshtml" />
     <Content Include="Areas\Admin\Views\Features\_EditFlight.cshtml" />
+    <Content Include="App_Data\Files\Content\AB-Test-Configuration.json" />
     <None Include="Properties\PublishProfiles\nuget-staging-frontend.pubxml" />
     <Content Include="Scripts\gallery\**\*" />
     <Content Include="Web.config">

--- a/src/NuGetGallery/Services/FeatureFlagService.cs
+++ b/src/NuGetGallery/Services/FeatureFlagService.cs
@@ -13,18 +13,17 @@ namespace NuGetGallery
     {
         private const string GalleryPrefix = "NuGetGallery.";
 
-        // Typosquatting detection
-        private const string TyposquattingFeatureName = GalleryPrefix + "Typosquatting";
-        private const string TyposquattingFlightName = GalleryPrefix + "TyposquattingFlight";
+        private const string ABTestingFlightName = GalleryPrefix + "ABTesting";
         private const string EmbeddedIconFlightName = GalleryPrefix + "EmbeddedIcons";
-        private const string SearchSideBySideFlightName = GalleryPrefix + "SearchSideBySide";
         private const string GitHubUsageFlightName = GalleryPrefix + "GitHubUsage";
-
-        private const string PackagesAtomFeedFeatureName = GalleryPrefix + "PackagesAtomFeed";
-
         private const string ManageDeprecationFeatureName = GalleryPrefix + "ManageDeprecation";
         private const string ManageDeprecationForManyVersionsFeatureName = GalleryPrefix + "ManageDeprecationMany";
         private const string ODataReadOnlyDatabaseFeatureName = GalleryPrefix + "ODataReadOnlyDatabase";
+        private const string PackagesAtomFeedFeatureName = GalleryPrefix + "PackagesAtomFeed";
+        private const string SearchCircuitBreakerFeatureName = GalleryPrefix + "SearchCircuitBreaker";
+        private const string SearchSideBySideFlightName = GalleryPrefix + "SearchSideBySide";
+        private const string TyposquattingFeatureName = GalleryPrefix + "Typosquatting";
+        private const string TyposquattingFlightName = GalleryPrefix + "TyposquattingFlight";
 
         private readonly IFeatureFlagClient _client;
 
@@ -87,6 +86,11 @@ namespace NuGetGallery
         public bool IsGitHubUsageEnabled(User user)
         {
             return _client.IsEnabled(GitHubUsageFlightName, user, defaultValue: false);
+        }
+
+        public bool IsABTestingEnabled(User user)
+        {
+            return _client.IsEnabled(ABTestingFlightName, user, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery/Services/IFeatureFlagService.cs
+++ b/src/NuGetGallery/Services/IFeatureFlagService.cs
@@ -58,5 +58,10 @@ namespace NuGetGallery
         /// Whether the OData controllers use the read-only replica.
         /// </summary>
         bool IsODataDatabaseReadOnlyEnabled();
+
+        /// <summary>
+        /// Whether the user can participate in A/B tests.
+        /// </summary>
+        bool IsABTestingEnabled(User user);
     }
 }

--- a/tests/NuGetGallery.Facts/Services/ContentObjectServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ContentObjectServiceFacts.cs
@@ -42,6 +42,10 @@ namespace NuGetGallery.Services
                 Assert.False(typosquattingConfiguration.IsCheckEnabled);
                 Assert.False(typosquattingConfiguration.IsBlockUsersEnabled);
                 Assert.Equal(TyposquattingConfiguration.DefaultPackageIdChecklistCacheExpireTimeInHours, typosquattingConfiguration.PackageIdChecklistCacheExpireTimeInHours);
+
+                var abTestConfiguration = service.ABTestConfiguration as ABTestConfiguration;
+
+                Assert.Equal(0, abTestConfiguration.PreviewSearchPercentage);
             }
 
             [Fact]
@@ -61,9 +65,6 @@ namespace NuGetGallery.Services
                 var alwaysEnabledForDomains = new[] { "a" };
                 var alwaysEnabledForEmailAddresses = new[] { "b" };
 
-                var packageIdChecklistLength = 20000;
-                var packageIdChecklistCacheExpireTimeInHours = 12.0;
-
                 var certificatesConfiguration = new CertificatesConfiguration(
                     isUIEnabledByDefault,
                     alwaysEnabledForDomains,
@@ -75,6 +76,9 @@ namespace NuGetGallery.Services
                     alwaysEnabledForDomains: alwaysEnabledForDomains,
                     alwaysEnabledForEmailAddresses: alwaysEnabledForEmailAddresses);
                 var symbolsJson = JsonConvert.SerializeObject(symbolsConfiguration);
+                
+                var packageIdChecklistLength = 20000;
+                var packageIdChecklistCacheExpireTimeInHours = 12.0;
 
                 var typosquattingConfiguration = new TyposquattingConfiguration(
                     packageIdChecklistLength: packageIdChecklistLength,
@@ -82,6 +86,12 @@ namespace NuGetGallery.Services
                     isBlockUsersEnabled: true,
                     packageIdChecklistCacheExpireTimeInHours: packageIdChecklistCacheExpireTimeInHours);
                 var typosquattingJson = JsonConvert.SerializeObject(typosquattingConfiguration);
+
+                var previewSearchPercentage = 2;
+
+                var abTestConfiguration = new ABTestConfiguration(
+                    previewSearchPercentage);
+                var abTestJson = JsonConvert.SerializeObject(abTestConfiguration);
 
                 var contentService = GetMock<IContentService>();
 
@@ -101,6 +111,10 @@ namespace NuGetGallery.Services
                     .Setup(x => x.GetContentItemAsync(ServicesConstants.ContentNames.TyposquattingConfiguration, It.IsAny<TimeSpan>()))
                     .Returns(Task.FromResult<IHtmlString>(new HtmlString(typosquattingJson)));
 
+                contentService
+                    .Setup(x => x.GetContentItemAsync(ServicesConstants.ContentNames.ABTestConfiguration, It.IsAny<TimeSpan>()))
+                    .Returns(Task.FromResult<IHtmlString>(new HtmlString(abTestJson)));
+
                 var service = GetService<ContentObjectService>();
 
                 // Act
@@ -110,6 +124,7 @@ namespace NuGetGallery.Services
                 certificatesConfiguration = service.CertificatesConfiguration as CertificatesConfiguration;
                 symbolsConfiguration = service.SymbolsConfiguration as SymbolsConfiguration;
                 typosquattingConfiguration = service.TyposquattingConfiguration as TyposquattingConfiguration;
+                abTestConfiguration = service.ABTestConfiguration as ABTestConfiguration;
 
                 // Assert
                 Assert.Equal(emails, loginDiscontinuationConfiguration.DiscontinuedForEmailAddresses);
@@ -129,6 +144,8 @@ namespace NuGetGallery.Services
                 Assert.True(typosquattingConfiguration.IsCheckEnabled);
                 Assert.True(typosquattingConfiguration.IsBlockUsersEnabled);
                 Assert.Equal(packageIdChecklistCacheExpireTimeInHours, typosquattingConfiguration.PackageIdChecklistCacheExpireTimeInHours);
+
+                Assert.Equal(previewSearchPercentage, abTestConfiguration.PreviewSearchPercentage);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -288,6 +288,14 @@ namespace NuGetGallery
                     yield return new object[] { "SearchSideBySide",
                         (TrackAction)(s => s.TrackSearchSideBySide("nuget", true, 1, true, 2))
                     };
+
+                    yield return new object[] { "ABTestEnrollmentInitialized",
+                        (TrackAction)(s => s.TrackABTestEnrollmentInitialized(1, 42))
+                    };
+
+                    yield return new object[] { "ABTestEvaluated",
+                        (TrackAction)(s => s.TrackABTestEvaluated("SearchPreview", true, true, 0, 20))
+                    };
                 }
             }
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/7166

1. Add a config type to content object service to define test percentage
1. Add a flight to turn the whole thing off if necessary
1. Add telemetry when A/B tests are evaluated and when users are enrolled

More PRs to come.