### PR TITLE
package list can be sorted by ID, owners, downloads and version

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -341,6 +341,9 @@ img.reserved-indicator-icon {
   z-index: 99999;
   right: 0;
 }
+.sortable {
+  cursor: pointer;
+}
 .modal-backdrop.in {
   opacity: 0.8 !important;
   position: fixed;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -425,3 +425,7 @@ img.reserved-indicator-icon {
   z-index: 99999;
   right: 0;
 }
+
+.sortable {
+	cursor: pointer;
+}

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -755,7 +755,7 @@ namespace NuGetGallery
                 return EmbeddedReadmeFileType.Markdown;
             }
 
-            throw new ArgumentException($"The file name for the package readme must have the \"md\" file extentsion: {packageMetadata.ReadmeFile}");
+            throw new ArgumentException($"The file name for the package readme must have the \"md\" file extension: {packageMetadata.ReadmeFile}");
         }
 
         private static void ValidateSupportedFrameworks(string[] supportedFrameworks)

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -585,9 +585,11 @@ namespace NuGetGallery
                 .ToList();
 
             for (int i = 0; i < listedPackages.Count; i++)
+            {
                 listedPackages[i].VersionSortOrder = i;
+            }
 
-            listedPackages.Sort((x, y) => x.Id.CompareTo(y.Id));
+            listedPackages.Sort((x, y) => string.Compare(x.Id,y.Id, StringComparison.OrdinalIgnoreCase));
 
             return listedPackages;
         }

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -12,6 +12,7 @@ using System.Web;
 using System.Web.Mvc;
 using NuGet.Services.Entities;
 using NuGet.Services.Messaging.Email;
+using NuGet.Versioning;
 using NuGetGallery.Areas.Admin;
 using NuGetGallery.Areas.Admin.ViewModels;
 using NuGetGallery.Authentication;
@@ -521,16 +522,12 @@ namespace NuGetGallery
             var wasAADLoginOrMultiFactorAuthenticated = User.WasMultiFactorAuthenticated() || User.WasAzureActiveDirectoryAccountUsedForSignin();
 
             var packages = PackageService.FindPackagesByAnyMatchingOwner(currentUser, includeUnlisted: true);
-            var listedPackages = packages
-                .Where(p => p.Listed && p.PackageStatusKey == PackageStatus.Available)
-                .Select(p => _listPackageItemRequiredSignerViewModelFactory.Create(p, currentUser, wasAADLoginOrMultiFactorAuthenticated))
-                .OrderBy(p => p.Id)
-                .ToList();
-            var unlistedPackages = packages
-                .Where(p => !p.Listed || p.PackageStatusKey != PackageStatus.Available)
-                .Select(p => _listPackageItemRequiredSignerViewModelFactory.Create(p, currentUser, wasAADLoginOrMultiFactorAuthenticated))
-                .OrderBy(p => p.Id)
-                .ToList();
+
+            var listedPackages = GetPackages(packages, currentUser, wasAADLoginOrMultiFactorAuthenticated,
+                p => p.Listed && p.PackageStatusKey == PackageStatus.Available);
+            
+            var unlistedPackages = GetPackages(packages, currentUser, wasAADLoginOrMultiFactorAuthenticated,
+                p => !p.Listed || p.PackageStatusKey != PackageStatus.Available);
 
             // find all received ownership requests
             var userReceived = _packageOwnerRequestService.GetPackageOwnershipRequests(newOwner: currentUser);
@@ -565,6 +562,34 @@ namespace NuGetGallery
                 IsCertificatesUIEnabled = ContentObjectService.CertificatesConfiguration?.IsUIEnabledForUser(currentUser) ?? false
             };
             return View(model);
