### PR TITLE
Add testData parameter to package list and V2 autocomplete

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -1018,11 +1018,16 @@ namespace NuGetGallery
         public virtual async Task<ActionResult> GetPackageIds(
             string partialId,
             bool? includePrerelease,
+            bool? testData,
             string semVerLevel = null)
         {
             return new JsonResult
             {
-                Data = await _autocompletePackageIdsQuery.Execute(partialId, includePrerelease, semVerLevel),
+                Data = await _autocompletePackageIdsQuery.Execute(
+                    partialId,
+                    includePrerelease,
+                    testData,
+                    semVerLevel),
                 JsonRequestBehavior = JsonRequestBehavior.AllowGet
             };
         }
@@ -1032,11 +1037,16 @@ namespace NuGetGallery
         public virtual async Task<ActionResult> GetPackageVersions(
             string id,
             bool? includePrerelease,
+            bool? testData,
             string semVerLevel = null)
         {
             return new JsonResult
             {
-                Data = await _autocompletePackageVersionsQuery.Execute(id, includePrerelease, semVerLevel),
+                Data = await _autocompletePackageVersionsQuery.Execute(
+                    id,
+                    includePrerelease,
+                    testData,
+                    semVerLevel),
                 JsonRequestBehavior = JsonRequestBehavior.AllowGet
             };
         }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -949,7 +949,8 @@ namespace NuGetGallery
                             packageType: null,
                             sortOrder: null,
                             context: SearchFilter.ODataSearchContext,
-                            semVerLevel: SemVerLevelKey.SemVerLevel2);
+                            semVerLevel: SemVerLevelKey.SemVerLevel2,
+                            includeTestData: true);
 
                         searchFilter.IncludeAllVersions = true;
 
@@ -1147,6 +1148,7 @@ namespace NuGetGallery
             var page = searchAndListModel.Page;
             var q = searchAndListModel.Q;
             var includePrerelease = searchAndListModel.Prerel ?? true;
+            var includeTestData = searchAndListModel.TestData ?? false;
 
             if (page < 1)
             {
@@ -1203,7 +1205,8 @@ namespace NuGetGallery
                         packageType: searchAndListModel.PackageType,
                         sortOrder: searchAndListModel.SortBy,
                         context: SearchFilter.UISearchContext,
-                        semVerLevel: SemVerLevelKey.SemVerLevel2);
+                        semVerLevel: SemVerLevelKey.SemVerLevel2,
+                        includeTestData: includeTestData);
 
                     results = await searchService.Search(searchFilter);
 
@@ -1231,7 +1234,8 @@ namespace NuGetGallery
                     packageType: searchAndListModel.PackageType,
                     sortOrder: searchAndListModel.SortBy,
                     context: SearchFilter.UISearchContext,
-                    semVerLevel: SemVerLevelKey.SemVerLevel2);
+                    semVerLevel: SemVerLevelKey.SemVerLevel2,
+                    includeTestData: includeTestData);
 
                 results = await searchService.Search(searchFilter);
             }

--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web;
@@ -71,7 +70,8 @@ namespace NuGetGallery.Infrastructure.Search
                 explain: false,
                 getAllVersions: filter.IncludeAllVersions,
                 supportedFramework: filter.SupportedFramework,
-                semVerLevel: filter.SemVerLevel);
+                semVerLevel: filter.SemVerLevel,
+                includeTestData: filter.IncludeTestData);
 
             SearchResults results = null;
             if (result.IsSuccessStatusCode)

--- a/src/NuGetGallery/Infrastructure/Lucene/GallerySearchClient.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/GallerySearchClient.cs
@@ -58,7 +58,8 @@ namespace NuGetGallery.Infrastructure.Search
             bool explain = false,
             bool getAllVersions = false,
             string supportedFramework = null,
