### PR TITLE
Not using Task.Result in async context.

### DIFF
--- a/src/NuGetGallery/Services/SqlAggregateStatsService.cs
+++ b/src/NuGetGallery/Services/SqlAggregateStatsService.cs
@@ -26,9 +26,9 @@ namespace NuGetGallery
             _connectionFactory = galleryDbConnectionFactory;
         }
 
-        public Task<AggregateStats> GetAggregateStats()
+        public async Task<AggregateStats> GetAggregateStats()
         {
-            var connection = Task.Run(() => _connectionFactory.CreateAsync()).Result;
+            var connection = await _connectionFactory.CreateAsync();
             using (var dbContext = new EntitiesContext(connection, readOnly: true)) // true - set readonly but it is ignored anyway, as this class doesn't call EntitiesContext.SaveChanges()
             {
                 var database = dbContext.Database;
@@ -41,15 +41,15 @@ namespace NuGetGallery
                         bool hasData = reader.Read();
                         if (!hasData)
                         {
-                            return Task.FromResult(new AggregateStats());
+                            return new AggregateStats();
                         }
 
-                        return Task.FromResult(new AggregateStats
+                        return new AggregateStats
                         {
                             Downloads = reader.IsDBNull(0) ? 0 : reader.GetInt32(0),
                             UniquePackages = reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
                             TotalPackages = reader.IsDBNull(2) ? 0 : reader.GetInt32(2)
-                        });
+                        };
                     }
                 }
             }


### PR DESCRIPTION
Unclear why the code was written this way originally, but we can get rid of `Task.Result` call here pretty painless.