### PR TITLE
Improve the display package page's performance

### DIFF
--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NuGet.Services.Entities;
 using NuGet.Services.FeatureFlags;
@@ -79,12 +80,22 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(registration));
             }
 
+            return IsManageDeprecationEnabled(user, registration.Packages);
+        }
+
+        public bool IsManageDeprecationEnabled(User user, IEnumerable<Package> allVersions)
+        {
+            if (allVersions == null)
+            {
+                throw new ArgumentNullException(nameof(allVersions));
+            }
+
             if (!_client.IsEnabled(ManageDeprecationFeatureName, user, defaultValue: false))
             {
                 return false;
             }
 
-            return registration.Packages.Count() < _manageDeprecationForManyVersionsThreshold 
+            return allVersions.Count() < _manageDeprecationForManyVersionsThreshold
                 || _client.IsEnabled(ManageDeprecationForManyVersionsFeatureName, user, defaultValue: true);
         }
 

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Services.Entities;
+using System.Collections.Generic;
 
 namespace NuGetGallery
 {
@@ -42,9 +43,13 @@ namespace NuGetGallery
 
         /// <summary>
         /// Whether or not the user can manage their package's deprecation state.
-        /// If disabled, 
         /// </summary>
         bool IsManageDeprecationEnabled(User user, PackageRegistration registration);
+
+        /// <summary>
+        /// Whether or not the user can manage their package's deprecation state.
+        /// </summary>
+        bool IsManageDeprecationEnabled(User user, IEnumerable<Package> allVersions);
 
         /// <summary>
         /// Whether or not the user can manage their package's deprecation state through the API.

--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -26,6 +26,12 @@ namespace NuGetGallery
             PackageDeprecationFieldsToInclude deprecationFields = PackageDeprecationFieldsToInclude.None);
 
         /// <summary>
+        /// Returns all packages with an <see cref="Package.Id"/> of <paramref name="id"/>.
+        /// Includes the <see cref="Package.PackageRegistration"/> fields based on <paramref name="includePackageRegistration"/>.
+        /// </summary>
+        IReadOnlyCollection<Package> FindPackagesById(string id, bool includePackageRegistration);
+
+        /// <summary>
         /// Gets the package with the given ID and version when exists;
         /// otherwise gets the latest package version for the given package ID matching the provided constraints.
         /// </summary>

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -142,6 +142,27 @@ namespace NuGetGallery
             return GetPackagesByIdQueryable(id, deprecationFields).ToList();
         }
 
