### PR TITLE
[A11y] Darken the GitHub star icon

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1139,7 +1139,7 @@ img.reserved-indicator-icon {
 .page-package-details .gh-star {
   font-size: 14px;
   line-height: 12px;
-  color: #ef8b00;
+  color: #d87e00;
 }
 .page-package-details .used-by h3 strong {
   font-weight: 400;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1139,6 +1139,7 @@ img.reserved-indicator-icon {
 .page-package-details .gh-star {
   font-size: 14px;
   line-height: 12px;
+  /* Use a slightly darker orange color to increase contrast for accessibility */
   color: #d87e00;
 }
 .page-package-details .used-by h3 strong {

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -171,7 +171,7 @@
   .gh-star {
     font-size: 14px;
     line-height: 12px;
-    color: @brand-warning;
+    color: darken(@brand-warning, 4.5%);
   }
 
   .used-by {

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -171,6 +171,7 @@
   .gh-star {
     font-size: 14px;
     line-height: 12px;
+    /* Use a slightly darker orange color to increase contrast for accessibility */
     color: darken(@brand-warning, 4.5%);
   }
 


### PR DESCRIPTION
Darkens the orange GitHub star icon for 3:1 color contrast ratio.

![image](https://user-images.githubusercontent.com/737941/96787480-ae051680-13a6-11eb-9416-e1ad91dc94fa.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/8286