### PR TITLE
Order by created ascending by default in FindPackagesById()

### DIFF
--- a/src/NuGetGallery/Infrastructure/Lucene/GallerySearchClient.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/GallerySearchClient.cs
@@ -37,7 +37,9 @@ namespace NuGetGallery.Infrastructure.Search
             {SearchModels.SortOrder.Relevance, "relevance"},
             {SearchModels.SortOrder.Published, "published"},
             {SearchModels.SortOrder.TitleAscending, "title-asc"},
-            {SearchModels.SortOrder.TitleDescending, "title-desc"}
+            {SearchModels.SortOrder.TitleDescending, "title-desc"},
+            {SearchModels.SortOrder.CreatedAscending, "created-asc"},
+            {SearchModels.SortOrder.CreatedDescending, "created-desc"},
         };
 
         // This code is copied from the SearchClient 

--- a/src/NuGetGallery/Infrastructure/Lucene/Models/SortOrder.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/Models/SortOrder.cs
@@ -8,6 +8,8 @@ namespace NuGetGallery.Infrastructure.Search.Models
         LastEdited,
         Published,
         TitleAscending,
-        TitleDescending
+        TitleDescending,
+        CreatedAscending,
+        CreatedDescending,
     }
 }

--- a/tests/NuGetGallery.Facts/Services/SearchAdaptorFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SearchAdaptorFacts.cs
@@ -2,9 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
 using System.Web.Http.OData;
 using System.Web.Http.OData.Query;
+using Moq;
+using NuGet.Services.Entities;
+using NuGetGallery.Infrastructure.Search.Models;
 using NuGetGallery.OData;
 using NuGetGallery.WebApi;
 using Xunit;
@@ -26,6 +33,171 @@ namespace NuGetGallery
             {
                 PageSize = 100
             };
