### PR TITLE
Packages with duplicated entries in zip file should be blocked on upload.

### DIFF
--- a/src/NuGetGallery/Helpers/ValidationHelper.cs
+++ b/src/NuGetGallery/Helpers/ValidationHelper.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using NuGet.Packaging;
+
+namespace NuGetGallery.Helpers
+{
+    public class ValidationHelper
+    {
+        public static bool HasDuplicatedEntries(PackageArchiveReader nuGetPackage)
+        {
+            // Normalize paths and ensures case sensitivity is also considered
+            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile.ToLower()));
+
+            return packageFiles.Count() != packageFiles.Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        }
+    }
+}

--- a/src/NuGetGallery/Helpers/ValidationHelper.cs
+++ b/src/NuGetGallery/Helpers/ValidationHelper.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery.Helpers
         public static bool HasDuplicatedEntries(PackageArchiveReader nuGetPackage)
         {
             // Normalize paths and ensures case sensitivity is also considered
-            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile.ToLower()));
+            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile));
 
             return packageFiles.Count() != packageFiles.Distinct(StringComparer.OrdinalIgnoreCase).Count();
         }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Controllers\ManageDeprecationJsonApiController.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="Extensions\ImageExtensions.cs" />
+    <Compile Include="Helpers\ValidationHelper.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeleteAccountListPackageItemViewModelFactory.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeletePackageViewModelFactory.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DisplayLicenseViewModelFactory.cs" />

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2052,9 +2052,6 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly">
       <Version>2.2.0</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Common">
-      <Version>5.5.1</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
       <Version>2.68.0</Version>
     </PackageReference>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2052,6 +2052,12 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly">
       <Version>2.2.0</Version>
     </PackageReference>
+    <PackageReference Include="NuGet.Common">
+      <Version>5.5.1</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Licenses">
+      <Version>2.68.0</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
     </PackageReference>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2052,9 +2052,6 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly">
       <Version>2.2.0</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.68.0</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.StrongName.AnglicanGeek.MarkdownMailer">
       <Version>1.2.0</Version>
     </PackageReference>

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -609,9 +609,9 @@ namespace NuGetGallery
         private PackageValidationResult CheckPackageDuplicatedEntries(PackageArchiveReader nuGetPackage)
         {
             // Normalize paths and ensures case sensitivity is also considered
-            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => Path.GetFullPath(packageFile.ToLower()));
+            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => Path.GetFullPath(packageFile.ToLowerInvariant()));
 
-            if (packageFiles.Count() != packageFiles.Distinct().Count())
+            if (packageFiles.Count() != packageFiles.Distinct(StringComparer.OrdinalIgnoreCase).Count())
             {
                 return PackageValidationResult.Invalid(Strings.UploadPackage_PackageContainsDuplicatedEntries);
             }

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -610,7 +610,7 @@ namespace NuGetGallery
         private PackageValidationResult CheckPackageDuplicatedEntries(PackageArchiveReader nuGetPackage)
         {
             // Normalize paths and ensures case sensitivity is also considered
-            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => PathUtility.StripLeadingDirectorySeparators(packageFile.ToLower()));
+            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile.ToLower()));
 
             if (packageFiles.Count() != packageFiles.Distinct(StringComparer.OrdinalIgnoreCase).Count())
             {

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -118,7 +118,7 @@ namespace NuGetGallery
                 return result;
             }
 
-            result = CheckPackageDuplicatedEntriesAsync(nuGetPackage);
+            result = CheckPackageDuplicatedEntries(nuGetPackage);
 
             if (result != null)
             {
@@ -606,11 +606,12 @@ namespace NuGetGallery
             return null;
         }
 
-        private PackageValidationResult CheckPackageDuplicatedEntriesAsync(PackageArchiveReader nuGetPackage)
+        private PackageValidationResult CheckPackageDuplicatedEntries(PackageArchiveReader nuGetPackage)
         {
-            var packageFiles = nuGetPackage.GetFiles();
+            // Normalize paths and ensures case sensitivity is also considered
+            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => Path.GetFullPath(packageFile.ToLower()));
 
