### PR TITLE
Reduce flakiness of functional tests

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/UploadHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/UploadHelper.cs
@@ -54,7 +54,7 @@ namespace NuGetGallery.FunctionalTests.Helpers
         {
             lock (UniqueLock)
             {
-                return $"NuGetFunctionalTest_{DateTimeOffset.UtcNow.Ticks}";
+                return $"NuGetFunctionalTest_{Guid.NewGuid():N}";
             }
         }
 

--- a/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/GalleryTestBase.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/XunitExtensions/GalleryTestBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Net;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/NuGetGallery.FunctionalTests/Commandline/NuGetCommandLineTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/Commandline/NuGetCommandLineTests.cs
@@ -116,7 +116,7 @@ namespace NuGetGallery.FunctionalTests.Commandline
         [Category("P0Tests")]
         public async Task UploadAndDownloadPackageWithMinClientVersion()
         {
-            string packageId = DateTime.Now.Ticks + "PackageWithDotCsNames.Cs";
+            string packageId = $"{Guid.NewGuid():N}PackageWithDotCsNames.Cs";
             string version = "1.0.0";
             string packageFullPath = await _packageCreationHelper.CreatePackageWithMinClientVersion(packageId, version, "2.3");
 

--- a/tests/NuGetGallery.FunctionalTests/License/LicenseTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/License/LicenseTests.cs
@@ -26,7 +26,7 @@ namespace NuGetGallery.FunctionalTests.License
         public async Task UploadInValidPackageWithLicenseExpression()
         {
             // Arrange
-            var packageName = $"TestPackageWithLicense.{DateTime.UtcNow.Ticks}";
+            var packageName = $"TestPackageWithLicense.{Guid.NewGuid():N}";
             var packageVersion = "1.0.0";
             
             var licenseUrl = "https://testNugetLicenseUrl";
@@ -51,7 +51,7 @@ namespace NuGetGallery.FunctionalTests.License
         [InlineData("https://aka.ms/deprecateLicenseUrl", "licensefolder\\license.txt", "license.txt", "It's a license", "does not exist in the package")]
         public async Task UploadInValidPackageWithLicenseFile(string licenseUrl, string licenseFile, string licenseFileName, string licenseFileContents, string expectedErrorMessage)
         {
-            var packageName = $"TestPackageWithLicense.{DateTime.UtcNow.Ticks}";
+            var packageName = $"TestPackageWithLicense.{Guid.NewGuid():N}";
             string packageVersion = "1.0.0";
             string packageFullPath = await _packageCreationHelper.CreatePackageWithLicenseFile(packageName, packageVersion, licenseUrl, licenseFile, licenseFileName, licenseFileContents);
 

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -7,9 +7,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using NuGetGallery.FunctionalTests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -69,13 +67,18 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
             {
                 var packageId = UploadHelper.GetUniquePackageId();
                 var packageFullPath = await _packageCreationHelper.CreatePackage(packageId, version);
-                await _commandlineHelper.UploadPackageAsync(packageFullPath, UrlHelper.V2FeedPushSourceUrl);
+                var commandOutput = await _commandlineHelper.UploadPackageAsync(packageFullPath, UrlHelper.V2FeedPushSourceUrl);
+
+                Assert.True(
+                    commandOutput.ExitCode == 0,
+                    $"Push failed with exit code {commandOutput.ExitCode}{Environment.NewLine}{commandOutput.StandardError}");
+
                 uploadedPackageIds.Add(packageId);
             }
 
             await Task.WhenAll(uploadedPackageIds.Select(id => _clientSdkHelper.VerifyPackageExistsInV2Async(id, version)));
 
-            await CheckPackageTimestampsInOrder(uploadedPackageIds, "Created", uploadStartTimestamp);
+            await CheckPackageTimestampsInOrder(uploadedPackageIds, "Created", uploadStartTimestamp, version);
 
             // Unlist the packages in order.
             var unlistedPackageIds = new List<string>();
@@ -86,12 +89,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 unlistedPackageIds.Add(uploadedPackageId);
             }
 
-            await CheckPackageTimestampsInOrder(unlistedPackageIds, "LastEdited", unlistStartTimestamp);
-        }
-
-        private static string GetPackagesAppearInFeedInOrderUrl(DateTime time, string timestamp)
-        {
-            return $"{UrlHelper.V2FeedRootUrl}/Packages?$filter={timestamp} gt DateTime'{time:o}'&$orderby={timestamp} desc&$select={timestamp}";
+            await CheckPackageTimestampsInOrder(unlistedPackageIds, "LastEdited", unlistStartTimestamp, version);
         }
 
         /// <summary>
@@ -100,24 +98,25 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         /// <param name="packageIds">An ordered list of package ids. Each package id in the list must have a timestamp in the feed earlier than all package ids after it.</param>
         /// <param name="timestampPropertyName">The timestamp property to test the ordering of. For example, "Created" or "LastEdited".</param>
         /// <param name="operationStartTimestamp">A timestamp that is before all of the timestamps expected to be found in the feed. This is used in a request to the feed.</param>
-        private async Task CheckPackageTimestampsInOrder(IEnumerable<string> packageIds, string timestampPropertyName,
-            DateTime operationStartTimestamp)
+        private async Task CheckPackageTimestampsInOrder(
+            IEnumerable<string> packageIds,
+            string timestampPropertyName,
+            DateTime operationStartTimestamp,
+            string version)
         {
             var lastTimestamp = DateTime.MinValue;
             var lastPackageId = string.Empty;
             foreach (var packageId in packageIds)
             {
-                TestOutputHelper.WriteLine($"Attempting to check order of package {packageId} {timestampPropertyName} timestamp in feed.");
+                TestOutputHelper.WriteLine($"Attempting to check order of package {packageId} {version} {timestampPropertyName} timestamp in feed.");
 
-                var newTimestamp =
-                    await
-                        _odataHelper.GetTimestampOfPackageFromResponse(
-                            GetPackagesAppearInFeedInOrderUrl(operationStartTimestamp, timestampPropertyName),
-                            timestampPropertyName,
-                            packageId);
+                var newTimestamp = await _odataHelper.GetTimestampOfPackageFromResponse(
+                    packageId,
+                    version,
+                    timestampPropertyName);
 
                 Assert.True(newTimestamp.HasValue);
-                Assert.True(newTimestamp.Value > lastTimestamp,
+                Assert.True(newTimestamp.Value >= lastTimestamp,
                     $"Package {packageId} was last modified after package {lastPackageId} but has an earlier {timestampPropertyName} timestamp ({newTimestamp} should be greater than {lastTimestamp}).");
                 lastTimestamp = newTimestamp.Value;
                 lastPackageId = packageId;
@@ -134,9 +133,9 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         public async Task GetUpdates1199RegressionTest()
         {
             // Use unique version to make the assertions simpler.
-            var ticks = DateTime.Now.Ticks.ToString();
-            var packageId = $"GetUpdates1199RegressionTest.{ticks}";
+            var packageId = $"GetUpdates1199RegressionTest.{Guid.NewGuid():N}";
             var version1 = "1.0.0";
+            var ticks = DateTime.Now.Ticks.ToString();
             var version2 = new Version(Convert.ToInt32(ticks.Substring(0, 6) + 1) + "." + ticks.Substring(6, 6) + "." + ticks.Substring(12, 6)).ToString();
             var package1Location = await _packageCreationHelper.CreatePackageWithTargetFramework(packageId, version1, "net45");
 

--- a/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
@@ -33,7 +33,7 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
         public async Task DuplicatePushesAreRejectedAndNotDeleted()
         {
             // Arrange
-            var packageId = $"{nameof(DuplicatePushesAreRejectedAndNotDeleted)}.{DateTime.UtcNow.Ticks}";
+            var packageId = $"{nameof(DuplicatePushesAreRejectedAndNotDeleted)}.{Guid.NewGuid():N}";
 
             int pushVersionCount = 10;
             var duplicatePushTasks = new List<Task>();

--- a/tests/NuGetGallery.FunctionalTests/PackageCreation/SecurityPolicyTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageCreation/SecurityPolicyTests.cs
@@ -36,7 +36,7 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
         public async Task PackagePush_Returns400IfMinClientVersionPolicyNotMet(string clientVersion)
         {
             // Arrange
-            var id = $"{nameof(PackagePush_Returns400IfMinClientVersionPolicyNotMet)}.{DateTime.UtcNow.Ticks}";
+            var id = $"ValidClientVersion{Guid.NewGuid():N}";
 
             // Act
             var response = await PushPackageAsync(GalleryConfiguration.Instance.Account.ApiKey, id, clientVersion);
@@ -54,7 +54,7 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
         public async Task PackagePush_Returns200IfMinClientVersionPolicyMet(string clientVersion)
         {
             // Arrange
-            var id = $"{nameof(PackagePush_Returns200IfMinClientVersionPolicyMet)}.{DateTime.UtcNow.Ticks}";
+            var id = $"ClientVersionTooLow{Guid.NewGuid():N}";
 
             // Act
             var response = await PushPackageAsync(GalleryConfiguration.Instance.Account.ApiKey, id, clientVersion);
@@ -70,7 +70,7 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
         public async Task PackagePush_Returns200IfMinProtocolVersionPolicyMet()
         {
             // Arrange
-            var id = $"{nameof(PackagePush_Returns200IfMinProtocolVersionPolicyMet)}.{DateTime.UtcNow.Ticks}";
+            var id = $"ValidProtocolVersion{Guid.NewGuid():N}";
 
             // Act
             var response = await PushPackageAsync(GalleryConfiguration.Instance.Account.ApiKey, id, clientVersion: null, protocolVersion: "4.1.0");
@@ -86,7 +86,7 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
         public async Task VerifyPackageKey_Returns400IfPackageVerifyScopePolicyNotMet()
         {
             // Arrange
-            var id = $"VerifyKeyReturns400IfScopeNotMet.{DateTime.UtcNow.Ticks}";
+            var id = $"InvalidScopeForVerify{Guid.NewGuid():N}";
 
             var pushResponse = await PushPackageAsync(GalleryConfiguration.Instance.Account.ApiKey, id, "4.1.0");
             Assert.Equal(HttpStatusCode.Created, pushResponse.StatusCode);
@@ -105,7 +105,7 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
         public async Task VerifyPackageKey_Returns200IfPackageVerifyScopePolicyMet()
         {
             // Arrange
-            var id = $"{nameof(VerifyPackageKey_Returns200IfPackageVerifyScopePolicyMet)}.{DateTime.UtcNow.Ticks}";
+            var id = $"ValidScopeForVerify{Guid.NewGuid():N}";
 
             var pushResponse = await PushPackageAsync(GalleryConfiguration.Instance.Account.ApiKey, id, "4.1.0");
             Assert.Equal(HttpStatusCode.Created, pushResponse.StatusCode);


### PR DESCRIPTION
This fixes two issues observed:

- `PackagesAppearInFeedInOrderTest` sometimes failed because too many pushes happened from other caller during the test. This causes it to not be able to find a package in the first 100 packages after an arbitrary timestamp.
- `DateTime.[Utc]Now.Ticks` is not a good way to generate unique identifiers. I've observed some 409s. See https://stackoverflow.com/a/2143163. As a side note, I think we had an SDL task about this but perhaps missed/skipped this test code.