### PR TITLE
Display SHA-256 instead of SHA-1 for user certificates

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -324,6 +324,10 @@ img.reserved-indicator-icon {
 .breadcrumb-menu h1 {
   margin-top: 0px;
 }
+.page-account-settings .small-fingerprint,
+.page-manage-organizations .small-fingerprint {
+  font-size: 75%;
+}
 .modal-backdrop.in {
   opacity: 0.8 !important;
   position: fixed;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -404,3 +404,9 @@ img.reserved-indicator-icon {
     margin-top: 0px;
   }
 }
+
+.page-account-settings, .page-manage-organizations {
+  .small-fingerprint {
+    font-size: 75%;
+  }
+}

--- a/src/NuGet.Services.Entities/Certificate.cs
+++ b/src/NuGet.Services.Entities/Certificate.cs
@@ -18,6 +18,7 @@ namespace NuGet.Services.Entities
         /// <summary>
         /// Gets or sets the SHA-1 thumbprint of the certificate.
         /// </summary>
+        [Obsolete("This property should not be used since SHA-1 usage is avoided in NuGetGallery.")]
         public string Sha1Thumbprint { get; set; }
 
         /// <summary>

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemViewModelFactory.cs
@@ -55,7 +55,7 @@ namespace NuGetGallery
             {
                 var owners = package.PackageRegistration?.Owners ?? Enumerable.Empty<User>();
                 var signerUsernames = owners.Where(owner => owner.UserCertificates.Any(uc => uc.CertificateKey == package.CertificateKey)).Select(owner => owner.Username).ToList();
-                viewModel.UpdateSignatureInformation(signerUsernames, package.Certificate.Sha1Thumbprint);
+                viewModel.UpdateSignatureInformation(signerUsernames, package.Certificate.Thumbprint);
             }
 
             return viewModel;

--- a/src/NuGetGallery/Services/CertificateService.cs
+++ b/src/NuGetGallery/Services/CertificateService.cs
@@ -59,7 +59,9 @@ namespace NuGetGallery
 
                     certificate = new Certificate()
                     {
+#pragma warning disable CS0618 // Only set the SHA1 thumbprint, for backwards compatibility. Never read it.
                         Sha1Thumbprint = certificateFile.Sha1Thumbprint,
+#pragma warning restore CS0618
                         Thumbprint = certificateFile.Sha256Thumbprint,
                         UserCertificates = new List<UserCertificate>()
                     };

--- a/src/NuGetGallery/ViewModels/ListCertificateItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListCertificateItemViewModel.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
         /// </summary>
         private const int AbbreviationLength = 36;
 
-        public string Sha1Thumbprint { get; }
+        public string Thumbprint { get; }
         public bool HasInfo { get; }
         public bool IsExpired { get; }
         public string ExpirationDisplay { get; }
@@ -34,7 +34,7 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(certificate));
             }
 
-            Sha1Thumbprint = certificate.Sha1Thumbprint;
+            Thumbprint = certificate.Thumbprint;
             HasInfo = certificate.Expiration.HasValue;
             if (certificate.Expiration.HasValue)
             {

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -16,7 +16,7 @@ namespace NuGetGallery
 
         private string _signatureInformation;
         private IReadOnlyCollection<string> _signerUsernames;
-        private string _sha1Thumbprint;
+        private string _thumbprint;
 
         public string Authors { get; set; }
         public IReadOnlyCollection<BasicUserViewModel> Owners { get; set; }
@@ -64,15 +64,15 @@ namespace NuGetGallery
             IsDescriptionTruncated = wasTruncated;
         }
 
-        public void UpdateSignatureInformation(IReadOnlyCollection<string> signerUsernames, string sha1Thumbprint)
+        public void UpdateSignatureInformation(IReadOnlyCollection<string> signerUsernames, string thumbprint)
         {
-            if ((signerUsernames == null && sha1Thumbprint != null) || (signerUsernames != null && sha1Thumbprint == null))
+            if ((signerUsernames == null && thumbprint != null) || (signerUsernames != null && thumbprint == null))
             {
-                throw new ArgumentException($"{nameof(signerUsernames)} and {nameof(sha1Thumbprint)} arguments must either be both null or both non-null.");
+                throw new ArgumentException($"{nameof(signerUsernames)} and {nameof(thumbprint)} arguments must either be both null or both non-null.");
             }
 
             _signerUsernames = signerUsernames;
-            _sha1Thumbprint = sha1Thumbprint;
+            _thumbprint = thumbprint;
             _signatureInformation = null;
         }
 