-            if(packageFiles.Count() != packageFiles.Distinct().Count())
+            if (packageFiles.Count() != packageFiles.Distinct().Count())
             {
                 return PackageValidationResult.Invalid(Strings.UploadPackage_PackageContainsDuplicatedEntries);
             }

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -609,7 +609,7 @@ namespace NuGetGallery
         private PackageValidationResult CheckPackageDuplicatedEntries(PackageArchiveReader nuGetPackage)
         {
             // Normalize paths and ensures case sensitivity is also considered
-            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => Path.GetFullPath(packageFile.ToLowerInvariant()));
+            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => Path.GetFullPath(packageFile.ToLower()));
 
             if (packageFiles.Count() != packageFiles.Distinct(StringComparer.OrdinalIgnoreCase).Count())
             {

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Licenses;
 using NuGet.Services.Entities;

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Licenses;
 using NuGet.Services.Entities;
@@ -609,7 +610,7 @@ namespace NuGetGallery
         private PackageValidationResult CheckPackageDuplicatedEntries(PackageArchiveReader nuGetPackage)
         {
             // Normalize paths and ensures case sensitivity is also considered
-            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => Path.GetFullPath(packageFile.ToLower()));
+            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => PathUtility.StripLeadingDirectorySeparators(packageFile.ToLower()));
 
             if (packageFiles.Count() != packageFiles.Distinct(StringComparer.OrdinalIgnoreCase).Count())
             {

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -118,6 +118,13 @@ namespace NuGetGallery
                 return result;
             }
 
+            result = CheckPackageDuplicatedEntriesAsync(nuGetPackage);
+
+            if (result != null)
+            {
+                return result;
+            }
+
             var nuspecFileEntry = nuGetPackage.GetEntry(nuGetPackage.GetNuspecFile());
             using (var nuspecFileStream = await nuGetPackage.GetNuspecAsync(CancellationToken.None))
             {
@@ -594,6 +601,18 @@ namespace NuGetGallery
             else if (packageEntryCount >= maxPackageEntryCount)
             {
                 return PackageValidationResult.Invalid(Strings.UploadPackage_PackageContainsTooManyEntries);
+            }
+
+            return null;
+        }
+
+        private PackageValidationResult CheckPackageDuplicatedEntriesAsync(PackageArchiveReader nuGetPackage)
+        {
+            var packageFiles = nuGetPackage.GetFiles();
+
+            if(packageFiles.Count() != packageFiles.Distinct().Count())
+            {
+                return PackageValidationResult.Invalid(Strings.UploadPackage_PackageContainsDuplicatedEntries);
             }
 
             return null;

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -608,10 +608,7 @@ namespace NuGetGallery
 
         private PackageValidationResult CheckPackageDuplicatedEntries(PackageArchiveReader nuGetPackage)
         {
-            // Normalize paths and ensures case sensitivity is also considered
-            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile.ToLower()));
-
-            if (packageFiles.Count() != packageFiles.Distinct(StringComparer.OrdinalIgnoreCase).Count())
+            if (ValidationHelper.HasDuplicatedEntries(nuGetPackage))
             {
                 return PackageValidationResult.Invalid(Strings.UploadPackage_PackageContainsDuplicatedEntries);
             }

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
+using NuGetGallery.Helpers;
 using NuGetGallery.Packaging;
 
 namespace NuGetGallery
@@ -86,6 +87,12 @@ namespace NuGetGallery
                             Strings.SymbolsPackage_PackageIdAndVersionNotFound,
                             id,
                             normalizedVersion));
