### PR TITLE
Store embedded readme file to storage

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -2624,7 +2624,7 @@ namespace NuGetGallery
                 
                 if (formData.Edit != null)
                 {
-                    if (package.HasReadMe && package.EmbeddedReadmeType != EmbeddedReadmeFileType.Absent)
+                    if (_readMeService.HasReadMeSource(formData.Edit.ReadMe) && package.HasReadMe && package.EmbeddedReadmeType != EmbeddedReadmeFileType.Absent)
                     {
                         return Json(HttpStatusCode.BadRequest, new[] { new JsonValidationMessage(Strings.ReadmeNotEditableWithEmbeddedReadme) });
                     }

--- a/src/NuGetGallery/Services/IPackageFileService.cs
+++ b/src/NuGetGallery/Services/IPackageFileService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using NuGet.Services.Entities;
@@ -32,6 +33,22 @@ namespace NuGetGallery
         /// <param name="package">The package associated with the readme.</param>
         /// <param name="readMeMd">Markdown content.</param>
         Task SaveReadMeMdFileAsync(Package package, string readMeMd);
+
+        /// <summary>
+        /// Save the readme file from package stream. This method should throw if the package
+        /// does not have an embedded readme file 
+        /// </summary>
+        /// <param name="package">Package information.</param>
+        /// <param name="packageStream">Package stream with .nupkg contents.</param>
+        Task ExtractAndSaveReadmeFileAsync(Package package, Stream packageStream);
+
+        /// <summary>
+        /// Saves the package readme.md file to storage. This method should throw if the package
+        /// does not have an embedded readme file 
+        /// </summary>
+        /// <param name="package">The package associated with the readme.</param>
+        /// <param name="readmeFile">The content of readme file.</param>
+        Task SaveReadmeFileAsync(Package package, Stream readmeFile);
 
         /// <summary>
         /// Downloads the readme.md from storage.

--- a/src/NuGetGallery/Services/PackageFileService.cs
+++ b/src/NuGetGallery/Services/PackageFileService.cs
@@ -6,7 +6,9 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web.Mvc;
+using NuGet.Packaging;
 using NuGet.Services.Entities;
+using NuGetGallery.Packaging;
 
 namespace NuGetGallery
 {
@@ -71,6 +73,70 @@ namespace NuGetGallery
             {
                 await _fileStorageService.SaveFileAsync(CoreConstants.Folders.PackageReadMesFolderName, fileName, readMeMdStream, overwrite: true);
             }
+        }
+
+        /// <summary>
+        /// Save the readme file from package stream. This method should throw if the package
+        /// does not have an embedded readme file 
+        /// </summary>
+        /// <param name="package">Package information.</param>
+        /// <param name="packageStream">Package stream with .nupkg contents.</param>
+        public async Task ExtractAndSaveReadmeFileAsync(Package package, Stream packageStream)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (packageStream == null)
+            {
+                throw new ArgumentNullException(nameof(packageStream));
+            }
+
+            packageStream.Seek(0, SeekOrigin.Begin);
+            using (var packageArchiveReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
+            {
+                var packageMetadata = PackageMetadata.FromNuspecReader(packageArchiveReader.GetNuspecReader(), strict: true);
+                if (string.IsNullOrWhiteSpace(packageMetadata.ReadmeFile))
+                {
+                    throw new InvalidOperationException("No readme file specified in the nuspec");
+                }
+
+                var filename = FileNameHelper.GetZipEntryPath(packageMetadata.ReadmeFile);
+                var ReadmeFileEntry = packageArchiveReader.GetEntry(filename); // throws on non-existent file
+                using (var readmeFileStream = ReadmeFileEntry.Open())
+                {
+                    await SaveReadmeFileAsync(package, readmeFileStream);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Saves the package readme.md file to storage. This method should throw if the package
+        /// does not have an embedded readme file 
+        /// </summary>
+        /// <param name="package">The package associated with the readme.</param>
+        /// <param name="readmeFile">The content of readme file.</param>
+        public Task SaveReadmeFileAsync(Package package, Stream readmeFile)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (readmeFile == null)
+            {
+                throw new ArgumentNullException(nameof(readmeFile));
+            }
+
+            if (package.EmbeddedReadmeType == EmbeddedReadmeFileType.Absent)
+            {
+                throw new ArgumentException("Package must have an embedded readme", nameof(package));
+            }
+
+            var fileName = FileNameHelper.BuildFileName(package, ReadMeFilePathTemplateActive, ServicesConstants.MarkdownFileExtension);
+
+            return _fileStorageService.SaveFileAsync(CoreConstants.Folders.PackageReadMesFolderName, fileName, readmeFile, overwrite: true);
         }
 
         /// <summary>

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Web.Mvc;
 using Moq;
 using NuGet.Services.Entities;
+using NuGetGallery.TestUtils;
 using Xunit;
 
 namespace NuGetGallery
@@ -262,6 +263,133 @@ namespace NuGetGallery
             }
         }
 
+        public class TheSaveReadmeFileAsyncMethod
+        {
+            [Fact]
+            public async Task WhenPackageNull_ThrowsArgumentNullException()
+            {
+                var service = CreateService();
+
+                await Assert.ThrowsAsync<ArgumentNullException>(async () => await service.SaveReadmeFileAsync(null, Stream.Null));
+            }
+
+            [Fact]
+            public async Task WhenStreamIsNull_ThrowsArgumentException()
+            {
+                var service = CreateService();
+                var package = CreatePackage();
+
+                await Assert.ThrowsAsync<ArgumentNullException>(async () => await service.SaveReadmeFileAsync(package, null));
+            }
+
+            [Fact]
+            public async Task WhenEmbeddedReadmeTypeIsAbsent_ThrowsArgumentException()
+            {
+                var service = CreateService();
+                var package = CreatePackage();
+                package.EmbeddedReadmeType = EmbeddedReadmeFileType.Absent;
+                var packageStream = GeneratePackageWithReadmeFile("readme.md");
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(() => service.SaveReadmeFileAsync(package, packageStream));
+                Assert.Equal("package", ex.ParamName);
+                Assert.Contains("embedded readme", ex.Message);
+            }
+
+            [Fact]
+            public async Task WhenValid_SavesReadmeFile()
+            {
+                // Arrange.
+                var fileServiceMock = new Mock<IFileStorageService>();
+                fileServiceMock.Setup(f => f.SaveFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<bool>()))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+                var service = CreateService(fileServiceMock);
+
+                var package = new Package()
+                {
+                    PackageRegistration = new PackageRegistration() { Id = "Foo" },
+                    Version = "1.0.0",
+                    EmbeddedReadmeType = EmbeddedReadmeFileType.Markdown
+                };
+                var packageStream = GeneratePackageWithReadmeFile("readme.md");
+
+                // Act.
+                await service.SaveReadmeFileAsync(package, packageStream);
+
+                // Assert.
+                fileServiceMock.Verify(f => f.SaveFileAsync(CoreConstants.Folders.PackageReadMesFolderName, "active/foo/1.0.0.md", It.IsAny<Stream>(), true),
+                    Times.Once);
+            }
+        }
+
+        public class ExtractAndSaveReadmeFileAsyncMethod
+        {
+            [Fact]
+            public async Task ThrowsWhenPackageIsNull()
+            {
+                var service = CreateService();
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.ExtractAndSaveReadmeFileAsync(
+                    package: null,
+                    packageStream: Mock.Of<Stream>()));
+
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task ThrowsWhenPackagesStreamIsNull()
+            {
+                var service = CreateService();
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => service.ExtractAndSaveReadmeFileAsync(
+                    package: Mock.Of<Package>(),
+                    packageStream: null));
+
+                Assert.Equal("packageStream", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task ThrowsOnMissingReadmeFile()
+            {
+                var service = CreateService();
+                const string readmeFileName = "readme.md";
+                var packageStream = GeneratePackageWithReadmeFile(readmeFileName, false);
+                var pacakge = PackageServiceUtility.CreateTestPackage();
+
+                var ex = await Assert.ThrowsAsync<FileNotFoundException>(() => service.ExtractAndSaveReadmeFileAsync(pacakge, packageStream));
+                Assert.Contains(readmeFileName, ex.Message);
+            }
+
+            [Theory]
+            [InlineData("readme.md")]
+            [InlineData("foo\\readme.md")]
+            [InlineData("foo/readme.md")]
+            public async Task SavesReadmeFile(String readmeFileName)
+            {
+                var fileServiceMock = new Mock<IFileStorageService>();
+                var service = CreateService(fileServiceMock);
+                var packageStream = GeneratePackageWithReadmeFile(readmeFileName);
+                var package = CreatePackage();
+                package.HasReadMe = true;
+                package.EmbeddedReadmeType = EmbeddedReadmeFileType.Markdown;
+                var savedReadmeBytes = new byte[ReadmeFileContents.Length];
+
+                fileServiceMock.Setup(x => x.SaveFileAsync(
+                    CoreConstants.Folders.PackageReadMesFolderName,
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    true))
+                    .Completes()
+                    .Callback<string, string, Stream, bool>((_, __, s, ___) => s.Read(savedReadmeBytes, 0, savedReadmeBytes.Length))
+                    .Verifiable();
+                
+                // Act.
+                await service.ExtractAndSaveReadmeFileAsync(package, packageStream);
+
+                // Assert.
+                fileServiceMock.VerifyAll();
+                Assert.Equal(ReadmeFileContents, savedReadmeBytes);
+            }
+        }
+
         public class TheDownloadReadMeMdFileAsyncMethod
         {
             [Fact]
@@ -353,9 +481,13 @@ namespace NuGetGallery
             return package;
         }
 
-        static MemoryStream CreatePackageFileStream()
+        private static byte[] ReadmeFileContents => Encoding.UTF8.GetBytes("Sample readme md file");
+
+        private static MemoryStream GeneratePackageWithReadmeFile(string readmeFileName = null, bool saveReadmeFile = true)
         {
-            return new MemoryStream(new byte[] { 0, 0, 1, 0, 1, 0, 1, 0 }, 0, 8, true, true);
+            return PackageServiceUtility.CreateNuGetPackageStream(
+                readmeFilename: readmeFileName,
+                readmeFileContents: readmeFileName != null && saveReadmeFile ? ReadmeFileContents : null);
         }
 
         static PackageFileService CreateService(Mock<IFileStorageService> fileStorageSvc = null)


### PR DESCRIPTION
Summary of the changes:

* Store embedded readme into readmes container

No change in terms of displaying view model, use the current implementation to display 

Display embedded readme on details page
![display](https://user-images.githubusercontent.com/64443925/90726901-50a1fb80-e277-11ea-93bf-a9fbbe64a665.PNG)


Addresses https://github.com/NuGet/Engineering/issues/3266