### PR TITLE
Make deprecation reasons have consistent punctuation

### DIFF
--- a/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
@@ -46,7 +46,7 @@
         <div class="form-group unbolded-label">
             <label>
                 <input name="hasCriticalBugs" type="checkbox" value="true" data-bind="checked: hasCriticalBugs" />
-                This package has <b>critical bugs</b> that make it unusable.
+                This package has <b>critical bugs</b> that make it unusable
             </label>
         </div>
         <div class="form-group unbolded-label">


### PR DESCRIPTION
The punctuation on the deprecation reasons are inconsistent:

![image](https://user-images.githubusercontent.com/737941/72563053-b3ef2980-3861-11ea-81fb-ad6c74314a77.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/7811