### PR TITLE
Format package URLs in descriptions

### DIFF
--- a/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
+++ b/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
@@ -63,7 +63,7 @@ namespace NuGetGallery.Configuration
         /// </summary>
         /// <param name="useHttps">If true, the root will be returned in HTTPS form, otherwise, HTTP.</param>
         /// <returns></returns>
-        public virtual string GetSiteRoot(bool useHttps)
+        public string GetSiteRoot(bool useHttps)
         {
             return useHttps ? _httpsSiteRootThunk.Value : _httpSiteRootThunk.Value;
         }

--- a/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
+++ b/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
@@ -63,7 +63,7 @@ namespace NuGetGallery.Configuration
         /// </summary>
         /// <param name="useHttps">If true, the root will be returned in HTTPS form, otherwise, HTTP.</param>
         /// <returns></returns>
-        public string GetSiteRoot(bool useHttps)
+        public virtual string GetSiteRoot(bool useHttps)
         {
             return useHttps ? _httpsSiteRootThunk.Value : _httpSiteRootThunk.Value;
         }

--- a/src/NuGetGallery/Helpers/HtmlExtensions.cs
+++ b/src/NuGetGallery/Helpers/HtmlExtensions.cs
@@ -82,7 +82,16 @@ namespace NuGetGallery.Helpers
 
                 if (PackageHelper.TryPrepareUrlForRendering(trimmedAnchorValue, out string formattedUri))
                 {
-                    return $"<a href=\"{formattedUri}\" rel=\"nofollow\">{formattedUri}</a>" + trimmedEntityValue;
+                    string anchorText = formattedUri;
+
+                    // Format links to NuGet packages
+                    Match packageMatch = RegexEx.MatchWithTimeout(formattedUri, @"((http|https):\/\/www.nuget.org\/packages\/(?<name>[\w.-]+)\/?$)", RegexOptions.IgnoreCase);
+                    if (packageMatch != null && packageMatch.Groups["name"].Success)
+                    {
+                        anchorText = packageMatch.Groups["name"].Value;
+                    }
+
+                    return $"<a href=\"{formattedUri}\" rel=\"nofollow\">{anchorText}</a>" + trimmedEntityValue;
                 }
 
                 return match.Value;

--- a/src/NuGetGallery/Helpers/HtmlExtensions.cs
+++ b/src/NuGetGallery/Helpers/HtmlExtensions.cs
@@ -86,7 +86,7 @@ namespace NuGetGallery.Helpers
                     string anchorText = formattedUri;
                     string siteRoot = configurationService.GetSiteRoot(useHttps: true);
                     // Format links to NuGet packages
