### PR TITLE
Removed some hot path logs

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -1138,7 +1138,6 @@ namespace NuGetGallery
 
                     return new ResilientSearchHttpClient(
                         httpClientWrappers,
-                        c.Resolve<ILogger<ResilientSearchHttpClient>>(),
                         c.Resolve<ITelemetryService>());
                 });
 

--- a/src/NuGetGallery/Infrastructure/Lucene/ResilientSearchHttpClient.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ResilientSearchHttpClient.cs
@@ -16,14 +16,12 @@ namespace NuGetGallery.Infrastructure.Search
     public class ResilientSearchHttpClient : IResilientSearchClient
     {
         private readonly IEnumerable<IHttpClientWrapper> _httpClients;
-        private readonly ILogger _logger;
         private readonly ITelemetryService _telemetryService;
 
-        public ResilientSearchHttpClient(IEnumerable<IHttpClientWrapper> searchClients, ILogger<ResilientSearchHttpClient> logger, ITelemetryService telemetryService)
+        public ResilientSearchHttpClient(IEnumerable<IHttpClientWrapper> searchClients, ITelemetryService telemetryService)
         {
-            _httpClients = searchClients ?? throw new ArgumentNullException(nameof(logger));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(logger));
+            _httpClients = searchClients ?? throw new ArgumentNullException(nameof(searchClients));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
         }
 
         public async Task<HttpResponseMessage> GetAsync(string path, string queryString)
@@ -33,7 +31,6 @@ namespace NuGetGallery.Infrastructure.Search
             foreach(var client in _httpClients)
             {
                 searchUri = client.BaseAddress.AppendPathToUri(path, queryString);
-                _logger.LogInformation("Sent GetAsync request for {Url}", searchUri.AbsoluteUri);
                 var result = await client.GetAsync(searchUri);
                 if (result.IsSuccessStatusCode)
                 {

--- a/tests/NuGetGallery.Facts/Infrastructure/Lucene/ResilientSearchServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Lucene/ResilientSearchServiceFacts.cs
@@ -123,7 +123,7 @@ namespace NuGet.Services.Search.Client
             mockISearchHttpClient2.Setup(x => x.GetAsync(It.IsAny<Uri>())).ReturnsAsync(getAsyncResultMessage2);
 
             List<IHttpClientWrapper> clients = new List<IHttpClientWrapper>() { mockISearchHttpClient1.Object, mockISearchHttpClient2.Object };
-            return new ResilientSearchHttpClient(clients, GetLogger(), mockTelemetryService.Object);
+            return new ResilientSearchHttpClient(clients, mockTelemetryService.Object);
         }
 
         private static HttpResponseMessage GetResponseMessage(Uri uri, HttpStatusCode statusCode)

--- a/tests/NuGetGallery.Facts/Queries/AutocompleteServicePackageIdsQueryFacts.cs
+++ b/tests/NuGetGallery.Facts/Queries/AutocompleteServicePackageIdsQueryFacts.cs
@@ -44,7 +44,7 @@ namespace NuGetGallery
             {
                 BaseAddress = new Uri("https://example")
             }));
-            return new ResilientSearchHttpClient(clients, GetLogger(), mockTelemetryService.Object);
+            return new ResilientSearchHttpClient(clients, mockTelemetryService.Object);
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/Queries/AutocompleteServicePackageVersionsQueryFacts.cs
+++ b/tests/NuGetGallery.Facts/Queries/AutocompleteServicePackageVersionsQueryFacts.cs
@@ -45,7 +45,7 @@ namespace NuGetGallery
             {
                 BaseAddress = new Uri("https://example")
             }));
-            return new ResilientSearchHttpClient(clients, GetLogger(), mockTelemetryService.Object);
+            return new ResilientSearchHttpClient(clients, mockTelemetryService.Object);
         }
 
         [Fact]


### PR DESCRIPTION
This was logging *every* time a search service request was sent. This line alone produces 500k-1m log lines per hour and duplicates the `dependencies` logging that is populated automatically.