### PR TITLE
Display warning when specified version was not found

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/PackageFilter.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageFilter.cs
@@ -44,6 +44,8 @@ namespace NuGetGallery.Services
                 result = result ?? _packageService.FilterLatestPackageBySuffix(packages, version, preRelease);
             }
             
+            // The package still wasn't found so let's just get the latest version. This applies when 
+            // no version is specified, or when the version asked for (in context.Version) wasn't found
             result =  result ?? _packageService.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, allowPrerelease: true);
             
             return result;

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -869,6 +869,12 @@ namespace NuGetGallery
                 model.GitHubDependenciesInformation = _contentObjectService.GitHubUsageConfiguration.GetPackageInformation(id);
             }
 
+            if (normalized != null && !string.Equals(package.NormalizedVersion, normalized, StringComparison.InvariantCultureIgnoreCase))
+            {
+                model.VersionRequested = normalized;
+                model.VersionRequestedWasNotFound = true;
+            }
+
             if (!string.IsNullOrWhiteSpace(package.LicenseExpression))
             {
                 try

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -869,7 +869,7 @@ namespace NuGetGallery
                 model.GitHubDependenciesInformation = _contentObjectService.GitHubUsageConfiguration.GetPackageInformation(id);
             }
 
-            if (normalized != null && !string.Equals(package.NormalizedVersion, normalized, StringComparison.InvariantCultureIgnoreCase))
+            if (normalized != null && !string.Equals(package.NormalizedVersion, normalized, StringComparison.OrdinalIgnoreCase))
             {
                 model.VersionRequested = normalized;
                 model.VersionRequestedWasNotFound = true;

--- a/src/NuGetGallery/ViewModels/PackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageViewModel.cs
@@ -15,6 +15,8 @@ namespace NuGetGallery
         public bool LatestStableVersionSemVer2 { get; set; }
         public bool DevelopmentDependency { get; set; }
         public bool Prerelease { get; set; }
+        public string VersionRequested { get; set; }
+        public bool VersionRequestedWasNotFound { get; set; }
         public int DownloadCount { get; set; }
         public bool Listed { get; set; }
         public bool FailedValidation { get; set; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -301,7 +301,14 @@
                     </text>
                 )
             }
-
+            @if (Model.VersionRequestedWasNotFound)
+            {
+                @ViewHelpers.AlertInfo(
+                    @<text>
+                        The specified version @Model.VersionRequested was not found, you have been taken to version @(Model.Version).
+                    </text>
+                )
+            }
             @if (Model.HasNewerRelease)
             {
                 @ViewHelpers.AlertInfo(

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -305,7 +305,7 @@
             {
                 @ViewHelpers.AlertWarning(
                     @<text>
-                        The specified version @Model.VersionRequested was not found, you have been taken to version @(Model.Version).
+                        The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
                     </text>
                 )
             }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -303,7 +303,7 @@
             }
             @if (Model.VersionRequestedWasNotFound)
             {
-                @ViewHelpers.AlertInfo(
+                @ViewHelpers.AlertWarning(
                     @<text>
                         The specified version @Model.VersionRequested was not found, you have been taken to version @(Model.Version).
                     </text>


### PR DESCRIPTION
Currently when specifying a version that doesn't exist (eg, https://www.nuget.org/packages/Newtonsoft.Json/1337.42.42.0)  it just takes you to the latest version with no warning. This PR adds that warning. 

![image](https://user-images.githubusercontent.com/2829865/90096480-b7567f00-dd76-11ea-96c9-cf71f0951247.png)

Addresses #4624 