### PR TITLE
Update NuGet client libraries to 5.8.0 prerelease

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -283,7 +283,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>5.0.0-preview1.5665</Version>
+      <Version>5.8.0-preview.3.6823</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>

--- a/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
@@ -276,7 +276,7 @@ namespace NuGetGallery.Packaging
             return new PackageMetadata(
                 nuspecReader.GetMetadata().ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
                 nuspecReader.GetDependencyGroups(useStrictVersionCheck: strict),
-                nuspecReader.GetFrameworkReferenceGroups(),
+                nuspecReader.GetFrameworkAssemblyGroups(),
                 nuspecReader.GetPackageTypes(),
                 nuspecReader.GetMinClientVersion(),
                 nuspecReader.GetRepositoryMetadata(),

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -298,10 +298,10 @@
       <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>5.0.0-preview1.5665</Version>
+      <Version>5.8.0-preview.3.6823</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
-      <Version>5.0.0-preview1.5665</Version>
+      <Version>5.8.0-preview.3.6823</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.74.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2236,10 +2236,10 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Configuration">
-      <Version>5.0.0-preview1.5665</Version>
+      <Version>5.8.0-preview.3.6823</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
-      <Version>5.0.0-preview1.5665</Version>
+      <Version>5.8.0-preview.3.6823</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
       <Version>2.74.0</Version>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -573,6 +573,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6823" newVersion="5.8.0.6823"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
       </dependentAssembly>
@@ -590,11 +594,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6823" newVersion="5.8.0.6823"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6823" newVersion="5.8.0.6823"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>

--- a/tests/NuGetGallery.Facts/Services/PackageMetadataValidationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageMetadataValidationServiceFacts.cs
@@ -67,13 +67,13 @@ namespace NuGetGallery
             return packageMetadataValidationService.Object;
         }
 
-        public class TheValidateMetadatabeforeUploadAsyn : FactsBase
+        public class TheValidateMetadataBeforeUploadAsync : FactsBase
         {
             private Mock<TestPackageReader> _nuGetPackage;
             private PackageRegistration _packageRegistration;
             private User _currentUser;
 
-            public TheValidateMetadatabeforeUploadAsyn()
+            public TheValidateMetadataBeforeUploadAsync()
             {
                 _nuGetPackage = GeneratePackage(isSigned: true);
                 _packageRegistration = _package.PackageRegistration;
@@ -611,7 +611,7 @@ namespace NuGetGallery
             [InlineData("Vim WITH Font-exception-2.0", true)] // we are not checking if license expression make sense
             [InlineData("Vim with Font-exception-2.0", false)]
             [InlineData("Vim With Font-exception-2.0", false)]
-            [InlineData("(EUPL-1.1+ OR (SPL-1.0 WITH Nokia-Qt-exception-1.1) AND Sleepycat)", true)]
+            [InlineData("(EUPL-1.1+ OR (SPL-1.0 WITH Font-exception-2.0) AND Sleepycat)", true)]
             public async Task ChecksLicenseExpressionCorrectness(string licenseExpression, bool expectedSuccess)
             {
                 _nuGetPackage = GeneratePackageWithUserContent(licenseUrl: GetLicenseExpressionDeprecationUrl(licenseExpression), licenseExpression: licenseExpression, licenseFilename: null);


### PR DESCRIPTION
The Gallery uses an older version of `NuGet.Packaging` that depends on `NuGet.Packaging.Core`. The Orchestrator was updated to use a newer version of `NuGet.Packaging` that no longer depends on `NuGet.Packaging.Core`. The Orchestrator uses assemblies produced from the Gallery, thereby causing runtime issues when these assemblies attempt to reference types from `NuGet.Packaging.Core.dll` which is unavailable.

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4116398&view=results
Release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=833326

Part of https://github.com/NuGet/NuGetGallery/issues/8228