### PR TITLE
Add link to search for pending validations

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
@@ -32,9 +32,9 @@ namespace NuGetGallery.Areas.Admin.Controllers
         {
             var validationSets = _validationAdminService.GetPending();
             var validatedPackages = ToValidatedPackages(validationSets);
-            var validationSetIds = validationSets
-                .Select(s => s.ValidationTrackingId)
-                .Distinct();
+            var validationSetIds = validatedPackages
+                .SelectMany(p => p.ValidationSets)
+                .Select(s => s.ValidationTrackingId);
             var query = string.Join("\r\n", validationSetIds);
 
             return View(nameof(Index), new ValidationPageViewModel(query, validatedPackages));

--- a/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
@@ -30,12 +30,12 @@ namespace NuGetGallery.Areas.Admin.Controllers
         [HttpGet]
         public virtual ActionResult Pending()
         {
-            var packageValidationSets = _validationAdminService.Pending();
-            var validatedPackages = ToValidatedPackages(packageValidationSets);
-            var packageIdentities = packageValidationSets
-                .Select(s => $"{s.PackageId} {s.PackageNormalizedVersion}")
+            var validationSets = _validationAdminService.GetPending();
+            var validatedPackages = ToValidatedPackages(validationSets);
+            var validationSetIds = validationSets
+                .Select(s => s.ValidationTrackingId)
                 .Distinct();
-            var query = string.Join("\r\n", packageIdentities);
+            var query = string.Join("\r\n", validationSetIds);
 
             return View(nameof(Index), new ValidationPageViewModel(query, validatedPackages));
         }

--- a/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
@@ -31,11 +31,11 @@ namespace NuGetGallery.Areas.Admin.Controllers
         public virtual ActionResult Pending()
         {
             var packageValidationSets = _validationAdminService.Pending();
-            var packageIdentities = packageValidationSets.Select(s => $"{s.PackageId} {s.PackageNormalizedVersion}");
-            var query = string.Join("\r\n", packageIdentities.Distinct());
-            var validatedPackages = new List<ValidatedPackageViewModel>();
-            AppendValidatedPackages(validatedPackages, packageValidationSets, ValidatingType.Package);
-            AppendValidatedPackages(validatedPackages, packageValidationSets, ValidatingType.SymbolPackage);
+            var validatedPackages = ToValidatedPackages(packageValidationSets);
+            var packageIdentities = packageValidationSets
+                .Select(s => $"{s.PackageId} {s.PackageNormalizedVersion}")
+                .Distinct();
+            var query = string.Join("\r\n", packageIdentities);
 
             return View(nameof(Index), new ValidationPageViewModel(query, validatedPackages));
         }
@@ -44,11 +44,18 @@ namespace NuGetGallery.Areas.Admin.Controllers
         public virtual ActionResult Search(string q)
         {
             var packageValidationSets = _validationAdminService.Search(q ?? string.Empty);
+            var validatedPackages = ToValidatedPackages(packageValidationSets);
+
+            return View(nameof(Index), new ValidationPageViewModel(q, validatedPackages));
+        }
+
+        private List<ValidatedPackageViewModel> ToValidatedPackages(IReadOnlyList<PackageValidationSet> packageValidationSets)
+        {
             var validatedPackages = new List<ValidatedPackageViewModel>();
             AppendValidatedPackages(validatedPackages, packageValidationSets, ValidatingType.Package);
             AppendValidatedPackages(validatedPackages, packageValidationSets, ValidatingType.SymbolPackage);
 
-            return View(nameof(Index), new ValidationPageViewModel(q, validatedPackages));
+            return validatedPackages;
         }
 
         private void AppendValidatedPackages(List<ValidatedPackageViewModel> validatedPackages, IEnumerable<PackageValidationSet> validationSets, ValidatingType validatingType)

--- a/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/ValidationController.cs
@@ -28,6 +28,19 @@ namespace NuGetGallery.Areas.Admin.Controllers
         }
 
         [HttpGet]
+        public virtual ActionResult Pending()
+        {
+            var packageValidationSets = _validationAdminService.Pending();
+            var packageIdentities = packageValidationSets.Select(s => $"{s.PackageId} {s.PackageNormalizedVersion}");
+            var query = string.Join("\r\n", packageIdentities.Distinct());
+            var validatedPackages = new List<ValidatedPackageViewModel>();
+            AppendValidatedPackages(validatedPackages, packageValidationSets, ValidatingType.Package);
+            AppendValidatedPackages(validatedPackages, packageValidationSets, ValidatingType.SymbolPackage);
+
+            return View(nameof(Index), new ValidationPageViewModel(query, validatedPackages));
+        }
+
+        [HttpGet]
         public virtual ActionResult Search(string q)
         {
             var packageValidationSets = _validationAdminService.Search(q ?? string.Empty);

--- a/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
+++ b/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
@@ -57,7 +57,7 @@ namespace NuGetGallery.Areas.Admin.Services
         }
 
         /// <summary>
