### PR TITLE
Revert "No longer depend on Obsolete AppInsights APIs"

### DIFF
--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -107,7 +107,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.3.0-dev-3309631</Version>
+      <Version>4.3.0-dev-3159955</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/AccountDeleter/Job.cs
+++ b/src/AccountDeleter/Job.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
+using System.ServiceModel.Configuration;
 using Autofac;
 using Autofac.Core;
 using Microsoft.Extensions.Configuration;
@@ -100,14 +101,14 @@ namespace NuGetGallery.AccountDeleter
                 services.AddTransient<IMessageServiceConfiguration, CoreMessageServiceConfiguration>();
             }
 
-            services.AddScoped<IEmailBuilderFactory, EmailBuilderFactory>();
-            services.AddScoped<ITelemetryClient, TelemetryClientWrapper>(
-                sp => TelemetryClientWrapper.UseTelemetryConfiguration(ApplicationInsightsConfiguration.TelemetryConfiguration));
 
-            ConfigureGalleryServices(services);
+            services.AddScoped<IEmailBuilderFactory, EmailBuilderFactory>();
+            services.AddScoped<ITelemetryClient, TelemetryClientWrapper>();
+
+            ConfigureGalleryServices(services, configurationRoot);
         }
 
-        protected void ConfigureGalleryServices(IServiceCollection services)
+        protected void ConfigureGalleryServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
             if (IsDebugMode)
             {
@@ -126,6 +127,7 @@ namespace NuGetGallery.AccountDeleter
                 services.AddScoped<IDeleteAccountService, DeleteAccountService>();
 
                 services.AddScoped<IUserService, AccountDeleteUserService>();
+                services.AddScoped<ITelemetryClient>(sp => { return TelemetryClientWrapper.Instance; });
                 services.AddScoped<IDiagnosticsService, DiagnosticsService>();
 
                 services.AddScoped<IPackageService, PackageService>();

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -64,10 +64,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3309631</Version>
+      <Version>4.3.0-dev-3159955</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/Program.cs
+++ b/src/DatabaseMigrationTools/Program.cs
@@ -16,7 +16,7 @@ namespace NuGetGallery.DatabaseMigrationTools
             var exitCode = JobRunner.RunOnce(job, args).GetAwaiter().GetResult();
 
             // Have to use Thread.Sleep() and wait for the logger.
-            // Calling "TelemetryChannel.Flush()" on TelemetryConfiguration is not reliable.
+            // "TelemetryConfiguration.Active.TelemetryChannel.Flush()" is not reliable.
             // Hit the issue: https://github.com/Microsoft/ApplicationInsights-dotnet/issues/407
             Thread.Sleep(30000);
 

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -86,10 +86,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3309631</Version>
+      <Version>4.3.0-dev-3159955</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -77,7 +77,7 @@
       <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3309631</Version>
+      <Version>4.3.0-dev-3159955</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -242,16 +242,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery.Services/Diagnostics/DiagnosticsService.cs
+++ b/src/NuGetGallery.Services/Diagnostics/DiagnosticsService.cs
@@ -15,6 +15,11 @@ namespace NuGetGallery.Diagnostics
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
         }
 
