### PR TITLE
Make server-side OData cache configurable

### DIFF
--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -30,6 +30,7 @@ namespace NuGetGallery
         private const string PreviewHijackFeatureName = GalleryPrefix + "PreviewHijack";
         private const string GravatarProxyFeatureName = GalleryPrefix + "GravatarProxy";
         private const string GravatarProxyEnSubdomainFeatureName = GalleryPrefix + "GravatarProxyEnSubdomain";
+        private const string ODataCacheDurationsFeatureName = GalleryPrefix + "ODataCacheDurations";
 
         private readonly IFeatureFlagClient _client;
 
@@ -137,6 +138,11 @@ namespace NuGetGallery
         public bool ProxyGravatarEnSubdomain()
         {
             return _client.IsEnabled(GravatarProxyEnSubdomainFeatureName, defaultValue: false);
+        }
+
+        public bool AreDynamicODataCacheDurationsEnabled()
+        {
+            return _client.IsEnabled(ODataCacheDurationsFeatureName, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -100,5 +100,10 @@ namespace NuGetGallery
         /// This is ignored if <see cref="IsGravatarProxyEnabled"/> is <see langword="false"/>.
         /// </summary>
         bool ProxyGravatarEnSubdomain();
+
+        /// <summary>
+        /// Whether or not to check the content object service for OData cache durations.
+        /// </summary>
+        bool AreDynamicODataCacheDurationsEnabled();
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IODataCacheConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IODataCacheConfiguration.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Services
+{
+    public interface IODataCacheConfiguration
+    {
+        /// <summary>
+        /// The cache duration for the OData endpoint that returns a single package by ID and version.
+        /// </summary>
+        int GetSpecificPackageCacheTimeInSeconds { get; }
+
+        /// <summary>
+        /// The cache duration for the OData endpoint that returns all versions for a single package ID.
+        /// </summary>
+        int FindPackagesByIdCacheTimeInSeconds { get; }
+
+        /// <summary>
+        /// The cache duration for the OData endpoint that returns the number of versions for a single package ID.
+        /// </summary>
+        int FindPackagesByIdCountCacheTimeInSeconds { get; }
+
+        /// <summary>
+        /// The cache duration for the OData endpoint that search results and the endpoint that returns the number of
+        /// search results.
+        /// </summary>
+        int SearchCacheTimeInSeconds { get; }
+    }
+}

--- a/src/NuGetGallery.Services/Configuration/ODataCacheConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/ODataCacheConfiguration.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Services
+{
+    public class ODataCacheConfiguration : IODataCacheConfiguration
+    {
+        public const int DefaultGetByIdAndVersionCacheTimeInSeconds = 60;
+        public const int DefaultSearchCacheTimeInSeconds = 45;
+        public const int DefaultFindPackagesByIdCountCacheTimeInSeconds = 0;
+
+        public int GetSpecificPackageCacheTimeInSeconds { get; set; } = DefaultGetByIdAndVersionCacheTimeInSeconds;
+
+        public int FindPackagesByIdCacheTimeInSeconds { get; set; } = DefaultGetByIdAndVersionCacheTimeInSeconds;
+
+        public int FindPackagesByIdCountCacheTimeInSeconds { get; set; } = DefaultFindPackagesByIdCountCacheTimeInSeconds;
+
+        public int SearchCacheTimeInSeconds { get; set; } = DefaultSearchCacheTimeInSeconds;
+    }
+}

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -113,10 +113,12 @@
     <Compile Include="Configuration\IGalleryConfigurationService.cs" />
     <Compile Include="Configuration\ILoginDiscontinuationConfiguration.cs" />
     <Compile Include="Configuration\IPackageDeleteConfiguration.cs" />
+    <Compile Include="Configuration\IODataCacheConfiguration.cs" />
     <Compile Include="Configuration\IServiceBusConfiguration.cs" />
     <Compile Include="Configuration\ISymbolsConfiguration.cs" />
     <Compile Include="Configuration\ITyposquattingConfiguration.cs" />
     <Compile Include="Configuration\LoginDiscontinuationConfiguration.cs" />
+    <Compile Include="Configuration\ODataCacheConfiguration.cs" />
     <Compile Include="Configuration\PackageDeleteConfiguration.cs" />
     <Compile Include="Configuration\SecretReader\EmptySecretReaderFactory.cs" />
     <Compile Include="Configuration\SecretReader\SecretReaderFactory.cs" />

--- a/src/NuGetGallery.Services/ServicesConstants.cs
+++ b/src/NuGetGallery.Services/ServicesConstants.cs
@@ -54,6 +54,7 @@ namespace NuGetGallery
             public static readonly string TyposquattingConfiguration = "Typosquatting-Configuration";
             public static readonly string NuGetPackagesGitHubDependencies = "GitHubUsage.v1";
             public static readonly string ABTestConfiguration = "AB-Test-Configuration";
+            public static readonly string ODataCacheConfiguration = "OData-Cache-Configuration";
         }
     }
 }

--- a/src/NuGetGallery.Services/Storage/ContentObjectService.cs
+++ b/src/NuGetGallery.Services/Storage/ContentObjectService.cs
@@ -24,6 +24,7 @@ namespace NuGetGallery
             SymbolsConfiguration = new SymbolsConfiguration();
             TyposquattingConfiguration = new TyposquattingConfiguration();
             ABTestConfiguration = new ABTestConfiguration();
