### PR TITLE
[Hotfix] Revert to ServerCommon 2.58.0

### DIFF
--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -107,7 +107,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.3.0-dev-3297551</Version>
+      <Version>4.3.0-dev-3159955</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -64,10 +64,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3297551</Version>
+      <Version>4.3.0-dev-3159955</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -85,10 +85,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3297551</Version>
+      <Version>4.3.0-dev-3159955</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -77,7 +77,7 @@
       <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3297551</Version>
+      <Version>4.3.0-dev-3159955</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -241,16 +241,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -293,10 +293,10 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -96,10 +96,6 @@ namespace NuGetGallery
 
                 // Add enrichers
                 TelemetryConfiguration.Active.TelemetryInitializers.Add(new DeploymentIdTelemetryEnricher());
-                if (config.Current.DeploymentLabel != null)
-                {
-                    TelemetryConfiguration.Active.TelemetryInitializers.Add(new DeploymentLabelEnricher(config.Current.DeploymentLabel));
-                }
                 TelemetryConfiguration.Active.TelemetryInitializers.Add(new ClientInformationTelemetryEnricher());
 
                 var telemetryProcessorChainBuilder = TelemetryConfiguration.Active.TelemetryProcessorChainBuilder;

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2110,7 +2110,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
@@ -2292,13 +2292,13 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.60.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>


### PR DESCRIPTION
Reverting to 2.58.0 of ServerCommon libraries until NuGet.Jobs has pulled in the latest version (2.60.0 or later).

Address https://github.com/NuGet/NuGetGallery/issues/7747.