### PR TITLE
Fix for: Malicious OData requests trigger exception monitoring

### DIFF
--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -124,7 +124,7 @@ namespace NuGetGallery.Controllers
             }
             catch (ODataException ex) when (ex.InnerException != null && ex.InnerException is FormatException)
             {
-                // Sometimes users make invalid requests. It's not excetpional behavior, don't trace.
+                // Sometimes users make invalid requests. It's not exceptional behavior, don't trace.
             }
             catch (Exception ex)
             {

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.OData;
 using System.Web.Http.OData.Query;
+using Microsoft.Data.OData;
 using NuGet.Frameworks;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
@@ -120,6 +121,10 @@ namespace NuGetGallery.Controllers
                 {
                     customQuery = true;
                 }
+            }
+            catch (ODataException ex) when (ex.InnerException != null && ex.InnerException is FormatException)
+            {
+                // Sometimes users make invalid requests. It's not excetpional behavior, don't trace.
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/3303

No need to log exceptions for user input errors. Those are not "exceptional". 