### PR TITLE
[A11y] Improve color contrast of focus outline on Firefox

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -303,9 +303,7 @@ a:focus {
   text-decoration: underline;
 }
 a:focus {
-  outline: 2px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
-  outline: revert;
   outline-offset: -2px;
 }
 figure {
@@ -1859,9 +1857,7 @@ select[size] {
 input[type="file"]:focus,
 input[type="radio"]:focus,
 input[type="checkbox"]:focus {
-  outline: 2px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
-  outline: revert;
   outline-offset: -2px;
 }
 output {
@@ -2343,9 +2339,7 @@ select[multiple].input-lg {
 .btn.focus,
 .btn:active.focus,
 .btn.active.focus {
-  outline: 2px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
-  outline: revert;
   outline-offset: -2px;
 }
 .btn:hover,

--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -305,6 +305,7 @@ a:focus {
 a:focus {
   outline: 2px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
+  outline: revert;
   outline-offset: -2px;
 }
 figure {
@@ -1860,6 +1861,7 @@ input[type="radio"]:focus,
 input[type="checkbox"]:focus {
   outline: 2px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
+  outline: revert;
   outline-offset: -2px;
 }
 output {
@@ -2343,6 +2345,7 @@ select[multiple].input-lg {
 .btn.active.focus {
   outline: 2px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
+  outline: revert;
   outline-offset: -2px;
 }
 .btn:hover,

--- a/src/Bootstrap/less/mixins/tab-focus.less
+++ b/src/Bootstrap/less/mixins/tab-focus.less
@@ -7,5 +7,6 @@
   // The next line came from: https://stackoverflow.com/a/38571103
   outline: 2px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
+  outline: revert;
   outline-offset: -2px;
 }

--- a/src/Bootstrap/less/mixins/tab-focus.less
+++ b/src/Bootstrap/less/mixins/tab-focus.less
@@ -4,9 +4,6 @@
   // WebKit-specific. Other browsers will keep their default outline style.
   // (Initially tried to also force default via `outline: initial`,
   // but that seems to erroneously remove the outline in Firefox altogether.)
-  // The next line came from: https://stackoverflow.com/a/38571103
-  outline: 2px auto Highlight;
   outline: 5px auto -webkit-focus-ring-color;
-  outline: revert;
   outline-offset: -2px;
 }


### PR DESCRIPTION
Improve the color contrast of Firefox's outline for focused items. This effectively reverts https://github.com/NuGet/NuGetGallery/commit/c245f2caeedc052be830a791879f2d4c8e0cc943 as Firefox now properly outlines elements.

Chromium browsers (Chrome, Edgium, Opera) are all unaffected by this change. I also verified that Internet Explorer's focus outlines pass the 3:1 color contrast requirement.

# Screenshots

## Firefox (new)

![image](https://user-images.githubusercontent.com/737941/97230620-7b3c9300-1797-11eb-9ffb-a90fe0f11046.png)

Note that radio buttons and checkboxes are unaffected by this change.

## Firefox (old)

![image](https://user-images.githubusercontent.com/737941/97230646-87285500-1797-11eb-8620-32f9c2e07bd9.png)

The color contrast for links on our white background is not 3:1

Addresses https://github.com/NuGet/NuGetGallery/issues/8185