### PR TITLE
Improve admin delete account page and add ability for admins to rename deleted accounts

### DIFF
--- a/src/AccountDeleter/AccountDeleteUserService.cs
+++ b/src/AccountDeleter/AccountDeleteUserService.cs
@@ -157,5 +157,10 @@ namespace NuGetGallery.AccountDeleter
         {
             throw new NotImplementedException();
         }
+
+        public Task RenameDeletedAccount(User user)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/AccountDeleter/EmptyUserService.cs
+++ b/src/AccountDeleter/EmptyUserService.cs
@@ -144,5 +144,10 @@ namespace NuGetGallery.AccountDeleter
         {
             throw new NotImplementedException();
         }
+
+        public Task RenameDeletedAccount(User user)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGetGallery.Services/Exceptions/UserSafeException.cs
+++ b/src/NuGetGallery.Services/Exceptions/UserSafeException.cs
@@ -48,7 +48,7 @@ namespace NuGetGallery
             {
                 return uvex.UserMessage;
             }
-            return Strings.DefaultUserSafeExceptionMessage;
+            return ServicesStrings.DefaultUserSafeExceptionMessage;
         }
 
         public static void Log(this Exception self)

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Diagnostics\SendErrorsToTelemetryAttribute.cs" />
     <Compile Include="Diagnostics\TraceDiagnosticsSource.cs" />
     <Compile Include="Diagnostics\TraceDiagnosticsSourceScope.cs" />
+    <Compile Include="Exceptions\UserSafeException.cs" />
     <Compile Include="Extensions\Base32Encoder.cs" />
     <Compile Include="Extensions\ClaimsExtensions.cs" />
     <Compile Include="Extensions\CredentialExtensions.cs" />

