### PR TITLE
Expose domain and diagnostics source in MEF container

### DIFF
--- a/src/NuGetGallery.Services/Providers/RuntimeServiceProvider.cs
+++ b/src/NuGetGallery.Services/Providers/RuntimeServiceProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.IO;
 using System.Linq;
@@ -39,6 +40,26 @@ namespace NuGetGallery
             var compositionContainer = CreateCompositionContainer(baseDirectoryPath);
 
             return new RuntimeServiceProvider(compositionContainer);
+        }
+
+        public void ComposeExportedValue<T>(string contractName, T exportedValue)
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(RuntimeServiceProvider));
+            }
+
+            _compositionContainer.ComposeExportedValue(contractName, exportedValue);
+        }
+
+        public void ComposeExportedValue<T>(T exportedValue)
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(RuntimeServiceProvider));
+            }
+
+            _compositionContainer.ComposeExportedValue(exportedValue);
         }
 
         public IEnumerable<T> GetExportedValues<T>()


### PR DESCRIPTION
This enables synchronous initialization (via the constructor) of the cookie compliance shim.
Also, move the refresh to the background so that initial start-up is not slowed down.

Fully lights up with https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGet.Shims/pullrequest/1342.
Related to https://github.com/NuGet/Engineering/issues/2980.