### PR TITLE
Use OPTIMIZE FOR UNKNOWN for dependents queries

### DIFF
--- a/src/NuGetGallery.Services/Configuration/IQueryHintConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IQueryHintConfiguration.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery.Services
+{
+    public interface IQueryHintConfiguration
+    {
+        /// <summary>
+        /// Determines whether the RECOMPILE query hint should be used for the package dependents query. Some popular
+        /// package IDs perform much better with their own dedicated query plan instead of OPTIMIZE FOR UNKNOWN.
+        /// </summary>
+        /// <param name="packageId">The package ID.</param>
+        /// <returns>True, if the RECOMPILE query hint should be used for the provided package ID.</returns>
+        bool ShouldUseRecompileForPackageDependents(string packageId);
+    }
+}

--- a/src/NuGetGallery.Services/Configuration/QueryHintConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/QueryHintConfiguration.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace NuGetGallery.Services
+{
+    public class QueryHintConfiguration : IQueryHintConfiguration
+    {
+        public QueryHintConfiguration() : this(Enumerable.Empty<string>())
+        {
+        }
+
+        [JsonConstructor]
+        public QueryHintConfiguration(IEnumerable<string> recompileForPackageDependents)
+        {
+            RecompileForPackageDependents = new HashSet<string>(
+                recompileForPackageDependents ?? Enumerable.Empty<string>(),
+                StringComparer.OrdinalIgnoreCase);
+        }
+
+        public HashSet<string> RecompileForPackageDependents { get; }
+
+        public bool ShouldUseRecompileForPackageDependents(string packageId)
+        {
+            return RecompileForPackageDependents.Contains(packageId);
+        }
+    }
+}

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -116,12 +116,14 @@
     <Compile Include="Configuration\ILoginDiscontinuationConfiguration.cs" />
     <Compile Include="Configuration\IPackageDeleteConfiguration.cs" />
     <Compile Include="Configuration\IODataCacheConfiguration.cs" />
+    <Compile Include="Configuration\IQueryHintConfiguration.cs" />
     <Compile Include="Configuration\IServiceBusConfiguration.cs" />
     <Compile Include="Configuration\ISymbolsConfiguration.cs" />
     <Compile Include="Configuration\ITyposquattingConfiguration.cs" />
     <Compile Include="Configuration\LoginDiscontinuationConfiguration.cs" />
     <Compile Include="Configuration\ODataCacheConfiguration.cs" />
     <Compile Include="Configuration\PackageDeleteConfiguration.cs" />
+    <Compile Include="Configuration\QueryHintConfiguration.cs" />
     <Compile Include="Configuration\SecretReader\EmptySecretReaderFactory.cs" />
     <Compile Include="Configuration\SecretReader\SecretReaderFactory.cs" />
     <Compile Include="Configuration\ServiceBusConfiguration.cs" />

--- a/src/NuGetGallery.Services/ServicesConstants.cs
+++ b/src/NuGetGallery.Services/ServicesConstants.cs
@@ -56,6 +56,7 @@ namespace NuGetGallery
             public static readonly string ABTestConfiguration = "AB-Test-Configuration";
             public static readonly string ODataCacheConfiguration = "OData-Cache-Configuration";
             public static readonly string CacheConfiguration = "Cache-Configuration";
+            public static readonly string QueryHintConfiguration = "Query-Hint-Configuration";
         }
     }
 }

--- a/src/NuGetGallery.Services/Storage/ContentObjectService.cs
+++ b/src/NuGetGallery.Services/Storage/ContentObjectService.cs
@@ -27,6 +27,7 @@ namespace NuGetGallery
             ABTestConfiguration = new ABTestConfiguration();
             ODataCacheConfiguration = new ODataCacheConfiguration();
             CacheConfiguration = new CacheConfiguration();
+            QueryHintConfiguration = new QueryHintConfiguration();
         }
 
         public ILoginDiscontinuationConfiguration LoginDiscontinuationConfiguration { get; private set; }
@@ -37,6 +38,7 @@ namespace NuGetGallery
         public IABTestConfiguration ABTestConfiguration { get; private set; }
         public IODataCacheConfiguration ODataCacheConfiguration { get; private set; }
         public ICacheConfiguration CacheConfiguration { get; private set; }
+        public IQueryHintConfiguration QueryHintConfiguration { get; private set; }
 
         public async Task Refresh()
         {
@@ -72,6 +74,10 @@ namespace NuGetGallery
             CacheConfiguration =
                 await Refresh<CacheConfiguration>(ServicesConstants.ContentNames.CacheConfiguration) ??
                 new CacheConfiguration();
+
+            QueryHintConfiguration =
+                await Refresh<QueryHintConfiguration>(ServicesConstants.ContentNames.QueryHintConfiguration) ??
+                new QueryHintConfiguration();
         }
 
         private async Task<T> Refresh<T>(string contentName)

