### PR TITLE
GitHub Usage expander should be tabbable

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -514,7 +514,7 @@
             @if(Model.IsGitHubUsageEnabled && !Model.IsDotnetToolPackageType)
             {
                 <h2>
-                    <a role="button" data-toggle="collapse" data-target="#github-usage"
+                    <a href="#" role="button" data-toggle="collapse" data-target="#github-usage"
                        aria-expanded="false" aria-controls="github-usage" id="show-github-usage">
                         <i class="ms-Icon ms-Icon--ChevronRight" aria-hidden="true"></i>
                         <span>GitHub Usage</span>


### PR DESCRIPTION
https://github.com/nuget/nugetgallery/issues/7452

This was the only difference between the other expanders on the page and this one.