### PR TITLE
Remove A/B test check for the package dependents feature

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/AB-Test-Configuration.json
+++ b/src/NuGetGallery/App_Data/Files/Content/AB-Test-Configuration.json
@@ -1,5 +1,5 @@
 {
   "PreviewSearchPercentage": 0,
   "PreviewHijackPercentage": 0,
-  "DependentsPercentage": 100
+  "DependentsPercentage": 0
 }

--- a/src/NuGetGallery/App_Data/Files/Content/AB-Test-Configuration.json
+++ b/src/NuGetGallery/App_Data/Files/Content/AB-Test-Configuration.json
@@ -1,5 +1,5 @@
 {
   "PreviewSearchPercentage": 0,
   "PreviewHijackPercentage": 0,
-  "DependentsPercentage": 0
+  "DependentsPercentage": 100
 }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -880,8 +880,7 @@ namespace NuGetGallery
             model.IsAtomFeedEnabled = _featureFlagService.IsPackagesAtomFeedEnabled();
             model.IsPackageDeprecationEnabled = _featureFlagService.IsManageDeprecationEnabled(currentUser, allVersions);
             model.IsPackageRenamesEnabled = _featureFlagService.IsPackageRenamesEnabled(currentUser);
-            model.IsPackageDependentsEnabled = _featureFlagService.IsPackageDependentsEnabled(currentUser) && 
-                _abTestService.IsPackageDependendentsABEnabled(currentUser);
+            model.IsPackageDependentsEnabled = _featureFlagService.IsPackageDependentsEnabled(currentUser);
            
             if (model.IsPackageDependentsEnabled)
             {

--- a/src/NuGetGallery/Infrastructure/ABTestEnrollment.cs
+++ b/src/NuGetGallery/Infrastructure/ABTestEnrollment.cs
@@ -27,9 +27,21 @@ namespace NuGetGallery
             PreviewSearchBucket = previewSearchBucket;
             PackageDependentBucket = packageDependentBucket;
         }
+
         public ABTestEnrollmentState State { get; }
         public int SchemaVersion { get; }
+
+        /// <summary>
+        /// Currently usabled and is represented by the "ps" property in the "nugetab" cookie.
+        /// </summary>
         public int PreviewSearchBucket { get; }
+
+        /// <summary>
+        /// Currently unused by the <see cref="CookieBasedABTestService"/> but still set in some user's cookies. See
+        /// <see cref="ABTestEnrollmentFactory"/> for the A/B test cookie data model. This C# property could be renamed
+        /// and reused for a future A/B test by leveraging the "pd" JSON property in the "nugetab" cookie or could be
+        /// ignored for the rest of time.
+        /// </summary>
         public int PackageDependentBucket { get; }
     }
 }

