### PR TITLE
Fix for iconUrl deprecation message appearing for packages without any icon

### DIFF
--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -350,7 +350,7 @@ namespace NuGetGallery
 
             if (iconElement == null)
             {
-                if (embeddedIconsEnabled && nuspecReader.GetIconUrl() != null)
+                if (embeddedIconsEnabled && !string.IsNullOrWhiteSpace(nuspecReader.GetIconUrl()))
                 {
                     warnings.Add(new IconUrlDeprecationValidationMessage());
                 }

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -1167,6 +1167,28 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public async Task DoesntWarnAboutPackagesWithNoIconForFlightedUsers()
+            {
+                _nuGetPackage = GeneratePackageWithUserContent(
+                    iconUrl: null,
+                    iconFilename: null,
+                    licenseExpression: "MIT",
+                    licenseUrl: new Uri("https://licenses.nuget.org/MIT"));
+                _featureFlagService
+                    .Setup(ffs => ffs.AreEmbeddedIconsEnabled(_currentUser))
+                    .Returns(true);
+
+                var result = await _target.ValidateBeforeGeneratePackageAsync(
+                    _nuGetPackage.Object,
+                    GetPackageMetadata(_nuGetPackage),
+                    _currentUser);
+
+                Assert.Equal(PackageValidationResultType.Accepted, result.Type);
+                Assert.Null(result.Message);
+                Assert.Empty(result.Warnings);
+            }
+
+            [Fact]
             public async Task DoesntWarnAboutPackagesWithIconUrl()
             {
                 _nuGetPackage = GeneratePackageWithUserContent(


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/7605.
