### PR TITLE
Make the cancel ownership request endpoint just redirect to Manage Owners

### DIFF
--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -147,10 +147,8 @@ namespace NuGetGallery
                         ownerRequest.ConfirmationCode,
                         relativeUrl: false);
 
-                    var cancellationUrl = Url.CancelPendingOwnershipRequest(
+                    var manageUrl = Url.ManagePackageOwnership(
                         model.Package.Id,
-                        model.CurrentUser.Username,
-                        model.User.Username,
                         relativeUrl: false);
 
                     var packageOwnershipRequestMessage = new PackageOwnershipRequestMessage(
@@ -168,7 +166,13 @@ namespace NuGetGallery
 
                     foreach (var owner in model.Package.Owners)
                     {
-                        var emailMessage = new PackageOwnershipRequestInitiatedMessage(_appConfiguration, model.CurrentUser, owner, model.User, model.Package, cancellationUrl);
+                        var emailMessage = new PackageOwnershipRequestInitiatedMessage(
+                            _appConfiguration,
+                            model.CurrentUser,
+                            owner,
+                            model.User,
+                            model.Package,
+                            manageUrl);
 
                         await _messageService.SendMessageAsync(emailMessage);
                     }

--- a/src/NuGetGallery/Controllers/OrganizationsController.cs
+++ b/src/NuGetGallery/Controllers/OrganizationsController.cs
@@ -155,8 +155,7 @@ namespace NuGetGallery
                     account,
                     currentUser,
                     request.NewMember,
-                    request.IsAdmin,
-                    cancellationUrl: Url.CancelOrganizationMembershipRequest(memberName, relativeUrl: false));
+                    request.IsAdmin);
                 await MessageService.SendMessageAsync(organizationMembershipRequestInitiatedMessage);
 
                 return Json(new OrganizationMemberViewModel(request));

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -2047,7 +2047,7 @@ namespace NuGetGallery
         [HttpGet]
         [UIAuthorize]
         [RequiresAccountConfirmation("cancel pending ownership request")]
-        public virtual async Task<ActionResult> CancelPendingOwnershipRequest(string id, string requestingUsername, string pendingUsername)
+        public virtual ActionResult CancelPendingOwnershipRequest(string id, string requestingUsername, string pendingUsername)
         {
             var package = _packageService.FindPackageRegistrationById(id);
             if (package == null)
@@ -2078,12 +2078,7 @@ namespace NuGetGallery
                 return HttpNotFound();
             }
 
-            await _packageOwnershipManagementService.DeletePackageOwnershipRequestAsync(package, pendingUser);
-
-            var emailMessage = new PackageOwnershipRequestCanceledMessage(_config, requestingUser, pendingUser, package);
-            await _messageService.SendMessageAsync(emailMessage);
-
-            return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, pendingUsername, ConfirmOwnershipResult.Cancelled));
+            return Redirect(Url.ManagePackageOwnership(id));
         }
 
         /// <summary>

--- a/src/NuGetGallery/Infrastructure/Mail/Messages/OrganizationMembershipRequestInitiatedMessage.cs
+++ b/src/NuGetGallery/Infrastructure/Mail/Messages/OrganizationMembershipRequestInitiatedMessage.cs
@@ -12,18 +12,15 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
     public class OrganizationMembershipRequestInitiatedMessage : MarkdownEmailBuilder
     {
         private readonly IMessageServiceConfiguration _configuration;
-        private readonly string _cancellationUrl;
 
         public OrganizationMembershipRequestInitiatedMessage(
             IMessageServiceConfiguration configuration,
             Organization organization,
             User requestingUser,
             User pendingUser,
-            bool isAdmin,
-            string cancellationUrl)
+            bool isAdmin)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _cancellationUrl = cancellationUrl ?? throw new ArgumentNullException(nameof(cancellationUrl));
 
             Organization = organization ?? throw new ArgumentNullException(nameof(organization));
             RequestingUser = requestingUser ?? throw new ArgumentNullException(nameof(requestingUser));

