### PR TITLE
Latest release version of NuGet.*

### DIFF
--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -89,7 +89,7 @@
       <Version>4.3.0-dev-3612825</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
+++ b/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
@@ -15,7 +15,7 @@
       <Version>10.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>5.8.0-preview.3.6823</Version>
+      <Version>5.8.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Packaging">
-      <Version>5.8.0-preview.3.6823</Version>
+      <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
       <Version>2.79.0</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -39,7 +39,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -48,13 +48,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -305,10 +305,10 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -299,10 +299,10 @@
       <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>5.8.0-preview.3.6823</Version>
+      <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
-      <Version>5.8.0-preview.3.6823</Version>
+      <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.79.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2237,13 +2237,13 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.79.0</Version>
+      <Version>2.81.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2231,10 +2231,10 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Configuration">
-      <Version>5.8.0-preview.3.6823</Version>
+      <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
-      <Version>5.8.0-preview.3.6823</Version>
+      <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
       <Version>2.79.0</Version>

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -91,7 +91,7 @@
       <Version>1.0.0.10</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.5.0</Version>
+      <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/8230

To enable Gallery to accept new OSI and FSF approved licenses need to bump NuGet.Packaging version.
The rest of NuGet.* packages were updated to align with NuGet.Packaging and get off preview version.