### PR TITLE
Manage Package page forms should link back to the Manage page

### DIFF
--- a/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
+++ b/src/NuGetGallery/Controllers/ManageDeprecationJsonApiController.cs
@@ -53,6 +53,13 @@ namespace NuGetGallery
                 return Json(error.Status, new { error = error.Message });
             }
 
+            var packagePluralString = request.Versions.Count() > 1 ? "packages have" : "package has";
+            var deprecatedString = request.IsLegacy || request.HasCriticalBugs || request.IsOther
+                ? "deprecated" : "undeprecated";
+            TempData["Message"] = 
+                $"Your {packagePluralString} been {deprecatedString}. " +
+                $"It may take several hours for this change to propagate through our system.";
+
             return Json(HttpStatusCode.OK);
         }
     }

--- a/src/NuGetGallery/Views/Packages/Manage.cshtml
+++ b/src/NuGetGallery/Views/Packages/Manage.cshtml
@@ -67,7 +67,7 @@
         // Set up owners section
         var packageId = "@Model.Id";
         var isUserAnAdmin = "@Model.IsCurrentUserAnAdmin";
-        var packageUrl = "@Url.Package(Model.Id)";
+        var packageUrl = "@Url.ManagePackage(new TrivialPackageVersionModel(Model.Id, Model.Version))";
         var getPackageOwnersUrl = "@Url.GetPackageOwners()";
         var addPackageOwnerUrl = "@Url.AddPackageOwner()";
         var removePackageOwnerUrl = "@Url.RemovePackageOwner()";

--- a/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
@@ -47,7 +47,7 @@ namespace NuGetGallery.Controllers
                 MemberDataHelper.Combine(
                     Enumerable
                         .Repeat(
-                            MemberDataHelper.BooleanDataSet(), 4)
+                            MemberDataHelper.BooleanDataSet(), 5)
                         .ToArray());
 
             [Theory]

--- a/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ManageDeprecationJsonApiControllerFacts.cs
@@ -56,11 +56,12 @@ namespace NuGetGallery.Controllers
                 bool isLegacy,
                 bool hasCriticalBugs,
                 bool isOther,
+                bool multipleVersions,
                 bool success)
             {
                 // Arrange
                 var id = "Crested.Gecko";
-                var versions = new[] { "1.0.0", "2.0.0" };
+                var versions = multipleVersions ? new[] { "1.0.0", "2.0.0" } : new[] { "1.0.0" };
                 var alternateId = "alt.Id";
                 var alternateVersion = "3.0.0";
                 var customMessage = "custom";
@@ -105,34 +106,44 @@ namespace NuGetGallery.Controllers
                 // Assert
                 if (success)
                 {
-                    AssertSuccessResponse(controller);
+                    AssertResponseStatusCode(controller, HttpStatusCode.OK);
+                    string expectedString;
+                    if (isLegacy || hasCriticalBugs || isOther)
+                    {
+                        if (multipleVersions)
+                        {
+                            expectedString = "Your packages have been deprecated.";
+                        }
+                        else
+                        {
+                            expectedString = "Your package has been deprecated.";
+                        }
+                    }
+                    else
+                    {
+                        if (multipleVersions)
+                        {
+                            expectedString = "Your packages have been undeprecated.";
+                        }
+                        else
+                        {
+                            expectedString = "Your package has been undeprecated.";
+                        }
+                    }
+
+                    Assert.StartsWith(expectedString, controller.TempData["Message"] as string);
                 }
                 else
                 {
-                    AssertErrorResponse(controller, result, errorStatus, errorMessage);
+                    AssertResponseStatusCode(controller, errorStatus);
+
+                    // Using JObject to get the property from the result easily.
+                    // Alternatively we could use reflection, but this is easier, and makes sense as the response is intended to be JSON anyway.
+                    var jObject = JObject.FromObject(result.Data);
+                    Assert.Equal(errorMessage, jObject["error"].Value<string>());
                 }
 
                 deprecationService.Verify();
-            }
-
-            private static void AssertErrorResponse(
-                ManageDeprecationJsonApiController controller,
-                JsonResult result,
-                HttpStatusCode code,
-                string error)
-            {
-                AssertResponseStatusCode(controller, code);
-
-                // Using JObject to get the property from the result easily.
-                // Alternatively we could use reflection, but this is easier, and makes sense as the response is intended to be JSON anyway.
-                var jObject = JObject.FromObject(result.Data);
-                Assert.Equal(error, jObject["error"].Value<string>());
-            }
-
-            private static void AssertSuccessResponse(
-                ManageDeprecationJsonApiController controller)
-            {
-                AssertResponseStatusCode(controller, HttpStatusCode.OK);
             }
 
             private static void AssertResponseStatusCode(

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -3627,7 +3627,7 @@ namespace NuGetGallery
                     GetConfigurationService(),
                     packageService: packageService);
                 controller.SetCurrentUser(currentUser);
