### PR TITLE
Enhance OData deprecation error message

### DIFF
--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1292,7 +1292,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This OData endpoint is disabled. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation.
+        ///   Looks up a localized string similar to This OData endpoint has been disabled. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation.
         /// </summary>
         public static string ODataDisabled {
             get {
@@ -1301,7 +1301,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The combination of parameters provided to this OData endpoint is not supported. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation.
+        ///   Looks up a localized string similar to The combination of parameters provided to this OData endpoint is no longer supported. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation.
         /// </summary>
         public static string ODataParametersDisabled {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1292,7 +1292,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This OData endpoint is disabled..
+        ///   Looks up a localized string similar to This OData endpoint is disabled. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation.
         /// </summary>
         public static string ODataDisabled {
             get {
@@ -1301,7 +1301,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The combination of parameters provided to this OData endpoint is not supported..
+        ///   Looks up a localized string similar to The combination of parameters provided to this OData endpoint is not supported. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation.
         /// </summary>
         public static string ODataParametersDisabled {
             get {
@@ -2589,7 +2589,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about Packaging License within the nupkg.
+        ///   Looks up a localized string similar to Learn more about including a license within the package.
         /// </summary>
         public static string UploadPackage_LearMore_PackagingLicense {
             get {
@@ -2607,7 +2607,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about Icon Url deprecation.
+        ///   Looks up a localized string similar to Learn more about icon URL deprecation.
         /// </summary>
         public static string UploadPackage_LearnMore_IconUrlDeprecation {
             get {
@@ -2616,7 +2616,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about Invalid License Url encoding.
+        ///   Looks up a localized string similar to Learn more about invalid license URL encoding.
         /// </summary>
         public static string UploadPackage_LearnMore_InvalidLicenseUrlEncoding {
             get {
@@ -2625,7 +2625,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about License Url deprecation.
+        ///   Looks up a localized string similar to Learn more about license URL deprecation.
         /// </summary>
         public static string UploadPackage_LearnMore_LicenseUrlDreprecation {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1179,10 +1179,10 @@ The {1} Team</value>
     <value>the name of &lt;readme&gt; element is case sensitive, must use the &lt;readme&gt;</value>
   </data>
   <data name="ODataDisabled" xml:space="preserve">
-    <value>This OData endpoint is disabled.</value>
+    <value>This OData endpoint is disabled. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation</value>
   </data>
   <data name="ODataParametersDisabled" xml:space="preserve">
-    <value>The combination of parameters provided to this OData endpoint is not supported.</value>
+    <value>The combination of parameters provided to this OData endpoint is not supported. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation</value>
   </data>
   <data name="ReadmeNotEditableWithEmbeddedReadme" xml:space="preserve">
     <value>The readme is not editable with the package has the embedded readme</value>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1179,10 +1179,10 @@ The {1} Team</value>
     <value>the name of &lt;readme&gt; element is case sensitive, must use the &lt;readme&gt;</value>
   </data>
   <data name="ODataDisabled" xml:space="preserve">
-    <value>This OData endpoint is disabled. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation</value>
+    <value>This OData endpoint has been disabled. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation</value>
   </data>
   <data name="ODataParametersDisabled" xml:space="preserve">
-    <value>The combination of parameters provided to this OData endpoint is not supported. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation</value>
+    <value>The combination of parameters provided to this OData endpoint is no longer supported. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation</value>
   </data>
   <data name="ReadmeNotEditableWithEmbeddedReadme" xml:space="preserve">
     <value>The readme is not editable with the package has the embedded readme</value>


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/3428

There are two variants of error messages because the `/api/v1/Packages()` endpoint will be entirely disabled (it does not hijack at all) and will therefore need different wording than the rest of the endpoints which just have some sets of parameter combinations disabled.

### `/api/v1/Packages` - endpoint disabled

```
https://localhost/api/v1/Packages()?$orderby=Version
```

Response with formatting (my browser):

![image](https://user-images.githubusercontent.com/94054/95260367-6f376400-07dd-11eb-8ec3-e0b296a98fe4.png)

Response without formatting (most likely experience):

<code>
&lt;?xml version="1.0" encoding="utf-8"?&gt;&lt;m:error xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"&gt;&lt;m:code /&gt;&lt;m:message xml:lang="en-US"&gt;This OData endpoint is disabled. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation&lt;/m:message&gt;&lt;/m:error&gt;
</code>

### All other non-hijacked queries - combinations of parameters disabled

```
https://localhost/api/v2/FindPackagesById()?id=%27Newtonsoft.Json%27&$orderby=Version
```

Response with formatting:

![image](https://user-images.githubusercontent.com/94054/95260626-ea007f00-07dd-11eb-857e-f93351bb923a.png)

Response without formatting (most likely experience):

<code>
&lt;?xml version="1.0" encoding="utf-8"?&gt;&lt;m:error xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"&gt;&lt;m:code /&gt;&lt;m:message xml:lang="en-US"&gt;The combination of parameters provided to this OData endpoint is not supported. Please refer to the following URL for more information about this deprecation: https://aka.ms/nuget/odata-deprecation&lt;/m:message&gt;&lt;/m:error&gt;
</code>

### Notes

- I could not find a good way to pretty format the XML with indentation or whitespace
- The link currently points to the root blog URL but will be fixed up to point to a real blog post/doc prior to the feature flags being used.