+            ODataCacheConfiguration = new ODataCacheConfiguration();
         }
 
         public ILoginDiscontinuationConfiguration LoginDiscontinuationConfiguration { get; private set; }
@@ -32,6 +33,7 @@ namespace NuGetGallery
         public ITyposquattingConfiguration TyposquattingConfiguration { get; private set; }
         public IGitHubUsageConfiguration GitHubUsageConfiguration { get; private set; }
         public IABTestConfiguration ABTestConfiguration { get; private set; }
+        public IODataCacheConfiguration ODataCacheConfiguration { get; private set; }
 
         public async Task Refresh()
         {
@@ -60,6 +62,10 @@ namespace NuGetGallery
             ABTestConfiguration =
                await Refresh<ABTestConfiguration>(ServicesConstants.ContentNames.ABTestConfiguration) ??
                new ABTestConfiguration();
+
+            ODataCacheConfiguration =
+               await Refresh<ODataCacheConfiguration>(ServicesConstants.ContentNames.ODataCacheConfiguration) ??
+               new ODataCacheConfiguration();
         }
 
         private async Task<T> Refresh<T>(string contentName)

--- a/src/NuGetGallery.Services/Storage/IContentObjectService.cs
+++ b/src/NuGetGallery.Services/Storage/IContentObjectService.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGetGallery.Services;
 
@@ -15,6 +14,7 @@ namespace NuGetGallery
         ITyposquattingConfiguration TyposquattingConfiguration { get; }
         IGitHubUsageConfiguration GitHubUsageConfiguration { get; }
         IABTestConfiguration ABTestConfiguration { get; }
+        IODataCacheConfiguration ODataCacheConfiguration { get; }
 
         Task Refresh();
     }

--- a/src/NuGetGallery/App_Data/Files/Content/OData-Cache-Configuration.json
+++ b/src/NuGetGallery/App_Data/Files/Content/OData-Cache-Configuration.json
@@ -1,0 +1,6 @@
+{
+  "FindPackagesByIdCacheTimeInSeconds": 60,
+  "FindPackagesByIdCountCacheTimeInSeconds": 0,
+  "GetSpecificPackageCacheTimeInSeconds": 60,
+  "SearchCacheTimeInSeconds": 45
+}

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -4,7 +4,8 @@
     "NuGetGallery.PackagesAtomFeed": "Enabled",
     "NuGetGallery.PreviewHijack": "Enabled",
     "NuGetGallery.GravatarProxy": "Enabled",
-    "NuGetGallery.GravatarProxyEnSubdomain": "Enabled"
+    "NuGetGallery.GravatarProxyEnSubdomain": "Enabled",
+    "NuGetGallery.ODataCacheDurations": "Enabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {

