### PR TITLE
Upgrade ServerCommon dependency

### DIFF
--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -107,16 +107,16 @@
       <Version>4.1.0-master-2602271</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
       <Version>4.1.0-dev-2759568</Version>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -75,10 +75,10 @@
       <Version>4.1.0-master-2758883</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -91,7 +91,7 @@
       <Version>4.1.0-master-2602271</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -235,19 +235,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -286,10 +286,10 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2051,7 +2051,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
@@ -2248,13 +2248,13 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.52.0</Version>
+      <Version>2.53.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/Services/AsynchronousPackageValidationInitiator.cs
+++ b/src/NuGetGallery/Services/AsynchronousPackageValidationInitiator.cs
@@ -50,7 +50,7 @@ namespace NuGetGallery
             var validatingType = ValidateAndGetType(package);
 
             var entityKey = package.Key == default(int) ? (int?)null : package.Key;
-            var data = new PackageValidationMessageData(
+            var data = PackageValidationMessageData.NewProcessValidationSet(
                 package.Id,
                 package.Version,
                 Guid.NewGuid(),
@@ -58,7 +58,8 @@ namespace NuGetGallery
                 entityKey: entityKey);
 
             var activityName = $"Enqueuing asynchronous package validation: " +
-                $"{data.PackageId} {data.PackageVersion} {data.ValidatingType} ({data.ValidationTrackingId})";
+                $"{data.ProcessValidationSet.PackageId} {data.ProcessValidationSet.PackageVersion} " +
+                $"{data.ProcessValidationSet.ValidatingType} ({data.ProcessValidationSet.ValidationTrackingId})";
             using (_diagnosticsSource.Activity(activityName))
             {
                 var postponeProcessingTill = DateTimeOffset.UtcNow + _appConfiguration.AsynchronousPackageValidationDelay;

--- a/tests/NuGetGallery.Facts/Services/AsynchronousPackageValidationInitiatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/AsynchronousPackageValidationInitiatorFacts.cs
@@ -29,7 +29,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.Equal(2, _data.Count);
-                Assert.NotEqual(_data[0].ValidationTrackingId, _data[1].ValidationTrackingId);
+                Assert.NotEqual(_data[0].ProcessValidationSet.ValidationTrackingId, _data[1].ProcessValidationSet.ValidationTrackingId);
             }
 
             [Fact]
@@ -47,8 +47,8 @@ namespace NuGetGallery
                     Times.Once);
                 Assert.Equal(1, _data.Count);
                 Assert.NotNull(_data[0]);
-                Assert.Equal(package.PackageRegistration.Id, _data[0].PackageId);
-                Assert.Equal(package.Version, _data[0].PackageVersion);
+                Assert.Equal(package.PackageRegistration.Id, _data[0].ProcessValidationSet.PackageId);
+                Assert.Equal(package.Version, _data[0].ProcessValidationSet.PackageVersion);
             }
 
             [Theory]
@@ -69,9 +69,9 @@ namespace NuGetGallery
                     Times.Once);
                 Assert.Equal(1, _data.Count);
                 Assert.NotNull(_data[0]);
-                Assert.Equal(package.PackageRegistration.Id, _data[0].PackageId);
-                Assert.Equal(package.Version, _data[0].PackageVersion);
-                Assert.Equal(expectedEntityKey, _data[0].EntityKey);
+                Assert.Equal(package.PackageRegistration.Id, _data[0].ProcessValidationSet.PackageId);
+                Assert.Equal(package.Version, _data[0].ProcessValidationSet.PackageVersion);
+                Assert.Equal(expectedEntityKey, _data[0].ProcessValidationSet.EntityKey);
             }
 
             [Fact]
@@ -152,7 +152,9 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.Equal(2, _data.Count);
-                Assert.NotEqual(_data[0].ValidationTrackingId, _data[1].ValidationTrackingId);
+                Assert.NotEqual(
+                    _data[0].ProcessValidationSet.ValidationTrackingId,
+                    _data[1].ProcessValidationSet.ValidationTrackingId);
             }
 
             [Fact]
@@ -170,8 +172,8 @@ namespace NuGetGallery
                     Times.Once);
                 Assert.Equal(1, _data.Count);
                 Assert.NotNull(_data[0]);
-                Assert.Equal(symbolPackage.Package.PackageRegistration.Id, _data[0].PackageId);
-                Assert.Equal(symbolPackage.Package.Version, _data[0].PackageVersion);
+                Assert.Equal(symbolPackage.Package.PackageRegistration.Id, _data[0].ProcessValidationSet.PackageId);
+                Assert.Equal(symbolPackage.Package.Version, _data[0].ProcessValidationSet.PackageVersion);
             }
 
             [Theory]
@@ -192,9 +194,9 @@ namespace NuGetGallery
                     Times.Once);
                 Assert.Equal(1, _data.Count);
                 Assert.NotNull(_data[0]);
-                Assert.Equal(symbolPackage.Package.PackageRegistration.Id, _data[0].PackageId);
-                Assert.Equal(symbolPackage.Package.Version, _data[0].PackageVersion);
-                Assert.Equal(expectedEntityKey, _data[0].EntityKey);
+                Assert.Equal(symbolPackage.Package.PackageRegistration.Id, _data[0].ProcessValidationSet.PackageId);
+                Assert.Equal(symbolPackage.Package.Version, _data[0].ProcessValidationSet.PackageVersion);
+                Assert.Equal(expectedEntityKey, _data[0].ProcessValidationSet.EntityKey);
             }
 
             [Fact]


### PR DESCRIPTION
React to the breaking API changes in https://github.com/NuGet/ServerCommon/pull/303, which blocks testing https://github.com/NuGet/ServerCommon/pull/297. This does not change any existing functionality.

Addresses https://github.com/NuGet/NuGetGallery/issues/7411