+        }
+
+        /// <summary>
+        /// Returns all packages based on the predicate, with the VersionSortOrder populated
+        /// </summary>
+        /// <param name="packages"></param>
+        /// <param name="currentUser"></param>
+        /// <param name="wasAADLoginOrMultiFactorAuthenticated"></param>
+        /// <param name="predicate"></param>
+        /// <returns></returns>
+        private List<ListPackageItemRequiredSignerViewModel> GetPackages(
+            IEnumerable<Package> packages,
+            User currentUser,
+            bool wasAADLoginOrMultiFactorAuthenticated,
+            Func<Package, bool> predicate)
+        {
+            var listedPackages = packages
+                .Where(p => predicate(p))
+                .Select(p => _listPackageItemRequiredSignerViewModelFactory.Create(p, currentUser, wasAADLoginOrMultiFactorAuthenticated))
+                .OrderBy(p => NuGetVersion.Parse(p.FullVersion))
+                .ToList();
+
+            for (int i = 0; i < listedPackages.Count; i++)
+                listedPackages[i].VersionSortOrder = i;
+
+            listedPackages.Sort((x, y) => x.Id.CompareTo(y.Id));
+
+            return listedPackages;
         }
 
         [HttpGet]

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -355,6 +355,39 @@
             this.RequestsSent = new OwnerRequestsListViewModel(this, initialData.RequestsSent, false, true);
         }
 
+        function setupColumnSorting() {
+            $('.sortable').click(function () {
+
+                var table = $(this).parents('table').eq(0)
+                var rows = table.find('tr:gt(0)').toArray().sort(comparer($(this).index()))
+                this.asc = !this.asc
+                if (!this.asc) { rows = rows.reverse() }
+                for (var i = 0; i < rows.length; i++) { table.append(rows[i]) }
+
+                table.find('.sortable').each(function () {
+                    var currentText = $(this).text();
+                    var newText = currentText.replace(' ▲', '').replace(' ▼', '');
+                    $(this).text(newText);
+                });
+
+                var columnText = $(this).text();
+                $(this).text(columnText + " " + (this.asc ? "▼" : "▲"));
+
+            })
+            function comparer(index) {
+                return function (a, b) {
+                    var valA = getCellValue(a, index), valB = getCellValue(b, index)
+                    return $.isNumeric(valA) && $.isNumeric(valB) ? valA - valB : valA.toString().localeCompare(valB)
+                }
+            }
+            function getCellValue(row, index) {
+                var v = $(row).children('td').eq(index).text();
+                if (v)
+                    v = v.replace(',', '');
+                return v;
+            }
+        }
+
         // Immediately load initial expander data
         showInitialPackagesData("#listed-data", initialData.ListedPackages);
         showInitialPackagesData("#unlisted-data", initialData.UnlistedPackages);
@@ -365,6 +398,11 @@
         // Set up the data binding.
         var managePackagesViewModel = new ManagePackagesViewModel(initialData);
         ko.applyBindings(managePackagesViewModel, document.body);
+
+        setupColumnSorting();
+
+        
+
     });
 
 })();

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -38,6 +38,7 @@
             this.CanEdit = packageItem.CanEdit;
             this.CanManageOwners = packageItem.CanManageOwners;
             this.CanDelete = packageItem.CanDelete;
+            this.VersionSortOrder = packageItem.VersionSortOrder;
 
             this.FormattedDownloadCount = ko.pureComputed(function () {
                 return ko.unwrap(this.DownloadCount).toLocaleString();
@@ -381,9 +382,16 @@
                 }
             }
             function getCellValue(row, index) {
-                var v = $(row).children('td').eq(index).text();
+                var td = $(row).children('td').eq(index);
+                var sortby = td.data('sortby');
+
+                if (sortby)
+                    return sortby;
+
+                var v = td.text();
                 if (v)
                     v = v.replace(',', '');
+
                 return v;
             }
         }
@@ -400,8 +408,6 @@
         ko.applyBindings(managePackagesViewModel, document.body);
 
         setupColumnSorting();
