### PR TITLE
[A11y] break word for a certificate thumbprint

### DIFF
--- a/src/NuGetGallery/Views/Shared/_AccountCertificates.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountCertificates.cshtml
@@ -90,7 +90,7 @@
                         </thead>
                         <tbody data-bind="foreach: $data.certificates">
                             <tr class="manage-certificate-listing" role="listitem">
-                                <td><samp class="small-fingerprint" data-bind="text: Thumbprint"></samp></td>
+                                <td><samp class="small-fingerprint break-word" data-bind="text: Thumbprint"></samp></td>
                                 <td data-bind="text: ShortSubject, attr: { title: Subject }"></td>
                                 <td data-bind="text: ExpirationDisplay, attr: {
                                     title: IsExpired ? 'This certificate\'s expiration date is in the past. Future packages signed with this certificate will fail validation. Upload a renewed certificate to enable signed package uploads.' : ExpirationIso,


### PR DESCRIPTION
I decide to move to a quicker solution, and just break word for a certificate thumbprint:
![image](https://user-images.githubusercontent.com/41028779/98195394-82217f00-1ed6-11eb-82e7-2da215d50d1f.png)

Before:
![image](https://user-images.githubusercontent.com/41028779/98195484-bb59ef00-1ed6-11eb-8175-5197aac8f4d5.png)

@ryuyu 