### PR TITLE
Allow admins to see users' MFA setting on profile page

### DIFF
--- a/src/NuGetGallery/ViewModels/UserProfileModel.cs
+++ b/src/NuGetGallery/ViewModels/UserProfileModel.cs
@@ -16,6 +16,7 @@ namespace NuGetGallery
             Username = user.Username;
             EmailAddress = user.EmailAddress;
             UnconfirmedEmailAddress = user.UnconfirmedEmailAddress;
+            HasEnabledMultiFactorAuthentication = user.EnableMultiFactorAuthentication;
             AllPackages = allPackages;
             TotalPackages = allPackages.Count;
             PackagePage = pageIndex;
@@ -41,6 +42,7 @@ namespace NuGetGallery
         public string Username { get; private set; }
         public string EmailAddress { get; private set; }
         public string UnconfirmedEmailAddress { get; set; }
+        public bool HasEnabledMultiFactorAuthentication { get; set; }
         public ICollection<ListPackageItemViewModel> AllPackages { get; private set; }
         public ICollection<ListPackageItemViewModel> PagedPackages { get; private set; }
         public long TotalPackageDownloadCount { get; private set; }

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -39,7 +39,7 @@
                             <dt>Unconfirmed Email Address:</dt>
                             <dd>@Model.UnconfirmedEmailAddress</dd>
                         }
-                        <dt>Multi-factor Authentication</dt>
+                        <dt>Multi-factor Authentication:</dt>
                         <dd>@(Model.HasEnabledMultiFactorAuthentication ? "Enabled" : "Disabled")</dd>
                     </dl>
                 </div>

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -39,6 +39,8 @@
                             <dt>Unconfirmed Email Address:</dt>
                             <dd>@Model.UnconfirmedEmailAddress</dd>
                         }
+                        <dt>Multi-factor Authentication</dt>
+                        <dd>@(Model.HasEnabledMultiFactorAuthentication ? "Enabled" : "Disabled")</dd>
                     </dl>
                 </div>
             }


### PR DESCRIPTION
As requested by @karann-msft 

![image](https://user-images.githubusercontent.com/18014088/68633547-211fc080-04a7-11ea-96e9-74703a3c29ce.png)
