### PR TITLE
Hotfix: Stats index page should not use integers to store download counts

### DIFF
--- a/src/NuGetGallery.Services/Telemetry/UserPackageDeleteEvent.cs
+++ b/src/NuGetGallery.Services/Telemetry/UserPackageDeleteEvent.cs
@@ -12,10 +12,10 @@ namespace NuGetGallery
             int packageKey,
             string packageId,
             string packageVersion,
-            int idDatabaseDownloads,
-            int idReportDownloads,
-            int versionDatabaseDownloads,
-            int versionReportDownloads,
+            long idDatabaseDownloads,
+            long idReportDownloads,
+            long versionDatabaseDownloads,
+            long versionReportDownloads,
             ReportPackageReason? reportPackageReason,
             PackageDeleteDecision? packageDeleteDecision)
         {
@@ -35,10 +35,10 @@ namespace NuGetGallery
         public int PackageKey { get; }
         public string PackageId { get; }
         public string PackageVersion { get; }
-        public int IdDatabaseDownloads { get; }
-        public int IdReportDownloads { get; }
-        public int VersionDatabaseDownloads { get; }
-        public int VersionReportDownloads { get; }
+        public long IdDatabaseDownloads { get; }
+        public long IdReportDownloads { get; }
+        public long VersionDatabaseDownloads { get; }
+        public long VersionReportDownloads { get; }
         public ReportPackageReason? ReportPackageReason { get; }
         public PackageDeleteDecision? PackageDeleteDecision { get; }
     }

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -321,7 +321,7 @@ namespace NuGetGallery
 
             if (groupby != null)
             {
-                Tuple<StatisticsPivot.TableEntry[][], int> result = StatisticsPivot.GroupBy(report.Facts, pivot);
+                var result = StatisticsPivot.GroupBy(report.Facts, pivot);
 
                 if (id != null)
                 {

--- a/src/NuGetGallery/Services/JsonStatisticsService.cs
+++ b/src/NuGetGallery/Services/JsonStatisticsService.cs
@@ -187,7 +187,7 @@ namespace NuGetGallery
                     new StatisticsPackagesItemViewModel
                     {
                         PackageId = item["PackageId"].ToString(),
-                        Downloads = item["Downloads"].Value<int>()
+                        Downloads = item["Downloads"].Value<long>()
                     }
                 );
 
@@ -247,7 +247,7 @@ namespace NuGetGallery
                     {
                         PackageId = item["PackageId"].ToString(),
                         PackageVersion = item["PackageVersion"].ToString(),
-                        Downloads = item["Downloads"].Value<int>(),
+                        Downloads = item["Downloads"].Value<long>(),
                     }
                 );
 
@@ -287,7 +287,7 @@ namespace NuGetGallery
                         new StatisticsNuGetUsageItem
                         {
                             Version = string.Format(CultureInfo.InvariantCulture, "{0}.{1}", item["Major"], item["Minor"]),
-                            Downloads = (int)item["Downloads"]
+                            Downloads = (long)item["Downloads"]
                         });
                 }
 
@@ -322,7 +322,7 @@ namespace NuGetGallery
                         {
                             Year = (int)item["Year"],
                             WeekOfYear = (int)item["WeekOfYear"],
-                            Downloads = (int)item["Downloads"]
+                            Downloads = (long)item["Downloads"]
                         });
                 }
 
@@ -475,7 +475,7 @@ namespace NuGetGallery
                         operation = (string)opt;
                     }
 
-                    var downloads = (int)perClient["Downloads"];
+                    var downloads = (long)perClient["Downloads"];
 
                     facts.Add(new StatisticsFact(CreateDimensions(version, clientName, clientVersion, operation), downloads));
                 }

