### PR TITLE
Fix PackageVulnerability indexing uniqueness error

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilityService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilityService.cs
@@ -231,7 +231,6 @@ namespace NuGetGallery
             var newRanges = vulnerability.AffectedRanges
                 .Except(existingVulnerability.AffectedRanges, rangeComparer)
                 .ToList();
-            _entitiesContext.VulnerableRanges.AddRange(newRanges);
             foreach (var newRange in newRanges)
             {
                 _logger.LogInformation(
@@ -240,7 +239,8 @@ namespace NuGetGallery
                     newRange.PackageVersionRange,
                     vulnerability.GitHubDatabaseKey);
 
-                newRange.Vulnerability = existingVulnerability;
+                newRange.Vulnerability = existingVulnerability; // this needs to happen before we update _entitiesContext, otherwise index uniqueness conflicts occur
+                _entitiesContext.VulnerableRanges.Add(newRange);
                 existingVulnerability.AffectedRanges.Add(newRange);
                 ProcessNewVulnerabilityRange(newRange, packagesToUpdate);
             }


### PR DESCRIPTION
Addresses: https://github.com/NuGet/Engineering/issues/3211

Move VulnerablePackageVersionRange entity update to after its vulnerability is correct. This stops a multiplicity issue which results in an INSERT sent by EF for a record which already exists.