--- a/src/NuGetGallery.Services/ServicesStrings.Designer.cs
+++ b/src/NuGetGallery.Services/ServicesStrings.Designer.cs
@@ -1571,6 +1571,24 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot rename a deleted account that was already renamed..
+        /// </summary>
+        public static string RenameDeletedAccount_AlreadyRenamed {
+            get {
+                return ResourceManager.GetString("RenameDeletedAccount_AlreadyRenamed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot renamed a deleted account that is not deleted..
+        /// </summary>
+        public static string RenameDeletedAccount_NotDeleted {
+            get {
+                return ResourceManager.GetString("RenameDeletedAccount_NotDeleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to At least one package owner has no certificate while at least one other package owner has at least one certificate, which means future package submissions may be unsigned or signed with any certificate registered to any owner..
         /// </summary>
         public static string RequiredSigner_AnyWithMixedResult {

--- a/src/NuGetGallery.Services/ServicesStrings.Designer.cs
+++ b/src/NuGetGallery.Services/ServicesStrings.Designer.cs
@@ -1580,7 +1580,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot renamed a deleted account that is not deleted..
+        ///   Looks up a localized string similar to Cannot rename an account that is not deleted..
         /// </summary>
         public static string RenameDeletedAccount_NotDeleted {
             get {

--- a/src/NuGetGallery.Services/ServicesStrings.resx
+++ b/src/NuGetGallery.Services/ServicesStrings.resx
@@ -1127,4 +1127,10 @@ The {1} Team</value>
   <data name="AsyncAccountDelete_Success" xml:space="preserve">
     <value>The account '{0}' was enqueued to be deleted successfully.</value>
   </data>
+  <data name="RenameDeletedAccount_AlreadyRenamed" xml:space="preserve">
+    <value>Cannot rename a deleted account that was already renamed.</value>
+  </data>
+  <data name="RenameDeletedAccount_NotDeleted" xml:space="preserve">
+    <value>Cannot renamed a deleted account that is not deleted.</value>
+  </data>
 </root>

--- a/src/NuGetGallery.Services/ServicesStrings.resx
+++ b/src/NuGetGallery.Services/ServicesStrings.resx
@@ -1131,6 +1131,6 @@ The {1} Team</value>
     <value>Cannot rename a deleted account that was already renamed.</value>
   </data>
   <data name="RenameDeletedAccount_NotDeleted" xml:space="preserve">
-    <value>Cannot renamed a deleted account that is not deleted.</value>
+    <value>Cannot rename an account that is not deleted.</value>
   </data>
 </root>

--- a/src/NuGetGallery.Services/UserManagement/IUserService.cs
+++ b/src/NuGetGallery.Services/UserManagement/IUserService.cs
@@ -60,5 +60,7 @@ namespace NuGetGallery
         IReadOnlyList<User> GetSiteAdmins();
 
         Task SetIsAdministrator(User user, bool isAdmin);
+
+        Task RenameDeletedAccount(User user);
     }
 }

--- a/src/NuGetGallery.Services/UserManagement/UserService.cs
+++ b/src/NuGetGallery.Services/UserManagement/UserService.cs
@@ -727,15 +727,14 @@ namespace NuGetGallery
 
             var accountDelete = AccountDeleteRepository
                 .GetAll()
-                .Where(d => d.DeletedAccountKey == user.Key)
-                .Single();
+                .Single(d => d.DeletedAccountKey == user.Key);
 
             if (accountDelete.WasUsernameReleased)
             {
                 throw new UserSafeException(ServicesStrings.RenameDeletedAccount_AlreadyRenamed);
             }
 
-            user.Username = Guid.NewGuid().ToString();
+            user.Username = "deleted-" + Guid.NewGuid().ToString();
             accountDelete.WasUsernameReleased = true;
 
             return AccountDeleteRepository.CommitChangesAsync();

--- a/src/NuGetGallery/Areas/Admin/Controllers/DeleteAccountController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/DeleteAccountController.cs
@@ -52,7 +52,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
             return Json(results, JsonRequestBehavior.AllowGet);
         }
 
-        [HttpGet]
+        [HttpPost]
         public virtual async Task<ActionResult> Rename(string accountName)
         {
             try

--- a/src/NuGetGallery/Areas/Admin/Controllers/DeleteAccountController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/DeleteAccountController.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Web.Mvc;
+using Microsoft.Build.Utilities;
+using NuGet.Services.Entities;
 using NuGetGallery.Areas.Admin.ViewModels;
 
 namespace NuGetGallery.Areas.Admin.Controllers
@@ -29,15 +32,41 @@ namespace NuGetGallery.Areas.Admin.Controllers
             var results = new List<DeleteAccountSearchResult>();
             if (!string.IsNullOrWhiteSpace(query))
             {
-                var user = _userService.FindByUsername(query);
-                if (user !=  null && user.Username != null && !user.IsDeleted)
+                var user = _userService.FindByUsername(query, includeDeleted: true);
+                if (user !=  null && user.Username != null)
                 {
-                    var result = new DeleteAccountSearchResult(user.Username);
+                    var result = new DeleteAccountSearchResult(
+                        user.Username, 
+                        user.IsDeleted,
+                        Url.User(user),
+                        user.IsDeleted 
+                            ? null 
+                            : (user is Organization ? Url.AdminDeleteOrganization(user.Username) : Url.AdminDeleteAccount(user.Username)),
+                        user.IsDeleted 
+                            ? Url.AdminRenameDeletedAccount(user.Username) 
+                            : null);
                     results.Add(result);
                 }
             }
            
             return Json(results, JsonRequestBehavior.AllowGet);
+        }
+
+        [HttpGet]
+        public virtual async Task<ActionResult> Rename(string accountName)
+        {
+            try
+            {
+                var user = _userService.FindByUsername(accountName, includeDeleted: true);
+                await _userService.RenameDeletedAccount(user);
+                TempData["Message"] = $"The account named {accountName} has been successfully renamed.";
+            }
+            catch (UserSafeException e)
+            {
+                TempData["ErrorMessage"] = e.Message;
+            }
+
+            return RedirectToAction(nameof(Index));
         }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/Controllers/DeleteAccountController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/DeleteAccountController.cs
@@ -53,6 +53,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         public virtual async Task<ActionResult> Rename(string accountName)
         {
             try

--- a/src/NuGetGallery/Areas/Admin/ViewModels/DeleteAccountSearchResult.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/DeleteAccountSearchResult.cs
@@ -6,10 +6,23 @@ namespace NuGetGallery.Areas.Admin.ViewModels
     public class DeleteAccountSearchResult
     {
         public string AccountName { get; }
+        public bool IsDeleted { get; }
+        public string ProfileLink { get; }
+        public string DeleteLink { get; }
+        public string RenameLink { get; }
 
-        public DeleteAccountSearchResult(string accountName)
+        public DeleteAccountSearchResult(
+            string accountName, 
+            bool isDeleted,
+            string profileLink,
+            string deleteLink,
+            string renameLink)
         {
             AccountName = accountName;
+            IsDeleted = isDeleted;
+            ProfileLink = profileLink;
+            DeleteLink = deleteLink;
+            RenameLink = renameLink;
         }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/Views/DeleteAccount/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/DeleteAccount/Index.cshtml
@@ -37,9 +37,12 @@
                         <a data-bind="visible: !IsDeleted, attr: { href: DeleteLink }">
                             <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
                         </a>
-                        <a data-bind="visible: IsDeleted, attr: { href: RenameLink }">
-                            <i class="ms-Icon ms-Icon--Rename" aria-hidden="true"></i>
-                        </a>
+                        <form method="post" data-bind="visible: IsDeleted, attr: { action: RenameLink, id: $parent.getRenameFormId(AccountName) }">
+                            @Html.AntiForgeryToken()
+                            <a href="#" title="Rename account"  data-bind="click: $parent.rename.bind(this, AccountName), attr: { 'aria-label': 'Rename account ' + AccountName }">
+                                <i class="ms-Icon ms-Icon--Rename" aria-hidden="true"></i>
+                            </a>
+                        </form>
                     </td>
                 </tr>
             </tbody>
@@ -91,6 +94,14 @@
                 };
 
                 this.searchResults = ko.observableArray([]);
+
+                this.getRenameFormId = function (accountName) {
+                    return 'rename-' + accountName;
+                }
+
+                this.rename = function (accountName) {
+                    $('#' + $self.getRenameFormId(accountName)).submit();
+                }
             };
 
             ko.applyBindings(new viewModel(), $('#stage').get(0));

--- a/src/NuGetGallery/Areas/Admin/Views/DeleteAccount/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/DeleteAccount/Index.cshtml
@@ -6,21 +6,45 @@
 
 <section role="main" class="container main-container">
     <h2>Delete Account</h2>
-    <form>
-        <textarea placeholder="Search for account to delete. Only one account at a time." autocomplete="off" autofocus style="width: 100%;" rows="5" data-bind="value: searchQuery"></textarea><br />
-        <input type="button" value="Search" data-bind="click: search" />
-    </form>
-    <div style="display: none" data-bind="visible: searchResults().length === 0 && doneSearching()">
-        <p>No account found.</p>
+    <div class="row">
+        <div class="col-xs-10 form-group">
+            <input class="form-control" type="text" placeholder="Search for an account to delete." data-bind="value: searchQuery" />
+        </div>
+        <div class="col-xs-2 form-group">
+            <input class="form-control" type="button" value="Search" data-bind="click: search" />
+        </div>
     </div>
-    <form id="searchResults" data-bind="visible: searchResults().length > 0">
+    <div style="display: none" data-bind="visible: searchResults().length === 0 && doneSearching()">
+        <p>No accounts found.</p>
+    </div>
+    <div id="searchResults" data-bind="visible: searchResults().length > 0">
         <p>The following accounts were found:</p>
-        <ul id="searchResultsTable" class="sexy-table" style="display: none" data-bind="visible: searchResults().length > 0">
-            <li data-bind="foreach: searchResults">
-                <a href="#" data-bind="text: AccountName, attr: { href: $parent.generateProfileUrl($data) }"></a>
-            </li>
-        </ul>
-    </form>
+        <table class="table">
+            <tr>
+                <th>Username</th>
+                <th>Status</th>
+                <th aria-label="Actions">&nbsp;</th>
+            </tr>
+            <tbody data-bind="foreach: searchResults">
+                <tr>
+                    <td>
+                        <a data-bind="text: AccountName, attr: { href: ProfileLink }"></a>
+                    </td>
+                    <td>
+                        <span data-bind="text: IsDeleted ? 'Deleted' : 'Active'"></span>
+                    </td>
+                    <td>
+                        <a data-bind="visible: !IsDeleted, attr: { href: DeleteLink }">
+                            <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
+                        </a>
+                        <a data-bind="visible: IsDeleted, attr: { href: RenameLink }">
+                            <i class="ms-Icon ms-Icon--Rename" aria-hidden="true"></i>
+                        </a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 </section>
 
 @section BottomScripts {
@@ -36,25 +60,36 @@
                     $self.doneSearching = ko.observable(false);
                     $.ajax({
                         url: '@Url.Action("Search", "DeleteAccount", new {area = "Admin"})?query=' + encodeURIComponent($self.searchQuery()),
-                            cache: false,
-                            dataType: 'json',
-                            success: function(data) {
-                                for (var i = 0; i < data.length; i++) {
-                                    data[i].Selected = ko.observable(false);
-                                }
-                                $self.searchResults(data);
+                        cache: false,
+                        dataType: 'json',
+                        success: function (data) {
+                            for (var i = 0; i < data.length; i++) {
+                                data[i].Selected = ko.observable(false);
                             }
-                        })
-                        .error(function(jqXhr, textStatus, errorThrown) {
+
+                            // Combine the new data with the old data.
+                            var seenAccountNames = [];
+                            var newData = data
+                                .concat($self.searchResults())
+                                // Remove any duplicates and prefer the most recent results.
+                                .filter(function (value, index, self) {
+                                    var nextAccountName = value.AccountName;
+                                    var hasSeenAccountName = seenAccountNames.includes(nextAccountName);
+                                    seenAccountNames.push(nextAccountName);
+                                    return !hasSeenAccountName;
+                                });
+
+                            $self.searchResults(newData);
+                        },
+                        error: function (jqXhr, textStatus, errorThrown) {
                             alert("Error: " + errorThrown);
-                        })
-                        .always(function () {
+                        },
+                        always: function () {
                             $self.doneSearching(true);
-                        });
+                        }
+                    });
                 };
-                this.generateProfileUrl = function (u) {
-                    return '/profiles/' + u.AccountName;
-                };
+
                 this.searchResults = ko.observableArray([]);
             };
 

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -955,7 +955,6 @@
     <Compile Include="Infrastructure\Lucene\PerFieldAnalyzer.cs" />
     <Compile Include="Infrastructure\Lucene\NuGetSearchTerm.cs" />
     <Compile Include="Infrastructure\TracingHttpHandler.cs" />
-    <Compile Include="Infrastructure\UserSafeException.cs" />
     <Compile Include="Migrations\201110060711357_Initial.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -731,15 +731,6 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An unexpected error occurred. Contact support for assistance..
-        /// </summary>
-        public static string DefaultUserSafeExceptionMessage {
-            get {
-                return ResourceManager.GetString("DefaultUserSafeExceptionMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Organization member &apos;{0}&apos; is the last administrator and cannot be deleted..
         /// </summary>
         public static string DeleteMember_CannotDeleteLastAdmin {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -268,9 +268,6 @@
   <data name="UploadPackage_MinClientVersionOutOfRange" xml:space="preserve">
     <value>This package requires version '{0}' of NuGet, which this gallery does not currently support. Please contact us if you have questions.</value>
   </data>
-  <data name="DefaultUserSafeExceptionMessage" xml:space="preserve">
-    <value>An unexpected error occurred. Contact support for assistance.</value>
-  </data>
   <data name="UserEmailUpdateCancelled" xml:space="preserve">
     <value>You canceled your email address change request.</value>
   </data>

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -872,6 +872,22 @@ namespace NuGetGallery
                 });
         }
 
+        public static string AdminRenameDeletedAccount(
+            this UrlHelper url,
+            string accountName,
+            bool relativeUrl = true)
+        {
+            return GetActionLink(url,
+                nameof(DeleteAccountController.Rename),
+                "DeleteAccount",
+                relativeUrl,
+                area: AdminAreaRegistration.Name,
+                routeValues: new RouteValueDictionary
+                {
+                    { "accountName", accountName }
+                });
+        }
+
         public static string ReportPackage(
             this UrlHelper url,
             IPackageVersionModel package,

--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/DeleteAccountControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/DeleteAccountControllerFacts.cs
@@ -9,13 +9,14 @@ using NuGetGallery.Framework;
 using Moq;
 using Xunit;
 using NuGet.Services.Entities;
+using System.Threading.Tasks;
+using Moq.Language.Flow;
+using Moq.Language;
 
 namespace NuGetGallery.Areas.Admin.Controllers
 {
-    public class DeleteAccountControllerFacts
+    public class DeleteAccountControllerFacts : TestContainer
     {
-        private Fakes _fakes = new Fakes();
-
         [Fact]
         public void CtorThrowsOnNullArg()
         {
@@ -23,9 +24,14 @@ namespace NuGetGallery.Areas.Admin.Controllers
             Assert.Throws<ArgumentNullException>(() => new DeleteAccountController(null));
         }
 
-        public class TheSearchMethod
+        public class TheSearchMethod : TestContainer
         {
-            private Fakes _fakes = new Fakes();
+            private Fakes _fakes;
+
+            public TheSearchMethod()
+            {
+                _fakes = Get<Fakes>();
+            }
 
             [Theory]
             [InlineData("")]
@@ -43,20 +49,24 @@ namespace NuGetGallery.Areas.Admin.Controllers
             public void WhenUser_ReturnsMatch()
             {
                 // Arrange & Act
-                var searchResult = SearchAccount(_fakes.User.Username, _fakes.User);
+                var user = _fakes.User;
+                var searchResult = SearchAccount(user.Username, user);
 
                 // Assert
-                Assert.Single(searchResult);
+                var result = Assert.Single(searchResult);
+                AssertDeleteAccountSearchResult(user, result);
             }
 
             [Fact]
             public void WhenOrganization_ReturnsMatch()
             {
                 // Arrange & Act
-                var searchResult = SearchAccount(_fakes.Organization.Username, _fakes.Organization);
+                var organization = _fakes.Organization;
+                var searchResult = SearchAccount(organization.Username, organization);
 
                 // Assert
-                Assert.Single(searchResult);
+                var result = Assert.Single(searchResult);
+                AssertDeleteAccountSearchResult(organization, result);
             }
 
             [Fact]
@@ -75,33 +85,96 @@ namespace NuGetGallery.Areas.Admin.Controllers
             public void WhenDeletedUser_ReturnsEmpty()
             {
                 // Arrange & Act
-                _fakes.ShaUser.IsDeleted = true;
+                var deletedUser = _fakes.ShaUser;
+                deletedUser.IsDeleted = true;
 
-                var searchResult = SearchAccount(_fakes.ShaUser.Username);
+                var searchResult = SearchAccount(deletedUser.Username, deletedUser);
 
                 // Assert
-                Assert.Empty(searchResult);
+                var result = Assert.Single(searchResult);
+                AssertDeleteAccountSearchResult(deletedUser, result);
             }
 
             private List<DeleteAccountSearchResult> SearchAccount(string userName, User findByUsernameResult = null, int findByUsernameTimes = 1)
             {
                 // Arrange
-                var userService = new Mock<IUserService>();
+                var userService = GetMock<IUserService>();
 
-                userService.Setup(m => m.FindByUsername(It.IsAny<string>(), It.IsAny<bool>()))
+                userService
+                    .Setup(m => m.FindByUsername(It.IsAny<string>(), It.IsAny<bool>()))
                     .Returns(findByUsernameResult)
                     .Verifiable();
 
-                var controller = new DeleteAccountController(userService.Object);
+                var controller = GetController<DeleteAccountController>();
 
                 // Act
                 var result = controller.Search(userName) as JsonResult;
 
                 // Assert
-                userService.Verify(m => m.FindByUsername(userName, false), Times.Exactly(findByUsernameTimes));
+                userService.Verify(
+                    m => m.FindByUsername(userName, true), 
+                    Times.Exactly(findByUsernameTimes));
 
                 Assert.NotNull(result);
                 return result.Data as List<DeleteAccountSearchResult>;
+            }
+
+            private void AssertDeleteAccountSearchResult(User user, DeleteAccountSearchResult result)
+            {
+                Assert.Equal(user.Username, result.AccountName);
+                Assert.Equal(user.IsDeleted, result.IsDeleted);
+                Assert.NotNull(result.ProfileLink);
+                Assert.Equal(user.IsDeleted, result.DeleteLink == null);
+                Assert.Equal(user.IsDeleted, result.RenameLink != null);
+            }
+        }
+
+        public class TheRenameMethod : TestContainer
+        {
+            private const string Username = "user";
+
+            [Fact]
+            public async Task WhenUserServiceThrowsUserSafeException_SetsErrorMessage()
+            {
+                var exceptionMessage = "woops";
+                var controller = await InvokeAndAssertRedirectToIndex(
+                    setup => setup.ThrowsAsync(new UserSafeException(exceptionMessage)));
+
+                Assert.Equal(exceptionMessage, controller.TempData["ErrorMessage"]);
+            }
+
+            [Fact]
+            public async Task Success()
+            {
+                var controller = await InvokeAndAssertRedirectToIndex(
+                    setup => setup.Completes());
+
+                Assert.Equal(
+                    $"The account named {Username} has been successfully renamed.",
+                    controller.TempData["Message"]);
+            }
+
+            private async Task<DeleteAccountController> InvokeAndAssertRedirectToIndex(Func<ISetup<IUserService, Task>, IVerifies> setupRenameDeletedAccount)
+            {
+                var user = new User { Key = 1 };
+
+                var userService = GetMock<IUserService>();
+                userService
+                    .Setup(x => x.FindByUsername(Username, true))
+                    .Returns(user)
+                    .Verifiable();
+
+                var renameDeletedAccountSetup = userService.Setup(x => x.RenameDeletedAccount(user));
+                setupRenameDeletedAccount(renameDeletedAccountSetup).Verifiable();
+
+                var controller = GetController<DeleteAccountController>();
+                var result = await controller.Rename(Username);
+
+                userService.Verify();
+
+                ResultAssert.IsRedirectToRoute(result, new { action = nameof(DeleteAccountController.Index) });
+
+                return controller;
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Framework/TestContainer.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestContainer.cs
@@ -42,6 +42,7 @@ namespace NuGetGallery.Framework
 
             var routeCollection = new RouteCollection();
             Routes.RegisterRoutes(routeCollection);
+            TestUtility.RegisterAdminRoutes(routeCollection);
             c.Url = new UrlHelper(c.ControllerContext.RequestContext, routeCollection);
 
             var appCtrl = c as AppController;

--- a/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UserServiceFacts.cs
@@ -2279,6 +2279,10 @@ namespace NuGetGallery
                     .Setup(x => x.CommitChangesAsync())
                     .Verifiable();
 
+                userService.MockAccountDeleteRepository
+                    .Setup(x => x.CommitChangesAsync())
+                    .Completes();
+
                 await userService.RenameDeletedAccount(user);
 
                 userService.MockAccountDeleteRepository.Verify();

--- a/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
@@ -19,6 +19,7 @@ namespace NuGetGallery.TestUtils
         public Mock<IAppConfiguration> MockConfig { get; protected set; }
         public Mock<ISecurityPolicyService> MockSecurityPolicyService { get; protected set; }
         public Mock<IEntityRepository<User>> MockUserRepository { get; protected set; }
+        public Mock<IEntityRepository<AccountDelete>> MockAccountDeleteRepository { get; protected set; }
         public Mock<IEntityRepository<Role>> MockRoleRepository { get; protected set; }
         public Mock<IEntityRepository<Credential>> MockCredentialRepository { get; protected set; }
         public Mock<IEntityRepository<Organization>> MockOrganizationRepository { get; protected set; }
@@ -34,6 +35,7 @@ namespace NuGetGallery.TestUtils
             Config = (MockConfig = new Mock<IAppConfiguration>()).Object;
             SecurityPolicyService = (MockSecurityPolicyService = new Mock<ISecurityPolicyService>()).Object;
             UserRepository = (MockUserRepository = new Mock<IEntityRepository<User>>()).Object;
+            AccountDeleteRepository = (MockAccountDeleteRepository = new Mock<IEntityRepository<AccountDelete>>()).Object;
             RoleRepository = (MockRoleRepository = new Mock<IEntityRepository<Role>>()).Object;
             CredentialRepository = (MockCredentialRepository = new Mock<IEntityRepository<Credential>>()).Object;
             OrganizationRepository = (MockOrganizationRepository = new Mock<IEntityRepository<Organization>>()).Object;

--- a/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestUtility.cs
@@ -11,6 +11,7 @@ using System.Web.Mvc;
 using System.Web.Routing;
 using Moq;
 using NuGet.Services.Entities;
+using NuGetGallery.Areas.Admin;
 
 namespace NuGetGallery
 {
@@ -80,8 +81,28 @@ namespace NuGetGallery
             controller.ControllerContext = controllerContext;
             var routeCollection = new RouteCollection();
             Routes.RegisterRoutes(routeCollection);
+            RegisterAdminRoutes(routeCollection);
             controller.Url = new UrlHelper(requestContext, routeCollection);
             return httpContext;
+        }
+
+        /// <remarks>
+        /// Admin routes are registered in <see cref="AdminAreaRegistration.RegisterArea(AreaRegistrationContext)"/> using a <see cref="AreaRegistrationContext"/> instead of in <see cref="Routes"/>.
+        /// Unfortunately, because we register the routing for our tests using a <see cref="RouteCollection"/> and not a <see cref="AreaRegistrationContext"/>, we must duplicate the logic.
+        /// </remarks>
+        public static void RegisterAdminRoutes(RouteCollection routeCollection)
+        {
+            routeCollection.MapRoute(
+                "Admin_default",
+                "Admin/{controller}/{action}/{id}",
+                new
+                {
+                    controller = "Home",
+                    action = "Index",
+                    id = UrlParameter.Optional,
+                    area = AdminAreaRegistration.Name
+                }
+            );
         }
 
         public static void SetupUrlHelper(Controller controller, Mock<HttpContextBase> mockHttpContext)


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGetGallery/pull/7471

Currently, we don't have a way for site admins to release the username of a deleted account. This PR adds that functionality to the admin delete account page and also improves the UI of the page.

![image](https://user-images.githubusercontent.com/18014088/63476908-8c716d80-c437-11e9-853f-edf3e45cfc3c.png)
