### PR TITLE
Fix unit test failed due to localized culture and line ending (#7779)

### DIFF
--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Services\CloudBlobCoreFileStorageServiceIntegrationTests.cs" />
     <Compile Include="Services\CorePackageFileServiceFacts.cs" />
     <Compile Include="Services\CorePackageServiceFacts.cs" />
+    <Compile Include="TestUtils\UseInvariantCultureAttribute.cs" />
     <Compile Include="TestUtils\CoreMockExtensions.cs" />
     <Compile Include="TestUtils\PackageServiceUtility.cs" />
     <Compile Include="TestUtils\TestPackage.cs" />

--- a/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
@@ -219,6 +219,7 @@ namespace NuGetGallery.Packaging
             // Act & Assert
             var ex = Assert.Throws<ArgumentException>(() => PackageMetadata.FromNuspecReader(nuspec, strict));
             Assert.StartsWith("'bad' is not a valid version string.", ex.Message);
+            Assert.Equal("value", ex.ParamName);
         }
 
         [Fact]
@@ -252,22 +253,18 @@ namespace NuGetGallery.Packaging
         }
 
         [Fact]
+        [UseInvariantCultureAttribute]
         public void ThrowsForEmptyAndNonEmptyDuplicatesWhenDuplicateMetadataElementsDetectedAndParsingIsNotStrict()
         {
             // Arrange
-            var useInvariantCultureAttr = new UseInvariantCultureAttribute();
             var packageStream = CreateTestPackageStreamWithDuplicateEmptyAndNonEmptyMetadataElements();
             var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
             var nuspec = nupkg.GetNuspecReader();
-
-            useInvariantCultureAttr.Before(null);
 
             // Act & Assert
             var ex = Assert.Throws<ArgumentException>(() => PackageMetadata.FromNuspecReader(
                 nuspec,
                 strict: false));
-
-            useInvariantCultureAttr.After(null);
 
             Assert.Equal(
                "An item with the same key has already been added.",

--- a/tests/NuGetGallery.Core.Facts/TestUtils/UseInvariantCultureAttribute.cs
+++ b/tests/NuGetGallery.Core.Facts/TestUtils/UseInvariantCultureAttribute.cs
@@ -14,8 +14,6 @@ namespace NuGetGallery.TestUtils
     {
         private CultureInfo originalUICulture;
 
-        public CultureInfo OriginalUICulture { get; set; }
-
         public override void Before(MethodInfo methodUnderTest)
         {
             originalUICulture = Thread.CurrentThread.CurrentUICulture;

--- a/tests/NuGetGallery.Core.Facts/TestUtils/UseInvariantCultureAttribute.cs
+++ b/tests/NuGetGallery.Core.Facts/TestUtils/UseInvariantCultureAttribute.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Threading;
+using Xunit.Sdk;
+
+namespace NuGetGallery.TestUtils
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class UseInvariantCultureAttribute : BeforeAfterTestAttribute
+    {
+        private CultureInfo originalUICulture;
+
+        public CultureInfo OriginalUICulture { get; set; }
+
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            originalUICulture = Thread.CurrentThread.CurrentUICulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            Thread.CurrentThread.CurrentUICulture = this.originalUICulture;
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -838,8 +838,8 @@ namespace NuGetGallery.Authentication
                 var ex = await Assert.ThrowsAsync<ArgumentException>(async () => await _authenticationService.Authenticate(cred));
 
                 // Assert
-                Assert.Equal(
-                    Strings.PasswordCredentialsCannotBeUsedHere + Environment.NewLine + "Parameter name: credential",
+                Assert.StartsWith(
+                    Strings.PasswordCredentialsCannotBeUsedHere,
                     ex.Message);
                 Assert.Equal("credential", ex.ParamName);
             }

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -6030,16 +6030,14 @@ namespace NuGetGallery
             }
 
             [Fact]
+            [UseInvariantCultureAttribute]
             public async Task WillRejectBrokenZipFiles()
             {
                 // Arrange
-                var useInvariantCultureAttr = new UseInvariantCultureAttribute();
                 var fakeUploadedFile = new Mock<HttpPostedFileBase>();
                 fakeUploadedFile.Setup(x => x.FileName).Returns("file.nupkg");
                 var fakeFileStream = new MemoryStream(TestDataResourceUtility.GetResourceBytes("Zip64Package.Corrupted.1.0.0.nupkg"));
                 fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
-
-                useInvariantCultureAttr.Before(null);
 
                 var controller = CreateController(
                     GetConfigurationService(),
@@ -6048,8 +6046,6 @@ namespace NuGetGallery
 
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
                 
-                useInvariantCultureAttr.After(null);
-
                 Assert.NotNull(result);
                 Assert.Equal("Central Directory corrupt.", (result.Data as JsonValidationMessage[])[0].PlainTextMessage);
             }
@@ -6083,16 +6079,14 @@ namespace NuGetGallery
             [Theory]
             [InlineData("Contains#Invalid$Characters!@#$%^&*")]
             [InlineData("Contains#Invalid$Characters!@#$%^&*EndsOnValidCharacter")]
+            [UseInvariantCultureAttribute]
             public async Task WillShowViewWithErrorsIfPackageIdIsBreaksParsing(string packageId)
             {
                 // Arrange
-                var useInvariantCultureAttr = new UseInvariantCultureAttribute();
                 var fakeUploadedFile = new Mock<HttpPostedFileBase>();
                 fakeUploadedFile.Setup(x => x.FileName).Returns(packageId + ".nupkg");
                 var fakeFileStream = TestPackage.CreateTestPackageStream(packageId, "1.0.0");
                 fakeUploadedFile.Setup(x => x.InputStream).Returns(fakeFileStream);
-
-                useInvariantCultureAttr.Before(null);
 
                 var controller = CreateController(
                     GetConfigurationService(),
@@ -6100,8 +6094,6 @@ namespace NuGetGallery
                 controller.SetCurrentUser(TestUtility.FakeUser);
 
                 var result = await controller.UploadPackage(fakeUploadedFile.Object) as JsonResult;
-
-                useInvariantCultureAttr.After(null);
 
                 Assert.NotNull(result);
                 Assert.StartsWith($"An error occurred while parsing EntityName.", (result.Data as JsonValidationMessage[])[0].PlainTextMessage);

--- a/tests/NuGetGallery.Facts/TestUtils/ContractAssert.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/ContractAssert.cs
@@ -38,8 +38,8 @@ namespace NuGetGallery
         {
             var argEx = Assert.Throws<ArgumentException>(() => act());
             Assert.Equal(paramName, argEx.ParamName);
-            Assert.Equal(
-                message + Environment.NewLine + $"Parameter name: {paramName}",
+            Assert.StartsWith(
+                message,
                 argEx.Message);
         }
 
@@ -47,8 +47,8 @@ namespace NuGetGallery
         {
             var argEx = await Assert.ThrowsAsync<ArgumentException>(async () => await act());
             Assert.Equal(paramName, argEx.ParamName);
-            Assert.Equal(
-                message + Environment.NewLine + $"Parameter name: {paramName}",
+            Assert.StartsWith(
+                message,
                 argEx.Message);
         }
     }


### PR DESCRIPTION
Summary of the changes:

* Change to Assert.StartWith instead of Assert.Equal, avoid checking localized 'parameter'  
* Add new class called 'UseInvariantCultureAttribute', change thread UI culture before test, and reset 
   after test
* Addressed those unit test:  1.NuGetGallery.Packaging.PackageMetadataFacts.ThrowsForEmptyAndNonEmptyDuplicatesWhenDuplicateMetadataElementsDetectedAndParsingIsNotStrict
2. NuGetGallery.Packaging.PackageMetadataFacts.ThrowsWhenInvalidMinClientVersion
3.NuGetGallery.PackagesControllerFacts+TheUploadFileActionForPostRequests.WillRejectBrokenZipFiles  NuGetGallery.PackagesControllerFacts+TheUploadFileActionForPostRequests.WillShowViewWithErrorsIfPackageIdIsBreaksParsing
4.NuGetGallery.Authentication.AuthenticationServiceFacts+TheAuthenticateMethod.GivenPasswordCredential_ItThrowsArgumentException
5.NuGetGallery.Diagnostics.DiagnosticsServiceFacts+TheGetSourceMethod.RequiresNonNullOrEmptyName
6.NuGetGallery.Services.ContentServiceFacts+TheGetContentItemMethod.GivenANullOrEmptyName_ItShouldThrow
 

Addresses https://github.com/NuGet/NuGetGallery/issues/123