### PR TITLE
Add RECOMPILE query hint to package dependents SQL

### DIFF
--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -56,7 +56,18 @@ namespace NuGetGallery
            ReadOnly = readOnly;
         }
 
+        public IDisposable WithQueryHint(string queryHint)
+        {
+            if (QueryHint != null)
+            {
+                throw new InvalidOperationException("A query hint is already applied.");
+            }
+
+            return new QueryHintScope(this, queryHint);
+        }
+
         public bool ReadOnly { get; private set; }
+        public string QueryHint { get; private set; }
         public DbSet<Package> Packages { get; set; }
         public DbSet<PackageDeprecation> Deprecations { get; set; }
         public DbSet<PackageRegistration> PackageRegistrations { get; set; }
@@ -503,5 +514,21 @@ namespace NuGetGallery
                 .WillCascadeOnDelete(false);
         }
 #pragma warning restore 618
+
+        private class QueryHintScope : IDisposable
+        {
+            private readonly EntitiesContext _entitiesContext;
+
+            public QueryHintScope(EntitiesContext entitiesContext, string queryHint)
+            {
+                _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
+                _entitiesContext.QueryHint = queryHint;
+            }
+
+            public void Dispose()
+            {
+                _entitiesContext.QueryHint = null;
+            }
+        }
     }
 }

--- a/src/NuGetGallery.Core/Entities/IReadOnlyEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IReadOnlyEntitiesContext.cs
@@ -14,5 +14,19 @@ namespace NuGetGallery
         DbSet<T> Set<T>() where T : class;
 
         void SetCommandTimeout(int? seconds);
+
+        /// <summary>
+        /// Sets the <see cref="QueryHint"/> for queries to the provided value until the returned disposable is disposed.
+        /// Note that this method MUST NOT be called with user input.
+        /// </summary>
+        /// <param name="queryHint">The query hint.</param>
+        /// <example>Provide "RECOMPILE" to disable query plan caching.</example>
+        /// <returns>A disposable that determines the lifetime of the provided query hint.</returns>
+        IDisposable WithQueryHint(string queryHint);
+
+        /// <summary>
+        /// The current query hint to use for queries. Can be set using <see cref="WithQueryHint(string)"/>.
+        /// </summary>
+        string QueryHint { get; }
     }
 }

--- a/src/NuGetGallery.Core/Entities/QueryHintInterceptor.cs
+++ b/src/NuGetGallery.Core/Entities/QueryHintInterceptor.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using System.Data.Entity.Infrastructure.Interception;
+using System.Diagnostics.CodeAnalysis;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// A global (static) interceptor for Entity Framework queries. This is used for
+    /// <see cref="IReadOnlyEntitiesContext.WithQueryHint(string)"/> to set a query hint for a short window of time on
+    /// a specific entity context. Inspired by: https://stackoverflow.com/a/45170243
+    /// </summary>
+    public class QueryHintInterceptor : DbCommandInterceptor
+    {
+        [SuppressMessage("Microsoft.Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "The query hint is not customer input.")]
+        public override void ReaderExecuting(DbCommand command, DbCommandInterceptionContext<DbDataReader> interceptionContext)
+        {
+            foreach (var dbContext in interceptionContext.DbContexts)
+            {
+                if (dbContext is IReadOnlyEntitiesContext entitiesContext)
+                {
+                    var queryHint = entitiesContext.QueryHint;
+                    if (queryHint != null)
+                    {
+                        command.CommandText += $" OPTION ( {queryHint} )";
+                    }
+
+                    break;
+                }
+            }
+
+            base.ReaderExecuting(command, interceptionContext);
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Entities/ReadOnlyEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/ReadOnlyEntitiesContext.cs
@@ -30,6 +30,8 @@ namespace NuGetGallery
             }
         }
 
+        public string QueryHint => _entitiesContext.QueryHint;
+
         DbSet<T> IReadOnlyEntitiesContext.Set<T>()
         {
             return _entitiesContext.Set<T>();
@@ -44,5 +46,7 @@ namespace NuGetGallery
         {
             _entitiesContext.Dispose();
         }
+
+        public IDisposable WithQueryHint(string queryHint) => _entitiesContext.WithQueryHint(queryHint);
     }
 }

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -121,6 +121,7 @@
     <Compile Include="DisposableAction.cs" />
     <Compile Include="Entities\DatabaseWrapper.cs" />
     <Compile Include="Entities\DbContextTransactionWrapper.cs" />
+    <Compile Include="Entities\QueryHintInterceptor.cs" />
     <Compile Include="Entities\ReadOnlyEntitiesContext.cs" />
     <Compile Include="Entities\IReadOnlyEntitiesContext.cs" />
     <Compile Include="Entities\ReadOnlyEntityRepository.cs" />

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -155,8 +155,13 @@ namespace NuGetGallery
             }
             
             PackageDependents result = new PackageDependents();
