### PR TITLE
Removing TLS banner

### DIFF
--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -8,17 +8,6 @@
     var rawErrorMessage = TempData.ContainsKey("RawErrorMessage") ? TempData["RawErrorMessage"].ToString() : null;
 }
 
-<div class="container-fluid banner banner-info text-center">
-    <div class="row">
-        <div class="col-sm-12">
-            <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
-            <span>
-                NuGet.org had TLS 1.0 and 1.1 disabled. Please refer to our <a href="https://devblogs.microsoft.com/nuget/deprecating-tls-1-0-and-1-1-on-nuget-org/">blog post</a> if you are having connection issues.
-            </span>
-        </div>
-    </div>
-</div>
-
 @if (!string.IsNullOrWhiteSpace(Config.Current.WarningBanner))
 {
     <div class="container-fluid banner banner-bright text-center">


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8100

This effectively reverses changes introduced by https://github.com/NuGet/NuGetGallery/pull/8012 and https://github.com/NuGet/NuGetGallery/pull/8046 dropping the `<div>` with the banner. The CSS changes are preserved for later reuse.