### PR TITLE
Remove an unnecessary SQL query

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -827,8 +827,9 @@ namespace NuGetGallery
                 return HttpNotFound();
             }
 
+            var readme = await _readMeService.GetReadMeHtmlAsync(package);
             var deprecation = _deprecationService.GetDeprecationByPackage(package);
-            var model = _displayPackageViewModelFactory.Create(package, currentUser, deprecation, await _readMeService.GetReadMeHtmlAsync(package));
+            var model = _displayPackageViewModelFactory.Create(package, packages, currentUser, deprecation, readme);
 
             model.ValidatingTooLong = _validationService.IsValidatingTooLong(package);
             model.PackageValidationIssues = _validationService.GetLatestPackageValidationIssues(package);
@@ -1637,7 +1638,7 @@ namespace NuGetGallery
                 return HttpForbidden();
             }
 
-            var model = _deletePackageViewModelFactory.Create(package, currentUser, DeleteReasons);
+            var model = _deletePackageViewModelFactory.Create(package, packages, currentUser, DeleteReasons);
 
             // Fetch all versions of the package with symbols.
             var versionsWithSymbols = packages

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
@@ -18,12 +18,12 @@ namespace NuGetGallery
 
         public DeletePackageViewModel Create(
             Package package,
-            IReadOnlyCollection<Package> packageRegistration,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
             IReadOnlyList<ReportPackageReason> reasons)
         {
             var viewModel = new DeletePackageViewModel();
-            return Setup(viewModel, package, packageRegistration, currentUser, reasons);
+            return Setup(viewModel, package, allVersions, currentUser, reasons);
         }
 
         public DeletePackageViewModel Setup(

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
@@ -18,20 +18,22 @@ namespace NuGetGallery
 
         public DeletePackageViewModel Create(
             Package package,
+            IReadOnlyCollection<Package> packageRegistration,
             User currentUser,
             IReadOnlyList<ReportPackageReason> reasons)
         {
             var viewModel = new DeletePackageViewModel();
-            return Setup(viewModel, package, currentUser, reasons);
+            return Setup(viewModel, package, packageRegistration, currentUser, reasons);
         }
 
         public DeletePackageViewModel Setup(
             DeletePackageViewModel viewModel,
             Package package,
+            IReadOnlyCollection<Package> packageRegistration,
             User currentUser,
             IReadOnlyList<ReportPackageReason> reasons)
         {
-            _displayPackageViewModelFactory.Setup(viewModel, package, currentUser, deprecation: null, readmeResult: null);
+            _displayPackageViewModelFactory.Setup(viewModel, package, packageRegistration, currentUser, deprecation: null, readmeResult: null);
             return SetupInternal(viewModel, package, reasons);
         }
 

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
@@ -29,11 +29,11 @@ namespace NuGetGallery
         public DeletePackageViewModel Setup(
             DeletePackageViewModel viewModel,
             Package package,
-            IReadOnlyCollection<Package> packageRegistration,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
             IReadOnlyList<ReportPackageReason> reasons)
         {
-            _displayPackageViewModelFactory.Setup(viewModel, package, packageRegistration, currentUser, deprecation: null, readmeResult: null);
+            _displayPackageViewModelFactory.Setup(viewModel, package, allVersions, currentUser, deprecation: null, readmeResult: null);
             return SetupInternal(viewModel, package, reasons);
         }
 

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -20,7 +20,7 @@ namespace NuGetGallery
 
         public DisplayPackageViewModel Create(
             Package package,
-            IReadOnlyCollection<Package> packageRegistration,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
             PackageDeprecation deprecation,
             RenderedReadMeResult readmeResult)
@@ -29,7 +29,7 @@ namespace NuGetGallery
             return Setup(
                 viewModel,
                 package,
-                packageRegistration,
+                allVersions,
                 currentUser,
                 deprecation,
                 readmeResult);
@@ -38,20 +38,20 @@ namespace NuGetGallery
         public DisplayPackageViewModel Setup(
             DisplayPackageViewModel viewModel,
             Package package,
-            IReadOnlyCollection<Package> packageRegistration,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
             PackageDeprecation deprecation,
             RenderedReadMeResult readmeResult)
         {
             _listPackageItemViewModelFactory.Setup(viewModel, package, currentUser);
             SetupCommon(viewModel, package, pushedBy: null);
-            return SetupInternal(viewModel, package, packageRegistration, currentUser, deprecation, readmeResult);
+            return SetupInternal(viewModel, package, allVersions, currentUser, deprecation, readmeResult);
         }
 
         private DisplayPackageViewModel SetupInternal(
             DisplayPackageViewModel viewModel,
             Package package,
-            IReadOnlyCollection<Package> packageRegistration,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
             PackageDeprecation deprecation,
             RenderedReadMeResult readmeResult)
@@ -64,7 +64,7 @@ namespace NuGetGallery
 
             viewModel.Dependencies = new DependencySetsViewModel(package.Dependencies);
 
-            var packageHistory = packageRegistration
+            var packageHistory = allVersions
                 .OrderByDescending(p => new NuGetVersion(p.Version))
                 .ToList();
             var pushedByCache = new Dictionary<User, string>();

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -20,6 +20,7 @@ namespace NuGetGallery
 
         public DisplayPackageViewModel Create(
             Package package,
+            IReadOnlyCollection<Package> packageRegistration,
             User currentUser,
             PackageDeprecation deprecation,
             RenderedReadMeResult readmeResult)
@@ -28,6 +29,7 @@ namespace NuGetGallery
             return Setup(
                 viewModel,
                 package,
+                packageRegistration,
                 currentUser,
                 deprecation,
                 readmeResult);
@@ -36,18 +38,20 @@ namespace NuGetGallery
         public DisplayPackageViewModel Setup(
             DisplayPackageViewModel viewModel,
             Package package,
+            IReadOnlyCollection<Package> packageRegistration,
             User currentUser,
             PackageDeprecation deprecation,
             RenderedReadMeResult readmeResult)
         {
             _listPackageItemViewModelFactory.Setup(viewModel, package, currentUser);
             SetupCommon(viewModel, package, pushedBy: null);
-            return SetupInternal(viewModel, package, currentUser, deprecation, readmeResult);
+            return SetupInternal(viewModel, package, packageRegistration, currentUser, deprecation, readmeResult);
         }
 
         private DisplayPackageViewModel SetupInternal(
             DisplayPackageViewModel viewModel,
             Package package,
+            IReadOnlyCollection<Package> packageRegistration,
             User currentUser,
             PackageDeprecation deprecation,
             RenderedReadMeResult readmeResult)
@@ -60,9 +64,7 @@ namespace NuGetGallery
 
             viewModel.Dependencies = new DependencySetsViewModel(package.Dependencies);
 
-            var packageHistory = package
-                .PackageRegistration
-                .Packages
+            var packageHistory = packageRegistration
                 .OrderByDescending(p => new NuGetVersion(p.Version))
                 .ToList();
             var pushedByCache = new Dictionary<User, string>();

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -422,6 +422,10 @@ namespace NuGetGallery
                 };
 
                 packageService
