### PR TITLE
Make the readme show more link not jump to the top of the page

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -41,8 +41,9 @@ $(function () {
         var showLess = $("#readme-less");
         $clamp(showLess[0], { clamp: 10, useNativeClamp: false });
 
-        $("#show-readme-more").click(function () {
+        $("#show-readme-more").click(function (e) {
             showLess.collapse("toggle");
+            e.preventDefault();
         });
         showLess.on('hide.bs.collapse', function (e) {
             e.stopPropagation();


### PR DESCRIPTION
As mentioned on https://github.com/NuGet/NuGetGallery/pull/7516#issuecomment-529023098. Thanks for the top, @304NotModified. Worked like a charm.