@@ -107,7 +107,7 @@ namespace NuGetGallery
                 builder.Append($" and {_signerUsernames.Last()}'s");
             }
 
-            builder.Append($" certificate ({_sha1Thumbprint})");
+            builder.Append($" certificate ({_thumbprint})");
 
             return builder.ToString();
         }

--- a/src/NuGetGallery/Views/Shared/_AccountCertificates.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountCertificates.cshtml
@@ -82,7 +82,7 @@
                     <table class="table" role="list">
                         <thead>
                             <tr class="manage-certificate-headings">
-                                <th>Fingerprint</th>
+                                <th>Fingerprint (SHA-256)</th>
                                 <th>Subject</th>
                                 <th>Expiration</th>
                                 <th>Issuer</th>
@@ -91,7 +91,7 @@
                         </thead>
                         <tbody data-bind="foreach: $data.certificates">
                             <tr class="manage-certificate-listing" role="listitem">
-                                <td data-bind="text: Sha1Thumbprint"></td>
+                                <td><samp class="small-fingerprint" data-bind="text: Thumbprint"></samp></td>
                                 <td data-bind="text: ShortSubject, attr: { title: Subject }"></td>
                                 <td data-bind="text: ExpirationDisplay, attr: {
                                     title: IsExpired ? 'This certificate\'s expiration date is in the past. Future packages signed with this certificate will fail validation. Upload a renewed certificate to enable signed package uploads.' : ExpirationIso,
@@ -109,6 +109,17 @@
                             </tr>
                         </tbody>
                     </table>
+
+                    <p>
+                        The SHA-256 fingerprint can be found by calculating the SHA-256 hash of the DER encoded
+                        certificate file (.cer). The fingerprint should be hex-encoded. This can be done with a variety
+                        of tools.
+                    </p>
+                    <p>
+                        <b>PowerShell:</b> <samp>Get-FileHash -Algorithm SHA256 .\my-public-certificate.cer</samp>
+                        <br />
+                        <b>nuget.exe:</b> <samp>nuget.exe verify -Signatures .\my-signed-package.1.0.0.nupkg</samp>
+                    </p>
                 </div>
             </div>
         </div>

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -1816,7 +1816,6 @@ namespace NuGetGallery
                 _certificate = new Certificate()
                 {
                     Key = 3,
-                    Sha1Thumbprint = "c",
                     Thumbprint = "d"
                 };
 
@@ -1936,7 +1935,7 @@ namespace NuGetGallery
 
                 Assert.True(viewModel.CanDelete);
                 Assert.Equal($"/organization/{_organization.Username}/certificates/{_certificate.Thumbprint}", viewModel.DeleteUrl);
-                Assert.Equal(_certificate.Sha1Thumbprint, viewModel.Sha1Thumbprint);
+                Assert.Equal(_certificate.Thumbprint, viewModel.Thumbprint);
                 Assert.Equal(JsonRequestBehavior.AllowGet, response.JsonRequestBehavior);
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
 
@@ -1960,7 +1959,7 @@ namespace NuGetGallery
 
                 Assert.False(viewModel.CanDelete);
                 Assert.Null(viewModel.DeleteUrl);
-                Assert.Equal(_certificate.Sha1Thumbprint, viewModel.Sha1Thumbprint);
+                Assert.Equal(_certificate.Thumbprint, viewModel.Thumbprint);
                 Assert.Equal(JsonRequestBehavior.AllowGet, response.JsonRequestBehavior);
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
 
@@ -1995,7 +1994,6 @@ namespace NuGetGallery
                 _certificate = new Certificate()
                 {
                     Key = 3,
-                    Sha1Thumbprint = "c",
                     Thumbprint = "d"
                 };
 
@@ -2102,7 +2100,7 @@ namespace NuGetGallery
 
                 Assert.True(viewModel.CanDelete);
                 Assert.Equal($"/organization/{_organization.Username}/certificates/{_certificate.Thumbprint}", viewModel.DeleteUrl);