+                    }
+
+                    // Check for duplicated entries in symbols package
+                    if (ValidationHelper.HasDuplicatedEntries(packageToPush))
+                    {
+                        return SymbolPackageValidationResult.Invalid(Strings.UploadPackage_PackageContainsDuplicatedEntries);
                     }
 
                     // Do not allow to upload a snupkg to a package which has symbols package pending validations.

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2643,7 +2643,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The package contains one or more duplicated files in a same folder..
+        ///   Looks up a localized string similar to The package contains one or more duplicated files in the same folder..
         /// </summary>
         public static string UploadPackage_PackageContainsDuplicatedEntries {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2643,6 +2643,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package contains one or more duplicated files in a same folder..
+        /// </summary>
+        public static string UploadPackage_PackageContainsDuplicatedEntries {
+            get {
+                return ResourceManager.GetString("UploadPackage_PackageContainsDuplicatedEntries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The package contains too many files and/or folders..
         /// </summary>
         public static string UploadPackage_PackageContainsTooManyEntries {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -958,7 +958,7 @@ Policy violations: {0}</value>
     <value>The package contains too many files and/or folders.</value>
   </data>
   <data name="UploadPackage_PackageContainsDuplicatedEntries" xml:space="preserve">
-    <value>The package contains one or more duplicated files in a same folder.</value>
+    <value>The package contains one or more duplicated files in the same folder.</value>
   </data>
   <data name="TyposquattingCheckFails" xml:space="preserve">
     <value>The uploaded package's id is too similar to the already existing packages: {0} </value>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -957,6 +957,9 @@ Policy violations: {0}</value>
   <data name="UploadPackage_PackageContainsTooManyEntries" xml:space="preserve">
     <value>The package contains too many files and/or folders.</value>
   </data>
+  <data name="UploadPackage_PackageContainsDuplicatedEntries" xml:space="preserve">
+    <value>The package contains one or more duplicated files in a same folder.</value>
+  </data>
   <data name="TyposquattingCheckFails" xml:space="preserve">
     <value>The uploaded package's id is too similar to the already existing packages: {0} </value>
     <comment>{0} is the existing collision Ids compared with the uploaded package Id.</comment>

--- a/tests/NuGetGallery.Core.Facts/TestUtils/PackageServiceUtility.cs
+++ b/tests/NuGetGallery.Core.Facts/TestUtils/PackageServiceUtility.cs
@@ -192,7 +192,7 @@ namespace NuGetGallery.TestUtils
                         }
                     }
 
-                    if(entryNames != null)
+                    if (entryNames != null)
                     {
                         foreach(var entryName in entryNames)
                         {

--- a/tests/NuGetGallery.Core.Facts/TestUtils/PackageServiceUtility.cs
+++ b/tests/NuGetGallery.Core.Facts/TestUtils/PackageServiceUtility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using Moq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
@@ -130,7 +131,8 @@ namespace NuGetGallery.TestUtils
             string licenseFilename = null,
             byte[] licenseFileContents = null,
             string iconFilename = null,
-            byte[] iconFileBinaryContents = null)
+            byte[] iconFileBinaryContents = null,
+            IReadOnlyList<string> entryNames = null)
         {
             if (packageDependencyGroups == null)
             {
@@ -189,13 +191,32 @@ namespace NuGetGallery.TestUtils
                             writer.Write("Fake signature file.");
                         }
                     }
-                }, desiredTotalEntryCount: desiredTotalEntryCount,
+
+                    if(entryNames != null)
+                    {
+                        foreach(var entryName in entryNames)
+                        {
+                            WriteEntry(archive, entryName);
+                        }
+                    }
+                }, 
+                desiredTotalEntryCount: desiredTotalEntryCount,
                 getCustomNuspecNodes: getCustomNuspecNodes,
                 licenseExpression: licenseExpression,
                 licenseFilename: licenseFilename,
                 licenseFileContents: licenseFileContents,
                 iconFilename: iconFilename,
                 iconFileContents: iconFileBinaryContents);
+        }
+
+        private static void WriteEntry(ZipArchive archive, string entryName)
+        {
+            var entry = archive.CreateEntry(entryName);
+            using (var stream = entry.Open())
+            using (var writer = new StreamWriter(stream))
+            {
+                writer.Write(entryName);
+            }
         }
 
         public static PackageArchiveReader CreateArchiveReader(Stream stream)

