### PR TITLE
[A/B Test 2] Add A/B test enrollment service and cookie

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -412,6 +412,8 @@ namespace NuGetGallery
 
             RegisterCookieComplianceService(builder, configuration, diagnosticsService);
 
+            RegisterABTestServices(builder);
+
             builder.RegisterType<MicrosoftTeamSubscription>()
                 .AsSelf()
                 .InstancePerLifetimeScope();
@@ -431,6 +433,17 @@ namespace NuGetGallery
 
             ConfigureAutocomplete(builder, configuration);
             builder.Populate(services);
+        }
+
+        private void RegisterABTestServices(ContainerBuilder builder)
+        {
+            builder
+                .RegisterType<ABTestEnrollmentFactory>()
+                .As<IABTestEnrollmentFactory>();
+
+            builder
+                .RegisterType<CookieBasedABTestService>()
+                .As<IABTestService>();
         }
 
         private static void RegisterFeatureFlagsService(ContainerBuilder builder, ConfigurationService configuration)

--- a/src/NuGetGallery/Infrastructure/ABTestEnrollment.cs
+++ b/src/NuGetGallery/Infrastructure/ABTestEnrollment.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// This class stores a specified user's configuration about what variants of A/B tests they are participating in.
+    /// Aside from the <see cref="State"/> and <see cref="SchemaVersion"/> properties, the other properties are about
+    /// which bucket number the user falls into for different A/B tests.
+    /// 
+    /// For each A/B test, an integer in the range [0, 99] is stored. This is a bucket number. An A/B test is
+    /// configured to include a specific percentage of these buckets. For example, suppose we want to point 50% of
+    /// users to a new preview search experience. If a "PreviewSearch" property has a value of less than 50, that means
+    /// this user along with all other bucket values in range [0, 49] will get the new preview experience.
+    /// 
+    /// The reason a bucket value is stored instead of a simple boolean (i.e. UsesPreviewSearch = true | false) is to
+    /// make percentage increase transitions consistent for users. If we start with 2% of users on preview search and
+    /// then later want 10% of users, the original 2% should still see the preview search. Storing the bucket value
+    /// means that each user's placement on the range of percentage thresholds remains consistent.
+    /// </summary>
+    public class ABTestEnrollment
+    {
+        public ABTestEnrollment(ABTestEnrollmentState state, int schemaVersion, int previewSearchBucket)
+        {
+            State = state;
+            SchemaVersion = schemaVersion;
+            PreviewSearchBucket = previewSearchBucket;
+        }
+
+        public ABTestEnrollmentState State { get; }
+        public int SchemaVersion { get; }
+        public int PreviewSearchBucket { get; }
+    }
+}

