### PR TITLE
[Hotfix] Fix AAD login issues for some tenants.

### DIFF
--- a/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
+++ b/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
@@ -188,7 +188,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
             emailClaim = emailClaim ?? preferredUsernameClaim;
             if (emailClaim == null)
             {
-                throw new ArgumentException($"External Authentication is missing required claim: '{V2Claims.EmailAddress}'");
+                throw new ArgumentException($"External Authentication is missing required claims: '{V2Claims.EmailAddress}' and '{V2Claims.PreferredUsername}");
             }
 
             var acrClaim = claimsIdentity.FindFirst(V2Claims.ACR);

--- a/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
+++ b/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
@@ -184,6 +184,8 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
 
             var nameClaim = claimsIdentity.FindFirst(V2Claims.Name);
             var emailClaim = claimsIdentity.FindFirst(V2Claims.EmailAddress);
+            var preferredUsernameClaim = claimsIdentity.FindFirst(V2Claims.PreferredUsername);
+            emailClaim = emailClaim ?? preferredUsernameClaim;
             if (emailClaim == null)
             {
                 throw new ArgumentException($"External Authentication is missing required claim: '{V2Claims.EmailAddress}'");

--- a/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
@@ -150,7 +150,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
             }
 
             [Fact]
-            public void ThrowsForMissingEmailClaim()
+            public void ThrowsForMissingEmailAndPreferredUsernameClaim()
             {
                 // Arrange
                 var authenticator = new AzureActiveDirectoryV2Authenticator();
@@ -163,6 +163,26 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
 
                 // Act and assert
                 Assert.Throws<ArgumentException>(() => authenticator.GetIdentityInformation(claimsIdentity));
+            }
+
+            [Fact]
+            public void DoesNotThrowForMissingEmailClaimIfPreferredUsernameClaimIsPresent()
+            {
+                // Arrange
+                var authenticator = new AzureActiveDirectoryV2Authenticator();
+                var claimsIdentity = new ClaimsIdentity(new[] {
+                    TestData.Issuer,
+                    TestData.TenantId,
+                    TestData.Identifier,
+                    TestData.Name,
+                    TestData.PreferredUsername
+                });
+
+                // Act
+                var result = authenticator.GetIdentityInformation(claimsIdentity);
+
+                // Assert
+                Assert.NotNull(result);
             }
 
             [Fact]
@@ -220,6 +240,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
             public static Claim Name = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.Name, "bloog", ClaimValueTypes.String, Authority);
             public static Claim TenantId = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.TenantId, TEST_TENANT_ID, ClaimValueTypes.String, Authority);
             public static Claim Email = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.EmailAddress, "blarg@bloog.test", ClaimValueTypes.String, Authority);
+            public static Claim PreferredUsername = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.PreferredUsername, "blarg@bloog.test", ClaimValueTypes.String, Authority);
 
             public static ClaimsIdentity GetIdentity()
             {
@@ -228,7 +249,8 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
                     TenantId,
                     Identifier,
                     Name,
-                    Email
+                    Email,
+                    PreferredUsername
                 });
             }
         }

--- a/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Providers/CommonAuth/AzureActiveDirectoryV2AuthenticatorFacts.cs
@@ -183,6 +183,29 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
 
                 // Assert
                 Assert.NotNull(result);
+                Assert.Equal(TestData.PreferredUsername.Value, result.Email);
+            }
+
+            [Fact]
+            public void EmailClaimIsPreferredOverPreferredUsernameClaime()
+            {
+                // Arrange
+                var authenticator = new AzureActiveDirectoryV2Authenticator();
+                var claimsIdentity = new ClaimsIdentity(new[] {
+                    TestData.Issuer,
+                    TestData.TenantId,
+                    TestData.Identifier,
+                    TestData.Name,
+                    TestData.Email,
+                    TestData.PreferredUsername
+                });
+
+                // Act
+                var result = authenticator.GetIdentityInformation(claimsIdentity);
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal(TestData.Email.Value, result.Email);
             }
 
             [Fact]
@@ -240,7 +263,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
             public static Claim Name = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.Name, "bloog", ClaimValueTypes.String, Authority);
             public static Claim TenantId = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.TenantId, TEST_TENANT_ID, ClaimValueTypes.String, Authority);
             public static Claim Email = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.EmailAddress, "blarg@bloog.test", ClaimValueTypes.String, Authority);
-            public static Claim PreferredUsername = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.PreferredUsername, "blarg@bloog.test", ClaimValueTypes.String, Authority);
+            public static Claim PreferredUsername = new Claim(AzureActiveDirectoryV2Authenticator.V2Claims.PreferredUsername, "preferredUsername@bloog.test", ClaimValueTypes.String, Authority);
 
             public static ClaimsIdentity GetIdentity()
             {


### PR DESCRIPTION
The fix for the https://github.com/NuGet/NuGetGallery/issues/7324 regressed the behavior for certain AAD logins. For some AAD tenants, the `EmailClaim` is null. In such scenarios `preferred_username` claim seems to have been giving us the correct data, which is what we were using previously.