### PR TITLE
Add hijack=false parameter to OData get specific package

### DIFF
--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -186,7 +186,7 @@ namespace NuGetGallery.Controllers
                 id, 
                 version, 
                 semVerLevel: SemVerLevelKey.SemVerLevel2, 
-                hijack: hijack,
+                allowHijack: hijack,
                 return404NotFoundWhenNoResults: true);
 
             return result.FormattedAsSingleResult<V2FeedPackage>();
@@ -223,7 +223,7 @@ namespace NuGetGallery.Controllers
                 id, 
                 version: null, 
                 semVerLevel: semVerLevel, 
-                hijack: true,
+                allowHijack: true,
                 return404NotFoundWhenNoResults: false);
         }
 
@@ -246,7 +246,7 @@ namespace NuGetGallery.Controllers
             string id, 
             string version, 
             string semVerLevel,
-            bool hijack,
+            bool allowHijack,
             bool return404NotFoundWhenNoResults)
         {
             var packages = GetAll()
@@ -270,7 +270,7 @@ namespace NuGetGallery.Controllers
             var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
             bool? customQuery = null;
 
-            if (hijack)
+            if (allowHijack)
             {
                 // try the search service
                 try
@@ -344,7 +344,7 @@ namespace NuGetGallery.Controllers
                 && options.RawValues.SkipToken == null
                 && options.RawValues.Top == null;
 
-            if (!hijack && !isSimpleLookup)
+            if (!allowHijack && !isSimpleLookup)
             {
                 return BadRequest(Strings.ODataParametersDisabled);
             }

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -329,6 +329,26 @@ namespace NuGetGallery.Controllers
                 }
             }
 
+            // When non-hijacked queries are disabled, allow only one non-hijacked pattern: query for a specific ID and
+            // version without any fancy OData options. This enables some monitoring and testing and is known to produce
+            // a very fast SQL query based on an optimized index.
+            var isSimpleLookup = !string.IsNullOrWhiteSpace(id)
+                && !string.IsNullOrWhiteSpace(version)
+                && options.RawValues.Expand == null
+                && options.RawValues.Filter == null
+                && options.RawValues.Format == null
+                && options.RawValues.InlineCount == null
+                && options.RawValues.OrderBy == null
+                && options.RawValues.Select == null
+                && options.RawValues.Skip == null
+                && options.RawValues.SkipToken == null
+                && options.RawValues.Top == null;
+
+            if (!hijack && !isSimpleLookup)
+            {
+                return BadRequest(Strings.ODataParametersDisabled);
+            }
+
             if (return404NotFoundWhenNoResults && !packages.Any())
             {
                 _telemetryService.TrackODataCustomQuery(customQuery);

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -175,7 +175,8 @@ namespace NuGetGallery.Controllers
         public async Task<IHttpActionResult> Get(
             ODataQueryOptions<V2FeedPackage> options, 
             string id, 
-            string version)
+            string version,
+            [FromUri] bool hijack = true)
         {
             // We are defaulting to semVerLevel = "2.0.0" by design.
             // The client is requesting a specific package version and should support what it requests.
@@ -185,6 +186,7 @@ namespace NuGetGallery.Controllers
                 id, 
                 version, 
                 semVerLevel: SemVerLevelKey.SemVerLevel2, 
+                hijack: hijack,
                 return404NotFoundWhenNoResults: true);
 
             return result.FormattedAsSingleResult<V2FeedPackage>();
@@ -221,6 +223,7 @@ namespace NuGetGallery.Controllers
                 id, 
                 version: null, 
                 semVerLevel: semVerLevel, 
+                hijack: true,
                 return404NotFoundWhenNoResults: false);
         }
 
@@ -243,6 +246,7 @@ namespace NuGetGallery.Controllers
             string id, 
             string version, 
             string semVerLevel,