--- a/tests/NuGetGallery.Facts/Helpers/ValidationHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/ValidationHelperFacts.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Moq;
+using NuGetGallery.TestUtils;
+using Xunit;
+
+namespace NuGetGallery.Helpers
+{
+    public class ValidationHelperFacts
+    {
+        public class HasDuplicatedEntriesMethod
+        {
+            [Theory]
+            [InlineData("duplicatedFile.txt", "duplicatedFile.txt")]
+            [InlineData("./temp/duplicatedFile.txt", "./temp/duplicatedFile.txt")]
+            [InlineData("./temp/duplicatedFile.txt", "./temp\\duplicatedFile.txt")]
+            [InlineData("./temp\\duplicatedFile.txt", "./temp\\duplicatedFile.txt")]
+            [InlineData("duplicatedFile.txt", "duplicatedFile.TXT")]
+            [InlineData("./duplicatedFile.txt", "duplicatedFile.txt")]
+            [InlineData("./duplicatedFile.txt", "/duplicatedFile.txt")]
+            [InlineData("/duplicatedFile.txt", "duplicatedFile.txt")]
+            [InlineData(".\\duplicatedFile.txt", "./duplicatedFile.txt")]
+            public void WithDuplicatedEntries_ReturnsFalse(params string[] entryNames)
+            {
+                // Arrange
+                var package = GeneratePackage(entryNames: entryNames);
+
+                // Act
+                var hasDuplicatedEntries = ValidationHelper.HasDuplicatedEntries(package.Object);
+
+                // Assert
+                Assert.True(hasDuplicatedEntries);
+            }
+
+            [Theory]
+            [InlineData("noDuplicatedFile.txt", "./temp/noDuplicatedFile.txt")]
+            [InlineData("./temp1/noDuplicatedFile.txt", "./temp2/noDuplicatedFile.txt")]
+            [InlineData("./temp1/noDuplicatedFile.txt", "./temp1/noDuplicatedFile.css")]
+            [InlineData("./temp1/noDuplicatedFile.txt", "./temp1\\noDuplicatedFile.css")]
+            public void WithNoDuplicatedEntries_ReturnsTrue(params string[] entryNames)
+            {
+                // Arrange
+                var package = GeneratePackage(entryNames: entryNames);
+
+                // Act
+                var hasDuplicatedEntries = ValidationHelper.HasDuplicatedEntries(package.Object);
+
+                // Assert
+                Assert.False(hasDuplicatedEntries);
+            }
+
+            private Mock<TestPackageReader> GeneratePackage(IReadOnlyList<string> entryNames)
+            {
+                var packageStream = PackageServiceUtility.CreateNuGetPackageStream(entryNames: entryNames);
+                return PackageServiceUtility.CreateNuGetPackage(packageStream);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Authentication\AuthenticationServiceFacts.cs" />
     <Compile Include="Authentication\Providers\CommonAuth\AzureActiveDirectoryV2AuthenticatorFacts.cs" />
     <Compile Include="Authentication\TestCredentialHelper.cs" />
+    <Compile Include="Helpers\ValidationHelperFacts.cs" />
     <Compile Include="Infrastructure\ODataCacheOutputAttributeFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageIdsQueryFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageVersionsQueryFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -512,6 +512,8 @@ namespace NuGetGallery
             [Theory]
             [InlineData("duplicatedFile.txt", "duplicatedFile.txt")]
             [InlineData("./temp/duplicatedFile.txt", "./temp/duplicatedFile.txt")]
+            [InlineData("./temp/duplicatedFile.txt", "./temp\\duplicatedFile.txt")]
+            [InlineData("./temp\\duplicatedFile.txt", "./temp\\duplicatedFile.txt")]
             [InlineData("duplicatedFile.txt", "duplicatedFile.TXT")]
             public async Task WithDuplicatedEntries_ReturnsInvalidPackage(params string[] entryNames)
             {
@@ -526,7 +528,7 @@ namespace NuGetGallery
 
                 // Assert
                 Assert.Equal(PackageValidationResultType.Invalid, result.Type);
-                Assert.Equal("The package contains one or more duplicated files in a same folder.", result.Message.PlainTextMessage);
+                Assert.Equal("The package contains one or more duplicated files in the same folder.", result.Message.PlainTextMessage);
                 Assert.Empty(result.Warnings);
             }
 
@@ -534,6 +536,7 @@ namespace NuGetGallery
             [InlineData("noDuplicatedFile.txt", "./temp/noDuplicatedFile.txt")]
             [InlineData("./temp1/noDuplicatedFile.txt", "./temp2/noDuplicatedFile.txt")]
             [InlineData("./temp1/noDuplicatedFile.txt", "./temp1/noDuplicatedFile.css")]
+            [InlineData("./temp1/noDuplicatedFile.txt", "./temp1\\noDuplicatedFile.css")]
             public async Task WithNoDuplicatedEntries_ReturnsAcceptedPackage(params string[] entryNames)
             {
                 // Arrange

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -515,6 +515,10 @@ namespace NuGetGallery
             [InlineData("./temp/duplicatedFile.txt", "./temp\\duplicatedFile.txt")]
             [InlineData("./temp\\duplicatedFile.txt", "./temp\\duplicatedFile.txt")]
             [InlineData("duplicatedFile.txt", "duplicatedFile.TXT")]
+            [InlineData("./duplicatedFile.txt", "duplicatedFile.txt")]
+            [InlineData("./duplicatedFile.txt", "/duplicatedFile.txt")]
+            [InlineData("/duplicatedFile.txt", "duplicatedFile.txt")]
+            [InlineData(".\\duplicatedFile.txt", "./duplicatedFile.txt")]
             public async Task WithDuplicatedEntries_ReturnsInvalidPackage(params string[] entryNames)
             {
                 // Arrange

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -511,7 +511,8 @@ namespace NuGetGallery
 
             [Theory]
             [InlineData("duplicatedFile.txt", "duplicatedFile.txt")]
-            [InlineData("/temp/duplicatedFile.txt", "/temp/duplicatedFile.txt")]
+            [InlineData("./temp/duplicatedFile.txt", "./temp/duplicatedFile.txt")]
+            [InlineData("duplicatedFile.txt", "duplicatedFile.TXT")]
             public async Task WithDuplicatedEntries_ReturnsInvalidPackage(params string[] entryNames)
             {
                 // Arrange
@@ -530,9 +531,9 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData("noDuplicatedFile.txt", "/temp/noDuplicatedFile.txt")]
-            [InlineData("/temp1/noDuplicatedFile.txt", "/temp2/noDuplicatedFile.txt")]
-            [InlineData("/temp1/noDuplicatedFile.txt", "/temp1/noDuplicatedFile.css")]
+            [InlineData("noDuplicatedFile.txt", "./temp/noDuplicatedFile.txt")]
+            [InlineData("./temp1/noDuplicatedFile.txt", "./temp2/noDuplicatedFile.txt")]
+            [InlineData("./temp1/noDuplicatedFile.txt", "./temp1/noDuplicatedFile.css")]
             public async Task WithNoDuplicatedEntries_ReturnsAcceptedPackage(params string[] entryNames)
             {
                 // Arrange

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -510,6 +510,47 @@ namespace NuGetGallery
             }
 
             [Theory]
+            [InlineData("duplicatedFile.txt", "duplicatedFile.txt")]
+            [InlineData("/temp/duplicatedFile.txt", "/temp/duplicatedFile.txt")]
+            public async Task WithDuplicatedEntries_ReturnsInvalidPackage(params string[] entryNames)
+            {
+                // Arrange
+                _nuGetPackage = GeneratePackage(entryNames: entryNames);
+
+                // Act
+                var result = await _target.ValidateBeforeGeneratePackageAsync(
+                    _nuGetPackage.Object,
+                    GetPackageMetadata(_nuGetPackage),
+                    _currentUser);
+
+                // Assert
+                Assert.Equal(PackageValidationResultType.Invalid, result.Type);
+                Assert.Equal("The package contains one or more duplicated files in a same folder.", result.Message.PlainTextMessage);
+                Assert.Empty(result.Warnings);
+            }
+
+            [Theory]
+            [InlineData("noDuplicatedFile.txt", "/temp/noDuplicatedFile.txt")]
+            [InlineData("/temp1/noDuplicatedFile.txt", "/temp2/noDuplicatedFile.txt")]
+            [InlineData("/temp1/noDuplicatedFile.txt", "/temp1/noDuplicatedFile.css")]
+            public async Task WithNoDuplicatedEntries_ReturnsAcceptedPackage(params string[] entryNames)
+            {
+                // Arrange
+                _nuGetPackage = GeneratePackage(entryNames: entryNames);
+
+                // Act
+                var result = await _target.ValidateBeforeGeneratePackageAsync(
+                    _nuGetPackage.Object,
+                    GetPackageMetadata(_nuGetPackage),
+                    _currentUser);
+
+                // Assert
+                Assert.Equal(PackageValidationResultType.Accepted, result.Type);
+                Assert.Null(result.Message);
+                Assert.Empty(result.Warnings);
+            }
+
+            [Theory]
             [InlineData(false, false)]
             [InlineData(true, true)]
             public async Task HandlesMissingLicenseAccordingToSettings(bool allowLicenselessPackages, bool expectedSuccess)
@@ -2309,6 +2350,7 @@ namespace NuGetGallery
                 RepositoryMetadata repositoryMetadata = null,
                 bool isSigned = true,
                 int? desiredTotalEntryCount = null,
+                IReadOnlyList<string> entryNames = null,
                 Func<string> getCustomNuspecNodes = null)
                 => GeneratePackageWithUserContent(
                     version: version,
@@ -2320,7 +2362,8 @@ namespace NuGetGallery
                     licenseExpression: "MIT",
                     licenseFilename: null,
                     licenseFileContents: null,
-                    licenseFileBinaryContents: null);
+                    licenseFileBinaryContents: null,
+                    entryNames: entryNames);
 
             protected static Mock<TestPackageReader> GeneratePackageWithUserContent(
                 string version = "1.2.3-alpha.0",
@@ -2335,7 +2378,8 @@ namespace NuGetGallery
                 string licenseFileContents = null,
                 byte[] licenseFileBinaryContents = null,
                 string iconFilename = null,
-                byte[] iconFileBinaryContents = null)
+                byte[] iconFileBinaryContents = null,
+                IReadOnlyList<string> entryNames = null)
             {
                 var packageStream = GeneratePackageStream(
                     version: version,
@@ -2350,7 +2394,8 @@ namespace NuGetGallery
                     licenseFileContents: licenseFileContents,
                     licenseFileBinaryContents: licenseFileBinaryContents,
                     iconFilename: iconFilename,
-                    iconFileBinaryContents: iconFileBinaryContents);
+                    iconFileBinaryContents: iconFileBinaryContents,
+                    entryNames: entryNames);
 
                 return PackageServiceUtility.CreateNuGetPackage(packageStream);
             }
@@ -2368,7 +2413,8 @@ namespace NuGetGallery
                 string licenseFileContents = null,
                 byte[] licenseFileBinaryContents = null,
                 string iconFilename = null,
-                byte[] iconFileBinaryContents = null)
+                byte[] iconFileBinaryContents = null,
+                IReadOnlyList<string> entryNames = null)
             {
                 return PackageServiceUtility.CreateNuGetPackageStream(
                     id: PackageId,
@@ -2383,7 +2429,8 @@ namespace NuGetGallery
                     licenseFilename: licenseFilename,
                     licenseFileContents: GetBinaryLicenseFileContents(licenseFileBinaryContents, licenseFileContents),
                     iconFilename: iconFilename,
-                    iconFileBinaryContents: iconFileBinaryContents);
+                    iconFileBinaryContents: iconFileBinaryContents,
+                    entryNames: entryNames);
             }
 
             private static byte[] GetBinaryLicenseFileContents(byte[] binaryContents, string stringContents)


### PR DESCRIPTION
A new validation was added at the ValidateBeforeGeneratePackageAsync method.

#7922 