### PR TITLE
Add functional tests on Gallery for Advanced Search

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Constants.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Constants.cs
@@ -32,7 +32,11 @@ namespace NuGetGallery.FunctionalTests
         public const string StatsPageDefaultText = "Statistics last updated";
         public const string ContactOwnersText = "Your message has been sent to the owners of";
         public const string UnListedPackageText = "This package is unlisted and hidden from package listings";
+        public const string TestAccount = "NugetTestAccount";
         public const string TestPackageId = "BaseTestPackage";
+        public const string TestPackageIdDotNetTool = "BaseTestPackage.DotnetTool";
+        public const string TestPackageIdARandomType = "BaseTestPackage.ARandomType";
+        public const string TestPackageIdTemplate = "BaseTestPackage.Template";
         public const string TestPackageIdWithPrereleases = "BaseTestPackage.SearchFilters";
         public const string TestPackageIdNoStable = "BaseTestPackage.NoStable";
         public const string TestOrganizationCollaboratorPackageId = "BaseTestOrganizationCollaboratorPackage";

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ErrorHandling\SimulatedErrorType.cs" />
     <Compile Include="ErrorHandling\TestResponse.cs" />
     <Compile Include="PackageRetrieval\LatestTests.cs" />
+    <Compile Include="PackageRetrieval\PackageListTests.cs" />
     <Compile Include="ProfileTests.cs" />
     <Compile Include="ODataFeeds\CuratedFeedTest.cs" />
     <Compile Include="ODataFeeds\SearchTest.cs" />

--- a/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
@@ -38,7 +38,7 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             // Arrange
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?owner%3A{Constants.TestAccount}{sortByParam}");
+                $"/packages?q=owner%3A{Constants.TestAccount}{sortByParam}");
 
             // Act
             using (var httpClient = new HttpClient())
@@ -59,13 +59,13 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
         [Theory]
         [InlineData("created-desc")]
         [InlineData("cReAtEd-DeSc")]
-        public async Task MakeSureLastUpodatedSortingWorks(string sortBy)
+        public async Task MakeSureLastUpdatedSortingWorks(string sortBy)
         {
             var sortByParam = string.IsNullOrEmpty(sortBy) ? string.Empty : $"&sortBy={sortBy}";
             // Arrange
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?owner%3A{Constants.TestAccount}{sortByParam}");
+                $"/packages?q=owner%3A{Constants.TestAccount}{sortByParam}");
 
             // Act
             using (var httpClient = new HttpClient())
@@ -97,7 +97,7 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             // Arrange
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?q={id}+owner%3A{Constants.TestAccount}{packageTypeParam}");
+                $"/packages?q=packageid:{Uri.EscapeUriString(id)}+owner%3A{Constants.TestAccount}{packageTypeParam}");
 
             // Act
             using (var httpClient = new HttpClient())

--- a/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -38,7 +38,7 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             // Arrange
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?q={Constants.TestPackageId}+owner%3A{Constants.TestAccount}{sortByParam}");
+                $"/packages?owner%3A{Constants.TestAccount}{sortByParam}");
 
             // Act
             using (var httpClient = new HttpClient())
@@ -51,7 +51,6 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
                 var content = await response.Content.ReadAsStringAsync();
                 var downloads = GetPackagesDownloads(content);
                 var expectedDownloads = expectDescending ? downloads.OrderByDescending(x => x) : downloads.Select(x => x);
-                Assert.Contains($"/packages/{Constants.TestPackageId}", content); // It found the package
                 Assert.True(downloads.Count > 1);
                 Assert.Equal(expectedDownloads, downloads); // The downloads are sorted as expected
             }
@@ -66,7 +65,7 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             // Arrange
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?q={Constants.TestPackageId}+owner%3A{Constants.TestAccount}{sortByParam}");
+                $"/packages?owner%3A{Constants.TestAccount}{sortByParam}");
 
             // Act
             using (var httpClient = new HttpClient())

--- a/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
@@ -97,7 +97,7 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             // Arrange
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?q=packageid:{Uri.EscapeUriString(id)}+owner%3A{Constants.TestAccount}{packageTypeParam}");
+                $"/packages?q=packageid%3A{Uri.EscapeUriString(id)}+owner%3A{Constants.TestAccount}{packageTypeParam}");
 
             // Act
             using (var httpClient = new HttpClient())