--- a/src/NuGetGallery/ViewModels/StatisticsFact.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsFact.cs
@@ -7,13 +7,13 @@ namespace NuGetGallery
 {
     public class StatisticsFact
     {
-        public StatisticsFact(IDictionary<string, string> dimensions, int amount)
+        public StatisticsFact(IDictionary<string, string> dimensions, long amount)
         {
             Dimensions = new Dictionary<string, string>(dimensions);
             Amount = amount;
         }
 
         public IDictionary<string, string> Dimensions { get; private set; }
-        public int Amount { get; private set; }
+        public long Amount { get; private set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/StatisticsNuGetUsageItem.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsNuGetUsageItem.cs
@@ -6,6 +6,6 @@ namespace NuGetGallery
     public class StatisticsNuGetUsageItem
     {
         public string Version { get; set; }
-        public int Downloads { get; set; }
+        public long Downloads { get; set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesItemViewModel.cs
@@ -10,6 +10,6 @@ namespace NuGetGallery
         public string PackageTitle { get; set; }
         public string PackageDescription { get; set; }
         public string PackageIconUrl { get; set; }
-        public int Downloads { get; set; }
+        public long Downloads { get; set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesReport.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesReport.cs
@@ -10,7 +10,7 @@ namespace NuGetGallery
     public class StatisticsPackagesReport
     {
         public IList<StatisticsPackagesItemViewModel> Rows { get; private set; }
-        public int Total { get; set; }
+        public long Total { get; set; }
 
         public IList<StatisticsDimension> Dimensions { get; private set; }
         public IList<StatisticsFact> Facts { get; set; }

--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -56,7 +56,7 @@ namespace NuGetGallery
 
         public bool IsLast6WeeksAvailable { get; set; }
 
-        public int NuGetClientVersionTotalDownloads { get; private set; }
+        public long NuGetClientVersionTotalDownloads { get; private set; }
 
         public string PackageId { get; private set; }
 
@@ -81,7 +81,7 @@ namespace NuGetGallery
             PackageVersion = packageVersion;
         }
 
-        public string DisplayDownloads(int downloads)
+        public string DisplayDownloads(long downloads)
         {
             return downloads.ToNuGetNumberString();
         }
@@ -142,7 +142,7 @@ namespace NuGetGallery
             return (amount / total).ToString("P0", CultureInfo.CurrentCulture);
         }
 
-        public string DisplayShortNumber(int number)
+        public string DisplayShortNumber(long number)
         {
             var numDiv = 0;
 

--- a/src/NuGetGallery/ViewModels/StatisticsPivot.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPivot.cs
@@ -14,7 +14,7 @@ namespace NuGetGallery
 {
     public class StatisticsPivot
     {
-        public static Tuple<TableEntry[][], int> GroupBy(IList<StatisticsFact> facts, string[] pivot)
+        public static Tuple<TableEntry[][], long> GroupBy(IList<StatisticsFact> facts, string[] pivot)
         {
             // Firstly take the facts and the pivot vector and produce a tree structure
 
@@ -36,7 +36,7 @@ namespace NuGetGallery
 
             PopulateTable(level, table);
 
-            return new Tuple<TableEntry[][], int>(table, level.Total);
+            return new Tuple<TableEntry[][], long>(table, level.Total);
         }
 
         private static void AddOrderedNext(Level level)
@@ -126,7 +126,7 @@ namespace NuGetGallery
 
             if (depth == dimensions.Length - 1)
             {
-                int current = result.Next[fact.Dimensions[dimensions[depth]]].Amount;
+                var current = result.Next[fact.Dimensions[dimensions[depth]]].Amount;
 
                 result.Next[fact.Dimensions[dimensions[depth]]].Amount = current + fact.Amount;
             }
@@ -162,9 +162,9 @@ namespace NuGetGallery
         // The total in a pivot can be found by adding up all the leaf nodes
         // The subtotals are also stored in the tree.
 
-        private static int Total(Level level)
+        private static long Total(Level level)
         {
-            int total = 0;
+            long total = 0;
             foreach (KeyValuePair<string, Level> item in level.Next)
             {
                 if (item.Value.Next == null)
@@ -188,7 +188,7 @@ namespace NuGetGallery
         public class TableEntry
         {
             public string Data { get; set; }
-            public int Rowspan { get; set; }
+            public long Rowspan { get; set; }
             public string Uri { get; set; }
             public bool IsNumeric { get; set; }
 
@@ -217,15 +217,15 @@ namespace NuGetGallery
             // Either Next is not null or this is a leaf in the pivot tree, in which case Amount is valid
 
             public IDictionary<string, Level> Next { get; set; }
-            public int Amount { get; set; }
+            public long Amount { get; set; }
 
             // Count is the count of child nodes in the tree - recursively so grandchildren etc. also get counted
 
-            public int Count { get; set; }
+            public long Count { get; set; }
 
             // Total is the sum Total of all the Amounts in all the descendants. (See Total function above.)
 
-            public int Total { get; set; }
+            public long Total { get; set; }
 
             // An ordered list for each level
 

--- a/src/NuGetGallery/ViewModels/StatisticsWeeklyUsageItem.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsWeeklyUsageItem.cs
@@ -7,6 +7,6 @@ namespace NuGetGallery
     {
         public int Year { get; set; }
         public int WeekOfYear { get; set; }
-        public int Downloads { get; set; }
+        public long Downloads { get; set; }
     }
 }

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -142,7 +142,7 @@
 
                                 for (var i = 0; i < numYAxisLabels; i++)
                                 {
-                                    @:<text class="graph-y-axis-text" x="0" y="@Format(i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
+                                    @:<text class="graph-y-axis-text" x="0" y="@Format(i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((long)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
                                 }
                             }
                         </svg>
@@ -222,7 +222,7 @@
 
                                 for (var i = 0; i < numYAxisLabels; i++)
                                 {
-                                    @:<text class="graph-y-axis-text" x="0" y="@Format(topOffset + i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((int)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
+                                    @:<text class="graph-y-axis-text" x="0" y="@Format(topOffset + i / numYAxisLabels * chartFullHeightInPercent)%" dy="1em" text-overflow="clip">@Model.DisplayShortNumber((long)Math.Floor(max * (numYAxisLabels - i) / numYAxisLabels))</text>
                                 }
 
                             }

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -112,7 +112,7 @@ namespace NuGetGallery
 
             var model = (StatisticsPackagesViewModel)((ViewResult)await controller.Index()).Model;
 
-            int sum = 0;
+            long sum = 0;
 
             if (model.IsDownloadPackageAvailable)
             {
@@ -286,7 +286,7 @@ namespace NuGetGallery
 
             var model = (StatisticsPackagesViewModel)((ViewResult)await controller.Packages()).Model;
 
-            int sum = 0;
+            long sum = 0;
 
             foreach (var item in model.DownloadPackagesAll)
             {
@@ -334,7 +334,7 @@ namespace NuGetGallery
 
             var model = (StatisticsPackagesViewModel)((ViewResult)await controller.PackageVersions()).Model;
 
-            int sum = 0;
+            long sum = 0;
 
             foreach (var item in model.DownloadPackageVersionsAll)
             {


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/7543

Tested locally against stats files with 1 trillion downloads and works great.