### PR TITLE
[Hotfix] PackagesAppearInFeedInOrderTest should wait for unlisted packages to be unlisted in feed before checking timestamps

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -73,8 +73,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 uploadedPackageIds.Add(packageId);
             }
 
-            await Task.WhenAll(uploadedPackageIds.Select(id => _clientSdkHelper.VerifyPackageExistsInV2Async(id, version)));
-
+            await Task.WhenAll(uploadedPackageIds.Select(id => _clientSdkHelper.VerifyPackageExistsInV2Async(id, version, listed: true)));
             await CheckPackageTimestampsInOrder(uploadedPackageIds, "Created", uploadStartTimestamp);
 
             // Unlist the packages in order.
@@ -86,6 +85,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
                 unlistedPackageIds.Add(uploadedPackageId);
             }
 
+            await Task.WhenAll(unlistedPackageIds.Select(id => _clientSdkHelper.VerifyPackageExistsInV2Async(id, version, listed: false)));
             await CheckPackageTimestampsInOrder(unlistedPackageIds, "LastEdited", unlistStartTimestamp);
         }
 


### PR DESCRIPTION
A recent backend change has made this test flaky, because listing changes are not immediately available in OData. This causes a race condition between the unlist becoming available in OData and the timestamp comparison.