### PR TITLE
Preview readme 

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -648,6 +648,16 @@ img.reserved-indicator-icon {
   margin-left: 10px;
   width: 100%;
 }
+.readme .readme-container {
+  display: block;
+  padding: 10.5px;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  word-break: normal;
+  margin-bottom: 24px;
+  overflow: auto;
+  max-height: 450px;
+}
 .user-package-list .manage-package-listing .package-icon {
   max-height: 2em;
   min-width: 20px;

--- a/src/Bootstrap/less/theme/all.less
+++ b/src/Bootstrap/less/theme/all.less
@@ -5,6 +5,7 @@
 @import "common-licenses.less";
 @import "common-list-packages.less";
 @import "common-multi-select-dropdown.less";
+@import "common-readme.less";
 @import "common-user-package-list.less";
 @import "page-about.less";
 @import "page-account-settings.less";

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -1,0 +1,12 @@
+.readme {
+    .readme-container{
+        display: block;
+        padding: 10.5px;
+        background-color: @pre-bg;
+        border: 1px solid #ccc;
+        word-break: normal;
+        margin-bottom: @default-margin-bottom;
+        overflow: auto;
+        max-height: 450px;
+    }
+}

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -692,6 +692,7 @@ namespace NuGetGallery
             package.EmbeddedLicenseType = GetEmbeddedLicenseType(packageMetadata);
             package.LicenseExpression = GetLicenseExpression(packageMetadata);
             package.HasEmbeddedIcon = !string.IsNullOrWhiteSpace(packageMetadata.IconFile);
+            package.HasReadMe = !string.IsNullOrWhiteSpace(packageMetadata.ReadmeFile);
             package.EmbeddedReadmeType = GetEmbeddedReadmeType(packageMetadata);
 
             return package;
@@ -750,7 +751,7 @@ namespace NuGetGallery
 
             var extension = Path.GetExtension(packageMetadata.ReadmeFile);
 
-            if (MarkdownFileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase) || string.Empty == extension)
+            if (MarkdownFileExtension.Equals(extension, StringComparison.OrdinalIgnoreCase))
             {
                 return EmbeddedReadmeFileType.Markdown;
             }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using System.Web;
 using System.Web.Caching;
 using System.Web.Mvc;
+using System.Windows.Forms;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
 using NuGet.Services.Licenses;
@@ -343,6 +344,8 @@ namespace NuGetGallery
             verifyRequest.IsSymbolsPackage = false;
             verifyRequest.LicenseFileContents = await GetLicenseFileContentsOrNullAsync(packageMetadata, packageArchiveReader);
             verifyRequest.LicenseExpressionSegments = GetLicenseExpressionSegmentsOrNull(packageMetadata.LicenseMetadata);
+            verifyRequest.ReadmeFileContents = await GetReadmeFileContentsOrNullAsync(packageMetadata, packageArchiveReader);
+
             model.InProgressUpload = verifyRequest;
             return View(model);
         }
@@ -613,6 +616,7 @@ namespace NuGetGallery
             model.Warnings.AddRange(packageContentData.Warnings.Select(w => new JsonValidationMessage(w)));
             model.LicenseFileContents = packageContentData.LicenseFileContents;
             model.LicenseExpressionSegments = packageContentData.LicenseExpressionSegments;
+            model.ReadmeFileContents = packageContentData.ReadmeFileContents;
 
             if (packageContentData.EmbeddedIconInformation != null)
             {
@@ -635,13 +639,15 @@ namespace NuGetGallery
                 IReadOnlyList<IValidationMessage> warnings,
                 string licenseFileContents,
                 IReadOnlyCollection<CompositeLicenseExpressionSegmentViewModel> licenseExpressionSegments,
-                EmbeddedIconInformation embeddedIconInformation)
+                EmbeddedIconInformation embeddedIconInformation,
+                string readmeFileContents)
             {
                 PackageMetadata = packageMetadata;
                 Warnings = warnings;
                 LicenseFileContents = licenseFileContents;
                 LicenseExpressionSegments = licenseExpressionSegments;
                 EmbeddedIconInformation = embeddedIconInformation;
+                ReadmeFileContents = readmeFileContents;
             }
 
             public JsonResult ErrorResult { get; }
