### PR TITLE
Add support for custom default request options in CloudBlobClientWrapper

### DIFF
--- a/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
@@ -12,6 +12,7 @@ namespace NuGetGallery
     public class CloudBlobClientWrapper : ICloudBlobClient
     {
         private readonly string _storageConnectionString;
+        private readonly BlobRequestOptions _defaultRequestOptions;
         private readonly bool _readAccessGeoRedundant;
         private CloudBlobClient _blobClient;
 
@@ -19,6 +20,12 @@ namespace NuGetGallery
         {
             _storageConnectionString = storageConnectionString;
             _readAccessGeoRedundant = readAccessGeoRedundant;
+        }
+
+        public CloudBlobClientWrapper(string storageConnectionString, BlobRequestOptions defaultRequestOptions)
+        {
+            _storageConnectionString = storageConnectionString;
+            _defaultRequestOptions = defaultRequestOptions;
         }
 
         public ISimpleCloudBlob GetBlobFromUri(Uri uri)
@@ -52,7 +59,12 @@ namespace NuGetGallery
                 {
                     _blobClient.DefaultRequestOptions.LocationMode = LocationMode.PrimaryThenSecondary;
                 }
+                else if (_defaultRequestOptions != null)
+                {
+                    _blobClient.DefaultRequestOptions = _defaultRequestOptions;
+                }
             }
+
             return new CloudBlobContainerWrapper(_blobClient.GetContainerReference(containerAddress));
         }
     }


### PR DESCRIPTION
Related to https://github.com/NuGet/Engineering/issues/2633

See https://github.com/Azure/azure-storage-net/issues/470#issuecomment-306245417 for more information.

There is no timeout by default. This API change will allow Azure Search Service to set a reasonable timeout instead of being unbounded.