### PR TITLE
Switch to NuGetTestData for static test packages

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Constants.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Constants.cs
@@ -32,14 +32,13 @@ namespace NuGetGallery.FunctionalTests
         public const string StatsPageDefaultText = "Statistics last updated";
         public const string ContactOwnersText = "Your message has been sent to the owners of";
         public const string UnListedPackageText = "This package is unlisted and hidden from package listings";
-        public const string TestAccount = "NugetTestAccount";
+        public const string TestDataAccount = "NuGetTestData";
         public const string TestPackageId = "BaseTestPackage";
         public const string TestPackageIdDotNetTool = "BaseTestPackage.DotnetTool";
         public const string TestPackageIdARandomType = "BaseTestPackage.ARandomType";
         public const string TestPackageIdTemplate = "BaseTestPackage.Template";
         public const string TestPackageIdWithPrereleases = "BaseTestPackage.SearchFilters";
         public const string TestPackageIdNoStable = "BaseTestPackage.NoStable";
-        public const string TestOrganizationCollaboratorPackageId = "BaseTestOrganizationCollaboratorPackage";
         public const string ReadOnlyModeError = "Error 503 - Read-only Mode";
         public const string UploadFailureMessage = "The package upload via Nuget.exe didnt succeed properly. Check the logs to see the process error and output stream";
         public const string PackageInstallFailureMessage = "Package install failed. Either the file is not present on disk or it is corrupted. Check logs for details";

--- a/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageRetrieval/PackageListTests.cs
@@ -38,7 +38,7 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             var sortByParam = string.IsNullOrEmpty(sortBy) ? string.Empty : $"&sortBy={sortBy}";
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?testData=true&q=owner%3A{Constants.TestAccount}{sortByParam}");
+                $"/packages?testData=true&q=owner%3A{Constants.TestDataAccount}{sortByParam}");
 
             // Act
             using (var httpClient = new HttpClient())
@@ -65,7 +65,7 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             var sortByParam = string.IsNullOrEmpty(sortBy) ? string.Empty : $"&sortBy={sortBy}";
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?testData=true&q=owner%3A{Constants.TestAccount}{sortByParam}");
+                $"/packages?testData=true&q=owner%3A{Constants.TestDataAccount}{sortByParam}");
 
             // Act
             using (var httpClient = new HttpClient())
@@ -97,7 +97,7 @@ namespace NuGetGallery.FunctionalTests.PackageRetrieval
             var packageTypeParam = string.IsNullOrEmpty(packageType) ? string.Empty : $"&packageType={packageType}";
             var feedUrl = new Uri(
                 new Uri(UrlHelper.BaseUrl),
-                $"/packages?testData=true&q=packageid%3A{Uri.EscapeUriString(id)}+owner%3A{Constants.TestAccount}{packageTypeParam}");
+                $"/packages?testData=true&q=packageid%3A{Uri.EscapeUriString(id)}+owner%3A{Constants.TestDataAccount}{packageTypeParam}");
 
             // Act
             using (var httpClient = new HttpClient())


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/3513

All temporary test data will be owed by the NugetTestAccount and orgs. This data should be cleaned up.
All static test data that should not be deleted will be owned by NuGetTestData organization.