--- a/src/NuGetGallery/Infrastructure/ABTestEnrollmentFactory.cs
+++ b/src/NuGetGallery/Infrastructure/ABTestEnrollmentFactory.cs
@@ -4,28 +4,32 @@
 using System;
 using System.Security.Cryptography;
 using System.Threading;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace NuGetGallery
 {
+    /// <summary>
+    /// This is the implementation that handles all current and past versions of the "nugetab" cookie. This, along
+    /// with <see cref="CookieBasedABTestService"/>, makes the A/B test settings per browsing session "sticky" so that
+    /// an A/B test feature is always on or off for a single user browser.
+    /// </summary>
     public class ABTestEnrollmentFactory : IABTestEnrollmentFactory
     {
-        private const int SchemaVersion1 = 1;
-        private const int SchemaVersion2 = 2;
+        private const int SchemaVersion1 = 1; // PreviewSearch: {"v":1,"ps":100}
+        private const int SchemaVersion2 = 2; // PreviewSearch + PackageDependent: {"v":2,"ps":100,"pd":100}
+
+        // Note that a new schema version could theoretically reused any currently unused cookie properties. However
+        // this does have questionable statistical correctness due treatment assignment of one A/B test being reused
+        // for another, i.e. each A/B test population is not independent.
 
         private static readonly RNGCryptoServiceProvider _secureRng = new RNGCryptoServiceProvider();
         private static readonly ThreadLocal<byte[]> _bytes = new ThreadLocal<byte[]>(() => new byte[sizeof(ulong)]);
 
         private readonly ITelemetryService _telemetryService;
-        private readonly ILogger<ABTestEnrollmentFactory> _logger;
 
-        public ABTestEnrollmentFactory(
-            ITelemetryService telemetryService,
-            ILogger<ABTestEnrollmentFactory> logger)
+        public ABTestEnrollmentFactory(ITelemetryService telemetryService)
         {
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public ABTestEnrollment Initialize()
@@ -85,7 +89,8 @@ namespace NuGetGallery
                 return false;
             }
 
-            return TryDeserializeStateVer2(serialized, out enrollment) || TryDeserializeStateVer1(serialized, out enrollment);
+            return TryDeserializeStateVer2(serialized, out enrollment)
+                || TryDeserializeStateVer1(serialized, out enrollment);
         }
 
         private bool TryDeserializeStateVer1(string serialized, out ABTestEnrollment enrollment)

--- a/src/NuGetGallery/Infrastructure/ABTestEnrollmentFactory.cs
+++ b/src/NuGetGallery/Infrastructure/ABTestEnrollmentFactory.cs
@@ -18,7 +18,7 @@ namespace NuGetGallery
         private const int SchemaVersion1 = 1; // PreviewSearch: {"v":1,"ps":100}
         private const int SchemaVersion2 = 2; // PreviewSearch + PackageDependent: {"v":2,"ps":100,"pd":100}
 
-        // Note that a new schema version could theoretically reused any currently unused cookie properties. However
+        // Note that a new schema version could theoretically reuse any currently unused cookie properties. However
         // this does have questionable statistical correctness due treatment assignment of one A/B test being reused
         // for another, i.e. each A/B test population is not independent.
 

--- a/src/NuGetGallery/Infrastructure/CookieBasedABTestService.cs
+++ b/src/NuGetGallery/Infrastructure/CookieBasedABTestService.cs
@@ -47,17 +47,6 @@ namespace NuGetGallery
                 config => config.PreviewSearchPercentage);
         }
 
-        public bool IsPackageDependendentsABEnabled(User user)
-        {
-            var isActive = IsActive(
-                nameof(Enrollment.PackageDependentBucket),
-                user,
-                enrollment => enrollment.PackageDependentBucket,
-                config => config.DependentsPercentage);
-
-            return isActive;
-        }
-
         private ABTestEnrollment Enrollment => _lazyEnrollment.Value;
         private IABTestConfiguration Config => _contentObjectService.ABTestConfiguration;
 

--- a/src/NuGetGallery/Infrastructure/IABTestService.cs
+++ b/src/NuGetGallery/Infrastructure/IABTestService.cs
@@ -11,10 +11,5 @@ namespace NuGetGallery
         /// Whether or not the user should see the preview search implementation.
         /// </summary>
         bool IsPreviewSearchEnabled(User user);
-
-        /// <summary>
-        /// Whether or not the user should see the reverse dependencies implementation.
-        /// </summary>
-        bool IsPackageDependendentsABEnabled(User user);
     }
 }

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Caching;
@@ -45,7 +44,6 @@ using NuGetGallery.Services;
 using NuGetGallery.Services.Helpers;
 using NuGetGallery.TestUtils;
 using Xunit;
-using Xunit.Sdk;
 
 namespace NuGetGallery
 {
@@ -187,6 +185,9 @@ namespace NuGetGallery
                 contentObjectService
                     .SetupGet(c => c.GitHubUsageConfiguration)
                     .Returns(new GitHubUsageConfiguration(Array.Empty<RepositoryInformation>()));
+                contentObjectService
+                    .SetupGet(c => c.CacheConfiguration)
+                    .Returns(new CacheConfiguration());
             }
 
             if (symbolPackageUploadService == null)

--- a/tests/NuGetGallery.Facts/Infrastructure/ABTestEnrollmentFactoryFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/ABTestEnrollmentFactoryFacts.cs
@@ -133,9 +133,7 @@ namespace NuGetGallery
             public Facts()
             {
                 TelemetryService = new Mock<ITelemetryService>();
-                Logger = new Mock<ILogger<ABTestEnrollmentFactory>>();
-
-                Target = new ABTestEnrollmentFactory(TelemetryService.Object, Logger.Object);
+                Target = new ABTestEnrollmentFactory(TelemetryService.Object);
             }
 
             public Mock<ITelemetryService> TelemetryService { get; }


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/8250

Also, did a little thinking about what the next A/B test would do. Either re-use the "pd" property in the cookie if you don't care much about independent treatment groups or add a new schema version and leave "pd" as vestigial. 