### PR TITLE
[Hotfix] Revert "Click on "show more" should not scroll page to top (#7420)"

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -43,7 +43,6 @@ $(function () {
 
         $("#show-readme-more").click(function () {
             showLess.collapse("toggle");
-            return false;
         });
         showLess.on('hide.bs.collapse', function (e) {
             e.stopPropagation();


### PR DESCRIPTION
This reverts commit 8c5b4e8836f57b050dff8ef98d458cb82fb4379a.

This causes the documentation of more than 10 lines to stay collapsed even if you click "Show more"

![recording](https://user-images.githubusercontent.com/94054/64452121-8ec00280-d09a-11e9-8a9a-36afa049b73e.gif)

/cc @304NotModified, I'll look into the root cause later. For now we are reverting it to unblock our deployment.