### PR TITLE
add the dotnet fsi extensions

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -97,14 +97,14 @@
             {
                 Id = "dotnet-fsi-nuget",
                 CommandPrefix = "fsi> ",
-                InstallPackageCommand = string.Format("#r \"nuget: {0} >= {1}\"", Model.Id, Model.Version),
+                InstallPackageCommand = string.Format("#r \"nuget: {0},{1}\"", Model.Id, Model.Version),
             },
 
             new ThirdPartyPackageManagerViewModel("dotnet fsi (paket)", "https://fsprojects.github.io/Paket/fsi-integration.html")
             {
                 Id = "dotnet-fsi-paket",
                 CommandPrefix = "fsi> ",
-                InstallPackageCommand = string.Format("#r \"paket: nuget {0} >= {1}\"", Model.Id, Model.Version),
+                InstallPackageCommand = string.Format("#r \"paket: nuget {0} = {1}\"", Model.Id, Model.Version),
             },
 
         };

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -91,7 +91,22 @@
                 Id = "paket-cli",
                 CommandPrefix = "> ",
                 InstallPackageCommand = string.Format("paket add {0} --version {1}", Model.Id, Model.Version),
-            }
+            },
+
+            new ThirdPartyPackageManagerViewModel("dotnet fsi (nuget)", "https://github.com/dotnet/fsharp/tree/main/src/fsharp/FSharp.DependencyManager.Nuget")
+            {
+                Id = "dotnet-fsi-nuget",
+                CommandPrefix = "fsi> ",
+                InstallPackageCommand = string.Format("#r \"nuget: {0} >= {1}\"", Model.Id, Model.Version),
+            },
+
+            new ThirdPartyPackageManagerViewModel("dotnet fsi (paket)", "https://fsprojects.github.io/Paket/fsi-integration.html")
+            {
+                Id = "dotnet-fsi-paket",
+                CommandPrefix = "fsi> ",
+                InstallPackageCommand = string.Format("#r \"paket: nuget {0} >= {1}\"", Model.Id, Model.Version),
+            },
+
         };
     }
 }


### PR DESCRIPTION
add the dotnet fsi extensions which allow to load packages in F# Interactive

Since net 5 shipped, it is possible to use nuget packages from `dotnet fsi` through extensions: https://devblogs.microsoft.com/dotnet/announcing-f-5/#package-references-in-f-scripts