-            string semVerLevel = null)
+            string semVerLevel = null,
+            bool includeTestData = false)
         {
             IDictionary<string, string> nameValue = new Dictionary<string, string>();
             nameValue.Add("q", query);
@@ -108,6 +109,11 @@ namespace NuGetGallery.Infrastructure.Search
             if (countOnly)
             {
                 nameValue.Add("countOnly", "true");
+            }
+
+            if (includeTestData)
+            {
+                nameValue.Add("testData", "true");
             }
 
             var qs = new FormUrlEncodedContent(nameValue);

--- a/src/NuGetGallery/Infrastructure/Lucene/ISearchClient.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ISearchClient.cs
@@ -24,6 +24,7 @@ namespace NuGetGallery.Infrastructure.Search
         /// <param name="getAllVersions">GetAllVersions</param>
         /// <param name="supportedFramework">SupportedFramework</param>
         /// <param name="semVerLevel">SemVerLevel</param>
+        /// <param name="includeTestData">Whether or not to include test data in the results.</param>
         /// <returns></returns>
         Task<ServiceResponse<SearchModels.SearchResults>> Search(
             string query,
@@ -38,7 +39,8 @@ namespace NuGetGallery.Infrastructure.Search
             bool explain,
             bool getAllVersions,
             string supportedFramework,
-            string semVerLevel);
+            string semVerLevel,
+            bool includeTestData);
 
         /// <summary>
         /// Returns the search diag.

--- a/src/NuGetGallery/OData/SearchService/SearchAdaptor.cs
+++ b/src/NuGetGallery/OData/SearchService/SearchAdaptor.cs
@@ -39,7 +39,15 @@ namespace NuGetGallery.OData
             { GalleryConstants.SearchSortNames.TotalDownloadsDesc, SortOrder.TotalDownloadsDescending },
         };
 
-        public static SearchFilter GetSearchFilter(string q, int page, bool includePrerelease, string packageType, string sortOrder, string context, string semVerLevel)
+        public static SearchFilter GetSearchFilter(
+            string q,
+            int page,
+            bool includePrerelease,
+            string packageType,
+            string sortOrder,
+            string context,
+            string semVerLevel,
+            bool includeTestData)
         {
             page = page < 1 ? 1 : page; // pages are 1-based. 
             packageType = packageType ?? string.Empty;
@@ -52,6 +60,7 @@ namespace NuGetGallery.OData
                 IncludePrerelease = includePrerelease,
                 SemVerLevel = semVerLevel,
                 PackageType = packageType,
+                IncludeTestData = includeTestData,
             };
 
             if (sortOrder == null || !SortOrders.TryGetValue(sortOrder, out var sortOrderValue))

--- a/src/NuGetGallery/Queries/AutocompleteDatabasePackageIdsQuery.cs
+++ b/src/NuGetGallery/Queries/AutocompleteDatabasePackageIdsQuery.cs
@@ -23,6 +23,7 @@ namespace NuGetGallery
         public Task<IReadOnlyList<string>> Execute(
             string partialId,
             bool? includePrerelease = false,
+            bool? includeTestData = false, // ignored on this implementation
             string semVerLevel = null)
         {
             var query = _packageRepository.GetAll()

--- a/src/NuGetGallery/Queries/AutocompleteDatabasePackageVersionsQuery.cs
+++ b/src/NuGetGallery/Queries/AutocompleteDatabasePackageVersionsQuery.cs
@@ -22,6 +22,7 @@ namespace NuGetGallery
         public Task<IReadOnlyList<string>> Execute(
             string id,
             bool? includePrerelease = false,
+            bool? includeTestData = false, // ignored on this implementation
             string semVerLevel = null)
         {
             if (string.IsNullOrWhiteSpace(id))

--- a/src/NuGetGallery/Queries/AutocompleteServicePackageIdsQuery.cs
+++ b/src/NuGetGallery/Queries/AutocompleteServicePackageIdsQuery.cs
@@ -20,11 +20,16 @@ namespace NuGetGallery
         public async Task<IReadOnlyList<string>> Execute(
             string partialId, 
             bool? includePrerelease,
+            bool? includeTestData,
             string semVerLevel = null)
         {
             partialId = partialId ?? string.Empty;
 
-            return await RunServiceQuery("take=30&q=" + Uri.EscapeUriString(partialId), includePrerelease, semVerLevel);
+            return await RunServiceQuery(
+                "take=30&q=" + Uri.EscapeUriString(partialId),
+                includePrerelease,
+                includeTestData,
+                semVerLevel);
         }
     }
 }

