### PR TITLE
Display net5.0 using ToString instead of custom logic

### DIFF
--- a/src/NuGetGallery/ExtensionMethods.cs
+++ b/src/NuGetGallery/ExtensionMethods.cs
@@ -243,6 +243,15 @@ namespace NuGetGallery
                 throw new ArgumentNullException(nameof(frameworkName));
             }
 
+            // Defer to the NuGet client logic for displaying .NET 5 frameworks. This aligns with Visual Studio package
+            // management UI.
+            var isNet5Era = frameworkName.Version.Major >= 5
+                && StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, frameworkName.Framework);
+            if (isNet5Era)
+            {
+                return frameworkName.ToString();
+            }
+
             var sb = new StringBuilder();
             if (String.Equals(frameworkName.Framework, ".NETPortable", StringComparison.OrdinalIgnoreCase))
             {

--- a/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
+++ b/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
@@ -14,6 +14,19 @@ namespace NuGetGallery
         public class TheToFriendlyNameMethod
         {
             [Theory]
+            [InlineData("net5.0", "net5.0")]
+            [InlineData("net5.0", "NET5.0")]
+            [InlineData("net5.0", "net5")]
+            [InlineData("net5.0", "net50")]
+            [InlineData("net5.0", "netcoreapp5.0")]
+            [InlineData("net5.0", "netcoreapp50")]
+            [InlineData("net5.0-windows", "net5.0-windows")]
+            [InlineData("net5.0-windows9.0", "net5.0-windows9")]
+            [InlineData("net5.0-ios14.0", "net5.0-ios14.0")]
+            [InlineData("net5.0", "netcoreapp5.0-windows")] // See: https://github.com/NuGet/Home/issues/10177
+            [InlineData("net5.0", "netcoreapp5.0-windows9")] // See: https://github.com/NuGet/Home/issues/10177
+            [InlineData("net6.0", "net6.0")]
+            [InlineData("net10.0", "net10.0")]
             [InlineData(".NETFramework 4.0", "net40")]
             [InlineData("Silverlight 4.0", "sl40")]
             [InlineData("WindowsPhone 8.0", "wp8")]


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/8235
Address https://github.com/NuGet/NuGetGallery/issues/8268

Instead of using the custom framework display logic that nuget.org currently has for framework names in dependency groups, use `NuGetFramework.ToString()`. This is the recommended approach from client team and aligns with the package management UI in Visual Studio. The VS UI is spec'd here which we are mimicking.
https://github.com/dotnet/designs/blob/main/accepted/2020/net5/net5.md

> - Package Manager UI in VS
>    - [Use short form](https://github.com/dotnet/designs/blob/main/accepted/2020/net5/net5.md#tfms-in-the-ui)

### Example without platform

![image](https://user-images.githubusercontent.com/94054/96912935-e153ae00-1457-11eb-9b3a-30c05f1246ff.png)

### Example with platform

![image](https://user-images.githubusercontent.com/94054/96912993-ed3f7000-1457-11eb-9dfb-3f79504a043c.png)