--- a/src/NuGetGallery.Services/Storage/IContentObjectService.cs
+++ b/src/NuGetGallery.Services/Storage/IContentObjectService.cs
@@ -16,6 +16,7 @@ namespace NuGetGallery
         IABTestConfiguration ABTestConfiguration { get; }
         IODataCacheConfiguration ODataCacheConfiguration { get; }
         ICacheConfiguration CacheConfiguration { get; }
+        IQueryHintConfiguration QueryHintConfiguration { get; }
 
         Task Refresh();
     }

--- a/src/NuGetGallery/App_Data/Files/Content/Query-Hint-Configuration.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Query-Hint-Configuration.json
@@ -1,0 +1,3 @@
+{
+  "RecompileForPackageDependents": []
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2302,6 +2302,9 @@
   <ItemGroup>
     <Content Include="App_Data\Files\Content\Cache-Configuration.json" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="App_Data\Files\Content\Query-Hint-Configuration.json" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -360,7 +360,7 @@
     </customErrors>
     <sessionState mode="Off"/>
     <machineKey configProtectionProvider="GalleryMachineKeyConfigurationProvider">
-      <EncryptedData />
+      <EncryptedData/>
     </machineKey>
   </system.web>
   <system.webServer>

--- a/src/VerifyMicrosoftPackage/Application.cs
+++ b/src/VerifyMicrosoftPackage/Application.cs
@@ -265,6 +265,7 @@ namespace NuGet.VerifyMicrosoftPackage
             var telemetryService = new FakeTelemetryService();
             var securityPolicyService = new FakeSecurityPolicyService();
             var contextFake = new FakeEntitiesContext();
+            var contentObjectService = new FakeContentObjectService();
 
             var packageService = new PackageService(
                 packageRegistrationRepository,
@@ -273,7 +274,9 @@ namespace NuGet.VerifyMicrosoftPackage
                 auditingService,
                 telemetryService,
                 securityPolicyService,
-                contextFake);
+                contextFake,
+                contentObjectService);
+
             return packageService;
         }
 

--- a/src/VerifyMicrosoftPackage/Fakes/FakeContentObjectService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeContentObjectService.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using NuGetGallery;
+using NuGetGallery.Services;
+
+namespace NuGet.VerifyMicrosoftPackage.Fakes
+{
+    public class FakeContentObjectService : IContentObjectService
+    {
+        public ILoginDiscontinuationConfiguration LoginDiscontinuationConfiguration => throw new NotImplementedException();
+
+        public ICertificatesConfiguration CertificatesConfiguration => throw new NotImplementedException();
+
+        public ISymbolsConfiguration SymbolsConfiguration => throw new NotImplementedException();
+
+        public ITyposquattingConfiguration TyposquattingConfiguration => throw new NotImplementedException();
+
+        public IGitHubUsageConfiguration GitHubUsageConfiguration => throw new NotImplementedException();
+
+        public IABTestConfiguration ABTestConfiguration => throw new NotImplementedException();
+
+        public IODataCacheConfiguration ODataCacheConfiguration => throw new NotImplementedException();
+
+        public ICacheConfiguration CacheConfiguration => throw new NotImplementedException();
+
+        public IQueryHintConfiguration QueryHintConfiguration => throw new NotImplementedException();
+
+        public Task Refresh()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/VerifyMicrosoftPackage/VerifyMicrosoftPackage.csproj
+++ b/src/VerifyMicrosoftPackage/VerifyMicrosoftPackage.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <Compile Include="Application.cs" />
     <Compile Include="Fakes\FakeAuditingService.cs" />
+    <Compile Include="Fakes\FakeContentObjectService.cs" />
     <Compile Include="Fakes\FakeEntitiesContext.cs" />
     <Compile Include="Fakes\FakeEntityRepository.cs" />
     <Compile Include="Fakes\FakeSecurityPolicyService.cs" />

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -16,6 +16,7 @@ using NuGetGallery.Auditing;
 using NuGetGallery.Framework;
 using NuGetGallery.Packaging;
 using NuGetGallery.Security;
+using NuGetGallery.Services;
 using NuGetGallery.TestUtils;
 using Xunit;
 
@@ -31,7 +32,8 @@ namespace NuGetGallery
             Mock<ITelemetryService> telemetryService = null,
             Mock<ISecurityPolicyService> securityPolicyService = null,
             Action<Mock<PackageService>> setup = null,
-            Mock<IEntitiesContext> context = null)
+            Mock<IEntitiesContext> context = null,
+            Mock<IContentObjectService> contentObjectService = null)
         {
             packageRegistrationRepository = packageRegistrationRepository ?? new Mock<IEntityRepository<PackageRegistration>>();
             packageRepository = packageRepository ?? new Mock<IEntityRepository<Package>>();
@@ -41,6 +43,12 @@ namespace NuGetGallery
             securityPolicyService = securityPolicyService ?? new Mock<ISecurityPolicyService>();
             context = context ?? new Mock<IEntitiesContext>();
 
+            if (contentObjectService == null)
+            {
+                contentObjectService = new Mock<IContentObjectService>();
+                contentObjectService.Setup(x => x.QueryHintConfiguration).Returns(Mock.Of<IQueryHintConfiguration>());
+            }
+
             var packageService = new Mock<PackageService>(
                 packageRegistrationRepository.Object,
                 packageRepository.Object,
@@ -48,7 +56,8 @@ namespace NuGetGallery
                 auditingService,
                 telemetryService.Object,
                 securityPolicyService.Object,
-                context.Object);
+                context.Object,
+                contentObjectService.Object);
 
             packageService.CallBase = true;
 
