### PR TITLE
Update to latest ServerCommon

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,7 @@ param (
     [string]$PackageSuffix,
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranch = 'd298565f387e93995a179ef8ae6838f1be37904f',
+    [string]$BuildBranch = '6d1fcf147a7af8b6b4db842494bc7beed3b1d0e9',
     [string]$VerifyMicrosoftPackageVersion = $null
 )
 

--- a/ops.cmd
+++ b/ops.cmd
@@ -1,1 +1,0 @@
-@powershell -ExecutionPolicy RemoteSigned -NoProfile -NoExit "%~dp0ops\Scripts\Enter-NuGetOps.ps1"

--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -107,7 +107,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.3.0-dev-3555917</Version>
+      <Version>4.3.0-dev-3612825</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -64,7 +64,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -86,10 +86,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3555917</Version>
+      <Version>4.3.0-dev-3612825</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -77,7 +77,7 @@
       <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-3555917</Version>
+      <Version>4.3.0-dev-3612825</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -242,16 +242,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -294,10 +294,10 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2304,13 +2304,13 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.71.0</Version>
+      <Version>2.74.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -574,14 +574,6 @@
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.71.0.0" newVersion="2.71.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Services.Configuration" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.71.0.0" newVersion="2.71.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
       </dependentAssembly>


### PR DESCRIPTION
This brings in the NoWarn and the 3.0.0.0 assembly version for ServerCommon assemblies.
Depends on https://github.com/NuGet/NuGet.Jobs/pull/880