+                    .Setup(p => p.FindPackagesById(id, It.IsAny<PackageDeprecationFieldsToInclude>()))
+                    .Returns(new List<Package> { package });
+
+                packageService
                     .Setup(p => p.FilterExactPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<string>()))
                     .Returns(package);
 

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -831,11 +831,11 @@ namespace NuGetGallery.ViewModels
             PackageDeprecation deprecation = null,
             string readmeHtml = null)
         {
-            var packages = (IReadOnlyCollection<Package>)package.PackageRegistration.Packages;
+            var allVersions = (IReadOnlyCollection<Package>)package.PackageRegistration.Packages;
 
             return new DisplayPackageViewModelFactory(Mock.Of<IIconUrlProvider>()).Create(
                 package,
-                packages,
+                allVersions,
                 currentUser: currentUser,
                 deprecation: deprecation,
                 readmeResult: new RenderedReadMeResult { Content = readmeHtml });

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -732,11 +732,8 @@ namespace NuGetGallery.ViewModels
             [MemberData(nameof(Data))]
             public void ReturnsExpectedUser(Package package, User currentUser, string expected)
             {
-                var packages = (IReadOnlyCollection<Package>)package.PackageRegistration.Packages;
-
                 var model = CreateDisplayPackageViewModel(
                     package,
-                    packages,
                     currentUser,
                     deprecation: null,
                     readmeHtml: null);

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -732,7 +732,14 @@ namespace NuGetGallery.ViewModels
             [MemberData(nameof(Data))]
             public void ReturnsExpectedUser(Package package, User currentUser, string expected)
             {
-                var model = CreateDisplayPackageViewModel(package, currentUser, deprecation: null, readmeHtml: null);
+                var packages = (IReadOnlyCollection<Package>)package.PackageRegistration.Packages;
+
+                var model = CreateDisplayPackageViewModel(
+                    package,
+                    packages,
+                    currentUser,
+                    deprecation: null,
+                    readmeHtml: null);
 
                 Assert.Equal(expected, model.PushedBy);
             }
@@ -825,10 +832,17 @@ namespace NuGetGallery.ViewModels
             Assert.Null(versionModel.CustomMessage);
         }
 
-        private static DisplayPackageViewModel CreateDisplayPackageViewModel(Package package, User currentUser = null, PackageDeprecation deprecation = null, string readmeHtml = null)
+        private static DisplayPackageViewModel CreateDisplayPackageViewModel(
+            Package package,
+            User currentUser = null,
+            PackageDeprecation deprecation = null,
+            string readmeHtml = null)
         {
+            var packages = (IReadOnlyCollection<Package>)package.PackageRegistration.Packages;
+
             return new DisplayPackageViewModelFactory(Mock.Of<IIconUrlProvider>()).Create(
                 package,
+                packages,
                 currentUser: currentUser,
                 deprecation: deprecation,
                 readmeResult: new RenderedReadMeResult { Content = readmeHtml });

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -732,11 +732,7 @@ namespace NuGetGallery.ViewModels
             [MemberData(nameof(Data))]
             public void ReturnsExpectedUser(Package package, User currentUser, string expected)
             {
-                var model = CreateDisplayPackageViewModel(
-                    package,
-                    currentUser,
-                    deprecation: null,
-                    readmeHtml: null);
+                var model = CreateDisplayPackageViewModel(package, currentUser, deprecation: null, readmeHtml: null);
 
                 Assert.Equal(expected, model.PushedBy);
             }


### PR DESCRIPTION
The display package page gets data through lazy loading. One such lazily loaded queries was a repeat:

1. Eagerly load all versions of a package: https://github.com/NuGet/NuGetGallery/blob/90f8fbea00217db2e5d918e140621c0aea0ca12d/src/NuGetGallery/Controllers/PackagesController.cs#L800
1. Lazily load all versions of a package: https://github.com/NuGet/NuGetGallery/blob/90f8fbea00217db2e5d918e140621c0aea0ca12d/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs#L63

These queries are particularly expensive when a package many versions. Given that the second query is redundant, I piped the data from the first query down to the view model factory. 

Test build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3350351
Test release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=541799

Part of https://github.com/NuGet/Engineering/issues/2910