### PR TITLE
Changing the banner to indicate that TLS 1.2 enforcement took place

### DIFF
--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -23,7 +23,7 @@
         <div class="col-sm-12">
             <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
             <span>
-                NuGet.org had TLS 1.0 and 1.1 disabled. Please, refer to our <a href="https://devblogs.microsoft.com/nuget/deprecating-tls-1-0-and-1-1-on-nuget-org/">blog post</a> if you are having connection issues.
+                NuGet.org had TLS 1.0 and 1.1 disabled. Please refer to our <a href="https://devblogs.microsoft.com/nuget/deprecating-tls-1-0-and-1-1-on-nuget-org/">blog post</a> if you are having connection issues.
             </span>
         </div>
     </div>

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -23,8 +23,7 @@
         <div class="col-sm-12">
             <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
             <span>
-                NuGet.org will permanently <a href="https://devblogs.microsoft.com/nuget/nuget-org-will-permanently-remove-support-for-tls-1-0-and-1-1-on-june-15th/">
-                remove support</a> for TLS 1.0 and 1.1 on June 15th. Please ensure that your systems use TLS 1.2.
+                NuGet.org had TLS 1.0 and 1.1 disabled. Please, refer to our <a href="https://devblogs.microsoft.com/nuget/deprecating-tls-1-0-and-1-1-on-nuget-org/">blog post</a> if you are having connection issues.
             </span>
         </div>
     </div>


### PR DESCRIPTION
Linked directly to a blog post with workarounds for affected systems outlined.