### PR TITLE
Functional test script update to wait for the service to start up after the deployment

### DIFF
--- a/tests/Scripts/RunTestScripts.ps1
+++ b/tests/Scripts/RunTestScripts.ps1
@@ -13,6 +13,56 @@ Write-Host $fullDivider
 
 $failedTests = New-Object System.Collections.ArrayList
 
+Function Wait-ForServiceStart($MaxWaitSeconds) {
+    $configurationFile = $env:ConfigurationFilePath
+    if ($null -eq $configurationFile) {
+        Write-Error "Configuration file path environment variable is not specified"
+        return $false;
+    }
+    if (-not (Test-Path $configurationFile)) {
+        Write-Error "Missing configuration file: $configurationFile"
+        return $false
+    }
+    $configuration = Get-Content $configurationFile | ConvertFrom-Json;
+    if ($null -eq $configuration.Slot) {
+        Write-Error "`"Slot`" property was not found in the test configuration object: $configurationFile"
+        return $false
+    }
+    $baseUrlPropertyName = if ($configuration.Slot -eq "staging") { "StagingBaseUrl" } else { "ProductionBaseUrl" }
+    if ($null -eq $configuration.$baseUrlPropertyName) {
+        Write-Error "`"$($baseUrlPropertyName)`" property was not found in the test configuration object: $configurationFile"
+        return $false
+    }
+
+    $galleryUrl = $configuration.$baseUrlPropertyName
+    $response = $null
+    Write-Host "$(Get-Date -Format s) Sleeping before querying the service";
+    Start-Sleep -Seconds 120
+    Write-Host "$(Get-Date -Format s) Waiting until service ($galleryUrl) responds with non-502"
+    $start = Get-Date
+    $maxWait = New-TimeSpan -Seconds $MaxWaitSeconds
+    do
+    {
+        if ($null -ne $response) {
+            Start-Sleep -Seconds 5
+        }
+        $response = try { Invoke-WebRequest -Uri $galleryUrl -Method Get -UseBasicParsing } catch [System.Net.WebException] {$_.Exception.Response}
+        if ($response.StatusCode -eq 502) {
+            $elapsed = (Get-Date) - $start
+            if ($elapsed -ge $maxWait) {
+                Write-Error "$(Get-Date -Format s) Service start timeout expired"
+                return $false
+            } else {
+                Write-Host "$(Get-Date -Format s) Still waiting for the service to stop responding with 502 after $elapsed"
+            }
+        } else {
+            Write-Host "$(Get-Date -Format s) Got a $($response.StatusCode) response";
+        }
+    } while($response.StatusCode -eq 502)
+
+    return $true;
+}
+
 Function Output-Job {
     [CmdletBinding()]
     param(
@@ -39,6 +89,11 @@ Function Output-Job {
         }
     }
     Remove-Job $job | Out-Host
+}
+
+$serviceAvailable = Wait-ForServiceStart -MaxWaitSeconds 300
+if (-not $serviceAvailable) {
+    exit 1;
 }
 
 $finished = $false


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2863

App service deployment reports success way before the service initialization completes successfully and is able to serve requests. This breaks our tests that encounter 502 responses and fail.
This change adds a delay and a response test to the test run script to make sure we run tests against the working service.