### PR TITLE
Add codeowners for the NuGetGallery repo to get reviews requested automatically

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# review when someone opens a pull request.
+# For more on how to customize the CODEOWNERS file - https://help.github.com/en/articles/about-code-owners
+*       @agr @cristinamanu @dannyjdev @joelverhagen @loic-sharma @ryuyu  @scottbommarito @skofman1 @shishirx34 @xavierdecoster @zhhyu 
+ 


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Scott was a fan of our code owners file on client side. 

https://github.com/NuGet/NuGet.Client/blob/dev/.github/CODEOWNERS

I think server gallery should have it as well :) 

Example: https://github.com/NuGet/NuGet.Client/pull/3053
Look at the key near most of the names in the reviewers :) 

//cc @scottbommarito 