@@ -2189,6 +2198,33 @@ namespace NuGetGallery
                 disposable.Verify(x => x.Dispose(), Times.Once);
                 context.Verify(x => x.WithQueryHint(It.IsAny<string>()), Times.Once);
                 context.Verify(x => x.WithQueryHint("OPTIMIZE FOR UNKNOWN"), Times.Once);
+            }
+
+            [Fact]
+            public void UsesRecompileIfConfigured()
+            {
+                string id = "Newtonsoft.Json";
+
+                var context = new Mock<IEntitiesContext>();
+                var contentObjectService = new Mock<IContentObjectService>();
+                var queryHintConfiguration = new Mock<IQueryHintConfiguration>();
+                contentObjectService.Setup(x => x.QueryHintConfiguration).Returns(() => queryHintConfiguration.Object);
+                queryHintConfiguration.Setup(x => x.ShouldUseRecompileForPackageDependents(id)).Returns(true);
+
+                var entityContext = new FakeEntitiesContext();
+
+                context.Setup(f => f.PackageDependencies).Returns(entityContext.PackageDependencies);
+                context.Setup(f => f.Packages).Returns(entityContext.Packages);
+                context.Setup(f => f.PackageRegistrations).Returns(entityContext.PackageRegistrations);
+
+                var service = CreateService(context: context, contentObjectService: contentObjectService);
+
+                service.GetPackageDependents(id);
+
+                queryHintConfiguration.Verify(x => x.ShouldUseRecompileForPackageDependents(It.IsAny<string>()), Times.Once);
+                queryHintConfiguration.Verify(x => x.ShouldUseRecompileForPackageDependents(id), Times.Once);
+                context.Verify(x => x.WithQueryHint(It.IsAny<string>()), Times.Once);
+                context.Verify(x => x.WithQueryHint("RECOMPILE"), Times.Once);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -2140,7 +2140,7 @@ namespace NuGetGallery
         public class TheGetPackageDependentsMethod
         {
             [Fact]
-            public void AllQueriesShouldUseRecompileQueryHint()
+            public void AllQueriesShouldUseQueryHint()
             {
                 string id = "foo";
                 var context = new Mock<IEntitiesContext>();
@@ -2188,7 +2188,7 @@ namespace NuGetGallery
 
                 disposable.Verify(x => x.Dispose(), Times.Once);
                 context.Verify(x => x.WithQueryHint(It.IsAny<string>()), Times.Once);
-                context.Verify(x => x.WithQueryHint("RECOMPILE"), Times.Once);
+                context.Verify(x => x.WithQueryHint("OPTIMIZE FOR UNKNOWN"), Times.Once);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -34,12 +34,14 @@ namespace NuGetGallery
             packageService = packageService ?? new Mock<PackageService>();
             packageFileService = packageFileService ?? new Mock<IPackageFileService>();
             telemetryService = telemetryService ?? new Mock<ITelemetryService>();
+            var contentObjectService = new Mock<IContentObjectService>();
 
             var reflowPackageService = new Mock<ReflowPackageService>(
                 entitiesContext.Object,
                 packageService.Object,
                 packageFileService.Object,
-                telemetryService.Object);
+                telemetryService.Object,
+                contentObjectService.Object);
 
             reflowPackageService.CallBase = true;
 

--- a/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReflowPackageServiceFacts.cs
@@ -34,14 +34,12 @@ namespace NuGetGallery
             packageService = packageService ?? new Mock<PackageService>();
             packageFileService = packageFileService ?? new Mock<IPackageFileService>();
             telemetryService = telemetryService ?? new Mock<ITelemetryService>();
-            var contentObjectService = new Mock<IContentObjectService>();
 
             var reflowPackageService = new Mock<ReflowPackageService>(
                 entitiesContext.Object,
                 packageService.Object,
                 packageFileService.Object,
-                telemetryService.Object,
-                contentObjectService.Object);
+                telemetryService.Object);
 
             reflowPackageService.CallBase = true;
 
@@ -346,6 +344,7 @@ namespace NuGetGallery
             var telemetryService = new Mock<ITelemetryService>();
             var securityPolicyService = new Mock<ISecurityPolicyService>();
             var entitiesContext = new Mock<IEntitiesContext>();
+            var contentObjectService = new Mock<IContentObjectService>();
 
             var packageService = new Mock<PackageService>(
                 packageRegistrationRepository.Object,
@@ -354,7 +353,8 @@ namespace NuGetGallery
                 auditingService,
                 telemetryService.Object,
                 securityPolicyService.Object,
-                entitiesContext.Object);
+                entitiesContext.Object,
+                contentObjectService.Object);
 
             packageService.CallBase = true;
 

