### PR TITLE
Unwrap error messages generated by jQuery Validation

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -35,6 +35,7 @@
 
         // Source: https://stackoverflow.com/questions/18754020/bootstrap-3-with-jquery-validation-plugin
         // Set the JQuery validation plugin's defaults to use classes recognized by Bootstrap.
+        var validatorErrorClass = 'help-block';
         $.validator.setDefaults({
             highlight: function (element) {
                 $(element).closest('.form-group').addClass('has-error');
@@ -43,7 +44,7 @@
                 $(element).closest('.form-group').removeClass('has-error');
             },
             errorElement: 'span',
-            errorClass: 'help-block',
+            errorClass: validatorErrorClass,
             errorPlacement: function (error, element) {
                 if (element.parent('.input-group').length) {
                     error.insertAfter(element.parent());
@@ -59,23 +60,25 @@
                 // This code removes the aria-describedby if the describing element is missing or empty.
                 var i;
                 for (i = 0; this.errorList[i]; i++) {
-                    removeInvalidAriaDescribedBy(this.errorList[i].element);
+                    removeInvalidAriaDescribedBy(this.errorList[i].element, validatorErrorClass);
                 }
 
                 for (i = 0; this.successList[i]; i++) {
-                    removeInvalidAriaDescribedBy(this.successList[i]);
+                    removeInvalidAriaDescribedBy(this.successList[i], validatorErrorClass);
                 }
             }
         });
     }
 
-    function removeInvalidAriaDescribedBy(element) {
+    function removeInvalidAriaDescribedBy(element, validatorErrorClass) {
         var describedBy = element.getAttribute("aria-describedby");
         if (!describedBy) {
             return;
         }
 
-        var ids = describedBy.split(" ")
+        var uniqueIds = [];
+        var ids = describedBy
+            .split(" ")
             .filter(function (describedById) {
                 if (!describedById) {
                     return false;
@@ -83,6 +86,29 @@
 
                 var describedByElement = $("#" + describedById);
                 return describedByElement && describedByElement.text();
+            })
+            .map(function (describedById) {
+                // By default, showErrors puts the error inside a container.
+                // This causes Narrator to read the error as being part of a group, even though it is the only error.
+                // JQuery Validator only ever shows a single error for each form input so it is always possible for us to simply unwrap the error.
+                var describedByElement = $("#" + describedById);
+                var parent = describedByElement.parent();
+                if (parent.hasClass(validatorErrorClass)) {
+                    parent.text(describedByElement.text());
+                    describedByElement.remove();
+                    return parent.attr('id');
+                } else {
+                    return describedById;
+                }
+            })
+            .filter(function (describedById) {
+                // Remove any duplicate IDs.
+                var isUnique = $.inArray(describedById, uniqueIds) === -1;
+                if (isUnique) {
+                    uniqueIds.push(describedById);
+                }
+
+                return isUnique;
             });
 
         if (ids.length) {

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -55,22 +55,19 @@
             showErrors: function (errorMap, errorList) {
                 this.defaultShowErrors();
 
-                // By default, showErrors adds an aria-describedby attribute to every field that it validates, even if it finds no issues.
-                // This is a problem, because the aria-describedby attribute will then link to an empty element.
-                // This code removes the aria-describedby if the describing element is missing or empty.
                 var i;
                 for (i = 0; this.errorList[i]; i++) {
-                    removeInvalidAriaDescribedBy(this.errorList[i].element, validatorErrorClass);
+                    fixAccessibilityIssuesWithAriaDescribedBy(this.errorList[i].element, validatorErrorClass);
                 }
 
                 for (i = 0; this.successList[i]; i++) {
-                    removeInvalidAriaDescribedBy(this.successList[i], validatorErrorClass);
+                    fixAccessibilityIssuesWithAriaDescribedBy(this.successList[i], validatorErrorClass);
                 }
             }
         });
     }
 
-    function removeInvalidAriaDescribedBy(element, validatorErrorClass) {
+    function fixAccessibilityIssuesWithAriaDescribedBy(element, validatorErrorClass) {
         var describedBy = element.getAttribute("aria-describedby");
         if (!describedBy) {
             return;
@@ -84,11 +81,14 @@
                     return false;
                 }
 
+                // The default showErrors adds an aria-describedby attribute to every field that it validates, even if it finds no issues.
+                // This is a problem, because the aria-describedby attribute will then link to an empty element.
+                // If the element linked to by the aria-describedby attribute is empty, remove the aria-describedby.
                 var describedByElement = $("#" + describedById);
                 return describedByElement && describedByElement.text();
             })
             .map(function (describedById) {
-                // By default, showErrors puts the error inside a container.
+                // The default showErrors puts the error inside a container.
                 // This causes Narrator to read the error as being part of a group, even though it is the only error.
                 // JQuery Validator only ever shows a single error for each form input so it is always possible for us to simply unwrap the error.
                 var describedByElement = $("#" + describedById);


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/905677

When the jQuery Validation plugin finds an issue with an input field, it adds a `span` containing the error message to a `span` that has `role=alert`. As a result, Narrator reads `alert group <the error message>`. This is because Narrator thinks the `div` is a `group` containing multiple elements instead of just one. Furthermore, [the jQuery Validation plugin only supports a single error message for every field](https://github.com/jquery-validation/jquery-validation/issues/2146), so there will never be more than one error message anyway, so wrapping the error message in a container is invalid.

To fix this, I have added some post-processing logic that gets rid of the nested `span` and moves the error message to the parent span.

To demonstrate what is going on here...

Before post-processing:
```
<input name="a" aria-describedby="error" />
<span id="validation-container">
    <span id="error">Invalid input!</span>
</span>
```

After post-processing:
```
<input name="a" aria-describedby="validation-container" />
<span id="validation-container">Invalid input!</span>
```