### PR TITLE
Use ef6.exe instead of migrate.exe

### DIFF
--- a/test.ps1
+++ b/test.ps1
@@ -38,6 +38,9 @@ Function Run-Tests {
         & $xUnitExe (Join-Path $PSScriptRoot $Test) -xml "Results.$TestCount.xml"
         $TestCount++
     }
+
+    Write-Host "Ensuring the EntityFramework version can be discovered."
+    . (Join-Path $PSScriptRoot "tools\Update-Databases.ps1") -MigrationTargets @("FakeMigrationTarget")
 }
     
 Write-Host ("`r`n" * 3)

--- a/tools/Setup-DevEnvironment.ps1
+++ b/tools/Setup-DevEnvironment.ps1
@@ -119,6 +119,6 @@ Invoke-Netsh http add sslcert hostnameport="$(Get-SiteHttpsHost)" certhash="$($s
 Write-Host "[DONE] Setting SSL Certificate" -ForegroundColor Cyan
 Write-Host "[BEGIN] Running Migrations" -ForegroundColor Cyan
 
-& "$ScriptRoot\Update-Databases.ps1" -MigrationTargets NugetGallery,NugetGallerySupportRequest -NugetGallerySitePath $SitePhysicalPath
+& "$ScriptRoot\Update-Databases.ps1" -MigrationTargets NuGetGallery,NuGetGallerySupportRequest -NuGetGallerySitePath $SitePhysicalPath
 
 Write-Host "[DONE] Running Migrations" -ForegroundColor Cyan


### PR DESCRIPTION
This addresses a breaking change introduced in 6.3.0 which eliminates migrate.exe and replaces it with ef6.exe.
Address https://github.com/NuGet/NuGetGallery/issues/7699
Migration details available here: https://github.com/aspnet/EntityFramework.Docs/issues/1740#issuecomment-557204757

I also removed some sad "Nuget" instances with "NuGet". You're welcome, marketing!