### PR TITLE
Update `websocket-extensions` dependency

### DIFF
--- a/src/Bootstrap/package-lock.json
+++ b/src/Bootstrap/package-lock.json
@@ -2334,9 +2334,9 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
     "which": {


### PR DESCRIPTION
Bump `websocket-extensions` to the latest version. This is pulled in transitively by the `grunt-contrib-watch` development dependency. I verified this change by ensuring `grunt` still ran fine.

Addresses https://github.com/NuGet/NuGetGallery/network/alert/src/Bootstrap/package-lock.json/websocket-extensions/open
Addresses https://github.com/nuget/engineering/issues/3231