--- a/src/NuGetGallery/App_Start/NuGetODataConfig.cs
+++ b/src/NuGetGallery/App_Start/NuGetODataConfig.cs
@@ -12,9 +12,6 @@ namespace NuGetGallery
 {
     public static class NuGetODataConfig
     {
-        public const int GetByIdAndVersionCacheTimeInSeconds = 60;
-        public const int SearchCacheTimeInSeconds = 45;
-
         public static void Register(HttpConfiguration config)
         {
             // Add OData formatters (application/atom+xml)

--- a/src/NuGetGallery/Controllers/ODataV1FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV1FeedController.cs
@@ -12,6 +12,7 @@ using NuGet.Services.Entities;
 using NuGetGallery.Configuration;
 using NuGetGallery.OData;
 using NuGetGallery.OData.QueryFilter;
+using NuGetGallery.Services;
 using NuGetGallery.WebApi;
 using WebApi.OutputCache.V2;
 
@@ -76,7 +77,11 @@ namespace NuGetGallery.Controllers
 
         // /api/v1/Packages(Id=,Version=)
         [HttpGet]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.GetSpecificPackage,
+            serverTimeSpan: ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds,
+            Private = true,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds)]
         public async Task<IHttpActionResult> Get(ODataQueryOptions<V1FeedPackage> options, string id, string version)
         {
             var result = await GetCore(options, id, version, return404NotFoundWhenNoResults: true);
@@ -86,7 +91,11 @@ namespace NuGetGallery.Controllers
         // /api/v1/FindPackagesById()?id=
         [HttpGet]
         [HttpPost]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.FindPackagesById,
+            serverTimeSpan: ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds,
+            Private = true,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds)]
         public async Task<IHttpActionResult> FindPackagesById(ODataQueryOptions<V1FeedPackage> options, [FromODataUri]string id)
         {
             return await GetCore(options, id, version: null, return404NotFoundWhenNoResults: false);
@@ -94,7 +103,10 @@ namespace NuGetGallery.Controllers
 
         // /api/v1/FindPackagesById()/$count?id=
         [HttpGet]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.FindPackagesByIdCount,
+            serverTimeSpan: ODataCacheConfiguration.DefaultFindPackagesByIdCountCacheTimeInSeconds,
+            NoCache = true)]
         public async Task<IHttpActionResult> FindPackagesByIdCount(ODataQueryOptions<V1FeedPackage> options, [FromODataUri]string id)
         {
             var result = await FindPackagesById(options, id);
@@ -196,7 +208,10 @@ namespace NuGetGallery.Controllers
         // /api/v1/Search()?searchTerm=&targetFramework=&includePrerelease=
         [HttpGet]
         [HttpPost]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds, ClientTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.Search,
+            serverTimeSpan: ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds)]
         public async Task<IHttpActionResult> Search(
             ODataQueryOptions<V1FeedPackage> options,
             [FromODataUri]string searchTerm = "",
@@ -280,7 +295,10 @@ namespace NuGetGallery.Controllers
 
         // /api/v1/Search()/$count?searchTerm=&targetFramework=&includePrerelease=
         [HttpGet]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds, ClientTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.Search,
+            serverTimeSpan: ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds)]
         public async Task<IHttpActionResult> SearchCount(
             ODataQueryOptions<V1FeedPackage> options,
             [FromODataUri]string searchTerm = "",

--- a/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2CuratedFeedController.cs
@@ -12,6 +12,7 @@ using NuGet.Services.Entities;
 using NuGetGallery.Configuration;
 using NuGetGallery.OData;
 using NuGetGallery.OData.QueryInterceptors;
+using NuGetGallery.Services;
 using NuGetGallery.WebApi;
 using QueryInterceptor;
 using WebApi.OutputCache.V2;
@@ -103,7 +104,11 @@ namespace NuGetGallery.Controllers
 
         // /api/v2/curated-feed/curatedFeedName/Packages(Id=,Version=)
         [HttpGet]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.GetSpecificPackage,
+            serverTimeSpan: ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds,
+            Private = true,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds)]
         public async Task<IHttpActionResult> Get(ODataQueryOptions<V2FeedPackage> options, string curatedFeedName, string id, string version)
         {
             var result = await GetCore(options, curatedFeedName, id, version, return404NotFoundWhenNoResults: true, semVerLevel: SemVerLevelKey.SemVerLevel2);
@@ -113,7 +118,11 @@ namespace NuGetGallery.Controllers
         // /api/v2/curated-feed/curatedFeedName/FindPackagesById()?id=&semVerLevel=
         [HttpGet]
         [HttpPost]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.FindPackagesById,
+            serverTimeSpan: ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds,
+            Private = true,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds)]
         public async Task<IHttpActionResult> FindPackagesById(
             ODataQueryOptions<V2FeedPackage> options,
             string curatedFeedName,
@@ -135,7 +144,10 @@ namespace NuGetGallery.Controllers
 
         // /api/v2/curated-feed/curatedFeedName/FindPackagesById()/$count?id=&semVerLevel=
         [HttpGet]
-        [CacheOutput(NoCache = true)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.FindPackagesByIdCount,
+            serverTimeSpan: ODataCacheConfiguration.DefaultFindPackagesByIdCountCacheTimeInSeconds,
+            NoCache = true)]
         public async Task<IHttpActionResult> FindPackagesByIdCount(
             ODataQueryOptions<V2FeedPackage> options,
             string curatedFeedName,
@@ -256,7 +268,10 @@ namespace NuGetGallery.Controllers
         // /api/v2/curated-feed/curatedFeedName/Search()?searchTerm=&targetFramework=&includePrerelease=&semVerLevel=
         [HttpGet]
         [HttpPost]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds, ClientTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.Search,
+            serverTimeSpan: ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds)]
         public async Task<IHttpActionResult> Search(
             ODataQueryOptions<V2FeedPackage> options,
             string curatedFeedName,
@@ -364,7 +379,10 @@ namespace NuGetGallery.Controllers
 
         // /api/v2/curated-feed/curatedFeedName/Search()/$count?searchTerm=&targetFramework=&includePrerelease=
         [HttpGet]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds, ClientTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.Search,
+            serverTimeSpan: ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds)]
         public async Task<IHttpActionResult> SearchCount(
             ODataQueryOptions<V2FeedPackage> options,
             string curatedFeedName,

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -17,6 +17,7 @@ using NuGetGallery.Infrastructure.Search;
 using NuGetGallery.OData;
 using NuGetGallery.OData.QueryFilter;
 using NuGetGallery.OData.QueryInterceptors;
+using NuGetGallery.Services;
 using NuGetGallery.WebApi;
 using QueryInterceptor;
 using WebApi.OutputCache.V2;
@@ -154,7 +155,11 @@ namespace NuGetGallery.Controllers
 
         // /api/v2/Packages(Id=,Version=)
         [HttpGet]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.GetSpecificPackage,
+            serverTimeSpan: ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds,
+            Private = true,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds)]
         public async Task<IHttpActionResult> Get(
             ODataQueryOptions<V2FeedPackage> options, 
             string id, 
@@ -176,7 +181,11 @@ namespace NuGetGallery.Controllers
         // /api/v2/FindPackagesById()?id=&semVerLevel=
         [HttpGet]
         [HttpPost]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds, Private = true, ClientTimeSpan = NuGetODataConfig.GetByIdAndVersionCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.FindPackagesById,
+            serverTimeSpan: ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds,
+            Private = true,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds)]
         public async Task<IHttpActionResult> FindPackagesById(
             ODataQueryOptions<V2FeedPackage> options, 
             [FromODataUri]string id,
@@ -205,7 +214,10 @@ namespace NuGetGallery.Controllers
 
         // /api/v2/FindPackagesById()/$count?semVerLevel=
         [HttpGet]
-        [CacheOutput(NoCache = true)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.FindPackagesByIdCount,
+            serverTimeSpan: ODataCacheConfiguration.DefaultFindPackagesByIdCountCacheTimeInSeconds,
+            NoCache = true)]
         public async Task<IHttpActionResult> FindPackagesByIdCount(
             ODataQueryOptions<V2FeedPackage> options,
             [FromODataUri]string id,
@@ -328,7 +340,10 @@ namespace NuGetGallery.Controllers
         // /api/v2/Search()?searchTerm=&targetFramework=&includePrerelease=
         [HttpGet]
         [HttpPost]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds, ClientTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.Search,
+            serverTimeSpan: ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds)]
         public async Task<IHttpActionResult> Search(
             ODataQueryOptions<V2FeedPackage> options,
             [FromODataUri]string searchTerm = "",
@@ -433,7 +448,10 @@ namespace NuGetGallery.Controllers
 
         // /api/v2/Search()/$count?searchTerm=&targetFramework=&includePrerelease=&semVerLevel=
         [HttpGet]
-        [CacheOutput(ServerTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds, ClientTimeSpan = NuGetODataConfig.SearchCacheTimeInSeconds)]
+        [ODataCacheOutput(
+            ODataCachedEndpoint.Search,
+            serverTimeSpan: ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds,
+            ClientTimeSpan = ODataCacheConfiguration.DefaultSearchCacheTimeInSeconds)]
         public async Task<IHttpActionResult> SearchCount(
             ODataQueryOptions<V2FeedPackage> options,
             [FromODataUri]string searchTerm = "",

--- a/src/NuGetGallery/Infrastructure/ODataCacheOutputAttribute.cs
+++ b/src/NuGetGallery/Infrastructure/ODataCacheOutputAttribute.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Web.Http.Controllers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NuGetGallery.Services;
+using WebApi.OutputCache.V2;
+
+namespace NuGetGallery
+{
+    public class ODataCacheOutputAttribute : CacheOutputAttribute
+    {
+        private static readonly IReadOnlyDictionary<ODataCachedEndpoint, Func<IODataCacheConfiguration, int>> EndpointToGetSeconds =
+            new Dictionary<ODataCachedEndpoint, Func<IODataCacheConfiguration, int>>
+            {
+                { ODataCachedEndpoint.GetSpecificPackage, x => x.GetSpecificPackageCacheTimeInSeconds },
+                { ODataCachedEndpoint.FindPackagesById, x => x.FindPackagesByIdCacheTimeInSeconds },
+                { ODataCachedEndpoint.FindPackagesByIdCount, x => x.FindPackagesByIdCountCacheTimeInSeconds },
+                { ODataCachedEndpoint.Search, x => x.SearchCacheTimeInSeconds },
+            };
+
+        private DynamicSettings _dynamicSettings;
+        private readonly object _settingsLock = new object();
+        private readonly ODataCachedEndpoint _endpoint;
+        private readonly int _defaultServerTimeSpan;
+
+        /// <summary>
+        /// The <paramref name="configurationName"/> refers to an integer property name on
+        /// <see cref="IODataCacheConfiguration"/>. This property will be uses to override the
+        /// <see cref="CacheOutputAttribute.ServerTimeSpan"/>.
+        /// </summary>
+        public ODataCacheOutputAttribute(ODataCachedEndpoint endpoint, int serverTimeSpan)
+        {
+            _endpoint = endpoint;
+            _defaultServerTimeSpan = serverTimeSpan;
+            ServerTimeSpan = serverTimeSpan;
+        }
+
+        /// <summary>
+        /// This setting determines how frequently the cache duration setting should be checked. Since the OData
+        /// endpoints get a lot of traffic, we don't want to check every time. The 60 seconds here is picked to mimic
+        /// the feature flag reload time and the value has nothing to do with the cache durations themselves.
+        /// </summary>
+        public TimeSpan ReloadDuration { get; set; } = TimeSpan.FromSeconds(60);
+
+        public override void OnActionExecuting(HttpActionContext actionContext)
+        {
+            // This is a very hot path, so cache the configuration and only reload every so often.
+            var now = DateTimeOffset.Now;
+            var currentSettings = _dynamicSettings;
+            if (currentSettings == null || now - currentSettings.CalculatedAt >= ReloadDuration)
+            {
+                SetLatestSettings(actionContext, now, currentSettings);
+            }
+
+            base.OnActionExecuting(actionContext);
+        }
+
+        private void SetLatestSettings(HttpActionContext actionContext, DateTimeOffset now, DynamicSettings currentSettings)
+        {
+            var secondsOrNull = GetSecondsOrNull(actionContext);
+            var newServerTimeSpan = secondsOrNull ?? _defaultServerTimeSpan;
+            if (newServerTimeSpan != currentSettings?.ServerTimeSpan)
+            {
+                var logger = GetLogger(actionContext);
+                if (secondsOrNull == null)
+                {
+                    logger.LogInformation(
+                        "For OData caching, no dynamic server-side cache time is available for endpoint {Endpoint}. " +
+                        "Falling back to the default of {Default} seconds.",
+                        _endpoint,
+                        _defaultServerTimeSpan);
+                }
+                else
+                {
+                    logger.LogInformation(
+                        "For OData caching, the server-side cache time of {Seconds} seconds will now be used for endpoint {Endpoint}.",
+                        secondsOrNull,
+                        _endpoint);
+                }
+
+                lock (_settingsLock)
+                {
+                    if (ReferenceEquals(_dynamicSettings, currentSettings))
+                    {
+                        ServerTimeSpan = newServerTimeSpan;
+                        ResetCacheTimeQuery();
+                        _dynamicSettings = new DynamicSettings(now, newServerTimeSpan);
+                    }
+                }
+            }
+        }
+
+        private ILogger GetLogger(HttpActionContext actionContext)
+        {
+            var requestScope = actionContext.Request.GetDependencyScope();
+            if (requestScope == null)
+            {
+                return NullLogger<ODataCacheOutputAttribute>.Instance;
+            }
+
+            var logger = requestScope.GetService(typeof(ILogger<ODataCacheOutputAttribute>)) as ILogger<ODataCacheOutputAttribute>;
+            if (logger == null)
+            {
+                return NullLogger<ODataCacheOutputAttribute>.Instance;
+            }
+
+            return logger;
+        }
+
+        private int? GetSecondsOrNull(HttpActionContext actionContext)
+        {
+            if (!EndpointToGetSeconds.TryGetValue(_endpoint, out var getSeconds))
+            {
+                return null;
+            }
+
+            var requestScope = actionContext.Request.GetDependencyScope();
+            if (requestScope == null)
+            {
+                return null;
+            }
+
+            var featureFlagService = requestScope.GetService(typeof(IFeatureFlagService)) as IFeatureFlagService;
+            if (featureFlagService == null || !featureFlagService.AreDynamicODataCacheDurationsEnabled())
+            {
+                return null;
+            }
+
+            var contentObjectService = requestScope.GetService(typeof(IContentObjectService)) as IContentObjectService;
+            if (contentObjectService == null)
+            {
+                return null;
+            }
+
+            var config = contentObjectService.ODataCacheConfiguration;
+            if (config == null)
+            {
+                return null;
+            }
+
+            return getSeconds(config);
+        }
+
+        private class DynamicSettings
+        {
+            public DynamicSettings(DateTimeOffset calculatedAt, int serverTimeSpan)
+            {
+                CalculatedAt = calculatedAt;
+                ServerTimeSpan = serverTimeSpan;
+            }
+
+            public DateTimeOffset CalculatedAt { get; }
+            public int ServerTimeSpan { get; }
+        }
+    }
+}

--- a/src/NuGetGallery/Infrastructure/ODataCachedEndpoint.cs
+++ b/src/NuGetGallery/Infrastructure/ODataCachedEndpoint.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// The OData endpoints that support caching. This is used by <see cref="ODataCacheOutputAttribute"/> to specify
+    /// which property on <see cref="Services.ODataCacheConfiguration"/> should be used to define the cache time.
+    /// </summary>
+    public enum ODataCachedEndpoint
+    {
+        GetSpecificPackage,
+        FindPackagesById,
+        FindPackagesByIdCount,
+        Search,
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -241,6 +241,8 @@
     <Compile Include="Infrastructure\Lucene\ServiceResponse.cs" />
     <Compile Include="Infrastructure\Mail\Messages\SearchSideBySideMessage.cs" />
     <Compile Include="Infrastructure\HijackSearchServiceFactory.cs" />
+    <Compile Include="Infrastructure\ODataCachedEndpoint.cs" />
+    <Compile Include="Infrastructure\ODataCacheOutputAttribute.cs" />
     <Compile Include="Infrastructure\UserDeletedErrorFilter.cs" />
     <Compile Include="Infrastructure\SearchServiceFactory.cs" />
     <Compile Include="Migrations\201903020136235_CvesCanBeEmpty.cs" />
@@ -1819,6 +1821,8 @@
     <Content Include="App_Data\Files\Content\AB-Test-Configuration.json" />
     <Content Include="Areas\Admin\Views\SiteAdmins\Index.cshtml" />
     <Content Include="Areas\Admin\Views\ApiKeys\Index.cshtml" />
+    <Content Include="App_Data\Files\Content\OData-Cache-Configuration.json" />
+    <Content Include="App_Data\Files\Content\GitHubUsage.v1.json" />
     <None Include="Properties\PublishProfiles\nuget-staging-frontend.pubxml" />
     <Content Include="Scripts\gallery\async-file-upload.js" />
     <Content Include="Scripts\gallery\autocomplete.js" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -548,84 +548,84 @@
       </listeners>
     </trace>
   </system.diagnostics>
-	<runtime>
-		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.58.0.0" newVersion="2.58.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="EntityFramework" publicKeyToken="B77A5C561934E089" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Autofac.Integration.Owin" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0"/>
-			</dependentAssembly>
-		</assemblyBinding>
-	</runtime>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.58.0.0" newVersion="2.58.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.10.0.0" newVersion="2.10.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EntityFramework" publicKeyToken="B77A5C561934E089" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac.Integration.Owin" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/tests/NuGetGallery.Facts/Infrastructure/ODataCacheOutputAttributeFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/ODataCacheOutputAttributeFacts.cs
@@ -1,0 +1,358 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using System.Web.Http.Routing;
+using Autofac;
+using Autofac.Integration.WebApi;
+using Moq;
+using NuGetGallery.Services;
+using WebApi.OutputCache.Core.Cache;
+using Xunit;
+
+namespace NuGetGallery
+{
+    public class ODataCacheOutputAttributeFacts
+    {
+        public class OnActionExecutedAsync : Facts
+        {
+            [Theory]
+            [MemberData(nameof(CacheEndpointTestData))]
+            public async Task ObservesConfiguredValue(ODataCachedEndpoint endpoint)
+            {
+                var cacheTime = 600;
+                SetCacheTime(endpoint, cacheTime);
+                var target = new ODataCacheOutputAttribute(endpoint, 100);
+                target.OnActionExecuting(ActionContext);
+
+                var before = DateTimeOffset.Now;
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+                var after = DateTimeOffset.Now;
+
+                Cache.Verify(
+                    x => x.Add(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.Is<DateTimeOffset>(e => before.AddSeconds(cacheTime) <= e && e <= after.AddSeconds(cacheTime)),
+                        null),
+                    Times.Once);
+            }
+
+            [Theory]
+            [MemberData(nameof(CacheEndpointTestData))]
+            public async Task HasCorrectDefaultConfiguredCacheTime(ODataCachedEndpoint endpoint)
+            {
+                var cacheTime = DefaultCacheTime[endpoint];
+                var target = new ODataCacheOutputAttribute(endpoint, 0);
+                target.OnActionExecuting(ActionContext);
+
+                var before = DateTimeOffset.Now;
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+                var after = DateTimeOffset.Now;
+
+                if (cacheTime <= 0)
+                {
+                    Cache.Verify(
+                        x => x.Add(
+                            It.IsAny<string>(),
+                            It.IsAny<object>(),
+                            It.IsAny<DateTimeOffset>(),
+                            It.IsAny<string>()),
+                        Times.Never);
+                }
+                else
+                {
+                    Cache.Verify(
+                        x => x.Add(
+                            It.IsAny<string>(),
+                            It.IsAny<object>(),
+                            It.Is<DateTimeOffset>(e => before.AddSeconds(cacheTime) <= e && e <= after.AddSeconds(cacheTime)),
+                            null),
+                        Times.Once);
+                }
+            }
+
+            [Fact]
+            public async Task UsesDefaultCacheValueWhenFeatureFlagIsOff()
+            {
+                FeatureFlagService.Setup(x => x.AreDynamicODataCacheDurationsEnabled()).Returns(false);
+                SetCacheTime(ODataCachedEndpoint.GetSpecificPackage, 600);
+                var target = new ODataCacheOutputAttribute(ODataCachedEndpoint.GetSpecificPackage, 100);
+                target.OnActionExecuting(ActionContext);
+
+                var before = DateTimeOffset.Now;
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+                var after = DateTimeOffset.Now;
+
+                Cache.Verify(
+                    x => x.Add(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.Is<DateTimeOffset>(e => before.AddSeconds(100) <= e && e <= after.AddSeconds(100)),
+                        null),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task RevertsToDefaultValueWhenFeatureFlagIsTurnedOff()
+            {
+                SetCacheTime(ODataCachedEndpoint.GetSpecificPackage, 600);
+                var target = new ODataCacheOutputAttribute(ODataCachedEndpoint.GetSpecificPackage, 100)
+                {
+                    ReloadDuration = TimeSpan.Zero,
+                };
+                target.OnActionExecuting(ActionContext);
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+                FeatureFlagService.Setup(x => x.AreDynamicODataCacheDurationsEnabled()).Returns(false);
+                Cache.ResetCalls();
+                target.OnActionExecuting(ActionContext);
+
+                var before = DateTimeOffset.Now;
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+                var after = DateTimeOffset.Now;
+
+                Cache.Verify(
+                    x => x.Add(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.Is<DateTimeOffset>(e => before.AddSeconds(100) <= e && e <= after.AddSeconds(100)),
+                        null),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task CanChangeCacheTime()
+            {
+                SetCacheTime(ODataCachedEndpoint.GetSpecificPackage, 300);
+                var target = new ODataCacheOutputAttribute(ODataCachedEndpoint.GetSpecificPackage, 100)
+                {
+                    ReloadDuration = TimeSpan.Zero,
+                };
+                target.OnActionExecuting(ActionContext);
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+                SetCacheTime(ODataCachedEndpoint.GetSpecificPackage, 600);
+                Cache.ResetCalls();
+                target.OnActionExecuting(ActionContext);
+
+                var before = DateTimeOffset.Now;
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+                var after = DateTimeOffset.Now;
+
+                Cache.Verify(
+                    x => x.Add(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.Is<DateTimeOffset>(e => before.AddSeconds(600) <= e && e <= after.AddSeconds(600)),
+                        null),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task CanUseZeroWhenConfigurationIsTurnedOff()
+            {
+                SetCacheTime(ODataCachedEndpoint.GetSpecificPackage, 600);
+                var target = new ODataCacheOutputAttribute(ODataCachedEndpoint.GetSpecificPackage, 0);
+                FeatureFlagService.Setup(x => x.AreDynamicODataCacheDurationsEnabled()).Returns(false);
+                target.OnActionExecuting(ActionContext);
+
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+
+                Cache.Verify(
+                    x => x.Add(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.IsAny<DateTimeOffset>(),
+                        It.IsAny<string>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task CanUseZeroFromConfiguration()
+            {
+                SetCacheTime(ODataCachedEndpoint.GetSpecificPackage, 0);
+                var target = new ODataCacheOutputAttribute(ODataCachedEndpoint.GetSpecificPackage, 100);
+                target.OnActionExecuting(ActionContext);
+
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+
+                Cache.Verify(
+                    x => x.Add(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.IsAny<DateTimeOffset>(),
+                        It.IsAny<string>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task CachesSettings()
+            {
+                SetCacheTime(ODataCachedEndpoint.GetSpecificPackage, 300);
+                var target = new ODataCacheOutputAttribute(ODataCachedEndpoint.GetSpecificPackage, 100)
+                {
+                    ReloadDuration = TimeSpan.FromHours(1),
+                };
+                target.OnActionExecuting(ActionContext);
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+                SetCacheTime(ODataCachedEndpoint.GetSpecificPackage, 600);
+                Cache.ResetCalls();
+                target.OnActionExecuting(ActionContext);
+
+                var before = DateTimeOffset.Now;
+                await target.OnActionExecutedAsync(ActionExecutedContext, CancellationToken.None);
+                var after = DateTimeOffset.Now;
+
+                Cache.Verify(
+                    x => x.Add(
+                        It.IsAny<string>(),
+                        It.IsAny<object>(),
+                        It.Is<DateTimeOffset>(e => before.AddSeconds(300) <= e && e <= after.AddSeconds(300)),
+                        null),
+                    Times.Once);
+            }
+        }
+
+        /// <summary>
+        /// Helpers from:
+        /// https://github.com/OData/WebApi/blob/5061dcad757599b93ff990079832123a73e0e091/test/UnitTest/Microsoft.AspNet.OData.Test.Shared/ContextUtil.cs
+        /// https://stackoverflow.com/questions/11848137/how-can-you-unit-test-an-action-filter-in-asp-net-web-api
+        /// </summary>
+        public abstract class Facts
+        {
+            public Facts()
+            {
+                ContentObjectService = new Mock<IContentObjectService>();
+                FeatureFlagService = new Mock<IFeatureFlagService>();
+                Cache = new Mock<IApiOutputCache>();
+
+                CacheConfiguration = new ODataCacheConfiguration();
+                ContentObjectService.Setup(x => x.ODataCacheConfiguration).Returns(() => CacheConfiguration);
+                FeatureFlagService.SetReturnsDefault(true);
+                FeatureFlagService.Setup(x => x.AreDynamicODataCacheDurationsEnabled()).Returns(() => true);
+
+                var builder = new ContainerBuilder();
+                builder.Register(c => ContentObjectService.Object);
+                builder.Register(c => FeatureFlagService.Object);
+                builder.Register(c => Cache.Object);
+                HttpConfiguration = new HttpConfiguration();
+                HttpConfiguration.DependencyResolver = new AutofacWebApiDependencyResolver(builder.Build());
+
+                ActionDescriptor = new Mock<HttpActionDescriptor> { CallBase = true };
+                ActionDescriptor.Setup(x => x.ActionName).Returns("FooAction");
+                ActionDescriptor.Setup(x => x.ReturnType).Returns(typeof(HttpResponseMessage));
+                ControllerContext = CreateControllerContext(HttpConfiguration);
+                ActionContext = CreateActionContext(ControllerContext, ActionDescriptor.Object);
+                ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("Got 'em.", Encoding.UTF8, "text/plain"),
+                };
+                ActionExecutedContext = CreateActionExecutedContext(ActionContext, ResponseMessage);
+            }
+
+            public static HttpControllerContext CreateControllerContext(
+                HttpConfiguration configuration = null,
+                IHttpController instance = null,
+                IHttpRouteData routeData = null,
+                HttpRequestMessage request = null)
+            {
+                HttpConfiguration config = configuration ?? new HttpConfiguration();
+                IHttpRouteData route = routeData ?? new HttpRouteData(new HttpRoute());
+                HttpRequestMessage req = request ?? new HttpRequestMessage();
+                req.SetConfiguration(config);
+                req.SetRouteData(route);
+
+                HttpControllerContext context = new HttpControllerContext(config, route, req);
+                if (instance != null)
+                {
+                    context.Controller = instance;
+                }
+                context.ControllerDescriptor = CreateControllerDescriptor(config);
+
+                return context;
+            }
+
+            public static HttpControllerDescriptor CreateControllerDescriptor(HttpConfiguration config = null)
+            {
+                if (config == null)
+                {
+                    config = new HttpConfiguration();
+                }
+
+                return new HttpControllerDescriptor
+                {
+                    Configuration = config,
+                    ControllerName = "FooController",
+                    ControllerType = typeof(ApiController),
+                };
+            }
+
+            public static HttpActionContext CreateActionContext(HttpControllerContext controllerContext = null, HttpActionDescriptor actionDescriptor = null)
+            {
+                HttpControllerContext context = controllerContext ?? CreateControllerContext();
+                HttpActionDescriptor descriptor = actionDescriptor ?? new Mock<HttpActionDescriptor>() { CallBase = true }.Object;
+                return new HttpActionContext(context, descriptor);
+            }
+
+            public static HttpActionExecutedContext CreateActionExecutedContext(
+                HttpActionContext actionContext,
+                HttpResponseMessage response)
+            {
+                return new HttpActionExecutedContext(actionContext, null) { Response = response };
+            }
+
+            public static IEnumerable<object[]> CacheEndpointTestData => Enum
+                .GetValues(typeof(ODataCachedEndpoint))
+                .Cast<ODataCachedEndpoint>()
+                .Select(x => new object[] { x });
+
+            public static readonly IReadOnlyDictionary<ODataCachedEndpoint, int> DefaultCacheTime =
+                new Dictionary<ODataCachedEndpoint, int>()
+                {
+                    { ODataCachedEndpoint.GetSpecificPackage, 60 },
+                    { ODataCachedEndpoint.FindPackagesById, 60 },
+                    { ODataCachedEndpoint.FindPackagesByIdCount, 0 },
+                    { ODataCachedEndpoint.Search, 45 },
+                };
+
+            public void SetCacheTime(ODataCachedEndpoint endpoint, int cacheTime)
+            {
+                switch (endpoint)
+                {
+                    case ODataCachedEndpoint.GetSpecificPackage:
+                        CacheConfiguration.GetSpecificPackageCacheTimeInSeconds = cacheTime;
+                        break;
+                    case ODataCachedEndpoint.FindPackagesById:
+                        CacheConfiguration.FindPackagesByIdCacheTimeInSeconds = cacheTime;
+                        break;
+                    case ODataCachedEndpoint.FindPackagesByIdCount:
+                        CacheConfiguration.FindPackagesByIdCountCacheTimeInSeconds = cacheTime;
+                        break;
+                    case ODataCachedEndpoint.Search:
+                        CacheConfiguration.SearchCacheTimeInSeconds = cacheTime;
+                        break;
+                }
+            }
+
+            public Mock<IContentObjectService> ContentObjectService { get; }
+            public Mock<IFeatureFlagService> FeatureFlagService { get; }
+            public Mock<IApiOutputCache> Cache { get; }
+            public Mock<HttpActionDescriptor> ActionDescriptor { get; }
+            public ODataCacheConfiguration CacheConfiguration { get; }
+            public HttpConfiguration HttpConfiguration { get; }
+            public HttpControllerContext ControllerContext { get; }
+            public HttpActionContext ActionContext { get; }
+            public HttpResponseMessage ResponseMessage { get; }
+            public HttpActionExecutedContext ActionExecutedContext { get; }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Authentication\AuthenticationServiceFacts.cs" />
     <Compile Include="Authentication\Providers\CommonAuth\AzureActiveDirectoryV2AuthenticatorFacts.cs" />
     <Compile Include="Authentication\TestCredentialHelper.cs" />
+    <Compile Include="Infrastructure\ODataCacheOutputAttributeFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageIdsQueryFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageVersionsQueryFacts.cs" />
     <Compile Include="Queries\AutocompleteServiceQueryFacts.cs" />


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2773#issuecomment-551338259.

This introduces a feature flag and JSON configuration file to manipulating cache duration on OData endpoints.

My plan is to ship this to PROD and take the following steps:

1. Bring FindPackagesById/$count caching up to 60 seconds (to match with the non-count endpoint).
   - Wait 1 full business day
1. Bring Increase FindPackagesById and FindPackageById/$count caching up to 120 seconds
   - Wait 1 full business day
1. ... repeat until duration is 5 minutes
1. Wait 7 days and closely observe memory and search service impact (i.e. cache "misses").
   - Memory should not go out of control and cache misses should decrease

This is the state of cache durations today:

Endpoint | Controller | Cache Duration (seconds)
-- | -- | --
FindPackagesById | V1 | 60
FindPackagesById | V2 | 60
FindPackagesById | V2 Curated | 60
FindPackagesById/$count | V1 | 60
FindPackagesById/$count | V2 | 0
FindPackagesById/$count | V2 Curated | 0
Search | V1 | 45
Search | V2 | 45
Search | V2 Curated | 45
Search/$count | V1 | 45
Search/$count | V2 | 45
Search/$count | V2 Curated  | 45
Specific Package | V1 | 60
Specific Package | V2 | 60
Specific Package | V2 Curated | 60

Yes, today the FindPackagesById/$count endpoint is cached on V1 but not on V2 or V2 curated (???). Another oddity to note is that Search/$count is cached everywhere but FindPackagesById/$count is not (??????).

Another improvement that can be done is to update the curated feed routes to point to the main V2 controller so that the endpoint caches are shared. This is tracked here: https://github.com/NuGet/NuGetGallery/issues/7689.

Without the feature flag being turned on, the only impact of this change is to bring V1 $count endpoint into alignment with the other two controllers (i.e. disable server-side caching) The volume of this endpoint is very low so the impact will be unnoticable.

Client-side cache durations are unaffected by this PR. In general client-side cache durations are not important for us since official client does not observe them.