### PR TITLE
[Queue-Back 1] Split read vs. read/write feature flag storage services

### DIFF
--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -109,16 +109,16 @@
       <Version>4.1.0-master-2602271</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
       <Version>4.1.0-dev-2759568</Version>

--- a/src/AccountDeleter/Job.cs
+++ b/src/AccountDeleter/Job.cs
@@ -136,7 +136,7 @@ namespace NuGetGallery.AccountDeleter
                 services.AddScoped<IAuthenticationService, AuthenticationService>();
                 services.AddScoped<ISupportRequestService, ISupportRequestService>();
 
-                services.AddScoped<IEditableFeatureFlagStorageService, FeatureFlagFileStorageService>();
+                services.AddScoped<IEditableFeatureFlagStorageService, EditableFeatureFlagFileStorageService>();
                 services.AddScoped<ICoreFileStorageService, CloudBlobFileStorageService>();
                 services.AddScoped<ICloudBlobContainerInformationProvider, GalleryCloudBlobContainerInformationProvider>();
 

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -75,10 +75,10 @@
       <Version>4.1.0-master-2758883</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -91,7 +91,7 @@
       <Version>4.1.0-master-2602271</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGetGallery.Core/Features/EditableFeatureFlagFileStorageService.cs
+++ b/src/NuGetGallery.Core/Features/EditableFeatureFlagFileStorageService.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage;
+using Newtonsoft.Json;
+using NuGet.Services.Entities;
+using NuGet.Services.FeatureFlags;
+using NuGetGallery.Auditing;
+
+namespace NuGetGallery.Features
+{
+    public class EditableFeatureFlagFileStorageService : FeatureFlagFileStorageService, IEditableFeatureFlagStorageService
+    {
+        private const int MaxRemoveUserAttempts = 3;
+
+        private readonly IAuditingService _auditing;
+        private readonly ILogger<EditableFeatureFlagFileStorageService> _logger;
+
+        public EditableFeatureFlagFileStorageService(
+            ICoreFileStorageService storage,
+            IAuditingService auditing,
+            ILogger<EditableFeatureFlagFileStorageService> logger) : base(storage)
+        {
+            _auditing = auditing ?? throw new ArgumentNullException(nameof(auditing));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<FeatureFlagReference> GetReferenceAsync()
+        {
+            var reference = await _storage.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName);
+
+            return new FeatureFlagReference(
+                ReadFeatureFlagsFromStream(reference.OpenRead()),
+                reference.ContentId);
+        }
+
+        public async Task RemoveUserAsync(User user)
+        {
+            for (var attempt = 0; attempt < MaxRemoveUserAttempts; attempt++)
+            {
+                var reference = await _storage.GetFileReferenceAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName);
+
+                FeatureFlags flags;
+                using (var stream = reference.OpenRead())
+                using (var streamReader = new StreamReader(stream))
+                using (var reader = new JsonTextReader(streamReader))
+                {
+                    flags = Serializer.Deserialize<FeatureFlags>(reader);
+                }
+
+                // Don't update the flags if the user isn't listed in any of the flights.
+                if (!flags.Flights.Any(f => f.Value.Accounts.Contains(user.Username, StringComparer.OrdinalIgnoreCase)))
+                {
+                    return;
+                }
+
+                // The user is listed in the flights. Build a new feature flag object that
+                // no longer contains the user.
+                var result = new FeatureFlags(
+                   flags.Features,
+                   flags.Flights
+                       .ToDictionary(
+                           f => f.Key,
+                           f => RemoveUser(f.Value, user)));
+
+                var saveResult = await TrySaveAsync(result, reference.ContentId);
+                if (saveResult == FeatureFlagSaveResult.Ok)
+                {
+                    return;
+                }
+
+                _logger.LogWarning(
+                    0,
+                    "Failed to remove user from feature flags, attempt {Attempt} of {MaxAttempts}...",
+                    attempt + 1,
+                    MaxRemoveUserAttempts);
+            }
+
+            throw new InvalidOperationException($"Unable to remove user from feature flags after {MaxRemoveUserAttempts} attempts");
+        }
+
+        public async Task<FeatureFlagSaveResult> TrySaveAsync(FeatureFlags flags, string contentId)
+        {
+            var result = await TrySaveInternalAsync(flags, contentId);
+            await _auditing.SaveAuditRecordAsync(
+                new FeatureFlagsAuditRecord(
+                    AuditedFeatureFlagsAction.Update, 
+                    flags, 
+                    contentId, 
+                    result));
+
+            return result;
+        }
+
+        private async Task<FeatureFlagSaveResult> TrySaveInternalAsync(FeatureFlags flags, string contentId)
+        {
+            var accessCondition = AccessConditionWrapper.GenerateIfMatchCondition(contentId);
+
+            try
+            {
+                using (var stream = new MemoryStream())
+                using (var writer = new StreamWriter(stream))
+                using (var jsonWriter = new JsonTextWriter(writer))
+                {
+                    Serializer.Serialize(jsonWriter, flags);
+                    jsonWriter.Flush();
+                    stream.Position = 0;
+
+                    await _storage.SaveFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName, stream, accessCondition);
+
+                    return FeatureFlagSaveResult.Ok;
+                }
+            }
+            catch (StorageException e) when (e.IsPreconditionFailedException())
+            {
+                return FeatureFlagSaveResult.Conflict;
+            }
+        }
+
+        private Flight RemoveUser(Flight flight, User user)
+        {
+            return new Flight(
+                flight.All,
+                flight.SiteAdmins,
+                flight.Accounts.Where(a => !a.Equals(user.Username, StringComparison.OrdinalIgnoreCase)).ToList(),
+                flight.Domains);
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Features/FeatureFlagSaveResult.cs
+++ b/src/NuGetGallery.Core/Features/FeatureFlagSaveResult.cs
@@ -4,7 +4,7 @@
 namespace NuGetGallery.Features
 {
     /// <summary>
-    /// The result of calling <see cref="FeatureFlagFileStorageService.TrySaveAsync(string, string)"/>.
+    /// The result of calling <see cref="EditableFeatureFlagFileStorageService.TrySaveAsync(string, string)"/>.
     /// </summary>
     public enum FeatureFlagSaveResult
     {

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -142,8 +142,9 @@
     <Compile Include="Extensions\StorageExceptionExtensions.cs" />
     <Compile Include="Extensions\UserExtensionsCore.cs" />
     <Compile Include="Extensions\ValidationIssueExtensions.cs" />
-    <Compile Include="Features\FeatureFlagFileStorageService.cs" />
+    <Compile Include="Features\EditableFeatureFlagFileStorageService.cs" />
     <Compile Include="Features\FeatureFlagClientExtensions.cs" />
+    <Compile Include="Features\FeatureFlagFileStorageService.cs" />
     <Compile Include="Features\FeatureFlagReference.cs" />
     <Compile Include="Features\FeatureFlagSaveResult.cs" />
     <Compile Include="Features\IEditableFeatureFlagStorageService.cs" />
@@ -235,19 +236,19 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -291,10 +291,10 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -525,7 +525,7 @@ namespace NuGetGallery
                 .SingleInstance();
 
             builder
-                .Register(context => context.Resolve<FeatureFlagFileStorageService>())
+                .Register(context => context.Resolve<EditableFeatureFlagFileStorageService>())
                 .As<IEditableFeatureFlagStorageService>()
                 .SingleInstance();
 

--- a/src/NuGetGallery/App_Start/StorageDependent.cs
+++ b/src/NuGetGallery/App_Start/StorageDependent.cs
@@ -93,7 +93,7 @@ namespace NuGetGallery
                 Create<UploadFileService, IUploadFileService>(configuration.AzureStorage_Uploads_ConnectionString, isSingleInstance: false),
                 Create<CoreLicenseFileService, ICoreLicenseFileService>(configuration.AzureStorage_FlatContainer_ConnectionString, isSingleInstance: false),
                 Create<RevalidationStateService, IRevalidationStateService>(configuration.AzureStorage_Revalidation_ConnectionString, isSingleInstance: false),
-                Create<FeatureFlagFileStorageService, IFeatureFlagStorageService>(configuration.AzureStorage_Content_ConnectionString, isSingleInstance: true)
+                Create<EditableFeatureFlagFileStorageService, IFeatureFlagStorageService>(configuration.AzureStorage_Content_ConnectionString, isSingleInstance: true)
             };
 
             var connectionStringToBindingKey = dependents

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2049,7 +2049,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
@@ -2246,13 +2246,13 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.53.0</Version>
+      <Version>2.54.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/tests/NuGetGallery.Core.Facts/Features/EditableFeatureFlagFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Features/EditableFeatureFlagFileStorageServiceFacts.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace NuGetGallery.Features
 {
-    public class FeatureFlagFileStorageServiceFacts
+    public class EditableFeatureFlagFileStorageServiceFacts
     {
         public static FeatureFlags Example = new FeatureFlags(
             new Dictionary<string, FeatureStatus>
@@ -619,16 +619,16 @@ namespace NuGetGallery.Features
         {
             protected readonly Mock<ICoreFileStorageService> _storage;
             protected readonly Mock<IAuditingService> _auditing;
-            protected readonly FeatureFlagFileStorageService _target;
+            protected readonly EditableFeatureFlagFileStorageService _target;
             protected readonly StorageException _preconditionException;
 
             public FactsBase()
             {
-                var logger = Mock.Of<ILogger<FeatureFlagFileStorageService>>();
+                var logger = Mock.Of<ILogger<EditableFeatureFlagFileStorageService>>();
 
                 _storage = new Mock<ICoreFileStorageService>();
                 _auditing = new Mock<IAuditingService>();
-                _target = new FeatureFlagFileStorageService(
+                _target = new EditableFeatureFlagFileStorageService(
                     _storage.Object, _auditing.Object, logger);
 
                 _preconditionException = new StorageException(

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -80,7 +80,7 @@
     <Compile Include="Certificates\CertificateFileFacts.cs" />
     <Compile Include="Cookies\CookieComplianceServiceBaseFacts.cs" />
     <Compile Include="Features\FeatureFlagClientExtensionsFacts.cs" />
-    <Compile Include="Features\FeatureFlagFileStorageServiceFacts.cs" />
+    <Compile Include="Features\EditableFeatureFlagFileStorageServiceFacts.cs" />
     <Compile Include="GitHub\GitHubUsageConfigurationFacts.cs" />
     <Compile Include="Infrastructure\ElmahExceptionFacts.cs" />
     <Compile Include="Extensions\UserExtensionsCoreFacts.cs" />

--- a/tests/NuGetGallery.Facts/App_Start/StorageDependentFacts.cs
+++ b/tests/NuGetGallery.Facts/App_Start/StorageDependentFacts.cs
@@ -75,7 +75,7 @@ namespace NuGetGallery
             Assert.Contains(typeof(UploadFileService), implementationToInterface.Keys);
             Assert.Contains(typeof(CoreLicenseFileService), implementationToInterface.Keys);
             Assert.Contains(typeof(RevalidationStateService), implementationToInterface.Keys);
-            Assert.Contains(typeof(FeatureFlagFileStorageService), implementationToInterface.Keys);
+            Assert.Contains(typeof(EditableFeatureFlagFileStorageService), implementationToInterface.Keys);
             Assert.Equal(8, implementationToInterface.Count);
             Assert.Equal(typeof(ICertificateService), implementationToInterface[typeof(CertificateService)]);
             Assert.Equal(typeof(IContentService), implementationToInterface[typeof(ContentService)]);
@@ -84,7 +84,7 @@ namespace NuGetGallery
             Assert.Equal(typeof(IUploadFileService), implementationToInterface[typeof(UploadFileService)]);
             Assert.Equal(typeof(ICoreLicenseFileService), implementationToInterface[typeof(CoreLicenseFileService)]);
             Assert.Equal(typeof(IRevalidationStateService), implementationToInterface[typeof(RevalidationStateService)]);
-            Assert.Equal(typeof(IFeatureFlagStorageService), implementationToInterface[typeof(FeatureFlagFileStorageService)]);
+            Assert.Equal(typeof(IFeatureFlagStorageService), implementationToInterface[typeof(EditableFeatureFlagFileStorageService)]);
         }
 
         [Fact]


### PR DESCRIPTION
Update to latest server common to pull in https://github.com/NuGet/ServerCommon/pull/306
Progress on https://github.com/NuGet/NuGetGallery/issues/7439

This will allow other components (e.g. NuGet.Jobs) to use feature flags without needing the "write" feature flag method. In particular, the "write" feature flag service (`EditableFeatureFlagFileStorageService`) needs an `IAuditingService` which shouldn't be needed in a background job context where only "read" feature flag operations are performed.

The NuGet.Services.FeatureFlags update makes app shutdown much faster. I was able to trigger the cancellation token provided by `HostingEnvironment.QueueBackgroundWorkItem` getting to a cancelled state by stopping the site in IIS Express. It seems like the shutdown before this change triggered some sort of timeout case in IIS where the background work item `Task` would be abandoned after about 30 seconds. In other words, previously if the feature flag `RefreshInterval` has more than ~30 seconds left, IIS would stop the app anyway. This was not harmful to the app since it was shutting down anyway but it did delay shutdown.