### PR TITLE
No longer depend on Obsolete AppInsights APIs

### DIFF
--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -107,7 +107,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.3.0-dev-3159955</Version>
+      <Version>4.3.0-dev-3309631</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/AccountDeleter/Job.cs
+++ b/src/AccountDeleter/Job.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
-using System.ServiceModel.Configuration;
 using Autofac;
 using Autofac.Core;
 using Microsoft.Extensions.Configuration;
@@ -101,14 +100,14 @@ namespace NuGetGallery.AccountDeleter
                 services.AddTransient<IMessageServiceConfiguration, CoreMessageServiceConfiguration>();
             }
 
-
             services.AddScoped<IEmailBuilderFactory, EmailBuilderFactory>();
-            services.AddScoped<ITelemetryClient, TelemetryClientWrapper>();
+            services.AddScoped<ITelemetryClient, TelemetryClientWrapper>(
+                sp => TelemetryClientWrapper.UseTelemetryConfiguration(ApplicationInsightsConfiguration.TelemetryConfiguration));
 
-            ConfigureGalleryServices(services, configurationRoot);
+            ConfigureGalleryServices(services);
         }
 
-        protected void ConfigureGalleryServices(IServiceCollection services, IConfigurationRoot configurationRoot)
+        protected void ConfigureGalleryServices(IServiceCollection services)
         {
             if (IsDebugMode)
             {
@@ -127,7 +126,6 @@ namespace NuGetGallery.AccountDeleter
                 services.AddScoped<IDeleteAccountService, DeleteAccountService>();
 
                 services.AddScoped<IUserService, AccountDeleteUserService>();
-                services.AddScoped<ITelemetryClient>(sp => { return TelemetryClientWrapper.Instance; });
                 services.AddScoped<IDiagnosticsService, DiagnosticsService>();
 
                 services.AddScoped<IPackageService, PackageService>();

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -64,10 +64,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3159955</Version>
+      <Version>4.3.0-dev-3309631</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/Program.cs
+++ b/src/DatabaseMigrationTools/Program.cs
@@ -16,7 +16,7 @@ namespace NuGetGallery.DatabaseMigrationTools
             var exitCode = JobRunner.RunOnce(job, args).GetAwaiter().GetResult();
 
             // Have to use Thread.Sleep() and wait for the logger.
-            // "TelemetryConfiguration.Active.TelemetryChannel.Flush()" is not reliable.
+            // Calling "TelemetryChannel.Flush()" on TelemetryConfiguration is not reliable.
             // Hit the issue: https://github.com/Microsoft/ApplicationInsights-dotnet/issues/407
             Thread.Sleep(30000);
 

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -85,10 +85,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3159955</Version>
+      <Version>4.3.0-dev-3309631</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -77,7 +77,7 @@
       <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3159955</Version>
+      <Version>4.3.0-dev-3309631</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -241,16 +241,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery.Services/Diagnostics/DiagnosticsService.cs
+++ b/src/NuGetGallery.Services/Diagnostics/DiagnosticsService.cs
@@ -15,11 +15,6 @@ namespace NuGetGallery.Diagnostics
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
         }
 
-        // Test constructor
-        internal DiagnosticsService() : this(TelemetryClientWrapper.Instance)
-        {
-        }
-
         public IDiagnosticsSource GetSource(string name)
         {
             if (string.IsNullOrEmpty(name))

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -293,10 +293,10 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/Telemetry/QuietLog.cs
+++ b/src/NuGetGallery.Services/Telemetry/QuietLog.cs
@@ -11,7 +11,12 @@ namespace NuGetGallery
 {
     public static class QuietLog
     {
-        public static ITelemetryClient Telemetry = TelemetryClientWrapper.Instance;
+        private static ITelemetryClient Telemetry;
+
+        public static void UseTelemetryClient(ITelemetryClient telemetryClient)
+        {
+            Telemetry = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        }
 
         public static void LogHandledException(Exception e)
         {

--- a/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Logging;
 
 namespace NuGetGallery
@@ -18,19 +19,19 @@ namespace NuGetGallery
         private const string TelemetryPropertyEventName = "EventName";
 
         private static readonly Lazy<TelemetryClientWrapper> Singleton
-            = new Lazy<TelemetryClientWrapper>(() => new TelemetryClientWrapper());
+            = new Lazy<TelemetryClientWrapper>(() => new TelemetryClientWrapper(TelemetryConfiguration));
 
-        public static TelemetryClientWrapper Instance
+        private static TelemetryConfiguration TelemetryConfiguration;
+
+        public static TelemetryClientWrapper UseTelemetryConfiguration(TelemetryConfiguration configuration)
         {
-            get
-            {
-                return Singleton.Value;
-            }
+            TelemetryConfiguration = configuration;
+            return Singleton.Value;
         }
 
-        private TelemetryClientWrapper()
+        private TelemetryClientWrapper(TelemetryConfiguration telemetryConfiguration)
         {
-            UnderlyingClient = new TelemetryClient();
+            UnderlyingClient = new TelemetryClient(telemetryConfiguration);
         }
 
         public TelemetryClient UnderlyingClient { get; }

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -220,21 +220,10 @@ namespace NuGetGallery
         public const string TestBucket = "TestBucket";
         public const string TestPercentage = "TestPercentage";
 
-        public TelemetryService(IDiagnosticsService diagnosticsService, ITelemetryClient telemetryClient = null)
+        public TelemetryService(IDiagnosticsSource diagnosticsSource, ITelemetryClient telemetryClient)
         {
-            if (diagnosticsService == null)
-            {
-                throw new ArgumentNullException(nameof(diagnosticsService));
-            }
-
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
-
-            _diagnosticsSource = diagnosticsService.GetSource("TelemetryService");
-        }
-
-        // Used by ODataQueryVerifier. Should consider refactoring to make this non-static.
-        public TelemetryService() : this(new DiagnosticsService(), TelemetryClientWrapper.Instance)
-        {
+            _diagnosticsSource = diagnosticsSource ?? throw new ArgumentNullException(nameof(diagnosticsSource));
         }
 
         public void TraceException(Exception exception)
@@ -333,7 +322,8 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(readMeSourceType));
             }
 
-            TrackMetric(Events.PackageReadMeChanged, 1, properties => {
+            TrackMetric(Events.PackageReadMeChanged, 1, properties =>
+            {
                 properties.Add(PackageId, package.PackageRegistration.Id);
                 properties.Add(PackageVersion, package.NormalizedVersion);
                 properties.Add(ReadMeSourceType, readMeSourceType);
@@ -355,7 +345,8 @@ namespace NuGetGallery
         {
             var normalizedVersion = version?.ToNormalizedString();
 
-            TrackMetric(Events.PackagePushFailure, 1, properties => {
+            TrackMetric(Events.PackagePushFailure, 1, properties =>
+            {
                 properties.Add(ClientVersion, GetClientVersion());
                 properties.Add(ProtocolVersion, GetProtocolVersion());
                 properties.Add(PackageId, id ?? ValueUnknown);
@@ -435,7 +426,8 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(packageVersion));
             }
 
-            TrackMetric(Events.UserPackageDeleteExecuted, 1, properties => {
+            TrackMetric(Events.UserPackageDeleteExecuted, 1, properties =>
+            {
                 properties.Add(PackageKey, packageKey.ToString());
                 properties.Add(PackageId, packageId);
                 properties.Add(PackageVersion, packageVersion);
@@ -490,7 +482,7 @@ namespace NuGetGallery
             bool hasCustomMessage)
         {
             TrackMetricForPackageVersions(
-                Events.PackageDeprecate, 
+                Events.PackageDeprecate,
                 packages,
                 properties =>
                 {
@@ -504,10 +496,11 @@ namespace NuGetGallery
         public void TrackPackageMetadataComplianceError(string packageId, string packageVersion, IEnumerable<string> complianceFailures)
         {
             TrackMetricForPackage(
-                Events.PackageMetadataComplianceError, 
-                packageId, 
+                Events.PackageMetadataComplianceError,
+                packageId,
                 packageVersion,
-                properties => {
+                properties =>
+                {
                     properties.Add(ComplianceFailures, JsonConvert.SerializeObject(complianceFailures, _defaultJsonSerializerSettings));
                 });
         }
@@ -518,7 +511,8 @@ namespace NuGetGallery
                 Events.PackageMetadataComplianceWarning,
                 packageId,
                 packageVersion,
-                properties => {
+                properties =>
+                {
                     properties.Add(ComplianceWarnings, JsonConvert.SerializeObject(complianceWarnings, _defaultJsonSerializerSettings));
                 });
         }
@@ -526,8 +520,8 @@ namespace NuGetGallery
         public void TrackPackageOwnershipAutomaticallyAdded(string packageId, string packageVersion)
         {
             TrackMetricForPackage(
-                Events.PackageOwnershipAutomaticallyAdded, 
-                packageId, 
+                Events.PackageOwnershipAutomaticallyAdded,
+                packageId,
                 packageVersion);
         }
 
@@ -553,7 +547,8 @@ namespace NuGetGallery
                 throw new ArgumentException(ServicesStrings.ArgumentCannotBeNullOrEmpty, nameof(packageId));
             }
 
-            TrackMetric(Events.PackageRegistrationRequiredSignerSet, 1, properties => {
+            TrackMetric(Events.PackageRegistrationRequiredSignerSet, 1, properties =>
+            {
                 properties.Add(PackageId, packageId);
             });
         }
@@ -601,7 +596,8 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(user));
             }
 
-            TrackMetric(eventName, 1, properties => {
+            TrackMetric(eventName, 1, properties =>
+            {
                 properties.Add(ClientVersion, GetClientVersion());
                 properties.Add(ProtocolVersion, GetProtocolVersion());
                 properties.Add(AccountCreationDate, GetAccountCreationDate(user));
@@ -617,7 +613,8 @@ namespace NuGetGallery
                 throw new ArgumentException(ServicesStrings.ArgumentCannotBeNullOrEmpty, nameof(thumbprint));
             }
 
-            TrackMetric(eventName, 1, properties => {
+            TrackMetric(eventName, 1, properties =>
+            {
                 properties.Add(Sha256Thumbprint, thumbprint);
             });
         }
@@ -664,7 +661,8 @@ namespace NuGetGallery
             string packageVersion,
             Action<Dictionary<string, string>> addProperties = null)
         {
-            TrackMetric(metricName, 1, properties => {
+            TrackMetric(metricName, 1, properties =>
+            {
                 properties.Add(ClientVersion, GetClientVersion());
                 properties.Add(ProtocolVersion, GetProtocolVersion());
                 properties.Add(ClientInformation, GetClientInformation());
@@ -692,7 +690,8 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(identity));
             }
 
-            TrackMetric(metricName, 1, properties => {
+            TrackMetric(metricName, 1, properties =>
+            {
                 properties.Add(ClientVersion, GetClientVersion());
                 properties.Add(ProtocolVersion, GetProtocolVersion());
                 properties.Add(ClientInformation, GetClientInformation());
@@ -729,7 +728,8 @@ namespace NuGetGallery
             string packageVersion,
             Action<Dictionary<string, string>> addProperties = null)
         {
-            TrackMetric(metricName, 1, properties => {
+            TrackMetric(metricName, 1, properties =>
+            {
                 properties.Add(ClientVersion, GetClientVersion());
                 properties.Add(ProtocolVersion, GetProtocolVersion());
                 properties.Add(ClientInformation, GetClientInformation());
@@ -762,7 +762,8 @@ namespace NuGetGallery
             IReadOnlyList<string> packageVersions,
             Action<Dictionary<string, string>> addProperties = null)
         {
-            TrackMetric(metricName, packageVersions.Count(), properties => {
+            TrackMetric(metricName, packageVersions.Count(), properties =>
+            {
                 properties.Add(ClientVersion, GetClientVersion());
                 properties.Add(ProtocolVersion, GetProtocolVersion());
                 properties.Add(ClientInformation, GetClientInformation());
@@ -781,7 +782,8 @@ namespace NuGetGallery
 
             var hours = details.SinceCreated.TotalHours;
 
-            TrackMetric(Events.UserPackageDeleteCheckedAfterHours, hours, properties => {
+            TrackMetric(Events.UserPackageDeleteCheckedAfterHours, hours, properties =>
+            {
                 properties.Add(Outcome, outcome.ToString());
                 properties.Add(PackageKey, details.PackageKey.ToString());
                 properties.Add(PackageId, details.PackageId);
@@ -850,7 +852,8 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(deletedBy));
             }
 
-            TrackMetric(Events.AccountDeleteCompleted, 1, properties => {
+            TrackMetric(Events.AccountDeleteCompleted, 1, properties =>
+            {
                 properties.Add(AccountDeletedByRole, BuildArrayProperty(deletedBy.Roles?.Select(role => role.Name) ?? new string[0]));
                 properties.Add(AccountIsSelfDeleted, $"{deletedUser.Key == deletedBy.Key}");
                 properties.Add(AccountDeletedIsOrganization, $"{deletedUser is Organization}");
@@ -864,8 +867,9 @@ namespace NuGetGallery
             {
                 throw new ArgumentNullException(nameof(user));
             }
-           
-            TrackMetric(Events.AccountDeleteRequested, 1, properties => {
+
+            TrackMetric(Events.AccountDeleteRequested, 1, properties =>
+            {
                 properties.Add(CreatedDateForAccountToBeDeleted, $"{user.CreatedUtc}");
             });
         }
@@ -887,7 +891,8 @@ namespace NuGetGallery
             int checkListLength,
             TimeSpan checkListCacheExpireTime)
         {
-            TrackMetric(Events.TyposquattingCheckResultAndTotalTimeInMs, totalTime.TotalMilliseconds, properties => {
+            TrackMetric(Events.TyposquattingCheckResultAndTotalTimeInMs, totalTime.TotalMilliseconds, properties =>
+            {
                 properties.Add(PackageId, packageId);
                 properties.Add(WasUploadBlocked, wasUploadBlocked.ToString());
                 properties.Add(CollisionPackageIds, BuildArrayProperty(collisionPackageIds.Take(TyposquattingCollisionIdsMaxPropertyValue)));
@@ -900,21 +905,24 @@ namespace NuGetGallery
 
         public void TrackMetricForTyposquattingChecklistRetrievalTime(string packageId, TimeSpan checklistRetrievalTime)
         {
-            TrackMetric(Events.TyposquattingChecklistRetrievalTimeInMs, checklistRetrievalTime.TotalMilliseconds, properties => {
+            TrackMetric(Events.TyposquattingChecklistRetrievalTimeInMs, checklistRetrievalTime.TotalMilliseconds, properties =>
+            {
                 properties.Add(PackageId, packageId);
             });
         }
 
         public void TrackMetricForTyposquattingAlgorithmProcessingTime(string packageId, TimeSpan algorithmProcessingTime)
         {
-            TrackMetric(Events.TyposquattingAlgorithmProcessingTimeInMs, algorithmProcessingTime.TotalMilliseconds, properties => {
+            TrackMetric(Events.TyposquattingAlgorithmProcessingTimeInMs, algorithmProcessingTime.TotalMilliseconds, properties =>
+            {
                 properties.Add(PackageId, packageId);
             });
         }
 
         public void TrackMetricForTyposquattingOwnersCheckTime(string packageId, TimeSpan ownersCheckTime)
         {
-            TrackMetric(Events.TyposquattingOwnersCheckTimeInMs, ownersCheckTime.TotalMilliseconds, properties => {
+            TrackMetric(Events.TyposquattingOwnersCheckTimeInMs, ownersCheckTime.TotalMilliseconds, properties =>
+            {
                 properties.Add(PackageId, packageId);
             });
         }
@@ -936,7 +944,8 @@ namespace NuGetGallery
 
         public void TrackMetricForSearchExecutionDuration(string url, TimeSpan duration, bool executionSuccessStatus)
         {
-            TrackMetric(Events.SearchExecutionDuration, duration.TotalMilliseconds, properties => {
+            TrackMetric(Events.SearchExecutionDuration, duration.TotalMilliseconds, properties =>
+            {
                 properties.Add(SearchUrl, url);
                 properties.Add(SearchSuccessExecutionStatus, executionSuccessStatus.ToString());
             });
@@ -944,7 +953,8 @@ namespace NuGetGallery
 
         public void TrackMetricForSearchCircuitBreakerOnBreak(string searchName, Exception exception, HttpResponseMessage responseMessage, string correlationId, string uri)
         {
-            TrackMetric(Events.SearchCircuitBreakerOnBreak, 1, properties => {
+            TrackMetric(Events.SearchCircuitBreakerOnBreak, 1, properties =>
+            {
                 properties.Add(SearchName, searchName);
                 properties.Add(SearchException, exception?.ToString() ?? string.Empty);
                 properties.Add(SearchHttpResponseCode, responseMessage?.StatusCode.ToString() ?? string.Empty);
@@ -955,7 +965,8 @@ namespace NuGetGallery
 
         public void TrackMetricForSearchCircuitBreakerOnReset(string searchName, string correlationId, string uri)
         {
-            TrackMetric(Events.SearchCircuitBreakerOnReset, 1, properties => {
+            TrackMetric(Events.SearchCircuitBreakerOnReset, 1, properties =>
+            {
                 properties.Add(SearchName, searchName);
                 properties.Add(SearchPollyCorrelationId, correlationId);
                 properties.Add(SearchUrl, uri);
@@ -964,7 +975,8 @@ namespace NuGetGallery
 
         public void TrackMetricForSearchOnRetry(string searchName, Exception exception, string correlationId, string uri, string circuitBreakerStatus)
         {
-            TrackMetric(Events.SearchOnRetry, 1, properties => {
+            TrackMetric(Events.SearchOnRetry, 1, properties =>
+            {
                 properties.Add(SearchName, searchName);
                 properties.Add(SearchException, exception?.ToString() ?? string.Empty);
                 properties.Add(SearchPollyCorrelationId, correlationId);
@@ -975,7 +987,8 @@ namespace NuGetGallery
 
         public void TrackMetricForSearchOnTimeout(string searchName, string correlationId, string uri, string circuitBreakerStatus)
         {
-            TrackMetric(Events.SearchOnTimeout, 1, properties => {
+            TrackMetric(Events.SearchOnTimeout, 1, properties =>
+            {
                 properties.Add(SearchName, searchName);
                 properties.Add(SearchPollyCorrelationId, correlationId);
                 properties.Add(SearchUrl, uri);
@@ -993,7 +1006,8 @@ namespace NuGetGallery
             bool hasComments,
             bool hasEmailAddress)
         {
-            TrackMetric(Events.SearchSideBySideFeedback, 1, properties => {
+            TrackMetric(Events.SearchSideBySideFeedback, 1, properties =>
+            {
                 properties.Add(SearchTerm, searchTerm);
                 properties.Add(OldHits, oldHits.ToString());
                 properties.Add(NewHits, newHits.ToString());
@@ -1012,7 +1026,8 @@ namespace NuGetGallery
             bool newSuccess,
             int newHits)
         {
-            TrackMetric(Events.SearchSideBySide, 1, properties => {
+            TrackMetric(Events.SearchSideBySide, 1, properties =>
+            {
                 properties.Add(SearchTerm, searchTerm);
                 properties.Add(OldSuccess, oldSuccess.ToString());
                 properties.Add(OldHits, oldHits.ToString());
@@ -1025,7 +1040,8 @@ namespace NuGetGallery
             int schemaVersion,
             int previewSearchBucket)
         {
-            TrackMetric(Events.ABTestEnrollmentInitialized, 1, properties => {
+            TrackMetric(Events.ABTestEnrollmentInitialized, 1, properties =>
+            {
                 properties.Add(SchemaVersion, schemaVersion.ToString());
                 properties.Add(PreviewSearchBucket, previewSearchBucket.ToString());
             });
@@ -1038,7 +1054,8 @@ namespace NuGetGallery
             int testBucket,
             int testPercentage)
         {
-            TrackMetric(Events.ABTestEvaluated, 1, properties => {
+            TrackMetric(Events.ABTestEvaluated, 1, properties =>
+            {
                 properties.Add(TestName, name);
                 properties.Add(IsActive, isActive.ToString());
                 properties.Add(IsAuthenticated, isAuthenticated.ToString());

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -20,6 +20,7 @@ using Autofac;
 using Autofac.Core;
 using Autofac.Extensions.DependencyInjection;
 using Elmah;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
@@ -93,30 +94,16 @@ namespace NuGetGallery
 
             configuration.SecretInjector = secretInjector;
 
-            // Register the ILoggerFactory and configure it to use AppInsights if an instrumentation key is provided.
-            var instrumentationKey = configuration.Current.AppInsightsInstrumentationKey;
-            if (!string.IsNullOrEmpty(instrumentationKey))
-            {
-                var heartbeatIntervalSeconds = configuration.Current.AppInsightsHeartbeatIntervalSeconds;
-
-                if (heartbeatIntervalSeconds > 0)
-                {
-                    // Configure instrumentation key, heartbeat interval, 
-                    // and register NuGet.Services.Logging.TelemetryContextInitializer.
-                    ApplicationInsights.Initialize(instrumentationKey, TimeSpan.FromSeconds(heartbeatIntervalSeconds));
-                }
-                else
-                {
-                    // Configure instrumentation key,
-                    // and register NuGet.Services.Logging.TelemetryContextInitializer.
-                    ApplicationInsights.Initialize(instrumentationKey);
-                }
-            }
+            // Register the ILoggerFactory and configure AppInsights.
+            var applicationInsightsConfiguration = ConfigureApplicationInsights(
+                configuration.Current,
+                out ITelemetryClient telemetryClient);
 
             var loggerConfiguration = LoggingSetup.CreateDefaultLoggerConfiguration(withConsoleLogger: false);
-            var loggerFactory = LoggingSetup.CreateLoggerFactory(loggerConfiguration);
+            var loggerFactory = LoggingSetup.CreateLoggerFactory(
+                loggerConfiguration,
+                telemetryConfiguration: applicationInsightsConfiguration.TelemetryConfiguration);
 
-            var telemetryClient = TelemetryClientWrapper.Instance;
             builder.RegisterInstance(telemetryClient)
                 .AsSelf()
                 .As<ITelemetryClient>()
@@ -149,7 +136,10 @@ namespace NuGetGallery
             builder.Register(c => configuration.PackageDelete)
                 .As<IPackageDeleteConfiguration>();
 
-            var telemetryService = new TelemetryService(diagnosticsService, telemetryClient);
+            var telemetryService = new TelemetryService(
+                new TraceDiagnosticsSource(nameof(TelemetryService), telemetryClient),
+                telemetryClient);
+
             builder.RegisterInstance(telemetryService)
                 .AsSelf()
                 .As<ITelemetryService>()
@@ -480,6 +470,75 @@ namespace NuGetGallery
 
             ConfigureAutocomplete(builder, configuration);
             builder.Populate(services);
+        }
+
+        private static ApplicationInsightsConfiguration ConfigureApplicationInsights(
+            IAppConfiguration configuration,
+            out ITelemetryClient telemetryClient)
+        {
+            var instrumentationKey = configuration.AppInsightsInstrumentationKey;
+            var heartbeatIntervalSeconds = configuration.AppInsightsHeartbeatIntervalSeconds;
+
+            ApplicationInsightsConfiguration applicationInsightsConfiguration;
+
+            if (heartbeatIntervalSeconds > 0)
+            {
+                applicationInsightsConfiguration = ApplicationInsights.Initialize(
+                    instrumentationKey,
+                    TimeSpan.FromSeconds(heartbeatIntervalSeconds));
+            }
+            else
+            {
+                applicationInsightsConfiguration = ApplicationInsights.Initialize(instrumentationKey);
+            }
+
+            var telemetryConfiguration = applicationInsightsConfiguration.TelemetryConfiguration;
+
+            // Add enrichers
+            telemetryConfiguration.TelemetryInitializers.Add(new DeploymentIdTelemetryEnricher());
+
+            if (configuration.DeploymentLabel != null)
+            {
+                telemetryConfiguration.TelemetryInitializers.Add(new DeploymentLabelEnricher(configuration.DeploymentLabel));
+            }
+
+            telemetryConfiguration.TelemetryInitializers.Add(new ClientInformationTelemetryEnricher());
+
+            // Add processors
+            telemetryConfiguration.TelemetryProcessorChainBuilder.Use(next =>
+            {
+                var processor = new RequestTelemetryProcessor(next);
+
+                processor.SuccessfulResponseCodes.Add(400);
+                processor.SuccessfulResponseCodes.Add(404);
+                processor.SuccessfulResponseCodes.Add(405);
+
+                return processor;
+            });
+
+            telemetryConfiguration.TelemetryProcessorChainBuilder.Use(next => new ClientTelemetryPIIProcessor(next));
+
+            var telemetryClientWrapper = TelemetryClientWrapper.UseTelemetryConfiguration(applicationInsightsConfiguration.TelemetryConfiguration);
+
+            telemetryConfiguration.TelemetryProcessorChainBuilder.Use(
+                next => new ExceptionTelemetryProcessor(next, telemetryClientWrapper.UnderlyingClient));
+
+            // Note: sampling rate must be a factor 100/N where N is a whole number
+            // e.g.: 50 (= 100/2), 33.33 (= 100/3), 25 (= 100/4), ...
+            // https://azure.microsoft.com/en-us/documentation/articles/app-insights-sampling/
+            var instrumentationSamplingPercentage = configuration.AppInsightsSamplingPercentage;
+            if (instrumentationSamplingPercentage > 0 && instrumentationSamplingPercentage < 100)
+            {
+                telemetryConfiguration.TelemetryProcessorChainBuilder.UseSampling(instrumentationSamplingPercentage);
+            }
+
+            telemetryConfiguration.TelemetryProcessorChainBuilder.Build();
+
+            QuietLog.UseTelemetryClient(telemetryClientWrapper);
+
+            telemetryClient = telemetryClientWrapper;
+
+            return applicationInsightsConfiguration;
         }
 
         private void RegisterABTestServices(ContainerBuilder builder)

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -11,14 +11,11 @@ using System.Web.Hosting;
 using System.Web.Http;
 using System.Web.Mvc;
 using Elmah;
-using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Owin;
 using Microsoft.Owin.Logging;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using NuGet.Services.FeatureFlags;
-using NuGet.Services.Logging;
 using NuGetGallery.Authentication;
 using NuGetGallery.Authentication.Providers;
 using NuGetGallery.Authentication.Providers.Cookie;
@@ -74,61 +71,6 @@ namespace NuGetGallery
                     await Task.Delay(ContentObjectService.RefreshInterval, token);
                 }
             });
-
-            // Setup telemetry
-            var instrumentationKey = config.Current.AppInsightsInstrumentationKey;
-            if (!string.IsNullOrEmpty(instrumentationKey))
-            {
-                var heartbeatIntervalSeconds = config.Current.AppInsightsHeartbeatIntervalSeconds;
-
-                if (heartbeatIntervalSeconds > 0)
-                {
-                    // Configure instrumentation key, heartbeat interval, 
-                    // and register NuGet.Services.Logging.TelemetryContextInitializer.
-                    ApplicationInsights.Initialize(instrumentationKey, TimeSpan.FromSeconds(heartbeatIntervalSeconds));
-                }
-                else
-                {
-                    // Configure instrumentation key,
-                    // and register NuGet.Services.Logging.TelemetryContextInitializer.
-                    ApplicationInsights.Initialize(instrumentationKey);
-                }
-
-                // Add enrichers
-                TelemetryConfiguration.Active.TelemetryInitializers.Add(new DeploymentIdTelemetryEnricher());
-                TelemetryConfiguration.Active.TelemetryInitializers.Add(new ClientInformationTelemetryEnricher());
-
-                var telemetryProcessorChainBuilder = TelemetryConfiguration.Active.TelemetryProcessorChainBuilder;
-
-                // Add processors
-                telemetryProcessorChainBuilder.Use(next =>
-                {
-                    var processor = new RequestTelemetryProcessor(next);
-
-                    processor.SuccessfulResponseCodes.Add(400);
-                    processor.SuccessfulResponseCodes.Add(404);
-                    processor.SuccessfulResponseCodes.Add(405);
-
-                    return processor;
-                });
-
-                telemetryProcessorChainBuilder.Use(next => new ClientTelemetryPIIProcessor(next));
-
-                var telemetry = dependencyResolver.GetService<TelemetryClientWrapper>();
-                telemetryProcessorChainBuilder.Use(
-                    next => new ExceptionTelemetryProcessor(next, telemetry.UnderlyingClient));
-
-                // Note: sampling rate must be a factor 100/N where N is a whole number
-                // e.g.: 50 (= 100/2), 33.33 (= 100/3), 25 (= 100/4), ...
-                // https://azure.microsoft.com/en-us/documentation/articles/app-insights-sampling/
-                var instrumentationSamplingPercentage = config.Current.AppInsightsSamplingPercentage;
-                if (instrumentationSamplingPercentage > 0 && instrumentationSamplingPercentage < 100)
-                {
-                    telemetryProcessorChainBuilder.UseSampling(instrumentationSamplingPercentage);
-                }
-
-                telemetryProcessorChainBuilder.Build();
-            }
 
             // Configure logging
             app.SetLoggerFactory(new DiagnosticsLoggerFactory());
@@ -192,7 +134,7 @@ namespace NuGetGallery
                 // Send to AppInsights
                 try
                 {
-                    var telemetryClient = new TelemetryClient();
+                    var telemetryClient = DependencyResolver.Current.GetService<ITelemetryClient>();
                     telemetryClient.TrackException(exArgs.Exception, new Dictionary<string, string>()
                     {
                         {"ExceptionOrigin", "UnobservedTaskException"}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2112,7 +2112,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
@@ -2294,13 +2294,13 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.58.0</Version>
+      <Version>2.61.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/OData/NuGetODataController.cs
+++ b/src/NuGetGallery/OData/NuGetODataController.cs
@@ -8,6 +8,7 @@ using System.Web.Http;
 using System.Web.Http.OData;
 using System.Web.Http.OData.Query;
 using NuGetGallery.Configuration;
+using NuGetGallery.OData.QueryFilter;
 using NuGetGallery.WebApi;
 
 namespace NuGetGallery.OData
@@ -27,7 +28,11 @@ namespace NuGetGallery.OData
         {
             _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+
+            ODataQueryVerifier = ODataQueryVerifier.Build(telemetryService);
         }
+
+        internal ODataQueryVerifier ODataQueryVerifier { get; }
 
         protected virtual HttpContextBase GetTraditionalHttpContext()
         {

--- a/src/NuGetGallery/OData/QueryAllowed/ODataQueryVerifier.cs
+++ b/src/NuGetGallery/OData/QueryAllowed/ODataQueryVerifier.cs
@@ -3,29 +3,40 @@
 
 using System;
 using System.Web.Http.OData.Query;
+using NuGetGallery.Diagnostics;
 
 namespace NuGetGallery.OData.QueryFilter
 {
-    public static class ODataQueryVerifier
+    public sealed class ODataQueryVerifier
     {
         private static Lazy<ODataQueryFilter> _v2GetUpdates =
             new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv2getupdates.json"); }, isThreadSafe: true);
         private static Lazy<ODataQueryFilter> _v2Packages =
-            new Lazy<ODataQueryFilter>(() =>{ return new ODataQueryFilter("apiv2packages.json"); }, isThreadSafe: true);
+            new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv2packages.json"); }, isThreadSafe: true);
         private static Lazy<ODataQueryFilter> _v2Search =
-            new Lazy<ODataQueryFilter>(() =>{ return new ODataQueryFilter("apiv2search.json"); }, isThreadSafe: true);
+            new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv2search.json"); }, isThreadSafe: true);
         private static Lazy<ODataQueryFilter> _v1Packages =
             new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv1packages.json"); }, isThreadSafe: true);
         private static Lazy<ODataQueryFilter> _v1Search =
-            new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv1search.json");}, isThreadSafe: true);
+            new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv1search.json"); }, isThreadSafe: true);
 
-        private static ITelemetryService _telemetryService = new TelemetryService();
+        private readonly ITelemetryService _telemetryService;
+
+        private ODataQueryVerifier(ITelemetryService telemetryService)
+        {
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+        }
+
+        public static ODataQueryVerifier Build(ITelemetryService telemetryService)
+        {
+            return new ODataQueryVerifier(telemetryService);
+        }
 
         #region Filters for ODataV2FeedController
         /// <summary>
         /// The OData query filter for /api/v2/GetUpdates().
         /// </summary>
-        public static ODataQueryFilter V2GetUpdates
+        public ODataQueryFilter V2GetUpdates
         {
             get
             {
@@ -40,7 +51,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <summary>
         /// The OData query filter for /api/v2/Packages.
         /// </summary>
-        public static ODataQueryFilter V2Packages
+        public ODataQueryFilter V2Packages
         {
             get
             {
@@ -55,7 +66,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <summary>
         /// The OData query filter for /api/v2/Search().
         /// </summary>
-        public static ODataQueryFilter V2Search
+        public ODataQueryFilter V2Search
         {
             get
             {
@@ -72,7 +83,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <summary>
         /// The OData query filter for /api/v1/Packages.
         /// </summary>
-        public static ODataQueryFilter V1Packages
+        public ODataQueryFilter V1Packages
         {
             get
             {
@@ -87,7 +98,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <summary>
         /// The OData query filter for /api/v1/Search()
         /// </summary>
-        public static ODataQueryFilter V1Search
+        public ODataQueryFilter V1Search
         {
             get
             {
@@ -109,7 +120,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <param name="isFeatureEnabled">The configuration state for the feature.</param>
         /// <param name="telemetryContext">Information to be used by the telemetry events.</param>
         /// <returns>True if the options are allowed.</returns>
-        public static bool AreODataOptionsAllowed<TEntity>(ODataQueryOptions<TEntity> odataOptions,
+        public bool AreODataOptionsAllowed<TEntity>(ODataQueryOptions<TEntity> odataOptions,
                                                            ODataQueryFilter allowedQueryStructure,
                                                            bool isFeatureEnabled,
                                                            string telemetryContext)
@@ -123,7 +134,8 @@ namespace NuGetGallery.OData.QueryFilter
             }
             catch (Exception ex)
             {
-                _telemetryService.TrackException(ex, properties => {
+                _telemetryService.TrackException(ex, properties =>
+                {
                     properties.Add(TelemetryService.CallContext, $"{telemetryContext}:{nameof(AreODataOptionsAllowed)}");
                     properties.Add(TelemetryService.IsEnabled, $"{isFeatureEnabled}");
                 });

--- a/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
+++ b/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
@@ -43,7 +43,7 @@ namespace GitHubVulnerabilities2Db.Facts
                     GhsaId = "ghsa",
                     Severity = "MODERATE",
                     References = new[] { new SecurityAdvisoryReference { Url = "https://vulnerable" } },
-                    WithdrawnAt = withdrawn ? new DateTime() : (DateTime?)null
+                    WithdrawnAt = withdrawn ? new DateTimeOffset() : (DateTimeOffset?)null
                 };
 
                 PackageVulnerabilityServiceMock
@@ -86,7 +86,7 @@ namespace GitHubVulnerabilities2Db.Facts
                     GhsaId = "ghsa",
                     Severity = "CRITICAL",
                     References = new[] { new SecurityAdvisoryReference { Url = "https://vulnerable" } },
-                    WithdrawnAt = withdrawn ? new DateTime() : (DateTime?)null,
+                    WithdrawnAt = withdrawn ? new DateTimeOffset() : (DateTimeOffset?)null,
                     Vulnerabilities = new ConnectionResponseData<SecurityVulnerability>
                     {
                         Edges = new[]

--- a/tests/NuGetGallery.Facts/Diagnostics/DiagnosticsServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Diagnostics/DiagnosticsServiceFacts.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using Moq;
 using Xunit;
 
 namespace NuGetGallery.Diagnostics
@@ -11,7 +12,12 @@ namespace NuGetGallery.Diagnostics
             [Fact]
             public void RequiresNonNullOrEmptyName()
             {
-                ContractAssert.ThrowsArgNullOrEmpty(s => new DiagnosticsService().GetSource(s), "name");
+                // Arrange
+                var telemetryClient = new Mock<ITelemetryClient>().Object;
+                var diagnosticsService = new DiagnosticsService(telemetryClient);
+
+                // Act and Assert
+                ContractAssert.ThrowsArgNullOrEmpty(s => diagnosticsService.GetSource(s), "name");
             }
         }
     }

--- a/tests/NuGetGallery.Facts/OData/Filter/ODataFilterFacts.cs
+++ b/tests/NuGetGallery.Facts/OData/Filter/ODataFilterFacts.cs
@@ -4,6 +4,7 @@
 using System.Net.Http;
 using System.Web.Http.OData;
 using System.Web.Http.OData.Query;
+using Moq;
 using NuGetGallery.OData.QueryFilter;
 using Xunit;
 
@@ -13,6 +14,14 @@ namespace NuGetGallery.OData.Filter
     {
         const string Host = "https://localhost:8081/";
 
+        private readonly ODataQueryVerifier queryVerifier;
+
+        public ODataFilterFacts()
+        {
+            var telemetryService = new Mock<ITelemetryService>().Object;
+            queryVerifier = ODataQueryVerifier.Build(telemetryService);
+        }
+
         [Theory]
         [InlineData("apiv2getupdates.json")]
         [InlineData("apiv2packages.json")]
@@ -21,19 +30,19 @@ namespace NuGetGallery.OData.Filter
         {
             // Arrange
             var odataOptions = new ODataQueryOptions<V2FeedPackage>(
-                new ODataQueryContext(NuGetODataV2FeedConfig.GetEdmModel(), typeof(V2FeedPackage)), 
+                new ODataQueryContext(NuGetODataV2FeedConfig.GetEdmModel(), typeof(V2FeedPackage)),
                 new HttpRequestMessage(HttpMethod.Get, Host));
 
             var queryFilter = new ODataQueryFilter(apiResourceFileName);
 
             // Act
-            var result = ODataQueryVerifier.AreODataOptionsAllowed(odataOptions, queryFilter, true,"TestContext");
+            var result = queryVerifier.AreODataOptionsAllowed(odataOptions, queryFilter, true, "TestContext");
 
             // Assert
             Assert.True(result, "A request with no OData operators should be allowed.");
         }
 
-        [Theory]  
+        [Theory]
         [InlineData("apiv1packages.json")]
         [InlineData("apiv1search.json")]
         public void ODataNoOperatorsAreAllowedV1(string apiResourceFileName)
@@ -46,7 +55,7 @@ namespace NuGetGallery.OData.Filter
             var queryFilter = new ODataQueryFilter(apiResourceFileName);
 
             // Act
-            var result = ODataQueryVerifier.AreODataOptionsAllowed(odataOptions, queryFilter, true, "TestContext");
+            var result = queryVerifier.AreODataOptionsAllowed(odataOptions, queryFilter, true, "TestContext");
 
             // Assert
             Assert.True(result, "A request with no OData operators should be allowed.");

--- a/tests/NuGetGallery.Facts/Security/TestSecurityPolicyService.cs
+++ b/tests/NuGetGallery.Facts/Security/TestSecurityPolicyService.cs
@@ -72,7 +72,11 @@ namespace NuGetGallery.Security
 
             Configuration = configuration ?? new AppConfiguration();
 
-            Diagnostics = new DiagnosticsService().GetSource(nameof(TestSecurityPolicyService));
+            var telemetryClient = new Mock<ITelemetryClient>().Object;
+
+            Diagnostics = new TraceDiagnosticsSource(
+                nameof(TestSecurityPolicyService),
+                telemetryClient);
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
@@ -450,13 +450,18 @@ namespace NuGetGallery
                 [Fact]
                 public async Task ODataQueryFilterV2Search()
                 {
-                    ODataQueryVerifier.V1Search = GetQueryFilter<V1FeedPackage>(false);
+                    // Arrange
                     var v1Service = GetService("https://localhost:8081/");
+                    v1Service.ODataQueryVerifier.V1Search = GetQueryFilter<V1FeedPackage>(false);
+
+                    // Act
                     var result = (await v1Service.Search(
                        new ODataQueryOptions<V1FeedPackage>(new ODataQueryContext(
                            NuGetODataV1FeedConfig.GetEdmModel(),
                            typeof(V1FeedPackage)),
                            v1Service.Request)));
+
+                    // Assert
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }
@@ -464,13 +469,18 @@ namespace NuGetGallery
                 [Fact]
                 public void ODataQueryFilterV1Packages()
                 {
-                    ODataQueryVerifier.V1Packages = GetQueryFilter<V1FeedPackage>(false);
+                    // Arrange
                     var service = GetService("https://localhost:8081/");
+                    service.ODataQueryVerifier.V1Packages = GetQueryFilter<V1FeedPackage>(false);
+
+                    // Act
                     var result = service.Get(
                        new ODataQueryOptions<V1FeedPackage>(new ODataQueryContext(
                            NuGetODataV1FeedConfig.GetEdmModel(),
                            typeof(V1FeedPackage)),
                            service.Request));
+
+                    // Assert
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }
@@ -1996,14 +2006,19 @@ namespace NuGetGallery
                 [Fact]
                 public void ODataQueryFilterV2FeedGetUpdates()
                 {
-                    ODataQueryVerifier.V2GetUpdates = GetQueryFilter<V2FeedPackage>(false);
+                    // Arrange
                     var v2Service = GetService("https://localhost:8081/");
-                    var result = (v2Service.GetUpdates(
+                    v2Service.ODataQueryVerifier.V2GetUpdates = GetQueryFilter<V2FeedPackage>(false);
+
+                    // Act
+                    var result = v2Service.GetUpdates(
                        new ODataQueryOptions<V2FeedPackage>(
                            new ODataQueryContext(NuGetODataV2FeedConfig.GetEdmModel(),
                            typeof(V2FeedPackage)),
                            v2Service.Request),
-                       "Pid", "Version", false, false));
+                       "Pid", "Version", false, false);
+
+                    // Assert
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }
@@ -2011,13 +2026,18 @@ namespace NuGetGallery
                 [Fact]
                 public async Task ODataQueryFilterV2Search()
                 {
-                    ODataQueryVerifier.V2Search = GetQueryFilter<V2FeedPackage>(false);
+                    // Arrange
                     var v2Service = GetService("https://localhost:8081/");
-                    var result = (await v2Service.Search(
+                    v2Service.ODataQueryVerifier.V2Search = GetQueryFilter<V2FeedPackage>(false);
+
+                    // Act
+                    var result = await v2Service.Search(
                        new ODataQueryOptions<V2FeedPackage>(new ODataQueryContext(
                            NuGetODataV2FeedConfig.GetEdmModel(),
                            typeof(V2FeedPackage)),
-                           v2Service.Request)));
+                           v2Service.Request));
+
+                    // Assert
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }
@@ -2025,13 +2045,18 @@ namespace NuGetGallery
                 [Fact]
                 public async Task ODataQueryFilterV2Packages()
                 {
-                    ODataQueryVerifier.V2Packages = GetQueryFilter<V2FeedPackage>(false);
+                    // Arrange
                     var v2Service = GetService("https://localhost:8081/");
-                    var result = (await v2Service.Get(
+                    v2Service.ODataQueryVerifier.V2Packages = GetQueryFilter<V2FeedPackage>(false);
+
+                    // Act
+                    var result = await v2Service.Get(
                        new ODataQueryOptions<V2FeedPackage>(new ODataQueryContext(
                            NuGetODataV2FeedConfig.GetEdmModel(),
                            typeof(V2FeedPackage)),
-                           v2Service.Request)));
+                           v2Service.Request));
+
+                    // Assert
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }

--- a/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
@@ -81,7 +81,9 @@ namespace NuGetGallery.TestUtils
             UserRepository = new EntityRepository<User>(FakeEntitiesContext);
             RoleRepository = new EntityRepository<Role>(FakeEntitiesContext);
             Auditing = new TestAuditingService();
-            TelemetryService = new TelemetryService();
+            TelemetryService = new TelemetryService(
+                new Mock<IDiagnosticsSource>().Object,
+                new Mock<ITelemetryClient>().Object);
         }
     }
 


### PR DESCRIPTION
This PR updates the Gallery (and the jobs within the solution) to use the new Application Insights initialization logic introduced in ServerCommon 2.60.0 and NuGet.Jobs (current dev branch).

Goal is to move off obsolete AppInsights APIs, such as `TelemetryConfiguration.Active`.

In doing so, some legacy code and static classes required refactoring. Work in progress, but opening the PR already to collect feedback early on.

Also needs to consume a to-be-released update of `NuGet.Services.Logging` ([PR pending](https://github.com/NuGet/ServerCommon/pull/324))