+        public virtual IReadOnlyCollection<Package> FindPackagesById(
+            string id,
+            bool includePackageRegistration)
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            var packages = GetPackagesByIdQueryable(
+                id,
+                includeLicenseReports: false,
+                includePackageRegistration: includePackageRegistration,
+                includeUser: false,
+                includeSymbolPackages: false,
+                includeDeprecation: false,
+                includeDeprecationRelationships: false);
+
+            return packages.ToList();
+        }
+
         public virtual Package FindPackageByIdAndVersion(
             string id,
             string version,

--- a/src/NuGetGallery.Services/Permissions/ActionRequiringEntityPermissions.cs
+++ b/src/NuGetGallery.Services/Permissions/ActionRequiringEntityPermissions.cs
@@ -76,6 +76,9 @@ namespace NuGetGallery
 
             if (currentUser != null)
             {
+                // Lazily load the current user's organizations from the database.
+                // TODO: Entity Framework performs n+1 SQL queries, where n is the number of organizations the user is in.
+                // See: https://github.com/NuGet/NuGetGallery/issues/7794
                 possibleAccountsOnBehalfOf.AddRange(currentUser.Organizations.Select(o => o.Organization));
             }
 

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
@@ -18,20 +18,29 @@ namespace NuGetGallery
 
         public DeletePackageViewModel Create(
             Package package,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
             IReadOnlyList<ReportPackageReason> reasons)
         {
             var viewModel = new DeletePackageViewModel();
-            return Setup(viewModel, package, currentUser, reasons);
+            return Setup(viewModel, package, allVersions, currentUser, reasons);
         }
 
         public DeletePackageViewModel Setup(
             DeletePackageViewModel viewModel,
             Package package,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
             IReadOnlyList<ReportPackageReason> reasons)
         {
-            _displayPackageViewModelFactory.Setup(viewModel, package, currentUser, deprecation: null, readmeResult: null);
+            _displayPackageViewModelFactory.Setup(
+                viewModel,
+                package,
+                allVersions,
+                currentUser,
+                packageKeyToDeprecation: null,
+                readmeResult: null);
+
             return SetupInternal(viewModel, package, reasons);
         }
 

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -20,49 +20,52 @@ namespace NuGetGallery
 
         public DisplayPackageViewModel Create(
             Package package,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
-            PackageDeprecation deprecation,
+            IReadOnlyDictionary<int, PackageDeprecation> packageKeyToDeprecation,
             RenderedReadMeResult readmeResult)
         {
             var viewModel = new DisplayPackageViewModel();
             return Setup(
                 viewModel,
                 package,
+                allVersions,
                 currentUser,
-                deprecation,
+                packageKeyToDeprecation,
                 readmeResult);
         }
 
         public DisplayPackageViewModel Setup(
             DisplayPackageViewModel viewModel,
             Package package,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
-            PackageDeprecation deprecation,
+            IReadOnlyDictionary<int, PackageDeprecation> packageKeyToDeprecation,
             RenderedReadMeResult readmeResult)
         {
             _listPackageItemViewModelFactory.Setup(viewModel, package, currentUser);
-            SetupCommon(viewModel, package, pushedBy: null);
-            return SetupInternal(viewModel, package, currentUser, deprecation, readmeResult);
+            SetupCommon(viewModel, package, pushedBy: null, packageKeyToDeprecation: packageKeyToDeprecation);
+            return SetupInternal(viewModel, package, allVersions, currentUser, packageKeyToDeprecation, readmeResult);
         }
 
         private DisplayPackageViewModel SetupInternal(
             DisplayPackageViewModel viewModel,
             Package package,
+            IReadOnlyCollection<Package> allVersions,
             User currentUser,
-            PackageDeprecation deprecation,
+            IReadOnlyDictionary<int, PackageDeprecation> packageKeyToDeprecation,
             RenderedReadMeResult readmeResult)
         {
+            var dependencies = package.Dependencies.ToList();
+
+            viewModel.Dependencies = new DependencySetsViewModel(dependencies);
             viewModel.HasSemVer2Version = viewModel.NuGetVersion.IsSemVer2;
-            viewModel.HasSemVer2Dependency = package.Dependencies.ToList()
+            viewModel.HasSemVer2Dependency = dependencies
                 .Where(pd => !string.IsNullOrEmpty(pd.VersionSpec))
                 .Select(pd => VersionRange.Parse(pd.VersionSpec))
                 .Any(p => (p.HasUpperBound && p.MaxVersion.IsSemVer2) || (p.HasLowerBound && p.MinVersion.IsSemVer2));
 
-            viewModel.Dependencies = new DependencySetsViewModel(package.Dependencies);
-
-            var packageHistory = package
-                .PackageRegistration
-                .Packages
+            var packageHistory = allVersions
                 .OrderByDescending(p => new NuGetVersion(p.Version))
                 .ToList();
             var pushedByCache = new Dictionary<User, string>();
@@ -72,7 +75,7 @@ namespace NuGetGallery
                     {
                         var vm = new DisplayPackageViewModel();
                         _listPackageItemViewModelFactory.Setup(vm, p, currentUser);
-                        return SetupCommon(vm, p, GetPushedBy(p, currentUser, pushedByCache));
+                        return SetupCommon(vm, p, GetPushedBy(p, currentUser, pushedByCache), packageKeyToDeprecation);
                     })
                 .ToList();
 
@@ -92,11 +95,13 @@ namespace NuGetGallery
                 viewModel.TotalDaysSinceCreated = Convert.ToInt32(Math.Max(1, Math.Round((DateTime.UtcNow - packageHistory.Min(p => p.Created)).TotalDays)));
                 viewModel.DownloadsPerDay = viewModel.TotalDownloadCount / viewModel.TotalDaysSinceCreated; // for the package
                 viewModel.DownloadsPerDayLabel = viewModel.DownloadsPerDay < 1 ? "<1" : viewModel.DownloadsPerDay.ToNuGetNumberString();
+
+                // Lazily load the package types from the database.
                 viewModel.IsDotnetToolPackageType = package.PackageTypes.Any(e => e.Name.Equals("DotnetTool", StringComparison.OrdinalIgnoreCase));
                 viewModel.IsDotnetNewTemplatePackageType = package.PackageTypes.Any(e => e.Name.Equals("Template", StringComparison.OrdinalIgnoreCase));
             }
 
