### PR TITLE
Make the ESLint ignore pattern more generic

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,6 @@
 #
 # Prepend each file with a globbing '**/' because our official builds run in a complex way that makes it hard to depend
 # on specific relative paths.
-**/src/NuGetGallery/Scripts/gallery/jquery-3.4.1.js
-**/src/NuGetGallery/Scripts/gallery/knockout-3.5.1.js
-**/src/NuGetGallery/Scripts/gallery/moment-2.18.1.js
+**/Scripts/gallery/jquery-3.4.1.js
+**/Scripts/gallery/knockout-3.5.1.js
+**/Scripts/gallery/moment-2.18.1.js


### PR DESCRIPTION
VS2019 seems to put temporary files in one more place that ESLint now catches.
See https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4150098&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=e900fa28-66c4-55e5-4e9c-0ba63fb92fbd.