### PR TITLE
Don't track the package push failure if the client has disconnected

### DIFF
--- a/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
+++ b/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
@@ -236,6 +236,11 @@ namespace GitHubVulnerabilities2Db.Gallery
             throw new NotImplementedException();
         }
 
+        public void TrackPackagePushDisconnectEvent()
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackPackagePushEvent(Package package, User user, IIdentity identity)
         {
             throw new NotImplementedException();
@@ -312,6 +317,11 @@ namespace GitHubVulnerabilities2Db.Gallery
         }
 
         public void TrackSymbolPackageFailedGalleryValidationEvent(string packageId, string packageVersion)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void TrackSymbolPackagePushDisconnectEvent()
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -32,6 +32,8 @@ namespace NuGetGallery
 
         void TrackPackagePushFailureEvent(string id, NuGetVersion version);
 
+        void TrackPackagePushDisconnectEvent();
+
         void TrackPackageUnlisted(Package package);
 
         void TrackPackageListed(Package package);
@@ -201,6 +203,11 @@ namespace NuGetGallery
         /// <param name="packageId">The id of the package that has the symbols uploaded.</param>
         /// <param name="packageVersion">The version of the package that has the symbols uploaded.</param>
         void TrackSymbolPackagePushFailureEvent(string packageId, string packageVersion);
+
+        /// <summary>
+        /// A telemetry event emitted when a symbol package push failed due to client disconnect.
+        /// </summary>
+        void TrackSymbolPackagePushDisconnectEvent();
 
         /// <summary>
         /// A telemetry event emitted when a symbol package fails Gallery validation.

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -87,6 +87,8 @@ namespace NuGetGallery
             public const string ABTestEnrollmentInitialized = "ABTestEnrollmentInitialized";
             public const string ABTestEnrollmentUpgraded = "ABTestEnrollmentUpgraded";
             public const string ABTestEvaluated = "ABTestEvaluated";
+            public const string PackagePushDisconnect = "PackagePushDisconnect";
+            public const string SymbolPackagePushDisconnect = "SymbolPackagePushDisconnect";
         }
 
         private readonly IDiagnosticsSource _diagnosticsSource;
@@ -1080,6 +1082,16 @@ namespace NuGetGallery
                 properties.Add(TestBucket, testBucket.ToString());
                 properties.Add(TestPercentage, testPercentage.ToString());
             });
+        }
+
+        public void TrackPackagePushDisconnectEvent()
+        {
+            TrackMetric(Events.PackagePushDisconnect, 1, p => { });
+        }
+
+        public void TrackSymbolPackagePushDisconnectEvent()
+        {
+            TrackMetric(Events.SymbolPackagePushDisconnect, 1, p => { });
         }
 
         /// <summary>

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -512,6 +512,15 @@ namespace NuGetGallery
                     HttpStatusCode.RequestEntityTooLarge,
                     Strings.PackageFileTooLarge);
             }
