### PR TITLE
[A/B Test 3] Integrate A/B test service with package search

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -68,6 +68,11 @@ namespace NuGetGallery
             public const string PreviewSearchClient = "PreviewSearchClientBindingKey";
         }
 
+        public static class ParameterNames
+        {
+            public const string PackagesController_PreviewSearchService = "previewSearchService";
+        }
+
         protected override void Load(ContainerBuilder builder)
         {
             var services = new ServiceCollection();
@@ -801,6 +806,14 @@ namespace NuGetGallery
                     c.Resolve<IMessageService>(),
                     c.Resolve<IMessageServiceConfiguration>()))
                 .As<ISearchSideBySideService>()
+                .InstancePerLifetimeScope();
+
+            builder
+                .RegisterType<PackagesController>()
+                .WithParameter(new ResolvedParameter(
+                    (pi, ctx) => pi.ParameterType == typeof(ISearchService) && pi.Name == ParameterNames.PackagesController_PreviewSearchService,
+                    (pi, ctx) => ctx.ResolveKeyed<ISearchService>(BindingKeys.PreviewSearchClient)))
+                .As<PackagesController>()
                 .InstancePerLifetimeScope();
         }
 

--- a/src/NuGetGallery/ViewModels/PackageListViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageListViewModel.cs
@@ -20,7 +20,8 @@ namespace NuGetGallery
             int pageIndex,
             int pageSize,
             UrlHelper url,
-            bool includePrerelease)
+            bool includePrerelease,
+            bool isPreviewSearch)
         {
             // TODO: Implement actual sorting
             IEnumerable<ListPackageItemViewModel> items = packages.ToList().Select(pv => new ListPackageItemViewModel(pv, currentUser));
@@ -41,6 +42,7 @@ namespace NuGetGallery
             LastResultIndex = FirstResultIndex + Items.Count() - 1;
             Pager = pager;
             IncludePrerelease = includePrerelease;
+            IsPreviewSearch = isPreviewSearch;
         }
 
         public int FirstResultIndex { get; }
@@ -62,5 +64,7 @@ namespace NuGetGallery
         public DateTime? IndexTimestampUtc { get; }
 
         public bool IncludePrerelease { get; }
+
+        public bool IsPreviewSearch { get; }
     }
 }

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -61,12 +61,15 @@
     }
 
     <div class="list-packages" role="list">
-        @{ var itemIndex = Model.PageIndex * Model.PageSize; }
+        @{
+            var itemIndex = Model.PageIndex * Model.PageSize;
+            var eventName = Model.IsPreviewSearch ? "preview-search-selection" : "search-selection";
+        }
         @foreach (var package in Model.Items)
         {
             // Only set an item index when there is a search query, for now.
             var thisItemIndex = string.IsNullOrWhiteSpace(Model.SearchTerm) ? null : (int?) itemIndex;
-            @Html.Partial("_ListPackage", package, new ViewDataDictionary { { "itemIndex", thisItemIndex } })
+            @Html.Partial("_ListPackage", package, new ViewDataDictionary { { "itemIndex", thisItemIndex }, { "eventName", eventName } })
             itemIndex++;
         }
     </div>
@@ -88,16 +91,18 @@
         var sincePageLoadCount = 0;
         @if (!string.IsNullOrWhiteSpace(Model.SearchTerm) && (Model.PageIndex == 0 || Model.Items.Count() > 0))
         {
+            var category = Model.IsPreviewSearch ? "preview-search-page" : "search-page";
             var action = Model.IncludePrerelease ? "search-prerel" : "search-stable";
             // Emit an event representing the search page and the page index. This make it easier for the search selection
             // event to be correlated in Google Analytics.
             <text>
-            window.nuget.sendAnalyticsEvent('search-page', '@action', @Html.Raw(Json.Encode(Model.SearchTerm)), @Model.PageIndex);
+            window.nuget.sendAnalyticsEvent('@category', '@action', @Html.Raw(Json.Encode(Model.SearchTerm)), @Model.PageIndex);
             window.nuget.sendAiMetric('BrowserSearchPage', @Model.PageIndex, {
                 SearchTerm: @Html.Raw(Json.Encode(Model.SearchTerm)),
                 IncludePrerelease: '@Model.IncludePrerelease',
                 PageIndex: @Model.PageIndex,
-                TotalCount: @Model.TotalCount
+                TotalCount: @Model.TotalCount,
+                IsPreviewSearch: '@Model.IsPreviewSearch'
             });
             </text>
         }
@@ -142,7 +147,8 @@
                         PackageVersion: data.packageVersion,
                         UseVersion: data.useVersion,
                         SincePageLoadMs: Date.now() - pageLoadTime,
-                        SincePageLoadCount: sincePageLoadCount
+                        SincePageLoadCount: sincePageLoadCount,
+                        IsPreviewSearch: '@Model.IsPreviewSearch'
                     });
 
                     sincePageLoadCount++;


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGetGallery/pull/7311
Address https://github.com/NuGet/NuGetGallery/issues/7166

This toggles the search client used for package search based on the user's cookie. This also toggles the telemetry emitted.