### PR TITLE
Fix for being unable to delete user account certificates

### DIFF
--- a/src/NuGetGallery/Views/Users/Account.cshtml
+++ b/src/NuGetGallery/Views/Users/Account.cshtml
@@ -4,6 +4,7 @@
     ViewBag.MdPageColumns = GalleryConstants.ColumnsFormMd;
     TempData["Parent"] = this;
 }
+@ViewHelpers.AjaxAntiForgeryToken(Html)
 
 <section role="main" class="container main-container page-account-settings">
     <div class="row">


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8302.

The page was missing anti-forgery token for ajax requests.