### PR TITLE
Remove redirects from error handling and clean Elmah

### DIFF
--- a/src/NuGetGallery/App_400.aspx
+++ b/src/NuGetGallery/App_400.aspx
@@ -1,0 +1,13 @@
+﻿<% Response.StatusCode = 400 %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bad Request</title>
+</head>
+<body>
+    Bad Request
+</body>
+</html>

--- a/src/NuGetGallery/App_404.aspx
+++ b/src/NuGetGallery/App_404.aspx
@@ -1,0 +1,13 @@
+﻿<% Response.StatusCode = 404 %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Not Found</title>
+</head>
+<body>
+    Not Found
+</body>
+</html>

--- a/src/NuGetGallery/App_500.aspx
+++ b/src/NuGetGallery/App_500.aspx
@@ -1,0 +1,13 @@
+﻿<% Response.StatusCode = 500 %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Internal Server Error</title>
+</head>
+<body>
+    Internal Server Error
+</body>
+</html>

--- a/src/NuGetGallery/App_Start/AppActivator.cs
+++ b/src/NuGetGallery/App_Start/AppActivator.cs
@@ -237,6 +237,7 @@ namespace NuGetGallery
             GlobalFilters.Filters.Add(new ReadOnlyModeErrorFilter());
             GlobalFilters.Filters.Add(new AntiForgeryErrorFilter());
             GlobalFilters.Filters.Add(new UserDeletedErrorFilter());
+            GlobalFilters.Filters.Add(new RequestValidationExceptionFilter());
             ValueProviderFactories.Factories.Add(new HttpHeaderValueProviderFactory());
         }
 

--- a/src/NuGetGallery/Infrastructure/CookieTempDataProvider.cs
+++ b/src/NuGetGallery/Infrastructure/CookieTempDataProvider.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Net;
 using System.Web;
 using System.Web.Mvc;
 
