### PR TITLE
Add token expiration of 14 days

### DIFF
--- a/src/AccountDeleter/AccountDeleteUserService.cs
+++ b/src/AccountDeleter/AccountDeleteUserService.cs
@@ -46,7 +46,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public Task<bool> CancelTransformUserToOrganizationRequest(User accountToTransform, string token)
+        public Task<TransformOrganizationResult> CancelTransformUserToOrganizationRequest(User accountToTransform, string token)
         {
             throw new NotImplementedException();
         }
@@ -128,7 +128,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public Task<bool> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token)
+        public Task<TransformOrganizationResult> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token)
         {
             throw new NotImplementedException();
         }
@@ -138,7 +138,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
+        public Task<TransformOrganizationResult> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
         {
             throw new NotImplementedException();
         }

--- a/src/AccountDeleter/EmptyUserService.cs
+++ b/src/AccountDeleter/EmptyUserService.cs
@@ -45,7 +45,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public Task<bool> CancelTransformUserToOrganizationRequest(User accountToTransform, string token)
+        public Task<TransformOrganizationResult> CancelTransformUserToOrganizationRequest(User accountToTransform, string token)
         {
             throw new NotImplementedException();
         }
@@ -115,7 +115,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public Task<bool> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token)
+        public Task<TransformOrganizationResult> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token)
         {
             throw new NotImplementedException();
         }
@@ -125,7 +125,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
+        public Task<TransformOrganizationResult> TransformUserToOrganization(User accountToTransform, User adminUser, string token)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Services/Extensions/RequestEntityExtensions.cs
+++ b/src/NuGetGallery.Services/Extensions/RequestEntityExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Services.Entities;
+
+namespace NuGetGallery
+{
+    public static class RequestEntityExtensions
+    {
+        private static readonly TimeSpan RequestTokenLifetime = TimeSpan.FromDays(14);
+
+        public static bool IsExpired(this OrganizationMigrationRequest request)
+        {
+            return IsExpired(request.RequestDate);
+        }
+
+        public static bool IsExpired(this MembershipRequest request)
+        {
+            return IsExpired(request.RequestDate);
+        }
+
+        public static bool IsExpired(this PackageOwnerRequest request)
+        {
+            return IsExpired(request.RequestDate);
+        }
+
+        private static bool IsExpired(DateTime requestDate)
+        {
+            return DateTime.UtcNow - requestDate > RequestTokenLifetime;
+        }
+    }
+}

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Extensions\ObjectExtensions.cs" />
     <Compile Include="Extensions\PackageExtensions.cs" />
     <Compile Include="Extensions\PrincipalExtensions.cs" />
+    <Compile Include="Extensions\RequestEntityExtensions.cs" />
     <Compile Include="Extensions\ScopeExtensions.cs" />
     <Compile Include="Extensions\UriExtensions.cs" />
     <Compile Include="Extensions\UserExtensions.cs" />
@@ -225,6 +226,7 @@
     <Compile Include="Telemetry\UserPackageDeleteEvent.cs" />
     <Compile Include="Telemetry\UserPackageDeleteOutcome.cs" />
     <Compile Include="UserManagement\IUserService.cs" />
+    <Compile Include="UserManagement\TransformOrganizationResult.cs" />
     <Compile Include="UserManagement\UserService.cs" />
     <Compile Include="ServicesConstants.cs" />
     <Compile Include="ServicesStrings.Designer.cs">