-                    Match packageMatch = RegexEx.MatchWithTimeout(formattedUri, $@"({Regex.Escape(siteRoot)}\/packages\/(?<name>[^\/]+(\/[0-9a-zA-Z-.]+)?)\/?$)", RegexOptions.IgnoreCase);
+                    Match packageMatch = RegexEx.MatchWithTimeout(formattedUri, $@"({Regex.Escape(siteRoot)}\/packages\/(?<name>\w+([_.-]\w+)*(\/[0-9a-zA-Z-.]+)?)\/?$)", RegexOptions.IgnoreCase);
                     if (packageMatch != null && packageMatch.Groups["name"].Success)
                     {
                         anchorText = packageMatch.Groups["name"].Value;

--- a/src/NuGetGallery/Helpers/HtmlExtensions.cs
+++ b/src/NuGetGallery/Helpers/HtmlExtensions.cs
@@ -85,7 +85,7 @@ namespace NuGetGallery.Helpers
                     string anchorText = formattedUri;
 
                     // Format links to NuGet packages
-                    Match packageMatch = RegexEx.MatchWithTimeout(formattedUri, @"((http|https):\/\/www.nuget.org\/packages\/(?<name>[\w.-]+)\/?$)", RegexOptions.IgnoreCase);
+                    Match packageMatch = RegexEx.MatchWithTimeout(formattedUri, @"((http|https):\/\/www.nuget.org\/packages\/(?<name>[^\/]+(\/[0-9a-zA-Z-.]+)?)\/?$)", RegexOptions.IgnoreCase);
                     if (packageMatch != null && packageMatch.Groups["name"].Success)
                     {
                         anchorText = packageMatch.Groups["name"].Value;

--- a/src/NuGetGallery/Helpers/HtmlExtensions.cs
+++ b/src/NuGetGallery/Helpers/HtmlExtensions.cs
@@ -86,7 +86,7 @@ namespace NuGetGallery.Helpers
                     string anchorText = formattedUri;
                     string siteRoot = configurationService.GetSiteRoot(useHttps: true);
                     // Format links to NuGet packages
-                    Match packageMatch = RegexEx.MatchWithTimeout(formattedUri, $@"({Regex.Escape(siteRoot)}packages\/(?<name>[^\/]+(\/[0-9a-zA-Z-.]+)?)\/?$)", RegexOptions.IgnoreCase);
+                    Match packageMatch = RegexEx.MatchWithTimeout(formattedUri, $@"({Regex.Escape(siteRoot)}\/packages\/(?<name>[^\/]+(\/[0-9a-zA-Z-.]+)?)\/?$)", RegexOptions.IgnoreCase);
                     if (packageMatch != null && packageMatch.Groups["name"].Success)
                     {
                         anchorText = packageMatch.Groups["name"].Value;

--- a/src/NuGetGallery/Helpers/RegexEx.cs
+++ b/src/NuGetGallery/Helpers/RegexEx.cs
@@ -25,5 +25,20 @@ namespace NuGetGallery.Helpers
                 return input;
             }
         }
+
+        public static Match MatchWithTimeout(
+            string input,
+            string pattern,
+            RegexOptions options)
+        {
+            try
+            {
+                return Regex.Match(input, pattern, options, Timeout);
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                return null;
+            }
+        }
     }
 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -219,7 +219,7 @@
 
             @if (!Model.Deleted && !String.IsNullOrWhiteSpace(Model.Description))
             {
-                <p>@Html.PreFormattedText(Model.Description)</p>
+                <p>@Html.PreFormattedText(Model.Description, Config)</p>
             }
 
             @if (Model.Validating)
