### PR TITLE
Change commit SHA to point to updated ServerCommon build scripts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,7 @@ param (
     [string]$PackageSuffix,
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranch = 'cb2b9e41b18cb77ee644a51951d8c8f24cde9adf'
+    [string]$BuildBranch = '1f60ff35a3cebf1a0c5fb631d2534fd5b4a11edc'
 )
 
 Set-StrictMode -Version 1.0


### PR DESCRIPTION
Addresses build script errors on VS2019-only machines.