### PR TITLE
Fixed breadcrumb links for packages with build metadata

### DIFF
--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -228,7 +228,7 @@ namespace NuGetGallery
             string version,
             bool relativeUrl = true)
         {
-            string normalized = NuGetVersionFormatter.Normalize(version);
+            string normalized = (version != null) ? NuGetVersionFormatter.Normalize(version) : version;
 
             string result = GetRouteLink(
                 url,

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -228,6 +228,8 @@ namespace NuGetGallery
             string version,
             bool relativeUrl = true)
         {
+            string normalized = NuGetVersionFormatter.Normalize(version);
+
             string result = GetRouteLink(
                 url,
                 RouteName.DisplayPackage,
@@ -235,7 +237,7 @@ namespace NuGetGallery
                 routeValues: new RouteValueDictionary
                 {
                     { "id", id },
-                    { "version", version }
+                    { "version", normalized }
                 });
 
             // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -2856,8 +2856,8 @@ namespace NuGetGallery
 
                 JArray result = JArray.Parse(contentResult.Content);
 
-                Assert.True((string)result[3]["Gallery"] == "/packages/B/1.1", "unexpected content result[3].Gallery");
-                Assert.True((int)result[2]["Downloads"] == 5, "unexpected content result[2].Downloads");
+                Assert.Equal("/packages/B/1.1.0", (string)result[3]["Gallery"]);
+                Assert.Equal(5, (int)result[2]["Downloads"]);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
@@ -31,6 +31,30 @@ namespace NuGetGallery
             }
         }
 
+    
+        public class ThePackageBaseHelperMethod
+            : TestContainer
+        {
+            [Fact]
+            public void UsesNormalizedVersionInUrls()
+            {
+                var package = new Package
+                {
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "TestPackageId"
+                    },
+                    NormalizedVersion = "1.0.0-alpha.1",
+                    Version = "1.0.0-alpha.1+metadata"
+                };
+
+                string fixedUrl = UrlHelperExtensions.Package(TestUtility.MockUrlHelper(), package.Id, package.Version);
+
+                Assert.DoesNotContain("metadata", fixedUrl);
+                Assert.EndsWith(package.NormalizedVersion, fixedUrl);
+            }
+
+        }
         public class ThePackageHelperMethod
             : TestContainer
         {
@@ -52,6 +76,7 @@ namespace NuGetGallery
                 Assert.DoesNotContain("metadata", fixedUrl);
                 Assert.EndsWith(package.NormalizedVersion, fixedUrl);
             }
+
 
             [Theory]
             [InlineData("https://nuget.org", true, "/packages/id/1.0.0")]

--- a/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
@@ -30,7 +30,6 @@ namespace NuGetGallery
                 Assert.Null(fixedUrl);
             }
         }
-
     
         public class ThePackageBaseHelperMethod
             : TestContainer
@@ -53,8 +52,8 @@ namespace NuGetGallery
                 Assert.DoesNotContain("metadata", fixedUrl);
                 Assert.EndsWith(package.NormalizedVersion, fixedUrl);
             }
-
         }
+
         public class ThePackageHelperMethod
             : TestContainer
         {
@@ -76,7 +75,6 @@ namespace NuGetGallery
                 Assert.DoesNotContain("metadata", fixedUrl);
                 Assert.EndsWith(package.NormalizedVersion, fixedUrl);
             }
-
 
             [Theory]
             [InlineData("https://nuget.org", true, "/packages/id/1.0.0")]


### PR DESCRIPTION
Fixes breadcrumb links for packages with build metadata:

![image](https://user-images.githubusercontent.com/2829865/90097307-f71e6600-dd78-11ea-9d7d-144d7f7ff3ec.png)

The only question now is if we want to continue to display the build metadata in the link (the +6...) part. I think it's ok, but that's me. 

Addresses #8136