+            bool hijack,
             bool return404NotFoundWhenNoResults)
         {
             var packages = GetAll()
@@ -266,60 +270,63 @@ namespace NuGetGallery.Controllers
             var semVerLevelKey = SemVerLevelKey.ForSemVerLevel(semVerLevel);
             bool? customQuery = null;
 
-            // try the search service
-            try
+            if (hijack)
             {
-                var searchService = _searchServiceFactory.GetService();
-                var searchAdaptorResult = await SearchAdaptor.FindByIdAndVersionCore(
-                    searchService,
-                    GetTraditionalHttpContext().Request, 
-                    packages, 
-                    id, 
-                    version, 
-                    semVerLevel: semVerLevel);
-
-                // If intercepted, create a paged queryresult
-                if (searchAdaptorResult.ResultsAreProvidedBySearchService)
+                // try the search service
+                try
                 {
-                    customQuery = false;
+                    var searchService = _searchServiceFactory.GetService();
+                    var searchAdaptorResult = await SearchAdaptor.FindByIdAndVersionCore(
+                        searchService,
+                        GetTraditionalHttpContext().Request,
+                        packages,
+                        id,
+                        version,
+                        semVerLevel: semVerLevel);
 
-                    // Packages provided by search service
-                    packages = searchAdaptorResult.Packages;
-
-                    // Add explicit Take() needed to limit search hijack result set size if $top is specified
-                    var totalHits = packages.LongCount();
-
-                    if (totalHits == 0 && return404NotFoundWhenNoResults)
+                    // If intercepted, create a paged queryresult
+                    if (searchAdaptorResult.ResultsAreProvidedBySearchService)
                     {
-                        _telemetryService.TrackODataCustomQuery(customQuery);
-                        return NotFound();
+                        customQuery = false;
+
+                        // Packages provided by search service
+                        packages = searchAdaptorResult.Packages;
+
+                        // Add explicit Take() needed to limit search hijack result set size if $top is specified
+                        var totalHits = packages.LongCount();
+
+                        if (totalHits == 0 && return404NotFoundWhenNoResults)
+                        {
+                            _telemetryService.TrackODataCustomQuery(customQuery);
+                            return NotFound();
+                        }
+
+                        var pagedQueryable = packages
+                            .Take(options.Top != null ? Math.Min(options.Top.Value, MaxPageSize) : MaxPageSize)
+                            .ToV2FeedPackageQuery(
+                                GetSiteRoot(),
+                                _configurationService.Features.FriendlyLicenses,
+                                semVerLevelKey);
+
+                        return TrackedQueryResult(
+                            options,
+                            pagedQueryable,
+                            MaxPageSize,
+                            totalHits,
+                            (o, s, resultCount) => SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s, semVerLevelKey),
+                            customQuery);
                     }
-
-                    var pagedQueryable = packages
-                        .Take(options.Top != null ? Math.Min(options.Top.Value, MaxPageSize) : MaxPageSize)
-                        .ToV2FeedPackageQuery(
-                            GetSiteRoot(), 
-                            _configurationService.Features.FriendlyLicenses, 
-                            semVerLevelKey);
-
-                    return TrackedQueryResult(
-                        options,
-                        pagedQueryable,
-                        MaxPageSize,
-                        totalHits,
-                        (o, s, resultCount) => SearchAdaptor.GetNextLink(Request.RequestUri, resultCount, new { id }, o, s, semVerLevelKey),
-                        customQuery);
+                    else
+                    {
+                        customQuery = true;
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    customQuery = true;
+                    // Swallowing Exception intentionally. If *anything* goes wrong in search, just fall back to the database.
+                    // We don't want to break package restores. We do want to know if this happens, so here goes:
+                    QuietLog.LogHandledException(ex);
                 }
-            }
-            catch (Exception ex)
-            {
-                // Swallowing Exception intentionally. If *anything* goes wrong in search, just fall back to the database.
-                // We don't want to break package restores. We do want to know if this happens, so here goes:
-                QuietLog.LogHandledException(ex);
             }
 
             if (return404NotFoundWhenNoResults && !packages.Any())

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -344,9 +344,14 @@ namespace NuGetGallery.Controllers
                 && options.RawValues.SkipToken == null
                 && options.RawValues.Top == null;
 
-            if (!allowHijack && !isSimpleLookup)
+            if (!allowHijack)
             {
-                return BadRequest(Strings.ODataParametersDisabled);
+                if (!isSimpleLookup)
+                {
+                    return BadRequest(Strings.ODataParametersDisabled);
+                }
+
+                customQuery = true;
             }
 
             if (return404NotFoundWhenNoResults && !packages.Any())

--- a/src/NuGetGallery/Infrastructure/ODataCacheOutputAttribute.cs
+++ b/src/NuGetGallery/Infrastructure/ODataCacheOutputAttribute.cs
@@ -40,6 +40,22 @@ namespace NuGetGallery
             ServerTimeSpan = serverTimeSpan;
         }
 