@@ -650,6 +656,7 @@ namespace NuGetGallery
             public string LicenseFileContents { get; }
             public IReadOnlyCollection<CompositeLicenseExpressionSegmentViewModel> LicenseExpressionSegments { get; }
             public EmbeddedIconInformation EmbeddedIconInformation { get; }
+            public string ReadmeFileContents { get; }
         }
 
         private class EmbeddedIconInformation
@@ -673,6 +680,7 @@ namespace NuGetGallery
             IReadOnlyCollection<CompositeLicenseExpressionSegmentViewModel> licenseExpressionSegments = null;
             PackageMetadata packageMetadata = null;
             EmbeddedIconInformation embeddedIconInformation = null;
+            string readmeFileContents = null;
 
             using (Stream uploadedFile = await _uploadFileService.GetUploadFileAsync(currentUser.Key))
             {
@@ -720,6 +728,7 @@ namespace NuGetGallery
                     licenseFileContents = await GetLicenseFileContentsOrNullAsync(packageMetadata, packageArchiveReader);
                     licenseExpressionSegments = GetLicenseExpressionSegmentsOrNull(packageMetadata.LicenseMetadata);
                     embeddedIconInformation = await GetEmbeddedIconOrNullAsync(packageMetadata, packageArchiveReader);
+                    readmeFileContents = await GetReadmeFileContentsOrNullAsync(packageMetadata, packageArchiveReader);          
                 }
                 catch (Exception ex)
                 {
@@ -730,7 +739,7 @@ namespace NuGetGallery
                 }
             }
 
-            return new PackageContentData(packageMetadata, warnings, licenseFileContents, licenseExpressionSegments, embeddedIconInformation);
+            return new PackageContentData(packageMetadata, warnings, licenseFileContents, licenseExpressionSegments, embeddedIconInformation, readmeFileContents);
         }
 
         private IReadOnlyCollection<CompositeLicenseExpressionSegmentViewModel> GetLicenseExpressionSegmentsOrNull(LicenseMetadata licenseMetadata)
@@ -786,6 +795,18 @@ namespace NuGetGallery
             }
 
             return new EmbeddedIconInformation(imageContentType, imageData);
+        }
+
+        private async Task<string> GetReadmeFileContentsOrNullAsync(PackageMetadata packageMetadata, PackageArchiveReader packageArchiveReader)
+        {
+            if (string.IsNullOrWhiteSpace(packageMetadata.ReadmeFile))
+            {
+                return null;
+            }
+
+            var readmeFilename = FileNameHelper.GetZipEntryPath(packageMetadata.ReadmeFile);
+            var readmeResult = await _readMeService.GetReadMeHtmlAsync(readmeFilename, packageArchiveReader, Encoding.UTF8);
+            return readmeResult?.Content;
         }
 
         private static async Task<byte[]> ReadPackageFile(PackageArchiveReader packageArchiveReader, string filename)
@@ -2600,9 +2621,14 @@ namespace NuGetGallery
                 {
                     return afterValidationJsonResult;
                 }
