### PR TITLE
Fix nuspec for GitHubVulnerabilities2Db

### DIFF
--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.nuspec
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.nuspec
@@ -10,7 +10,7 @@
     <copyright>Copyright .NET Foundation</copyright>
   </metadata>
   <files>
-    <file src="bin\$configuration$\*.*" target="bin"/>
+    <file src="bin\$configuration$\**\*.*" target="bin"/>
 
     <file src="Scripts\Functions.ps1" />
     <file src="Scripts\PreDeploy.ps1" />


### PR DESCRIPTION
When I made it, I copied the nuspec from NuGet.Jobs instead of the nuspec from AccountDeleter, so it had the wrong `bin` path.

Succeeded with this fix at https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3212606