-            if (deprecation != null)
+            if (packageKeyToDeprecation != null && packageKeyToDeprecation.TryGetValue(package.Key, out var deprecation))
             {
                 viewModel.AlternatePackageId = deprecation.AlternatePackageRegistration?.Id;
 
@@ -122,7 +127,8 @@ namespace NuGetGallery
         private DisplayPackageViewModel SetupCommon(
             DisplayPackageViewModel viewModel,
             Package package,
-            string pushedBy)
+            string pushedBy,
+            IReadOnlyDictionary<int, PackageDeprecation> packageKeyToDeprecation)
         {
             viewModel.NuGetVersion = NuGetVersion.Parse(NuGetVersionFormatter.ToFullString(package.Version));
             viewModel.Copyright = package.Copyright;
@@ -156,8 +162,14 @@ namespace NuGetGallery
                 }
             }
 
-            viewModel.DeprecationStatus = package.Deprecations.SingleOrDefault()?.Status
-                ?? PackageDeprecationStatus.NotDeprecated;
+            if (packageKeyToDeprecation != null && packageKeyToDeprecation.TryGetValue(package.Key, out var deprecation))
+            {
+                viewModel.DeprecationStatus = deprecation.Status;
+            }
+            else
+            {
+                viewModel.DeprecationStatus = PackageDeprecationStatus.NotDeprecated;
+            }
 
             return viewModel;
         }

--- a/src/NuGetGallery/Services/IPackageDeprecationService.cs
+++ b/src/NuGetGallery/Services/IPackageDeprecationService.cs
@@ -24,6 +24,6 @@ namespace NuGetGallery
             string customMessage,
             User user);
 
-        PackageDeprecation GetDeprecationByPackage(Package package);
+        IReadOnlyList<PackageDeprecation> GetDeprecationsById(string id);
     }
 }

--- a/src/NuGetGallery/Services/PackageDeprecationService.cs
+++ b/src/NuGetGallery/Services/PackageDeprecationService.cs
@@ -126,12 +126,13 @@ namespace NuGetGallery
             }
         }
 
-        public PackageDeprecation GetDeprecationByPackage(Package package)
+        public IReadOnlyList<PackageDeprecation> GetDeprecationsById(string id)
         {
             return _entitiesContext.Deprecations
                 .Include(d => d.AlternatePackage.PackageRegistration)
                 .Include(d => d.AlternatePackageRegistration)
-                .SingleOrDefault(d => d.PackageKey == package.Key);
+                .Where(d => d.Package.PackageRegistration.Id == id)
+                .ToList();
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/FeatureFlagServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FeatureFlagServiceFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Moq;
 using NuGet.Services.Entities;
 using NuGet.Services.FeatureFlags;
@@ -54,7 +55,21 @@ namespace NuGetGallery
 
                 // Act & Assert
                 Assert.Throws<ArgumentNullException>(
-                    () => service.IsManageDeprecationEnabled(user, null));
+                    () => service.IsManageDeprecationEnabled(user, registration: null));
+            }
+
+            [Fact]
+            public void WhenAllVersionsNull_ThrowsArgumentNullException()
+            {
+                // Arrange
+                var user = new User();
+
+                var clientMock = new Mock<IFeatureFlagClient>(MockBehavior.Strict);
+                var service = new FeatureFlagService(clientMock.Object);
+
+                // Act & Assert
+                Assert.Throws<ArgumentNullException>(
+                    () => service.IsManageDeprecationEnabled(user, allVersions: null));
             }
 
             [Fact]