@@ -347,7 +347,7 @@
                     @ViewHelpers.AlertWarning(
                         @<text>
                             <strong>The symbols for this package have not been indexed yet.</strong> They are not available
-                            for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete. 
+                            for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
                             Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
 
                         @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
@@ -470,7 +470,7 @@
                 {
                     <h2>Release Notes</h2>
 
-                    <p>@Html.PreFormattedText(Model.ReleaseNotes)</p>
+                    <p>@Html.PreFormattedText(Model.ReleaseNotes, Config)</p>
                 }
 
                 if (Model.Dependencies.DependencySets == null)
@@ -582,7 +582,7 @@
                             </tbody>
                         </table>
                         <p>
-                            Read more about the GitHub Usage information on 
+                            Read more about the GitHub Usage information on
 
                             <a href="https://docs.microsoft.com/en-us/nuget/consume-packages/finding-and-choosing-packages#evaluating-packages" title="Read more about the GitHub Usage information">our documentation</a>.
                         </p>

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
@@ -63,7 +63,7 @@
             @if (!string.IsNullOrEmpty(Model.CustomMessage))
             {
                 <b>Additional Details</b>
-                <p>@Html.PreFormattedText(Model.CustomMessage)</p>
+                <p>@Html.PreFormattedText(Model.CustomMessage, Config)</p>
             }
         </div>
     </div>

--- a/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
@@ -19,11 +19,12 @@ namespace NuGetGallery.Helpers
             public void ConvertsNewLinesToBrTags()
             {
                 // Arrange
+                var config = CreateConfiguration();
                 var htmlHelper = CreateHtmlHelper(new ViewDataDictionary());
                 var input = "first line\nsecond line";
 
                 // Act
-                var output = htmlHelper.PreFormattedText(input);
+                var output = htmlHelper.PreFormattedText(input, config);
 
                 // Assert
                 var html = output.ToHtmlString();
@@ -34,11 +35,12 @@ namespace NuGetGallery.Helpers
             public void ConvertsSpacesToNbsp()
             {
                 // Arrange
+                var config = CreateConfiguration();
                 var htmlHelper = CreateHtmlHelper(new ViewDataDictionary());
                 var input = "Five spaces:     END";
 
                 // Act
-                var output = htmlHelper.PreFormattedText(input);
+                var output = htmlHelper.PreFormattedText(input, config);
 
                 // Assert
                 var html = output.ToHtmlString();
@@ -49,11 +51,12 @@ namespace NuGetGallery.Helpers
             public void EncodesHtml()
             {
                 // Arrange
+                var config = CreateConfiguration();
                 var htmlHelper = CreateHtmlHelper(new ViewDataDictionary());
                 var input = "<script>alert('foo!')</script>";
 
                 // Act
-                var output = htmlHelper.PreFormattedText(input);
+                var output = htmlHelper.PreFormattedText(input, config);
 
                 // Assert
                 var html = output.ToHtmlString();
@@ -85,10 +88,11 @@ namespace NuGetGallery.Helpers
             public void ConvertsUrlsToLinks(string input, string expected)
             {
                 // Arrange
+                var config = CreateConfiguration();
                 var htmlHelper = CreateHtmlHelper(new ViewDataDictionary());
 
                 // Act
-                var output = htmlHelper.PreFormattedText(input);
+                var output = htmlHelper.PreFormattedText(input, config);
 
                 // Assert
                 var html = output.ToHtmlString();
@@ -116,10 +120,11 @@ namespace NuGetGallery.Helpers
             public void ConvertsPackageUrlsToLinksWithShortText(string input, string expected)
             {
                 // Arrange
+                var config = CreateConfiguration();
                 var htmlHelper = CreateHtmlHelper(new ViewDataDictionary());
 
                 // Act
-                var output = htmlHelper.PreFormattedText(input);
+                var output = htmlHelper.PreFormattedText(input, config);
 
                 // Assert
                 var html = output.ToHtmlString();
@@ -132,29 +137,27 @@ namespace NuGetGallery.Helpers
         /// </summary>
         private static HtmlHelper CreateHtmlHelper(ViewDataDictionary vd)
         {
-            var appConfigurationMock = new Mock<ConfigurationService>();
-            appConfigurationMock.Setup(c => c.GetSiteRoot(true)).Returns("https://www.nuget.org");
-
-            var httpContextMock = new Mock<HttpContextBase>();
-            httpContextMock
-                .Setup(c => c.GetService(typeof(ConfigurationService)))
-                .Returns(appConfigurationMock.Object);
-
             var mockViewContext = new Mock<ViewContext>(
                 new ControllerContext(
-                    httpContextMock.Object,
+                    new Mock<HttpContextBase>().Object,
                     new RouteData(),
                     new Mock<ControllerBase>().Object),
                 new Mock<IView>().Object,
                 vd,
                 new TempDataDictionary(),
                 new StringWriter());
-            mockViewContext.Setup(c => c.HttpContext).Returns(httpContextMock.Object);
 
             var mockViewDataContainer = new Mock<IViewDataContainer>();
             mockViewDataContainer.Setup(v => v.ViewData).Returns(vd);
 
             return new HtmlHelper(mockViewContext.Object, mockViewDataContainer.Object);
+        }
+
+        private static IGalleryConfigurationService CreateConfiguration()
+        {
+            var appConfigurationMock = new Mock<IGalleryConfigurationService>();
+            appConfigurationMock.Setup(c => c.GetSiteRoot(true)).Returns("https://www.nuget.org/");
+            return appConfigurationMock.Object;
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
@@ -156,7 +156,7 @@ namespace NuGetGallery.Helpers
         private static IGalleryConfigurationService CreateConfiguration()
         {
             var appConfigurationMock = new Mock<IGalleryConfigurationService>();
-            appConfigurationMock.Setup(c => c.GetSiteRoot(true)).Returns("https://www.nuget.org/");
+            appConfigurationMock.Setup(c => c.GetSiteRoot(true)).Returns("https://www.nuget.org");
             return appConfigurationMock.Object;
         }
     }

--- a/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
@@ -96,10 +96,10 @@ namespace NuGetGallery.Helpers
 
             [Theory]
             [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage.", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage\" rel=\"nofollow\">WindowsAzure.Storage</a>.")]
+            [InlineData("MY PACKAGE IS HTTPS://WWW.NUGET.ORG/PACKAGES/WINDOWSAZURE.STORAGE.", "MY PACKAGE IS <a href=\"https://www.nuget.org/PACKAGES/WINDOWSAZURE.STORAGE\" rel=\"nofollow\">WINDOWSAZURE.STORAGE</a>.")]
             [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage/!", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>!")]
             [InlineData("My package is http://www.nuget.org/packages/WindowsAzure.Storage/", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>")]
             [InlineData("My package is http://www.nuget.org/packages/WindowsAzure.Storage/sub/path/", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/sub/path/\" rel=\"nofollow\">https://www.nuget.org/packages/WindowsAzure.Storage/sub/path/</a>")]
-            [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage/packages.", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/packages\" rel=\"nofollow\">https://www.nuget.org/packages/WindowsAzure.Storage/packages</a>.")]
             [InlineData("My package is http://www.nuget.org/packages/WindowsAzure.Storage/?foo&bar=2#a", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/?foo&amp;bar=2#a\" rel=\"nofollow\">https://www.nuget.org/packages/WindowsAzure.Storage/?foo&amp;bar=2#a</a>")]
             [InlineData("My package is http://www.nuget.org/packages/WindowsAzure.Storage/?foo[]=a", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/?foo\" rel=\"nofollow\">https://www.nuget.org/packages/WindowsAzure.Storage/?foo</a>[]=a")]
             [InlineData("http://www.nuget.org/packages/WindowsAzure.Storage is my package.", "<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage\" rel=\"nofollow\">WindowsAzure.Storage</a> is my package.")]
@@ -109,6 +109,8 @@ namespace NuGetGallery.Helpers
             [InlineData("(http://www.nuget.org/packages/WindowsAzure.Storage/) is my package.", "(<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>) is my package.")]
             [InlineData("http://www.nuget.org/packages/WindowsAzure.Storage/; is my package.", "<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>; is my package.")]
             [InlineData("http://www.nuget.org/packages/WindowsAzure.Storage/- is my package.", "<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>- is my package.")]
+            [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1.", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1\" rel=\"nofollow\">WindowsAzure.Storage/9.3.1</a>.")]
+            [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1/.", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1/\" rel=\"nofollow\">WindowsAzure.Storage/9.3.1</a>.")]
             public void ConvertsPackageUrlsToLinksWithShortText(string input, string expected)
             {
                 // Arrange

--- a/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
@@ -115,6 +115,7 @@ namespace NuGetGallery.Helpers
             [InlineData("http://www.nuget.org/packages/WindowsAzure.Storage/; is my package.", "<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>; is my package.")]
             [InlineData("http://www.nuget.org/packages/WindowsAzure.Storage/- is my package.", "<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>- is my package.")]
             [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1.", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1\" rel=\"nofollow\">WindowsAzure.Storage/9.3.1</a>.")]
+            [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1-preview.7", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1-preview.7\" rel=\"nofollow\">WindowsAzure.Storage/9.3.1-preview.7</a>")]
             [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1/.", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/9.3.1/\" rel=\"nofollow\">WindowsAzure.Storage/9.3.1</a>.")]
             [InlineData("My package is https://nuget.org/packages/WindowsAzure.Storage/9.3.1/.", "My package is <a href=\"https://nuget.org/packages/WindowsAzure.Storage/9.3.1/\" rel=\"nofollow\">https://nuget.org/packages/WindowsAzure.Storage/9.3.1/</a>.")]
             public void ConvertsPackageUrlsToLinksWithShortText(string input, string expected)

--- a/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/HtmlExtensionsFacts.cs
@@ -93,6 +93,34 @@ namespace NuGetGallery.Helpers
                 var html = output.ToHtmlString();
                 Assert.Equal(expected, html);
             }
+
+            [Theory]
+            [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage.", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage\" rel=\"nofollow\">WindowsAzure.Storage</a>.")]
+            [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage/!", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>!")]
+            [InlineData("My package is http://www.nuget.org/packages/WindowsAzure.Storage/", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>")]
+            [InlineData("My package is http://www.nuget.org/packages/WindowsAzure.Storage/sub/path/", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/sub/path/\" rel=\"nofollow\">https://www.nuget.org/packages/WindowsAzure.Storage/sub/path/</a>")]
+            [InlineData("My package is https://www.nuget.org/packages/WindowsAzure.Storage/packages.", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/packages\" rel=\"nofollow\">https://www.nuget.org/packages/WindowsAzure.Storage/packages</a>.")]
+            [InlineData("My package is http://www.nuget.org/packages/WindowsAzure.Storage/?foo&bar=2#a", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/?foo&amp;bar=2#a\" rel=\"nofollow\">https://www.nuget.org/packages/WindowsAzure.Storage/?foo&amp;bar=2#a</a>")]
+            [InlineData("My package is http://www.nuget.org/packages/WindowsAzure.Storage/?foo[]=a", "My package is <a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/?foo\" rel=\"nofollow\">https://www.nuget.org/packages/WindowsAzure.Storage/?foo</a>[]=a")]
+            [InlineData("http://www.nuget.org/packages/WindowsAzure.Storage is my package.", "<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage\" rel=\"nofollow\">WindowsAzure.Storage</a> is my package.")]
+            [InlineData("\"http://www.nuget.org/packages/WindowsAzure.Storage/\" is my package.", "&quot;<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>&quot; is my package.")]
+            [InlineData("\'http://www.nuget.org/packages/WindowsAzure.Storage/\' is my package.", "&#39;<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>&#39; is my package.")]
+            [InlineData("http://www.nuget.org/packages/WindowsAzure.Storage/, is my package.", "<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>, is my package.")]
+            [InlineData("(http://www.nuget.org/packages/WindowsAzure.Storage/) is my package.", "(<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>) is my package.")]
+            [InlineData("http://www.nuget.org/packages/WindowsAzure.Storage/; is my package.", "<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>; is my package.")]
+            [InlineData("http://www.nuget.org/packages/WindowsAzure.Storage/- is my package.", "<a href=\"https://www.nuget.org/packages/WindowsAzure.Storage/\" rel=\"nofollow\">WindowsAzure.Storage</a>- is my package.")]
+            public void ConvertsPackageUrlsToLinksWithShortText(string input, string expected)
+            {
+                // Arrange
+                var htmlHelper = CreateHtmlHelper(new ViewDataDictionary());
+
+                // Act
+                var output = htmlHelper.PreFormattedText(input);
+
+                // Assert
+                var html = output.ToHtmlString();
+                Assert.Equal(expected, html);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Just a suggestion. 

Currently package links in descriptions look like this:

![image](https://user-images.githubusercontent.com/1697911/73567108-83d78700-441a-11ea-988a-ad0a8161e951.png)

What if we did something similar to what github does with issue links and formatted them with a shorter text:

![image](https://user-images.githubusercontent.com/1697911/73567252-d87b0200-441a-11ea-9959-f01f7fa09db3.png)

Current regex is relatively strict to avoid any other links masquerading as nuget ones.
