### PR TITLE
Add aria-label to Add Organization page logo

### DIFF
--- a/src/NuGetGallery/Views/Organizations/Add.cshtml
+++ b/src/NuGetGallery/Views/Organizations/Add.cshtml
@@ -26,7 +26,14 @@
             <div>
                 <aside class="col-sm-3 col-sm-push-9">
                     <b>Logo</b>
-                    <img src="@Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")" class="owner-image img-responsive" height="332" id="gravatar-image" width="332" alt="gravatar" title="Organization logo">
+                    <img src="@Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")" 
+                         class="owner-image img-responsive" 
+                         height="332" 
+                         id="gravatar-image" 
+                         width="332" 
+                         alt="gravatar" 
+                         title="Organization logo" 
+                         aria-label="Organization logo">
                     <p class="ms-font-s">
                         We use the email address for your organization and gravatar.com to get the logo.
                     </p>


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/904941

I misread this bug--turns out they were talking about the organization image's tooltip and not the logo icon's tooltip (which we've removed).