### PR TITLE
[A11y] Improve the color contrast of the header's search button

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -2585,27 +2585,27 @@ fieldset[disabled] .btn-info.focus {
 }
 .btn-warning {
   color: #fff;
-  background-color: #d27a00;
-  border-color: #b86b00;
+  background-color: #d87e00;
+  border-color: #bf6f00;
 }
 .btn-warning:focus,
 .btn-warning.focus {
   color: #fff;
-  background-color: #9f5c00;
-  border-color: #392100;
+  background-color: #a56000;
+  border-color: #3f2500;
 }
 .btn-warning:hover {
   color: #fff;
-  background-color: #9f5c00;
-  border-color: #7b4800;
+  background-color: #a56000;
+  border-color: #814b00;
 }
 .btn-warning:active,
 .btn-warning.active,
 .open > .dropdown-toggle.btn-warning {
   color: #fff;
-  background-color: #9f5c00;
+  background-color: #a56000;
   background-image: none;
-  border-color: #7b4800;
+  border-color: #814b00;
 }
 .btn-warning:active:hover,
 .btn-warning.active:hover,
@@ -2617,8 +2617,8 @@ fieldset[disabled] .btn-info.focus {
 .btn-warning.active.focus,
 .open > .dropdown-toggle.btn-warning.focus {
   color: #fff;
-  background-color: #7b4800;
-  border-color: #392100;
+  background-color: #814b00;
+  border-color: #3f2500;
 }
 .btn-warning.disabled:hover,
 .btn-warning[disabled]:hover,
@@ -2629,11 +2629,11 @@ fieldset[disabled] .btn-warning:focus,
 .btn-warning.disabled.focus,
 .btn-warning[disabled].focus,
 fieldset[disabled] .btn-warning.focus {
-  background-color: #d27a00;
-  border-color: #b86b00;
+  background-color: #d87e00;
+  border-color: #bf6f00;
 }
 .btn-warning .badge {
-  color: #d27a00;
+  color: #d87e00;
   background-color: #fff;
 }
 .btn-danger {

--- a/src/Bootstrap/less/variables.less
+++ b/src/Bootstrap/less/variables.less
@@ -166,7 +166,7 @@
 @btn-info-border:                darken(@btn-info-bg, 5%);
 
 @btn-warning-color:              #fff;
-@btn-warning-bg:                 darken(@brand-warning, 5.75%);
+@btn-warning-bg:                 darken(@brand-warning, 4.5%);
 @btn-warning-border:             darken(@btn-warning-bg, 5%);
 
 @btn-danger-color:               #fff;


### PR DESCRIPTION
Updates the orange button's color such that its color contrast is at least 3:1 on both our body's and header's background colors. Currently, the color is dark enough on our white background, but too dark for our blue background.

Addresses https://github.com/NuGet/NuGetGallery/issues/8265

Screenshot:

![image](https://user-images.githubusercontent.com/737941/96027883-6b26ca00-0e0d-11eb-882b-dec3748bf78a.png)

💡 Pro tip: Chrome may render different colors than requested by the stylesheet (see [this StackOverflow](https://stackoverflow.com/questions/48642753/css-color-difference-between-browsers)). If you work on color contrast accessibility issues using Chrome, make sure to disable this behavior here: chrome://flags/

![image](https://user-images.githubusercontent.com/737941/96028119-c062db80-0e0d-11eb-8ffb-8337b964d762.png)

Here is an excerpt from WCAG 2.1 ([here](https://w3c.github.io/wcag21/guidelines/#dfn-contrast-ratio)):

> WCAG conformance should be evaluated for color pairs specified in the content that an author would expect to appear adjacent in typical presentation. Authors need not consider unusual presentations, such as color changes made by the user agent, except where caused by authors' code.
