### PR TITLE
Render dotnet-new-install for template packages

### DIFF
--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -93,6 +93,7 @@ namespace NuGetGallery
                 viewModel.DownloadsPerDay = viewModel.TotalDownloadCount / viewModel.TotalDaysSinceCreated; // for the package
                 viewModel.DownloadsPerDayLabel = viewModel.DownloadsPerDay < 1 ? "<1" : viewModel.DownloadsPerDay.ToNuGetNumberString();
                 viewModel.IsDotnetToolPackageType = package.PackageTypes.Any(e => e.Name.Equals("DotnetTool", StringComparison.OrdinalIgnoreCase));
+                viewModel.IsDotnetNewTemplatePackageType = package.PackageTypes.Any(e => e.Name.Equals("Template", StringComparison.OrdinalIgnoreCase));
             }
 
             if (deprecation != null)

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -31,6 +31,7 @@ namespace NuGetGallery
         public bool HasSemVer2Version { get; set; }
         public bool HasSemVer2Dependency { get; set; }
         public bool IsDotnetToolPackageType { get; set; }
+        public bool IsDotnetNewTemplatePackageType { get; set; }
         public bool IsAtomFeedEnabled { get; set; }
         public bool IsPackageDeprecationEnabled { get; set; }
         public bool IsGitHubUsageEnabled { get; set; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -28,13 +28,27 @@
     {
         packageManagers = new PackageManagerViewModel[]
         {
-            new PackageManagerViewModel(".NET CLI")
+            new PackageManagerViewModel(".NET CLI Tool")
             {
                 Id = "dotnet-cli",
                 CommandPrefix = "> ",
                 InstallPackageCommand = string.Format("dotnet tool install --global {0} --version {1}", Model.Id, Model.Version),
                 AlertLevel = AlertLevel.Info,
-                AlertMessage = string.Format("This package contains a <a href=\"{0}\">.NET Core Global Tool</a> you can call from the shell/command line.", "https://aka.ms/global-tools"),
+                AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET Core Global Tool</a> you can call from the shell/command line.",
+            }
+        };
+    }
+    else if (Model.IsDotnetNewTemplatePackageType)
+    {
+        packageManagers = new PackageManagerViewModel[]
+        {
+            new PackageManagerViewModel(".NET CLI Template")
+            {
+                Id = "dotnet-cli",
+                CommandPrefix = "> ",
+                InstallPackageCommand = string.Format("dotnet new --install {0}::{1}", Model.Id, Model.Version),
+                AlertLevel = AlertLevel.Info,
+                AlertMessage = "This package contains a <a href='https://aka.ms/dotnet-new'>.NET Core Template Package</a> you can call from the shell/command line.",
             }
         };
     }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -28,7 +28,7 @@
     {
         packageManagers = new PackageManagerViewModel[]
         {
-            new PackageManagerViewModel(".NET CLI Tool")
+            new PackageManagerViewModel(".NET CLI")
             {
                 Id = "dotnet-cli",
                 CommandPrefix = "> ",
@@ -42,7 +42,7 @@
     {
         packageManagers = new PackageManagerViewModel[]
         {
-            new PackageManagerViewModel(".NET CLI Template")
+            new PackageManagerViewModel(".NET CLI")
             {
                 Id = "dotnet-cli",
                 CommandPrefix = "> ",


### PR DESCRIPTION
With this change, the donet CLI template packages will show the `dotnet-new-install` command.

![image](https://user-images.githubusercontent.com/3840695/64808531-22fcfe80-d5a0-11e9-91f7-6d867b1a72d7.png)



Addresses https://github.com/NuGet/NuGetGallery/issues/5216