### PR TITLE
Remove non-existent endpoints from robots.txt

### DIFF
--- a/src/NuGetGallery/Public/robots.txt
+++ b/src/NuGetGallery/Public/robots.txt
@@ -1,7 +1,3 @@
-﻿User-agent: * 
+User-agent: * 
 Disallow: /api/v2/package/*$
 Disallow: /api/v2/package/*/*$
-Disallow: /packages/*/*/Contents$
-Disallow: /packages/*/*/contents$
-Disallow: /Packages/*/*/Contents$
-Disallow: /Packages/*/*/contents$


### PR DESCRIPTION
The `/packages/*/*/Contents` route does not exist
Thanks for the heads up @xavierdecoster