### PR TITLE
Additional Statistics Telemetry

### DIFF
--- a/src/AccountDeleter/Telemetry/GalleryTelemetryService.cs
+++ b/src/AccountDeleter/Telemetry/GalleryTelemetryService.cs
@@ -42,7 +42,27 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
+        public void TrackDownloadCountDecreasedDuringRefresh(string packageId, string packageVersion, long oldCount, long newCount)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void TrackDownloadJsonRefreshDuration(long milliseconds)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackException(Exception exception, Action<Dictionary<string, string>> addProperties)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void TrackGetPackageDownloadCountFailed(string packageId, string packageVersion)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void TrackGetPackageRegistrationDownloadCountFailed(string packageId)
         {
             throw new NotImplementedException();
         }
@@ -162,6 +182,11 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
+        public void TrackPackageDownloadCountDecreasedFromGallery(string packageId, string packageVersion, long galleryCount, long jsonCount)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackPackageHardDeleteReflow(string packageId, string packageVersion)
         {
             throw new NotImplementedException();
@@ -208,6 +233,11 @@ namespace NuGetGallery.AccountDeleter
         }
 
         public void TrackPackageReflow(Package package)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void TrackPackageRegistrationDownloadCountDecreasedFromGallery(string packageId, long galleryCount, long jsonCount)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -12,6 +12,18 @@ namespace NuGetGallery
 {
     public interface ITelemetryService
     {
+        void TrackGetPackageDownloadCountFailed(string packageId, string packageVersion);
+
+        void TrackGetPackageRegistrationDownloadCountFailed(string packageId);
+
+        void TrackDownloadJsonRefreshDuration(long milliseconds);
+
+        void TrackDownloadCountDecreasedDuringRefresh(string packageId, string packageVersion, long oldCount, long newCount);
+
+        void TrackPackageDownloadCountDecreasedFromGallery(string packageId, string packageVersion, long galleryCount, long jsonCount);
+
+        void TrackPackageRegistrationDownloadCountDecreasedFromGallery(string packageId, long galleryCount, long jsonCount);
+
         void TrackODataQueryFilterEvent(string callContext, bool isEnabled, bool isAllowed, string queryPattern);
 
         void TrackODataCustomQuery(bool? customQuery);

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -1053,7 +1053,7 @@ namespace NuGetGallery
                 .AsSelf()
                 .As<IDownloadCountService>()
                 .SingleInstance();
-            ObjectMaterializedInterception.AddInterceptor(new DownloadCountObjectMaterializedInterceptor(downloadCountService));
+            ObjectMaterializedInterception.AddInterceptor(new DownloadCountObjectMaterializedInterceptor(downloadCountService, telemetryClient));
 
             builder.RegisterType<JsonStatisticsService>()
                 .AsSelf()

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -401,7 +401,7 @@ namespace NuGetGallery
                     defaultAuditingService = GetAuditingServiceForLocalFileSystem(configuration);
                     break;
                 case StorageType.AzureStorage:
-                    ConfigureForAzureStorage(builder, configuration, telemetryClient);
+                    ConfigureForAzureStorage(builder, configuration, telemetryService);
                     defaultAuditingService = GetAuditingServiceForAzureStorage(builder, configuration);
                     break;
             }
@@ -982,7 +982,7 @@ namespace NuGetGallery
             return new FileSystemAuditingService(auditingPath, AuditActor.GetAspNetOnBehalfOfAsync);
         }
 
