### PR TITLE
Block version ranges that NuGet pack does not allow

### DIFF
--- a/src/NuGetGallery.Core/CoreStrings.Designer.cs
+++ b/src/NuGetGallery.Core/CoreStrings.Designer.cs
@@ -196,6 +196,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package manifest contains an invalid Dependency Version Range: &apos;{0}&apos;.
+        /// </summary>
+        public static string Manifest_InvalidDependencyVersionRange {
+            get {
+                return ResourceManager.GetString("Manifest_InvalidDependencyVersionRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package manifest contains an invalid ID: &apos;{0}&apos;.
         /// </summary>
         public static string Manifest_InvalidId {

--- a/src/NuGetGallery.Core/CoreStrings.resx
+++ b/src/NuGetGallery.Core/CoreStrings.resx
@@ -217,4 +217,8 @@
     <value>The package manifest contains an invalid package type name: '{0}'</value>
     <comment>{0} is the package type name.</comment>
   </data>
+  <data name="Manifest_InvalidDependencyVersionRange" xml:space="preserve">
+    <value>The package manifest contains an invalid Dependency Version Range: '{0}'</value>
+    <comment>{0} is the original dependency version range string.</comment>
+  </data>
 </root>

--- a/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
+++ b/src/NuGetGallery.Core/Packaging/ManifestValidator.cs
@@ -145,6 +145,14 @@ namespace NuGetGallery.Packaging
                         }
 
                         // Versions
+                        if (dependency.VersionRange.IsFloating)
+                        {
+                            yield return new ValidationResult(String.Format(
+                                CultureInfo.CurrentCulture,
+                                CoreStrings.Manifest_InvalidDependencyVersionRange,
+                                dependency.VersionRange.OriginalString));
+                        }
+
                         if (dependency.VersionRange.MinVersion != null)
                         {
                             var versionRangeValidationResult =

--- a/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/ManifestValidatorFacts.cs
@@ -350,6 +350,20 @@ namespace NuGetGallery.Packaging
                   </metadata>
                 </package>";
 
+        private const string NuspecDependencyWithVersionRangeFormat = @"<?xml version=""1.0""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                  <metadata>
+                    <id>packageA</id>
+                    <version>1.0.1-alpha</version>
+                    <description>package A description.</description>
+                    <dependencies>
+                        <group targetFramework=""net40"">
+                          <dependency id=""SomeDependency"" version=""{0}"" />
+                        </group>
+                    </dependencies>
+                  </metadata>
+                </package>";
+
         [Fact]
         public void ReturnsErrorIfIdNotPresent()
         {
@@ -496,6 +510,22 @@ namespace NuGetGallery.Packaging
             var nuspecStream = CreateNuspecStream(NuSpecFrameworkAssemblyReferenceContainsDuplicateDependency);
 
             Assert.Equal(new[] { String.Format(CoreStrings.Manifest_DuplicateDependency, "net40", "SomeDependency") }, GetErrors(nuspecStream));
+        }
+
+        [Theory]
+        [InlineData("*")]
+        [InlineData("1.*")]
+        [InlineData("1.0.*")]
+        [InlineData("1.0.0.*")]
+        [InlineData("1.0.0-beta*")]
+        [InlineData("1.0.0-beta-*")]
+        [InlineData("1.0.0-beta.*")]
+        public void ReturnsErrorIfDependencyHasInvalidVersionRange(string versionRange)
+        {
+            var nuspec = string.Format(NuspecDependencyWithVersionRangeFormat, versionRange);
+            var nuspecStream = CreateNuspecStream(nuspec);
+
+            Assert.Equal(new[] { string.Format(CoreStrings.Manifest_InvalidDependencyVersionRange, versionRange) }, GetErrors(nuspecStream));
         }
 
         [Fact]


### PR DESCRIPTION
When you try to pack a .nuspec with a floating version in it, NuGet pack prevents this by taking out the floating part and substituting in min version. "12.*" turns into "12.0.0". However, someone can hand-craft a .nuspec to get around it.

When we moved from 2.x APIs to 3.x APIs in gallery, we started supporting this without realizing it. Our .nuspec validation looks at each dependency version and parses it as a `VersionRange` which supports floating (since it's the same model that is used for `<PackageReference>` version).

These are the only packages that have utilized this:

Id | Version | Created
-- | -- | --
PInvokeCompiler  |  1.0.0-rc1 |  2017-01-09
Scissorhands.Helpers |   1.0.0-alpha-17  |  2016-01-13
Scissorhands.Helpers |   1.0.0-alpha-16  | 2016-01-13

Thanks @zivkan for the data.

We should block these since it has unpredictable impact on the restore graph and is a totally undocumented case for transitive package dependencies.

If we want to open the flood gates later we can but it would be coupled with official client support and a well thought through plan of how this will impact package consumers as a whole.