--- a/src/NuGetGallery/Queries/AutocompleteServicePackageVersionsQuery.cs
+++ b/src/NuGetGallery/Queries/AutocompleteServicePackageVersionsQuery.cs
@@ -20,6 +20,7 @@ namespace NuGetGallery
         public async Task<IReadOnlyList<string>> Execute(
             string id, 
             bool? includePrerelease,
+            bool? includeTestData,
             string semVerLevel = null)
         {
             if (string.IsNullOrWhiteSpace(id))
@@ -27,7 +28,11 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(id));
             }
 
-            return await RunServiceQuery("id=" + Uri.EscapeUriString(id), includePrerelease, semVerLevel);
+            return await RunServiceQuery(
+                "id=" + Uri.EscapeUriString(id),
+                includePrerelease,
+                includeTestData,
+                semVerLevel);
         }
     }
 }

--- a/src/NuGetGallery/Queries/AutocompleteServiceQuery.cs
+++ b/src/NuGetGallery/Queries/AutocompleteServiceQuery.cs
@@ -30,9 +30,10 @@ namespace NuGetGallery
         public async Task<IReadOnlyList<string>> RunServiceQuery(
             string queryString, 
             bool? includePrerelease,
+            bool? includeTestData,
             string semVerLevel = null)
         {
-            queryString = BuildQueryString(queryString, includePrerelease, semVerLevel);
+            queryString = BuildQueryString(queryString, includePrerelease, includeTestData, semVerLevel);
             var result = await ExecuteQuery(queryString);
             var resultObject = JObject.Parse(result);
 
@@ -45,9 +46,18 @@ namespace NuGetGallery
             return await response.Content.ReadAsStringAsync();
         }
 
-        internal string BuildQueryString(string queryString, bool? includePrerelease, string semVerLevel = null)
+        internal string BuildQueryString(
+            string queryString,
+            bool? includePrerelease,
+            bool? includeTestData,
+            string semVerLevel = null)
         {
             queryString += $"&prerelease={includePrerelease ?? false}";
+
+            if (includeTestData == true)
+            {
+                queryString += "&testData=true";
+            }
 
             NuGetVersion semVerLevelVersion;
             if (!string.IsNullOrEmpty(semVerLevel) && NuGetVersion.TryParse(semVerLevel, out semVerLevelVersion))

--- a/src/NuGetGallery/Queries/IAutocompletePackageIdsQuery.cs
+++ b/src/NuGetGallery/Queries/IAutocompletePackageIdsQuery.cs
@@ -11,6 +11,7 @@ namespace NuGetGallery
         Task<IReadOnlyList<string>> Execute(
             string partialId,
             bool? includePrerelease = false,
+            bool? includeTestData = false,
             string semVerLevel = null);
     }
 }

--- a/src/NuGetGallery/Queries/IAutocompletePackageVersionsQuery.cs
+++ b/src/NuGetGallery/Queries/IAutocompletePackageVersionsQuery.cs
@@ -11,6 +11,7 @@ namespace NuGetGallery
         Task<IReadOnlyList<string>> Execute(
             string id,
             bool? includePrerelease = false,
+            bool? icnludeTestData = false,
             string semVerLevel = null);
     }
 }

--- a/src/NuGetGallery/Services/SearchFilter.cs
+++ b/src/NuGetGallery/Services/SearchFilter.cs
@@ -37,6 +37,8 @@ namespace NuGetGallery
 
         public bool IncludeAllVersions { get; set; }
 
+        public bool IncludeTestData { get; set; }
+
         /// <summary>
         /// Constructs a new search filter
         /// </summary>

--- a/src/NuGetGallery/Services/SearchSideBySideService.cs
+++ b/src/NuGetGallery/Services/SearchSideBySideService.cs
@@ -114,7 +114,8 @@ namespace NuGetGallery
                 packageType: null,
                 sortOrder: null,
                 context: SearchFilter.UISearchContext,