+        }
+
+        public class TheSearchCoreMethod : Facts
+        {
+            public TheSearchCoreMethod()
+            {
+                RawUrl = "http://example/api/v2/Search()?q=%27json%27&";
+                SearchTerm = "json";
+                TargetFramework = string.Empty;
+                IncludePrerelease = true;
+            }
+
+            public string SearchTerm { get; }
+            public string TargetFramework { get; }
+            public bool IncludePrerelease { get; }
+
+            [Theory]
+            [MemberData(nameof(DefaultOrderByData))]
+            public async Task DefaultsToOrderByRelevance(string queryString)
+            {
+                await TestOrderBy(queryString, SortOrder.Relevance);
+            }
+
+            [Theory]
+            [MemberData(nameof(OrderByData))]
+            public async Task ProperlyParsesOrderBy(string queryString, SortOrder? expected)
+            {
+                await TestOrderBy(queryString, expected);
+            }
+
+            private async Task TestOrderBy(string queryString, SortOrder? expected)
+            {
+                RawUrl += "&" + queryString;
+
+                var result = await SearchAdaptor.SearchCore(
+                    SearchService.Object,
+                    Request.Object,
+                    Packages,
+                    SearchTerm,
+                    TargetFramework,
+                    IncludePrerelease,
+                    SemVerLevel);
+
+                VerifySortOrder(expected);
+            }
+        }
+
+        public class TheFindByIdAndVersionCoreMethod : Facts
+        {
+            public TheFindByIdAndVersionCoreMethod()
+            {
+                RawUrl = "http://example/api/v2/FindPackagesById()?id=%27NuGet.Versioning%27";
+                Id = "NuGet.Versioning";
+                Version = null;
+            }
+
+            public string Id { get; }
+            public string Version { get; set; }
+
+            [Theory]
+            [MemberData(nameof(DefaultOrderByData))]
+            public async Task DefaultsToOrderByRelevance(string queryString)
+            {
+                await TestOrderBy(queryString, SortOrder.CreatedAscending);
+            }
+
+            [Theory]
+            [MemberData(nameof(OrderByData))]
+            public async Task ProperlyParsesOrderBy(string queryString, SortOrder? expected)
+            {
+                await TestOrderBy(queryString, expected);
+            }
+
+            private async Task TestOrderBy(string queryString, SortOrder? expected)
+            {
+                RawUrl += "&" + queryString;
+
+                var result = await SearchAdaptor.FindByIdAndVersionCore(
+                    SearchService.Object,
+                    Request.Object,
+                    Packages,
+                    Id,
+                    Version,
+                    SemVerLevel);
+
+                VerifySortOrder(expected);
+            }
+        }
+
+        public abstract class Facts
+        {
+            public Facts()
+            {
+                SearchService = new Mock<ISearchService>();
+                Request = new Mock<HttpRequestBase>();
+                Packages = new List<Package>().AsQueryable();
+
+                RawUrl = "http://example/api/v2/Packages()";
+                SemVerLevel = SemVerLevelKey.SemVerLevel2;
+                SearchResults = new SearchResults(0, indexTimestampUtc: null);
+
+                Request
+                    .Setup(x => x.RawUrl)
+                    .Returns(() => RawUrl);
+                SearchService
+                    .Setup(x => x.ContainsAllVersions)
+                    .Returns(true);
+                SearchService
+                    .Setup(x => x.Search(It.IsAny<SearchFilter>()))
+                    .ReturnsAsync(() => SearchResults)
+                    .Callback<SearchFilter>(sf => LastSearchFilter = sf);
+            }
+
+            public Mock<ISearchService> SearchService { get; }
+            public Mock<HttpRequestBase> Request { get; }
+            public IQueryable<Package> Packages { get; }
+            public string RawUrl { get; set; }
+            public string SemVerLevel { get; }
+            public SearchResults SearchResults { get; }
+            public SearchFilter LastSearchFilter { get; set; }
+
+            public static IEnumerable<object[]> DefaultOrderByData => new[]
+            {
+                new object[] { "" },
+                new object[] { "$orderby" },
+                new object[] { "$orderby=" },
+            };
+
+            public static IEnumerable<object[]> OrderByData => new[]
+            {
+                new object[] { "$orderby=Created", SortOrder.CreatedAscending },
+                new object[] { "$orderby=Published&$orderby=Created", SortOrder.CreatedAscending }, // Last one wins
+                new object[] { "$orderby=Created%20asc", SortOrder.CreatedAscending },
+                new object[] { "$orderby=Created%20ASC", SortOrder.CreatedAscending },
+                new object[] { "$orderby=Created%20foo", SortOrder.CreatedAscending },
+                new object[] { "$orderby=CreatedFOO", SortOrder.CreatedAscending }, // Probably shouldn't work, but it does today
+                new object[] { "$orderby=Created%20DESC", SortOrder.CreatedAscending },
+                new object[] { "$orderby=Created%20desc", SortOrder.CreatedDescending },
+                new object[] { "$orderby=Created%20asc%20desc", SortOrder.CreatedDescending }, // Probably shouldn't work, but it does today
+                new object[] { "$orderby=DownloadCount", SortOrder.Relevance },
+                new object[] { "$orderby=Published", SortOrder.Published },
+                new object[] { "$orderby=LastEdited", SortOrder.LastEdited },
+                new object[] { "$orderby=Id", SortOrder.TitleAscending },
+                new object[] { "$orderby=Id%20desc", SortOrder.TitleAscending }, // Probably should be TitleDescending, but it doesn't do this today
+                new object[] { "$orderby=concat", SortOrder.TitleAscending },
+                new object[] { "$orderby=concat%20desc", SortOrder.TitleDescending },
+                new object[] { "$orderby=Dependencies", null },
+                new object[] { "$orderby=created", null },
+            };
+
+            public void VerifySortOrder(SortOrder? expected)
+            {
+                if (expected == null)
+                {
+                    // The hijack to search service was not possible given the parameters.
+                    Assert.Null(LastSearchFilter);
+                    SearchService.Verify(x => x.Search(It.IsAny<SearchFilter>()), Times.Never);
+                }
+                else
+                {
+                    Assert.NotNull(LastSearchFilter);
+                    Assert.Equal(expected, LastSearchFilter.SortOrder);
+                    SearchService.Verify(x => x.Search(It.IsAny<SearchFilter>()), Times.Once);
+                }
+            }
         }
 
         public class TheGetNextLinkMethod


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/5432.

For `/api/v2/FindPackagesById()`, if no `$orderby` is specified, use order by Created timestamp (ascending) by default. The previous behavior was to use relevance ordering which makes no sense on such an API. This code can ship immediately because both old search and Azure Search default unrecognized sort orders to `Relevance`. In other words, this will begin to work when both a) we move hijack queries over to Azure Search and b) Azure Search supports order by created.

The `/api/v2/Search()` endpoint still defaults to ordering by relevance.