### PR TITLE
[UI] No need to use form-group for Account Change Email

### DIFF
--- a/src/NuGetGallery/Views/Shared/_AccountChangeEmail.cshtml
+++ b/src/NuGetGallery/Views/Shared/_AccountChangeEmail.cshtml
@@ -15,7 +15,7 @@
                 {
                     @Html.AntiForgeryToken()
 
-                    <div class="row form-group">
+                    <div class="row">
                         <div class="col-sm-6">
                             <input type="submit" class="btn btn-primary form-control" value="Reset to Confirmed Email Address" />
                         </div>
@@ -47,7 +47,7 @@
                         @Html.ShowValidationMessagesFor(m => m.ChangeEmail.NewEmail)
                     </div>
 
-                    <div class="row form-group">
+                    <div class="row">
                         <div class="col-sm-6">
                             <input type="submit" class="btn btn-primary form-control" value="Save" />
                         </div>


### PR DESCRIPTION
It's a better UI when reflowing to align Account Change Email with others, by dropping the form-group:
![image](https://user-images.githubusercontent.com/41028779/98197105-bbf48480-1eda-11eb-9fe0-5a23a92192ac.png)

Before:
![image](https://user-images.githubusercontent.com/41028779/98197212-0413a700-1edb-11eb-8d42-5d160ea931ee.png)


