### PR TITLE
[Hotfix]Pass through version on a timestamp check.

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -77,7 +77,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
             }
 
             await Task.WhenAll(uploadedPackageIds.Select(id => _clientSdkHelper.VerifyPackageExistsInV2Async(id, version, listed: true)));
-            await CheckPackageTimestampsInOrder(uploadedPackageIds, "Created", uploadStartTimestamp);
+            await CheckPackageTimestampsInOrder(uploadedPackageIds, "Created", uploadStartTimestamp, version);
 
             // Unlist the packages in order.
             var unlistedPackageIds = new List<string>();
@@ -89,7 +89,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
             }
 
             await Task.WhenAll(unlistedPackageIds.Select(id => _clientSdkHelper.VerifyPackageExistsInV2Async(id, version, listed: false)));
-            await CheckPackageTimestampsInOrder(unlistedPackageIds, "LastEdited", unlistStartTimestamp);
+            await CheckPackageTimestampsInOrder(unlistedPackageIds, "LastEdited", unlistStartTimestamp, version);
         }
 
         private static string GetPackagesAppearInFeedInOrderUrl(DateTime time, string timestamp)


### PR DESCRIPTION
Resolution of a merge conflict ended up causing a build issue. This patch fixes the error.