### PR TITLE
Removes the height differences when switching to the organization page

### DIFF
--- a/src/NuGetGallery/Views/Users/Organizations.cshtml
+++ b/src/NuGetGallery/Views/Users/Organizations.cshtml
@@ -12,7 +12,7 @@
                         Url, 
                         CurrentUser, 
                         false, 
-                        @<text>Organizations&nbsp;<span aria-hidden="true" class="ms-font-xxl organizations-divider">|</span>&nbsp;<a href="@Url.AddOrganization()"><span aria-hidden="true" class="ms-font-m ms-Icon ms-Icon--Add"></span>&nbsp;Add new</a></text>)
+                        @<text>Organizations&nbsp;<span aria-hidden="true" class="ms-font-xl organizations-divider">|</span>&nbsp;<a href="@Url.AddOrganization()"><span aria-hidden="true" class="ms-font-m ms-Icon ms-Icon--Add"></span>&nbsp;Add new</a></text>)
                 </div>
             </div>
             <hr class="breadcrumb-divider"/>


### PR DESCRIPTION
I was browsing through the NuGet UI and notices a UI glitch on the organization page:

![before](https://user-images.githubusercontent.com/756703/67987512-e2c80d00-fc2d-11e9-8a84-ad7dad5efcb4.gif)

The "divider" is using the "ms-font-xxl", which enlarges the complete navigation bread crumb area. With a smaller version it keeps the same size as similar pages. 

![after](https://user-images.githubusercontent.com/756703/67987637-36d2f180-fc2e-11e9-8d4c-3d64e158701d.gif)

Be aware:
There are (at least) two other pages with this xxl dividers, but they have some other controls on the same line, so... it would be more complicated to fix those.

![image](https://user-images.githubusercontent.com/756703/67987679-510ccf80-fc2e-11e9-87a8-45fb66eb57cc.png)

![image](https://user-images.githubusercontent.com/756703/67987717-67b32680-fc2e-11e9-9bce-b65277d9cf6e.png)

Hope this helps :)