--- a/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/TestServiceUtility.cs
@@ -196,6 +196,7 @@ namespace NuGetGallery.TestUtils
             var telemetryService = new Mock<ITelemetryService>();
             var securityPolicyService = new Mock<ISecurityPolicyService>();
             var entitiesContext = new Mock<IEntitiesContext>();
+            var contentObjectService = new Mock<IContentObjectService>();
 
             var packageService = new Mock<PackageService>(
                  packageRegistrationRepository.Object,
@@ -204,7 +205,8 @@ namespace NuGetGallery.TestUtils
                  auditingService,
                  telemetryService.Object,
                  securityPolicyService.Object,
-                 entitiesContext.Object);
+                 entitiesContext.Object,
+                 contentObjectService.Object);
 
             packageService.CallBase = true;
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/8078.

Some parameter values, such as EPPlus, CsvHelper, and others perform poorly even with up-to-date statistics when using `RECOMPILE`. I have provided these cases to the SQL Server team but in the meantime we can't use the `RECOMPILE` approach. The other suggestion that SQL Server team provided was the `OPTIMIZE FOR UNKNOWN` query hint. This essentially tells SQL Server to treat all parameter values as if they have no statistics (i.e. no dependents at all). This causes SQL Server to use the index that we original anticipated using and added for this purpose. Unfortunately, this query plan is not very fast for very depended upon packages (where the `RECOMPILE` approach really shined).

I took a data set of the top 1000 package IDs viewed on the display packages package and another sampling of 1000 random packages then compared the new vs. old approach.

As you can see, there are several parameter values where the top 5 query with `RECOMPILE` takes well over 10 seconds. This is the crux of the problem with the current implementation.
![image](https://user-images.githubusercontent.com/94054/87811893-3e661500-c814-11ea-963a-d89cf0ee9f63.png)

The same package IDs do very well with `OPTIMIZE FOR UNKNOWN`. For the `OPTIMIZE FOR UNKNOWN` implementation, the maximum durations are less extreme and correspond to heavily view pages meaning the in-memory cache will be effective.

![image](https://user-images.githubusercontent.com/94054/87812115-93099000-c814-11ea-8948-c94b11e62b6d.png)

For based on a 1 hour cache duration and 10 nodes, this increased duration will affect only 1.4% of the Newtonsoft.Json page views (i.e. it will only be seen at the 99th percentile). If we feel that this is still unacceptable, we could take some additional steps:

1. **Done:** Increase cache duration to, say, 8 hours. I propose we do this. There is no code chance, just a JSON config change.
1. **Done:** Use `RECOMPILE` for a specific "allow list" of package IDs and `OPTIMIZE FOR UNKNOWN` in other cases. This is not great since it still depends on up-to-date statistics and needs to be manually updated but is perhaps the simplest way to "get back" the good perf for Newtonsoft.Json and others.
1. Have a dynamic cache duration based on the number of dependents. Since we only show the top five and a "1.8K" form for the total count, the more dependents a package has, the less often this information will significantly change.
1. Update the cache in the background. This complex implementation-wise (today the query is performed in the request context) and it perhaps not great for less viewed packages.
1. Completely redesign the implementation, perhaps based on some new schema or a background job.

My proposal is to use `OPTIMIZE FOR UNKNOWN`, update the cache duration to 8 hours (reducing the affected Newtonsoft.Json page views from 1.4% to 0.175%) and carefully watching how it performs in PROD.