### PR TITLE
Don't index search results pages

### DIFF
--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -3,6 +3,7 @@
     ViewBag.Title = String.IsNullOrWhiteSpace(Model.SearchTerm) ? "Packages" : "Packages matching " + Model.SearchTerm;
     ViewBag.SortText = String.IsNullOrWhiteSpace(Model.SearchTerm) ? "recent installs" : "relevance";
     ViewBag.Tab = "Packages";
+    ViewBag.BlockSearchEngineIndexing = !String.IsNullOrWhiteSpace(Model.SearchTerm) || Model.PageIndex != 0;
 }
 
 <section role="main" class="container main-container page-list-packages">


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7187

The one place I think we should index is the base search results page so `nuget.org search` Google search still works:

![image](https://user-images.githubusercontent.com/94054/61242316-3d2e7380-a6fa-11e9-8fcd-4eed0ec257bd.png)
