### PR TITLE
Emit AI event when install command is copied

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -85,6 +85,11 @@ $(function () {
             setTimeout(function () {
                 copyButton.popover('destroy');
             }, 1000);
+            window.nuget.sendMetric("CopyInstallCommand", 1, {
+                ButtonId: id,
+                PackageId: packageId,
+                PackageVersion: packageVersion
+            });
         });
     }  
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1146,6 +1146,8 @@
     </style>
 
     <script type="text/javascript">
+        var packageId = @Html.ToJson(Model.Id);
+        var packageVersion = @Html.ToJson(Model.Version);
         var packageManagers = @Html.ToJson(packageManagers.Select(pm => pm.Id).ToList());
     </script>
 


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/3400

Currently we have very little understanding of whether a user is "successful" after they reach a package details page. We have floated the idea several times in the past about instrumenting the "Copy" button. I decided to do that now so we can establish a baseline leading up to the next feature, whatever that might be (perhaps readmes? 👍)

The event looks like this:

![image](https://user-images.githubusercontent.com/94054/93124915-3513f000-f67f-11ea-81e7-50e5510d19bf.png)