+        // Test constructor
+        internal DiagnosticsService() : this(TelemetryClientWrapper.Instance)
+        {
+        }
+
         public IDiagnosticsSource GetSource(string name)
         {
             if (string.IsNullOrEmpty(name))

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -293,10 +293,10 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/Telemetry/QuietLog.cs
+++ b/src/NuGetGallery.Services/Telemetry/QuietLog.cs
@@ -11,12 +11,7 @@ namespace NuGetGallery
 {
     public static class QuietLog
     {
-        private static ITelemetryClient Telemetry;
-
-        public static void UseTelemetryClient(ITelemetryClient telemetryClient)
-        {
-            Telemetry = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
-        }
+        public static ITelemetryClient Telemetry = TelemetryClientWrapper.Instance;
 
         public static void LogHandledException(Exception e)
         {

--- a/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Logging;
 
 namespace NuGetGallery
@@ -19,19 +18,19 @@ namespace NuGetGallery
         private const string TelemetryPropertyEventName = "EventName";
 
         private static readonly Lazy<TelemetryClientWrapper> Singleton
-            = new Lazy<TelemetryClientWrapper>(() => new TelemetryClientWrapper(TelemetryConfiguration));
+            = new Lazy<TelemetryClientWrapper>(() => new TelemetryClientWrapper());
 
-        private static TelemetryConfiguration TelemetryConfiguration;
-
-        public static TelemetryClientWrapper UseTelemetryConfiguration(TelemetryConfiguration configuration)
+        public static TelemetryClientWrapper Instance
         {
-            TelemetryConfiguration = configuration;
-            return Singleton.Value;
+            get
+            {
+                return Singleton.Value;
+            }
         }
 
-        private TelemetryClientWrapper(TelemetryConfiguration telemetryConfiguration)
+        private TelemetryClientWrapper()
         {
-            UnderlyingClient = new TelemetryClient(telemetryConfiguration);
+            UnderlyingClient = new TelemetryClient();
         }
 
         public TelemetryClient UnderlyingClient { get; }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2121,7 +2121,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
@@ -2303,13 +2303,13 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.61.0</Version>
+      <Version>2.58.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/OData/NuGetODataController.cs
+++ b/src/NuGetGallery/OData/NuGetODataController.cs
@@ -8,7 +8,6 @@ using System.Web.Http;
 using System.Web.Http.OData;
 using System.Web.Http.OData.Query;
 using NuGetGallery.Configuration;
-using NuGetGallery.OData.QueryFilter;
 using NuGetGallery.WebApi;
 
 namespace NuGetGallery.OData
@@ -28,11 +27,7 @@ namespace NuGetGallery.OData
         {
             _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
-
-            ODataQueryVerifier = ODataQueryVerifier.Build(telemetryService);
         }
-
-        internal ODataQueryVerifier ODataQueryVerifier { get; }
 
         protected virtual HttpContextBase GetTraditionalHttpContext()
         {

--- a/src/NuGetGallery/OData/QueryAllowed/ODataQueryVerifier.cs
+++ b/src/NuGetGallery/OData/QueryAllowed/ODataQueryVerifier.cs
@@ -3,40 +3,29 @@
 
 using System;
 using System.Web.Http.OData.Query;
-using NuGetGallery.Diagnostics;
 
 namespace NuGetGallery.OData.QueryFilter
 {
-    public sealed class ODataQueryVerifier
+    public static class ODataQueryVerifier
     {
         private static Lazy<ODataQueryFilter> _v2GetUpdates =
             new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv2getupdates.json"); }, isThreadSafe: true);
         private static Lazy<ODataQueryFilter> _v2Packages =
-            new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv2packages.json"); }, isThreadSafe: true);
+            new Lazy<ODataQueryFilter>(() =>{ return new ODataQueryFilter("apiv2packages.json"); }, isThreadSafe: true);
         private static Lazy<ODataQueryFilter> _v2Search =
-            new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv2search.json"); }, isThreadSafe: true);
+            new Lazy<ODataQueryFilter>(() =>{ return new ODataQueryFilter("apiv2search.json"); }, isThreadSafe: true);
         private static Lazy<ODataQueryFilter> _v1Packages =
             new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv1packages.json"); }, isThreadSafe: true);
         private static Lazy<ODataQueryFilter> _v1Search =
-            new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv1search.json"); }, isThreadSafe: true);
+            new Lazy<ODataQueryFilter>(() => { return new ODataQueryFilter("apiv1search.json");}, isThreadSafe: true);
 
-        private readonly ITelemetryService _telemetryService;
-
-        private ODataQueryVerifier(ITelemetryService telemetryService)
-        {
-            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
-        }
-
-        public static ODataQueryVerifier Build(ITelemetryService telemetryService)
-        {
-            return new ODataQueryVerifier(telemetryService);
-        }
+        private static ITelemetryService _telemetryService = new TelemetryService();
 
         #region Filters for ODataV2FeedController
         /// <summary>
         /// The OData query filter for /api/v2/GetUpdates().
         /// </summary>
-        public ODataQueryFilter V2GetUpdates
+        public static ODataQueryFilter V2GetUpdates
         {
             get
             {
@@ -51,7 +40,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <summary>
         /// The OData query filter for /api/v2/Packages.
         /// </summary>
-        public ODataQueryFilter V2Packages
+        public static ODataQueryFilter V2Packages
         {
             get
             {
@@ -66,7 +55,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <summary>
         /// The OData query filter for /api/v2/Search().
         /// </summary>
-        public ODataQueryFilter V2Search
+        public static ODataQueryFilter V2Search
         {
             get
             {
@@ -83,7 +72,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <summary>
         /// The OData query filter for /api/v1/Packages.
         /// </summary>
-        public ODataQueryFilter V1Packages
+        public static ODataQueryFilter V1Packages
         {
             get
             {
@@ -98,7 +87,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <summary>
         /// The OData query filter for /api/v1/Search()
         /// </summary>
-        public ODataQueryFilter V1Search
+        public static ODataQueryFilter V1Search
         {
             get
             {
@@ -120,7 +109,7 @@ namespace NuGetGallery.OData.QueryFilter
         /// <param name="isFeatureEnabled">The configuration state for the feature.</param>
         /// <param name="telemetryContext">Information to be used by the telemetry events.</param>
         /// <returns>True if the options are allowed.</returns>
-        public bool AreODataOptionsAllowed<TEntity>(ODataQueryOptions<TEntity> odataOptions,
+        public static bool AreODataOptionsAllowed<TEntity>(ODataQueryOptions<TEntity> odataOptions,
                                                            ODataQueryFilter allowedQueryStructure,
                                                            bool isFeatureEnabled,
                                                            string telemetryContext)
@@ -134,8 +123,7 @@ namespace NuGetGallery.OData.QueryFilter
             }
             catch (Exception ex)
             {
-                _telemetryService.TrackException(ex, properties =>
-                {
+                _telemetryService.TrackException(ex, properties => {
                     properties.Add(TelemetryService.CallContext, $"{telemetryContext}:{nameof(AreODataOptionsAllowed)}");
                     properties.Add(TelemetryService.IsEnabled, $"{isFeatureEnabled}");
                 });

--- a/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
+++ b/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
@@ -42,7 +42,7 @@ namespace GitHubVulnerabilities2Db.Facts
                     DatabaseId = 1,
                     GhsaId = "ghsa",
                     Severity = "MODERATE",
-                    WithdrawnAt = withdrawn ? new DateTimeOffset() : (DateTimeOffset?)null
+                    WithdrawnAt = withdrawn ? new DateTime() : (DateTime?)null
                 };
 
                 PackageVulnerabilityServiceMock
@@ -84,7 +84,7 @@ namespace GitHubVulnerabilities2Db.Facts
                     DatabaseId = 1,
                     GhsaId = "ghsa",
                     Severity = "CRITICAL",
-                    WithdrawnAt = withdrawn ? new DateTimeOffset() : (DateTimeOffset?)null,
+                    WithdrawnAt = withdrawn ? new DateTime() : (DateTime?)null,
                     Vulnerabilities = new ConnectionResponseData<SecurityVulnerability>
                     {
                         Edges = new[]

--- a/tests/NuGetGallery.Facts/Diagnostics/DiagnosticsServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Diagnostics/DiagnosticsServiceFacts.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-using Moq;
 using Xunit;
 
 namespace NuGetGallery.Diagnostics
@@ -12,12 +11,7 @@ namespace NuGetGallery.Diagnostics
             [Fact]
             public void RequiresNonNullOrEmptyName()
             {
-                // Arrange
-                var telemetryClient = new Mock<ITelemetryClient>().Object;
-                var diagnosticsService = new DiagnosticsService(telemetryClient);
-
-                // Act and Assert
-                ContractAssert.ThrowsArgNullOrEmpty(s => diagnosticsService.GetSource(s), "name");
+                ContractAssert.ThrowsArgNullOrEmpty(s => new DiagnosticsService().GetSource(s), "name");
             }
         }
     }

--- a/tests/NuGetGallery.Facts/OData/Filter/ODataFilterFacts.cs
+++ b/tests/NuGetGallery.Facts/OData/Filter/ODataFilterFacts.cs
@@ -4,7 +4,6 @@
 using System.Net.Http;
 using System.Web.Http.OData;
 using System.Web.Http.OData.Query;
-using Moq;
 using NuGetGallery.OData.QueryFilter;
 using Xunit;
 
@@ -14,14 +13,6 @@ namespace NuGetGallery.OData.Filter
     {
         const string Host = "https://localhost:8081/";
 
-        private readonly ODataQueryVerifier queryVerifier;
-
-        public ODataFilterFacts()
-        {
-            var telemetryService = new Mock<ITelemetryService>().Object;
-            queryVerifier = ODataQueryVerifier.Build(telemetryService);
-        }
-
         [Theory]
         [InlineData("apiv2getupdates.json")]
         [InlineData("apiv2packages.json")]
@@ -30,19 +21,19 @@ namespace NuGetGallery.OData.Filter
         {
             // Arrange
             var odataOptions = new ODataQueryOptions<V2FeedPackage>(
-                new ODataQueryContext(NuGetODataV2FeedConfig.GetEdmModel(), typeof(V2FeedPackage)),
+                new ODataQueryContext(NuGetODataV2FeedConfig.GetEdmModel(), typeof(V2FeedPackage)), 
                 new HttpRequestMessage(HttpMethod.Get, Host));
 
             var queryFilter = new ODataQueryFilter(apiResourceFileName);
 
             // Act
-            var result = queryVerifier.AreODataOptionsAllowed(odataOptions, queryFilter, true, "TestContext");
+            var result = ODataQueryVerifier.AreODataOptionsAllowed(odataOptions, queryFilter, true,"TestContext");
 
             // Assert
             Assert.True(result, "A request with no OData operators should be allowed.");
         }
 
-        [Theory]
+        [Theory]  
         [InlineData("apiv1packages.json")]
         [InlineData("apiv1search.json")]
         public void ODataNoOperatorsAreAllowedV1(string apiResourceFileName)
@@ -55,7 +46,7 @@ namespace NuGetGallery.OData.Filter
             var queryFilter = new ODataQueryFilter(apiResourceFileName);
 
             // Act
-            var result = queryVerifier.AreODataOptionsAllowed(odataOptions, queryFilter, true, "TestContext");
+            var result = ODataQueryVerifier.AreODataOptionsAllowed(odataOptions, queryFilter, true, "TestContext");
 
             // Assert
             Assert.True(result, "A request with no OData operators should be allowed.");

--- a/tests/NuGetGallery.Facts/Security/TestSecurityPolicyService.cs
+++ b/tests/NuGetGallery.Facts/Security/TestSecurityPolicyService.cs
@@ -72,11 +72,7 @@ namespace NuGetGallery.Security
 
             Configuration = configuration ?? new AppConfiguration();
 
-            var telemetryClient = new Mock<ITelemetryClient>().Object;
-
-            Diagnostics = new TraceDiagnosticsSource(
-                nameof(TestSecurityPolicyService),
-                telemetryClient);
+            Diagnostics = new DiagnosticsService().GetSource(nameof(TestSecurityPolicyService));
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FeedServiceFacts.cs
@@ -450,18 +450,13 @@ namespace NuGetGallery
                 [Fact]
                 public async Task ODataQueryFilterV2Search()
                 {
-                    // Arrange
+                    ODataQueryVerifier.V1Search = GetQueryFilter<V1FeedPackage>(false);
                     var v1Service = GetService("https://localhost:8081/");
-                    v1Service.ODataQueryVerifier.V1Search = GetQueryFilter<V1FeedPackage>(false);
-
-                    // Act
                     var result = (await v1Service.Search(
                        new ODataQueryOptions<V1FeedPackage>(new ODataQueryContext(
                            NuGetODataV1FeedConfig.GetEdmModel(),
                            typeof(V1FeedPackage)),
                            v1Service.Request)));
-
-                    // Assert
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }
@@ -469,18 +464,13 @@ namespace NuGetGallery
                 [Fact]
                 public void ODataQueryFilterV1Packages()
                 {
-                    // Arrange
+                    ODataQueryVerifier.V1Packages = GetQueryFilter<V1FeedPackage>(false);
                     var service = GetService("https://localhost:8081/");
-                    service.ODataQueryVerifier.V1Packages = GetQueryFilter<V1FeedPackage>(false);
-
-                    // Act
                     var result = service.Get(
                        new ODataQueryOptions<V1FeedPackage>(new ODataQueryContext(
                            NuGetODataV1FeedConfig.GetEdmModel(),
                            typeof(V1FeedPackage)),
                            service.Request));
-
-                    // Assert
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }
@@ -2006,19 +1996,14 @@ namespace NuGetGallery
                 [Fact]
                 public void ODataQueryFilterV2FeedGetUpdates()
                 {
-                    // Arrange
+                    ODataQueryVerifier.V2GetUpdates = GetQueryFilter<V2FeedPackage>(false);
                     var v2Service = GetService("https://localhost:8081/");
-                    v2Service.ODataQueryVerifier.V2GetUpdates = GetQueryFilter<V2FeedPackage>(false);
-
-                    // Act
-                    var result = v2Service.GetUpdates(
+                    var result = (v2Service.GetUpdates(
                        new ODataQueryOptions<V2FeedPackage>(
                            new ODataQueryContext(NuGetODataV2FeedConfig.GetEdmModel(),
                            typeof(V2FeedPackage)),
                            v2Service.Request),
-                       "Pid", "Version", false, false);
-
-                    // Assert
+                       "Pid", "Version", false, false));
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }
@@ -2026,18 +2011,13 @@ namespace NuGetGallery
                 [Fact]
                 public async Task ODataQueryFilterV2Search()
                 {
-                    // Arrange
+                    ODataQueryVerifier.V2Search = GetQueryFilter<V2FeedPackage>(false);
                     var v2Service = GetService("https://localhost:8081/");
-                    v2Service.ODataQueryVerifier.V2Search = GetQueryFilter<V2FeedPackage>(false);
-
-                    // Act
-                    var result = await v2Service.Search(
+                    var result = (await v2Service.Search(
                        new ODataQueryOptions<V2FeedPackage>(new ODataQueryContext(
                            NuGetODataV2FeedConfig.GetEdmModel(),
                            typeof(V2FeedPackage)),
-                           v2Service.Request));
-
-                    // Assert
+                           v2Service.Request)));
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }
@@ -2045,18 +2025,13 @@ namespace NuGetGallery
                 [Fact]
                 public async Task ODataQueryFilterV2Packages()
                 {
-                    // Arrange
+                    ODataQueryVerifier.V2Packages = GetQueryFilter<V2FeedPackage>(false);
                     var v2Service = GetService("https://localhost:8081/");
-                    v2Service.ODataQueryVerifier.V2Packages = GetQueryFilter<V2FeedPackage>(false);
-
-                    // Act
-                    var result = await v2Service.Get(
+                    var result = (await v2Service.Get(
                        new ODataQueryOptions<V2FeedPackage>(new ODataQueryContext(
                            NuGetODataV2FeedConfig.GetEdmModel(),
                            typeof(V2FeedPackage)),
-                           v2Service.Request));
-
-                    // Assert
+                           v2Service.Request)));
                     var badRequest = result as BadRequestErrorMessageResult;
                     Assert.NotNull(badRequest);
                 }

--- a/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
@@ -81,9 +81,7 @@ namespace NuGetGallery.TestUtils
             UserRepository = new EntityRepository<User>(FakeEntitiesContext);
             RoleRepository = new EntityRepository<Role>(FakeEntitiesContext);
             Auditing = new TestAuditingService();
-            TelemetryService = new TelemetryService(
-                new Mock<IDiagnosticsSource>().Object,
-                new Mock<ITelemetryClient>().Object);
+            TelemetryService = new TelemetryService();
         }
     }
 


### PR DESCRIPTION
This reverts commit bb5a8eb46483c383c9c4e42317b9a62bb6f27856. The PR that pushed this in was https://github.com/NuGet/NuGetGallery/pull/7745.