### PR TITLE
Add support for alternate instrumentation system in browser 

### DIFF
--- a/src/AccountDeleter/Configuration/GalleryConfiguration.cs
+++ b/src/AccountDeleter/Configuration/GalleryConfiguration.cs
@@ -112,5 +112,6 @@ namespace NuGetGallery.AccountDeleter
         public int? MaxWorkerThreads { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public int? MinIoThreads { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public int? MaxIoThreads { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string InternalMicrosoftTenantKey { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
@@ -413,5 +413,6 @@ namespace NuGetGallery.Configuration
         public int? MinIoThreads { get; set; }
         [DefaultValue(null)]
         public int? MaxIoThreads { get; set; }
+        public string InternalMicrosoftTenantKey { get; set; }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
@@ -211,6 +211,12 @@ namespace NuGetGallery.Configuration
         int AppInsightsHeartbeatIntervalSeconds { get; set; }
 
         /// <summary>
+        /// The tenant key used for Microsoft's internal instrumentation system similar to Application Insights.
+        /// Because it is internal, this setting is not useful if used outside of Microsoft.
+        /// </summary>
+        string InternalMicrosoftTenantKey { get; set; }
+
+        /// <summary>
         /// Gets the protocol-independent site root
         /// </summary>
         string SiteRoot { get; set; }

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -223,17 +223,32 @@
 
 @helper InstrumentationScript()
 {
-    // Get instrumentation key
+    // Get instrumentation keys
     var config = DependencyResolver.Current.GetService<IGalleryConfigurationService>();
     var iKey = config == null ? string.Empty : config.Current.AppInsightsInstrumentationKey;
     var samplingPct = config == null ? 100 : config.Current.AppInsightsSamplingPercentage;
+    var tenantKey = config == null ? string.Empty : config.Current.InternalMicrosoftTenantKey;
 
-    if (!string.IsNullOrEmpty(iKey))
+    if (!string.IsNullOrEmpty(iKey) || !string.IsNullOrEmpty(tenantKey))
     {
         var cookieService = DependencyResolver.Current.GetService<ICookieComplianceService>();
         if (cookieService.CanWriteNonEssentialCookies(Request))
         {
-            <!-- Telemetry -->
+            if (!string.IsNullOrEmpty(tenantKey))
+            {
+                @System.Web.Optimization.Scripts.Render("~/Scripts/gallery/instrumentation.min.js")
+                <script type="text/javascript">
+                if (window.initializeNuGetInstrumentation) {
+                    window.NuGetInstrumentation = window.initializeNuGetInstrumentation({
+                        appInsightsInstrumentationKey: "@iKey",
+                        appInsightsSamplingPercentage: @samplingPct,
+                        tenantKey: "@tenantKey",
+                    });
+                }
+                </script>
+            }
+            else
+            {
             <script type="text/javascript">
                 var appInsights = window.appInsights || function (config) {
                     function s(config) {
@@ -257,6 +272,7 @@
                 window.appInsights = appInsights;
                 appInsights.trackPageView();
             </script>
+            }
         }
     }
 }

--- a/src/NuGetGallery/App_Start/AppActivator.cs
+++ b/src/NuGetGallery/App_Start/AppActivator.cs
@@ -124,6 +124,10 @@ namespace NuGetGallery
                 .Include("~/Content/gallery/css/fabric.css");
             BundleTable.Bundles.Add(newStyleBundle);
 
+            var instrumentationBundle = new ScriptBundle("~/Scripts/gallery/instrumentation.min.js")
+                .Include("~/Scripts/gallery/instrumentation.js");
+            BundleTable.Bundles.Add(instrumentationBundle);
+
             var scriptBundle = new ScriptBundle("~/Scripts/gallery/site.min.js")
                 .Include("~/Scripts/gallery/jquery-3.4.1.js")
                 .Include("~/Scripts/gallery/jquery.validate-1.16.0.js")

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1635,6 +1635,7 @@
     </Content>
     <Content Include="Areas\Admin\Views\Revalidation\Index.cshtml" />
     <Content Include="App_Data\Files\Content\Symbols-Configuration.json" />
+    <Content Include="Scripts\gallery\instrumentation.js" />
     <Content Include="Views\Shared\SiteMenu.cshtml">
       <SubType>Code</SubType>
     </Content>

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -340,6 +340,10 @@
         return typeof window.appInsights === 'object';
     };
 
+    nuget.isInstrumentationAvailable = function () {
+        return typeof window.NuGetInstrumentation === 'object';
+    };
+
     nuget.getDateFormats = function (input) {
         var datetime = moment.utc(input);
 
@@ -444,8 +448,16 @@
         }
     };
 
-    nuget.sendAiMetric = function (name, value, properties) {
-        if (window.nuget.isAiAvailable()) {
+    nuget.sendMetric = function (name, value, properties) {
+        if (window.nuget.isInstrumentationAvailable()) {
+            window.NuGetInstrumentation.trackMetric({
+                name: name,
+                average: value,
+                sampleCount: 1,
+                min: value,
+                max: value
+            }, properties);
+        } else if (window.nuget.isAiAvailable()) {
             window.appInsights.trackMetric(name, value, 1, value, value, properties);
         }
     };

--- a/src/NuGetGallery/Scripts/gallery/instrumentation.js
+++ b/src/NuGetGallery/Scripts/gallery/instrumentation.js
@@ -1,0 +1,12 @@
+window["initializeNuGetInstrumentation"] = function (config) {
+    var instrumentation = {
+        initialize: function () {
+            console.log("NuGet instrumentation shim: initialized %o", config);
+        },
+        trackMetric: function (metric, customProperties) {
+            console.log("NuGet instrumentation shim: metric %o %o", metric, customProperties);
+        }
+    };
+    instrumentation.initialize();
+    return instrumentation;
+};

--- a/src/NuGetGallery/Scripts/gallery/page-home.js
+++ b/src/NuGetGallery/Scripts/gallery/page-home.js
@@ -49,7 +49,7 @@ $(function () {
                 data: obj,
                 success: function (data) {
                     if (data.success) {
-                        emitAIMetric("Enable2FAModalProvidedFeedback");
+                        emitMetric("Enable2FAModalProvidedFeedback");
                         viewModel.dismissModalOrGetFeedback(false);
                     } else {
                         viewModel.message(data.message);
@@ -65,7 +65,7 @@ $(function () {
                 viewModel.setupFeedbackView();
             }
             else {
-                emitAIMetric('Enable2FAModalDismissed');
+                emitMetric('Enable2FAModalDismissed');
                 $("#popUp2FAModal").modal('hide');
             }
         },
@@ -109,15 +109,15 @@ $(function () {
 
     function show2FAModal() {
         viewModel.setupEnable2FAView();
-        emitAIMetric("Enable2FAModalShown");
+        emitMetric("Enable2FAModalShown");
         $("#popUp2FAModal").modal({
             show: true,
             focus: true
         });
     }
 
-    function emitAIMetric(metricName) {
-        window.nuget.sendAiMetric(metricName, 1, {});
+    function emitMetric(metricName) {
+        window.nuget.sendMetric(metricName, 1, {});
     }
 
     function updateStats() {

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -91,7 +91,7 @@
             // event to be correlated in Google Analytics.
             <text>
             window.nuget.sendAnalyticsEvent('@category', '@action', @Html.Raw(Json.Encode(Model.SearchTerm)), @Model.PageIndex);
-            window.nuget.sendAiMetric('BrowserSearchPage', @Model.PageIndex, {
+            window.nuget.sendMetric('BrowserSearchPage', @Model.PageIndex, {
                 SearchId: '@searchId',
                 SearchTerm: @Html.Raw(Json.Encode(Model.SearchTerm)),
                 IncludePrerelease: '@Model.IncludePrerelease',
@@ -103,15 +103,11 @@
         }
 
         $(function () {
-            var emitAiClickEvent = function () {
-                if (!window.nuget.isAiAvailable()) {
-                    return;
-                }
-
+            var emitClickEvent = function () {
                 var $this = $(this);
                 var data = $this.data();
                 if ($this.attr('href') && data.track) {
-                    window.nuget.sendAiMetric('BrowserSearchSelection', data.trackValue, {
+                    window.nuget.sendMetric('BrowserSearchSelection', data.trackValue, {
                         SearchId: '@searchId',
                         SearchTerm: @Html.Raw(Json.Encode(Model.SearchTerm)),
                         IncludePrerelease: '@Model.IncludePrerelease',
@@ -132,11 +128,11 @@
             $.each($('a[data-track]'), function () {
                 $(this).on('mouseup', function (e) {
                     if (e.which === 2) { // Middle-mouse click
-                        emitAiClickEvent.call(this, e);
+                        emitClickEvent.call(this, e);
                     }
                 });
                 $(this).on('click', function (e) {
-                    emitAiClickEvent.call(this, e);
+                    emitClickEvent.call(this, e);
                 });
             });
         });


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/3020

We will use this on nuget.org to swap out the instrumentation system with the Microsoft internal one that allows sending data to both Application Insights and to the internal endpoint which uses the "tenant key" configuration that I added.