### PR TITLE
Dropping the narration completely for absent signature and deprecation information

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -682,11 +682,11 @@
                             }
                             @if (Model.IsCertificatesUIEnabled)
                             {
-                                <th aria-label="Signature Information" abbr="Signature Information"></th>
+                                <th aria-hidden="true" abbr="Signature Information"></th>
                             }
                             @if (Model.IsPackageDeprecationEnabled)
                             {
-                                <th aria-label="Deprecation Information" abbr="Deprecation Information"></th>
+                                <th aria-hidden="true" abbr="Deprecation Information"></th>
                             }
                         </tr>
                     </thead>
@@ -744,7 +744,7 @@
                                     {
                                         if (string.IsNullOrEmpty(packageVersion.SignatureInformation))
                                         {
-                                            <td class="package-icon-cell" aria-label="No signature"></td>
+                                            <td class="package-icon-cell" aria-hidden="true"></td>
                                         }
                                         else
                                         {
@@ -757,7 +757,7 @@
                                     {
                                         if (packageVersion.DeprecationStatus == PackageDeprecationStatus.NotDeprecated)
                                         {
-                                            <td class="package-icon-cell" aria-label="Not deprecated"></td>
+                                            <td class="package-icon-cell" aria-hidden="true"></td>
                                         }
                                         else
                                         {


### PR DESCRIPTION
Another take on https://github.com/NuGet/NuGetGallery/issues/8196 (Previous attempt: https://github.com/NuGet/NuGetGallery/pull/8287)

The expectation actually was that empty cells are not read completely by a narrator, instead of producing an explanation regarding why the cell is empty.

The new behavior is as follows: if there are no deprecation or signature icons in the table, narrator completely ignores the existence of those columns (i.e. says "3 by 4" instead of "3 by 6" for the table size and it is no longer possible to navigate to those empty cells with Ctrl+Alt+Arrow keys); if there are deprecation or signature icons the column number will accommodate (i.e. will become "3 by 5" or "3 by 6" depending on number of icons) and those icons can be focused, empty cells still cannot be focused.