### PR TITLE
Fix #6622 via CSS (multiline on verify page)

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -467,6 +467,9 @@ img.reserved-indicator-icon {
   max-width: 300px;
   max-height: 300px;
 }
+#verify-package-container .verify-package-field p {
+  white-space: pre-wrap;
+}
 @media (-ms-high-contrast: active) {
   svg {
     color: WindowText;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -468,7 +468,7 @@ img.reserved-indicator-icon {
   max-height: 300px;
 }
 #verify-package-container .verify-package-field p {
-  white-space: pre-wrap;
+  white-space: pre-line;
 }
 @media (-ms-high-contrast: active) {
   svg {

--- a/src/Bootstrap/less/theme/common-edit-metadata.less
+++ b/src/Bootstrap/less/theme/common-edit-metadata.less
@@ -58,9 +58,9 @@
 }
 
 #verify-package-container {
-    .verify-package-field { 
-	    p {
+    .verify-package-field {
+        p {
             white-space: pre-line;
         }
-    }	
+    }
 }

--- a/src/Bootstrap/less/theme/common-edit-metadata.less
+++ b/src/Bootstrap/less/theme/common-edit-metadata.less
@@ -60,7 +60,7 @@
 #verify-package-container {
     .verify-package-field { 
 	    p {
-            white-space: pre-wrap;
+            white-space: pre-line;
         }
     }	
 }

--- a/src/Bootstrap/less/theme/common-edit-metadata.less
+++ b/src/Bootstrap/less/theme/common-edit-metadata.less
@@ -56,3 +56,11 @@
         max-height: 300px;
     }
 }
+
+#verify-package-container {
+    .verify-package-field { 
+	    p {
+            white-space: pre-wrap;
+        }
+    }	
+}


### PR DESCRIPTION
As suggested in the issue, this should solve the bug. Not sure if I found the correct location for this less changes. 

Summary of the changes (in less than 80 characters):

* Added a new less rule to display multiline in a correct way
* The CSS is should only affect the verify package site.
* Didn't found any other CSS/LESS stuff, so I used the "common-edit-metadata.less" file. 

Works in more or less all modern browsers :)

Addresses https://github.com/NuGet/NuGetGallery/issues/6622