-                Assert.Equal(_certificate.Sha1Thumbprint, viewModel.Sha1Thumbprint);
+                Assert.Equal(_certificate.Thumbprint, viewModel.Thumbprint);
                 Assert.Equal(JsonRequestBehavior.AllowGet, response.JsonRequestBehavior);
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
 
@@ -2126,7 +2124,7 @@ namespace NuGetGallery
 
                 Assert.False(viewModel.CanDelete);
                 Assert.Null(viewModel.DeleteUrl);
-                Assert.Equal(_certificate.Sha1Thumbprint, viewModel.Sha1Thumbprint);
+                Assert.Equal(_certificate.Thumbprint, viewModel.Thumbprint);
                 Assert.Equal(JsonRequestBehavior.AllowGet, response.JsonRequestBehavior);
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
 
@@ -2165,7 +2163,6 @@ namespace NuGetGallery
                 _certificate = new Certificate()
                 {
                     Key = 3,
-                    Sha1Thumbprint = "c",
                     Thumbprint = "d"
                 };
 
@@ -2354,7 +2351,6 @@ namespace NuGetGallery
                 _certificate = new Certificate()
                 {
                     Key = 3,
-                    Sha1Thumbprint = "c",
                     Thumbprint = "d"
                 };
 

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -3292,7 +3292,6 @@ namespace NuGetGallery
                 _certificate = new Certificate()
                 {
                     Key = 2,
-                    Sha1Thumbprint = "b",
                     Thumbprint = "c"
                 };
             }
@@ -3354,7 +3353,7 @@ namespace NuGetGallery
 
                 Assert.True(viewModel.CanDelete);
                 Assert.Equal($"/account/certificates/{_certificate.Thumbprint}", viewModel.DeleteUrl);
-                Assert.Equal(_certificate.Sha1Thumbprint, viewModel.Sha1Thumbprint);
+                Assert.Equal(_certificate.Thumbprint, viewModel.Thumbprint);
                 Assert.Equal(JsonRequestBehavior.AllowGet, response.JsonRequestBehavior);
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
 
@@ -3381,7 +3380,6 @@ namespace NuGetGallery
                 _certificate = new Certificate()
                 {
                     Key = 2,
-                    Sha1Thumbprint = "b",
                     Thumbprint = "c"
                 };
             }
@@ -3430,7 +3428,7 @@ namespace NuGetGallery
 
                 Assert.True(viewModel.CanDelete);
                 Assert.Equal($"/account/certificates/{_certificate.Thumbprint}", viewModel.DeleteUrl);
-                Assert.Equal(_certificate.Sha1Thumbprint, viewModel.Sha1Thumbprint);
+                Assert.Equal(_certificate.Thumbprint, viewModel.Thumbprint);
                 Assert.Equal(JsonRequestBehavior.AllowGet, response.JsonRequestBehavior);
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
 
@@ -3461,7 +3459,6 @@ namespace NuGetGallery
                 _certificate = new Certificate()
                 {
                     Key = 2,
-                    Sha1Thumbprint = "b",
                     Thumbprint = "c"
                 };
             }
@@ -3589,7 +3586,6 @@ namespace NuGetGallery
                 _certificate = new Certificate()
                 {
                     Key = 2,
-                    Sha1Thumbprint = "b",
                     Thumbprint = "c"
                 };
             }

--- a/tests/NuGetGallery.Facts/Services/CertificateServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CertificateServiceFacts.cs
@@ -51,7 +51,9 @@ namespace NuGetGallery.Services
             _certificate = new Certificate()
             {
                 Key = 1,
+#pragma warning disable CS0618 // Set the value for minimal testing.
                 Sha1Thumbprint = _sha1Thumbprint,
+#pragma warning restore CS0618
                 Thumbprint = _sha256Thumbprint,
                 UserCertificates = new List<UserCertificate>()
             };
@@ -202,9 +204,7 @@ namespace NuGetGallery.Services
                 .Returns(new EnumerableQuery<Certificate>(Array.Empty<Certificate>()));
             _certificateRepository.Setup(
                 x => x.InsertOnCommit(
-                    It.Is<Certificate>(certificate =>
-                        certificate.Sha1Thumbprint == _sha1Thumbprint &&
-                        certificate.Thumbprint == _sha256Thumbprint)));
+                    It.Is<Certificate>(certificate => certificate.Thumbprint == _sha256Thumbprint)));
             _certificateRepository.Setup(x => x.CommitChangesAsync())
                 .Returns(Task.CompletedTask);
             _fileStorageService.Setup(
@@ -231,7 +231,9 @@ namespace NuGetGallery.Services
                 var certificate = await service.AddCertificateAsync(file);
 
                 Assert.NotNull(certificate);
+#pragma warning disable CS0618 // Assert the value is set properly, but we will never read it.
                 Assert.Equal(_sha1Thumbprint, certificate.Sha1Thumbprint);
+#pragma warning restore CS0618
                 Assert.Equal(_sha256Thumbprint, certificate.Thumbprint);
             }
 
