### PR TITLE
make attribute id value unique

### DIFF
--- a/src/NuGetGallery/Views/Shared/_AccountCertificates.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountCertificates.cshtml
@@ -47,7 +47,6 @@
         <span id="certificates-section-header"></span>
     </text>,
     @<text>
-        @ViewHelpers.AjaxAntiForgeryToken(Html)
 
         <form id="addCertificateForm" enctype="multipart/form-data" aria-hidden="true">
             @Html.AntiForgeryToken()


### PR DESCRIPTION
Remove additional call for @ViewHelpers.AjaxAntiForgeryToken(Html) in _AccountCertificates.cshtml to avoid duplicate attribute id value

Addresses https://github.com/NuGet/NuGetGallery/issues/8189