### PR TITLE
Add page for managing site admins

### DIFF
--- a/src/AccountDeleter/AccountDeleteUserService.cs
+++ b/src/AccountDeleter/AccountDeleteUserService.cs
@@ -147,5 +147,15 @@ namespace NuGetGallery.AccountDeleter
         {
             throw new NotImplementedException();
         }
+
+        public IReadOnlyList<User> GetSiteAdmins()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SetIsAdministrator(User user, bool isAdmin)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/AccountDeleter/EmptyUserService.cs
+++ b/src/AccountDeleter/EmptyUserService.cs
@@ -134,5 +134,15 @@ namespace NuGetGallery.AccountDeleter
         {
             throw new NotImplementedException();
         }
+
+        public IReadOnlyList<User> GetSiteAdmins()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SetIsAdministrator(User user, bool isAdmin)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGet.Services.Entities/Extensions/RoleExtensions.cs
+++ b/src/NuGet.Services.Entities/Extensions/RoleExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.Entities
+{
+    public static class RoleExtensions
+    {
+        public static bool Is(this Role role, string roleName)
+        {
+            return string.Equals(role.Name, roleName, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
+++ b/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
@@ -55,6 +55,7 @@
     <Compile Include="EntityException.cs" />
     <Compile Include="Extensions\PackageExtensions.cs" />
     <Compile Include="Extensions\PackageRegistrationExtensions.cs" />
+    <Compile Include="Extensions\RoleExtensions.cs" />
     <Compile Include="IEntity.cs" />
     <Compile Include="IPackageEntity.cs" />
     <Compile Include="Membership.cs" />

--- a/src/NuGet.Services.Entities/Role.cs
+++ b/src/NuGet.Services.Entities/Role.cs
@@ -20,7 +20,7 @@ namespace NuGet.Services.Entities
 
         public bool Is(string roleName)
         {
-            return Name.Equals(roleName, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(Name, roleName, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/NuGet.Services.Entities/Role.cs
+++ b/src/NuGet.Services.Entities/Role.cs
@@ -18,9 +18,9 @@ namespace NuGet.Services.Entities
             Users = new HashSet<User>();
         }
 
-        public bool Is(string name)
+        public bool Is(string roleName)
         {
-            return Name.Equals(name, StringComparison.OrdinalIgnoreCase);
+            return Name.Equals(roleName, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/NuGet.Services.Entities/Role.cs
+++ b/src/NuGet.Services.Entities/Role.cs
@@ -17,10 +17,5 @@ namespace NuGet.Services.Entities
         {
             Users = new HashSet<User>();
         }
-
-        public bool Is(string roleName)
-        {
-            return string.Equals(Name, roleName, StringComparison.OrdinalIgnoreCase);
-        }
     }
 }

--- a/src/NuGet.Services.Entities/Role.cs
+++ b/src/NuGet.Services.Entities/Role.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace NuGet.Services.Entities
@@ -15,6 +16,11 @@ namespace NuGet.Services.Entities
         public Role()
         {
             Users = new HashSet<User>();
+        }
+
+        public bool Is(string name)
+        {
+            return Name.Equals(name, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/NuGet.Services.Entities/User.cs
+++ b/src/NuGet.Services.Entities/User.cs
@@ -177,7 +177,7 @@ namespace NuGet.Services.Entities
 
         public bool IsInRole(string roleName)
         {
-            return Roles.Any(r => String.Equals(r.Name, roleName, StringComparison.OrdinalIgnoreCase));
+            return Roles.Any(r => r.Is(roleName));
         }
 
         public bool Equals(User other)

--- a/src/NuGetGallery.Services/UserManagement/IUserService.cs
+++ b/src/NuGetGallery.Services/UserManagement/IUserService.cs
@@ -56,5 +56,9 @@ namespace NuGetGallery
         Task<bool> CancelTransformUserToOrganizationRequest(User accountToTransform, string token);
 
         Task<Organization> AddOrganizationAsync(string username, string emailAddress, User adminUser);
+
+        IReadOnlyList<User> GetSiteAdmins();
+
+        Task SetIsAdministrator(User user, bool isAdmin);
     }
 }

--- a/src/NuGetGallery.Services/UserManagement/UserService.cs
+++ b/src/NuGetGallery.Services/UserManagement/UserService.cs
@@ -705,7 +705,6 @@ namespace NuGetGallery
         private Role GetAdminRole()
         {
             return RoleRepository.GetAll()
-                .Include(r => r.Users)
                 .ToList()
                 .Single(r => r.Is(Constants.AdminRoleName));
         }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -53,6 +53,7 @@ using SecretReaderFactory = NuGetGallery.Configuration.SecretReader.SecretReader
 using Microsoft.Extensions.Http;
 using NuGetGallery.Infrastructure.Lucene;
 using System.Threading;
+using Role = NuGet.Services.Entities.Role;
 
 namespace NuGetGallery
 {
@@ -176,6 +177,11 @@ namespace NuGetGallery
             builder.RegisterType<EntityRepository<User>>()
                 .AsSelf()
                 .As<IEntityRepository<User>>()
+                .InstancePerLifetimeScope();
+
+            builder.RegisterType<EntityRepository<Role>>()
+                .AsSelf()
+                .As<IEntityRepository<Role>>()
                 .InstancePerLifetimeScope();
 
             builder.RegisterType<EntityRepository<ReservedNamespace>>()

--- a/src/NuGetGallery/Areas/Admin/Controllers/SiteAdminsController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/SiteAdminsController.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+using NuGetGallery.Areas.Admin.ViewModels;
+
+namespace NuGetGallery.Areas.Admin.Controllers
+{
+    public class SiteAdminsController : AdminControllerBase
+    {
+        private readonly IUserService _userService;
+
+        public SiteAdminsController(IUserService userService)
+        {
+            _userService = userService ?? throw new ArgumentNullException(nameof(userService));
+        }
+
+        [HttpGet]
+        public ActionResult Index()
+        {
+            return View(
+                new SiteAdminsViewModel
+                {
+                    AdminUsernames = _userService.GetSiteAdmins().Select(u => u.Username)
+                });
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public Task<ActionResult> AddAdmin(string username)
+        {
+            return SetIsAdministrator(username, true);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public Task<ActionResult> RemoveAdmin(string username)
+        {
+            return SetIsAdministrator(username, false);
+        }
+
+        private async Task<ActionResult> SetIsAdministrator(string username, bool isAdmin)
+        {
+            var user = _userService.FindByUsername(username);
+            if (user == null)
+            {
+                TempData["ErrorMessage"] = $"User '{username}' does not exist!";
+            }
+            else
+            {
+                await _userService.SetIsAdministrator(user, isAdmin);
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/src/NuGetGallery/Areas/Admin/ViewModels/SiteAdminsViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/SiteAdminsViewModel.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGetGallery.Areas.Admin.ViewModels
+{
+    public class SiteAdminsViewModel
+    {
+        public IEnumerable<string> AdminUsernames { get; set; }
+    }
+}

--- a/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
@@ -147,13 +147,24 @@
         </li>
         <li>
             <h2>
-                <a href="@Url.Action(actionName: "Index", controllerName: "Features")">
+                <a href="@Url.Action(actionName: " Index", controllerName: "Features" )">
                     <i class="ms-Icon ms-Icon--Flag"></i>
                     <span>Feature Flags</span>
                 </a>
             </h2>
             <p>
                 Manage which features are enabled
+            </p>
+        </li>
+        <li>
+            <h2>
+                <a href="@Url.Action(actionName: "Index", controllerName: "SiteAdmins")">
+                    <i class="ms-Icon ms-Icon--Admin"></i>
+                    <span>Site Admins</span>
+                </a>
+            </h2>
+            <p>
+                Manage site admins
             </p>
         </li>
     </ul>

--- a/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
@@ -147,7 +147,7 @@
         </li>
         <li>
             <h2>
-                <a href="@Url.Action(actionName: " Index", controllerName: "Features" )">
+                <a href="@Url.Action(actionName: "Index", controllerName: "Features" )">
                     <i class="ms-Icon ms-Icon--Flag"></i>
                     <span>Feature Flags</span>
                 </a>

--- a/src/NuGetGallery/Areas/Admin/Views/SiteAdmins/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SiteAdmins/Index.cshtml
@@ -5,28 +5,29 @@
 
 <section role="main" class="container main-container">
     <h2>Current Admins</h2>
-    @foreach (var adminUsername in Model.AdminUsernames)
-    {
-        using (Html.BeginForm("RemoveAdmin", "SiteAdmins"))
+    <table class="table">
+        @foreach (var adminUsername in Model.AdminUsernames)
         {
-            <div class="row">
-                <div class="col-xs-6">
-                    <a href="@Url.User(adminUsername)"
-                        title="View profile of @adminUsername">
-                        @adminUsername
-                    </a>
-                </div>
-                <div class="col-xs-6">
-                    @Html.AntiForgeryToken()
-                    @Html.Hidden("username", adminUsername)
-                    <a href="#" onclick="$(this).closest('form').submit()">
-                        <i class="ms-Icon ms-Icon--Cancel" aria-hidden="true"></i>
-                        <span>Remove</span>
-                    </a>
-                </div>
-            </div>
+            <tr>
+                @using (Html.BeginForm("RemoveAdmin", "SiteAdmins"))
+                {
+                    <th>
+                        <a href="@Url.User(adminUsername)"
+                           title="View profile of @adminUsername">
+                            @adminUsername
+                        </a>
+                    </th>
+                    <th>
+                        @Html.AntiForgeryToken()
+                        @Html.Hidden("username", adminUsername)
+                        <button class="btn-link">
+                            <span>Remove</span>
+                        </button>
+                    </th>
+                }
+            </tr>
         }
-    }
+    </table>
 
     <h2>Add Admin</h2>
     @using (Html.BeginForm("AddAdmin", "SiteAdmins"))

--- a/src/NuGetGallery/Areas/Admin/Views/SiteAdmins/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SiteAdmins/Index.cshtml
@@ -1,0 +1,38 @@
+﻿@model SiteAdminsViewModel
+@{
+    ViewBag.Title = "Site Admins";
+}
+
+<section role="main" class="container main-container">
+    <h2>Current Admins</h2>
+    @foreach (var adminUsername in Model.AdminUsernames)
+    {
+        using (Html.BeginForm("RemoveAdmin", "SiteAdmins"))
+        {
+            <div class="row">
+                <div class="col-xs-6">
+                    <a href="@Url.User(adminUsername)"
+                        title="View profile of @adminUsername">
+                        @adminUsername
+                    </a>
+                </div>
+                <div class="col-xs-6">
+                    @Html.AntiForgeryToken()
+                    @Html.Hidden("username", adminUsername)
+                    <a href="#" onclick="$(this).closest('form').submit()" class="icon-link">
+                        <i class="ms-Icon ms-Icon--Cancel" aria-hidden="true"></i>
+                        <span>Remove</span>
+                    </a>
+                </div>
+            </div>
+        }
+    }
+
+    <h2>Add Admin</h2>
+    @using (Html.BeginForm("AddAdmin", "SiteAdmins"))
+    {
+        @Html.AntiForgeryToken()
+        <input type="text" name="username" />
+        <button type="submit">Add</button>
+    }
+</section>

--- a/src/NuGetGallery/Areas/Admin/Views/SiteAdmins/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SiteAdmins/Index.cshtml
@@ -19,7 +19,7 @@
                 <div class="col-xs-6">
                     @Html.AntiForgeryToken()
                     @Html.Hidden("username", adminUsername)
-                    <a href="#" onclick="$(this).closest('form').submit()" class="icon-link">
+                    <a href="#" onclick="$(this).closest('form').submit()">
                         <i class="ms-Icon ms-Icon--Cancel" aria-hidden="true"></i>
                         <span>Remove</span>
                     </a>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Areas\Admin\Controllers\ReservedNamespaceController.cs" />
     <Compile Include="Areas\Admin\Controllers\RevalidationController.cs" />
     <Compile Include="Areas\Admin\Controllers\SecurityPolicyController.cs" />
+    <Compile Include="Areas\Admin\Controllers\SiteAdminsController.cs" />
     <Compile Include="Areas\Admin\Controllers\SupportRequestController.cs" />
     <Compile Include="Areas\Admin\Controllers\ValidationController.cs" />
     <Compile Include="Areas\Admin\DynamicData\FieldTemplates\Url_Edit.ascx.cs">
@@ -185,6 +186,7 @@
     <Compile Include="Areas\Admin\ViewModels\LockPackageViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\ModifyFeatureFlagsFeatureViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\ModifyFeatureFlagsFlightViewModel.cs" />
+    <Compile Include="Areas\Admin\ViewModels\SiteAdminsViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\ValidatedPackageViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\RevalidationPageViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\ValidationPageViewModel.cs" />
@@ -1765,6 +1767,7 @@
     <Content Include="Areas\Admin\Views\Features\_AddFlight.cshtml" />
     <Content Include="Areas\Admin\Views\Features\_EditFlight.cshtml" />
     <Content Include="App_Data\Files\Content\AB-Test-Configuration.json" />
+    <Content Include="Areas\Admin\Views\SiteAdmins\Index.cshtml" />
     <None Include="Properties\PublishProfiles\nuget-staging-frontend.pubxml" />
     <Content Include="Scripts\gallery\async-file-upload.js" />
     <Content Include="Scripts\gallery\autocomplete.js" />

--- a/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
@@ -19,6 +19,7 @@ namespace NuGetGallery.TestUtils
         public Mock<IAppConfiguration> MockConfig { get; protected set; }
         public Mock<ISecurityPolicyService> MockSecurityPolicyService { get; protected set; }
         public Mock<IEntityRepository<User>> MockUserRepository { get; protected set; }
+        public Mock<IEntityRepository<Role>> MockRoleRepository { get; protected set; }
         public Mock<IEntityRepository<Credential>> MockCredentialRepository { get; protected set; }
         public Mock<IEntityRepository<Organization>> MockOrganizationRepository { get; protected set; }
         public Mock<IEntitiesContext> MockEntitiesContext { get; protected set; }
@@ -33,6 +34,7 @@ namespace NuGetGallery.TestUtils
             Config = (MockConfig = new Mock<IAppConfiguration>()).Object;
             SecurityPolicyService = (MockSecurityPolicyService = new Mock<ISecurityPolicyService>()).Object;
             UserRepository = (MockUserRepository = new Mock<IEntityRepository<User>>()).Object;
+            RoleRepository = (MockRoleRepository = new Mock<IEntityRepository<Role>>()).Object;
             CredentialRepository = (MockCredentialRepository = new Mock<IEntityRepository<Credential>>()).Object;
             OrganizationRepository = (MockOrganizationRepository = new Mock<IEntityRepository<Organization>>()).Object;
             EntitiesContext = (MockEntitiesContext = new Mock<IEntitiesContext>()).Object;
@@ -64,11 +66,20 @@ namespace NuGetGallery.TestUtils
             }
         }
 
+        public IEnumerable<Role> Roles
+        {
+            set
+            {
+                foreach (Role r in value) FakeEntitiesContext.Set<Role>().Add(r);
+            }
+        }
+
         public TestableUserServiceWithDBFaking(FakeEntitiesContext context = null)
         {
             FakeEntitiesContext = context ?? new FakeEntitiesContext();
             Config = (MockConfig = new Mock<IAppConfiguration>()).Object;
             UserRepository = new EntityRepository<User>(FakeEntitiesContext);
+            RoleRepository = new EntityRepository<Role>(FakeEntitiesContext);
             Auditing = new TestAuditingService();
             TelemetryService = new TelemetryService();
         }


### PR DESCRIPTION
Currently, we don't have a UI that allows us to manage site admins. Previously, we had the database editor, which we would use to do this, but we recently removed it. As a result, now, whenever we need to onboard someone to the team, we have to gain database access and make a SQL query to make them a site admin.

This PR adds a simple UI to the admin section of the site that allows us to easily and quickly manage site admins.

# Link to page in Admins index

![image](https://user-images.githubusercontent.com/18014088/62084147-70e6be80-b20d-11e9-93a6-2f611dd8cc48.png)

# Site Admins page

![image](https://user-images.githubusercontent.com/18014088/62085377-46e2cb80-b210-11e9-8571-b7922e52671b.png)