--- a/src/NuGetGallery/Infrastructure/Mail/Messages/PackageOwnershipRequestInitiatedMessage.cs
+++ b/src/NuGetGallery/Infrastructure/Mail/Messages/PackageOwnershipRequestInitiatedMessage.cs
@@ -12,8 +12,8 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
     public class PackageOwnershipRequestInitiatedMessage : MarkdownEmailBuilder
     {
         private readonly IMessageServiceConfiguration _configuration;
-        private readonly string _rawCancellationUrl;
-        private readonly string _cancellationUrl;
+        private readonly string _rawManageUrl;
+        private readonly string _manageUrl;
 
         public PackageOwnershipRequestInitiatedMessage(
             IMessageServiceConfiguration configuration,
@@ -21,12 +21,12 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             User receivingOwner,
             User newOwner,
             PackageRegistration packageRegistration,
-            string cancellationUrl)
+            string manageUrl)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
-            _rawCancellationUrl = cancellationUrl ?? throw new ArgumentNullException(nameof(cancellationUrl));
-            _cancellationUrl = EscapeLinkForMarkdown(cancellationUrl);
+            _rawManageUrl = manageUrl ?? throw new ArgumentNullException(nameof(manageUrl));
+            _manageUrl = EscapeLinkForMarkdown(manageUrl);
 
             RequestingOwner = requestingOwner ?? throw new ArgumentNullException(nameof(requestingOwner));
             ReceivingOwner = receivingOwner ?? throw new ArgumentNullException(nameof(receivingOwner));
@@ -64,7 +64,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
 
 To cancel this request:
 