-                semVerLevel: SemVerLevelKey.SemVerLevel2);
+                semVerLevel: SemVerLevelKey.SemVerLevel2,
+                includeTestData: false);
 
             searchFilter.Take = 10;
 

--- a/src/NuGetGallery/ViewModels/PackageListSearchViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageListSearchViewModel.cs
@@ -10,5 +10,6 @@ namespace NuGetGallery
         public bool? Prerel { get; set; }
         public string SortBy { get; set; }
         public string PackageType { get; set; }
+        public bool? TestData { get; set; }
     }
 }

--- a/tests/NuGetGallery.Facts/Queries/AutocompleteDatabasePackageIdsQueryFacts.cs
+++ b/tests/NuGetGallery.Facts/Queries/AutocompleteDatabasePackageIdsQueryFacts.cs
@@ -60,7 +60,7 @@ namespace NuGetGallery.Queries
             [InlineData("1.0.0-beta")]
             public async void WithValidSemVerLevelReturnIdsWhosePackagesSemVerLevelCompliant(string semVerLevel)
             {
-                var queryResult = await _packageIdsQuery.Execute("nuget", null, semVerLevel);
+                var queryResult = await _packageIdsQuery.Execute("nuget", null, null, semVerLevel);
 
                 var allIdsAreFromPackagesWithSemVerLevelCompliant = queryResult.All(id =>
                 {

--- a/tests/NuGetGallery.Facts/Queries/AutocompleteDatabasePackageVersionsQueryFacts.cs
+++ b/tests/NuGetGallery.Facts/Queries/AutocompleteDatabasePackageVersionsQueryFacts.cs
@@ -90,7 +90,7 @@ namespace NuGetGallery.Queries
             [InlineData("1.0.0-beta")]
             public async void ValidPackageIdWithSemVerLevelReturnVersionsWhosePackagesHaveSemVerLevelCompliant(string semVerLevel)
             {
-                var queryResult = await _packageVersionsQuery.Execute("nuget", null, semVerLevel);
+                var queryResult = await _packageVersionsQuery.Execute("nuget", null, null, semVerLevel);
                 
                 var allVersionsAreFromPackagesWithSemVerLevelCompliant = queryResult.All(version =>
                 {

--- a/tests/NuGetGallery.Facts/Queries/AutocompleteServiceQueryFacts.cs
+++ b/tests/NuGetGallery.Facts/Queries/AutocompleteServiceQueryFacts.cs
@@ -35,21 +35,27 @@ namespace NuGetGallery
         }
 
         [Theory]
-        [InlineData("someQueryString", true, null, "?someQueryString&prerelease=True")]
-        [InlineData("someQueryString", true, "1.0.0-beta.20.5", "?someQueryString&prerelease=True&semVerLevel=1.0.0-beta.20.5")]
-        [InlineData("someQueryString", true, "1.0.1+security.patch.2349", "?someQueryString&prerelease=True&semVerLevel=1.0.1+security.patch.2349")]
-        [InlineData("&someQueryString", false, "1.0.0-beta.20.5", "?someQueryString&prerelease=False&semVerLevel=1.0.0-beta.20.5")]
-        [InlineData("someQueryString", null, "1.0.0-beta.20.5", "?someQueryString&prerelease=False&semVerLevel=1.0.0-beta.20.5")]
-        [InlineData("", null, "1.0.0-beta.20.5", "?prerelease=False&semVerLevel=1.0.0-beta.20.5")]
-        [InlineData(null, null, "1.0.0-beta.20.5", "?prerelease=False&semVerLevel=1.0.0-beta.20.5")]
-        [InlineData("someQueryString", true, "", "?someQueryString&prerelease=True")]
-        public void BuildQueryStringReturnsTheExpectedString(string queryString, bool? includePrerelease, string semVerLevel, string expectedResult)
+        [InlineData("someQueryString", true, null, null, "?someQueryString&prerelease=True")]
+        [InlineData("someQueryString", true, null, "1.0.0-beta.20.5", "?someQueryString&prerelease=True&semVerLevel=1.0.0-beta.20.5")]
+        [InlineData("someQueryString", true, null, "1.0.1+security.patch.2349", "?someQueryString&prerelease=True&semVerLevel=1.0.1+security.patch.2349")]
+        [InlineData("&someQueryString", false, null, "1.0.0-beta.20.5", "?someQueryString&prerelease=False&semVerLevel=1.0.0-beta.20.5")]
+        [InlineData("someQueryString", null, null, "1.0.0-beta.20.5", "?someQueryString&prerelease=False&semVerLevel=1.0.0-beta.20.5")]
+        [InlineData("", null, null, "1.0.0-beta.20.5", "?prerelease=False&semVerLevel=1.0.0-beta.20.5")]
+        [InlineData(null, null, null, "1.0.0-beta.20.5", "?prerelease=False&semVerLevel=1.0.0-beta.20.5")]
+        [InlineData("someQueryString", true, null, "", "?someQueryString&prerelease=True")]
+        [InlineData("someQueryString", true, true, "", "?someQueryString&prerelease=True&testData=true")]
+        public void BuildQueryStringReturnsTheExpectedString(
+            string queryString,
+            bool? includePrerelease,
+            bool? includeTestData,
+            string semVerLevel,
+            string expectedResult)
         {
             // Arrange
             var autocompleteServiceQuery = TestAutocompleteServiceQuery.Instance(_baseAddress, queryString);
 
             // Act
-            var result = autocompleteServiceQuery.BuildQueryString(queryString, includePrerelease, semVerLevel);
+            var result = autocompleteServiceQuery.BuildQueryString(queryString, includePrerelease, includeTestData, semVerLevel);
 
             // Assert
             Assert.Equal(expectedResult, result);

--- a/tests/NuGetGallery.Facts/Services/SearchAdaptorFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SearchAdaptorFacts.cs
@@ -110,6 +110,7 @@ namespace NuGetGallery
                 const string sortOrder = GalleryConstants.SearchSortNames.Relevance;
                 const string context = "someContext";
                 const string semVerLevel = "someSemVer";
+                const bool includeTestData = true;
 
                 var searchFilter = SearchAdaptor.GetSearchFilter(
                     query,
@@ -118,7 +119,8 @@ namespace NuGetGallery
                     packageType,
                     sortOrder,
                     context,
-                    semVerLevel);
+                    semVerLevel,
+                    includeTestData);
 
                 Assert.Equal(query, searchFilter.SearchTerm);
                 Assert.Equal((page - 1) * GalleryConstants.DefaultPackageListPageSize, searchFilter.Skip);
@@ -128,6 +130,7 @@ namespace NuGetGallery
                 Assert.Equal(semVerLevel, searchFilter.SemVerLevel);
                 Assert.Equal(string.Empty, searchFilter.PackageType);
                 Assert.Equal(SortOrder.Relevance, searchFilter.SortOrder);
+                Assert.Equal(includeTestData, searchFilter.IncludeTestData);
             }
 
             [Fact]
@@ -140,7 +143,8 @@ namespace NuGetGallery
                     packageType: null,
                     sortOrder: null,
                     context: null,
-                    semVerLevel: null);
+                    semVerLevel: null,
+                    includeTestData: true);
 
                 Assert.Null(searchFilter.SearchTerm);
                 Assert.Equal(0, searchFilter.Skip);
@@ -150,6 +154,7 @@ namespace NuGetGallery
                 Assert.Null(searchFilter.SemVerLevel);
                 Assert.Equal(string.Empty, searchFilter.PackageType);
                 Assert.Equal(SortOrder.Relevance, searchFilter.SortOrder);
+                Assert.True(searchFilter.IncludeTestData);
             }
 
             [Theory]
@@ -163,16 +168,18 @@ namespace NuGetGallery
                    packageType: "Dependency",
                    sortOrder: SortNames[sortOrder],
                    context: string.Empty,
-                   semVerLevel: "SomeSemVer");
+                   semVerLevel: "SomeSemVer",
+                   includeTestData: true);
 
                 Assert.Equal(string.Empty, searchFilter.SearchTerm);
                 Assert.Equal(0, searchFilter.Skip);
                 Assert.Equal(GalleryConstants.DefaultPackageListPageSize, searchFilter.Take);