--- a/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace NuGetGallery.FunctionalTests.PackageRetrieval
+{
+    public class PackageListTests : GalleryTestBase
+    {
+        private readonly Regex TotalDownloadsExpr= new Regex(@"((\d+[,]?)+) total download[s]?");
+        private readonly Regex LastUpdatedExpr= new Regex(@"<span data-datetime=""(.+)"">");
+
+        public PackageListTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        private List<long> GetPackagesDownloads(string content)
+        {
+            return TotalDownloadsExpr
+                .Matches(content)
+                .Cast<Match>()
+                .Select(x => long.Parse(x.Groups[1].Value.Replace(",", ""))).ToList();
+        }
+
+        private List<DateTime> GetPackagesUpdateDates(string content)
+        {
+            var dates = LastUpdatedExpr
+                .Matches(content)
+                .Cast<Match>()
+                .ToList();
+                
+
+            return dates.Select(x => DateTime.Parse(x.Groups[1].Value)).ToList();
+        }
+
+        private static void AssertIsHtml(HttpResponseMessage response)
+        {
+            var contentType = Assert.Single(response.Content.Headers.GetValues("Content-Type"));
+            Assert.Equal("text/html; charset=utf-8", contentType);
+        }
+
+        [Theory]
+        [Priority(2)]
+        [Category("P2Tests")]
+        [InlineData("totaldownloads-desc", true)]
+        [InlineData("totaldownloads-asc", false)]
+        public async Task MakeSureSortedByDownloadsWork(
+            string sortBy = "",
+            bool expectDescending = true)
+        {
+            var sortByParam = string.IsNullOrEmpty(sortBy) ? string.Empty : $"&sortBy={sortBy}";
+            // Arrange
+            var feedUrl = new Uri(
+                new Uri(UrlHelper.BaseUrl), 
+                $"/packages?q={Constants.TestPackageId}++owner%3A{Constants.TestAccount}{sortByParam}");
+
+            // Act
+            using (var httpClient = new HttpClient())
+            using (var response = await httpClient.GetAsync(feedUrl))
+            {
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                AssertIsHtml(response);
+
+                var content = await response.Content.ReadAsStringAsync();
+                var downloads = GetPackagesDownloads(content);
+                var expectedDownloads = expectDescending ? downloads.OrderByDescending(x => x) : downloads.Select(x => x);
+                Assert.Contains($"/packages/{Constants.TestPackageId}", content); // It found the package
+                Assert.Equal(expectedDownloads, downloads); // The downloads are sorted as expected
+            }
+        }
+
+        [Theory]
+        [InlineData("created-desc")]
+        [InlineData("cReAtEd-DeSc")]
+        public async Task MakeSureLastUpodatedSortingWorks(string sortBy)
+        {
+            var sortByParam = string.IsNullOrEmpty(sortBy) ? string.Empty : $"&sortBy={sortBy}";
+            // Arrange
+            var feedUrl = new Uri(
+                new Uri(UrlHelper.BaseUrl),
+                $"/packages?q={Constants.TestPackageId}++owner%3A{Constants.TestAccount}{sortByParam}");
+
+            // Act
+            using (var httpClient = new HttpClient())
+            using (var response = await httpClient.GetAsync(feedUrl))
+            {
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                AssertIsHtml(response);
+
+                var content = await response.Content.ReadAsStringAsync();
+                var updateDates = GetPackagesUpdateDates(content);
+                var expectedDates = updateDates.OrderByDescending(x => x);
+                Assert.Equal(expectedDates, updateDates); // The "recently updated" dates are sorted as expected
+            }
+        }
+
+        [Theory]
+        [Priority(2)]
+        [Category("P2Tests")]
+        [InlineData(Constants.TestPackageId, "dependency")]
+        [InlineData(Constants.TestPackageIdDotNetTool, "dotnettool")]
+        [InlineData(Constants.TestPackageIdARandomType, "ARandomType")]
+        [InlineData(Constants.TestPackageIdTemplate, "template")]
+        public async Task ExpectPackageTypeFilterToWork(
+            string id,
+            string packageType = "")
+        {
+            var packageTypeParam = string.IsNullOrEmpty(packageType) ? string.Empty : $"&packageType={packageType}";
+            // Arrange
+            var feedUrl = new Uri(
+                new Uri(UrlHelper.BaseUrl),
+                $"/packages?q={id}++owner%3A{Constants.TestAccount}{packageTypeParam}");
+
+            // Act
+            using (var httpClient = new HttpClient())
+            using (var response = await httpClient.GetAsync(feedUrl))
+            {
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                AssertIsHtml(response);
+
+                var content = await response.Content.ReadAsStringAsync();
+                Assert.Contains($"/packages/{id}", content);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds some basic functional tests on the Gallery for Advanced Search. Stuff being tested:

- package type filter (dependency, template and a random type "ARandomType")
- total downloads sorting
- last updated sorting

Edit:
- Functional tests on [DEV](https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=72898)
- Functional tests on [PROD](https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=72897)