### PR TITLE
Make statistical significant figures formatting culture-sensitive

### DIFF
--- a/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/StatisticsPackagesViewModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 
 namespace NuGetGallery
 {
@@ -160,14 +161,20 @@ namespace NuGetGallery
             var roundedNum = Math.Round(number * roundingFactor) / roundingFactor;
 
             // Pad from right with zeroes to sigFigures length, so for 3 sig figs, 1.6 becomes 1.60
-            var formattedNum = roundedNum.ToString("F" + sigFigures);
-            var desiredLength = formattedNum.Contains('.') ? sigFigures + 1 : sigFigures;
+            var decimalPoint = Thread.CurrentThread.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
+            var formattedNum = roundedNum.ToString("F" + sigFigures, Thread.CurrentThread.CurrentUICulture.NumberFormat);
+            var desiredLength = formattedNum.Contains(decimalPoint) ? sigFigures + decimalPoint.Length : sigFigures;
             if (formattedNum.Length > desiredLength)
             {
                 formattedNum = formattedNum.Substring(0, desiredLength);
             }
 
-            formattedNum = formattedNum.TrimEnd('.');
+            // If trailing char/s is/are decimal point separator, trim it
+            if (formattedNum.Length > decimalPoint.Length && 
+                formattedNum.Substring(formattedNum.Length - decimalPoint.Length, decimalPoint.Length) == decimalPoint)
+            {
+                formattedNum = formattedNum.Substring(0, formattedNum.Length - decimalPoint.Length);
+            }
 
             if (numDiv >= _magnitudeAbbreviations.Length)
             {

--- a/tests/NuGetGallery.Facts/ViewModels/StatisticsPackagesViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/StatisticsPackagesViewModelFacts.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Globalization;
+using System.Threading;
 using Xunit;
 
 namespace NuGetGallery.ViewModels
@@ -15,9 +17,15 @@ namespace NuGetGallery.ViewModels
         [InlineData(1775856283, 3, "1.78B")]
         [InlineData(1775856283, 5, "1.7759B")]
         [InlineData(775856283, 3, "776M")]
+        [InlineData(775856283, 3, "776M", "en-US")] // culture-specific decimal separator test, right-clipping separator (776. -> 776)
+        [InlineData(775856283, 3, "776M", "ar-SA")] // culture-specific decimal separator test, right-clipping separator (776. -> 776)
+        [InlineData(775856283, 3, "776M", "fr-FR")] // culture-specific decimal separator test, right-clipping separator (776. -> 776)
         [InlineData(775856283, 5, "775.86M")]
         [InlineData(75856283, 3, "75.9M")]
         [InlineData(56283, 3, "56.3k")]
+        [InlineData(56283, 3, "56.3k", "en-US")] // culture-specific decimal separator test, no right-clipping of separator
+        [InlineData(56283, 3, "56.3k", "ar-SA")] // culture-specific decimal separator test, no right-clipping of separator
+        [InlineData(56283, 3, "56.3k", "fr-FR")] // culture-specific decimal separator test, no right-clipping of separator
         [InlineData(56283283283283, 3, "56.3T")]
         [InlineData(56283283283283283, 3, "56.3q")]
         [InlineData(56283283283283283283283283283283d, 3, "56.3n")]
@@ -25,9 +33,24 @@ namespace NuGetGallery.ViewModels
         [InlineData(1, 3, "1.00")]
         [InlineData(10, 3, "10.0")]
         [InlineData(100, 3, "100")]
-        public void CreatesShortNumberRespectingSignificantFigures(double number, int sigFigs, string expected)
+        public void CreatesShortNumberRespectingSignificantFigures(double number, int sigFigs, string expected, string culture = "")
         {
+            CultureInfo cacheCulture = null;
+            if (culture != "")
+            {
+                cacheCulture = Thread.CurrentThread.CurrentUICulture;
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
+            }
+
+            expected = expected.Replace(".", Thread.CurrentThread.CurrentUICulture.NumberFormat.NumberDecimalSeparator);
+
             var result = StatisticsPackagesViewModel.DisplayShortNumber(number, sigFigs);
+
+            if (cacheCulture != null)
+            {
+                Thread.CurrentThread.CurrentUICulture = cacheCulture;
+            }
+
             Assert.Equal(expected, result);
         }
     }


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8032

Adds culture-awareness to string operations creating short numbers for Y-axis on graphs. Added culture cases to unit tests. Examples:

fr-FR:
![image](https://user-images.githubusercontent.com/14225979/84342945-33531000-abea-11ea-94c0-410558360bbe.png)

en-US:
![image](https://user-images.githubusercontent.com/14225979/84342961-3ea63b80-abea-11ea-80f8-9d4e900f3c5e.png)