### PR TITLE
Upgrade to AppInsights v2.10

### DIFF
--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -252,7 +252,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.3.0</Version>
+      <Version>2.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.3</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2129,28 +2129,13 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept">
-      <Version>2.0.7</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector">
-      <Version>2.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector">
-      <Version>2.3.0</Version>
+      <Version>2.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.TraceListener">
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.Web">
-      <Version>2.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer">
-      <Version>2.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel">
-      <Version>2.3.0</Version>
+      <Version>2.10.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.DynamicData.EFProvider">
       <Version>6.0.0</Version>
@@ -2291,9 +2276,6 @@
       <Version>0.9.0</Version>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.Debug">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource">
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Linq.Expressions">

--- a/src/NuGetGallery/Telemetry/ClientInformationTelemetryEnricher.cs
+++ b/src/NuGetGallery/Telemetry/ClientInformationTelemetryEnricher.cs
@@ -24,19 +24,23 @@ namespace NuGetGallery
                     // cannot be used since it will fail if the key already exists.
                     // https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/977
 
+                    // We need to cast to ISupportProperties to avoid using the deprecated telemetry.Context.Properties API.
+                    // https://github.com/Microsoft/ApplicationInsights-Home/issues/300
+                    var itemTelemetry = (ISupportProperties)telemetry;
+
                     // ClientVersion is available for NuGet clients starting version 4.1.0-~4.5.0 
                     // Was deprecated and replaced by Protocol version
-                    telemetry.Context.Properties[TelemetryService.ClientVersion]
+                    itemTelemetry.Properties[TelemetryService.ClientVersion]
                         = httpContext.Request.Headers[ServicesConstants.ClientVersionHeaderName];
 
-                    telemetry.Context.Properties[TelemetryService.ProtocolVersion]
+                    itemTelemetry.Properties[TelemetryService.ProtocolVersion]
                         = httpContext.Request.Headers[ServicesConstants.NuGetProtocolHeaderName];
 
-                    telemetry.Context.Properties[TelemetryService.ClientInformation]
+                    itemTelemetry.Properties[TelemetryService.ClientInformation]
                         = httpContext.GetClientInformation();
 
                     // Is the user authenticated or this is an anonymous request?
-                    telemetry.Context.Properties[TelemetryService.IsAuthenticated]
+                    itemTelemetry.Properties[TelemetryService.IsAuthenticated]
                         = httpContext.Request.IsAuthenticated.ToString();
                 }
             }

--- a/src/NuGetGallery/Telemetry/DeploymentIdTelemetryEnricher.cs
+++ b/src/NuGetGallery/Telemetry/DeploymentIdTelemetryEnricher.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.WindowsAzure.ServiceRuntime;
 
@@ -34,13 +35,23 @@ namespace NuGetGallery
         public void Initialize(ITelemetry telemetry)
         {
             if (telemetry == null
-                || DeploymentId == null
-                || telemetry.Context.Properties.ContainsKey(PropertyKey))
+                || DeploymentId == null)
             {
                 return;
             }
 
-            telemetry.Context.Properties.Add(PropertyKey, DeploymentId);
+            var itemTelemetry = telemetry as ISupportProperties;
+            if (itemTelemetry == null)
+            {
+                return;
+            }
+
+            if (itemTelemetry.Properties.ContainsKey(PropertyKey))
+            {
+                return;
+            }
+
+            itemTelemetry.Properties.Add(PropertyKey, DeploymentId);
         }
     }
 }

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -772,7 +772,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EntityFramework" publicKeyToken="B77A5C561934E089" culture="neutral"/>

--- a/tests/NuGetGallery.Facts/Telemetry/ClientInformationTelemetryEnricherTests.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/ClientInformationTelemetryEnricherTests.cs
@@ -37,7 +37,9 @@ namespace NuGetGallery.Telemetry
         {
             // Arrange
             var telemetry = (ITelemetry)telemetryType.GetConstructor(new Type[] { }).Invoke(new object[] { });
-            telemetry.Context.Properties.Add("Test", "blala");
+
+            var itemTelemetry = telemetry as ISupportProperties;
+            itemTelemetry.Properties.Add("Test", "blala");
 
             var headers = new NameValueCollection
             {
@@ -54,11 +56,11 @@ namespace NuGetGallery.Telemetry
             // Assert
             if (telemetry is RequestTelemetry)
             {
-                Assert.Equal(5, telemetry.Context.Properties.Count);
+                Assert.Equal(5, itemTelemetry.Properties.Count);
             }
             else
             {
-                Assert.Equal(1, telemetry.Context.Properties.Count);
+                Assert.Equal(1, itemTelemetry.Properties.Count);
             }
         }
 
@@ -147,9 +149,9 @@ namespace NuGetGallery.Telemetry
             var httpContext = new Mock<HttpContextBase>(MockBehavior.Strict);
             httpContext.SetupGet(c => c.Request).Returns(httpRequest.Object);
 
-           return new TestableClientInformationTelemetryEnricher(httpContext.Object);
+            return new TestableClientInformationTelemetryEnricher(httpContext.Object);
         }
     }
 
-    
+
 }


### PR DESCRIPTION
This upgrades NuGetGallery to v2.10 of Application Insights.

Addresses https://github.com/NuGet/Engineering/issues/2537

Todo:
* [x] Verify telemetry (is all telemetry still there?)
* [x] Create performance baseline (without this change)
* [x] Verify performance of this change (load test)
* [x] If tests are good, merge https://github.com/NuGet/ServerCommon/pull/308 and actually release ServerCommon nupkgs
* [x] Upgrade ServerCommon dependencies to actually released nupkgs in https://github.com/nuget/nuget.jobs/issues/808
* [x] Upgrade ApplicationInsights in this PR to v2.10