### PR TITLE
Handle RequestTelemetry.Url == null (AI intermediate requests)

### DIFF
--- a/src/NuGetGallery/Telemetry/ClientTelemetryPIIProcessor.cs
+++ b/src/NuGetGallery/Telemetry/ClientTelemetryPIIProcessor.cs
@@ -28,22 +28,29 @@ namespace NuGetGallery
         private void ModifyItem(ITelemetry item)
         {
             var requestTelemetryItem = item as RequestTelemetry;
-            if(requestTelemetryItem != null)
+
+            // In some cases, Application Insights reports an intermediate request as a workaround 
+            // when AI lost correlation context and has to restore it.
+            // Hence, RequestTelemetry.Url may be null.
+            // See https://github.com/microsoft/ApplicationInsights-dotnet-server/pull/898
+            // and https://docs.microsoft.com/en-us/dotnet/api/microsoft.applicationinsights.datacontracts.requesttelemetry.url
+            if (requestTelemetryItem != null && requestTelemetryItem.Url != null)
             {
                 var route = GetCurrentRoute();
-                if(route == null)
+                if (route == null)
                 {
                     return;
                 }
+
                 requestTelemetryItem.Url = RouteExtensions.ObfuscateUrlQuery(requestTelemetryItem.Url, RouteExtensions.ObfuscatedReturnUrlMetadata);
                 // Removes the first /
                 var requestPath = requestTelemetryItem.Url.AbsolutePath.TrimStart('/');
                 var obfuscatedPath = route.ObfuscateUrlPath(requestPath);
-                if(obfuscatedPath != null)
+                if (obfuscatedPath != null)
                 {
                     requestTelemetryItem.Url = new Uri(requestTelemetryItem.Url.ToString().Replace(requestPath, obfuscatedPath));
                     requestTelemetryItem.Name = requestTelemetryItem.Name.Replace(requestPath, obfuscatedPath);
-                    if(requestTelemetryItem.Context.Operation?.Name != null)
+                    if (requestTelemetryItem.Context.Operation?.Name != null)
                     {
                         requestTelemetryItem.Context.Operation.Name = requestTelemetryItem.Context.Operation.Name.Replace(requestPath, obfuscatedPath);
                     }

--- a/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace NuGetGallery.Telemetry
 {
-    public class ClientTelemetryPIIProcessorTests 
+    public class ClientTelemetryPIIProcessorTests
     {
         private RouteCollection _currentRoutes;
 
@@ -35,6 +35,20 @@ namespace NuGetGallery.Telemetry
 
             // Act
             piiProcessor.Process(null);
+        }
+
+        [Fact]
+        public void NullRequestTelemetryUrlDoesNotThrow()
+        {
+            // Arange
+            var piiProcessor = CreatePIIProcessor();
+            var requestTelemetry = new RequestTelemetry
+            {
+                Url = null
+            };
+
+            // Act
+            piiProcessor.Process(requestTelemetry);
         }
 
         [Theory]
@@ -99,7 +113,7 @@ namespace NuGetGallery.Telemetry
 
         private ClientTelemetryPIIProcessor CreatePIIProcessor(string url = "")
         {
-            return new TestClientTelemetryPIIProcessor(new TestProcessorNext(), url );
+            return new TestClientTelemetryPIIProcessor(new TestProcessorNext(), url);
         }
 
         private class TestProcessorNext : ITelemetryProcessor
@@ -113,7 +127,7 @@ namespace NuGetGallery.Telemetry
         {
             private string _url = string.Empty;
 
-            public TestClientTelemetryPIIProcessor(ITelemetryProcessor next, string url) : base (next)
+            public TestClientTelemetryPIIProcessor(ITelemetryProcessor next, string url) : base(next)
             {
                 _url = url;
             }
@@ -132,7 +146,8 @@ namespace NuGetGallery.Telemetry
             {
                 Route webRoute = r as Route;
                 return webRoute != null ? IsPIIUrl(webRoute.Url.ToString()) : false;
-            }).Select((r) => {
+            }).Select((r) =>
+            {
                 var dd = ((Route)r).Defaults;
                 return $"{dd["controller"]}/{dd["action"]}";
             }).Distinct().ToList();
@@ -199,7 +214,7 @@ namespace NuGetGallery.Telemetry
 
         public static List<string> GenerateUserNames()
         {
-            return new List<string>{ "user1", "user.1", "user_1", "user-1"};
+            return new List<string> { "user1", "user.1", "user_1", "user-1" };
         }
     }
 }


### PR DESCRIPTION
Fixes `NullReferenceException` introduced by AI's new intermediate request support that causes `RequestTelemetry.Url` to be `null`.

```
Value cannot be null. Parameter name: uri 
System.ArgumentNullExceptionValue cannot be null. Parameter name: uri
System.ArgumentNullException: Value cannot be null.
Parameter name: uri
   at NuGetGallery.RouteExtensions.ObfuscateUrlQuery(Uri uri, ObfuscatedQueryMetadata[] metadata) in E:\A\_work\2455\s\src\Gallery\submodules\Gallery\src\NuGetGallery\Extensions\RouteExtensions.cs:line 105
   at NuGetGallery.ClientTelemetryPIIProcessor.ModifyItem(ITelemetry item) in E:\A\_work\2455\s\src\Gallery\submodules\Gallery\src\NuGetGallery\Telemetry\ClientTelemetryPIIProcessor.cs:line 52
   at NuGetGallery.ClientTelemetryPIIProcessor.Process(ITelemetry item) in E:\A\_work\2455\s\src\Gallery\submodules\Gallery\src\NuGetGallery\Telemetry\ClientTelemetryPIIProcessor.cs:line 24
   at NuGet.Services.Logging.RequestTelemetryProcessor.Process(ITelemetry item)
   at Microsoft.ApplicationInsights.TelemetryClient.Track(ITelemetry telemetry)
   at Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule.OnEndRequest(HttpContext context)
   at Microsoft.ApplicationInsights.Web.AspNetDiagnosticTelemetryModule.AspNetEventObserver.OnNext(KeyValuePair`2 value)
   at System.Diagnostics.DiagnosticListener.Write(String name, Object value)
   at Microsoft.AspNet.TelemetryCorrelation.ActivityHelper.StopLostActivity(Activity activity, HttpContext context)
   at Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule.Application_EndRequest(Object sender, EventArgs e)
   at System.Web.HttpApplication.SyncEventExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute()
   at System.Web.HttpApplication.<>c__DisplayClass285_0.<ExecuteStepImpl>b__0()
   at System.Web.HttpApplication.ExecuteStepImpl(IExecutionStep step)
   at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& completedSynchronously)
```