### PR TITLE
Fix locale sensitive API key copy

### DIFF
--- a/src/NuGetGallery.Services/Authentication/ApiKeyV4.cs
+++ b/src/NuGetGallery.Services/Authentication/ApiKeyV4.cs
@@ -143,7 +143,7 @@ namespace NuGetGallery.Infrastructure.Authentication
 
         private string Normalize(string input)
         {
-            return input.ToLower();
+            return input.ToLowerInvariant();
         }
     }
 }


### PR DESCRIPTION
Addressing https://github.com/NuGet/NuGetGallery/issues/7961

Issue was being caused by local sensitive lower casing.