### PR TITLE
Warn owners when ReadMe contains images that would be rewritten

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -2724,7 +2724,7 @@ namespace NuGetGallery
             try
             {
                 var readMeHtml = await _readMeService.GetReadMeHtmlAsync(formData, Request.ContentEncoding);
-                return Json(new[] { readMeHtml });
+                return Json(new[] { readMeHtml?.Content });
             }
             catch (Exception ex)
             {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -2723,8 +2723,8 @@ namespace NuGetGallery
 
             try
             {
-                var readMeHtml = await _readMeService.GetReadMeHtmlAsync(formData, Request.ContentEncoding);
-                return Json(new[] { readMeHtml?.Content });
+                var readMeResult = await _readMeService.GetReadMeHtmlAsync(formData, Request.ContentEncoding);
+                return Json(readMeResult);
             }
             catch (Exception ex)
             {

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
@@ -31,7 +31,7 @@ namespace NuGetGallery
             User currentUser,
             IReadOnlyList<ReportPackageReason> reasons)
         {
-            _displayPackageViewModelFactory.Setup(viewModel, package, currentUser, deprecation: null, readMeHtml: null);
+            _displayPackageViewModelFactory.Setup(viewModel, package, currentUser, deprecation: null, readmeResult: null);
             return SetupInternal(viewModel, package, reasons);
         }
 

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery
             Package package,
             User currentUser,
             PackageDeprecation deprecation,
-            string readmeHtml)
+            RenderedReadMeResult readmeResult)
         {
             var viewModel = new DisplayPackageViewModel();
             return Setup(
@@ -30,7 +30,7 @@ namespace NuGetGallery
                 package,
                 currentUser,
                 deprecation,
-                readmeHtml);
+                readmeResult);
         }
 
         public DisplayPackageViewModel Setup(
@@ -38,11 +38,11 @@ namespace NuGetGallery
             Package package,
             User currentUser,
             PackageDeprecation deprecation,
-            string readMeHtml)
+            RenderedReadMeResult readmeResult)
         {
             _listPackageItemViewModelFactory.Setup(viewModel, package, currentUser);
             SetupCommon(viewModel, package, pushedBy: null);
-            return SetupInternal(viewModel, package, currentUser, deprecation, readMeHtml);
+            return SetupInternal(viewModel, package, currentUser, deprecation, readmeResult);
         }
 
         private DisplayPackageViewModel SetupInternal(
@@ -50,7 +50,7 @@ namespace NuGetGallery
             Package package,
             User currentUser,
             PackageDeprecation deprecation,
-            string readMeHtml)
+            RenderedReadMeResult readmeResult)
         {
             viewModel.HasSemVer2Version = viewModel.NuGetVersion.IsSemVer2;
             viewModel.HasSemVer2Dependency = package.Dependencies.ToList()
@@ -111,7 +111,7 @@ namespace NuGetGallery
                 viewModel.CustomMessage = deprecation.CustomMessage;
             }
 
-            viewModel.ReadMeHtml = readMeHtml;
+            viewModel.ReadMeHtml = readmeResult?.Content;
             viewModel.HasEmbeddedIcon = package.HasEmbeddedIcon;
 
             return viewModel;

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -112,6 +112,7 @@ namespace NuGetGallery
             }
 
             viewModel.ReadMeHtml = readmeResult?.Content;
+            viewModel.ReadMeImagesRewritten = readmeResult != null ? readmeResult.ImagesRewritten : false;
             viewModel.HasEmbeddedIcon = package.HasEmbeddedIcon;
 
             return viewModel;

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -465,6 +465,7 @@
     <Compile Include="Services\PackageDeprecationService.cs" />
     <Compile Include="Services\PackageShouldNotBeSignedUserFixableValidationMessage.cs" />
     <Compile Include="Services\PlainTextOnlyValidationMessage.cs" />
