### PR TITLE
Embedded icon display on verify package page and indexing message

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -22,6 +22,8 @@ namespace NuGetGallery
         public const string MarkdownContentType = "text/markdown"; // rfc7763
         public const string CertificateContentType = "application/pkix-cert";
         public const string JsonContentType = "application/json";
+        public const string JpegContentType = "image/jpeg";
+        public const string PngContentType = "image/png";
 
         public const string DefaultCacheControl = "max-age=120";
 

--- a/src/NuGetGallery/Extensions/ImageExtensions.cs
+++ b/src/NuGetGallery/Extensions/ImageExtensions.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Lucene.Net.Documents;
+
+namespace NuGetGallery
+{
+    public static class ImageExtensions
+    {
+        /// <summary>
+        /// The PNG file header bytes. All PNG files are expected to have those at the beginning of the file.
+        /// </summary>
+        /// <remarks>
+        /// https://www.w3.org/TR/PNG/#5PNG-file-signature
+        /// </remarks>
+        private static readonly byte[] PngHeader = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+
+        /// <summary>
+        /// The JPG file heder bytes.
+        /// </summary>
+        /// <remarks>
+        /// Technically, JPEG start with SOI (start of image) segment: FFD8, followed by several other segments, but all of them
+        /// start with FF, so we check first 3 bytes instead of the first two.
+        /// http://www.digicamsoft.com/itu/itu-t81-36.html
+        /// </remarks>
+        private static readonly byte[] JpegHeader = new byte[] { 0xFF, 0xD8, 0xFF };
+
+        public static async Task<bool> HasPngHeaderAsync(this Stream stream)
+        {
+            return await StreamStartsWithAsync(stream, PngHeader);
+        }
+
+        public static async Task<bool> HasJpegHeaderAsync(this Stream stream)
+        {
+            return await StreamStartsWithAsync(stream, JpegHeader);
+        }
+
+        public static bool HasPngHeader(this byte[] imageData)
+        {
+            return ArrayStartsWith(imageData, PngHeader);
+        }
+
+        public static bool HasJpegHeader(this byte[] imageData)
+        {
+            return ArrayStartsWith(imageData, JpegHeader);
+        }
+
+        private static async Task<bool> StreamStartsWithAsync(Stream stream, byte[] expectedBytes)
+        {
+            var actualBytes = new byte[expectedBytes.Length];
+            var bytesRead = await stream.ReadAsync(actualBytes, 0, actualBytes.Length);
+
+            if (bytesRead != expectedBytes.Length)
+            {
+                return false;
+            }
+
+            return expectedBytes.SequenceEqual(actualBytes);
+        }
+
+        private static bool ArrayStartsWith(byte[] array, byte[] expectedBytes)
+        {
+            if (array.Length < expectedBytes.Length)
+            {
+                return false;
+            }
+
+            for (int index = 0; index < expectedBytes.Length; ++index)
+            {
+                if (array[index] != expectedBytes[index])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -112,6 +112,7 @@ namespace NuGetGallery
             }
 
             viewModel.ReadMeHtml = readMeHtml;
+            viewModel.HasEmbeddedIcon = package.HasEmbeddedIcon;
 
             return viewModel;
         }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Controllers\ExperimentsController.cs" />
     <Compile Include="Controllers\ManageDeprecationJsonApiController.cs" />
     <Compile Include="ExtensionMethods.cs" />
+    <Compile Include="Extensions\ImageExtensions.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeleteAccountListPackageItemViewModelFactory.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeletePackageViewModelFactory.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DisplayLicenseViewModelFactory.cs" />

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -45,24 +45,6 @@ namespace NuGetGallery
         };
 
         /// <summary>
-        /// The PNG file header bytes. All PNG files are expected to have those at the beginning of the file.
-        /// </summary>
-        /// <remarks>
-        /// https://www.w3.org/TR/PNG/#5PNG-file-signature
-        /// </remarks>
-        private static readonly byte[] PngHeader = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-
-        /// <summary>
-        /// The JPG file header bytes.
-        /// </summary>
-        /// <remarks>
-        /// Technically, JPEG start with two byte SOI (start of image) segment: FFD8, followed by several other segments or fill bytes.
-        /// All of the segments start with FF, and fill bytes are FF, so we check the first 3 bytes instead of the first two.
-        /// https://www.w3.org/Graphics/JPEG/itu-t81.pdf "B.1.1.2 Markers"
-        /// </remarks>
-        private static readonly byte[] JpegHeader = new byte[] { 0xFF, 0xD8, 0xFF };
-
-        /// <summary>
         /// The upper limit on allowed license file size.
         /// </summary>
         /// <remarks>
@@ -436,12 +418,12 @@ namespace NuGetGallery
 
         private static async Task<bool> IsPngAsync(PackageArchiveReader nuGetPackage, string iconPath)
         {
-            return await FileMatchesPredicate(nuGetPackage, iconPath, stream => stream.NextBytesMatchAsync(PngHeader));
+            return await FileMatchesPredicate(nuGetPackage, iconPath, stream => stream.NextBytesMatchPngHeaderAsync());
         }
 
         private static async Task<bool> IsJpegAsync(PackageArchiveReader nuGetPackage, string iconPath)
         {
-            return await FileMatchesPredicate(nuGetPackage, iconPath, stream => stream.NextBytesMatchAsync(JpegHeader));
+            return await FileMatchesPredicate(nuGetPackage, iconPath, stream => stream.NextBytesMatchJpegHeaderAsync());
         }
 
         private static bool FileExists(PackageArchiveReader nuGetPackage, string filename)

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -35,6 +35,7 @@ namespace NuGetGallery
         public bool IsPackageDeprecationEnabled { get; set; }
         public bool IsGitHubUsageEnabled { get; set; }
         public NuGetPackageGitHubInformation GitHubDependenciesInformation { get; set; }
+        public bool HasEmbeddedIcon { get; set; }
 
         public bool HasNewerPrerelease
         {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -312,6 +312,15 @@
                 )
             }
 
+            @if (Model.HasEmbeddedIcon && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
+            {
+                @ViewHelpers.AlertWarning(
+                    @<text>
+                        The package icon will become available after this package is indexed.
+                    </text>
+                )
+            }
+
             @if (Model.IsSemVer2)
             {
                 @ViewHelpers.AlertIsSemVer2Package(Model.HasSemVer2Version, Model.HasSemVer2Dependency)

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -201,11 +201,13 @@
                 <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.RepositoryUrl }}"></div>
             </div>
 
+            <!-- ko if: !$data.IconUrl || !$data.IconUrl.startsWith('data:') -->
             <div class="verify-package-field">
                 <!-- Bind an on change event here to update the preview below-->
                 <label class="verify-package-field-heading">Icon URL</label>
                 <div data-bind="template: { name: 'display-data-or-default', data: { DisplayText: $data.IconUrl }}"></div>
             </div>
+            <!-- /ko -->
 
             <!-- ko if: $data.IconUrl -->
             <div class="verify-package-field row">


### PR DESCRIPTION
Addresses #7239, #7093.

Moved the image type identification bits to the `ImageExtensions` to be shared between controllers and services.
Updated `PackagesController` to identify the image type from the image signature and generate data: url with proper content type.

On a verify package page it looks like this:
![image](https://user-images.githubusercontent.com/102933/63381038-b863f480-c34c-11e9-947c-b9b1360830fd.png)
(the icon in this case is 1024x1024 reduced by browser to our "regular size")