### PR TITLE
[A11y]Accessibility fixes 2

### DIFF
--- a/src/NuGetGallery/Helpers/GravatarHelper.cs
+++ b/src/NuGetGallery/Helpers/GravatarHelper.cs
@@ -84,7 +84,7 @@ namespace NuGetGallery.Helpers
                                 height=""{size}""
                                 width=""{size}""
                                 title=""{username}""
-                                alt=""gravatar"" />";
+                                alt=""{username} gravatar"" />";
 
                 return new HtmlString(html);
             }

--- a/src/NuGetGallery/Scripts/gallery/common-multi-select-dropdown.js
+++ b/src/NuGetGallery/Scripts/gallery/common-multi-select-dropdown.js
@@ -64,15 +64,15 @@ function MultiSelectDropdown(items, singularItemTitle, pluralItemTitle) {
     this.toggleLabel = ko.pureComputed(function () {
         var chosenItems = self.chosenItems();
         if (chosenItems.length === 0) {
-            return "No " + pluralItemTitle + " selected";
+            return "Select Versions: No " + pluralItemTitle + " selected";
         }
 
         if (chosenItems.length === self.items.length) {
-            return "All " + pluralItemTitle + " selected";
+            return "Select Versions: All " + pluralItemTitle + " selected";
         }
 
         var itemTitle = chosenItems.length > 1 ? pluralItemTitle : singularItemTitle;
-        return "Selected " + itemTitle + " " + chosenItems.join(', ');
+        return "Select Version: Selected " + itemTitle + " " + chosenItems.join(', ');
     }, this);
 
     this.selectAllText = ko.pureComputed(function () {

--- a/src/NuGetGallery/Scripts/gallery/common-multi-select-dropdown.js
+++ b/src/NuGetGallery/Scripts/gallery/common-multi-select-dropdown.js
@@ -72,7 +72,7 @@ function MultiSelectDropdown(items, singularItemTitle, pluralItemTitle) {
         }
 
         var itemTitle = chosenItems.length > 1 ? pluralItemTitle : singularItemTitle;
-        return "Select Version: Selected " + itemTitle + " " + chosenItems.join(', ');
+        return "Select Versions: Selected " + itemTitle + " " + chosenItems.join(', ');
     }, this);
 
     this.selectAllText = ko.pureComputed(function () {

--- a/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
@@ -6,7 +6,7 @@
            aria-controls="@id" role="tab" data-toggle="tab"
            data-source-type="@sourceType"
            data-bind="event: { 'show.bs.tab': OnReadmeTabChange }"
-           aria-label="@title">
+           aria-label="@label: @title .">
             @label
         </a>
     </li>

--- a/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ManageDeprecation.cshtml
@@ -39,19 +39,19 @@
         </div>
         <div class="form-group unbolded-label">
             <label>
-                <input name="isLegacy" type="checkbox" value="true" data-bind="checked: isLegacy" />
+                <input name="isLegacy" type="checkbox" value="true" data-bind="checked: isLegacy" aria-label="Select Reason: This package is legacy and is no longer maintained."/>
                 This package is <b>legacy</b> and is no longer maintained
             </label>
         </div>
         <div class="form-group unbolded-label">
             <label>
-                <input name="hasCriticalBugs" type="checkbox" value="true" data-bind="checked: hasCriticalBugs" />
+                <input name="hasCriticalBugs" type="checkbox" value="true" data-bind="checked: hasCriticalBugs" aria-label="Select Reason: This package has critical bugs that make it unusable."/>
                 This package has <b>critical bugs</b> that make it unusable
             </label>
         </div>
         <div class="form-group unbolded-label">
             <label>
-                <input name="isOther" type="checkbox" value="true" data-bind="checked: isOther" />
+                <input name="isOther" type="checkbox" value="true" data-bind="checked: isOther" aria-label="Select Reason: Other."/>
                 <b>Other</b>
             </label>
         </div>


### PR DESCRIPTION
Follow-up to https://github.com/NuGet/NuGetGallery/pull/7927
Addresses the following issues:
[A11y]Narrator is not reading the labels for "Select Version(s)" drop-down and "Select reason(s)" check-box group #7888
 - Update the descriptions on these to indicate context.

[A11y]The narrator announces same name for all 3 actionable images present under Owner section #7883
 - Updated gravatar image alt text to include username

[A11y]Incorrect name property provided for the "Custom" tab item. #7884
 - Updated descriptions to include proper title.