### PR TITLE
Add underline for banner

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -163,6 +163,7 @@ body h3 {
 }
 .banner a {
   color: #23527c;
+  text-decoration: underline;
 }
 .banner a:hover,
 .banner a:focus {

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -213,6 +213,7 @@ body {
 
   a {
     color: @link-hover-color;
+    text-decoration: underline;
   }
 
   a:hover, a:focus {

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -26,7 +26,7 @@
     <div class="row">
         <div class="col-sm-12">
             <span>
-                &#128075; What do you think about NuGet.org? We're looking for feedback from developers like you.&emsp;<a href="https://aka.ms/NuGetSurvey" target="_blank">Take the survey.</a>
+                &#128075; What do you think about NuGet.org? We're looking for feedback from developers like you. <a href="https://aka.ms/NuGetSurvey" target="_blank">Take the survey.</a>
             </span>
         </div>
     </div>


### PR DESCRIPTION
Add underline with survey link
Less space between like you and the link

UI: 
![bannerfinal](https://user-images.githubusercontent.com/64443925/95898745-5f230580-0d44-11eb-8a1b-acdff84a3f55.PNG)


Addresses https://github.com/NuGet/NuGetGallery/issues/8225