-        /// Fetch the list of pending package validation sets.
+        /// Fetch the list of validation sets whose packages are in the "validating" status.
         /// </summary>
         public IReadOnlyList<PackageValidationSet> Pending()
         {

--- a/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
+++ b/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
@@ -56,6 +56,32 @@ namespace NuGetGallery.Areas.Admin.Services
                 .ToList();
         }
 
+        /// <summary>
+        /// Fetch the list of pending package validation sets.
+        /// </summary>
+        public IReadOnlyList<PackageValidationSet> Pending()
+        {
+            var pendingPackages = _packages
+                .GetAll()
+                .Where(p => p.PackageStatusKey == PackageStatus.Validating)
+                .Select(p => p.Key)
+                .ToList();
+            var pendingSymbolPackages = _symbolPackages
+                .GetAll()
+                .Where(s => s.StatusKey == PackageStatus.Validating)
+                .Select(s => s.Key)
+                .ToList();
+
+            return _validationSets
+                .GetAll()
+                .Where(v =>
+                    (v.ValidatingType == ValidatingType.Package && pendingPackages.Contains(v.PackageKey)) ||
+                    (v.ValidatingType == ValidatingType.SymbolPackage && pendingSymbolPackages.Contains(v.PackageKey)))
+                .Include(v => v.PackageValidations)
+                .ToList();
+        }
+
+
         public PackageDeletedStatus GetDeletedStatus(int key, ValidatingType validatingType)
         {
             switch (validatingType)

--- a/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
@@ -17,6 +17,8 @@
 <section role="main" class="container main-container">
     <h2>Package Validations</h2>
 
+    <p>Get <a href="@Url.Action(actionName:"Pending")">pending validations</a>.</p>
+
     <form method="get" action="@Url.Action(actionName: "Search")">
         <p>
             <textarea name="q" placeholder="Search for package validations..." autocomplete="off" autofocus style="width: 100%" rows="5">@Model.Query</textarea>
@@ -30,7 +32,7 @@
     {
         <p>No results found. Try <a href="@Url.Action(actionName: "Pending")">pending validations</a>.</p>
     }
-    else if(!Model.HasQuery)
+    else if (!Model.HasQuery)
     {
         <p>You can search by:</p>
         <ul>
@@ -38,7 +40,6 @@
             <li>Package ID and version: <code>NuGet.Versioning 4.3.0</code></li>
             <li>Validation set tracking ID: <code>e6db6737-bd77-44cd-af8b-74826e054d36</code></li>
             <li>Validation ID: <code>218d075b-99b6-4151-ba12-121872ffe7fe</code></li>
-            <li><a href="@Url.Action(actionName: "Pending")">Pending validations</a></li>
         </ul>
     }
 

--- a/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
@@ -28,7 +28,7 @@
 
     @if (Model.HasQuery && !Model.HasResults)
     {
-        <p>No results found.</p>
+        <p>No results found. Try <a href="@Url.Action(actionName: "Pending")">pending validations</a>.</p>
     }
     else if(!Model.HasQuery)
     {
@@ -38,6 +38,7 @@
             <li>Package ID and version: <code>NuGet.Versioning 4.3.0</code></li>
             <li>Validation set tracking ID: <code>e6db6737-bd77-44cd-af8b-74826e054d36</code></li>
             <li>Validation ID: <code>218d075b-99b6-4151-ba12-121872ffe7fe</code></li>
+            <li><a href="@Url.Action(actionName: "Pending")">Pending validations</a></li>
         </ul>
     }
 
@@ -59,7 +60,17 @@
                         break;
                 }
 
-                <b>@package.ValidatingType Key:</b> @package.PackageKey<br />
+                @switch (package.ValidatingType)
+                {
+                    case ValidatingType.SymbolPackage:
+                        <b>Symbol Package Key:</b> @package.PackageKey<br />
+                        break;
+
+                    default:
+                        <b>@package.ValidatingType Key:</b> @package.PackageKey<br />
+                        break;
+                }
+
                 @if (package.DeletedStatus == PackageDeletedStatus.NotDeleted)
                 {
                     if (package.ValidatingType == ValidatingType.Package)
@@ -98,7 +109,7 @@
 
                 @if (package.DeletedStatus != PackageDeletedStatus.Unknown)
                 {
-                    <a href="@Url.Package(package)">Package Details</a>
+                    <a href="@Url.Package(package)">Package details</a>
                 }
             </p>
 


### PR DESCRIPTION
Today the on-call engineer has to connect to the database to find the pending validations. This adds a link to the admin panel to fetch the currently pending validations:

![image](https://user-images.githubusercontent.com/737941/77881538-0eb6e100-7214-11ea-8ecd-54188763e25c.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/7926

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3595685
Release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=628330