### PR TITLE
[A11y] Improve color contrast of grey buttons

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -2373,27 +2373,27 @@ fieldset[disabled] a.btn {
 }
 .btn-default {
   color: #333;
-  background-color: #f4f4f4;
-  border-color: #f4f4f4;
+  background-color: #fff;
+  border-color: #323130;
 }
 .btn-default:focus,
 .btn-default.focus {
   color: #333;
-  background-color: #dbdbdb;
-  border-color: #b4b4b4;
+  background-color: #e6e6e6;
+  border-color: #000000;
 }
 .btn-default:hover {
   color: #333;
-  background-color: #dbdbdb;
-  border-color: #d5d5d5;
+  background-color: #e6e6e6;
+  border-color: #131212;
 }
 .btn-default:active,
 .btn-default.active,
 .open > .dropdown-toggle.btn-default {
   color: #333;
-  background-color: #dbdbdb;
+  background-color: #e6e6e6;
   background-image: none;
-  border-color: #d5d5d5;
+  border-color: #131212;
 }
 .btn-default:active:hover,
 .btn-default.active:hover,
@@ -2405,8 +2405,8 @@ fieldset[disabled] a.btn {
 .btn-default.active.focus,
 .open > .dropdown-toggle.btn-default.focus {
   color: #333;
-  background-color: #c9c9c9;
-  border-color: #b4b4b4;
+  background-color: #d4d4d4;
+  border-color: #000000;
 }
 .btn-default.disabled:hover,
 .btn-default[disabled]:hover,
@@ -2417,11 +2417,11 @@ fieldset[disabled] .btn-default:focus,
 .btn-default.disabled.focus,
 .btn-default[disabled].focus,
 fieldset[disabled] .btn-default.focus {
-  background-color: #f4f4f4;
-  border-color: #f4f4f4;
+  background-color: #fff;
+  border-color: #323130;
 }
 .btn-default .badge {
-  color: #f4f4f4;
+  color: #fff;
   background-color: #333;
 }
 .btn-primary {

--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -2374,18 +2374,18 @@ fieldset[disabled] a.btn {
 .btn-default {
   color: #333;
   background-color: #fff;
-  border-color: #323130;
+  border-color: #7f7f7f;
 }
 .btn-default:focus,
 .btn-default.focus {
   color: #333;
   background-color: #e6e6e6;
-  border-color: #000000;
+  border-color: #3f3f3f;
 }
 .btn-default:hover {
   color: #333;
   background-color: #e6e6e6;
-  border-color: #131212;
+  border-color: #606060;
 }
 .btn-default:active,
 .btn-default.active,
@@ -2393,7 +2393,7 @@ fieldset[disabled] a.btn {
   color: #333;
   background-color: #e6e6e6;
   background-image: none;
-  border-color: #131212;
+  border-color: #606060;
 }
 .btn-default:active:hover,
 .btn-default.active:hover,
@@ -2406,7 +2406,7 @@ fieldset[disabled] a.btn {
 .open > .dropdown-toggle.btn-default.focus {
   color: #333;
   background-color: #d4d4d4;
-  border-color: #000000;
+  border-color: #3f3f3f;
 }
 .btn-default.disabled:hover,
 .btn-default[disabled]:hover,
@@ -2418,7 +2418,7 @@ fieldset[disabled] .btn-default:focus,
 .btn-default[disabled].focus,
 fieldset[disabled] .btn-default.focus {
   background-color: #fff;
-  border-color: #323130;
+  border-color: #7f7f7f;
 }
 .btn-default .badge {
   color: #fff;

--- a/src/Bootstrap/less/variables.less
+++ b/src/Bootstrap/less/variables.less
@@ -151,7 +151,7 @@
 
 @btn-default-color:              #333;
 @btn-default-bg:                 #fff;
-@btn-default-border:             #323130;
+@btn-default-border:             #7f7f7f;
 
 @btn-primary-color:              #fff;
 @btn-primary-bg:                 @brand-primary;

--- a/src/Bootstrap/less/variables.less
+++ b/src/Bootstrap/less/variables.less
@@ -150,8 +150,8 @@
 @btn-font-weight:                normal;
 
 @btn-default-color:              #333;
-@btn-default-bg:                 #f4f4f4;
-@btn-default-border:             #f4f4f4;
+@btn-default-bg:                 #fff;
+@btn-default-border:             #323130;
 
 @btn-primary-color:              #fff;
 @btn-primary-bg:                 @brand-primary;

--- a/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
+++ b/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
@@ -44,7 +44,7 @@
                             </select>
                         </div>
                         <div class="text-right col-xs-1">
-                            <button class="btn" type="submit" title="Add new member" aria-label="Add new member" data-bind="click: AddMember">Add</button>
+                            <button class="btn btn-primary" type="submit" title="Add new member" aria-label="Add new member" data-bind="click: AddMember">Add</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8192

Example:
![image](https://user-images.githubusercontent.com/737941/95800326-dfe1f300-0cab-11eb-8e3d-265f8d81a241.png)

Hovering over the button darkens it:

![image](https://user-images.githubusercontent.com/737941/95800561-83cb9e80-0cac-11eb-8f38-10ff56246ce1.png)

Note: this change also affects external login buttons. The new style is closer to Microsoft's [guidelines](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-branding-in-azure-ad-apps#visual-guidance-for-sign-in) but does not follow them completely. I've opened https://github.com/NuGet/NuGetGallery/issues/8258 to track this issue.

![image](https://user-images.githubusercontent.com/737941/95800471-48c96b00-0cac-11eb-8bc5-a54e29189069.png)

You can find the test plan here: https://github.com/NuGet/NuGetGallery/issues/8192#issuecomment-698598530