@@ -63,6 +78,7 @@ namespace NuGetGallery
                 // Arrange
                 var user = new User();
                 var registration = new PackageRegistration();
+                var allVersions = new List<Package>();
 
                 var clientMock = new Mock<IFeatureFlagClient>();
                 clientMock
@@ -71,11 +87,9 @@ namespace NuGetGallery
 
                 var service = new FeatureFlagService(clientMock.Object);
 
-                // Act
-                var result = service.IsManageDeprecationEnabled(user, registration);
-
-                // Assert
-                Assert.True(result);
+                // Act & Assert
+                Assert.True(service.IsManageDeprecationEnabled(user, registration));
+                Assert.True(service.IsManageDeprecationEnabled(user, allVersions));
             }
 
             [Theory]
@@ -86,11 +100,15 @@ namespace NuGetGallery
             {
                 // Arrange
                 var user = new User();
+                var allVersions = new List<Package>();
                 var registration = new PackageRegistration();
+
                 for (var i = 0; i < 1000; i++)
                 {
-                    registration.Packages.Add(new Package { Key = i });
+                    allVersions.Add(new Package { Key = i });
                 }
+
+                registration.Packages = allVersions;
 
                 var clientMock = new Mock<IFeatureFlagClient>();
                 clientMock
@@ -103,11 +121,9 @@ namespace NuGetGallery
 
                 var service = new FeatureFlagService(clientMock.Object);
 
-                // Act
-                var result = service.IsManageDeprecationEnabled(user, registration);
-
-                // Assert
-                Assert.Equal(isManyVersionsEnabled, result);
+                // Act & Assert
+                Assert.Equal(isManyVersionsEnabled, service.IsManageDeprecationEnabled(user, registration));
+                Assert.Equal(isManyVersionsEnabled, service.IsManageDeprecationEnabled(user, allVersions));
             }
         }
     }

--- a/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
@@ -307,61 +307,43 @@ namespace NuGetGallery.Services
             public void GetsDeprecationOfPackage()
             {
                 // Arrange
-                var key = 190304;
-                var package = new Package
-                {
-                    Key = key
-                };
-
                 var differentDeprecation = new PackageDeprecation
                 {
-                    PackageKey = 9925
-                };
-
-                var matchingDeprecation = new PackageDeprecation
-                {
-                    PackageKey = key
-                };
-
-                var context = GetFakeContext();
-                context.Deprecations.AddRange(
-                    new[] { differentDeprecation, matchingDeprecation });
-
-                // Act
-                var deprecation = Get<PackageDeprecationService>()
-                    .GetDeprecationByPackage(package);
-
-                // Assert
-                Assert.Equal(matchingDeprecation, deprecation);
-            }
-
-            [Fact]
-            public void ThrowsIfMultipleDeprecationsOfPackage()
-            {
-                // Arrange
-                var key = 190304;
-                var package = new Package
-                {
-                    Key = key
+                    Package = new Package
+                    {
+                        PackageRegistration = new PackageRegistration {  Id = "Bar" }
+                    }
                 };
 
                 var matchingDeprecation1 = new PackageDeprecation
                 {
-                    PackageKey = key
+                    Package = new Package
+                    {
+                        PackageRegistration = new PackageRegistration { Id = "Foo" }
+                    }
                 };
 
                 var matchingDeprecation2 = new PackageDeprecation
                 {
-                    PackageKey = key
+                    Package = new Package
+                    {
+                        PackageRegistration = new PackageRegistration { Id = "Foo" }
+                    }
                 };
 
                 var context = GetFakeContext();
                 context.Deprecations.AddRange(
-                    new[] { matchingDeprecation1, matchingDeprecation2 });
+                    new[] { differentDeprecation, matchingDeprecation1, matchingDeprecation2 });
 
