### PR TITLE
Move search timeout from HttpClient to Polly timeout policy

### DIFF
--- a/src/AccountDeleter/Configuration/GalleryConfiguration.cs
+++ b/src/AccountDeleter/Configuration/GalleryConfiguration.cs
@@ -99,7 +99,7 @@ namespace NuGetGallery.AccountDeleter
         public int SearchCircuitBreakerWaitAndRetryIntervalInMilliseconds { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public int SearchCircuitBreakerWaitAndRetryCount { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public int SearchCircuitBreakerBreakAfterCount { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public int SearchHttpClientTimeoutInMilliseconds { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public int SearchHttpRequestTimeoutInMilliseconds { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public MailAddress GalleryOwner { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public MailAddress GalleryNoReplyAddress { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string SqlReadOnlyReplicaConnectionString { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
@@ -383,8 +383,10 @@ namespace NuGetGallery.Configuration
         [DefaultValue(200)]
         public int SearchCircuitBreakerBreakAfterCount { get; set; }
 
-        // Default HttpClient.Timeout is 100 seconds == 100000 milliseconds
+        /// <summary>
+        /// We use the default of HttpClient.Timeout, which is is 100 seconds == 100000 milliseconds.
+        /// </summary>
         [DefaultValue(100000)]
-        public int SearchHttpClientTimeoutInMilliseconds { get; set; }
+        public int SearchHttpRequestTimeoutInMilliseconds { get; set; }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
@@ -422,8 +422,8 @@ namespace NuGetGallery.Configuration
         int SearchCircuitBreakerBreakAfterCount { get; set; }
 
         /// <summary>
-        /// The Search HttpClient timeout in seconds.
+        /// The Search timeout per request in milliseconds.
         /// </summary>
-        int SearchHttpClientTimeoutInMilliseconds { get; set; }
+        int SearchHttpRequestTimeoutInMilliseconds { get; set; }
     }
 }

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -313,6 +313,15 @@ namespace NuGetGallery
         void TrackMetricForSearchOnRetry(string searchName, Exception exception, string correlationId, string uri, string circuitBreakerStatus);
 
         /// <summary>
+        /// Tracks the OnTimeout for the search timeout policy.
+        /// </summary>
+        /// <param name="searchName">A name to identify the search instance.</param>
+        /// <param name="correlationId">CorrelationId set by Polly context.</param>
+        /// <param name="uri">The request uri.</param>
+        /// <param name="circuitBreakerStatus">The CircuitBreakerStatus at the time of the Retry action.</param>
+        void TrackMetricForSearchOnTimeout(string searchName, string correlationId, string uri, string circuitBreakerStatus);
+
+        /// <summary>
         /// Tracks that some feedback was left on the search side-by-side page.
         /// </summary>
         /// <param name="searchTerm">The search term used.</param>

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -81,6 +81,7 @@ namespace NuGetGallery
             public const string SearchCircuitBreakerOnBreak = "SearchCircuitBreakerOnBreak";
             public const string SearchCircuitBreakerOnReset = "SearchCircuitBreakerOnReset";
             public const string SearchOnRetry = "SearchOnRetry";
+            public const string SearchOnTimeout = "SearchOnTimeout";
             public const string SearchSideBySideFeedback = "SearchSideBySideFeedback";
             public const string SearchSideBySide = "SearchSideBySide";
             public const string ABTestEnrollmentInitialized = "ABTestEnrollmentInitialized";
@@ -958,6 +959,16 @@ namespace NuGetGallery
             TrackMetric(Events.SearchOnRetry, 1, properties => {
                 properties.Add(SearchName, searchName);
                 properties.Add(SearchException, exception?.ToString() ?? string.Empty);
+                properties.Add(SearchPollyCorrelationId, correlationId);
+                properties.Add(SearchUrl, uri);
+                properties.Add(SearchCircuitBreakerStatus, circuitBreakerStatus);
+            });
+        }
+
+        public void TrackMetricForSearchOnTimeout(string searchName, string correlationId, string uri, string circuitBreakerStatus)
+        {
+            TrackMetric(Events.SearchOnTimeout, 1, properties => {
+                properties.Add(SearchName, searchName);
                 properties.Add(SearchPollyCorrelationId, correlationId);
                 properties.Add(SearchUrl, uri);
                 properties.Add(SearchCircuitBreakerStatus, circuitBreakerStatus);

--- a/src/NuGetGallery/Infrastructure/Lucene/HttpClientBuilderExtensions.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/HttpClientBuilderExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NuGetGallery.Configuration;
+
+namespace NuGetGallery.Infrastructure.Search
+{
+    public static class HttpClientBuilderExtensions
+    {
+        public static IHttpClientBuilder AddSearchPolicyHandlers(
+            this IHttpClientBuilder builder,
+            ILogger logger,
+            string searchName,
+            ITelemetryService telemetryService,
+            IAppConfiguration config)
+        {
+            return builder
+                .AddPolicyHandler(SearchClientPolicies.SearchClientFallBackCircuitBreakerPolicy(
+                    logger,
+                    searchName,
+                    telemetryService))
+                .AddPolicyHandler(SearchClientPolicies.SearchClientWaitAndRetryPolicy(
+                    config.SearchCircuitBreakerWaitAndRetryCount,
+                    config.SearchCircuitBreakerWaitAndRetryIntervalInMilliseconds,
+                    logger,
+                    searchName,
+                    telemetryService))
+                .AddPolicyHandler(SearchClientPolicies.SearchClientCircuitBreakerPolicy(
+                    config.SearchCircuitBreakerBreakAfterCount,
+                    TimeSpan.FromSeconds(config.SearchCircuitBreakerDelayInSeconds),
+                    logger,
+                    searchName,
+                    telemetryService))
+                .AddPolicyHandler(SearchClientPolicies.SearchClientTimeoutPolicy(
+                    TimeSpan.FromMilliseconds(config.SearchHttpRequestTimeoutInMilliseconds),
+                    logger,
+                    searchName,
+                    telemetryService));
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Infrastructure\IABTestService.cs" />
     <Compile Include="Infrastructure\Lucene\Correlation\CorrelatingHttpClientHandler.cs" />
     <Compile Include="Infrastructure\Lucene\Correlation\WebApiCorrelationHandler.cs" />
+    <Compile Include="Infrastructure\Lucene\HttpClientBuilderExtensions.cs" />
     <Compile Include="Infrastructure\Lucene\IIndexingJobFactory.cs" />
     <Compile Include="Infrastructure\Lucene\ISearchClient.cs" />
     <Compile Include="Infrastructure\Lucene\Models\SearchResults.cs" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -136,8 +136,7 @@
     <add key="Gallery.SearchCircuitBreakerWaitAndRetryIntervalInMilliseconds" value="500"/>
     <add key="Gallery.SearchCircuitBreakerWaitAndRetryCount" value="3"/>
     <add key="Gallery.SearchCircuitBreakerBreakAfterCount" value="200"/>
-    <!--Default Client Timeout is 100000 milliseconds == 100 seconds-->
-    <add key="Gallery.SearchHttpClientTimeoutInMilliseconds" value="100000"/>
+    <add key="Gallery.SearchHttpRequestTimeoutInMilliseconds" value="100000"/>
     <add key="Gallery.Brand" value="NuGet Gallery"/>
     <add key="Gallery.GalleryOwner" value="NuGet Gallery &lt;support@nuget.org&gt;"/>
     <add key="Gallery.GalleryNoReplyAddress" value="NuGet Gallery &lt;noreply@nuget.org&gt;"/>

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -305,6 +305,10 @@ namespace NuGetGallery
                         (TrackAction)(s => s.TrackMetricForSearchOnRetry("SomeName", exception: null, correlationId: string.Empty, uri: string.Empty, circuitBreakerStatus: string.Empty))
                     };
 
+                    yield return new object[] { "SearchOnTimeout",
+                        (TrackAction)(s => s.TrackMetricForSearchOnTimeout("SomeName", correlationId: string.Empty, uri: string.Empty, circuitBreakerStatus: string.Empty))
+                    };
+
                     yield return new object[] { "SearchSideBySideFeedback",
                         (TrackAction)(s => s.TrackSearchSideBySideFeedback("nuget", 1, 2, "new", "nuget.core", null, true, true))
                     };


### PR DESCRIPTION
When a timeout occurs, consider this as an error for the circuit breaker.
Progress on https://github.com/NuGet/NuGetGallery/issues/7119

Previously everyone would always encounter the timeout case on USNC and the circuit breaker would never open.