-
-        
 
     });
 

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -377,7 +377,7 @@
             function comparer(index) {
                 return function (a, b) {
                     var valA = getCellValue(a, index), valB = getCellValue(b, index)
-                    return $.isNumeric(valA) && $.isNumeric(valB) ? valA - valB : valA.toString().localeCompare(valB)
+                    return $.isNumeric(valA) && $.isNumeric(valB) ? valB - valA : valA.toString().localeCompare(valB)
                 }
             }
             function getCellValue(row, index) {

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -391,7 +391,7 @@
                 // check for the data-sortby attribute, if found, use that data to sort by
                 var sortby = td.data('sortby');
 
-                if (sortby) {
+                if (typeof sortby !== 'undefined') {
                     return sortby;
                 }
 

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -359,11 +359,15 @@
         function setupColumnSorting() {
             $('.sortable').click(function () {
 
-                var table = $(this).parents('table').eq(0)
-                var rows = table.find('tr:gt(0)').toArray().sort(comparer($(this).index()))
-                this.asc = !this.asc
-                if (!this.asc) { rows = rows.reverse() }
-                for (var i = 0; i < rows.length; i++) { table.append(rows[i]) }
+                var table = $(this).parents('table').eq(0);
+                var rows = table.find('tr:gt(0)').toArray().sort(comparer($(this).index()));
+                this.asc = !this.asc;
+                if (!this.asc) {
+                    rows = rows.reverse();
+                }
+                for (var i = 0; i < rows.length; i++) {
+                    table.append(rows[i]);
+                }
 
                 table.find('.sortable').each(function () {
                     var currentText = $(this).text();
@@ -377,21 +381,25 @@
             })
             function comparer(index) {
                 return function (a, b) {
-                    var valA = getCellValue(a, index), valB = getCellValue(b, index)
-                    return $.isNumeric(valA) && $.isNumeric(valB) ? valB - valA : valA.toString().localeCompare(valB)
+                    var valA = getCellValue(a, index), valB = getCellValue(b, index);
+                    return $.isNumeric(valA) && $.isNumeric(valB) ? valB - valA : valA.toString().localeCompare(valB);
                 }
             }
             function getCellValue(row, index) {
                 var td = $(row).children('td').eq(index);
+
+                // check for the data-sortby attribute, if found, use that data to sort by
                 var sortby = td.data('sortby');
 
-                if (sortby)
+                if (sortby) {
                     return sortby;
+                }
 
+                // grab the text inside the td. Remove commas in case it's a number like 43,000
                 var v = td.text();
-                if (v)
+                if (v) {
                     v = v.replace(',', '');
-
+                }
                 return v;
             }
         }

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -395,12 +395,7 @@
                     return sortby;
                 }
 
-                // grab the text inside the td. Remove commas in case it's a number like 43,000
-                var v = td.text();
-                if (v) {
-                    v = v.replace(',', '');
-                }
-                return v;
+                return td.text();
             }
         }
 

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -25,6 +25,7 @@ namespace NuGetGallery
         public string ShortDescription { get; private set; }
         public bool IsDescriptionTruncated { get; set; }
         public bool? IsVerified { get; set; }
+        public int VersionSortOrder { get; set; }
         public string SignatureInformation
         {
             get

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -165,7 +165,7 @@
                             <!-- /ko -->
                         </td>
                     }
-                        <td class="align-middle text-nowrap">
+                        <td class="align-middle text-nowrap" data-bind="attr: { 'data-sortby': DownloadCount }">
                             <span data-bind="text: FormattedDownloadCount"></span>
                         </td>
                         <td class="align-middle text-nowrap" data-bind="attr: { 'data-sortby': VersionSortOrder }">

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -168,7 +168,7 @@
                         <td class="align-middle text-nowrap">
                             <span data-bind="text: FormattedDownloadCount"></span>
                         </td>
-                        <td class="align-middle text-nowrap">
+                        <td class="align-middle text-nowrap" data-bind="attr: { 'data-sortby': VersionSortOrder }">
                             <span data-bind="text: LatestVersion"></span>
                         </td>
                         <td class="text-right align-middle package-controls">
@@ -352,7 +352,8 @@
             CanDelete = p.CanUnlistOrRelist,
             p.CanEditRequiredSigner,
             p.ShowRequiredSigner,
-            p.ShowTextBox
+            p.ShowTextBox,
+            p.VersionSortOrder
         };
     }
 

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -4,11 +4,6 @@
     ViewBag.Title = "Manage My Package";
     ViewBag.Tab = "Packages";
 }