-                // Act / Assert
-                Assert.Throws<InvalidOperationException>(
-                    () => Get<PackageDeprecationService>().GetDeprecationByPackage(package));
+                var target = Get<PackageDeprecationService>();
+
+                // Act
+                var result = target.GetDeprecationsById("Foo");
+
+                // Assert
+                Assert.Equal(2, result.Count);
+                Assert.Equal(matchingDeprecation1, result[0]);
+                Assert.Equal(matchingDeprecation2, result[1]);
             }
         }
     }

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -58,7 +58,7 @@ namespace NuGetGallery.ViewModels
                 }
             };
 
-            var model = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
             Assert.Equal(expectedKind, model.RepositoryType);
             Assert.Equal(expectedUrl, model.RepositoryUrl);
         }
@@ -100,7 +100,7 @@ namespace NuGetGallery.ViewModels
                 }
             };
 
-            var model = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
             Assert.Equal(expected, model.ProjectUrl);
         }
 
@@ -130,7 +130,7 @@ namespace NuGetGallery.ViewModels
                 }
             };
 
-            var model = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
             Assert.Equal(expected, model.LicenseUrl);
         }
 
@@ -149,7 +149,7 @@ namespace NuGetGallery.ViewModels
                 }
             };
 
-            var packageViewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var packageViewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
             Assert.Equal(new string[] { "l1", "l2", "l3", "l4", "l5" }, packageViewModel.LicenseNames);
         }
 
@@ -177,7 +177,7 @@ namespace NuGetGallery.ViewModels
                     new Package { Version = "1.0.10", PackageRegistration = package.PackageRegistration }
                 };
 
-            var packageVersions = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null)
+            var packageVersions = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null)
                 .PackageVersions.ToList();
 
             // Descending
@@ -229,7 +229,7 @@ namespace NuGetGallery.ViewModels
                 });
             }
 
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Descending
             Assert.NotNull(viewModel.LatestSymbolsPackage);
@@ -267,7 +267,7 @@ namespace NuGetGallery.ViewModels
 
             package.SymbolPackages = symbolPackageList;
 
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             Assert.Equal(symbolPackageList[0], viewModel.LatestSymbolsPackage);
         }
@@ -305,7 +305,7 @@ namespace NuGetGallery.ViewModels
                 };
 
             // Act
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Assert
             Assert.Equal(daysSinceFirstPackageCreated, viewModel.TotalDaysSinceCreated);
@@ -334,7 +334,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package };
 
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Act
             var label = viewModel.DownloadsPerDayLabel;
@@ -366,7 +366,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package };
 
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Act
             var label = viewModel.DownloadsPerDayLabel;
@@ -414,7 +414,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package, otherPackage };
 
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Act
             var hasNewerPrerelease = viewModel.HasNewerPrerelease;
@@ -461,7 +461,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package, otherPackage };
 
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Act
             var hasNewerRelease = viewModel.HasNewerRelease;
@@ -500,7 +500,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package, otherPackage };
 
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Act
             var hasNewerPrerelease = viewModel.HasNewerPrerelease;
@@ -540,7 +540,7 @@ namespace NuGetGallery.ViewModels
 
             package.PackageRegistration.Packages = new[] { package, otherPackage };
 
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Act
             var hasNewerRelease = viewModel.HasNewerRelease;
@@ -558,7 +558,7 @@ namespace NuGetGallery.ViewModels
             var package = CreateTestPackage("1.0.0", dependencyVersion: versionSpec);
 
             // Act
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Assert
             Assert.False(viewModel.HasSemVer2Dependency);
@@ -574,7 +574,7 @@ namespace NuGetGallery.ViewModels
             var package = CreateTestPackage("1.0.0", dependencyVersion: versionSpec);
 
             // Act
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Assert
             Assert.True(viewModel.HasSemVer2Dependency);
@@ -590,7 +590,7 @@ namespace NuGetGallery.ViewModels
             var package = CreateTestPackage("1.0.0", dependencyVersion: versionSpec);
 
             // Act
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Assert
             Assert.False(viewModel.HasSemVer2Dependency);
