### PR TITLE
Version history table rendering update for accessibility

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -742,15 +742,15 @@
 
                                     @if (Model.IsCertificatesUIEnabled)
                                     {
-                                        if (!string.IsNullOrEmpty(packageVersion.SignatureInformation))
+                                        if (string.IsNullOrEmpty(packageVersion.SignatureInformation))
+                                        {
+                                            <td class="package-icon-cell" aria-label="No signature"></td>
+                                        }
+                                        else
                                         {
                                             <td class="package-icon-cell">
                                                     <i class="ms-Icon ms-Icon--Ribbon package-icon" title="@packageVersion.SignatureInformation"></i>
                                             </td>
-                                        }
-                                        else
-                                        {
-                                            <td class="package-icon-cell" aria-label="No signature"></td>
                                         }
                                     }
                                     @if (Model.IsPackageDeprecationEnabled)

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -729,7 +729,7 @@
 
                                         <td>
                                             @if (packageStatusSummary == PackageStatusSummary.Listed ||
-     packageStatusSummary == PackageStatusSummary.Unlisted)
+                                                 packageStatusSummary == PackageStatusSummary.Unlisted)
                                             {
                                                 <a href="@Url.ManagePackage(packageVersion)">@NuGetGallery.Helpers.EnumHelper.GetDescription(packageStatusSummary)</a>
                                             }
@@ -755,7 +755,11 @@
                                     }
                                     @if (Model.IsPackageDeprecationEnabled)
                                     {
-                                        if (packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                                        if (packageVersion.DeprecationStatus == PackageDeprecationStatus.NotDeprecated)
+                                        {
+                                            <td class="package-icon-cell" aria-label="Not deprecated"></td>
+                                        }
+                                        else
                                         {
                                             var deprecationTitle = packageVersion.Version;
                                             var isLegacy = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.Legacy);
@@ -783,10 +787,6 @@
                                             <td class="package-icon-cell">
                                                 <i class="ms-Icon ms-Icon--Warning package-icon" title="@deprecationTitle"></i>
                                             </td>
-                                        }
-                                        else
-                                        {
-                                            <td class="package-icon-cell" aria-label="Not deprecated"></td>
                                         }
                                     }
                                 </tr>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -680,8 +680,14 @@
                             {
                                 <th>Status</th>
                             }
-                            <th aria-label="Signature Information" abbr="Signature Information"></th>
-                            <th aria-label="Deprecation Information" abbr="Deprecation Information"></th>
+                            @if (Model.IsCertificatesUIEnabled)
+                            {
+                                <th aria-label="Signature Information" abbr="Signature Information"></th>
+                            }
+                            @if (Model.IsPackageDeprecationEnabled)
+                            {
+                                <th aria-label="Deprecation Information" abbr="Deprecation Information"></th>
+                            }
                         </tr>
                     </thead>
                     <tbody class="no-border">
@@ -723,7 +729,7 @@
 
                                         <td>
                                             @if (packageStatusSummary == PackageStatusSummary.Listed ||
-                                                 packageStatusSummary == PackageStatusSummary.Unlisted)
+     packageStatusSummary == PackageStatusSummary.Unlisted)
                                             {
                                                 <a href="@Url.ManagePackage(packageVersion)">@NuGetGallery.Helpers.EnumHelper.GetDescription(packageStatusSummary)</a>
                                             }
@@ -734,15 +740,22 @@
                                         </td>
                                     }
 
-                                    <td class="package-icon-cell">
-                                        @if (Model.IsCertificatesUIEnabled && !string.IsNullOrEmpty(packageVersion.SignatureInformation))
+                                    @if (Model.IsCertificatesUIEnabled)
+                                    {
+                                        if (!string.IsNullOrEmpty(packageVersion.SignatureInformation))
                                         {
-                                            <i class="ms-Icon ms-Icon--Ribbon package-icon" title="@packageVersion.SignatureInformation"></i>
+                                            <td class="package-icon-cell">
+                                                    <i class="ms-Icon ms-Icon--Ribbon package-icon" title="@packageVersion.SignatureInformation"></i>
+                                            </td>
                                         }
-                                    </td>
-
-                                    <td class="package-icon-cell">
-                                        @if (Model.IsPackageDeprecationEnabled && packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                                        else
+                                        {
+                                            <td class="package-icon-cell" aria-label="No signature"></td>
+                                        }
+                                    }
+                                    @if (Model.IsPackageDeprecationEnabled)
+                                    {
+                                        if (packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
                                         {
                                             var deprecationTitle = packageVersion.Version;
                                             var isLegacy = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.Legacy);
@@ -767,9 +780,15 @@
                                                 deprecationTitle += " is deprecated.";
                                             }
 
-                                            <i class="ms-Icon ms-Icon--Warning package-icon" title="@deprecationTitle"></i>
+                                            <td class="package-icon-cell">
+                                                <i class="ms-Icon ms-Icon--Warning package-icon" title="@deprecationTitle"></i>
+                                            </td>
                                         }
-                                    </td>
+                                        else
+                                        {
+                                            <td class="package-icon-cell" aria-label="Not deprecated"></td>
+                                        }
+                                    }
                                 </tr>
                             }
                             else if (packageVersion.Deleted && packageVersion.CanDisplayPrivateMetadata)


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8196

Previously, version history table always had 2 hardly visible columns: 1 for signature information and another for deprecation information. When user is not authenticated on the web site, we never show the package signature information, so the cells although exist are always empty. The deprecation information is present, but most of the time packages are not deprecated and empty cells do not have any narrator markup, so are not read (but headers are).

This change moves the `Model.IsCertificatesUIEnabled` check up to the lines that generate column header, causing the certificate column to be completely absent for unauthenticated users. Same is done for `Model.IsPackageDeprecationEnabled` but it is always `true` in our case. Also `aria-label` properties added for empty cells when those are rendered.