### PR TITLE
Add storage abstractions for list and snapshots

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -179,6 +179,7 @@
     <Compile Include="NuGetVersionExtensions.cs" />
     <Compile Include="SemVerLevelKey.cs" />
     <Compile Include="Services\AccessConditionWrapper.cs" />
+    <Compile Include="Services\BlobResultSegmentWrapper.cs" />
     <Compile Include="Services\CloudBlobClientWrapper.cs" />
     <Compile Include="Services\CloudBlobContainerWrapper.cs" />
     <Compile Include="Services\CloudBlobCoreFileStorageService.cs" />
@@ -194,6 +195,7 @@
     <Compile Include="Services\ICloudBlobContainerInformationProvider.cs" />
     <Compile Include="Services\IContentFileMetadataService.cs" />
     <Compile Include="Services\ICoreLicenseFileService.cs" />
+    <Compile Include="Services\ISimpleBlobResultSegment.cs" />
     <Compile Include="Services\IStringTemplateProcessor.cs" />
     <Compile Include="Services\PackageAlreadyExistsException.cs" />
     <Compile Include="Services\FileAlreadyExistsException.cs" />

--- a/src/NuGetGallery.Core/Services/BlobResultSegmentWrapper.cs
+++ b/src/NuGetGallery.Core/Services/BlobResultSegmentWrapper.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace NuGetGallery
+{
+    public class BlobResultSegmentWrapper : ISimpleBlobResultSegment
+    {
+        public BlobResultSegmentWrapper(BlobResultSegment segment)
+        {
+            // For now, assume all of the blobs are block blobs. This library's storage abstraction only allows
+            // creation of block blobs so it's good enough for now. If another caller created a non-block blob, this
+            // cast will fail at runtime.
+            Results = segment.Results.Cast<CloudBlockBlob>().Select(x => new CloudBlobWrapper(x)).ToList();
+            ContinuationToken = segment.ContinuationToken;
+        }
+
+        public IReadOnlyList<ISimpleCloudBlob> Results { get; }
+        public BlobContinuationToken ContinuationToken { get; }
+    }
+}

--- a/src/NuGetGallery.Core/Services/CloudBlobContainerWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobContainerWrapper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -14,6 +15,29 @@ namespace NuGetGallery
         public CloudBlobContainerWrapper(CloudBlobContainer blobContainer)
         {
             _blobContainer = blobContainer;
+        }
+
+        public async Task<ISimpleBlobResultSegment> ListBlobsSegmentedAsync(
+            string prefix,
+            bool useFlatBlobListing,
+            BlobListingDetails blobListingDetails,
+            int? maxResults,
+            BlobContinuationToken blobContinuationToken,
+            BlobRequestOptions options,
+            OperationContext operationContext,
+            CancellationToken cancellationToken)
+        {
+            var segment = await _blobContainer.ListBlobsSegmentedAsync(
+                prefix,
+                useFlatBlobListing,
+                blobListingDetails,
+                maxResults,
+                blobContinuationToken,
+                options,
+                operationContext,
+                cancellationToken);
+
+            return new BlobResultSegmentWrapper(segment);
         }
 
         public Task CreateIfNotExistAsync()

--- a/src/NuGetGallery.Core/Services/CloudBlobWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobWrapper.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Markdig.Extensions.Tables;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
@@ -24,6 +25,7 @@ namespace NuGetGallery
         public string Name => _blob.Name;
         public DateTime LastModifiedUtc => _blob.Properties.LastModified?.UtcDateTime ?? DateTime.MinValue;
         public string ETag => _blob.Properties.ETag;
+        public bool IsSnapshot => _blob.IsSnapshot;
 
         public CloudBlobWrapper(CloudBlockBlob blob)
         {
@@ -92,6 +94,11 @@ namespace NuGetGallery
         public async Task<bool> ExistsAsync()
         {
             return await _blob.ExistsAsync();
+        }
+
+        public async Task SnapshotAsync(CancellationToken token)
+        {
+            await _blob.SnapshotAsync(token);
         }
 
         public async Task SetPropertiesAsync()

--- a/src/NuGetGallery.Core/Services/ICloudBlobContainer.cs
+++ b/src/NuGetGallery.Core/Services/ICloudBlobContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -15,5 +16,14 @@ namespace NuGetGallery
         Task<bool> ExistsAsync(BlobRequestOptions options, OperationContext operationContext);
         Task<bool> DeleteIfExistsAsync();
         Task CreateAsync();
+        Task<ISimpleBlobResultSegment> ListBlobsSegmentedAsync(
+            string prefix,
+            bool useFlatBlobListing,
+            BlobListingDetails blobListingDetails,
+            int? maxResults,
+            BlobContinuationToken blobContinuationToken,
+            BlobRequestOptions options,
+            OperationContext operationContext,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/NuGetGallery.Core/Services/ISimpleBlobResultSegment.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleBlobResultSegment.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace NuGetGallery
+{
+    public interface ISimpleBlobResultSegment
+    {
+        IReadOnlyList<ISimpleCloudBlob> Results { get; }
+        BlobContinuationToken ContinuationToken { get; }
+    }
+}

--- a/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
@@ -20,6 +20,7 @@ namespace NuGetGallery
         string Name { get; }
         DateTime LastModifiedUtc { get; }
         string ETag { get; }
+        bool IsSnapshot { get; }
 
         Task<Stream> OpenReadAsync(AccessCondition accessCondition);
         Task<Stream> OpenWriteAsync(AccessCondition accessCondition);
@@ -64,5 +65,7 @@ namespace NuGetGallery
             TimeSpan serverTimeout,
             TimeSpan maxExecutionTime,
             CancellationToken cancellationToken);
+
+        Task SnapshotAsync(CancellationToken token);
     }
 }

--- a/tests/NuGetGallery.Core.Facts/TestUtils/BlobStorageFixture.cs
+++ b/tests/NuGetGallery.Core.Facts/TestUtils/BlobStorageFixture.cs
@@ -81,7 +81,7 @@ namespace NuGetGallery
 
                 foreach (var blob in blobs.OfType<CloudBlockBlob>())
                 {
-                    blob.DeleteIfExists();
+                    blob.DeleteIfExists(DeleteSnapshotsOption.IncludeSnapshots);
                 }
             }
         }


### PR DESCRIPTION
Add Azure Blob Storage enumeration and snapshot APIs.

This allows applications using the gallery-based storage abstractions to take snapshots of blobs if they one does not exist, which is a behavior supported by the V3 (NuGet.Services.Metadata) storage abstractions.

In particular, I am working on rewriting Catalog2Registration and I am aligning on the gallery storage abstractions. Current Catalog2Registration uses the V3 storage abstractions and ensures every blob has at least one snapshot to mitigate accidental deletion. In general the NuGetGallery.Core storage abstractions (`ISimpleCloudBlob` and friends) are better for mocking because they more closely match the shape of the underlying Azure Storage APIs. Many non-gallery jobs already use the gallery storage abstractions: Azure Search, validation pipeline.

Until we have aligned all of the code on a single set of storage abstractions we're going to have this situation where capabilities are added lazily/piecemeal.