### PR TITLE
Adding the "USNC-Preview" "region" for functional tests

### DIFF
--- a/tests/Scripts/Import-Configuration.ps1
+++ b/tests/Scripts/Import-Configuration.ps1
@@ -7,7 +7,7 @@ param (
     [Parameter(Mandatory=$true)][string]$Branch = "master",
     [Parameter(Mandatory=$true)][ValidateSet("production", "staging")][string]$Slot = "production",
     [Parameter(Mandatory=$true)][ValidateSet("Dev", "Int", "Prod")][string]$Environment,
-    [Parameter(Mandatory=$true)][ValidateSet("USNC", "USSC")][string]$Region
+    [Parameter(Mandatory=$true)][ValidateSet("USNC", "USSC", "USNC-Preview")][string]$Region
 )
 
 Write-Host "Importing configuration for Gallery Functional tests on $Environment $Region"

--- a/tests/Scripts/Import-Configuration.ps1
+++ b/tests/Scripts/Import-Configuration.ps1
@@ -7,7 +7,7 @@ param (
     [Parameter(Mandatory=$true)][string]$Branch = "master",
     [Parameter(Mandatory=$true)][ValidateSet("production", "staging")][string]$Slot = "production",
     [Parameter(Mandatory=$true)][ValidateSet("Dev", "Int", "Prod")][string]$Environment,
-    [Parameter(Mandatory=$true)][ValidateSet("USNC", "USSC", "USNC-Preview")][string]$Region
+    [Parameter(Mandatory=$true)][ValidateSet("USNC", "USSC", "USNC-PREVIEW")][string]$Region
 )
 
 Write-Host "Importing configuration for Gallery Functional tests on $Environment $Region"


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1912

Need to be able to run the functional tests against the app service. For that, new "region" is introduced, this change, extends the test parameter validation to include that new region. The main change is in the functional test configuration.