### PR TITLE
[ECR] Enable the active update of SQL certificates without restarting.

### DIFF
--- a/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
+++ b/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
@@ -31,6 +31,11 @@ namespace NuGetGallery.Configuration
         private readonly Lazy<FeatureConfiguration> _lazyFeatureConfiguration;
         private readonly Lazy<IServiceBusConfiguration> _lazyServiceBusConfiguration;
         private readonly Lazy<IPackageDeleteConfiguration> _lazyPackageDeleteConfiguration;
+        private readonly HashSet<string> _NotInjectedSettingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+            SettingPrefix + "SqlServer",
+            SettingPrefix + "SqlServerReadOnlyReplica",
+            SettingPrefix + "SupportRequestSqlServer",
+            SettingPrefix + "ValidationSqlServer" };
 
         public ISecretInjector SecretInjector { get; set; }
 
@@ -120,7 +125,7 @@ namespace NuGetGallery.Configuration
         {
             var value = ReadRawSetting(settingName);
 
-            if (!string.IsNullOrEmpty(value))
+            if (!string.IsNullOrEmpty(value) && !_NotInjectedSettingNames.Contains(settingName))
             {
                 value = await SecretInjector.InjectAsync(value);
             }

--- a/tests/NuGetGallery.Facts/App_Start/ConfigurationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/App_Start/ConfigurationServiceFacts.cs
@@ -187,6 +187,33 @@ namespace NuGetGallery.App_Start
                 // Assert
                 Assert.Equal("somevalueparsed", result);
             }
+
+            [Theory]
+            [InlineData("Gallery.SqlServer")]
+            [InlineData("Gallery.SqlServerReadOnlyReplica")]
+            [InlineData("Gallery.SupportRequestSqlServer")]
+            [InlineData("Gallery.ValidationSqlServer")]
+            [InlineData("Gallery.sqlserver")]
+            [InlineData("Gallery.sqlserverreadonlyreplica")]
+            [InlineData("Gallery.supportrequestsqlserver")]
+            [InlineData("Gallery.validationsqlserver")]
+            public async Task GivenNotInjectedSettingNameSecretInjectorIsNotRan(string settingName)
+            {
+                // Arrange
+                var secretInjectorMock = new Mock<ISecretInjector>();
+                secretInjectorMock.Setup(x => x.InjectAsync(It.IsAny<string>()))
+                    .Returns<string>(s => Task.FromResult(s + "parsed"));
+
+                var configurationService = new TestableConfigurationService(secretInjectorMock.Object);
+                configurationService.CloudSettingStub = "somevalue";
+
+                // Act
+                string result = await configurationService.ReadSettingAsync(settingName);
+
+                // Assert
+                secretInjectorMock.Verify(x => x.InjectAsync(It.IsAny<string>()), Times.Never);
+                Assert.Equal("somevalue", result);
+            }
         }
     }
 }


### PR DESCRIPTION
In order to enable the on-line active update of SQL certificates, we should not inject the SQL connection string to build the "SqlConnectionFactory".
Test locally and verify the behavior.