### PR TITLE
Transform form shouldn't ask for confirmation if form is invalid

### DIFF
--- a/src/NuGetGallery/Views/Users/TransformToOrganization.cshtml
+++ b/src/NuGetGallery/Views/Users/TransformToOrganization.cshtml
@@ -95,7 +95,12 @@
         $(function ()
         {
             var confirmation = "@Html.Raw(transformConfirmation)";
-            $("#transform").submit(function (event) {
+            var $transformForm = $("#transform");
+            $transformForm.submit(function (event) {
+                if (!$transformForm.valid()) {
+                    return false;
+                }
+
                 return window.nuget.confirmEvent(
                     window.nuget.formatString(confirmation, $("#AdminUsername").val()),
                     event);


### PR DESCRIPTION
https://github.com/nuget/nugetgallery/issues/7325

We shouldn't ask for user confirmation if the form is invalid--e.g. the username is empty or contains disallowed characters.