### PR TITLE
[MSA] Use EmailClaim instead of preferred_username during auth/register

### DIFF
--- a/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
+++ b/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
@@ -20,11 +20,12 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
     {
         public static class V2Claims
         {
-            public const string TenantId = "http://schemas.microsoft.com/identity/claims/tenantid";
+            public const string EmailAddress = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
             public const string Identifier = "http://schemas.microsoft.com/identity/claims/objectidentifier";
-            public const string Email = "preferred_username";
-            public const string Name = "name";
             public const string Issuer = "iss";
+            public const string Name = "name";
+            public const string PreferredUsername = "preferred_username";
+            public const string TenantId = "http://schemas.microsoft.com/identity/claims/tenantid";
 
             /// <summary>
             /// ACR is the Authentication Class Reference token, which is the claim that is returned by OpenId upon usage of multi-factor during authentication.
@@ -182,10 +183,10 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
             }
 
             var nameClaim = claimsIdentity.FindFirst(V2Claims.Name);
-            var emailClaim = claimsIdentity.FindFirst(V2Claims.Email);
+            var emailClaim = claimsIdentity.FindFirst(V2Claims.EmailAddress);
             if (emailClaim == null)
             {
-                throw new ArgumentException($"External Authentication is missing required claim: '{V2Claims.Email}'");
+                throw new ArgumentException($"External Authentication is missing required claim: '{V2Claims.EmailAddress}'");
             }
 
             var acrClaim = claimsIdentity.FindFirst(V2Claims.ACR);

--- a/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
+++ b/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
@@ -20,7 +20,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
     {
         public static class V2Claims
         {
-            public const string EmailAddress = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
+            public const string EmailAddress = ClaimTypes.Email;
             public const string Identifier = "http://schemas.microsoft.com/identity/claims/objectidentifier";
             public const string Issuer = "iss";
             public const string Name = "name";

--- a/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
@@ -219,7 +219,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
             public static Claim Identifier = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.Identifier, "blarg", ClaimValueTypes.String, Authority);
             public static Claim Name = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.Name, "bloog", ClaimValueTypes.String, Authority);
             public static Claim TenantId = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.TenantId, TEST_TENANT_ID, ClaimValueTypes.String, Authority);
-            public static Claim Email = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.EmailAddress, "blarg@bloog.com", ClaimValueTypes.String, Authority);
+            public static Claim Email = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.EmailAddress, "blarg@bloog.test", ClaimValueTypes.String, Authority);
 
             public static ClaimsIdentity GetIdentity()
             {

--- a/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
@@ -219,7 +219,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
             public static Claim Identifier = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.Identifier, "blarg", ClaimValueTypes.String, Authority);
             public static Claim Name = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.Name, "bloog", ClaimValueTypes.String, Authority);
             public static Claim TenantId = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.TenantId, TEST_TENANT_ID, ClaimValueTypes.String, Authority);
-            public static Claim Email = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.Email, "blarg@bloog.com", ClaimValueTypes.String, Authority);
+            public static Claim Email = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.EmailAddress, "blarg@bloog.com", ClaimValueTypes.String, Authority);
 
             public static ClaimsIdentity GetIdentity()
             {

--- a/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
@@ -180,7 +180,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
                 Assert.Equal("blarg", result.Identifier);
                 Assert.Equal("bloog", result.Name);
                 Assert.Equal(AzureActiveDirectoryV2Authenticator.AuthenticationType.AzureActiveDirectory, result.AuthenticationType);
-                Assert.Equal("blarg@bloog.com", result.Email);
+                Assert.Equal("blarg@bloog.test", result.Email);
                 Assert.Equal(TestData.TEST_TENANT_ID, result.TenantId);
             }
 
@@ -206,7 +206,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
                 Assert.Equal("0ae45d63e22e4a60", result.Identifier);
                 Assert.Equal("bloog", result.Name);
                 Assert.Equal(AzureActiveDirectoryV2Authenticator.AuthenticationType.MicrosoftAccount, result.AuthenticationType);
-                Assert.Equal("blarg@bloog.com", result.Email);
+                Assert.Equal("blarg@bloog.test", result.Email);
                 Assert.Equal(AzureActiveDirectoryV2Authenticator.PersonalMSATenant, result.TenantId);
             }
         }


### PR DESCRIPTION
Addresses: https://github.com/NuGet/NuGetGallery/issues/7324 

Earlier we were using `preferred_username` claim as the email, from my initial observations it was working fine. However, for certain accounts(skype account used as MSA) the `preferred_username` returns the handle rather than email. This fix addresses the bug and also keeps consistent with the expected claims.