--- a/src/NuGetGallery.Services/ServicesStrings.Designer.cs
+++ b/src/NuGetGallery.Services/ServicesStrings.Designer.cs
@@ -143,6 +143,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The request for user &apos;{0}&apos; to join the organization has expired. If you wish to continue, ask the administrators of the organization to reissue the membership request..
+        /// </summary>
+        public static string AddMember_Expired {
+            get {
+                return ResourceManager.GetString("AddMember_Expired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There is no request for user &apos;{0}&apos; for join this organization with that token..
         /// </summary>
         public static string AddMember_MissingRequest {
@@ -1540,6 +1549,15 @@ namespace NuGetGallery {
         public static string ReadMeUrlHostInvalid {
             get {
                 return ResourceManager.GetString("ReadMeUrlHostInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The request for user &apos;{0}&apos; to join the organization has expired. No additional action is required to reject the membership request..
+        /// </summary>
+        public static string RejectMembershipRequest_Expired {
+            get {
+                return ResourceManager.GetString("RejectMembershipRequest_Expired", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery.Services/ServicesStrings.resx
+++ b/src/NuGetGallery.Services/ServicesStrings.resx
@@ -1127,4 +1127,10 @@ The {1} Team</value>
   <data name="AsyncAccountDelete_Success" xml:space="preserve">
     <value>The account '{0}' was enqueued to be deleted successfully.</value>
   </data>
+  <data name="AddMember_Expired" xml:space="preserve">
+    <value>The request for user '{0}' to join the organization has expired. If you wish to continue, ask the administrators of the organization to reissue the membership request.</value>
+  </data>
+  <data name="RejectMembershipRequest_Expired" xml:space="preserve">
+    <value>The request for user '{0}' to join the organization has expired. No additional action is required to reject the membership request.</value>
+  </data>
 </root>

--- a/src/NuGetGallery.Services/UserManagement/IUserService.cs
+++ b/src/NuGetGallery.Services/UserManagement/IUserService.cs
@@ -49,11 +49,11 @@ namespace NuGetGallery
 
         Task RequestTransformToOrganizationAccount(User accountToTransform, User adminUser);
         
-        Task<bool> TransformUserToOrganization(User accountToTransform, User adminUser, string token);
+        Task<TransformOrganizationResult> TransformUserToOrganization(User accountToTransform, User adminUser, string token);
 
-        Task<bool> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token);
+        Task<TransformOrganizationResult> RejectTransformUserToOrganizationRequest(User accountToTransform, User adminUser, string token);
 
-        Task<bool> CancelTransformUserToOrganizationRequest(User accountToTransform, string token);
+        Task<TransformOrganizationResult> CancelTransformUserToOrganizationRequest(User accountToTransform, string token);
 
         Task<Organization> AddOrganizationAsync(string username, string emailAddress, User adminUser);
 

--- a/src/NuGetGallery.Services/UserManagement/TransformOrganizationResult.cs
+++ b/src/NuGetGallery.Services/UserManagement/TransformOrganizationResult.cs
@@ -3,12 +3,10 @@
 
 namespace NuGetGallery
 {
-    public enum ConfirmOwnershipResult
+    public enum TransformOrganizationResult
     {
         Success,
         Failure,
-        NotYourRequest,
-        AlreadyOwner,
         Rejected,
         Cancelled,
         Expired,

--- a/src/NuGetGallery.Services/UserManagement/UserService.cs
+++ b/src/NuGetGallery.Services/UserManagement/UserService.cs
@@ -569,9 +569,10 @@ namespace NuGetGallery
             if (result)
             {
                 await Auditing.SaveAuditRecordAsync(new UserAuditRecord(accountToTransform, AuditedUserAction.TransformOrganization, adminUser, affectedMemberIsAdmin: true));
+                return TransformOrganizationResult.Success;
             }
 
-            return result ? TransformOrganizationResult.Success : TransformOrganizationResult.Failure;
+            return TransformOrganizationResult.Failure;
         }
 
         public async Task<Organization> AddOrganizationAsync(string username, string emailAddress, User adminUser)

--- a/src/NuGetGallery/Controllers/JsonApiController.cs
+++ b/src/NuGetGallery/Controllers/JsonApiController.cs
@@ -72,6 +72,7 @@ namespace NuGetGallery
                     registration,
                     Url,
                     isPending: false,
+                    isExpired: false,
                     isNamespaceOwner: true));
 
             var packageOwnersOnlyResultViewModel =
@@ -82,6 +83,7 @@ namespace NuGetGallery
                     registration,
                     Url,
                     isPending: false,
+                    isExpired: false,
                     isNamespaceOwner: false));
 
             owners = owners.Union(packageOwnersOnlyResultViewModel);
@@ -94,6 +96,7 @@ namespace NuGetGallery
                     registration,
                     Url,
                     isPending: true,
+                    isExpired: r.IsExpired(),
                     isNamespaceOwner: false));
 
             var result = owners.Union(pending);
@@ -187,6 +190,7 @@ namespace NuGetGallery
                         model.Package,
                         Url,
                         isPending: !model.CurrentUserCanAcceptOnBehalfOfUser,
+                        isExpired: false,
                         isNamespaceOwner: false)
                 });
             }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -2023,6 +2023,11 @@ namespace NuGetGallery
                 return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, user.Username, ConfirmOwnershipResult.Failure));
             }
 
