### PR TITLE
[Cookies] Expire the AB test cookie in a year

### DIFF
--- a/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
+++ b/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
@@ -26,7 +26,7 @@ namespace GitHubVulnerabilities2Db.Gallery
             throw new NotImplementedException();
         }
 
-        public void TrackABTestEnrollmentUpgraded(int schemaVersion, int previewSearchBucket, int packageDepentsBucket)
+        public void TrackABTestEnrollmentUpgraded(int oldSchemaVersion, int newSchemaVersion, int previewSearchBucket, int packageDepentsBucket)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -378,11 +378,13 @@ namespace NuGetGallery
         /// <summary>
         /// Track when an A/B test enrollment is upgraded
         /// </summary>
-        /// <param name="schemaVersion">The schema version.</param>
+        /// <param name="oldSchemaVersion">The old schema version.</param>
+        /// <param name="newSchemaVersion">The new schema version.</param>
         /// <param name="previewSearchBucket">The bucket for the preview search test.</param>
         /// <param name="packageDependentBucket">The bucket for the package dependents test</param>
         void TrackABTestEnrollmentUpgraded(
-            int schemaVersion,
+            int oldSchemaVersion,
+            int newSchemaVersion,
             int previewSearchBucket,
             int packageDependentBucket);
 

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -1055,12 +1055,14 @@ namespace NuGetGallery
         }
 
         public void TrackABTestEnrollmentUpgraded(
+            int oldSchemaVersion,
             int newSchemaVersion,
             int previewSearchBucket,
             int packageDependentBucket)
         {
             TrackMetric(Events.ABTestEnrollmentUpgraded, 1, properties =>
             {
+                properties.Add(OldSchemaVersion, oldSchemaVersion.ToString());
                 properties.Add(NewSchemaVersion, newSchemaVersion.ToString());
                 properties.Add(PreviewSearchBucket, previewSearchBucket.ToString());
                 properties.Add(PackageDependentBucket, packageDependentBucket.ToString());

--- a/src/NuGetGallery/Infrastructure/ABTestEnrollmentFactory.cs
+++ b/src/NuGetGallery/Infrastructure/ABTestEnrollmentFactory.cs
@@ -72,7 +72,7 @@ namespace NuGetGallery
                 throw new NotImplementedException($"Serializing schema version {enrollment.SchemaVersion} is not implemented.");
             }
 
-            var deserialized3 = new StateVersion3
+            var deserialized3 = new StateVersion2OrVersion3
             {
                 SchemaVersion = SchemaVersion3,
                 PreviewSearchBucket = enrollment.PreviewSearchBucket,
@@ -133,7 +133,7 @@ namespace NuGetGallery
             enrollment = null;
             try
             {
-                var v2 = JsonConvert.DeserializeObject<StateVersion2>(serialized);
+                var v2 = JsonConvert.DeserializeObject<StateVersion2OrVersion3>(serialized);
                 if (v2 == null
                     || v2.SchemaVersion != SchemaVersion2
                     || IsNotPercentage(v2.PreviewSearchBucket)
@@ -167,7 +167,7 @@ namespace NuGetGallery
             enrollment = null;
             try
             {
-                var v3 = JsonConvert.DeserializeObject<StateVersion3>(serialized);
+                var v3 = JsonConvert.DeserializeObject<StateVersion2OrVersion3>(serialized);
                 if (v3 == null
                     || v3.SchemaVersion != SchemaVersion3
                     || IsNotPercentage(v3.PreviewSearchBucket)
@@ -204,19 +204,7 @@ namespace NuGetGallery
             public int PreviewSearchBucket { get; set; }
         }
 
-        private class StateVersion2
-        {
-            [JsonProperty("v", Required = Required.Always)]
-            public int SchemaVersion { get; set; }
-
-            [JsonProperty("ps", Required = Required.Always)]
-            public int PreviewSearchBucket { get; set; }
-
-            [JsonProperty("pd", Required = Required.Always)]
-            public int PackageDependentBucket { get; set; }
-        }
-
-        private class StateVersion3
+        private class StateVersion2OrVersion3
         {
             [JsonProperty("v", Required = Required.Always)]
             public int SchemaVersion { get; set; }

--- a/src/NuGetGallery/Infrastructure/CookieBasedABTestService.cs
+++ b/src/NuGetGallery/Infrastructure/CookieBasedABTestService.cs
@@ -20,6 +20,7 @@ namespace NuGetGallery
         private readonly ITelemetryService _telemetryService;
         private readonly ILogger<CookieBasedABTestService> _logger;
         private readonly Lazy<ABTestEnrollment> _lazyEnrollment;
+        private readonly IDateTimeProvider _dateTimeProvider;
 
         public CookieBasedABTestService(
             HttpContextBase httpContext,
@@ -27,7 +28,8 @@ namespace NuGetGallery
             IABTestEnrollmentFactory enrollmentFactory,
             IContentObjectService contentObjectService,
             ITelemetryService telemetryService,
-            ILogger<CookieBasedABTestService> logger)
+            ILogger<CookieBasedABTestService> logger,
+            IDateTimeProvider dateTimeProvider)
         {
             _httpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
             _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
@@ -36,6 +38,7 @@ namespace NuGetGallery
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _lazyEnrollment = new Lazy<ABTestEnrollment>(DetermineEnrollment);
+            _dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));
         }
 
         public bool IsPreviewSearchEnabled(User user)
@@ -74,7 +77,7 @@ namespace NuGetGallery
                     HttpOnly = true,
                     Secure = true,
                     Value = _enrollmentFactory.Serialize(enrollment),
-                    Expires = DateTime.MaxValue,
+                    Expires = _dateTimeProvider.UtcNow.AddYears(1),
                 };
                 _httpContext.Response.Cookies.Add(responseCookie);
             }

--- a/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
@@ -23,7 +23,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
-        public void TrackABTestEnrollmentUpgraded(int schemaVersion, int previewSearchBucket, int packageDepentsBucket)
+        public void TrackABTestEnrollmentUpgraded(int oldSchemaVersion, int newSchemaVersion, int previewSearchBucket, int packageDepentsBucket)
         {
             throw new NotImplementedException();
         }

--- a/tests/NuGetGallery.Facts/Infrastructure/ABTestEnrollmentFactoryFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/ABTestEnrollmentFactoryFacts.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -18,7 +19,7 @@ namespace NuGetGallery
 
                 Assert.NotNull(enrollment);
                 Assert.Equal(ABTestEnrollmentState.FirstHit, enrollment.State);
-                Assert.Equal(2, enrollment.SchemaVersion);
+                Assert.Equal(3, enrollment.SchemaVersion);
                 Assert.InRange(enrollment.PreviewSearchBucket, 1, 100);
                 Assert.InRange(enrollment.PackageDependentBucket, 1, 100);
             }
@@ -26,32 +27,37 @@ namespace NuGetGallery
 
         public class Serialize : Facts
         {
-            [Fact]
-            public void ProducesExpectedString()
+            [Theory]
+            [InlineData(1)]
+            [InlineData(2)]
+            [InlineData(4)]
+            public void SerializeWithNotImplementedSchemaVersion_ThrowNotImplementedException(int schemaVersion)
             {
                 var enrollment = new ABTestEnrollment(
-                    ABTestEnrollmentState.Active,
-                    schemaVersion: 2,
+                    state: It.IsAny<ABTestEnrollmentState>(),
+                    schemaVersion: schemaVersion,
+                    previewSearchBucket: It.IsAny<int>(),
+                    packageDependentBucket: It.IsAny<int>());
+
+                var exception = Assert.Throws<NotImplementedException>(() => Target.Serialize(enrollment));
+                Assert.Equal($"Serializing schema version {schemaVersion} is not implemented.", exception.Message);
+            }
+
+            [Theory]
+            [InlineData(3, ABTestEnrollmentState.Active)]
+            [InlineData(3, ABTestEnrollmentState.FirstHit)]
+            [InlineData(3, ABTestEnrollmentState.Upgraded)]
+            public void ProducesExpectedString(int schemaVersion, ABTestEnrollmentState state)
+            {
+                var enrollment = new ABTestEnrollment(
+                    state: state,
+                    schemaVersion: schemaVersion,
                     previewSearchBucket: 42,
                     packageDependentBucket: 82);
 
                 var serialized = Target.Serialize(enrollment);
 
-                Assert.Equal(@"{""v"":2,""ps"":42,""pd"":82}", serialized);
-            }
-
-            [Fact]
-            public void ProducesExpectedStringVersionTwo()
-            {
-                var enrollment = new ABTestEnrollment(
-                    ABTestEnrollmentState.Active,
-                    schemaVersion: 2,
-                    previewSearchBucket: 42,
-                    packageDependentBucket: 74);
-
-                var serialized = Target.Serialize(enrollment);
-
-                Assert.Equal(@"{""v"":2,""ps"":42,""pd"":74}", serialized);
+                Assert.Equal(@"{""v"":3,""ps"":42,""pd"":82}", serialized);
             }
         }
 
@@ -66,22 +72,33 @@ namespace NuGetGallery
             [InlineData("[]")]
             [InlineData("null")]
             [InlineData(@"{""ps"":42}")]
-            [InlineData(@"{""v"":2,""ps"":42}")]
+            [InlineData(@"{""pd"":42}")]
+            [InlineData(@"{""ps"":20,""pd"":82}")]
             [InlineData(@"{""v"":1}")]
             [InlineData(@"{""v"":1,""ps"":-1}")]
             [InlineData(@"{""v"":1,""ps"":0}")]
             [InlineData(@"{""v"":1,""ps"":101}")]
-            [InlineData(@"{""v"":2,""ps"":10,""pd"":101}")]
             [InlineData(@"{""v"":2}")]
-            [InlineData(@"{""pd"":42}")]
+            [InlineData(@"{""v"":2,""ps"":42}")]
+            [InlineData(@"{""v"":2,""pd"":42}")]
+            [InlineData(@"{""v"":2,""ps"":10,""pd"":101}")]
             [InlineData(@"{""v"":2,""ps"":1,""pd"":-1}")]
             [InlineData(@"{""v"":2,""ps"":10,""pd"":0}")]
-            [InlineData(@"{""v"":3,""ps"":42,""pd"":53}")]
             [InlineData(@"{""v"":2,""ps"":-1,""pd"":24}")]
             [InlineData(@"{""v"":2,""ps"":0,""pd"":35}")]
             [InlineData(@"{""v"":2,""ps"":101,""pd"":56}")]
             [InlineData(@"{""v"":2,""ps"":200,""pd"":82}")]
-            [InlineData(@"{""ps"":20,""pd"":82}")]
+            [InlineData(@"{""v"":3}")]
+            [InlineData(@"{""v"":3,""ps"":42}")]
+            [InlineData(@"{""v"":3,""pd"":42}")]
+            [InlineData(@"{""v"":3,""ps"":10,""pd"":101}")]
+            [InlineData(@"{""v"":3,""ps"":1,""pd"":-1}")]
+            [InlineData(@"{""v"":3,""ps"":10,""pd"":0}")]
+            [InlineData(@"{""v"":3,""ps"":-1,""pd"":24}")]
+            [InlineData(@"{""v"":3,""ps"":0,""pd"":35}")]
+            [InlineData(@"{""v"":3,""ps"":101,""pd"":56}")]
+            [InlineData(@"{""v"":3,""ps"":200,""pd"":82}")]
+            [InlineData(@"{""v"":4,""ps"":42,""pd"":53}")]
             public void RejectsInvalid(string input)
             {
                 var success = Target.TryDeserialize(input, out var enrollment);
@@ -95,14 +112,16 @@ namespace NuGetGallery
             [InlineData(@"{""v"":1,""ps"":42,""zzz"":false}", 42)]
             [InlineData(@"{""v"":1,""ps"":1}", 1)]
             [InlineData(@"{""v"":1,""ps"":100}", 100)]
-            public void UpgradesValidVersionV1(string input, int previewSearchBucket)
+            public void UpgradesValidVersion(string input, int previewSearchBucket)
             {
+                TelemetryService.Setup(t => t.TrackABTestEnrollmentUpgraded(1, 3, It.IsAny<int>(), It.IsAny<int>()));
                 var success = Target.TryDeserialize(input, out var enrollment);
 
+                TelemetryService.Verify(t => t.TrackABTestEnrollmentUpgraded(1, 3, It.IsAny<int>(), It.IsAny<int>()), Times.Once);
                 Assert.True(success, "The derialization should have succeeded.");
                 Assert.NotNull(enrollment);
                 Assert.Equal(ABTestEnrollmentState.Upgraded, enrollment.State);
-                Assert.Equal(2, enrollment.SchemaVersion);
+                Assert.Equal(3, enrollment.SchemaVersion);
                 Assert.Equal(previewSearchBucket, enrollment.PreviewSearchBucket);
                 Assert.InRange(enrollment.PackageDependentBucket, 1, 100);
             }
@@ -117,12 +136,34 @@ namespace NuGetGallery
             [InlineData(@"{""v"":2,""ps"":68,""pd"":100}", 68, 100)]
             public void ParsesValidVersion2(string input, int previewSearchBucket, int packageDependentBucket)
             {
+                TelemetryService.Setup(t => t.TrackABTestEnrollmentUpgraded(2, 3, It.IsAny<int>(), It.IsAny<int>()));
+                var success = Target.TryDeserialize(input, out var enrollment);
+
+                TelemetryService.Verify(t => t.TrackABTestEnrollmentUpgraded(2, 3, It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+                Assert.True(success, "The derialization should have succeeded.");
+                Assert.NotNull(enrollment);
+                Assert.Equal(ABTestEnrollmentState.Upgraded, enrollment.State);
+                Assert.Equal(3, enrollment.SchemaVersion);
+                Assert.Equal(previewSearchBucket, enrollment.PreviewSearchBucket);
+                Assert.Equal(packageDependentBucket, enrollment.PackageDependentBucket);
+            }
+
+            [Theory]
+            [InlineData(@"{""v"":3,""ps"":42,""pd"":57}", 42, 57)]
+            [InlineData(@"{""v"":3,""ps"":1,""pd"":1}", 1, 1)]
+            [InlineData(@"{""v"":3,""ps"":100,""pd"":100}", 100, 100)]
+            [InlineData(@"{""v"":3,""ps"":1,""pd"":32}", 1, 32)]
+            [InlineData(@"{""v"":3,""ps"":100,""pd"":57}", 100, 57)]
+            [InlineData(@"{""v"":3,""ps"":52,""pd"":1}", 52, 1)]
+            [InlineData(@"{""v"":3,""ps"":68,""pd"":100}", 68, 100)]
+            public void ParsesValidVersion3(string input, int previewSearchBucket, int packageDependentBucket)
+            {
                 var success = Target.TryDeserialize(input, out var enrollment);
 
                 Assert.True(success, "The derialization should have succeeded.");
                 Assert.NotNull(enrollment);
                 Assert.Equal(ABTestEnrollmentState.Active, enrollment.State);
-                Assert.Equal(2, enrollment.SchemaVersion);
+                Assert.Equal(3, enrollment.SchemaVersion);
                 Assert.Equal(previewSearchBucket, enrollment.PreviewSearchBucket);
                 Assert.Equal(packageDependentBucket, enrollment.PackageDependentBucket);
             }

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -325,7 +325,7 @@ namespace NuGetGallery
                     };
 
                     yield return new object[] { "ABTestEnrollmentUpgraded",
-                        (TrackAction)(s => s.TrackABTestEnrollmentUpgraded(2, 42, 47))
+                        (TrackAction)(s => s.TrackABTestEnrollmentUpgraded(1, 2, 42, 47))
                     };
 
                     yield return new object[] { "ABTestEvaluated",


### PR DESCRIPTION
We should expire any cookie in 13 months, no matter whether it's in EU or not.
We upgrade the cookie to V3, in order to handle these already dropped cookies.