### PR TITLE
Removed unused localIP member of CloudAuditingService.

### DIFF
--- a/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
@@ -22,19 +22,15 @@ namespace NuGetGallery.Auditing
         public static readonly string DefaultContainerName = "auditing";
 
         private CloudBlobContainer _auditContainer;
-        private string _instanceId;
-        private string _localIP;
         private Func<Task<AuditActor>> _getOnBehalfOf;
 
-        public CloudAuditingService(string instanceId, string localIP, string storageConnectionString, bool readAccessGeoRedundant, Func<Task<AuditActor>> getOnBehalfOf)
-            : this(instanceId, localIP, GetContainer(storageConnectionString, readAccessGeoRedundant), getOnBehalfOf)
+        public CloudAuditingService(string storageConnectionString, bool readAccessGeoRedundant, Func<Task<AuditActor>> getOnBehalfOf)
+            : this(GetContainer(storageConnectionString, readAccessGeoRedundant), getOnBehalfOf)
         {
         }
 
-        public CloudAuditingService(string instanceId, string localIP, CloudBlobContainer auditContainer, Func<Task<AuditActor>> getOnBehalfOf)
+        public CloudAuditingService(CloudBlobContainer auditContainer, Func<Task<AuditActor>> getOnBehalfOf)
         {
-            _instanceId = instanceId;
-            _localIP = localIP;
             _auditContainer = auditContainer;
             _getOnBehalfOf = getOnBehalfOf;
         }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -1404,11 +1404,7 @@ namespace NuGetGallery
 
         private static IAuditingService GetAuditingServiceForAzureStorage(ContainerBuilder builder, IGalleryConfigurationService configuration)
         {
-            string instanceId = HostMachine.Name;
-
-            var localIp = AuditActor.GetLocalIpAddressAsync().Result;
-
-            var service = new CloudAuditingService(instanceId, localIp, configuration.Current.AzureStorage_Auditing_ConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant, AuditActor.GetAspNetOnBehalfOfAsync);
+            var service = new CloudAuditingService(configuration.Current.AzureStorage_Auditing_ConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant, AuditActor.GetAspNetOnBehalfOfAsync);
 
             builder.RegisterInstance(service)
                 .As<ICloudStorageStatusDependency>()

--- a/tests/NuGetGallery.Core.Facts/Auditing/CloudAuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/CloudAuditingServiceTests.cs
@@ -18,7 +18,7 @@ namespace NuGetGallery.Auditing
         {
             // Arrange
             CloudBlobContainer nullBlobContainer = null;
-            var service = new CloudAuditingService("id", "1.1.1.1", nullBlobContainer, AuditActor.GetCurrentMachineActorAsync);
+            var service = new CloudAuditingService(nullBlobContainer, AuditActor.GetCurrentMachineActorAsync);
 
             AuditActor onBehalfOf = new AuditActor("machineName", "3.3.3.3", "userName1", "NoAuthentication", "someKey", DateTime.Now, null);
             AuditActor auditActor = new AuditActor("machineName", "2.2.2.2", "userName1", "NoAuthentication", "someKey", DateTime.Now, onBehalfOf);
@@ -57,7 +57,7 @@ namespace NuGetGallery.Auditing
         {
             // Arrange
             CloudBlobContainer nullBlobContainer = null;
-            var service = new CloudAuditingService("id", "1.1.1.1", nullBlobContainer, AuditActor.GetCurrentMachineActorAsync);
+            var service = new CloudAuditingService(nullBlobContainer, AuditActor.GetCurrentMachineActorAsync);
 
             // Act + Assert
             Assert.Equal<bool>(expectedResult, service.RecordWillBePersisted(record));


### PR DESCRIPTION
While looking for `Task.Result` code I stumbled upon `localIp = AuditActor.GetLocalIpAddressAsync().Result` call in `DefaultDepenenciesModule` that then was passed into the `CloudAuditingService` constructor, stored in its member and never used.
Looking at the [commit](https://github.com/NuGet/NuGetGallery/commit/0972d34ca76c22d8d0fde38c56634e0fd88008e3#diff-37cab84da1c323a1f9471a097fe7961e57f58238dd39a25cfa4558799920cc8eR27) that introduced that constructor argument, it was unused from the beginning. Removing it, will get rid of one `Task.Result` call.