-
+                
                 if (formData.Edit != null)
                 {
+                    if (package.HasReadMe && package.EmbeddedReadmeType != EmbeddedReadmeFileType.Absent)
+                    {
+                        return Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(Strings.ReadmeNotEditableWithEmbeddedReadme) });
+                    }
+
                     try
                     {
                         if (await _readMeService.SaveReadMeMdIfChanged(

--- a/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
+++ b/src/NuGetGallery/RequestModels/VerifyPackageRequest.cs
@@ -110,6 +110,7 @@ namespace NuGetGallery
         public string RepositoryUrl { get; set; }
         public string RepositoryType { get; set; }
         public string ReleaseNotes { get; set; }
+        public string ReadmeFileContents { get; set; }
         public bool RequiresLicenseAcceptance { get; set; }
         public string Summary { get; set; }
         public string Tags { get; set; }

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -255,6 +255,11 @@
                 $(reportContainerElement).attr("data-bind", "template: { name: 'verify-metadata-template', data: data }");
                 $("#verify-package-container").append(reportContainerElement);
                 ko.applyBindings({ data: model }, reportContainerElement);
+                if (model.ReadmeFileContents) {
+                    $('#import-readme-container').addClass('hidden');
+                } else {
+                    $('#import-readme-container').removeClass('hidden');
+                }
 
                 var submitContainerElement = document.createElement("div");
                 $(submitContainerElement).attr("id", "submit-block");

--- a/src/NuGetGallery/Services/IReadMeService.cs
+++ b/src/NuGetGallery/Services/IReadMeService.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Threading.Tasks;
+using NuGet.Packaging;
 using NuGet.Services.Entities;
 
 namespace NuGetGallery
@@ -29,6 +30,16 @@ namespace NuGetGallery
         /// <param name="package">Package entity associated with the ReadMe.</param>
         /// <returns>ReadMe converted to HTML.</returns>
         Task<RenderedReadMeResult> GetReadMeHtmlAsync(Package package);
+
+        /// <summary>
+        /// Get the converted HTML from the package with Readme markdown.
+        /// </summary>
+        /// <param name="readmeFileName">The path of Readme markdown.</param>
+        /// <param name="packageArchiveReader">
+        /// The <see cref="PackageArchiveReader"/> instance providing the package metadata.
+        /// </param>
+        /// <returns>ReadMe converted to HTML.</returns>
+        Task<RenderedReadMeResult> GetReadMeHtmlAsync(string readmeFileName, PackageArchiveReader packageArchiveReader, Encoding encoding);
 
         /// <summary>
         /// Get package ReadMe markdown from storage.

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1571,6 +1571,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The readme is not editable with the package has the embedded readme.
+        /// </summary>
+        public static string ReadmeNotEditableWithEmbeddedReadme {
+            get {
+                return ResourceManager.GetString("ReadmeNotEditableWithEmbeddedReadme", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The Documentation file must end with a Markdown extension &apos;{0}&apos;..
         /// </summary>
         public static string ReadMePostedFileExtensionInvalid {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1181,4 +1181,7 @@ The {1} Team</value>
   <data name="ODataParametersDisabled" xml:space="preserve">
     <value>The combination of parameters provided to this OData endpoint is not supported.</value>
   </data>
+  <data name="ReadmeNotEditableWithEmbeddedReadme" xml:space="preserve">
+    <value>The readme is not editable with the package has the embedded readme</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -251,6 +251,12 @@
                 </div>
             </div>
             <!-- /ko -->
+            <!-- ko if: $data.ReadmeFileContents -->
+            <div class="verify-package-field readme">
+                <label class="verify-package-field-heading">Readme File</label>
+                <div class="readme-container" data-bind="html: $data.ReadmeFileContents"></div>
+            </div>
+            <!-- /ko -->
             <!-- /ko -->
         </div>
     </div>


### PR DESCRIPTION
Summary of the changes:

* UI to display preview of readme content
* Disable documentation section at manage package page when embeddedReadme feature is enabled 

- EmbeddedReadme flag feature enable

    - 1. Uploading packages with embedded readme
 ![NuGet Gallery _ Upload Package (1)](https://user-images.githubusercontent.com/64443925/89562077-48a18080-d7ce-11ea-8a00-c293efe111b2.gif)
     - 2. Uploading packages without embedded readme
![legacyreadme](https://user-images.githubusercontent.com/64443925/89574386-e900a080-d7e0-11ea-9aa7-0347fb6aa177.PNG)

  



- EmbeddedReadme flag feature disable:

    - 1. Uploading packages with embedded readme: 
![readme](https://user-images.githubusercontent.com/64443925/89574159-8b6c5400-d7e0-11ea-8a32-1b37488d46f3.PNG)

    - 2.  Uploading packages without embedded readme:
![legacyreadme](https://user-images.githubusercontent.com/64443925/89574386-e900a080-d7e0-11ea-9aa7-0347fb6aa177.PNG)




Addresses :https://github.com/NuGet/Engineering/issues/3267