+        protected override bool IsCachingAllowed(HttpActionContext actionContext, bool anonymousOnly)
+        {
+            if (_endpoint == ODataCachedEndpoint.GetSpecificPackage)
+            {
+                // Don't cache the non-hijacked ID+version lookup pattern.
+                if (actionContext.ActionArguments.TryGetValue("hijack", out var hijackObj)
+                    && hijackObj is bool hijack
+                    && !hijack)
+                {
+                    return false;
+                }
+            }
+
+            return base.IsCachingAllowed(actionContext, anonymousOnly);
+        }
+
         /// <summary>
         /// This setting determines how frequently the cache duration setting should be checked. Since the OData
         /// endpoints get a lot of traffic, we don't want to check every time. The 60 seconds here is picked to mimic

--- a/src/NuGetGallery/Infrastructure/ODataCacheOutputAttribute.cs
+++ b/src/NuGetGallery/Infrastructure/ODataCacheOutputAttribute.cs
@@ -46,9 +46,10 @@ namespace NuGetGallery
             {
                 // Don't cache the non-hijacked ID+version lookup pattern.
                 if (actionContext.ActionArguments.TryGetValue("hijack", out var hijackObj)
-                    && hijackObj is bool hijack)
+                    && hijackObj is bool hijack
+                    && !hijack)
                 {
-                    return hijack;
+                    return false;
                 }
             }
 