-                controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
+                TestUtility.SetupUrlHelperForUrlGeneration(controller);
 
                 // Act
                 var result = await controller.UpdateListed("Foo", "1.0", false);
@@ -3635,7 +3635,6 @@ namespace NuGetGallery
                 // Assert
                 packageService.Verify();
                 Assert.IsType<RedirectResult>(result);
-                Assert.Equal(@"~\Bar.cshtml", ((RedirectResult)result).Url);
             }
 
             [Theory]
@@ -3647,6 +3646,7 @@ namespace NuGetGallery
                 {
                     PackageRegistration = new PackageRegistration { Id = "Foo" },
                     Version = "1.0",
+                    NormalizedVersion = "1.0.0",
                     Listed = true
                 };
                 package.PackageRegistration.Owners.Add(owner);
@@ -3664,7 +3664,7 @@ namespace NuGetGallery
                     GetConfigurationService(),
                     packageService: packageService);
                 controller.SetCurrentUser(currentUser);
-                controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
+                TestUtility.SetupUrlHelperForUrlGeneration(controller);
 
                 // Act
                 var result = await controller.UpdateListed("Foo", "1.0", true);
@@ -3672,7 +3672,6 @@ namespace NuGetGallery
                 // Assert
                 packageService.Verify();
                 Assert.IsType<RedirectResult>(result);
-                Assert.Equal(@"~\Bar.cshtml", ((RedirectResult)result).Url);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -3519,7 +3519,7 @@ namespace NuGetGallery
 
         public class TheUpdateListedMethod : TestContainer
         {
-            [Fact]
+            [Theory]
             [InlineData(false)]
             [InlineData(true)]
             public async Task Returns404IfNotFound(bool listed)

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -3562,7 +3562,7 @@ namespace NuGetGallery
                 controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
 
                 // Act
-                var result = await controller.Edit("Foo", "1.0", listed: false, urlFactory: (pkg, relativeUrl) => @"~\Bar.cshtml");
+                var result = await controller.UpdateListed("Foo", "1.0", false);
 
                 // Assert
                 Assert.IsType<HttpStatusCodeResult>(result);
@@ -3630,7 +3630,7 @@ namespace NuGetGallery
                 controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
 
                 // Act
-                var result = await controller.Edit("Foo", "1.0", listed: false, urlFactory: (pkg, relativeUrl) => @"~\Bar.cshtml");
+                var result = await controller.UpdateListed("Foo", "1.0", false);
 
                 // Assert
                 packageService.Verify();
@@ -3667,7 +3667,7 @@ namespace NuGetGallery
                 controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
 
                 // Act
-                var result = await controller.Edit("Foo", "1.0", listed: true, urlFactory: (pkg, relativeUrl) => @"~\Bar.cshtml");
+                var result = await controller.UpdateListed("Foo", "1.0", true);
 
                 // Assert
                 packageService.Verify();
@@ -3701,7 +3701,7 @@ namespace NuGetGallery
                 controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
 
                 // Act
-                var result = await controller.Edit("Foo", "1.0", listed: true, urlFactory: (pkg, relativeUrl) => @"~\Bar.cshtml");
+                var result = await controller.UpdateListed("Foo", "1.0", true);
 
                 // Assert
                 ResultAssert.IsStatusCode(result, HttpStatusCode.Forbidden);
@@ -3834,7 +3834,7 @@ namespace NuGetGallery
                 controller.Url = new UrlHelper(new RequestContext(), new RouteCollection());
 
                 // Act
-                var result = await controller.Edit("Foo", "1.0", listed: false, urlFactory: (pkg, relativeUrl) => @"~\Bar.cshtml");
+                var result = await controller.UpdateListed("Foo", "1.0", false);
 
                 // Assert
                 Assert.IsType<HttpStatusCodeResult>(result);

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -3539,9 +3539,7 @@ namespace NuGetGallery
                 var result = await controller.UpdateListed("Foo", "1.0", listed);
 
                 // Assert
-                Assert.IsType<HttpStatusCodeResult>(result);
-                var httpStatusCodeResult = result as HttpStatusCodeResult;
-                Assert.Equal((int)HttpStatusCode.NotFound, httpStatusCodeResult.StatusCode);
+                Assert.IsType<HttpNotFoundResult>(result);
             }
 
             public static IEnumerable<object[]> NotOwner_Data


### PR DESCRIPTION
https://github.com/nuget/nugetgallery/issues/7567
https://github.com/nuget/nugetgallery/issues/7495

Currently, when you submit a form on the Manage Package page (Deprecation, Listing, Documentation) you are linked back to the package details page. This is annoying when you are trying to do other management operations at the same time.

This changes it so that submitting the forms stays on the Manage Package page. Additionally, I added "TempData" messages so that it's clearer what operation was performed.