-<style type="text/css">
-    .sortable {
-        cursor: pointer;
-    }
-</style>
 <section role="main" class="container main-container page-manage-packages">
     @ViewHelpers.AjaxAntiForgeryToken(Html)
 

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -4,7 +4,11 @@
     ViewBag.Title = "Manage My Package";
     ViewBag.Tab = "Packages";
 }
-
+<style type="text/css">
+    .sortable {
+        cursor: pointer;
+    }
+</style>
 <section role="main" class="container main-container page-manage-packages">
     @ViewHelpers.AjaxAntiForgeryToken(Html)
 
@@ -113,14 +117,14 @@
                 <thead>
                     <tr class="manage-package-headings">
                         <th class="hidden-xs"><span class="hidden">Package Icon</span></th>
-                        <th>Package ID</th>
-                        <th>Owners</th>
+                        <th class="sortable">Package ID</th>
+                        <th class="sortable">Owners</th>
                     @if (Model.IsCertificatesUIEnabled)
                     {
-                        <th>Signing Owner</th>
+                        <th  class="sortable">Signing Owner</th>
                     }
-                        <th>Downloads</th>
-                        <th>Latest Version</th>
+                        <th  class="sortable">Downloads</th>
+                        <th  class="sortable">Latest Version</th>
                         <th><span class="hidden">Icon</span></th>
                     </tr>
                 </thead>

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -12,9 +12,12 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
+
 using Moq;
+
 using NuGet.Services.Entities;
 using NuGet.Services.Messaging.Email;
+
 using NuGetGallery.Areas.Admin;
 using NuGetGallery.Areas.Admin.Models;
 using NuGetGallery.Areas.Admin.ViewModels;
@@ -24,6 +27,7 @@ using NuGetGallery.Framework;
 using NuGetGallery.Infrastructure.Authentication;
 using NuGetGallery.Infrastructure.Mail.Messages;
 using NuGetGallery.Security;
+
 using Xunit;
 
 namespace NuGetGallery