@@ -255,7 +257,6 @@ namespace NuGetGallery.Services
 
                 Assert.NotNull(certificate);
                 Assert.Equal(1, certificate.Key);
-                Assert.Equal(_sha1Thumbprint, certificate.Sha1Thumbprint);
                 Assert.Equal(_sha256Thumbprint, certificate.Thumbprint);
             }
 

--- a/tests/NuGetGallery.Facts/ViewModels/ListCertificateItemViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListCertificateItemViewModelFacts.cs
@@ -22,12 +22,12 @@ namespace NuGetGallery.ViewModels
         [InlineData("a", "b")]
         [InlineData("c", null)]
         [InlineData("d", "")]
-        public void Constructor_InitializesProperties(string sha1Thumbprint, string deleteUrl)
+        public void Constructor_InitializesProperties(string thumbprint, string deleteUrl)
         {
-            var certificate = new Certificate() { Sha1Thumbprint = sha1Thumbprint };
+            var certificate = new Certificate() { Thumbprint = thumbprint };
             var viewModel = new ListCertificateItemViewModel(certificate, deleteUrl);
 
-            Assert.Equal(sha1Thumbprint, viewModel.Sha1Thumbprint);
+            Assert.Equal(thumbprint, viewModel.Thumbprint);
             Assert.Equal(deleteUrl, viewModel.DeleteUrl);
             Assert.Equal(!string.IsNullOrEmpty(deleteUrl), viewModel.CanDelete);
         }

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
@@ -253,7 +253,6 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
                 {
                     Key = 4,
                     Thumbprint = "D",
-                    Sha1Thumbprint = "E"
                 };
 
                 _packageRegistration = new PackageRegistration()
@@ -301,7 +300,7 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
 
                 viewModel.CanDisplayPrivateMetadata = true;
 
-                Assert.Equal("Signed with certificate (E)", viewModel.SignatureInformation);
+                Assert.Equal("Signed with certificate (D)", viewModel.SignatureInformation);
             }
 
             [Fact]
@@ -315,7 +314,7 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
                 var viewModel = CreateListPackageItemViewModel(_package, _user1);
 
                 Assert.True(viewModel.CanDisplayPrivateMetadata);
-                Assert.Equal("Signed with A's certificate (E)", viewModel.SignatureInformation);
+                Assert.Equal("Signed with A's certificate (D)", viewModel.SignatureInformation);
             }
 
             [Fact]
@@ -331,7 +330,7 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
                 var viewModel = CreateListPackageItemViewModel(_package, _user1);
 
                 Assert.True(viewModel.CanDisplayPrivateMetadata);
-                Assert.Equal("Signed with A and B's certificate (E)", viewModel.SignatureInformation);
+                Assert.Equal("Signed with A and B's certificate (D)", viewModel.SignatureInformation);
             }
 
             [Fact]
@@ -349,7 +348,7 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
                 var viewModel = CreateListPackageItemViewModel(_package, _user1);
 
                 Assert.True(viewModel.CanDisplayPrivateMetadata);
-                Assert.Equal("Signed with A, B, and C's certificate (E)", viewModel.SignatureInformation);
+                Assert.Equal("Signed with A, B, and C's certificate (D)", viewModel.SignatureInformation);
             }
 
             private void ActivateCertificate(User user)


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/2758.

In general we are avoiding the use of SHA-1 anyway as a cleanliness practice. SHA-256 or greater is the hash algorithm recommendation.

# Old

![image](https://user-images.githubusercontent.com/94054/66528651-9289df00-eab5-11e9-9ff8-0bc7f8bdc955.png)

# New

![image](https://user-images.githubusercontent.com/94054/66589606-bc89e280-eb43-11e9-9846-438a96fb5d1f.png)