-            result.TopPackages = GetListOfDependents(id);
-            result.TotalPackageCount = GetDependentCount(id);
+            
+            using (_entitiesContext.WithQueryHint("RECOMPILE"))
+            {
+                result.TopPackages = GetListOfDependents(id);
+                result.TotalPackageCount = GetDependentCount(id);
+            }
+
             return result;
         }
 

--- a/src/NuGetGallery/App_Data/Files/Content/AB-Test-Configuration.json
+++ b/src/NuGetGallery/App_Data/Files/Content/AB-Test-Configuration.json
@@ -1,5 +1,5 @@
 {
   "PreviewSearchPercentage": 0,
   "PreviewHijackPercentage": 0,
-  "DependentsPercentage": 0
+  "DependentsPercentage": 100
 }

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -48,8 +48,8 @@
       "Domains": []
     },
     "NuGetGallery.PackageDependents": {
-      "All": false,
-      "SiteAdmins": true,
+      "All": true,
+      "SiteAdmins": false,
       "Accounts": [],
       "Domains": []
     }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure.Interception;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -171,6 +172,8 @@ namespace NuGetGallery
                 .AsSelf()
                 .As<ICacheService>()
                 .InstancePerLifetimeScope();
+
+            DbInterception.Add(new QueryHintInterceptor());
 
             var galleryDbConnectionFactory = CreateDbConnectionFactory(
                 loggerFactory,

--- a/src/VerifyMicrosoftPackage/Fakes/FakeEntitiesContext.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeEntitiesContext.cs
@@ -27,6 +27,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public DbSet<Package> Packages { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DbSet<PackageRename> PackageRenames { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
+        public string QueryHint => throw new NotImplementedException();
+
         public void DeleteOnCommit<T>(T entity) where T : class
         {
             throw new NotImplementedException();
@@ -53,6 +55,11 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         }
 
         public void SetCommandTimeout(int? seconds)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDisposable WithQueryHint(string queryHint)
         {
             throw new NotImplementedException();
         }

--- a/tests/NuGetGallery.Facts/Entities/EntitiesContextFacts.cs
+++ b/tests/NuGetGallery.Facts/Entities/EntitiesContextFacts.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data;
 using NuGet.Services.Entities;
 using Xunit;
@@ -18,6 +19,28 @@ namespace NuGetGallery.Entities
                 Key = -1,
                 Username = "FredFredFred",
             }));
+        }
+
+        [Fact]
+        public void WithQueryHintDisposeClearsQueryHint()
+        {
+            var entitiesContext = new EntitiesContext("", readOnly: true);
+
+            Assert.Null(entitiesContext.QueryHint);
+            var disposable = entitiesContext.WithQueryHint("RECOMPILE");
+            Assert.Equal("RECOMPILE", entitiesContext.QueryHint);
+            disposable.Dispose();
+            Assert.Null(entitiesContext.QueryHint);
+        }
+
+        [Fact]
+        public void MultipleQueryHintsAreNotSupported()
+        {
+            var entitiesContext = new EntitiesContext("", readOnly: true);
+            entitiesContext.WithQueryHint("RECOMPILE");
+
+            Assert.Throws<InvalidOperationException>(() => entitiesContext.WithQueryHint("RECOMPILE"));
+
         }
     }
 }

--- a/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
@@ -209,6 +209,8 @@ namespace NuGetGallery
             }
         }
 
+        public virtual string QueryHint => throw new NotImplementedException();
+
         public Task<int> SaveChangesAsync()
         {
             _areChangesSaved = true;
@@ -311,6 +313,11 @@ namespace NuGetGallery
 
         public void Dispose()
         {
+        }
+
+        public virtual IDisposable WithQueryHint(string queryHint)
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/8078

The alternative was to revert to raw SQL. I discussed with @agr and we agreed to go with this EF extension approach.