+            catch (HttpException ex) when (!Response.IsClientConnected)
+            {
+                // ASP.NET throws HttpException when the client has disconnected during the upload.
+                TelemetryService.TrackSymbolPackagePushDisconnectEvent();
+                QuietLog.LogHandledException(ex);
+                return new HttpStatusCodeWithBodyResult(
+                    HttpStatusCode.BadRequest,
+                    Strings.PackageUploadCancelled);
+            }
             catch (Exception ex)
             {
                 ex.Log();
@@ -810,6 +819,15 @@ namespace NuGetGallery
                 return new HttpStatusCodeWithBodyResult(
                     HttpStatusCode.RequestEntityTooLarge,
                     Strings.PackageFileTooLarge);
+            }
+            catch (HttpException ex) when (!Response.IsClientConnected)
+            {
+                // ASP.NET throws HttpException when the client has disconnected during the upload.
+                TelemetryService.TrackPackagePushDisconnectEvent();
+                QuietLog.LogHandledException(ex);
+                return new HttpStatusCodeWithBodyResult(
+                    HttpStatusCode.BadRequest,
+                    Strings.PackageUploadCancelled);
             }
             catch (Exception)
             {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1427,6 +1427,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The package upload failed due to the client disconnecting..
+        /// </summary>
+        public static string PackageUploadCancelled {
+            get {
+                return ResourceManager.GetString("PackageUploadCancelled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package versions that differ only by metadata cannot be uploaded. A package with ID &apos;{0}&apos; and version &apos;{1}&apos; already exists and cannot be modified..
         /// </summary>
         public static string PackageVersionDiffersOnlyByMetadataAndCannotBeModified {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1159,4 +1159,7 @@ The {1} Team</value>
   <data name="TwoFAFeedback_Error" xml:space="preserve">
     <value>There was an unexpected error when submitting feedback. Please contact NuGet support.</value>
   </data>
+  <data name="PackageUploadCancelled" xml:space="preserve">
+    <value>The package upload failed due to the client disconnecting.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Telemetry/CustomerResourceIdEnricher.cs
+++ b/src/NuGetGallery/Telemetry/CustomerResourceIdEnricher.cs
@@ -20,6 +20,10 @@ namespace NuGetGallery
         {
             TelemetryService.Events.PackagePush,
             TelemetryService.Events.PackagePushFailure,
+            TelemetryService.Events.PackagePushDisconnect,
+            TelemetryService.Events.SymbolPackagePush,
+            TelemetryService.Events.SymbolPackagePushFailure,
+            TelemetryService.Events.SymbolPackagePushDisconnect,
         };
 
         public void Initialize(ITelemetry telemetry)

--- a/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
@@ -233,6 +233,11 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
+        public void TrackPackagePushDisconnectEvent()
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackPackagePushEvent(Package package, User user, IIdentity identity)
         {
             throw new NotImplementedException();
@@ -309,6 +314,11 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         }
 
         public void TrackSymbolPackageFailedGalleryValidationEvent(string packageId, string packageVersion)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void TrackSymbolPackagePushDisconnectEvent()
         {
             throw new NotImplementedException();
         }

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -331,6 +331,14 @@ namespace NuGetGallery
                     yield return new object[] { "ABTestEvaluated",
                         (TrackAction)(s => s.TrackABTestEvaluated("SearchPreview", true, true, 0, 20))
                     };
+
+                    yield return new object[] { "PackagePushDisconnect",
+                        (TrackAction)(s => s.TrackPackagePushDisconnectEvent())
+                    };
+
+                    yield return new object[] { "SymbolPackagePushDisconnect",
+                        (TrackAction)(s => s.TrackSymbolPackagePushDisconnectEvent())
+                    };
                 }
             }
 

--- a/tests/NuGetGallery.Facts/Telemetry/CustomerResourceIdEnricherFacts.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/CustomerResourceIdEnricherFacts.cs
@@ -123,6 +123,10 @@ namespace NuGetGallery.Telemetry
         {
             new object[] { "PackagePush" },
             new object[] { "PackagePushFailure" },
+            new object[] { "PackagePushDisconnect" },
+            new object[] { "SymbolPackagePush" },
+            new object[] { "SymbolPackagePushFailure" },
+            new object[] { "SymbolPackagePushDisconnect" },
         };
     }
 }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/8022

I was unable to reproduce the issue with many wild attempts (local devbox, app service directly, APIM, custom HTTP client implementation, raising firewall in the middle of request, killing connection via external tools, etc) but from reading online this seems like the recommended implementation. See https://stackoverflow.com/questions/4772597 for some recommendations. We can't use the cancellation token approach because the API that is throwing does not accept a token. It's this line that throws:
https://github.com/NuGet/NuGetGallery/blob/84ea5890b77e79b1f218521f2c031f8ee6c311f5/src/NuGetGallery/Controllers/ApiController.cs#L984