### PR TITLE
[HOTFIX] Increase migration's database timeout

### DIFF
--- a/src/NuGetGallery/Migrations/MigrationsConfiguration.cs
+++ b/src/NuGetGallery/Migrations/MigrationsConfiguration.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data.Entity.Migrations;
 using System.Linq;
 using NuGet.Services.Entities;
@@ -12,6 +13,7 @@ namespace NuGetGallery.Migrations
         public MigrationsConfiguration()
         {
             AutomaticMigrationsEnabled = false;
+            CommandTimeout = (int)TimeSpan.FromMinutes(30).TotalSeconds;
         }
 
         protected override void Seed(EntitiesContext context)


### PR DESCRIPTION
We added a migration to add an index on the `PackageDependencies` table. This migration takes longer than 30 seconds to run on PROD and is timing out. This change increases the timeout to 30 minutes which we hope is enough to create the new index.

⚠TODO: verify on DEV

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3820287&view=results
Release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=712036