### PR TITLE
[Azure Search] Allow default searches to go to preview search

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -994,13 +994,14 @@ namespace NuGetGallery
 
             SearchResults results;
 
-            var isPreviewSearchEnabled = !string.IsNullOrEmpty(q) && _abTestService.IsPreviewSearchEnabled(GetCurrentUser());
+            var isPreviewSearchEnabled = _abTestService.IsPreviewSearchEnabled(GetCurrentUser());
             var searchService = isPreviewSearchEnabled ? _previewSearchService : _searchService;
 
             // fetch most common query from cache to relieve load on the search service
-            if (string.IsNullOrEmpty(q) && page == 1 && includePrerelease && !isPreviewSearchEnabled)
+            if (string.IsNullOrEmpty(q) && page == 1 && includePrerelease)
             {
-                var cachedResults = HttpContext.Cache.Get("DefaultSearchResults");
+                var cacheKey = isPreviewSearchEnabled ? "DefaultPreviewSearchResults" : "DefaultSearchResults";
+                var cachedResults = HttpContext.Cache.Get(cacheKey);
                 if (cachedResults == null)
                 {
                     var searchFilter = SearchAdaptor.GetSearchFilter(
@@ -1015,7 +1016,7 @@ namespace NuGetGallery
 
                     // note: this is a per instance cache
                     HttpContext.Cache.Add(
-                        "DefaultSearchResults",
+                        cacheKey,
                         results,
                         null,
                         DateTime.UtcNow.AddMinutes(10),

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -62,9 +62,7 @@
         }
         @foreach (var package in Model.Items)
         {
-            // Only set an item index when there is a search query, for now.
-            var thisItemIndex = string.IsNullOrWhiteSpace(Model.SearchTerm) ? null : (int?) itemIndex;
-            @Html.Partial("_ListPackage", package, new ViewDataDictionary { { "itemIndex", thisItemIndex }, { "eventName", eventName } })
+            @Html.Partial("_ListPackage", package, new ViewDataDictionary { { "itemIndex", itemIndex }, { "eventName", eventName } })
             itemIndex++;
         }
     </div>
@@ -84,15 +82,17 @@
         // Used to track how many selections were made on this page. Multiple selections can happen if the user opens
         // a search selection in a new tab, instead of navigating away from this page.
         var sincePageLoadCount = 0;
-        @if (!string.IsNullOrWhiteSpace(Model.SearchTerm) && (Model.PageIndex == 0 || Model.Items.Count() > 0))
-        {
+        @{
+            var searchId = Guid.NewGuid().ToString();
             var category = Model.IsPreviewSearch ? "preview-search-page" : "search-page";
             var action = Model.IncludePrerelease ? "search-prerel" : "search-stable";
+
             // Emit an event representing the search page and the page index. This make it easier for the search selection
             // event to be correlated in Google Analytics.
             <text>
             window.nuget.sendAnalyticsEvent('@category', '@action', @Html.Raw(Json.Encode(Model.SearchTerm)), @Model.PageIndex);
             window.nuget.sendAiMetric('BrowserSearchPage', @Model.PageIndex, {
+                SearchId: '@searchId',
                 SearchTerm: @Html.Raw(Json.Encode(Model.SearchTerm)),
                 IncludePrerelease: '@Model.IncludePrerelease',
                 PageIndex: @Model.PageIndex,
@@ -112,6 +112,7 @@
                 var data = $this.data();
                 if ($this.attr('href') && data.track) {
                     window.nuget.sendAiMetric('BrowserSearchSelection', data.trackValue, {
+                        SearchId: '@searchId',
                         SearchTerm: @Html.Raw(Json.Encode(Model.SearchTerm)),
                         IncludePrerelease: '@Model.IncludePrerelease',
                         PageIndex: @Model.PageIndex,


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7455

Also, add a GUID to correlate clicks and searches more precisely than search term.