+            if (request.IsExpired())
+            {
+                return View("ConfirmOwner", new PackageOwnerConfirmationModel(id, user.Username, ConfirmOwnershipResult.Expired));
+            }
+
             if (accept)
             {
                 await _packageOwnershipManagementService.AddPackageOwnerAsync(package, user);

--- a/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
@@ -29,6 +29,7 @@
             this.ProfileUrl = parent.ProfileUrlTemplate.replace('{username}', this.Username);
             this.GravatarUrl = member.GravatarUrl;
             this.Pending = member.Pending;
+            this.Expired = member.Expired;
 
             this.DeleteMember = function () {
                 if (self.IsCurrentUser) {

--- a/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-owners.js
@@ -193,6 +193,7 @@
         this.profileUrl = ko.observable(data.ProfileUrl);
         this.imageUrl = ko.observable(data.ImageUrl);
         this.pending = ko.observable(data.Pending);
+        this.expired = ko.observable(data.Expired);
         this.grantsCurrentUserAccess = data.GrantsCurrentUserAccess;
         this.isCurrentUserAdminOfOrganization = data.IsCurrentUserAdminOfOrganization;
         this.isNamespaceOwner = ko.observable(data.IsNamespaceOwner);

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -279,6 +279,7 @@
             this.PackageUrl = ownerRequestItem.PackageUrl;
             this.CanAccept = ownerRequestItem.CanAccept;
             this.CanCancel = ownerRequestItem.CanCancel;
+            this.IsExpired = ownerRequestItem.IsExpired;
             this.ConfirmUrl = ownerRequestItem.ConfirmUrl;
             this.RejectUrl = ownerRequestItem.RejectUrl;
             this.ManagePackageOwnershipUrl = ownerRequestItem.ManagePackageOwnershipUrl;

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2202,6 +2202,33 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The tranform request for your account has expired. Recreate the request if you wish to continue..
+        /// </summary>
+        public static string TransformAccount_Expired {
+            get {
+                return ResourceManager.GetString("TransformAccount_Expired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The tranform request for your account has expired. No further action is necessary to cancel the account transformation..
+        /// </summary>
+        public static string TransformAccount_ExpiredCancel {
+            get {
+                return ResourceManager.GetString("TransformAccount_ExpiredCancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The tranform request for your account has expired. No further action is necessary to reject the account transformation..
+        /// </summary>
+        public static string TransformAccount_ExpiredReject {
+            get {
+                return ResourceManager.GetString("TransformAccount_ExpiredReject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An unexpected error occurred while transforming this account. Contact support for assistance..
         /// </summary>
         public static string TransformAccount_Failed {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1147,4 +1147,13 @@ The {1} Team</value>
   <data name="AccountDelete_SelfServiceSuccess" xml:space="preserve">
     <value>Your account is being deleted. You have been logged out.</value>
   </data>
+  <data name="TransformAccount_Expired" xml:space="preserve">
+    <value>The tranform request for your account has expired. Recreate the request if you wish to continue.</value>
+  </data>
+  <data name="TransformAccount_ExpiredCancel" xml:space="preserve">
+    <value>The tranform request for your account has expired. No further action is necessary to cancel the account transformation.</value>
+  </data>
+  <data name="TransformAccount_ExpiredReject" xml:space="preserve">
+    <value>The tranform request for your account has expired. No further action is necessary to reject the account transformation.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/ViewModels/ManageOrganizationsItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ManageOrganizationsItemViewModel.cs
@@ -44,6 +44,11 @@ namespace NuGetGallery
         public bool IsPendingTransformRequest { get; }
 
         /// <summary>
+        /// Whether or not this pending request is expired.
+        /// </summary>
+        public bool IsExpiredRequest { get; }
+
+        /// <summary>
         /// If this is a pending request, the confirmation token to confirm or decline the request.
         /// </summary>
         public string ConfirmationToken { get; }
@@ -75,6 +80,7 @@ namespace NuGetGallery
             : this(request.Organization, request.IsAdmin, packageService)
         {
             IsPendingRequest = true;
+            IsExpiredRequest = request.IsExpired();
             ConfirmationToken = request.ConfirmationToken;
         }
 
@@ -83,6 +89,7 @@ namespace NuGetGallery
         {
             IsPendingRequest = true;
             IsPendingTransformRequest = true;
+            IsExpiredRequest = request.IsExpired();
             ConfirmationToken = request.ConfirmationToken;
         }
     }

--- a/src/NuGetGallery/ViewModels/OrganizationMemberViewModel.cs
+++ b/src/NuGetGallery/ViewModels/OrganizationMemberViewModel.cs
@@ -21,6 +21,7 @@ namespace NuGetGallery
         {
             IsAdmin = request.IsAdmin;
             Pending = true;
+            Expired = request.IsExpired();
         }
 
         private OrganizationMemberViewModel(User member)
@@ -40,6 +41,8 @@ namespace NuGetGallery
         public bool IsAdmin { get; }
 
         public bool Pending { get; }
+
+        public bool Expired { get; }
 
         public string EmailAddress { get; }
 

--- a/src/NuGetGallery/ViewModels/OwnerRequestsListItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/OwnerRequestsListItemViewModel.cs
@@ -14,5 +14,7 @@ namespace NuGetGallery
         public bool CanAccept { get; set; }
 
         public bool CanCancel { get; set; }
+
+        public bool IsExpired { get; set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageOwnersResultViewModel.cs
@@ -23,9 +23,18 @@ namespace NuGetGallery
 
         public bool Pending;
 
+        public bool Expired;
+
         public bool IsNamespaceOwner;
 
-        public PackageOwnersResultViewModel(User user, User currentUser, PackageRegistration packageRegistration, UrlHelper url, bool isPending, bool isNamespaceOwner)
+        public PackageOwnersResultViewModel(
+            User user,
+            User currentUser,
+            PackageRegistration packageRegistration,
+            UrlHelper url,
+            bool isPending,
+            bool isExpired,
+            bool isNamespaceOwner)
         {
             Name = user.Username;
             EmailAddress = user.EmailAddress;
@@ -34,6 +43,7 @@ namespace NuGetGallery
             GrantsCurrentUserAccess = ActionsRequiringPermissions.ManagePackageOwnership.CheckPermissions(currentUser, user, packageRegistration) == PermissionsCheckResult.Allowed;
             IsCurrentUserAdminOfOrganization = (user as Organization)?.GetMembershipOfUser(currentUser)?.IsAdmin ?? false;
             Pending = isPending;
+            Expired = isExpired;
             IsNamespaceOwner = isNamespaceOwner;
         }
     }

--- a/src/NuGetGallery/Views/Organizations/HandleOrganizationMembershipRequest.cshtml
+++ b/src/NuGetGallery/Views/Organizations/HandleOrganizationMembershipRequest.cshtml
@@ -44,7 +44,7 @@
             else
             {
                 <p class="text-center">
-                    We were not able to add you as a member of the @(Model.OrganizationName).
+                    We were not able to add you as a member of the @(Model.OrganizationName) organization.
                 </p>
                 <p class="text-center">
                     @Model.FailureReason
@@ -63,7 +63,7 @@
             else
             {
                 <p class="text-center">
-                    We were not able to decline your membership request for the @(Model.OrganizationName).
+                    We were not able to decline your membership request for the @(Model.OrganizationName) organization.
                 </p>
                 <p class="text-center">
                     @Model.FailureReason

--- a/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
+++ b/src/NuGetGallery/Views/Organizations/ManageOrganization.cshtml
@@ -110,6 +110,7 @@
                 IsAdmin = m.IsAdmin,
                 IsCurrentUser = m.Username.Equals(CurrentUser.Username, StringComparison.OrdinalIgnoreCase),
                 Pending = m.Pending,
+                Expired = m.Expired,
                 GravatarUrl = m.GravatarUrl
             }),
             AddMemberUrl = Url.AddOrganizationMember(Model.AccountName),

--- a/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
+++ b/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
@@ -65,8 +65,11 @@
                             <!-- ko if: IsCurrentUser -->
                             <i>(that's you)</i>
                             <!-- /ko -->
-                            <!-- ko if: Pending -->
-                            <i>(pending)</i>
+                            <!-- ko if: !Expired && Pending -->
+                            <i>(pending approval)</i>
+                            <!-- /ko -->
+                            <!-- ko if: Expired -->
+                            <i>(request expired)</i>
                             <!-- /ko -->
                         </div>
                     </div>

--- a/src/NuGetGallery/Views/Packages/ConfirmOwner.cshtml
+++ b/src/NuGetGallery/Views/Packages/ConfirmOwner.cshtml
@@ -23,6 +23,10 @@
                     @:Ownership Request Cancelled
                     break;
 
+                case ConfirmOwnershipResult.Expired:
+                    @:Ownership Request Expired
+                    break;
+
                 default:
                     @:Ownership Confirmation Failed
                     break;
@@ -50,6 +54,15 @@
                 <p class="text-center">
                     You have cancelled your request for <strong>@Model.Username</strong> to become an owner of the
                     '<strong><a href="@Url.Package(@Model.PackageId)" title="The @Model.PackageId package">@Model.PackageId</a></strong>' package!
+                </p>
+                break;
+
+            case ConfirmOwnershipResult.Expired:
+                <p class="text-center">
+                    The package ownership request for <strong>@Model.Username</strong> to become an owner of the
+                    '<strong><a href="@Url.Package(@Model.PackageId)" title="The @Model.PackageId package">@Model.PackageId</a></strong>'
+                    package has expired. If you wish to gain ownership of the package, ask the existing owner(s) to
+                    reissue the request.
                 </p>
                 break;
 

--- a/src/NuGetGallery/Views/Packages/_ManageOwners.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageOwners.cshtml
@@ -30,7 +30,8 @@
                         <span style="font-style:italic">
                             <span data-bind="visible: grantsCurrentUserAccess && !isCurrentUserAdminOfOrganization">(that's you)</span>
                             <span data-bind="visible: isCurrentUserAdminOfOrganization">(your organization)</span>
-                            <span data-bind="visible: pending">(pending approval)</span>
+                            <span data-bind="visible: !expired() && pending()">(pending approval)</span>
+                            <span data-bind="visible: expired">(request expired)</span>
                         </span>
                     </div>
                     <!-- ko if: $parent.IsAllowedToRemove($data) -->

--- a/src/NuGetGallery/Views/Users/Organizations.cshtml
+++ b/src/NuGetGallery/Views/Users/Organizations.cshtml
@@ -47,9 +47,13 @@
                                     <a title="View Organization Profile" href="@Url.User(organization.OrganizationName)">
                                         @organization.OrganizationName
                                     </a>
-                                    @if (organization.IsPendingRequest)
+                                    @if (!organization.IsExpiredRequest && organization.IsPendingRequest)
                                     {
                                         <span>(pending approval)</span>
+                                    }
+                                    else if (organization.IsExpiredRequest)
+                                    {
+                                        <span>(request expired)</span>
                                     }
                                 </td>
                                 <td class="align-middle">
@@ -62,13 +66,13 @@
                                     @organization.PackagesCount
                                 </td>
                                 <td class="text-right align-middle package-controls">
-                                    @if (!organization.IsPendingRequest && !organization.IsPendingTransformRequest)
+                                    @if (!organization.IsExpiredRequest && !organization.IsPendingRequest && !organization.IsPendingTransformRequest)
                                     {
                                         <a class="btn" href="@Url.ManageMyOrganization(organization.OrganizationName)" title="Edit Organization" aria-label="@("Edit Organization " + organization.OrganizationName)">
                                             <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
                                         </a>
                                     }
-                                    else if (organization.IsPendingRequest)
+                                    else if (!organization.IsExpiredRequest && organization.IsPendingRequest)
                                     {
                                         var accept = organization.IsPendingTransformRequest ? Url.ConfirmTransformAccount(organization.OrganizationName, organization.ConfirmationToken) : Url.AcceptOrganizationMembershipRequest(organization.OrganizationName, organization.ConfirmationToken);
                                         var reject = organization.IsPendingTransformRequest ? Url.RejectTransformAccount(organization.OrganizationName, organization.ConfirmationToken) : Url.RejectOrganizationMembershipRequest(organization.OrganizationName, organization.ConfirmationToken);

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -259,6 +259,9 @@
                             <a title="View Package" data-bind="attr: { href: PackageUrl }">
                                 <span data-bind="text: Id"></span>
                             </a>
+                            <!-- ko if: IsExpired -->
+                            (request expired)
+                            <!-- /ko -->
                         </td>
                         <td class="align-middle">
                             <span class="ms-noWrap" data-bind="foreach: Owners">
@@ -271,7 +274,7 @@
                             <a data-bind="attr: { href: New.ProfileUrl }"><span data-bind="text: New.Username"></span></a>
                         </td>
                         <td class="text-right align-middle package-controls">
-                            <!-- ko if: CanAccept -->
+                            <!-- ko if: !IsExpired && CanAccept -->
                             <a class="btn" title="Confirm Ownership" data-bind="attr: { href: ConfirmUrl, 'aria-label': 'Confirm Ownership of ' + Id }">
                                 <i class="ms-Icon ms-Icon--Accept" aria-hidden="true"></i>
                             </a>
@@ -399,6 +402,7 @@
             New = GetSerializableOwner(r.Request.NewOwner),
             CanAccept = r.CanAccept,
             CanCancel = r.CanCancel,
+            IsExpired = r.IsExpired,
             ConfirmUrl = confirmUrlTemplate.Resolve(r),
             RejectUrl = rejectUrlTemplate.Resolve(r),
             ManagePackageOwnershipUrl = manageOwnershipUrlTemplate.Resolve(r)

--- a/tests/NuGetGallery.Facts/Extensions/RequestEntityExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/RequestEntityExtensionsFacts.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Services.Entities;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class RequestEntityExtensionsFacts
+    {
+        private static readonly TimeSpan Lifetime = TimeSpan.FromDays(14);
+        private static readonly TimeSpan FuzzFactor = TimeSpan.FromMinutes(1);
+
+        public class IsOrganizationMigrationRequestExpired : IsExpired
+        {
+            protected override bool Invoke(DateTime requestDate)
+            {
+                var request = new OrganizationMigrationRequest();
+                request.RequestDate = requestDate;
+
+                return request.IsExpired();
+            }
+        }
+
+        public class IsMembershipRequestExpired : IsExpired
+        {
+            protected override bool Invoke(DateTime requestDate)
+            {
+                var request = new MembershipRequest();
+                request.RequestDate = requestDate;
+
+                return request.IsExpired();
+            }
+        }
+
+        public class IsPackageOwnerRequestExpired : IsExpired
+        {
+            protected override bool Invoke(DateTime requestDate)
+            {
+                var request = new PackageOwnerRequest();
+                request.RequestDate = requestDate;
+
+                return request.IsExpired();
+            }
+        }
+
+        public abstract class IsExpired
+        {
+            protected abstract bool Invoke(DateTime requestDate);
+
+            [Fact]
+            public void ReturnsFalseForNow()
+            {
+                var now = DateTime.UtcNow;
+
+                Assert.False(Invoke(now));
+            }
+
+            [Fact]
+            public void ReturnsFalseForJustBeforeExpiration()
+            {
+                var justBeforeExpirationTime = DateTime
+                    .UtcNow
+                    .Subtract(Lifetime)
+                    .Add(FuzzFactor);
+
+                Assert.False(Invoke(justBeforeExpirationTime));
+            }
+
+            [Fact]
+            public void ReturnsTrueForNonExpired()
+            {
+                var justAfterExpirationTime = DateTime
+                    .UtcNow
+                    .Subtract(Lifetime)
+                    .Subtract(FuzzFactor);
+
+                Assert.True(Invoke(justAfterExpirationTime));
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Controllers\AccountsControllerFacts.cs" />
     <Compile Include="Controllers\OrganizationsControllerFacts.cs" />
     <Compile Include="Controllers\SupportControllerFacts.cs" />
+    <Compile Include="Extensions\RequestEntityExtensionsFacts.cs" />
     <Compile Include="Infrastructure\ABTestEnrollmentFactoryFacts.cs" />
     <Compile Include="Infrastructure\CookieBasedABTestServiceFacts.cs" />
     <Compile Include="Infrastructure\HijackSearchServiceFactoryFacts.cs" />


### PR DESCRIPTION
Tokens are used for:
 - adding owners to packages
 - adding members to organizations
 - transforming users to organizations

Progress on https://github.com/NuGet/Engineering/issues/2679

When a token is older than 14 days, it will no longer work. This means that "accept" / "reject" links in email will stop working 14 days after they are sent. All of these action links have counterparts in the web UI. When the request is older than 14 days, the recipient of the request will see "(request expired)".

The action links ("accept" / "reject") are not visible when the request is expired. In other words, the recipient sees that the request is expired for informational purposes only. I spoke offline with @karann-msft and we agreed that we don't need to implement a "dismiss" (essentially a POST-based ) button for the recipient. If we hear significant feedback from users, then we can revisit this decision later and likely add a `PostLink` to a new "dismiss" or "cancel" endpoint that supports POST.

## Existing state (no expiration concept)

Operation | Sender can cancel? | Sender can cancel? | Recipient can cancel? | Recipient can cancel?
-- | -- | -- | -- | --
&nbsp; | **Before expiration** | **After Expiration** | **Before Expiration** | **After Expiration**
Add owner to package |  ✅ | ✅ | ✅ | ✅
Add member to organization |  ✅ | ✅ | ✅ | ✅
Transform organization |  ❌ | ❌ | ✅ | ✅

Note that the recipient of the "Transform organization" operation is the user that was specified as the admin of the new organization. There is currently no way for the sender of a "transform organization" operation to cancel.

## After this PR

Operation | Sender can cancel? | Sender can cancel? | Recipient cancel? | Recipient cancel?
-- | -- | -- | -- | --
&nbsp; | **Before expiration** | **After Expiration** | **Before Expiration** | **After Expiration**
Add owner to package |  ✅ | ✅ | ✅ | ❌
Add member to organization |  ✅ | ✅ | ✅ | ❌
Transform organization |  ❌ | ❌ | ✅ | ❌

## Screenshots

## Sender: expired package ownership request

![image](https://user-images.githubusercontent.com/94054/64276448-d6a92300-cefc-11e9-9803-60af073ec316.png)

![image](https://user-images.githubusercontent.com/94054/64276366-a497c100-cefc-11e9-9bfb-166dae5b2f7b.png)

## Recipient: expired package ownership request

![image](https://user-images.githubusercontent.com/94054/64276422-ca24ca80-cefc-11e9-873c-a34cbf9474aa.png)

## Sender: expired organization membership request

![image](https://user-images.githubusercontent.com/94054/64276263-5b477180-cefc-11e9-891d-c8a6c1a0c38a.png)

## Recipient: expired organization membership request

![image](https://user-images.githubusercontent.com/94054/64276220-3f43d000-cefc-11e9-9b1d-9a74c638c977.png)

## Recipient: expired transform organization

![image](https://user-images.githubusercontent.com/94054/64276119-ff7ce880-cefb-11e9-8352-1dea07508556.png)