--- a/src/NuGetGallery/Infrastructure/ABTestEnrollmentFactory.cs
+++ b/src/NuGetGallery/Infrastructure/ABTestEnrollmentFactory.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace NuGetGallery
+{
+    public class ABTestEnrollmentFactory : IABTestEnrollmentFactory
+    {
+        private const int SchemaVersion1 = 1;
+
+        private static readonly RNGCryptoServiceProvider _secureRng = new RNGCryptoServiceProvider();
+        private static readonly ThreadLocal<byte[]> _bytes = new ThreadLocal<byte[]>(() => new byte[sizeof(ulong)]);
+
+        private readonly ITelemetryService _telemetryService;
+        private readonly ILogger<ABTestEnrollmentFactory> _logger;
+
+        public ABTestEnrollmentFactory(
+            ITelemetryService telemetryService,
+            ILogger<ABTestEnrollmentFactory> logger)
+        {
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public ABTestEnrollment Initialize()
+        {
+            var enrollment = new ABTestEnrollment(
+                ABTestEnrollmentState.FirstHit,
+                SchemaVersion1,
+                previewSearchBucket: GetRandomWholePercentage());
+
+            _telemetryService.TrackABTestEnrollmentInitialized(
+                enrollment.SchemaVersion,
+                enrollment.PreviewSearchBucket);
+
+            return enrollment;
+        }
+
+        /// <summary>
+        /// Returns a random integer in range [1, 100].
+        /// </summary>
+        private static int GetRandomWholePercentage()
+        {
+            _secureRng.GetBytes(_bytes.Value);
+            var value = BitConverter.ToUInt64(_bytes.Value, 0);
+
+            // Note that this is very slightly biased towards values 1 through 16 because the maximum value of an
+            // unsigned 64-bit integer is not evenly divisible by 100 and therefore remainders (of mod operator) are
+            // more likely than others. This is okay since the possible range of this integer type is so much larger
+            // than 100 that the bias will be unnoticeable for us. We could mitigate this by rejecting unfavorable
+            // numbers before the mod operation but that's too much work.
+            return (int)(value % 100) + 1;
+        }
+
+        public string Serialize(ABTestEnrollment enrollment)
+        {
+            if (enrollment.SchemaVersion != SchemaVersion1)
+            {
+                throw new NotImplementedException($"Serializing schema version {enrollment.SchemaVersion} is not implemented.");
+            }
+
+            var deserialized = new StateVersion1
+            {
+                SchemaVersion = SchemaVersion1,
+                PreviewSearchBucket = enrollment.PreviewSearchBucket,
+            };
+
+            return JsonConvert.SerializeObject(deserialized);
+        }
+
+        public bool TryDeserialize(string serialized, out ABTestEnrollment enrollment)
+        {
+            enrollment = null;
+            if (string.IsNullOrWhiteSpace(serialized))
+            {
+                return false;
+            }
+
+            try
+            {
+                var v1 = JsonConvert.DeserializeObject<StateVersion1>(serialized);
+                if (v1 == null
+                    || v1.SchemaVersion != SchemaVersion1
+                    || IsNotPercentage(v1.PreviewSearchBucket))
+                {
+                    return false;
+                }
+
+                enrollment = new ABTestEnrollment(
+                    ABTestEnrollmentState.Active,
+                    v1.SchemaVersion,
+                    v1.PreviewSearchBucket);
+
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsNotPercentage(int input)
+        {
+            return input < 1 || input > 100;
+        }
+
+        private class StateVersion1
+        {
+            [JsonProperty("v", Required = Required.Always)]
+            public int SchemaVersion { get; set; }
+
+            [JsonProperty("ps", Required = Required.Always)]
+            public int PreviewSearchBucket { get; set; }
+        }
+    }
+}

--- a/src/NuGetGallery/Infrastructure/ABTestEnrollmentState.cs
+++ b/src/NuGetGallery/Infrastructure/ABTestEnrollmentState.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public enum ABTestEnrollmentState
+    {
+        /// <summary>
+        /// The user was enrolled for A/B testing in the current request.
+        /// </summary>
+        FirstHit,
+
+        /// <summary>
+        /// The user is already enrolled in the latest version A/B testing.
+        /// </summary>
+        Active,
+    }
+}

--- a/src/NuGetGallery/Infrastructure/CookieBasedABTestService.cs
+++ b/src/NuGetGallery/Infrastructure/CookieBasedABTestService.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Web;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.Entities;
+using NuGetGallery.Cookies;
+using NuGetGallery.Services;
+
+namespace NuGetGallery
+{
+    public class CookieBasedABTestService : IABTestService
+    {
+        private const string CookieName = "nugetab";
+
+        private readonly HttpContextBase _httpContext;
+        private readonly IFeatureFlagService _featureFlagService;
+        private readonly IABTestEnrollmentFactory _enrollmentFactory;
+        private readonly IContentObjectService _contentObjectService;
+        private readonly ICookieComplianceService _cookieComplianceService;
+        private readonly ITelemetryService _telemetryService;
+        private readonly ILogger<CookieBasedABTestService> _logger;
+        private readonly Lazy<ABTestEnrollment> _lazyEnrollment;
+
+        public CookieBasedABTestService(
+            HttpContextBase httpContext,
+            IFeatureFlagService featureFlagService,
+            IABTestEnrollmentFactory enrollmentFactory,
+            IContentObjectService contentObjectService,
+            ICookieComplianceService cookieComplianceService,
+            ITelemetryService telemetryService,
+            ILogger<CookieBasedABTestService> logger)
+        {
+            _httpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
+            _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
+            _enrollmentFactory = enrollmentFactory ?? throw new ArgumentNullException(nameof(enrollmentFactory));
+            _contentObjectService = contentObjectService ?? throw new ArgumentNullException(nameof(contentObjectService));
+            _cookieComplianceService = cookieComplianceService ?? throw new ArgumentNullException(nameof(cookieComplianceService));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _lazyEnrollment = new Lazy<ABTestEnrollment>(DetermineEnrollment);
+        }
+
+        public bool IsPreviewSearchEnabled(User user)
+        {
+            return IsActive(
+                nameof(Enrollment.PreviewSearchBucket),
+                user,
+                enrollment => enrollment.PreviewSearchBucket,
+                config => config.PreviewSearchPercentage);
+        }
+
+        private ABTestEnrollment Enrollment => _lazyEnrollment.Value;
+        private IABTestConfiguration Config => _contentObjectService.ABTestConfiguration;
+
+        private ABTestEnrollment DetermineEnrollment()
+        {
+            // Try to read the cookie from the request cookies.
+            ABTestEnrollment enrollment;
+            var requestCookie = _httpContext.Request.Cookies[CookieName];
+            if (requestCookie == null || string.IsNullOrWhiteSpace(requestCookie.Value))
+            {
+                // There is no A/B test cookie at all. Initialize one.
+                enrollment = _enrollmentFactory.Initialize();
+            }
+            else if (!_enrollmentFactory.TryDeserialize(requestCookie.Value, out enrollment))
+            {
+                // The A/B test cookie could not be deserialized.
+                enrollment = _enrollmentFactory.Initialize();
+                _logger.LogWarning("An A/B test cookie could not be deserialized: {Value}", requestCookie.Value);
+            }
+
+            if (enrollment.State == ABTestEnrollmentState.FirstHit)
+            {
+                var responseCookie = new HttpCookie(CookieName)
+                {
+                    HttpOnly = true,
+                    Secure = true,
+                    Value = _enrollmentFactory.Serialize(enrollment),
+                    Expires = DateTime.MaxValue,
+                };
+                _httpContext.Response.Cookies.Add(responseCookie);
+            }
+
+            return enrollment;
+        }
+
+        private bool IsActive(
+            string name,
+            User user,
+            Func<ABTestEnrollment, int> getTestBucket,
+            Func<IABTestConfiguration, int> getTestPercentage)
+        {
+            var isAuthenticated = user != null;
+            var authStatus = isAuthenticated ? "authenticated" : "anonymous";
+            const string inactive = "inactive";
+            const string active = "active";
+
+            if (!_cookieComplianceService.CanWriteNonEssentialCookies(_httpContext.Request))
+            {
+                _logger.LogInformation(
+                    "A/B test {Name} is {TestStatus} for an {AuthStatus} user due to no cookie consent.",
+                    name,
+                    inactive,
+                    authStatus);
+
+                return false;
+            }
+
+            if (!_featureFlagService.IsABTestingEnabled(user))
+            {
+                _logger.LogInformation(
+                    "A/B test {Name} is {TestStatus} for an {AuthStatus} user due to the general A/B testing " +
+                    "feature flag.",
+                    name,
+                    inactive,
+                    authStatus);
+
+                return false;
+            }
+
+            var testBucket = getTestBucket(Enrollment);
+            var testPercentage = getTestPercentage(Config);
+            var isActive = testBucket <= testPercentage;
+
+            _telemetryService.TrackABTestEvaluated(
+                name,
+                isActive,
+                isAuthenticated,
+                testBucket,
+                testPercentage);
+            _logger.LogInformation(
+                "A/B test {Name} is {TestStatus} for an {AuthStatus} user due to enrollment value " +
+                "{EnrollmentValue} and config value {ConfigValue}.",
+                name,
+                isActive ? active : inactive,
+                authStatus,
+                testBucket,
+                testPercentage);
+
+            return isActive;
+        }
+    }
+}

--- a/src/NuGetGallery/Infrastructure/IABTestEnrollmentFactory.cs
+++ b/src/NuGetGallery/Infrastructure/IABTestEnrollmentFactory.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Responsible for initializing, serializing, and deserializing <see cref="ABTestEnrollment"/> instances.
+    /// </summary>
+    public interface IABTestEnrollmentFactory
+    {
+        /// <summary>
+        /// Initialize the A/B test enrollment instance. This is where the "coin is flipped" regarding which variants
+        /// of a behavior a user will experience.
+        /// </summary>
+        ABTestEnrollment Initialize();
+
+        /// <summary>
+        /// Serialize an existing A/B test enrollment to a string.
+        /// </summary>
+        string Serialize(ABTestEnrollment enrollment);
+
+        /// <summary>
+        /// Try to deserialize an A/B test enrollment from a string. <paramref name="enrollment"/> will be set to null
+        /// if the return value is false. It will be set to a non-null enrollment instance if the return value is true.
+        /// </summary>
+        /// <param name="serialized">The serialized A/B test enrollment.</param>
+        /// <param name="enrollment">The output enrollment.</param>
+        /// <returns>True if the enrollment was deserialized. False otherwise.</returns>
+        bool TryDeserialize(string serialized, out ABTestEnrollment enrollment);
+    }
+}

--- a/src/NuGetGallery/Infrastructure/IABTestService.cs
+++ b/src/NuGetGallery/Infrastructure/IABTestService.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Services.Entities;
+
+namespace NuGetGallery
+{
+    public interface IABTestService
+    {
+        /// <summary>
+        /// Whether or not the user should see the preview search implementation.
+        /// </summary>
+        bool IsPreviewSearchEnabled(User user);
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -227,6 +227,12 @@
     <Compile Include="Controllers\ExperimentsController.cs" />
     <Compile Include="Controllers\ManageDeprecationJsonApiController.cs" />
     <Compile Include="ExtensionMethods.cs" />
+    <Compile Include="Infrastructure\ABTestEnrollment.cs" />
+    <Compile Include="Infrastructure\ABTestEnrollmentState.cs" />
+    <Compile Include="Infrastructure\ABTestEnrollmentFactory.cs" />
+    <Compile Include="Infrastructure\CookieBasedABTestService.cs" />
+    <Compile Include="Infrastructure\IABTestEnrollmentFactory.cs" />
+    <Compile Include="Infrastructure\IABTestService.cs" />
     <Compile Include="Infrastructure\Lucene\Correlation\CorrelatingHttpClientHandler.cs" />
     <Compile Include="Infrastructure\Lucene\Correlation\WebApiCorrelationHandler.cs" />
     <Compile Include="Infrastructure\Lucene\IIndexingJobFactory.cs" />

--- a/tests/NuGetGallery.Facts/Infrastructure/ABTestEnrollmentFactoryFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/ABTestEnrollmentFactoryFacts.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class ABTestEnrollmentFactoryFacts
+    {
+        public class Initialize : Facts
+        {
+            [Fact]
+            public void CreatesANewEnrollmentInstance()
+            {
+                var enrollment = Target.Initialize();
+
+                Assert.NotNull(enrollment);
+                Assert.Equal(ABTestEnrollmentState.FirstHit, enrollment.State);
+                Assert.Equal(1, enrollment.SchemaVersion);
+                Assert.InRange(enrollment.PreviewSearchBucket, 1, 100);
+            }
+        }
+
+        public class Serialize : Facts
+        {
+            [Fact]
+            public void ProducesExpectedString()
+            {
+                var enrollment = new ABTestEnrollment(
+                    ABTestEnrollmentState.Active,
+                    schemaVersion: 1,
+                    previewSearchBucket: 42);
+
+                var serialized = Target.Serialize(enrollment);
+
+                Assert.Equal(@"{""v"":1,""ps"":42}", serialized);
+            }
+        }
+
+        public class Deserialize : Facts
+        {
+            [Theory]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData("   ")]
+            [InlineData(" \t ")]
+            [InlineData("{}")]
+            [InlineData("[]")]
+            [InlineData("null")]
+            [InlineData(@"{""ps"":42}")]
+            [InlineData(@"{""v"":2,""ps"":42}")]
+            [InlineData(@"{""v"":1}")]
+            [InlineData(@"{""v"":1,""ps"":-1}")]
+            [InlineData(@"{""v"":1,""ps"":0}")]
+            [InlineData(@"{""v"":1,""ps"":101}")]
+            public void RejectsInvalid(string input)
+            {
+                var success = Target.TryDeserialize(input, out var enrollment);
+
+                Assert.False(success, "The derialization should have failed.");
+                Assert.Null(enrollment);
+            }
+
+            [Theory]
+            [InlineData(@"{""v"":1,""ps"":42}", 42)]
+            [InlineData(@"{""v"":1,""ps"":42,""zzz"":false}", 42)]
+            [InlineData(@"{""v"":1,""ps"":1}", 1)]
+            [InlineData(@"{""v"":1,""ps"":100}", 100)]
+            public void ParsesValid(string input, int previewSearchBucket)
+            {
+                var success = Target.TryDeserialize(input, out var enrollment);
+
+                Assert.True(success, "The derialization should have succeeded.");
+                Assert.NotNull(enrollment);
+                Assert.Equal(ABTestEnrollmentState.Active, enrollment.State);
+                Assert.Equal(1, enrollment.SchemaVersion);
+                Assert.Equal(previewSearchBucket, enrollment.PreviewSearchBucket);
+            }
+        }
+
+        public abstract class Facts
+        {
+            public Facts()
+            {
+                TelemetryService = new Mock<ITelemetryService>();
+                Logger = new Mock<ILogger<ABTestEnrollmentFactory>>();
+
+                Target = new ABTestEnrollmentFactory(TelemetryService.Object, Logger.Object);
+            }
+
+            public Mock<ITelemetryService> TelemetryService { get; }
+            public Mock<ILogger<ABTestEnrollmentFactory>> Logger { get; }
+            public ABTestEnrollmentFactory Target { get; }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Infrastructure/CookieBasedABTestServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/CookieBasedABTestServiceFacts.cs
@@ -1,0 +1,226 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Web;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Services.Entities;
+using NuGetGallery.Cookies;
+using NuGetGallery.Services;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class CookieBasedABTestServiceFacts
+    {
+        public class IsPreviewSearchEnabled : BaseSerializationFacts
+        {
+            [Theory]
+            [InlineData(1, 0, false)]
+            [InlineData(1, 1, true)]
+            [InlineData(49, 50, true)]
+            [InlineData(50, 50, true)]
+            [InlineData(50, 51, true)]
+            [InlineData(99, 100, true)]
+            [InlineData(100, 100, true)]
+            public void ComparesEnrollmentToConfig(int enrollment, int config, bool enabled)
+            {
+                InitializedEnrollment = new ABTestEnrollment(
+                    ABTestEnrollmentState.FirstHit,
+                    schemaVersion: 1,
+                    previewSearchBucket: enrollment);
+                Configuration.Setup(x => x.PreviewSearchPercentage).Returns(config);
+
+                var result = Target.IsPreviewSearchEnabled(User);
+
+                Assert.Equal(enabled, result);
+            }
+
+            protected override bool RunTest(User user)
+            {
+                return Target.IsPreviewSearchEnabled(user);
+            }
+        }
+
+        public abstract class BaseSerializationFacts : Facts
+        {
+            [Fact]
+            public void ReturnsFalseWhenCookieConsentIsNotGiven()
+            {
+                CookieComplianceService
+                    .Setup(x => x.CanWriteNonEssentialCookies(It.IsAny<HttpRequestBase>()))
+                    .Returns(false);
+
+                var result = RunTest(User);
+
+                Assert.False(result, "The test should not be enabled.");
+                CookieComplianceService.Verify(x => x.CanWriteNonEssentialCookies(HttpContext.Object.Request), Times.Once);
+                Assert.Empty(ResponseCookies);
+                EnrollmentFactory.Verify(x => x.Initialize(), Times.Never);
+                ABTestEnrollment outEnrollment;
+                EnrollmentFactory.Verify(x => x.TryDeserialize(It.IsAny<string>(), out outEnrollment), Times.Never);
+            }
+
+            [Fact]
+            public void ReturnsFalseWhenUserIsNotInFlight()
+            {
+                FeatureFlagService
+                    .Setup(x => x.IsABTestingEnabled(It.IsAny<User>()))
+                    .Returns(false);
+
+                var result = RunTest(User);
+
+                Assert.False(result, "The test should not be enabled.");
+                FeatureFlagService.Verify(x => x.IsABTestingEnabled(User), Times.Once);
+                Assert.Empty(ResponseCookies);
+                EnrollmentFactory.Verify(x => x.Initialize(), Times.Never);
+                ABTestEnrollment outEnrollment;
+                EnrollmentFactory.Verify(x => x.TryDeserialize(It.IsAny<string>(), out outEnrollment), Times.Never);
+            }
+
+            [Fact]
+            public void InitializesWhenCookieIsMissing()
+            {
+                var result = RunTest(User);
+
+                Assert.True(result, "The test should be enabled.");
+                Assert.Contains(CookieName, ResponseCookies.Keys.Cast<string>());
+                var cookie = ResponseCookies[CookieName];
+                VerifyCookie(cookie);
+                EnrollmentFactory.Verify(x => x.Initialize(), Times.Once);
+                EnrollmentFactory.Verify(x => x.Serialize(InitializedEnrollment), Times.Once);
+                EnrollmentFactory.Verify(x => x.Serialize(It.IsAny<ABTestEnrollment>()), Times.Once);
+                EnrollmentFactory.Verify(x => x.TryDeserialize(It.IsAny<string>(), out OutEnrollment), Times.Never);
+            }
+
+            [Fact]
+            public void DeserializesWhenCookieIsPresentAndValid()
+            {
+                RequestCookies.Add(new HttpCookie(CookieName, SerializedEnrollment));
+
+                var result = RunTest(User);
+
+                Assert.True(result, "The test should be enabled.");
+                Assert.Empty(ResponseCookies.Keys.Cast<string>());
+                EnrollmentFactory.Verify(x => x.Initialize(), Times.Never);
+                EnrollmentFactory.Verify(x => x.Serialize(It.IsAny<ABTestEnrollment>()), Times.Never);
+                EnrollmentFactory.Verify(x => x.TryDeserialize(It.IsAny<string>(), out OutEnrollment), Times.Once);
+            }
+
+            [Fact]
+            public void InitializesWhenCookieIsPresentAndInvalid()
+            {
+                RequestCookies.Add(new HttpCookie(CookieName, SerializedEnrollment));
+                EnrollmentFactory
+                    .Setup(x => x.TryDeserialize(It.IsAny<string>(), out OutEnrollment))
+                    .Returns(false);
+
+                var result = RunTest(User);
+
+                Assert.True(result, "The test should be enabled.");
+                Assert.Contains(CookieName, ResponseCookies.Keys.Cast<string>());
+                var cookie = ResponseCookies[CookieName];
+                VerifyCookie(cookie);
+                EnrollmentFactory.Verify(x => x.Initialize(), Times.Once);
+                EnrollmentFactory.Verify(x => x.Serialize(InitializedEnrollment), Times.Once);
+                EnrollmentFactory.Verify(x => x.Serialize(It.IsAny<ABTestEnrollment>()), Times.Once);
+                EnrollmentFactory.Verify(x => x.TryDeserialize(It.IsAny<string>(), out OutEnrollment), Times.Once);
+            }
+
+            /// <summary>
+            /// Run the test. The caller expects the method to return true.
+            /// </summary>
+            protected abstract bool RunTest(User user);
+        }
+
+        public abstract class Facts
+        {
+            public const string CookieName = "nugetab";
+
+            public Facts()
+            {
+                HttpContext = new Mock<HttpContextBase>();
+                FeatureFlagService = new Mock<IFeatureFlagService>();
+                EnrollmentFactory = new Mock<IABTestEnrollmentFactory>();
+                ContentObjectService = new Mock<IContentObjectService>();
+                Configuration = new Mock<IABTestConfiguration>();
+                CookieComplianceService = new Mock<ICookieComplianceService>();
+                TelemetryService = new Mock<ITelemetryService>();
+                Logger = new Mock<ILogger<CookieBasedABTestService>>();
+
+                User = new User();
+                InitializedEnrollment = new ABTestEnrollment(
+                    ABTestEnrollmentState.FirstHit,
+                    schemaVersion: 1,
+                    previewSearchBucket: 23);
+                DeserializedEnrollment = new ABTestEnrollment(
+                    ABTestEnrollmentState.Active,
+                    schemaVersion: 1,
+                    previewSearchBucket: 42);
+                OutEnrollment = DeserializedEnrollment;
+                SerializedEnrollment = "fake-serialization";
+                RequestCookies = new HttpCookieCollection();
+                ResponseCookies = new HttpCookieCollection();
+                PreviewSearchPercentage = 100;
+
+                HttpContext.Setup(x => x.Request.Cookies).Returns(() => RequestCookies);
+                HttpContext.Setup(x => x.Response.Cookies).Returns(() => ResponseCookies);
+                CookieComplianceService.SetReturnsDefault(true);
+                FeatureFlagService.SetReturnsDefault(true);
+
+                EnrollmentFactory.Setup(x => x.Initialize()).Returns(() => InitializedEnrollment);
+                EnrollmentFactory
+                    .Setup(x => x.TryDeserialize(It.IsAny<string>(), out OutEnrollment))
+                    .Returns(true);
+                EnrollmentFactory
+                    .Setup(x => x.Serialize(It.IsAny<ABTestEnrollment>()))
+                    .Returns(() => SerializedEnrollment);
+
+                ContentObjectService.Setup(x => x.ABTestConfiguration).Returns(() => Configuration.Object);
+                Configuration.Setup(x => x.PreviewSearchPercentage).Returns(() => PreviewSearchPercentage);
+
+                Target = new CookieBasedABTestService(
+                    HttpContext.Object,
+                    FeatureFlagService.Object,
+                    EnrollmentFactory.Object,
+                    ContentObjectService.Object,
+                    CookieComplianceService.Object,
+                    TelemetryService.Object,
+                    Logger.Object);
+            }
+
+            public Mock<HttpContextBase> HttpContext { get; }
+            public Mock<IFeatureFlagService> FeatureFlagService { get; }
+            public Mock<IABTestEnrollmentFactory> EnrollmentFactory { get; }
+            public Mock<IContentObjectService> ContentObjectService { get; }
+            public Mock<IABTestConfiguration> Configuration { get; }
+            public Mock<ICookieComplianceService> CookieComplianceService { get; }
+            public Mock<ITelemetryService> TelemetryService { get; }
+            public Mock<ILogger<CookieBasedABTestService>> Logger { get; }
+            public User User { get; }
+            public ABTestEnrollment InitializedEnrollment { get; set; }
+            public ABTestEnrollment DeserializedEnrollment { get; }
+            public ABTestEnrollment OutEnrollment;
+            public string SerializedEnrollment { get; }
+            public HttpCookieCollection RequestCookies { get; }
+            public HttpCookieCollection ResponseCookies { get; }
+            public int PreviewSearchPercentage { set; get; }
+            public CookieBasedABTestService Target { get; }
+
+            public void VerifyCookie(HttpCookie cookie)
+            {
+                Assert.NotNull(cookie);
+                Assert.Equal(SerializedEnrollment, cookie.Value);
+                Assert.True(cookie.HttpOnly, "The cookie should be HTTP only.");
+                Assert.True(cookie.Secure, "The cookie should be secure.");
+                Assert.Equal(DateTime.MaxValue, cookie.Expires);
+                Assert.Equal("/", cookie.Path);
+                Assert.Null(cookie.Domain);
+                Assert.False(cookie.HasKeys, "The cookie itself should not have keys.");
+                Assert.False(cookie.Shareable, "The cookie should not be shareable.");
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -85,6 +85,8 @@
     <Compile Include="Controllers\AccountsControllerFacts.cs" />
     <Compile Include="Controllers\OrganizationsControllerFacts.cs" />
     <Compile Include="Controllers\SupportControllerFacts.cs" />
+    <Compile Include="Infrastructure\ABTestEnrollmentFactoryFacts.cs" />
+    <Compile Include="Infrastructure\CookieBasedABTestServiceFacts.cs" />
     <Compile Include="Infrastructure\Lucene\SearchPolicyFacts.cs" />
     <Compile Include="Infrastructure\Lucene\ResilientSearchServiceFacts.cs" />
     <Compile Include="Infrastructure\Lucene\GallerySearchServiceFacts.cs" />


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/7166
Depends on https://github.com/NuGet/NuGetGallery/pull/7310

This is the meat of the assignment logic for A/B testing.