### PR TITLE
Add abbr tags to hidden column headers in display package version history table

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -591,8 +591,8 @@
                             {
                                 <th>Status</th>
                             }
-                            <th aria-label="Signature Information"></th>
-                            <th aria-label="Deprecation Information"></th>
+                            <th aria-label="Signature Information" abbr="Signature Information"></th>
+                            <th aria-label="Deprecation Information" abbr="Deprecation Information"></th>
                         </tr>
                     </thead>
                     <tbody class="no-border">


### PR DESCRIPTION
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/905742

Although we are compliant with `aria-label` alone, according to one of our accessibility contacts, we should add `abbr` as well.