-[{_cancellationUrl}]({_rawCancellationUrl})
+[{_manageUrl}]({_rawManageUrl})
 
 Thanks,
 The {_configuration.GalleryOwner.DisplayName} Team");

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -203,7 +203,8 @@
 
     nuget.configureExpander = function (prefix, lessIcon, lessMessage, moreIcon, moreMessage) {
         var hidden = $('#' + prefix);
-        var show = $('#show-' + prefix);
+        var showId = '#show-' + prefix;
+        var show = $(showId);
         var showIcon = $('#show-' + prefix + ' i');
         var showText = $('#show-' + prefix + ' span');
         hidden.on('hide.bs.collapse', function (e) {
@@ -225,6 +226,11 @@
         show.on('click', function (e) {
             e.preventDefault();
         });
+
+        // If the URI fragment (hash) matches the expander ID, automatically expand the section.
+        if (document.location.hash === showId) {
+            hidden.collapse('show');
+        }
     };
 
     nuget.configureExpanderHeading = function (prefix) {

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -281,7 +281,7 @@
             this.CanCancel = ownerRequestItem.CanCancel;
             this.ConfirmUrl = ownerRequestItem.ConfirmUrl;
             this.RejectUrl = ownerRequestItem.RejectUrl;
-            this.CancelUrl = ownerRequestItem.CancelUrl;
+            this.ManagePackageOwnershipUrl = ownerRequestItem.ManagePackageOwnershipUrl;
             this.ShowReceived = showReceived;
             this.ShowSent = showSent;
 

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -21,6 +21,11 @@ namespace NuGetGallery
         private static IGalleryConfigurationService _configuration;
         private const string PackageExplorerDeepLink = @"https://npe.codeplex.com/releases/clickonce/NuGetPackageExplorer.application?url={0}&id={1}&version={2}";
 
+        public static class Fragments
+        {
+            public const string ManagePackageOwnership = "#show-Owners-container";
+        }
+
         // Shorthand for current url
         public static string Current(this UrlHelper url)
         {
@@ -726,6 +731,40 @@ namespace NuGetGallery
             return url.PackageVersionActionTemplate(nameof(PackagesController.Manage), relativeUrl);
         }
 
+        public static string ManagePackageOwnership(
+            this UrlHelper url,
+            string id,
+            bool relativeUrl = true)
+        {
+            return GetRouteLink(
+                url,
+                RouteName.PackageAction,
+                relativeUrl,
+                routeValues: new RouteValueDictionary
+                {
+                    { "action", nameof(PackagesController.Manage) },
+                    { "id", id }
+                }) + Fragments.ManagePackageOwnership;
+        }
+
+        public static RouteUrlTemplate<OwnerRequestsListItemViewModel> ManagePackageOwnershipTemplate(
+            this UrlHelper url, bool relativeUrl = true)
+        {
+            var routesGenerator = new Dictionary<string, Func<OwnerRequestsListItemViewModel, object>>
+            {
+                { "id", r => r.Package.Id },
+            };
+
+            Func<RouteValueDictionary, string> linkGenerator = rv => GetActionLink(
+                url,
+                nameof(PackagesController.Manage),
+                "Packages",
+                relativeUrl,
+                routeValues: rv) + Fragments.ManagePackageOwnership;
+
+            return new RouteUrlTemplate<OwnerRequestsListItemViewModel>(linkGenerator, routesGenerator);
+        }
+
         public static string ManagePackage(
             this UrlHelper url,
             IPackageVersionModel package,
@@ -1134,43 +1173,6 @@ namespace NuGetGallery
             };
 
             return GetActionLink(url, routeName, "Packages", relativeUrl, routeValues);
-        }
-
-        public static RouteUrlTemplate<OwnerRequestsListItemViewModel> CancelPendingOwnershipRequestTemplate(
-            this UrlHelper url, bool relativeUrl = true)
-        {
-            var routesGenerator = new Dictionary<string, Func<OwnerRequestsListItemViewModel, object>>
-            {
-                { "id", r => r.Package.Id },
-                { "requestingUsername", r => r.Request.RequestingOwner.Username },
-                { "pendingUsername", r => r.Request.NewOwner.Username }
-            };
-
-            Func<RouteValueDictionary, string> linkGenerator = rv => GetActionLink(
-                url,
-                "CancelPendingOwnershipRequest",
-                "Packages",
-                relativeUrl,
-                routeValues: rv);
-
-            return new RouteUrlTemplate<OwnerRequestsListItemViewModel>(linkGenerator, routesGenerator);
-        }
-
-        public static string CancelPendingOwnershipRequest(
-            this UrlHelper url,
-            string packageId,
-            string requestingUsername,
-            string pendingUsername,
-            bool relativeUrl = true)
-        {
-            var routeValues = new RouteValueDictionary
-            {
-                ["id"] = packageId,
-                ["requestingUsername"] = requestingUsername,
-                ["pendingUsername"] = pendingUsername
-            };
-
-            return GetActionLink(url, "CancelPendingOwnershipRequest", "Packages", relativeUrl, routeValues);
         }
 
         public static string ConfirmEmail(

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -280,8 +280,8 @@
                             </a>
                             <!-- /ko -->
                             <!-- ko if: !CanAccept && CanCancel -->
-                            <a class="btn" title="Cancel Ownership" data-bind="attr: { href: CancelUrl, 'aria-label': 'Cancel Ownership of ' + Id }">
-                                <i class="ms-Icon ms-Icon--Cancel" aria-hidden="true"></i>
+                            <a class="btn" title="Manage Ownership" data-bind="attr: { href: ManagePackageOwnershipUrl, 'aria-label': 'Manage Ownership of ' + Id }">
+                                <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
                             </a>
                             <!-- /ko -->
                         </td>
@@ -310,7 +310,7 @@
 
     private RouteUrlTemplate<OwnerRequestsListItemViewModel> confirmUrlTemplate;
     private RouteUrlTemplate<OwnerRequestsListItemViewModel> rejectUrlTemplate;
-    private RouteUrlTemplate<OwnerRequestsListItemViewModel> cancelUrlTemplate;
+    private RouteUrlTemplate<OwnerRequestsListItemViewModel> manageOwnershipUrlTemplate;
 
     dynamic GetSerializablePackage(ListPackageItemRequiredSignerViewModel p)
     {
@@ -384,9 +384,9 @@
             rejectUrlTemplate = Url.RejectPendingOwnershipRequestTemplate();
         }
 
-        if (cancelUrlTemplate == null)
+        if (manageOwnershipUrlTemplate == null)
         {
-            cancelUrlTemplate = Url.CancelPendingOwnershipRequestTemplate();
+            manageOwnershipUrlTemplate = Url.ManagePackageOwnershipTemplate();
         }
 
         return new
@@ -401,7 +401,7 @@
             CanCancel = r.CanCancel,
             ConfirmUrl = confirmUrlTemplate.Resolve(r),
             RejectUrl = rejectUrlTemplate.Resolve(r),
-            CancelUrl = cancelUrlTemplate.Resolve(r)
+            ManagePackageOwnershipUrl = manageOwnershipUrlTemplate.Resolve(r)
         };
     }
 

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/MarkdownMessageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/MarkdownMessageServiceFacts.cs
@@ -1846,7 +1846,6 @@ namespace NuGetGallery
                 var organization = GetOrganizationWithRecipients();
                 var requestingUser = new User("optimusprime") { EmailAddress = "optimusprime@transformers.com" };
                 var pendingUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
-                var cancelUrl = "www.cancel.com";
 
                 var configurationService = GetConfigurationService();
                 var messageService = TestableMarkdownMessageService.Create(configurationService);
@@ -1855,8 +1854,7 @@ namespace NuGetGallery
                     organization,
                     requestingUser,
                     pendingUser,
-                    isAdmin,
-                    cancelUrl);
+                    isAdmin);
 
                 // Act
                 await messageService.SendMessageAsync(emailMessage);