-                Assert.Equal(true, searchFilter.IncludePrerelease);
+                Assert.True(searchFilter.IncludePrerelease);
                 Assert.Equal(string.Empty, searchFilter.Context);
                 Assert.Equal("SomeSemVer", searchFilter.SemVerLevel);
                 Assert.Equal("Dependency", searchFilter.PackageType);
                 Assert.Equal(sortOrder, searchFilter.SortOrder);
+                Assert.True(searchFilter.IncludeTestData);
             }
 
             [Theory]
@@ -186,16 +193,18 @@ namespace NuGetGallery
                        packageType: "Dependency",
                        sortOrder: SortNames[sortOrder].ToUpper(),
                        context: string.Empty,
-                       semVerLevel: "SomeSemVer");
+                       semVerLevel: "SomeSemVer",
+                       includeTestData: true);
 
                 Assert.Equal(string.Empty, searchFilter.SearchTerm);
                 Assert.Equal(0, searchFilter.Skip);
                 Assert.Equal(GalleryConstants.DefaultPackageListPageSize, searchFilter.Take);
-                Assert.Equal(true, searchFilter.IncludePrerelease);
+                Assert.True(searchFilter.IncludePrerelease);
                 Assert.Equal(string.Empty, searchFilter.Context);
                 Assert.Equal("SomeSemVer", searchFilter.SemVerLevel);
                 Assert.Equal("Dependency", searchFilter.PackageType);
                 Assert.Equal(sortOrder, searchFilter.SortOrder);
