### PR TITLE
Add an entry for (soon to be stable) scripting usages

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -91,6 +91,15 @@
                 Id = "paket-cli",
                 CommandPrefix = "> ",
                 InstallPackageCommand = string.Format("paket add {0} --version {1}", Model.Id, Model.Version),
+            },
+
+            new PackageManagerViewModel("F# Interactive", "https://docs.microsoft.com/en-us/dotnet/fsharp/tutorials/fsharp-interactive/#scripting-with-f")
+            {
+                Id = "fsharp-interactive",
+                CommandPrefix = "> ",
+                InstallPackageCommand = string.Format("#r \"nuget: {0}, Version={1}\"", Model.Id, Model.Version),
+                AlertLevel = AlertLevel.Info,
+                AlertMessage = string.Format("Until F# 5.0 releases, you will need to launch `dotnet fsi` with the `--langversion:preview` argument in order to use package management.")
             }
         };
     }


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* F# 5.0 (which will release with .Net 5) and the dotnet/interactive project allow for using a variation of the `#r` syntax for including DLLs explicitly to also include packages.  This syntax is of the form:

```
#r "nuget: <package name>[, <list of options>*]"
```

where `<list of options>` is primarily used for specifying the `Version` of the package (which defaults to '*').

In the interests of making it easier for users to use nuget packages in scripting/interactive/notebook scenarios, I think there's value in showing that syntax on Nuget.org.