### PR TITLE
Make the admin index page a little better looking

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -695,6 +695,10 @@ img.reserved-indicator-icon {
   margin-top: 6px;
   margin-bottom: 6px;
 }
+.page-admin-index h2 {
+  margin-bottom: 8px;
+  margin-top: 32px;
+}
 .page-api-keys .example-commands {
   background-color: #002440;
   font-family: Consolas, Menlo, Monaco, "Courier New", monospace;

--- a/src/Bootstrap/less/theme/all.less
+++ b/src/Bootstrap/less/theme/all.less
@@ -9,6 +9,7 @@
 @import "page-about.less";
 @import "page-account-settings.less";
 @import "page-add-organization.less";
+@import "page-admin-index.less";
 @import "page-api-keys.less";
 @import "page-blog.less";
 @import "page-delete-account.less";

--- a/src/Bootstrap/less/theme/page-admin-index.less
+++ b/src/Bootstrap/less/theme/page-admin-index.less
@@ -1,0 +1,6 @@
+.page-admin-index {
+    h2 {
+        margin-bottom: 8px;
+        margin-top: 32px;
+    }
+}

--- a/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
@@ -4,9 +4,9 @@
     ViewBag.Tab = "Admin";
 }
 
-<section role="main" class="container main-container">
+<section role="main" class="container main-container page-admin-index">
     <h1>Site Administration</h1>
-    <ul>
+    <ul class="list-unstyled">
         @if (Model.ShowDatabaseAdmin)
         {
             <li>


### PR DESCRIPTION
The `<ul>` dots before the icons look bad. Also it's too spaced out.

## Before 

![screencapture-localhost-Admin-2019-08-10-14_03_54](https://user-images.githubusercontent.com/94054/62826838-cf019300-bb77-11e9-8727-54a4dc458a5c.png)

## After

![screencapture-localhost-Admin-2019-08-10-14_03_06](https://user-images.githubusercontent.com/94054/62826840-d32db080-bb77-11e9-8cf8-df034ecf6edd.png)
