### PR TITLE
Darken the orange buttons for accessibility

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -2585,27 +2585,27 @@ fieldset[disabled] .btn-info.focus {
 }
 .btn-warning {
   color: #fff;
-  background-color: #ef8b00;
-  border-color: #d67c00;
+  background-color: #d27a00;
+  border-color: #b86b00;
 }
 .btn-warning:focus,
 .btn-warning.focus {
   color: #fff;
-  background-color: #bc6d00;
-  border-color: #563200;
+  background-color: #9f5c00;
+  border-color: #392100;
 }
 .btn-warning:hover {
   color: #fff;
-  background-color: #bc6d00;
-  border-color: #985900;
+  background-color: #9f5c00;
+  border-color: #7b4800;
 }
 .btn-warning:active,
 .btn-warning.active,
 .open > .dropdown-toggle.btn-warning {
   color: #fff;
-  background-color: #bc6d00;
+  background-color: #9f5c00;
   background-image: none;
-  border-color: #985900;
+  border-color: #7b4800;
 }
 .btn-warning:active:hover,
 .btn-warning.active:hover,
@@ -2617,8 +2617,8 @@ fieldset[disabled] .btn-info.focus {
 .btn-warning.active.focus,
 .open > .dropdown-toggle.btn-warning.focus {
   color: #fff;
-  background-color: #985900;
-  border-color: #563200;
+  background-color: #7b4800;
+  border-color: #392100;
 }
 .btn-warning.disabled:hover,
 .btn-warning[disabled]:hover,
@@ -2629,11 +2629,11 @@ fieldset[disabled] .btn-warning:focus,
 .btn-warning.disabled.focus,
 .btn-warning[disabled].focus,
 fieldset[disabled] .btn-warning.focus {
-  background-color: #ef8b00;
-  border-color: #d67c00;
+  background-color: #d27a00;
+  border-color: #b86b00;
 }
 .btn-warning .badge {
-  color: #ef8b00;
+  color: #d27a00;
   background-color: #fff;
 }
 .btn-danger {

--- a/src/Bootstrap/less/variables.less
+++ b/src/Bootstrap/less/variables.less
@@ -166,7 +166,7 @@
 @btn-info-border:                darken(@btn-info-bg, 5%);
 
 @btn-warning-color:              #fff;
-@btn-warning-bg:                 @brand-warning;
+@btn-warning-bg:                 darken(@brand-warning, 5.75%);
 @btn-warning-border:             darken(@btn-warning-bg, 5%);
 
 @btn-danger-color:               #fff;


### PR DESCRIPTION
For WCAG 2.1, web components must have a 3:1 contrast ratio. This darkens both the "search" button in the header as well as the "copy" button for installation instructions.

Before:
![image](https://user-images.githubusercontent.com/737941/94200502-5d65d080-fe6f-11ea-9860-c4ffe1a83351.png)

After:
![image](https://user-images.githubusercontent.com/737941/94318820-31fde700-ff3e-11ea-914a-e3f74808316a.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/8195