+    <Compile Include="Services\RenderedReadMeResult.cs" />
     <Compile Include="Services\SearchSideBySideService.cs" />
     <Compile Include="Services\SymbolPackageValidationResult.cs" />
     <Compile Include="Services\FlatContainerContentFileMetadataService.cs" />

--- a/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
+++ b/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
@@ -308,7 +308,7 @@ var BindReadMeDataManager = (function () {
         }
 
         function displayReadMePreview(response) {
-            $("#readme-preview-contents").html(response);
+            $("#readme-preview-contents").html(response.Content);
             $("#readme-preview").removeClass("hidden");
 
             $('.readme-tabs').children().hide();

--- a/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
+++ b/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
@@ -316,6 +316,10 @@ var BindReadMeDataManager = (function () {
             $("#edit-markdown").removeClass("hidden");
             $("#preview-html").addClass("hidden");
             clearReadMeError();
+
+            if (response.ImagesRewritten) {
+                displayReadMeWarning("Some images were automatically rewritten to use secure links and might be broken.");
+            }
         }
 
         function displayReadMeEditMarkdown() {
@@ -328,6 +332,11 @@ var BindReadMeDataManager = (function () {
             $("#preview-html").removeClass("hidden");
         }
 
+        function displayReadMeWarning(errorMsg) {
+            $("#readme-warnings").removeClass("hidden");
+            $("#readme-warning-content").text(errorMsg);
+        }
+
         function displayReadMeError(errorMsg) {
             $("#readme-errors").removeClass("hidden");
             $("#preview-readme-button").attr("disabled", "disabled");
@@ -335,6 +344,11 @@ var BindReadMeDataManager = (function () {
         }
 
         function clearReadMeError() {
+            if (!$("#readme-warnings").hasClass("hidden")) {
+                $("#readme-warnings").addClass("hidden");
+                $("#readme-warning-content").text("");
+            }
+
             if (!$("#readme-errors").hasClass("hidden")) {
                 $("#readme-errors").addClass("hidden");
                 $("#readme-error-content").text("");

--- a/src/NuGetGallery/Services/IReadMeService.cs
+++ b/src/NuGetGallery/Services/IReadMeService.cs
@@ -21,14 +21,14 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="readMeRequest">Request object.</param>
         /// <returns>HTML from markdown conversion.</returns>
-        Task<string> GetReadMeHtmlAsync(ReadMeRequest readMeRequest, Encoding encoding);
+        Task<RenderedReadMeResult> GetReadMeHtmlAsync(ReadMeRequest readMeRequest, Encoding encoding);
 
         /// <summary>
         /// Get the converted HTML from the stored ReadMe markdown.
         /// </summary>
         /// <param name="package">Package entity associated with the ReadMe.</param>
         /// <returns>ReadMe converted to HTML.</returns>
-        Task<string> GetReadMeHtmlAsync(Package package);
+        Task<RenderedReadMeResult> GetReadMeHtmlAsync(Package package);
 
         /// <summary>
         /// Get package ReadMe markdown from storage.

--- a/src/NuGetGallery/Services/ReadMeService.cs
+++ b/src/NuGetGallery/Services/ReadMeService.cs
@@ -248,8 +248,8 @@ namespace NuGetGallery
                             }
                             else
                             {
+                                output.ImagesRewritten = output.ImagesRewritten || (inline.TargetUrl != readyUriString);
                                 inline.TargetUrl = readyUriString;
-                                output.ImagesRewritten = true;
                             }
                         }
                     }

--- a/src/NuGetGallery/Services/ReadMeService.cs
+++ b/src/NuGetGallery/Services/ReadMeService.cs
@@ -90,7 +90,6 @@ namespace NuGetGallery
             var result = new RenderedReadMeResult
             {
                 Content = readMeMd,
-                LinksRewritten = false,
                 ImagesRewritten = false
             };
 
@@ -180,7 +179,6 @@ namespace NuGetGallery
         {
             var output = new RenderedReadMeResult()
             {
-                LinksRewritten = false,
                 ImagesRewritten = false,
                 Content = ""
             };
@@ -236,7 +234,6 @@ namespace NuGetGallery
                             else
                             {
                                 inline.TargetUrl = readyUriString;
-                                output.LinksRewritten = true;
                             }
                         }
 

--- a/src/NuGetGallery/Services/RenderedReadMeResult.cs
+++ b/src/NuGetGallery/Services/RenderedReadMeResult.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    public class RenderedReadMeResult
+    {
+        public string Content { get; set; }
+        
+        public bool ImagesRewritten { get; set; }
+
+        public bool LinksRewritten { get; set; }
+    }
+}

--- a/src/NuGetGallery/Services/RenderedReadMeResult.cs
+++ b/src/NuGetGallery/Services/RenderedReadMeResult.cs
@@ -8,7 +8,5 @@ namespace NuGetGallery
         public string Content { get; set; }
         
         public bool ImagesRewritten { get; set; }
-
-        public bool LinksRewritten { get; set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -21,6 +21,7 @@ namespace NuGetGallery
         public IReadOnlyCollection<DisplayPackageViewModel> PackageVersions { get; set; }
         public string Copyright { get; set; }
         public string ReadMeHtml { get; set; }
+        public bool ReadMeImagesRewritten { get; set; }
         public DateTime? LastEdited { get; set; }
         public int DownloadsPerDay { get; set; }
         public int TotalDaysSinceCreated { get; set; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -432,6 +432,10 @@
                         </h2>
                     </div>
                     <div id="readme-container" class="collapse in">
+                        @if (Model.ReadMeImagesRewritten && Model.CanDisplayPrivateMetadata)
+                        {
+                            @ViewHelpers.AlertWarning(@<text>This documentation had some images automatically rewritten to use secure links and may be broken.</text>);
+                        }
                         <div id="readme-less" class="collapse in">
                             @Html.Raw(Model.ReadMeHtml)
                         </div>

--- a/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
@@ -38,6 +38,17 @@
             </div>
         </div>
 
+        <div id="readme-warnings" class="hidden">
+            <div class="alert alert-warning" role="alert" aria-live="assertive">
+                <ul class="list-unstyled ms-Icon-ul">
+                    <li>
+                        <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
+                        <span id="readme-warning-content"></span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
         <div class="readme-tabs">
             <input type="hidden" data-bind="value: SelectedTab" name="Edit.ReadMe.SourceType" />
             <ul class="nav nav-tabs" role="tablist">
@@ -47,32 +58,32 @@
             </ul>
             <div class="tab-content">
                 @ReadMePanel(
-                    @<div class="form-group editable">
-                        <textarea class="form-control" data-bind="value: Edit.ReadMe.SourceText" name="Edit.ReadMe.SourceText" id="ReadMeTextInput"
-                                  rows="10" placeholder="Add Markdown Documentation here..." aria-label="Enter custom documentation.md">
+                        @<div class="form-group editable">
+                            <textarea class="form-control" data-bind="value: Edit.ReadMe.SourceText" name="Edit.ReadMe.SourceText" id="ReadMeTextInput"
+                                      rows="10" placeholder="Add Markdown Documentation here..." aria-label="Enter custom documentation.md">
                         </textarea>
-                    </div>,
-                    "readme-written", active: true)
+                        </div>,
+                  "readme-written", active: true)
 
                 @ReadMePanel(
-                    @<div class="form-group editable">
-                        <input type="url" data-bind="value: Edit.ReadMe.SourceUrl" name="Edit.ReadMe.SourceUrl" class="form-control" id="ReadMeUrlInput"
-                               placeholder="https://raw.githubusercontent.com/*.md" aria-label="Enter documentation.md URL" />
-                        <label id="ReadMeURLLabel" class="input-group-btn"></label>
-                    </div>,        
-                   "readme-url", active: false)
+                        @<div class="form-group editable">
+                            <input type="url" data-bind="value: Edit.ReadMe.SourceUrl" name="Edit.ReadMe.SourceUrl" class="form-control" id="ReadMeUrlInput"
+                                   placeholder="https://raw.githubusercontent.com/*.md" aria-label="Enter documentation.md URL" />
+                            <label id="ReadMeURLLabel" class="input-group-btn"></label>
+                        </div>,
+                 "readme-url", active: false)
 
                 @ReadMePanel(
-                    @<div class="input-group">
-                        <input type="text" id="ReadMeFileText" class="form-control" value="Browse for a Markdown Documentation file..."
-                               aria-label="Upload documentation.md file" readonly />
-                        <label for="ReadMeFileInput" id="ReadMeFileLabel" class="input-group-btn">
-                            <span id="browse-for-readme-button" class="btn btn-primary form-control" tabindex="0" aria-label="Browse for a Markdown Documentation file" role="button">
-                                Browse&hellip;<input type="file" accept=".md" data-bind="value: Edit.ReadMe.SourceFile" name="Edit.ReadMe.SourceFile" aria-labelledby="ReadMeFileLabel" id="ReadMeFileInput" style="display:none;" />
-                            </span>
-                        </label>
-                    </div>,
-                    "readme-file", active: false)
+                        @<div class="input-group">
+                            <input type="text" id="ReadMeFileText" class="form-control" value="Browse for a Markdown Documentation file..."
+                                   aria-label="Upload documentation.md file" readonly />
+                            <label for="ReadMeFileInput" id="ReadMeFileLabel" class="input-group-btn">
+                                <span id="browse-for-readme-button" class="btn btn-primary form-control" tabindex="0" aria-label="Browse for a Markdown Documentation file" role="button">
+                                    Browse&hellip;<input type="file" accept=".md" data-bind="value: Edit.ReadMe.SourceFile" name="Edit.ReadMe.SourceFile" aria-labelledby="ReadMeFileLabel" id="ReadMeFileInput" style="display:none;" />
+                                </span>
+                            </label>
+                        </div>,
+                  "readme-file", active: false)
             </div>
         </div>
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -8350,9 +8350,8 @@ namespace NuGetGallery
 
                 var result = await controller.PreviewReadMe(request);
 
-                var stringArray = Assert.IsType<string[]>(result.Data);
-                Assert.Single(stringArray);
-                Assert.Equal(html, stringArray[0]);
+                var readmeResult = Assert.IsType<RenderedReadMeResult>(result.Data);
+                Assert.Equal(html, readmeResult.Content);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -8346,7 +8346,7 @@ namespace NuGetGallery
 
                 readmeService
                     .Setup(rs => rs.GetReadMeHtmlAsync(request, It.IsAny<Encoding>()))
-                    .ReturnsAsync(html);
+                    .ReturnsAsync(new RenderedReadMeResult { Content = html } );
 
                 var result = await controller.PreviewReadMe(request);
 

--- a/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
@@ -258,7 +258,7 @@ namespace NuGetGallery
             [InlineData("<a href=\"javascript:alert('test');\">", "<p>&lt;a href=&quot;javascript:alert('test');&quot;&gt;</p>")]
             public void EncodesHtmlInMarkdown(string originalMd, string expectedHtml)
             {
-                Assert.Equal(expectedHtml, StripNewLines(ReadMeService.GetReadMeHtml(originalMd)));
+                Assert.Equal(expectedHtml, StripNewLines(ReadMeService.GetReadMeHtml(originalMd).Content));
             }
 
             [Theory]
@@ -274,7 +274,7 @@ namespace NuGetGallery
             [InlineData("![image](http://www.otherurl.net/fake.jpg)", "<p><img src=\"https://www.otherurl.net/fake.jpg\" alt=\"image\" /></p>")]
             public void ConvertsMarkdownToHtml(string originalMd, string expectedHtml)
             {
-                Assert.Equal(expectedHtml, StripNewLines(ReadMeService.GetReadMeHtml(originalMd)));
+                Assert.Equal(expectedHtml, StripNewLines(ReadMeService.GetReadMeHtml(originalMd).Content));
             }
 
             [Fact]
@@ -285,7 +285,7 @@ namespace NuGetGallery
                 var package = new Package() { HasReadMe = false };
 
                 // Act & Assert
-                Assert.Null(await readMeService.GetReadMeHtmlAsync(package));
+                Assert.Null((await readMeService.GetReadMeHtmlAsync(package)).Content);
             }
 
             private static string StripNewLines(string text)

--- a/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
@@ -262,19 +262,21 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData("# Heading", "<h2>Heading</h2>")]
-            [InlineData("- List", "<ul><li>List</li></ul>")]
-            [InlineData("[text](http://www.test.com)", "<p><a href=\"http://www.test.com/\" rel=\"nofollow\">text</a></p>")]
-            [InlineData("[text](javascript:alert('hi'))", "<p><a href=\"\" rel=\"nofollow\">text</a></p>")]
-            [InlineData("> <text>Blockquote</text>", "<blockquote><p>&lt;text&gt;Blockquote&lt;/text&gt;</p></blockquote>")]
-            [InlineData("[text](http://www.asp.net)", "<p><a href=\"https://www.asp.net/\" rel=\"nofollow\">text</a></p>")]
-            [InlineData("[text](badurl://www.asp.net)", "<p><a href=\"\" rel=\"nofollow\">text</a></p>")]
-            [InlineData("![image](http://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" alt=\"image\" /></p>")]
-            [InlineData("![image](https://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" alt=\"image\" /></p>")]
-            [InlineData("![image](http://www.otherurl.net/fake.jpg)", "<p><img src=\"https://www.otherurl.net/fake.jpg\" alt=\"image\" /></p>")]
-            public void ConvertsMarkdownToHtml(string originalMd, string expectedHtml)
+            [InlineData("# Heading", "<h2>Heading</h2>", false)]
+            [InlineData("- List", "<ul><li>List</li></ul>", false)]
+            [InlineData("[text](http://www.test.com)", "<p><a href=\"http://www.test.com/\" rel=\"nofollow\">text</a></p>", false)]
+            [InlineData("[text](javascript:alert('hi'))", "<p><a href=\"\" rel=\"nofollow\">text</a></p>", false)]
+            [InlineData("> <text>Blockquote</text>", "<blockquote><p>&lt;text&gt;Blockquote&lt;/text&gt;</p></blockquote>", false)]
+            [InlineData("[text](http://www.asp.net)", "<p><a href=\"https://www.asp.net/\" rel=\"nofollow\">text</a></p>", false)]
+            [InlineData("[text](badurl://www.asp.net)", "<p><a href=\"\" rel=\"nofollow\">text</a></p>", false)]
+            [InlineData("![image](http://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" alt=\"image\" /></p>", true)]
+            [InlineData("![image](https://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" alt=\"image\" /></p>", false)]
+            [InlineData("![image](http://www.otherurl.net/fake.jpg)", "<p><img src=\"https://www.otherurl.net/fake.jpg\" alt=\"image\" /></p>", true)]
+            public void ConvertsMarkdownToHtml(string originalMd, string expectedHtml, bool imageRewriteExpected)
             {
-                Assert.Equal(expectedHtml, StripNewLines(ReadMeService.GetReadMeHtml(originalMd).Content));
+                var readMeResult = ReadMeService.GetReadMeHtml(originalMd);
+                Assert.Equal(expectedHtml, StripNewLines(readMeResult.Content));
+                Assert.Equal(imageRewriteExpected, readMeResult.ImagesRewritten);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -831,7 +831,7 @@ namespace NuGetGallery.ViewModels
                 package,
                 currentUser: currentUser,
                 deprecation: deprecation,
-                readmeHtml: readmeHtml);
+                readmeResult: new RenderedReadMeResult { Content = readmeHtml });
         }
     }
 }


### PR DESCRIPTION
We introduced a change that causes http images in readme files to be rewritten using https.

This change alerts an owner when their documentation contains an image that causes this to happen, both at edit time, and on package details page.

Introduces compound return type from readme service.