### PR TITLE
UI fix for long username in profile page and display package(#7809)

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -998,6 +998,10 @@ img.reserved-indicator-icon {
 }
 .page-package-details .owner-list li {
   margin-bottom: 8px;
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .page-package-details .owner-list img {
   margin-right: 8px;
@@ -1438,6 +1442,9 @@ img.reserved-indicator-icon {
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -103,6 +103,10 @@
   .owner-list {
     li {
       margin-bottom: 8px;
+      display: block;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
 
     img {

--- a/src/Bootstrap/less/theme/page-profile.less
+++ b/src/Bootstrap/less/theme/page-profile.less
@@ -4,6 +4,7 @@
     margin-top: (@padding-large-vertical * 5);
 
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: baseline;
 


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Fix the long username in profile page with newline if there is not enough space
![newline](https://user-images.githubusercontent.com/64443925/82522150-64558e80-9add-11ea-88c1-e61d56d4cbb9.PNG)

* Fix the long username in display package, use ... if context has overflow, show full username when hover it
![fix1](https://user-images.githubusercontent.com/64443925/82522279-c7dfbc00-9add-11ea-810e-9b3cb3c056e0.PNG)




Addresses https://github.com/NuGet/NuGetGallery/issues/123