+                Assert.True(searchFilter.IncludeTestData);
             }
         }
 

--- a/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
@@ -34,11 +34,11 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             string sortBy = "",
             bool expectDescending = true)
         {
-            var sortByParam = string.IsNullOrEmpty(sortBy) ? string.Empty : $"&sortBy={sortBy}";
             // Arrange
+            var sortByParam = string.IsNullOrEmpty(sortBy) ? string.Empty : $"&sortBy={sortBy}";
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?q=owner%3A{Constants.TestAccount}{sortByParam}");
+                $"/packages?testData=true&q=owner%3A{Constants.TestAccount}{sortByParam}");
 
             // Act
             using (var httpClient = new HttpClient())
@@ -61,11 +61,11 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
         [InlineData("cReAtEd-DeSc")]
         public async Task MakeSureLastUpdatedSortingWorks(string sortBy)
         {
-            var sortByParam = string.IsNullOrEmpty(sortBy) ? string.Empty : $"&sortBy={sortBy}";
             // Arrange
+            var sortByParam = string.IsNullOrEmpty(sortBy) ? string.Empty : $"&sortBy={sortBy}";
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?q=owner%3A{Constants.TestAccount}{sortByParam}");
+                $"/packages?testData=true&q=owner%3A{Constants.TestAccount}{sortByParam}");
 
             // Act
             using (var httpClient = new HttpClient())
@@ -93,11 +93,11 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             string id,
             string packageType = "")
         {
-            var packageTypeParam = string.IsNullOrEmpty(packageType) ? string.Empty : $"&packageType={packageType}";
             // Arrange
+            var packageTypeParam = string.IsNullOrEmpty(packageType) ? string.Empty : $"&packageType={packageType}";
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?q=packageid%3A{Uri.EscapeUriString(id)}+owner%3A{Constants.TestAccount}{packageTypeParam}");
+                $"/packages?testData=true&q=packageid%3A{Uri.EscapeUriString(id)}+owner%3A{Constants.TestAccount}{packageTypeParam}");
 
             // Act
             using (var httpClient = new HttpClient())


### PR DESCRIPTION
These endpoints are used by automated tests and must allow test data to be shown. It is filtered out of search qeuries by default with https://github.com/NuGet/NuGet.Jobs/pull/915.

The package list (`/packages`) is hit by gallery functional tests when testing the advanced search sorting behavior.

The V2 autocomplete endpoints (`/api/v2/package-ids` and `/api/v2/package-version`) are used by end-to-end tests to verify V2 autocomplete behavior.

Related to https://github.com/NuGet/NuGetGallery/issues/8172