### PR TITLE
Add site admin check for tenant

### DIFF
--- a/src/AccountDeleter/Configuration/GalleryConfiguration.cs
+++ b/src/AccountDeleter/Configuration/GalleryConfiguration.cs
@@ -63,6 +63,7 @@ namespace NuGetGallery.AccountDeleter
         public bool CollectPerfLogs { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public bool AutoUpdateSearchIndex { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string EnforcedAuthProviderForAdmin { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string EnforcedTenantIdForAdmin { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string UserPasswordRegex { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string UserPasswordHint { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public int ExpirationInDaysForApiKeyV1 { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
@@ -232,6 +232,13 @@ namespace NuGetGallery.Configuration
         public string EnforcedAuthProviderForAdmin { get; set; }
 
         /// <summary>
+        /// Gets a string indicating which AAD Tenant Id should be used for administrators. 
+        /// When specified, the gallery will ensure admin users are logging in using only the specified tenant ID.
+        /// Blank means any AAD tenant ID can be used by administrators.
+        /// </summary>
+        public string EnforcedTenantIdForAdmin { get; set; }
+
+        /// <summary>
         /// A regex to validate password format. The default regex requires the password to be atlease 8 characters, 
         /// include at least one uppercase letter, one lowercase letter and a digit.
         /// </summary>

--- a/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
@@ -243,6 +243,13 @@ namespace NuGetGallery.Configuration
         string EnforcedAuthProviderForAdmin { get; set; }
 
         /// <summary>
+        /// Gets a string indicating which AAD Tenant Id should be used for administrators. 
+        /// When specified, the gallery will ensure admin users are logging in using only the specified tenant ID.
+        /// Blank means any AAD tenant ID can be used by administrators.
+        /// </summary>
+        string EnforcedTenantIdForAdmin { get; set; }
+
+        /// <summary>
         /// The required format for a user password.
         /// </summary>
         string UserPasswordRegex { get; set; }

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -343,7 +343,6 @@ namespace NuGetGallery
             if (!SiteAdminHasValidTenant(user))
             {
                 ModelState.AddModelError("Register", string.Format(Strings.SiteAdminNotLoggedInWithRequiredTenant, NuGetContext.Config.Current.EnforcedTenantIdForAdmin));
-
                 return RegisterOrExternalLinkView(model, linkingAccount);
             }
 

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1968,6 +1968,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The site admins are required to sign in with the &apos;{0}&apos; tenant only..
+        /// </summary>
+        public static string SiteAdminNotLoggedInWithRequiredTenant {
+            get {
+                return ResourceManager.GetString("SiteAdminNotLoggedInWithRequiredTenant", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The requested resource can only be accessed via SSL..
         /// </summary>
         public static string SSLRequired {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1147,4 +1147,7 @@ The {1} Team</value>
   <data name="AccountDelete_SelfServiceSuccess" xml:space="preserve">
     <value>Your account is being deleted. You have been logged out.</value>
   </data>
+  <data name="SiteAdminNotLoggedInWithRequiredTenant" xml:space="preserve">
+    <value>The site admins are required to sign in with the '{0}' tenant only.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -95,8 +95,9 @@
     <add key="Auth.AzureActiveDirectory.ClientId" value=""/>
     <add key="Auth.AzureActiveDirectory.Authority" value=""/>
     <add key="Auth.AzureActiveDirectory.Issuer" value=""/>
-    <add key="Auth.AzureActiveDirectory.ShowOnLoginPage" value="true"/>
+    <add key="Auth.AzureActiveDirectory.ShowOnLoginPage" value="false"/>
     <add key="Gallery.EnforcedAuthProviderForAdmin" value=""/>
+    <add key="Gallery.EnforcedTenantIdForAdmin" value=""/>
     <add key="Gallery.ExpirationInDaysForApiKeyV1" value="365"/>
     <add key="Gallery.WarnAboutExpirationInDaysForApiKeyV1" value="10"/>
     <!-- Semi-colon separated list of domains for the alternate site root for gallery, used for MSA authentication by AADv2-->


### PR DESCRIPTION
As part of getting rid of old AAD/MSA configs, we want to bolster the site admin check. https://github.com/NuGet/Engineering/issues/2567

This PR needs the new configs, will send that PR out separately.

![image](https://user-images.githubusercontent.com/1646506/64389418-7054fb00-cff7-11e9-8cae-7ee7ff3680eb.png)