--- a/src/NuGetGallery/Infrastructure/ODataCacheOutputAttribute.cs
+++ b/src/NuGetGallery/Infrastructure/ODataCacheOutputAttribute.cs
@@ -46,10 +46,9 @@ namespace NuGetGallery
             {
                 // Don't cache the non-hijacked ID+version lookup pattern.
                 if (actionContext.ActionArguments.TryGetValue("hijack", out var hijackObj)
-                    && hijackObj is bool hijack
-                    && !hijack)
+                    && hijackObj is bool hijack)
                 {
-                    return false;
+                    return hijack;
                 }
             }
 

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1292,6 +1292,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The combination of parameters provided to this OData endpoint is not supported..
+        /// </summary>
+        public static string ODataParametersDisabled {
+            get {
+                return ResourceManager.GetString("ODataParametersDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You have successfully confirmed the organization email address..
         /// </summary>
         public static string OrganizationEmailConfirmed {
@@ -2549,6 +2558,15 @@ namespace NuGetGallery {
         public static string UploadPackage_InvalidReadmeFileExtension {
             get {
                 return ResourceManager.GetString("UploadPackage_InvalidReadmeFileExtension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to the name of &lt;readme&gt; element is case sensitive, must use the &lt;readme&gt;.
+        /// </summary>
+        public static string UploadPackage_InvalidReadmeName {
+            get {
+                return ResourceManager.GetString("UploadPackage_InvalidReadmeName", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1178,4 +1178,7 @@ The {1} Team</value>
   <data name="UploadPackage_InvalidReadmeName" xml:space="preserve">
     <value>the name of &lt;readme&gt; element is case sensitive, must use the &lt;readme&gt;</value>
   </data>
+  <data name="ODataParametersDisabled" xml:space="preserve">
+    <value>The combination of parameters provided to this OData endpoint is not supported.</value>
+  </data>
 </root>

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ClientSdkHelper.cs
@@ -68,7 +68,7 @@ namespace NuGetGallery.FunctionalTests
         }
 
         /// <summary>
-        /// Checks if the given package version is present in V2 and V3. This method bypasses the hijack.
+        /// Checks if the given package version is present in V2. This method bypasses the hijack.
         /// </summary>
         private async Task<bool> CheckIfPackageVersionExistsInV2Async(string packageId, string version, bool? shouldBeListed)
         {

--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/ODataHelper.cs
@@ -64,7 +64,7 @@ namespace NuGetGallery.FunctionalTests
             string version,
             string timestampPropertyName)
         {
-            var url = GetPackagesAppearInFeedInOrderUrl(packageId, version, timestampPropertyName);
+            var url = $"{UrlHelper.V2FeedRootUrl}/Packages(Id='{packageId}',Version='{version}')?hijack=false";
             WriteLine($"Fetching URL: {url}");
             var packageResponse = await GetPackageDataInResponse(url, packageId, version);
 
@@ -89,13 +89,6 @@ namespace NuGetGallery.FunctionalTests
             var timestamp = DateTime.Parse(packageResponse.Substring(timestampStartIndex, timestampLength));
             WriteLine($"'{timestampPropertyName}' timestamp of package '{packageId}' with version '{version}' is '{timestamp}'");
             return timestamp;
-        }
-
-        private static string GetPackagesAppearInFeedInOrderUrl(string packageId, string version, string timestampPropertyName)
-        {
-            return $"{UrlHelper.V2FeedRootUrl}/Packages?" +
-                $"$filter=Id eq '{packageId}' and NormalizedVersion eq '{version}' and 1 eq 1&" +
-                $"$select={timestampPropertyName}";
         }
 
         public async Task<string> GetPackageDataInResponse(string url, string packageId, string version)

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/CuratedFeedTest.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/CuratedFeedTest.cs
@@ -34,7 +34,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         public async Task SearchMicrosoftDotNetCuratedFeed()
         {
             var packageId = "microsoft.aspnet.webpages";
-            var requestUrl = UrlHelper.DotnetCuratedFeedUrl + @"Packages()?$filter=tolower(Id)%20eq%20'" + packageId + "'&$orderby=Id&$skip=0&$top=30";
+            var requestUrl = UrlHelper.DotnetCuratedFeedUrl + @"Search()?searchTerm='packageid%3A" + packageId + "'";
 
             string responseText;
             using (var httpClient = new HttpClient())

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/CuratedFeedTest.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/CuratedFeedTest.cs
@@ -54,7 +54,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         {
             using (var httpClient = new HttpClient())
             {
-                var requestUrl = UrlHelper.DotnetCuratedFeedUrl + "Packages";
+                var requestUrl = UrlHelper.DotnetCuratedFeedUrl + "FindPackagesById()?id='AutoMapper'";
 
                 string responseText;
                 using (var response = await httpClient.GetAsync(requestUrl))

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedExtendedTests.cs
@@ -42,7 +42,7 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
 
             var packageId = packageInfo.Id;
             var packageVersion = packageInfo.Version;
-            string url = UrlHelper.V2FeedRootUrl + @"/FindPackagesById()?id='" + packageId + "'&$orderby=Version";
+            string url = UrlHelper.V2FeedRootUrl + $"/Packages(Id='{packageId}',Version='{packageVersion}')?hijack=false";
             var containsResponseText = await _odataHelper.ContainsResponseText(url, @"<id>" + UrlHelper.V2FeedRootUrl + "Packages(Id='" + packageId + "',Version='" + packageVersion + "')</id>");
             Assert.True(containsResponseText);
         }
@@ -91,11 +91,6 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
 
             await Task.WhenAll(unlistedPackageIds.Select(id => _clientSdkHelper.VerifyPackageExistsInV2Async(id, version, listed: false)));
             await CheckPackageTimestampsInOrder(unlistedPackageIds, "LastEdited", unlistStartTimestamp, version);
-        }
-
-        private static string GetPackagesAppearInFeedInOrderUrl(DateTime time, string timestamp)
-        {
-            return $"{UrlHelper.V2FeedRootUrl}/Packages?$filter={timestamp} gt DateTime'{time:o}'&$orderby={timestamp} desc&$select={timestamp}";
         }
 
         /// <summary>

--- a/tests/NuGetGallery.LoadTests/LoadTests.cs
+++ b/tests/NuGetGallery.LoadTests/LoadTests.cs
@@ -87,8 +87,8 @@ namespace NuGetGallery.LoadTests
         [TestCategory("P0Tests")]
         public async Task PackagesApiTest()
         {
-            string packageId = "newtonsoft.json";
-            string url = UrlHelper.V2FeedRootUrl + @"Packages()?$filter=tolower(Id) eq '" + packageId + "'&$orderby=Id";
+            string packageId = "Newtonsoft.Json";
+            string url = UrlHelper.V2FeedRootUrl + $"Packages()?$filter=Id eq '{packageId}'";
             string expectedText = @"<id>" + UrlHelper.V2FeedRootUrl + "Packages(Id='" + packageId;
             var odataHelper = new ODataHelper();
             var containsResponseText = await odataHelper.ContainsResponseTextIgnoreCase(url, expectedText);
@@ -168,7 +168,7 @@ namespace NuGetGallery.LoadTests
         public async Task SearchMicrosoftDotNetCuratedFeed()
         {
             var packageId = "microsoft.aspnet.webpages";
-            var requestUrl = UrlHelper.DotnetCuratedFeedUrl + @"Packages()?$filter=tolower(Id)%20eq%20'" + packageId + "'&$orderby=Id&$skip=0&$top=30";
+            var requestUrl = UrlHelper.DotnetCuratedFeedUrl + @"Search()?searchTerm='packageid%3A" + packageId + "'";
 
             string responseText;
             using (var httpClient = new HttpClient())


### PR DESCRIPTION
This will facilitate functional tests and end-to-end tests that require querying for package availability in DB instead of availability in V3 (search hijack). See the functional tests containing `hijack=true` for context. There is also one such case in the end-to-end tests. In short, there are many integration tests today that depend on checking for a package's availability prior to V3 indexing.

Essentially the difference when the new parameter is specified as `hijack=false`, you can see a package even before it has made its way the search service but _after_ validation is complete. This was previously achieved in various monitoring and testing places in our code via opaque hacks like adding an `$orderby` that can't be hijacked or adding `1 eq 1` to a `$filter`. 

Given the excellent performance of an ID+version lookup, it is acceptable to allow this non-hijacked query from a performance perspective. By the way, the package details page does this SQL query and much more.

An alternative approach could have been to carefully scrutinize each place that uses `hijack=false` and convince ourselves that moving from a non-hijacked to a hijacked query is acceptable from both a test coverage and flakiness perspective. My feeling is that this is not worth the risk. Also, in general we would be giving up from a testing/monitoring perspective on observing the state before a package is fully indexed in search but after it is validated.

I think that this PR (simple test hook) is better than the alternative. I think it is reasonable to have a programmatic way of fetching the DB state of a package and this is the simplest approach given our current various codebases. This will be undocumented on our public API surface area and not intended for external consumption, much like the internal `/search/query` endpoint on the search service.

Progress on https://github.com/NuGet/Engineering/issues/2902.