@@ -1881,7 +1879,6 @@ namespace NuGetGallery
                 var organization = GetOrganizationWithoutRecipients();
                 var requestingUser = new User("optimusprime") { EmailAddress = "optimusprime@transformers.com" };
                 var pendingUser = new User("shia_labeouf") { EmailAddress = "justdoit@shia.com" };
-                var cancelUrl = "www.cancel.com";
 
                 var configurationService = GetConfigurationService();
                 var messageService = TestableMarkdownMessageService.Create(configurationService);
@@ -1890,8 +1887,7 @@ namespace NuGetGallery
                     organization,
                     requestingUser,
                     pendingUser,
-                    isAdmin,
-                    cancelUrl);
+                    isAdmin);
 
                 // Act
                 await messageService.SendMessageAsync(emailMessage);

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestInitiatedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/OrganizationMembershipRequestInitiatedMessageFacts.cs
@@ -18,11 +18,10 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
             {
                 get
                 {
-                    yield return new object[] { null, Fakes.RequestingOrganization, Fakes.RequestingUser, Fakes.RequestingUser, It.IsAny<bool>(), Fakes.CancellationUrl };
-                    yield return new object[] { Configuration, null, Fakes.RequestingUser, Fakes.RequestingUser, It.IsAny<bool>(), Fakes.CancellationUrl };
-                    yield return new object[] { Configuration, Fakes.RequestingOrganization, null, Fakes.RequestingUser, It.IsAny<bool>(), Fakes.CancellationUrl };
-                    yield return new object[] { Configuration, Fakes.RequestingOrganization, Fakes.RequestingUser, null, It.IsAny<bool>(), Fakes.CancellationUrl };
-                    yield return new object[] { Configuration, Fakes.RequestingOrganization, Fakes.RequestingUser, null, It.IsAny<bool>(), null };
+                    yield return new object[] { null, Fakes.RequestingOrganization, Fakes.RequestingUser, Fakes.RequestingUser, It.IsAny<bool>() };
+                    yield return new object[] { Configuration, null, Fakes.RequestingUser, Fakes.RequestingUser, It.IsAny<bool>() };
+                    yield return new object[] { Configuration, Fakes.RequestingOrganization, null, Fakes.RequestingUser, It.IsAny<bool>() };
+                    yield return new object[] { Configuration, Fakes.RequestingOrganization, Fakes.RequestingUser, null, It.IsAny<bool>() };
                 }
             }
 
@@ -33,16 +32,14 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
                 Organization organization,
                 User requestingUser,
                 User pendingUser,
-                bool isAdmin,
-                string cancellationUrl)
+                bool isAdmin)
             {
                 Assert.Throws<ArgumentNullException>(() => new OrganizationMembershipRequestInitiatedMessage(
                     configuration,
                     organization,
                     requestingUser,
                     pendingUser,
-                    isAdmin,
-                    cancellationUrl));
+                    isAdmin));
             }
         }
 
@@ -162,8 +159,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
                 organization,
                 Fakes.RequestingUser,
                 pendingUser,
-                isAdmin,
-                Fakes.CancellationUrl);
+                isAdmin);
         }
 
         private const string _expectedMessageBodyForAdmin =


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2679
Depends on https://github.com/NuGet/NuGetGallery/pull/7497.

The `CancelPendingOwnershipRequest` endpoint was a GET without a token but it performed an action. This is against CSRF rules. The fix was to make the endpoint redirect the existing URL to the manage package page with the owners section auto-expanded. This is so existing links in the email are not broken.

The new UI on the Packages page is this (a pencil instead of an "x"):

![image](https://user-images.githubusercontent.com/94054/64045795-11871180-cb1f-11e9-856f-507ec8d172d7.png)

The old UI looked like this:
![image](https://user-images.githubusercontent.com/94054/64046189-1ac4ae00-cb20-11e9-87e6-b847b529d06c.png)

I considered the word "Manage" instead of a pencil but I thought this was more consistent with the rest of the page. Note that this adds an additional hope to cancel an ownership request from the packages page. I could do a POST on click here but this would take some non-trivial code sharing with the manage package page. 

The new email looks like this:
![image](https://user-images.githubusercontent.com/94054/64045541-6c6c3900-cb1e-11e9-9419-f89895693a7f.png)

The old email looked like this:
![image](https://user-images.githubusercontent.com/94054/64046163-054f8400-cb20-11e9-8a29-51c113fda082.png)

When you click the link it looks like this:
![image](https://user-images.githubusercontent.com/94054/64045574-83129000-cb1e-11e9-8580-462e7a0135d5.png)