-        private static void ConfigureForAzureStorage(ContainerBuilder builder, IGalleryConfigurationService configuration, ITelemetryClient telemetryClient)
+        private static void ConfigureForAzureStorage(ContainerBuilder builder, IGalleryConfigurationService configuration, ITelemetryService telemetryService)
         {
             /// The goal here is to initialize a <see cref="ICloudBlobClient"/> and <see cref="IFileStorageService"/>
             /// instance for each unique connection string. Each dependent of <see cref="IFileStorageService"/> (that
@@ -1045,7 +1045,7 @@ namespace NuGetGallery
 
             // when running on Windows Azure, download counts come from the downloads.v1.json blob
             var downloadCountService = new CloudDownloadCountService(
-                telemetryClient,
+                telemetryService,
                 configuration.Current.AzureStorage_Statistics_ConnectionString,
                 configuration.Current.AzureStorageReadAccessGeoRedundant);
 
@@ -1053,7 +1053,7 @@ namespace NuGetGallery
                 .AsSelf()
                 .As<IDownloadCountService>()
                 .SingleInstance();
-            ObjectMaterializedInterception.AddInterceptor(new DownloadCountObjectMaterializedInterceptor(downloadCountService, telemetryClient));
+            ObjectMaterializedInterception.AddInterceptor(new DownloadCountObjectMaterializedInterceptor(downloadCountService, telemetryService));
 
             builder.RegisterType<JsonStatisticsService>()
                 .AsSelf()

--- a/src/NuGetGallery/Services/DownloadCountObjectMaterializedInterceptor.cs
+++ b/src/NuGetGallery/Services/DownloadCountObjectMaterializedInterceptor.cs
@@ -16,8 +16,8 @@ namespace NuGetGallery
 
         public DownloadCountObjectMaterializedInterceptor(IDownloadCountService downloadCountService, ITelemetryService telemetryService)
         {
-            _downloadCountService = downloadCountService;
-            _telemetryService = telemetryService;
+            _downloadCountService = downloadCountService ?? throw new ArgumentNullException(nameof(downloadCountService));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
         }
 
         public void InterceptObjectMaterialized(object entity)

--- a/src/NuGetGallery/Services/DownloadCountObjectMaterializedInterceptor.cs
+++ b/src/NuGetGallery/Services/DownloadCountObjectMaterializedInterceptor.cs
@@ -11,21 +11,13 @@ namespace NuGetGallery
     public class DownloadCountObjectMaterializedInterceptor
         : IObjectMaterializedInterceptor
     {
-        private const string TelemetrySourcePrefix = "DownloadCountObjectMaterializedInterceptor.";
-
-        private const string PackageIdDimensionName = "PackageId";
-        private const string PackageVersionDimensionName = "PackageVersion";
-        private const string TelemetryOriginDimensionName = "Origin";
-
-        private const string GalleryDownloadCountLargerThanDownloadJsonByMetricName = TelemetrySourcePrefix + "GalleryDownloadCountLargerThanDownloadJsonBy";
-
-        private readonly ITelemetryClient _telemetryClient;
+        private readonly ITelemetryService _telemetryService;
         private readonly IDownloadCountService _downloadCountService;
 
-        public DownloadCountObjectMaterializedInterceptor(IDownloadCountService downloadCountService, ITelemetryClient telemetryClient)
+        public DownloadCountObjectMaterializedInterceptor(IDownloadCountService downloadCountService, ITelemetryService telemetryService)
         {
             _downloadCountService = downloadCountService;
-            _telemetryClient = telemetryClient;
+            _telemetryService = telemetryService;
         }
 
         public void InterceptObjectMaterialized(object entity)
@@ -50,12 +42,7 @@ namespace NuGetGallery
             {
                 if (downloadCount < package.DownloadCount)
                 {
-                    _telemetryClient.TrackMetric(GalleryDownloadCountLargerThanDownloadJsonByMetricName, package.DownloadCount - downloadCount, new Dictionary<string, string>
-                        {
-                            { TelemetryOriginDimensionName, TelemetrySourcePrefix + "InterceptPackageMaterialized" },
-                            { PackageIdDimensionName, package.PackageRegistration.Id },
-                            { PackageVersionDimensionName, packageNormalizedVersion }
-                        });
+                    _telemetryService.TrackPackageDownloadCountDecreasedFromGallery(package.PackageRegistration.Id, packageNormalizedVersion, package.DownloadCount, downloadCount);
                 }
 
                 package.DownloadCount = downloadCount;
@@ -74,12 +61,7 @@ namespace NuGetGallery
             {
                 if (downloadCount < packageRegistration.DownloadCount)
                 {
-                    _telemetryClient.TrackMetric(GalleryDownloadCountLargerThanDownloadJsonByMetricName, packageRegistration.DownloadCount - downloadCount, new Dictionary<string, string>
-                        {
-                            { TelemetryOriginDimensionName,  TelemetrySourcePrefix + "InterceptPackageRegistrationMaterialized" },
-                            { PackageIdDimensionName, packageRegistration.Id },
-                            { PackageVersionDimensionName, "" }
-                        });
+                    _telemetryService.TrackPackageRegistrationDownloadCountDecreasedFromGallery(packageRegistration.Id, packageRegistration.DownloadCount, downloadCount);
                 }
 
                 packageRegistration.DownloadCount = downloadCount;

--- a/src/NuGetGallery/Services/DownloadCountObjectMaterializedInterceptor.cs
+++ b/src/NuGetGallery/Services/DownloadCountObjectMaterializedInterceptor.cs
@@ -2,18 +2,30 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using NuGet.Services.Entities;
+using NuGet.Services.Logging;
 
 namespace NuGetGallery
 {
     public class DownloadCountObjectMaterializedInterceptor
         : IObjectMaterializedInterceptor
     {
+        private const string TelemetrySourcePrefix = "DownloadCountObjectMaterializedInterceptor.";
+
+        private const string PackageIdDimensionName = "PackageId";
+        private const string PackageVersionDimensionName = "PackageVersion";
+        private const string TelemetryOriginDimensionName = "Origin";
+
+        private const string GalleryDownloadCountLargerThanDownloadJsonByMetricName = TelemetrySourcePrefix + "GalleryDownloadCountLargerThanDownloadJsonBy";
+
+        private readonly ITelemetryClient _telemetryClient;
         private readonly IDownloadCountService _downloadCountService;
 
-        public DownloadCountObjectMaterializedInterceptor(IDownloadCountService downloadCountService)
+        public DownloadCountObjectMaterializedInterceptor(IDownloadCountService downloadCountService, ITelemetryClient telemetryClient)
         {
             _downloadCountService = downloadCountService;
+            _telemetryClient = telemetryClient;
         }
 
         public void InterceptObjectMaterialized(object entity)
@@ -36,6 +48,16 @@ namespace NuGetGallery
             int downloadCount;
             if (_downloadCountService.TryGetDownloadCountForPackage(package.PackageRegistration.Id, packageNormalizedVersion, out downloadCount))
             {
+                if (downloadCount < package.DownloadCount)
+                {
+                    _telemetryClient.TrackMetric(GalleryDownloadCountLargerThanDownloadJsonByMetricName, package.DownloadCount - downloadCount, new Dictionary<string, string>
+                        {
+                            { TelemetryOriginDimensionName, TelemetrySourcePrefix + "InterceptPackageMaterialized" },
+                            { PackageIdDimensionName, package.PackageRegistration.Id },
+                            { PackageVersionDimensionName, packageNormalizedVersion }
+                        });
+                }
+
                 package.DownloadCount = downloadCount;
             }
         }
@@ -50,6 +72,16 @@ namespace NuGetGallery
             int downloadCount;
             if (_downloadCountService.TryGetDownloadCountForPackageRegistration(packageRegistration.Id, out downloadCount))
             {
+                if (downloadCount < packageRegistration.DownloadCount)
+                {
+                    _telemetryClient.TrackMetric(GalleryDownloadCountLargerThanDownloadJsonByMetricName, packageRegistration.DownloadCount - downloadCount, new Dictionary<string, string>
+                        {
+                            { TelemetryOriginDimensionName,  TelemetrySourcePrefix + "InterceptPackageRegistrationMaterialized" },
+                            { PackageIdDimensionName, packageRegistration.Id },
+                            { PackageVersionDimensionName, "" }
+                        });
+                }
+
                 packageRegistration.DownloadCount = downloadCount;
             }
         }

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -32,6 +32,12 @@ namespace NuGetGallery
             public const string NewUserRegistration = "NewUserRegistration";
             public const string CredentialAdded = "CredentialAdded";
             public const string CredentialUsed = "CredentialUsed";
+            public const string DownloadCountDecreasedDuringRefresh = "DownloadCountDecreasedDuringRefresh";
+            public const string DownloadJsonRefreshDuration = "DownloadJsonRefreshDuration";
+            public const string GalleryDownloadGreaterThanJsonForPackage = "GalleryDownloadGreaterThanJsonForPackage";
+            public const string GalleryDownloadGreaterThanJsonForPackageRegistration = "GalleryDownloadGreaterThanJsonForPackageRegistration";
+            public const string GetPackageDownloadCountFailed = "GetPackageDownloadCountFailed";
+            public const string GetPackageRegistrationDownloadCountFailed = "GetPackageRegistrationDownloadCountFailed";
             public const string UserPackageDeleteCheckedAfterHours = "UserPackageDeleteCheckedAfterHours";
             public const string UserPackageDeleteExecuted = "UserPackageDeleteExecuted";
             public const string UserMultiFactorAuthenticationEnabled = "UserMultiFactorAuthenticationEnabled";
@@ -88,6 +94,12 @@ namespace NuGetGallery
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
             Formatting = Formatting.None
         };
+
+        // Download Count properties
+        public const string OldJsonDownloadCount = "OldDownloadCount";
+        public const string NewJsonDownloadCount = "NewDownloadCount";
+        public const string GalleryDownloadCount = "GalleryDownloadCount";
+        public const string JsonDownloadCount = "JsonDownloadCount";
 
         // ODataQueryFilter properties
         public const string CallContext = "CallContext";
@@ -223,6 +235,60 @@ namespace NuGetGallery
             }
 
             _diagnosticsSource.Warning(exception.ToString());
+        }
+
+        public void TrackGetPackageDownloadCountFailed(string packageId, string packageVersion)
+        {
+            TrackMetric(Events.GetPackageRegistrationDownloadCountFailed, 1, properties =>
+            {
+                properties.Add(PackageId, packageId);
+                properties.Add(PackageVersion, packageVersion);
+            });
+        }
+
+        public void TrackGetPackageRegistrationDownloadCountFailed(string packageId)
+        {
+            TrackMetric(Events.GetPackageRegistrationDownloadCountFailed, 1, properties =>
+            {
+                properties.Add(PackageId, packageId);
+            });
+        }
+
+        public void TrackDownloadJsonRefreshDuration(long milliseconds)
+        {
+            TrackMetric(Events.DownloadJsonRefreshDuration, milliseconds, properties => { });
+        }
+
+        public void TrackDownloadCountDecreasedDuringRefresh(string packageId, string packageVersion, long oldCount, long newCount)
+        {
+            TrackMetric(Events.DownloadCountDecreasedDuringRefresh, 1, properties =>
+            {
+                properties.Add(PackageId, packageId);
+                properties.Add(PackageVersion, packageVersion);
+                properties.Add(OldJsonDownloadCount, oldCount.ToString());
+                properties.Add(NewJsonDownloadCount, newCount.ToString());
+            });
+        }
+
+        public void TrackPackageDownloadCountDecreasedFromGallery(string packageId, string packageVersion, long galleryCount, long jsonCount)
+        {
+            TrackMetric(Events.GalleryDownloadGreaterThanJsonForPackage, 1, properties =>
+            {
+                properties.Add(PackageId, packageId);
+                properties.Add(PackageVersion, packageVersion);
+                properties.Add(GalleryDownloadCount, galleryCount.ToString());
+                properties.Add(JsonDownloadCount, jsonCount.ToString());
+            });
+        }
+
+        public void TrackPackageRegistrationDownloadCountDecreasedFromGallery(string packageId, long galleryCount, long jsonCount)
+        {
+            TrackMetric(Events.GalleryDownloadGreaterThanJsonForPackageRegistration, 1, properties =>
+            {
+                properties.Add(PackageId, packageId);
+                properties.Add(GalleryDownloadCount, galleryCount.ToString());
+                properties.Add(JsonDownloadCount, jsonCount.ToString());
+            });
         }
 
         public void TrackODataQueryFilterEvent(string callContext, bool isEnabled, bool isAllowed, string queryPattern)

--- a/src/NuGetGallery/Services/TelemetryService.cs
+++ b/src/NuGetGallery/Services/TelemetryService.cs
@@ -239,7 +239,7 @@ namespace NuGetGallery
 
         public void TrackGetPackageDownloadCountFailed(string packageId, string packageVersion)
         {
-            TrackMetric(Events.GetPackageRegistrationDownloadCountFailed, 1, properties =>
+            TrackMetric(Events.GetPackageDownloadCountFailed, 1, properties =>
             {
                 properties.Add(PackageId, packageId);
                 properties.Add(PackageVersion, packageVersion);

--- a/tests/NuGetGallery.Facts/Services/CloudDownloadCountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudDownloadCountServiceFacts.cs
@@ -143,14 +143,14 @@ namespace NuGetGallery
 
         public class BaseFacts
         {
-            internal readonly Mock<ITelemetryClient> _telemetryService;
+            internal readonly Mock<ITelemetryService> _telemetryService;
             internal string _content;
             internal Func<IDictionary<string, int>, int> _calculateSum;
             internal TestableCloudDownloadCountService _target;
 
             public BaseFacts()
             {
-                _telemetryService = new Mock<ITelemetryClient>();
+                _telemetryService = new Mock<ITelemetryService>();
                 _content = "[[\"NuGet.Versioning\",[\"4.6.0\",23],[\"4.6.2\",42]]";
                 _calculateSum = null;
                 _target = new TestableCloudDownloadCountService(this);

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -57,6 +57,30 @@ namespace NuGetGallery
                         (TrackAction)(s => s.TrackRequiredSignerSet(package.PackageRegistration.Id))
                     };
 
+                    yield return new object[] { "",
+                        (TrackAction)(s => s.TrackDownloadJsonRefreshDuration(0))
+                    };
+
+                    yield return new object[] { "",
+                        (TrackAction)(s => s.TrackDownloadCountDecreasedDuringRefresh(package.PackageRegistration.Id, package.Version, 0, 0))
+                    };
+
+                    yield return new object[] { "",
+                        (TrackAction)(s => s.TrackPackageDownloadCountDecreasedFromGallery(package.PackageRegistration.Id, package.Version, 0, 0))
+                    };
+
+                    yield return new object[] { "",
+                        (TrackAction)(s => s.TrackPackageRegistrationDownloadCountDecreasedFromGallery(package.PackageRegistration.Id, 0, 0))
+                    };
+
+                    yield return new object[] { "",
+                        (TrackAction)(s => s.TrackGetPackageDownloadCountFailed(package.PackageRegistration.Id, package.Version))
+                    };
+
+                    yield return new object[] { "",
+                        (TrackAction)(s => s.TrackGetPackageRegistrationDownloadCountFailed(package.PackageRegistration.Id))
+                    };
+
                     yield return new object[] { "ODataQueryFilter",
                         (TrackAction)(s => s.TrackODataQueryFilterEvent("callContext", true, true, "queryPattern"))
                     };

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -57,27 +57,27 @@ namespace NuGetGallery
                         (TrackAction)(s => s.TrackRequiredSignerSet(package.PackageRegistration.Id))
                     };
 
-                    yield return new object[] { "",
+                    yield return new object[] { "DownloadJsonRefreshDuration",
                         (TrackAction)(s => s.TrackDownloadJsonRefreshDuration(0))
                     };
 
-                    yield return new object[] { "",
+                    yield return new object[] { "DownloadCountDecreasedDuringRefresh",
                         (TrackAction)(s => s.TrackDownloadCountDecreasedDuringRefresh(package.PackageRegistration.Id, package.Version, 0, 0))
                     };
 
-                    yield return new object[] { "",
+                    yield return new object[] { "GalleryDownloadGreaterThanJsonForPackage",
                         (TrackAction)(s => s.TrackPackageDownloadCountDecreasedFromGallery(package.PackageRegistration.Id, package.Version, 0, 0))
                     };
 
-                    yield return new object[] { "",
+                    yield return new object[] { "GalleryDownloadGreaterThanJsonForPackageRegistration",
                         (TrackAction)(s => s.TrackPackageRegistrationDownloadCountDecreasedFromGallery(package.PackageRegistration.Id, 0, 0))
                     };
 
-                    yield return new object[] { "",
+                    yield return new object[] { "GetPackageDownloadCountFailed",
                         (TrackAction)(s => s.TrackGetPackageDownloadCountFailed(package.PackageRegistration.Id, package.Version))
                     };
 
-                    yield return new object[] { "",
+                    yield return new object[] { "GetPackageRegistrationDownloadCountFailed",
                         (TrackAction)(s => s.TrackGetPackageRegistrationDownloadCountFailed(package.PackageRegistration.Id))
                     };
 


### PR DESCRIPTION
Adding additional telemetry around statistics in gallery.
Adds metrics for the following:
Interceptor replaces a gallery values with a smaller values from downloads for package
Interceptor replaces a gallery values with a smaller values from downloads for package registration
Request to get stats for package fails
Request to get stats for package registration fails
Duration of downloads.v1.json refresh
Update of downloads.v1.json causes a decrease in download count.

Also rejects updates to internal download count in service if it would lower the download count of a package.

@cristinamanum 