### PR TITLE
[Hotfix]Update modal dialog show binding.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-home.js
+++ b/src/NuGetGallery/Scripts/gallery/page-home.js
@@ -22,11 +22,9 @@ $(function () {
     });
 
     function showModal() {
-        $(function (e) {
-            $("#popUpModal").modal({
-                show: true,
-                focus: true
-            });
+        $("#popUpModal").modal({
+            show: true,
+            focus: true
         });
     };
 

--- a/src/NuGetGallery/Scripts/gallery/page-home.js
+++ b/src/NuGetGallery/Scripts/gallery/page-home.js
@@ -22,12 +22,12 @@ $(function () {
     });
 
     function showModal() {
-        $(document).on('ready', function (e) {
+        $(function (e) {
             $("#popUpModal").modal({
                 show: true,
                 focus: true
             });
-        })
+        });
     };
 
     function updateStats() {


### PR DESCRIPTION
jQuery3.x has fully removed the $(document).on("ready") binding for binding events to page ready (see https://api.jquery.com/ready/ for details).

This caused the modal dialog "show" method to never actually get called.

This appears to be the only place we use the document.on('ready') pattern, so update it to the proper, non-deprecated jQuery3.x ready binding.

Thanks to @adamjcooper for catching and reporting this (https://github.com/NuGet/NuGetGallery/issues/7415)