### PR TITLE
Append FAQ address to AAD unmanaged tenant authentication error

### DIFF
--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -811,9 +811,20 @@ namespace NuGetGallery
 
         private ActionResult AuthenticationFailureOrExternalLinkExpired(string errorMessage = null)
         {
-            // User got here without an external login cookie (or an expired one)
-            // Send them to the logon action with a message
-            TempData["ErrorMessage"] = string.IsNullOrEmpty(errorMessage) ? Strings.ExternalAccountLinkExpired : errorMessage;
+            // We need a special case here because of https://github.com/NuGet/NuGetGallery/issues/7544. An unmanaged tenant scenario
+            // needs the FAQ URI appended to the AAD error, and we do that here so it appears in the header.
+            if ((errorMessage?.IndexOf("AADSTS65005", StringComparison.OrdinalIgnoreCase) ?? -1) > -1)
+            {
+                TempData["RawErrorMessage"] = errorMessage + "<br/>" + string.Format(Strings.DirectUserToUnmanagedTenantFAQ,
+                    UriExtensions.GetExternalUrlAnchorTag("FAQs page", GalleryConstants.FAQLinks.AccountBelongsToUnmanagedTenant));
+            }
+            else
+            {
+                // User got here without an external login cookie (or an expired one)
+                // Send them to the logon action with a message
+                TempData["ErrorMessage"] = string.IsNullOrEmpty(errorMessage) ? Strings.ExternalAccountLinkExpired : errorMessage;
+            }
+
             return Redirect(Url.LogOn(null, relativeUrl: false));
         }
 

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -813,7 +813,9 @@ namespace NuGetGallery
         {
             // We need a special case here because of https://github.com/NuGet/NuGetGallery/issues/7544. An unmanaged tenant scenario
             // needs the FAQ URI appended to the AAD error, and we do that here so it appears in the header.
-            if ((errorMessage?.IndexOf("AADSTS65005", StringComparison.OrdinalIgnoreCase) ?? -1) > -1)
+            if (!string.IsNullOrEmpty(errorMessage) &&
+                errorMessage.IndexOf("AADSTS65005", StringComparison.OrdinalIgnoreCase) > -1 &&
+                errorMessage.IndexOf("unmanaged", StringComparison.OrdinalIgnoreCase) > -1)
             {
                 TempData["RawErrorMessage"] = errorMessage + "<br/>" + string.Format(Strings.DirectUserToUnmanagedTenantFAQ,
                     UriExtensions.GetExternalUrlAnchorTag("FAQs page", GalleryConstants.FAQLinks.AccountBelongsToUnmanagedTenant));

--- a/src/NuGetGallery/GalleryConstants.cs
+++ b/src/NuGetGallery/GalleryConstants.cs
@@ -113,6 +113,7 @@ namespace NuGetGallery
             public const string NuGetChangeUsername = "https://aka.ms/nuget-faq-change-username";
             public const string NuGetDeleteAccount = "https://aka.ms/nuget-faq-delete-account";
             public const string TransformToOrganization = "https://aka.ms/nuget-faq-transform-org";
+            public const string AccountBelongsToUnmanagedTenant = "https://aka.ms/nuget-faq-unmanaged-tenant";
         }
     }
 }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -866,6 +866,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please refer to the {0} for steps to resolve this issue..
+        /// </summary>
+        public static string DirectUserToUnmanagedTenantFAQ {
+            get {
+                return ResourceManager.GetString("DirectUserToUnmanagedTenantFAQ", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The password login is discontinued and has been removed for your account. Please use your Microsoft account to log into {0} going forward..
         /// </summary>
         public static string DiscontinuedLogin_PasswordRemoved {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -693,6 +693,9 @@ For more information, please contact '{2}'.</value>
     <value>The account with the email {0} is linked to another Microsoft account.
 If you would like to update the linked Microsoft account you can do so from the account settings page.</value>
   </data>
+  <data name="DirectUserToUnmanagedTenantFAQ" xml:space="preserve">
+    <value>Please refer to the {0} for steps to resolve this issue.</value>
+  </data>
   <data name="ChangeCredential_Failed" xml:space="preserve">
     <value>Failed to update the Microsoft account with '{0}'. This could happen if it is already linked to another NuGet account. See {1} for more details.</value>
   </data>


### PR DESCRIPTION
Appending a FAQ link to the AAD authentication error when user account is in an unmanaged tenant state. Also added aka.ms to support this.

Addresses https://github.com/NuGet/NuGetGallery/issues/7544

Resultant error message on page (this change adds the last sentence):

![image](https://user-images.githubusercontent.com/14225979/81895786-6eb3ec00-95f6-11ea-800f-ae59d949c427.png)