### PR TITLE
Do not throw if trying to list an unlisted package that is marked latest

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/PackageUpdateService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageUpdateService.cs
@@ -54,11 +54,6 @@ namespace NuGetGallery
                 throw new InvalidOperationException("A package that failed validation should never be listed!");
             }
 
-            if (!package.Listed && (package.IsLatestStable || package.IsLatest || package.IsLatestSemVer2 || package.IsLatestStableSemVer2))
-            {
-                throw new InvalidOperationException("An unlisted package should never be latest or latest stable!");
-            }
-
             package.Listed = true;
             package.LastUpdated = DateTime.UtcNow;
             // NOTE: LastEdited will be overwritten by a trigger defined in the migration named "AddTriggerForPackagesLastEdited".
@@ -98,7 +93,7 @@ namespace NuGetGallery
             // NOTE: LastEdited will be overwritten by a trigger defined in the migration named "AddTriggerForPackagesLastEdited".
             package.LastEdited = DateTime.UtcNow;
 
-            if (ShouldUpdateIsLatestForPackageWhenUnlisting(package))
+            if (package.IsLatest || package.IsLatestStable || package.IsLatestSemVer2 || package.IsLatestStableSemVer2)
             {
                 await _packageService.UpdateIsLatestAsync(package.PackageRegistration, commitChanges: false);
             }
@@ -171,11 +166,6 @@ WHERE [Key] IN ({0})";
                     $"Updated an unexpected number of packages when performing a bulk update! " +
                     $"Updated {result} packages instead of {expectedResult}.");
             }
-        }
-
-        private bool ShouldUpdateIsLatestForPackageWhenUnlisting(Package package)
-        {
-            return package.IsLatest || package.IsLatestStable || package.IsLatestSemVer2 || package.IsLatestStableSemVer2;
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/PackageUpdateServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUpdateServiceFacts.cs
@@ -60,22 +60,6 @@ namespace NuGetGallery.Services
                 await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.MarkPackageListedAsync(package));
             }
 
-            public static IEnumerable<object[]> ThrowsWhenPackageIsLatest_Data
-            {
-                get
-                {
-                    foreach (var latestState in Enum.GetValues(typeof(PackageLatestState)).Cast<PackageLatestState>())
-                    {
-                        if (latestState == PackageLatestState.Not)
-                        {
-                            continue;
-                        }
-
-                        yield return MemberDataHelper.AsData(latestState);
-                    }
-                }
-            }
-
             [Fact]
             public async Task WritesAnAuditRecord()
             {

--- a/tests/NuGetGallery.Facts/Services/PackageUpdateServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUpdateServiceFacts.cs
@@ -76,25 +76,6 @@ namespace NuGetGallery.Services
                 }
             }
 
-            [Theory]
-            [MemberData(nameof(ThrowsWhenPackageIsLatest_Data))]
-            public async Task ThrowsWhenPackageIsLatest(PackageLatestState latestState)
-            {
-                var packageRegistration = new PackageRegistration { Id = "theId" };
-                var package = new Package
-                {
-                    Version = "1.0",
-                    PackageRegistration = packageRegistration,
-                    Listed = false
-                };
-
-                SetLatestOfPackage(package, latestState);
-
-                var service = Get<PackageUpdateService>();
-
-                await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.MarkPackageListedAsync(package));
-            }
-
             [Fact]
             public async Task WritesAnAuditRecord()
             {


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/7536

Relisting a package properly resets the latest state of the package, so any packages that are unlisted and marked latest will be fixed. By throwing here, we are making it so that users cannot fix the data issue they have. 