@@ -606,7 +606,7 @@ namespace NuGetGallery.ViewModels
             var package = CreateTestPackage(version);
 
             // Act
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Assert
             Assert.False(viewModel.HasSemVer2Version);
@@ -622,7 +622,7 @@ namespace NuGetGallery.ViewModels
             var package = CreateTestPackage(version);
 
             // Act
-            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: null, readmeHtml: null);
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
 
             // Assert
             Assert.True(viewModel.HasSemVer2Version);
@@ -632,6 +632,7 @@ namespace NuGetGallery.ViewModels
         {
             var package = new Package
             {
+                Key = 123,
                 Version = version,
                 PackageRegistration = new PackageRegistration
                 {
@@ -732,7 +733,7 @@ namespace NuGetGallery.ViewModels
             [MemberData(nameof(Data))]
             public void ReturnsExpectedUser(Package package, User currentUser, string expected)
             {
-                var model = CreateDisplayPackageViewModel(package, currentUser, deprecation: null, readmeHtml: null);
+                var model = CreateDisplayPackageViewModel(package, currentUser, packageKeyToDeprecation: null, readmeHtml: null);
 
                 Assert.Equal(expected, model.PushedBy);
             }
@@ -754,7 +755,8 @@ namespace NuGetGallery.ViewModels
             // Arrange
             var deprecation = new PackageDeprecation
             {
-                CustomMessage = "hello"
+                Status = status,
+                CustomMessage = "hello",
             };
 
             var alternateRegistrationId = "alternateRegistrationId";
@@ -788,15 +790,17 @@ namespace NuGetGallery.ViewModels
 
             var package = CreateTestPackage("1.0.0");
 
-            var linkedDeprecation = new PackageDeprecation
+            var packageKeyToDeprecation = new Dictionary<int, PackageDeprecation>
             {
-                Status = status
+                { 123, deprecation }
             };
 
-            package.Deprecations.Add(linkedDeprecation);
-
             // Act
-            var model = CreateDisplayPackageViewModel(package, currentUser: null, deprecation: deprecation, readmeHtml: null);
+            var model = CreateDisplayPackageViewModel(
+                package,
+                currentUser: null,
+                packageKeyToDeprecation: packageKeyToDeprecation,
+                readmeHtml: null);
 
             // Assert
             Assert.Equal(status, model.DeprecationStatus);
@@ -825,12 +829,19 @@ namespace NuGetGallery.ViewModels
             Assert.Null(versionModel.CustomMessage);
         }
 
-        private static DisplayPackageViewModel CreateDisplayPackageViewModel(Package package, User currentUser = null, PackageDeprecation deprecation = null, string readmeHtml = null)
+        private static DisplayPackageViewModel CreateDisplayPackageViewModel(
+            Package package,
+            User currentUser = null,
+            Dictionary<int, PackageDeprecation> packageKeyToDeprecation = null,
+            string readmeHtml = null)
         {
+            var allVersions = (IReadOnlyCollection<Package>)package.PackageRegistration.Packages;
+
             return new DisplayPackageViewModelFactory(Mock.Of<IIconUrlProvider>()).Create(
                 package,
+                allVersions,
                 currentUser: currentUser,
-                deprecation: deprecation,
+                packageKeyToDeprecation: packageKeyToDeprecation,
                 readmeResult: new RenderedReadMeResult { Content = readmeHtml });
         }
     }


### PR DESCRIPTION
## Introduction

This change improves the display package page's performance by optimizing its SQL queries:

1. The first SQL query gets the metadata for all versions of the package, including their deprecations. Our telemetry shows this query is particularly expensive. I've simplified this query.
1. I reduced the number of lazily loaded SQL queries.

Part of https://github.com/NuGet/Engineering/issues/2910.
I will validate this change using this [test plan](https://microsoft.sharepoint.com/teams/NuGet/_layouts/15/Doc.aspx?sourcedoc={15b3fddd-11c7-4f67-8f84-456297b3b279}&action=edit&wd=target%28BugBash.one%7Ce898229f-c60d-49f9-8c4a-1906ea8efd76%2FDisplay%20package%20page%20performance%20improvements%7C63ebcec6-9f14-4f20-ab2f-39a73e1b045d%2F%29&wdorigin=703).
See [postmortem #303385](https://icm.ad.msft.net/imp/v3/incidents/postmortem/303385) to learn about motivations for this change.

## Results

I load tested the current display package page (the "baseline") and this change (the "treatment"). The load test ran for 5 minutes using "expensive" traffic captured during incidents. I ran each load test twice to ensure the gallery cloud service and database were "warm". Results:

Test | Request count | Exceptions | Max SQL queries per request | Average Duration (s) | 99 % duration (s) | Max duration (s) | Max DTU | Max Gallery CPU
---- | ---------------- | ------------ | ----------------------------- | ---------------------- | -------------------- | ------------------- | ---------- | ------------------
Baseline |  7,596 | 0 | 9 | 5.074 | 7.026 | 9.282 |  25% | 78%
Treatment | 18,226 | 0 | 9 | 1.582 | 3.78 | 5.82 | 15% | 97%

Takeaways:

* ⚠Gallery CPU increased. This is likely because the database is no longer the bottleneck. I'm not too concerned by this as we have autoscaling 
* Request duration performance has improved. Requests were 68.8% faster on average and 46.2% faster at the 99th percentile.
* Database DTU decreased by 10%

<details>
<summary>Results dump</summary>

Baseline release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=550687
Baseline perf test 1: [LINK](https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-cloudloadtest-web.hub-loadtest-test?_a=summary&runId=9c11b02c-ae85-457f-aea7-583c06a033d4&name=nuget-gallery-perf.jmx&definitionId=ecebeb3b-4a7a-4992-9091-d24962688de8&definitionType=jMeter)
Baseline perf test 2: [LINK](https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-cloudloadtest-web.hub-loadtest-test?_a=summary&runId=8fa2a813-710a-4f11-bd95-05a0d4ac5a22&name=nuget-gallery-perf.jmx&definitionId=2020221c-7da0-4667-a199-ce9f7cea38da&definitionType=jMeter)

Treatment build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3381244
Treatment release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=552513
Treatment perf test 1: [LINK](https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-cloudloadtest-web.hub-loadtest-test?_a=summary&runId=a1465d27-86b8-4f41-b0a3-f8a2f4093a81&name=nuget-gallery-perf.jmx&definitionId=a206e723-ed05-4019-a343-be96c9fd2694&definitionType=jMeter)
Treatment perf test 2: [LINK](https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-cloudloadtest-web.hub-loadtest-test?_a=summary&runId=5f8395cf-36d3-4b8d-8f14-e476a3537082&name=nuget-gallery-perf.jmx&definitionId=c25b5694-5c08-483b-a27e-f5bebedcd41a&definitionType=jMeter)

```
// Baseline #2
requests
| where timestamp > todatetime("1/14/2020, 11:15:00.000 PM") and timestamp < todatetime("1/14/2020, 11:25:30.000 PM")
| extend CloudDeploymentId_ = tostring(customDimensions.CloudDeploymentId)
| where CloudDeploymentId_ == "207fc935d47e46c5962e92d262931556" 
| where name == "GET packages/DisplayPackage"
| summarize count(), avg(duration/1000), percentiles(duration/1000, 99), max(duration/1000)  //by bin(timestamp, 10s)

// Treatment #2
requests
| where timestamp > todatetime('2020-01-15T23:10:00Z') and timestamp < todatetime('2020-01-15T23:30:00Z') 
| extend CloudDeploymentId_ = tostring(customDimensions.CloudDeploymentId)
| where CloudDeploymentId_ == "987d6561696b4b6d8718d9d18820b8cf" 
| where name == "GET packages/DisplayPackage"
| summarize count(), avg(duration/1000), percentiles(duration/1000, 99), max(duration/1000)  //by bin(timestamp, 10s)
```
</details>