### PR TITLE
"Include prerelease" checkbox should be a link

### DIFF
--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -37,13 +37,7 @@
             </h1>
         </div>
         <div class="cell-controls">
-            <form action="@Url.PackageList()" method="get">
-                @Html.Hidden("q", Model.SearchTerm, new { id = "search-term" })
-                <label>
-                    <input type="checkbox" id="include-prerelease" @(Model.IncludePrerelease ? "checked" : string.Empty) />
-                    Include prerelease
-                </label>
-            </form>
+            <a href="?q=@Model.SearchTerm&prerel=@(Model.IncludePrerelease ? "false" : "true")">@(Model.IncludePrerelease ? "Hide" : "Show") prerelease</a>
         </div>
     </div>
 

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -103,6 +103,27 @@
         }
 
         $(function () {
+            $("#include-prerelease").on('change', function () {
+                var parameters = {};
+                var q = $('#search-term').val();
+                if (q) {
+                    parameters.q = q;
+                }
+                if (!$("#include-prerelease").is(':checked')) {
+                    parameters.prerel = 'false'
+                }
+                var queryString = $.param(parameters);
+                var url = [
+                    location.protocol,
+                    '//',
+                    location.host,
+                    location.pathname,
+                    queryString ? '?' : '',
+                    queryString
+                ].join('');
+                window.location.href = url;
+            });
+
             var emitAiClickEvent = function () {
                 if (!window.nuget.isAiAvailable()) {
                     return;

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -103,27 +103,6 @@
         }
 
         $(function () {
-            $("#include-prerelease").on('change', function () {
-                var parameters = {};
-                var q = $('#search-term').val();
-                if (q) {
-                    parameters.q = q;
-                }
-                if (!$("#include-prerelease").is(':checked')) {
-                    parameters.prerel = 'false'
-                }
-                var queryString = $.param(parameters);
-                var url = [
-                    location.protocol,
-                    '//',
-                    location.host,
-                    location.pathname,
-                    queryString ? '?' : '',
-                    queryString
-                ].join('');
-                window.location.href = url;
-            });
-
             var emitAiClickEvent = function () {
                 if (!window.nuget.isAiAvailable()) {
                     return;

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -37,7 +37,7 @@
             </h1>
         </div>
         <div class="cell-controls">
-            <a href="?q=@Model.SearchTerm&prerel=@(Model.IncludePrerelease ? "false" : "true")">@(Model.IncludePrerelease ? "Hide" : "Show") prerelease</a>
+            <a href="?q=@Model.SearchTerm@(Model.IncludePrerelease ? "&prerel=false" : "")">@(Model.IncludePrerelease ? "Hide" : "Show") prerelease</a>
         </div>
     </div>
 


### PR DESCRIPTION
Currently, it is a checkbox that refreshes the page upon checking/unchecking, which is very confusing for screen readers. Functionally, it behaves like a link, so we have changed it to a link.

Alternatively, we considered changing the form to ajax, but ultimately that is a very nontrivial change.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/910827
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/905602

# Hide prerelease

![image](https://user-images.githubusercontent.com/18014088/62254654-db833000-b3ae-11e9-802e-0f5b4fc09072.png)

# Show prerelease

![image](https://user-images.githubusercontent.com/18014088/62254667-e938b580-b3ae-11e9-9b3d-5f6df7c9df7e.png)
