### PR TITLE
Breadcrumbs should be represented as lists to screenreaders

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -585,10 +585,10 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
 
 @helper Breadcrumb(bool showDivider, params Func<MvcHtmlString, HelperResult>[] segments)
 {
-    <h1 class="ms-font-xl breadcrumb-title">
+    <h1 role="list" class="ms-font-xl breadcrumb-title">
         @for (int i = 0; i < segments.Length; i++)
         {
-            <span class="ms-noWrap">@segments[i](MvcHtmlString.Empty)</span>
+            <span role="listitem" class="ms-noWrap">@segments[i](MvcHtmlString.Empty)</span>
 
             if (i < segments.Length - 1)
             {


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/917879

For some reason, the last nodes in our breadcrumbs do not read aloud to screen readers. I was not able to figure out why narrator was refusing to read the span, but it appears that, [according to accessibility guidance available online](https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html), breadcrumbs should be represented as lists. When I added the roles to the HTML, the screen reader began to properly read the breadcrumbs.

I started by rewriting the HTML into `<ol>` and `<ul>`, but doing so started a fight against the default CSS, so I felt that adding the roles, given that it is functionally equivalent to a screen reader, was a better choice.