@@ -3704,43 +3708,115 @@ namespace NuGetGallery
 
         public class ThePackagesAction : TestContainer
         {
+            private UsersController _testController;
+            private User _testUser;
+            private string userName = "RegularUser";
+            private Fakes _fakes;
+
+            public ThePackagesAction()
+            {
+                _testController = GetController<UsersController>();
+                _fakes = Get<Fakes>();
+                _testUser = _fakes.CreateUser(userName);
+                _testUser.IsDeleted = false;
+                _testUser.Key = 1;
+                _testController.SetCurrentUser(_testUser);
+            }
+
+            private PackageRegistration CreatePackageRegistration(string Id, int Key, string Version, string Description)
+            {
+                var packageRegistration = new PackageRegistration();
+                packageRegistration.Id = Id;
+                packageRegistration.Owners.Add(_testUser);
+
+                var userPackage1 = new Package()
+                {
+                    Key = Key,
+                    Version = Version,
+                    PackageRegistration = packageRegistration,
+                    Description = Description
+                };
+                packageRegistration.Packages.Add(userPackage1);
+                return packageRegistration;
+            }
+
+            [Fact]
+            public void PackagesAreSortedById()
+            {
+                PackageRegistration packageRegistration1 = CreatePackageRegistration("Company.ZebraPackage", 1, "1.0.0", "last");
+                PackageRegistration packageRegistration2 = CreatePackageRegistration("Company.AlphaPackage", 1, "1.0.0", "first");
+                PackageRegistration packageRegistration3 = CreatePackageRegistration("Company.NormalPackage", 1, "1.0.0", "middle");
+
+                var userPackages = new List<Package>() { 
+                    packageRegistration1.Packages.First() ,
+                    packageRegistration2.Packages.First(),
+                    packageRegistration3.Packages.First()
+                };
+
+                GetMock<IUserService>()
+                    .Setup(stub => stub.FindByUsername(userName, false))
+                    .Returns(_testUser);
+
+                GetMock<IPackageService>()
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false))
+                    .Returns(userPackages);
+
+                var model = ResultAssert.IsView<ManagePackagesViewModel>(_testController.Packages());
+
+                Assert.Equal("Company.AlphaPackage", model.ListedPackages.ToArray()[0].Id);
+                Assert.Equal("Company.NormalPackage", model.ListedPackages.ToArray()[1].Id);
+                Assert.Equal("Company.ZebraPackage", model.ListedPackages.ToArray()[2].Id);
+            }
+
+            [Fact]
+            public void PackagesVersionSortOrderIsSetBySemVer()  
+            {
+                PackageRegistration packageRegistration1 = CreatePackageRegistration("Company.ZebraPackage", 1, "1.0.0", "middle");
+                PackageRegistration packageRegistration2 = CreatePackageRegistration("Company.NormalPackage", 1, "0.0.1", "first");
+                PackageRegistration packageRegistration3 = CreatePackageRegistration("Company.AlphaPackage", 1, "1.1.0", "last");
+
+                var userPackages = new List<Package>() {
+                    packageRegistration1.Packages.First() ,
+                    packageRegistration2.Packages.First(),
+                    packageRegistration3.Packages.First()
+                };
+
+                GetMock<IUserService>()
+                    .Setup(stub => stub.FindByUsername(userName, false))
+                    .Returns(_testUser);
+
+                GetMock<IPackageService>()
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false))
+                    .Returns(userPackages);
+
+                var model = ResultAssert.IsView<ManagePackagesViewModel>(_testController.Packages());
+
+                // The "VersionSortOrder" should be set according to Semantic Version sort order, not package Id
+                Assert.Equal(0, model.ListedPackages.First(x => x.Version == "0.0.1").VersionSortOrder);
+                Assert.Equal(1, model.ListedPackages.First(x => x.Version == "1.0.0").VersionSortOrder);
+                Assert.Equal(2, model.ListedPackages.First(x => x.Version == "1.1.0").VersionSortOrder);
+            }
+
             [Fact]
             public void UsesProperIconUrl()
             {
-                string userName = "RegularUser";
-                var controller = GetController<UsersController>();
-                var fakes = Get<Fakes>();
-                var testUser = fakes.CreateUser(userName);
-                testUser.IsDeleted = false;
-                testUser.Key = 1;
-                controller.SetCurrentUser(testUser);
-
-                var packageRegistration = new PackageRegistration();
-                packageRegistration.Owners.Add(testUser);
-
-                var userPackage = new Package()
-                {
-                    Description = "TestPackage",
-                    Key = 1,
-                    Version = "1.0.0",
-                    PackageRegistration = packageRegistration,
-                };
-                packageRegistration.Packages.Add(userPackage);
-
+                PackageRegistration packageRegistration1 = CreatePackageRegistration("TestPackage", 1, "1.0.0", "TestPackage");
+                Package userPackage = packageRegistration1.Packages.First();
                 var userPackages = new List<Package>() { userPackage };
 
                 const string iconUrl = "https://some.test/icon";
+
                 GetMock<IIconUrlProvider>()
                     .Setup(iup => iup.GetIconUrlString(It.IsAny<Package>()))
                     .Returns(iconUrl);
                 GetMock<IUserService>()
                     .Setup(stub => stub.FindByUsername(userName, false))
-                    .Returns(testUser);
+                    .Returns(_testUser);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>(), false))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false))
                     .Returns(userPackages);
 
-                var model = ResultAssert.IsView<ManagePackagesViewModel>(controller.Packages());
+                var model = ResultAssert.IsView<ManagePackagesViewModel>(_testController.Packages());
 
                 GetMock<IIconUrlProvider>()
                     .Verify(iup => iup.GetIconUrlString(userPackage), Times.AtLeastOnce);


### PR DESCRIPTION
This adds support for ordering the "Published Packages" and "Unlisted Packages" tables on the "Manage my packages" screen, eg:

![sorting](https://user-images.githubusercontent.com/2829865/90201003-e7585d80-de1c-11ea-97f4-63af32948f99.gif)

Clicking on any of the column headers sorts by that column. I am by no means a JS guru but hopefully this does what we want and works for most people.

Addresses https://github.com/NuGet/NuGetGallery/issues/7806