### PR TITLE
[MSA] Audit the external credential for attempted login in Gallery

### DIFF
--- a/src/NuGetGallery.Core/Auditing/AuditedUserAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedUserAction.cs
@@ -24,6 +24,6 @@ namespace NuGetGallery.Auditing
         UpdateOrganizationMember,
         EnabledMultiFactorAuthentication,
         DisabledMultiFactorAuthentication,
-        ExternalLoginAttempt
+        ExternalLoginAttempt,
     }
 }

--- a/src/NuGetGallery.Core/Auditing/AuditedUserAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedUserAction.cs
@@ -23,6 +23,7 @@ namespace NuGetGallery.Auditing
         RemoveOrganizationMember,
         UpdateOrganizationMember,
         EnabledMultiFactorAuthentication,
-        DisabledMultiFactorAuthentication
+        DisabledMultiFactorAuthentication,
+        ExternalLoginAttempt
     }
 }

--- a/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
@@ -18,6 +18,7 @@ namespace NuGetGallery.Auditing
         public DateTime Created { get; }
         public DateTime? Expires { get; }
         public DateTime? LastUsed { get; }
+        public string TenantId { get; }
 
         public CredentialAuditRecord(Credential credential, bool removed)
         {
@@ -30,6 +31,7 @@ namespace NuGetGallery.Auditing
             Type = credential.Type;
             Description = credential.Description;
             Identity = credential.Identity;
+            TenantId = credential.TenantId;
 
             // Track the value for credentials that are definitely revocable (API Key, etc.) and have been removed
             if (removed)

--- a/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
@@ -33,8 +33,12 @@ namespace NuGetGallery.Auditing
             Identity = credential.Identity;
             TenantId = credential.TenantId;
 
-            // Track the value for credentials that are definitely revocable (API Key, etc.) and have been removed
-            if (removed)
+            // Track the value for credentials that are external (object id) or definitely revocable (API Key, etc.) and have been removed
+            if (credential.IsExternal())
+            {
+                Value = credential.Value;
+            }
+            else if (removed)
             {
                 if (Type == null)
                 {

--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -675,6 +675,9 @@ namespace NuGetGallery.Authentication
             // Authenticate!
             if (result.Credential != null)
             {
+                // We want to audit the received credential from external authentication. We use the UserAuditRecord
+                // for easier logging, since it actually needs a `User`, instead we use a dummy user because at this point
+                // we do not have the actual user context since this request has not yet been authenticated.
                 await Auditing.SaveAuditRecordAsync(new UserAuditRecord(
                     new User("NonExistentDummyAuditUser"), AuditedUserAction.ExternalLoginAttempt, result.Credential));
 

--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -675,6 +675,9 @@ namespace NuGetGallery.Authentication
             // Authenticate!
             if (result.Credential != null)
             {
+                await Auditing.SaveAuditRecordAsync(new UserAuditRecord(
+                    new User("NonExistentDummyAuditUser"), AuditedUserAction.ExternalLoginAttempt, result.Credential));
+
                 result.Authentication = await Authenticate(result.Credential);
             }
 

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditedUserActionTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditedUserActionTests.cs
@@ -30,7 +30,8 @@ namespace NuGetGallery.Auditing
                 "RemoveOrganizationMember",
                 "UpdateOrganizationMember",
                 "EnabledMultiFactorAuthentication",
-                "DisabledMultiFactorAuthentication"
+                "DisabledMultiFactorAuthentication",
+                "ExternalLoginAttempt"
             };
 
             Verify(typeof(AuditedUserAction), expectedNames);

--- a/tests/NuGetGallery.Core.Facts/Auditing/CredentialAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/CredentialAuditRecordTests.cs
@@ -51,6 +51,17 @@ namespace NuGetGallery.Auditing
             Assert.Null(record.Value);
         }
 
+        [Theory]
+        [InlineData(CredentialTypes.External.MicrosoftAccount)]
+        [InlineData(CredentialTypes.External.AzureActiveDirectoryAccount)]
+        public void Constructor_ExternalCredentialSetsValue(string externalType)
+        {
+            var credential = new Credential(type: externalType, value: "b");
+            var record = new CredentialAuditRecord(credential, removed: false);
+
+            Assert.Equal("b", record.Value);
+        }
+
         [Fact]
         public void Constructor_NonRemovalOfPasswordDoesNotSetValue()
         {
@@ -72,6 +83,7 @@ namespace NuGetGallery.Auditing
                 Description = "a",
                 Expires = expires,
                 Identity = "b",
+                TenantId = "c",
                 Key = 1,
                 LastUsed = lastUsed,
                 Scopes = new List<Scope>() { new Scope(subject: "c", allowedAction: "d") },
@@ -84,6 +96,7 @@ namespace NuGetGallery.Auditing
             Assert.Equal("a", record.Description);
             Assert.Equal(expires, record.Expires);
             Assert.Equal("b", record.Identity);
+            Assert.Equal("c", record.TenantId);
             Assert.Equal(1, record.Key);
             Assert.Equal(lastUsed, record.LastUsed);
             Assert.Single(record.Scopes);


### PR DESCRIPTION
We need to audit the credential which was used to attempt to login in the gallery before it was identified and authorized(from DB). This is necessary for retrospective analysis. Also, log the `Tenant Id` and `OID` used with the external credential.

This depends on the shims changes.

Addresses: https://github.com/NuGet/Engineering/issues/2652 