@@ -50,7 +52,19 @@ namespace NuGetGallery
 
         protected virtual IDictionary<string, object> LoadTempData(ControllerContext controllerContext)
         {
-            var cookie = _httpContext.Request.Cookies[TempDataCookieKey];
+            HttpCookie cookie;
+            try
+            {
+                cookie = _httpContext.Request.Cookies[TempDataCookieKey];
+            }
+            catch (HttpRequestValidationException ex)
+            {
+                throw new HttpException(
+                    (int)HttpStatusCode.BadRequest,
+                    $"The cookie {TempDataCookieKey} could not be read.",
+                    ex);
+            }
+
             var dictionary = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             if ((cookie == null) || String.IsNullOrEmpty(cookie.Value))
             {

--- a/src/NuGetGallery/Infrastructure/RequestValidationExceptionFilter.cs
+++ b/src/NuGetGallery/Infrastructure/RequestValidationExceptionFilter.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Web;
 using System.Web.Mvc;
 
 namespace NuGetGallery.Infrastructure
 {
-    public sealed class AntiForgeryErrorFilter : FilterAttribute, IExceptionFilter
+    public sealed class RequestValidationExceptionFilter : FilterAttribute, IExceptionFilter
     {
         public void OnException(ExceptionContext context)
         {
-            if (context.Exception is HttpAntiForgeryException)
+            if (context.Exception is HttpRequestValidationException)
             {
                 context.HttpContext.Response.Clear();
                 context.HttpContext.Response.TrySkipIisCustomErrors = true;

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Infrastructure\ABTestEnrollmentState.cs" />
     <Compile Include="Infrastructure\ABTestEnrollmentFactory.cs" />
     <Compile Include="Infrastructure\CookieBasedABTestService.cs" />
+    <Compile Include="Infrastructure\RequestValidationExceptionFilter.cs" />
     <Compile Include="Infrastructure\IABTestEnrollmentFactory.cs" />
     <Compile Include="Infrastructure\IABTestService.cs" />
     <Compile Include="Infrastructure\ILuceneDocumentFactory.cs" />
@@ -1275,6 +1276,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
+    <Content Include="App_404.aspx" />
+    <Content Include="App_400.aspx" />
+    <Content Include="App_500.aspx" />
     <Content Include="Areas\Admin\DynamicData\FieldTemplates\Url_Edit.ascx" />
     <Content Include="Areas\Admin\DynamicData\PageTemplates\ListDetails.aspx" />
     <Content Include="Content\admin\SupportRequestStyles.css" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -211,7 +211,18 @@
     <security allowRemoteAccess="true"/>
     <errorFilter>
       <test>
-        <equal binding="HttpStatusCode" value="404" type="Int32"/>
+        <or>
+          <equal binding="HttpStatusCode" value="404" type="Int32"/>
+          <equal binding="HttpStatusCode" value="409" type="Int32"/>
+          
+          <regex binding="Exception.Message" pattern="(?ix: \b potentially \b.+?\b dangerous \b.+?\b value \b.+?\b detected \b.+?\b client \b )" />
+          
+          <!-- Ignore errors from the simulated error (fault injection) test path. -->
+          <equal binding="Context.Request.Path" value="/pages/simulate-error" type="String" />
+          <equal binding="Context.Request.Path" value="/api/simulate-error" type="String" />
+          <equal binding="Context.Request.Path" value="/api/v1/SimulateError()" type="String" />
+          <regex binding="Exception.Message" pattern="^SimulatedErrorType \w+$" />
+        </or>
       </test>
     </errorFilter>
     <errorLog type="Elmah.SqlErrorLog, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL" connectionStringName="NuGetGallery"/>
@@ -339,12 +350,10 @@
       <!-- Remove Default HTTP Handler -->
       <remove path="*" verb="GET,HEAD,POST"/>
     </httpHandlers>
-    <customErrors mode="RemoteOnly" defaultRedirect="~/Errors/500" redirectMode="ResponseRedirect">
-      <!-- Adding ? at the end of the redirect URL prevents the illegal request to be passed
-           as a query parameter to the redirect URL and causing additional failures -->
-      <error statusCode="400" redirect="~/Errors/400"/>
-      <error statusCode="404" redirect="~/Errors/404"/>
-      <error statusCode="500" redirect="~/Errors/500"/>
+    <customErrors mode="RemoteOnly" defaultRedirect="~/App_500.aspx" redirectMode="ResponseRewrite">
+      <error statusCode="400" redirect="~/App_400.aspx"/>
+      <error statusCode="404" redirect="~/App_404.aspx"/>
+      <error statusCode="500" redirect="~/App_500.aspx"/>
     </customErrors>
     <sessionState mode="Off"/>
   </system.web>


### PR DESCRIPTION
The core purpose of this change is to stop redirecting when some kind of error occurs. The root cause of this is the `ResponseRedirect` directive in the web.config. This makes telemetry more difficult because we see a lot of 302 cases but really it's a bad request or an exception getting thrown by our application.

I also cleaned up the things that get logged to Elmah since this will make Elmah useful again to see real problems (right now it is flooded by nasty URL exceptions).

I spent quite some time evaluating the best options and it seems there is not a very effective way to use the pretty error pages for cases that escape MVC error handling and are dealt with by IIS. Therefore, I introduced three simple HTML pages that IIS can `ResponseRewrite` to. Another way of explaining this is: _what should happen if MVC can't even render the pretty error page?_

We can reduce the non-pretty error page cases by making our routes and error handling inside MVC more bullet proof in the future. This PR is meant to improve the "what if" when MVC itself bubbles an exception out.

This blog post has some of the background is you are interested:
https://benfoster.io/blog/aspnet-mvc-custom-error-pages

Fixes:

1. 400, 404, and 500 never redirect now.
   - Example: `GET /.nuGetV3/feed.json:properties`
     - Before: 302 to `/Errors/400?aspxerrorpath=/.nuGetV3/feed.json:properties`
     - After: 400, but not the pretty HTML
   - Example: `GET /packages/BaseTestPackage/invalid-version`
     - Before: 302 to `/Errors/404?aspxerrorpath=/packages/BaseTestPackage/invalid-version`
     - After: 404, but not the pretty HTML
   - Example: `GET /pages/simulate-error?type=HttpException503`
     - Before 302 to `/Errors/500?aspxerrorpath=/pages/simulate-error`
     - After: 500, but not the pretty HTML
2. Bad cookies now cause a 400 not a 500
   - Example: cookie `__Controller::TempData` = `<script>alert(1)</script>`
     - Before: 302 to `/Errors/500?aspxerrorpath=/`
     - After: 400, but not the pretty HTML
3. No longer put the following things in Elmah:
   - HTTP 409 (these are common from functional tests)
   - The nasty path exception
     - Ex: `A potentially dangerous Request.Path value was detected from the client (:).`
   - Exceptions coming from the simulated error routes

Progress on https://github.com/NuGet/NuGetGallery/issues/7868.