### PR TITLE
Surface vulnerabilities in package detail page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1038,6 +1038,45 @@ img.reserved-indicator-icon {
 .page-package-details .deprecation-container .deprecation-content-container p:last-of-type {
   margin-bottom: 0px;
 }
+.page-package-details .vulnerabilities-container .vulnerabilities-expander {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  vertical-align: middle;
+  width: 100%;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-expander .vulnerabilities-expander-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-expander .vulnerabilities-expander-container .vulnerabilities-expander-icon {
+  position: unset;
+  top: unset;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-expander .vulnerabilities-expander-container .vulnerabilities-expander-info-right {
+  padding-left: 15px;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-expander .vulnerabilities-expander-container .vulnerabilities-expander-severity-rating {
+  margin-left: 5px;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-content-container {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid lightgray;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-content-container p {
+  margin-top: 5px;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-content-container p:last-of-type {
+  margin-bottom: 0px;
+}
 .page-package-details .failed-validation-alert-list {
   margin-top: 15px;
   margin-bottom: 15px;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -63,6 +63,46 @@
     }
   }
 
+  .vulnerabilities-container {
+    .vulnerabilities-expander {
+      display: flex;
+      justify-content: space-between;
+      vertical-align: middle;
+      width: 100%;
+
+      .vulnerabilities-expander-container {
+        display: flex;
+
+        .vulnerabilities-expander-icon {
+          position: unset;
+          top: unset;
+        }
+
+        .vulnerabilities-expander-info-right {
+          padding-left: 15px;
+        }
+
+        .vulnerabilities-expander-severity-rating {
+          margin-left: 5px;
+        }
+      }
+    }
+
+    .vulnerabilities-content-container {
+      margin-top: 15px;
+      padding-top: 15px;
+      border-top: 1px solid lightgray;
+
+      p {
+        margin-top: 5px;
+      }
+
+      p:last-of-type {
+        margin-bottom: 0px;
+      }
+    }
+  }
+
   .failed-validation-alert-list {
     margin-top: 15px;
     margin-bottom: 15px;

--- a/src/NuGet.Services.Entities/Package.cs
+++ b/src/NuGet.Services.Entities/Package.cs
@@ -24,7 +24,7 @@ namespace NuGet.Services.Entities
             SymbolPackages = new HashSet<SymbolPackage>();
             Deprecations = new HashSet<PackageDeprecation>();
             AlternativeOf = new HashSet<PackageDeprecation>();
-            Vulnerabilities = new HashSet<VulnerablePackageVersionRange>();
+            VulnerableVersionRanges = new HashSet<VulnerablePackageVersionRange>();
             Listed = true;
         }
 #pragma warning restore 618
@@ -279,7 +279,7 @@ namespace NuGet.Services.Entities
         /// <summary>
         /// Gets or sets the list of vulnerabilites that this package has.
         /// </summary>
-        public ICollection<VulnerablePackageVersionRange> Vulnerabilities { get; set; }
+        public ICollection<VulnerablePackageVersionRange> VulnerableVersionRanges { get; set; }
 
         /// <summary>
         /// A flag that indicates that the package metadata had an embedded icon specified.

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -482,7 +482,7 @@ namespace NuGetGallery
             modelBuilder.Entity<VulnerablePackageVersionRange>()
                 .HasKey(pv => pv.Key)
                 .HasMany(pv => pv.Packages)
-                .WithMany(p => p.Vulnerabilities);
+                .WithMany(p => p.VulnerableVersionRanges);
 
             modelBuilder.Entity<VulnerablePackageVersionRange>()
                 .HasIndex(pv => pv.PackageId);
@@ -490,6 +490,13 @@ namespace NuGetGallery
             modelBuilder.Entity<VulnerablePackageVersionRange>()
                 .HasIndex(pv => new { pv.VulnerabilityKey, pv.PackageId, pv.PackageVersionRange })
                 .IsUnique();
+
+            modelBuilder.Entity<VulnerablePackageVersionRange>()
+                .HasMany<Package>(vpvr => vpvr.Packages)
+                .WithMany(p => p.VulnerableVersionRanges)
+                .Map(c => c.ToTable("VulnerablePackageVersionRangePackages")
+                    .MapLeftKey("VulnerablePackageVersionRange_Key")
+                    .MapRightKey("Package_Key"));
 
             modelBuilder.Entity<PackageRename>()
                 .HasKey(r => r.Key)

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -25,6 +25,7 @@ namespace NuGetGallery
         private const string ManageDeprecationFeatureName = GalleryPrefix + "ManageDeprecation";
         private const string ManageDeprecationForManyVersionsFeatureName = GalleryPrefix + "ManageDeprecationMany";
         private const string ManageDeprecationApiFeatureName = GalleryPrefix + "ManageDeprecationApi";
+        private const string DisplayVulnerabilitiesFeatureName = GalleryPrefix + "DisplayVulnerabilities";
         private const string ODataReadOnlyDatabaseFeatureName = GalleryPrefix + "ODataReadOnlyDatabase";
         private const string PackagesAtomFeedFeatureName = GalleryPrefix + "PackagesAtomFeed";
         private const string SearchSideBySideFlightName = GalleryPrefix + "SearchSideBySide";
@@ -124,6 +125,11 @@ namespace NuGetGallery
         public bool IsManageDeprecationApiEnabled(User user)
         {
             return _client.IsEnabled(ManageDeprecationApiFeatureName, user, defaultValue: false);
+        }
+
+        public bool IsDisplayVulnerabilitiesEnabled()
+        {
+            return _client.IsEnabled(DisplayVulnerabilitiesFeatureName, defaultValue: false);
         }
 
         public bool AreEmbeddedIconsEnabled(User user)

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -57,6 +57,11 @@ namespace NuGetGallery
         bool IsManageDeprecationApiEnabled(User user);
 
         /// <summary>
+        /// Whether or not a package owner can view vulnerability advisory information on their package.
+        /// </summary>
+        bool IsDisplayVulnerabilitiesEnabled();
+
+        /// <summary>
         /// Whether the user is allowed to publish packages with an embedded icon.
         /// </summary>
         bool AreEmbeddedIconsEnabled(User user);

--- a/src/NuGetGallery.Services/PackageManagement/IPackageVulnerabilityService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageVulnerabilityService.cs
@@ -9,7 +9,7 @@ namespace NuGetGallery
     public interface IPackageVulnerabilityService
     {
         /// <summary>
-        /// Adds any <see cref="VulnerablePackageVersionRange"/>s to <see cref="Package.Vulnerabilities"/> that it is a part of.
+        /// Adds any <see cref="VulnerablePackageVersionRange"/>s to <see cref="Package.VulnerableVersionRanges"/> that it is a part of.
         /// </summary>
         /// <remarks>
         /// Does not commit changes. The caller is expected to commit any changes separately.

--- a/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilityService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilityService.cs
@@ -45,7 +45,7 @@ namespace NuGetGallery
                 var versionRange = VersionRange.Parse(possibleRange.PackageVersionRange);
                 if (versionRange.Satisfies(version))
                 {
-                    package.Vulnerabilities.Add(possibleRange);
+                    package.VulnerableVersionRanges.Add(possibleRange);
                     possibleRange.Packages.Add(package);
                 }
             }
@@ -278,7 +278,7 @@ namespace NuGetGallery
                         package.NormalizedVersion,
                         range.PackageVersionRange);
 
-                    package.Vulnerabilities.Add(range);
+                    package.VulnerableVersionRanges.Add(range);
                     range.Packages.Add(package);
                     packagesToUpdate.Add(package);
                 }

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -22,7 +22,8 @@
     "NuGetGallery.ODataV2FindPackagesByIdNonHijacked": "Enabled",
     "NuGetGallery.ODataV2FindPackagesByIdCountNonHijacked": "Enabled",
     "NuGetGallery.ODataV2SearchNonHijacked": "Enabled",
-    "NuGetGallery.ODataV2SearchCountNonHijacked": "Enabled"
+    "NuGetGallery.ODataV2SearchCountNonHijacked": "Enabled",
+    "NuGetGallery.DisplayVulnerabilities": "Enabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -422,6 +422,10 @@ namespace NuGetGallery
                 .As<IPackageDeprecationService>()
                 .InstancePerLifetimeScope();
 
+            builder.RegisterType<PackageVulnerabilitiesService>()
+                .As<IPackageVulnerabilitiesService>()
+                .InstancePerLifetimeScope();
+
             builder.RegisterType<PackageRenameService>()
                 .As<IPackageRenameService>()
                 .InstancePerLifetimeScope();

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -121,6 +121,7 @@ namespace NuGetGallery
         private readonly ILicenseExpressionSplitter _licenseExpressionSplitter;
         private readonly IFeatureFlagService _featureFlagService;
         private readonly IPackageDeprecationService _deprecationService;
+        private readonly IPackageVulnerabilitiesService _vulnerabilitiesService;
         private readonly IPackageRenameService _renameService;
         private readonly IABTestService _abTestService;
         private readonly IMarkdownService _markdownService;
@@ -161,6 +162,7 @@ namespace NuGetGallery
             ILicenseExpressionSplitter licenseExpressionSplitter,
             IFeatureFlagService featureFlagService,
             IPackageDeprecationService deprecationService,
+            IPackageVulnerabilitiesService vulnerabilitiesService,
             IPackageRenameService renameService,
             IABTestService abTestService,
             IIconUrlProvider iconUrlProvider,
@@ -197,6 +199,7 @@ namespace NuGetGallery
             _licenseExpressionSplitter = licenseExpressionSplitter ?? throw new ArgumentNullException(nameof(licenseExpressionSplitter));
             _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
             _deprecationService = deprecationService ?? throw new ArgumentNullException(nameof(deprecationService));
+            _vulnerabilitiesService = vulnerabilitiesService ?? throw new ArgumentNullException(nameof(vulnerabilitiesService));
             _renameService = renameService ?? throw new ArgumentNullException(nameof(renameService));
             _abTestService = abTestService ?? throw new ArgumentNullException(nameof(abTestService));
             _iconUrlProvider = iconUrlProvider ?? throw new ArgumentNullException(nameof(iconUrlProvider));
@@ -875,6 +878,8 @@ namespace NuGetGallery
                 .GroupBy(d => d.PackageKey)
                 .ToDictionary(g => g.Key, g => g.First());
 
+            var packageKeyToVulnerabilities = _vulnerabilitiesService.GetVulnerabilitiesById(id);
+
             IReadOnlyList<PackageRename> packageRenames = null;
             if (_featureFlagService.IsPackageRenamesEnabled(currentUser))
             {
@@ -886,6 +891,7 @@ namespace NuGetGallery
                 allVersions,
                 currentUser,
                 packageKeyToDeprecation,
+                packageKeyToVulnerabilities,
                 packageRenames,
                 readme);
 
@@ -895,6 +901,7 @@ namespace NuGetGallery
             model.IsCertificatesUIEnabled = _contentObjectService.CertificatesConfiguration?.IsUIEnabledForUser(currentUser) ?? false;
             model.IsAtomFeedEnabled = _featureFlagService.IsPackagesAtomFeedEnabled();
             model.IsPackageDeprecationEnabled = _featureFlagService.IsManageDeprecationEnabled(currentUser, allVersions);
+            model.IsPackageVulnerabilitiesEnabled = _featureFlagService.IsDisplayVulnerabilitiesEnabled();
             model.IsPackageRenamesEnabled = _featureFlagService.IsPackageRenamesEnabled(currentUser);
             model.IsPackageDependentsEnabled = _featureFlagService.IsPackageDependentsEnabled(currentUser);
            

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
@@ -39,6 +39,7 @@ namespace NuGetGallery
                 allVersions,
                 currentUser,
                 packageKeyToDeprecation: null,
+                packageKeyToVulnerabilities: null,
                 packageRenames: null,
                 readmeResult: null);
 

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -305,8 +305,10 @@
     <Compile Include="Modules\CookieComplianceHttpModule.cs" />
     <Compile Include="RequestModels\DeletePackagesApiRequest.cs" />
     <Compile Include="Services\IMarkdownService.cs" />
+    <Compile Include="Services\IPackageVulnerabilitiesService.cs" />
     <Compile Include="Services\IPackageMetadataValidationService.cs" />
     <Compile Include="Services\MarkdownService.cs" />
+    <Compile Include="Services\PackageVulnerabilitiesService.cs" />
     <Compile Include="Services\PackageMetadataValidationService.cs" />
     <Compile Include="Services\ConfigurationIconFileProvider.cs" />
     <Compile Include="Services\IconUrlDeprecationValidationMessage.cs" />
@@ -2302,6 +2304,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="App_Data\Files\Content\Query-Hint-Configuration.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Packages\_DisplayPackageVulnerabilities.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -5,6 +5,26 @@ $(function () {
     window.nuget.configureExpander("rename-content-container", "ChevronDown", null, "ChevronUp");
     configureExpanderWithEnterKeydown($('#show-rename-content-container'));
 
+    // Configure the vulnerability information container
+    var container = $('#show-vulnerabilities-content-container');
+    if ($('#vulnerabilities-content-container').children().length) {
+        // If the deprecation information container has content, configure it as an expander.
+        window.nuget.configureExpander("vulnerabilities-content-container", "ChevronDown", null, "ChevronUp");
+        configureExpanderWithEnterKeydown(container)
+    }
+    else {
+        // If the container does not have content, remove its expander attributes
+        var expanderAttributes = ['data-toggle', 'data-target', 'aria-expanded', 'aria-controls', 'tabindex'];
+        for (var i in expanderAttributes) {
+            container.removeAttr(expanderAttributes[i]);
+        }
+
+        // The expander should not be clickable when it doesn't have content
+        container.find('.vulnerabilities-expander').removeAttr('role');
+
+        $('#vulnerabilities-expander-icon-right').hide();
+    }
+
     // Configure the deprecation information container
     var container = $('#show-deprecation-content-container');
     if ($('#deprecation-content-container').children().length) {

--- a/src/NuGetGallery/Services/IPackageVulnerabilitiesService.cs
+++ b/src/NuGetGallery/Services/IPackageVulnerabilitiesService.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Services.Entities;
+
+namespace NuGetGallery
+{
+    public interface IPackageVulnerabilitiesService
+    {
+        /// <summary>
+        /// Returns a dictionary mapping package keys to collections of vulnerabilities for that package/version
+        /// </summary>
+        /// <param name="id">id of the package for this query</param>
+        IReadOnlyDictionary<int, IReadOnlyList<PackageVulnerability>> GetVulnerabilitiesById(string id);
+    }
+}

--- a/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
+++ b/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Services.Entities;
+using NuGetGallery.Auditing;
+
+namespace NuGetGallery
+{
+    public class PackageVulnerabilitiesService : IPackageVulnerabilitiesService
+    {
+        private readonly IEntitiesContext _entitiesContext;
+
+        public PackageVulnerabilitiesService(IEntitiesContext entitiesContext)
+        {
+            _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
+        }
+
+        public IReadOnlyDictionary<int, IReadOnlyList<PackageVulnerability>> GetVulnerabilitiesById(string id)
+        {
+            var result = new Dictionary<int, List<PackageVulnerability>>();
+            foreach (var package in _entitiesContext.Packages.Where(p => p.PackageRegistration != null && p.PackageRegistration.Id == id)
+                .Include(p => p.VulnerableVersionRanges).Include("VulnerableVersionRanges.Vulnerability"))
+            {
+                if (package.VulnerableVersionRanges == null)
+                {
+                    continue;
+                }
+
+                var packageVulnerabilities = (List<PackageVulnerability>)null;
+                foreach (var vulnerabilityVersionRange in package.VulnerableVersionRanges)
+                {
+                    if (packageVulnerabilities == null)
+                    {
+                        packageVulnerabilities = new List<PackageVulnerability>();
+                        result.Add(package.Key, packageVulnerabilities);
+                    }
+
+                    packageVulnerabilities.Add(vulnerabilityVersionRange.Vulnerability);
+                }
+            }
+
+            return result.Count == 0 ? null :
+                result.ToDictionary(kv => kv.Key, kv => kv.Value as IReadOnlyList<PackageVulnerability>);
+        }
+    }
+}

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -33,6 +33,7 @@ namespace NuGetGallery
         public bool IsDotnetNewTemplatePackageType { get; set; }
         public bool IsAtomFeedEnabled { get; set; }
         public bool IsPackageDeprecationEnabled { get; set; }
+        public bool IsPackageVulnerabilitiesEnabled { get; set; }
         public bool IsPackageRenamesEnabled { get; set; }
         public bool IsGitHubUsageEnabled { get; set; }
         public bool IsPackageDependentsEnabled { get; set; }
@@ -81,6 +82,8 @@ namespace NuGetGallery
         public EmbeddedLicenseFileType EmbeddedLicenseType { get; set; }
 
         public PackageDeprecationStatus DeprecationStatus { get; set; }
+        public IReadOnlyCollection<PackageVulnerability> Vulnerabilities { get; set; }
+        public PackageVulnerabilitySeverity MaxVulnerabilitySeverity { get; set; }
         public string AlternatePackageId { get; set; }
         public string AlternatePackageVersion { get; set; }
         public string CustomMessage { get; set; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -283,6 +283,11 @@
                 )
             }
 
+            @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities!= null && Model.Vulnerabilities.Any())
+            {
+                @Html.Partial("_DisplayPackageVulnerabilities")
+            }
+
             @if (Model.IsPackageDeprecationEnabled && Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
             {
                 @Html.Partial("_DisplayPackageDeprecation")
@@ -359,7 +364,7 @@
 
                         @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
                         </text>
-                     )
+                    )
                 }
                 else if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.FailedValidation)
                 {
@@ -404,7 +409,7 @@
                     @ViewHelpers.AlertWarning(
                         @<text>
                             The owner has unlisted this package.
-                            This could mean that the package is deprecated or shouldn't be used anymore.
+                            This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
                         </text>
                     )
                 }
@@ -684,9 +689,19 @@
                             {
                                 <th aria-hidden="true" abbr="Signature Information"></th>
                             }
-                            @if (Model.IsPackageDeprecationEnabled)
+                            @if (Model.IsPackageDeprecationEnabled || Model.IsPackageVulnerabilitiesEnabled)
                             {
-                                <th aria-hidden="true" abbr="Deprecation Information"></th>
+                                var abbreviation = "Vulnerability Information";
+                                if (Model.IsPackageDeprecationEnabled && Model.IsPackageVulnerabilitiesEnabled)
+                                {
+                                    abbreviation = "Deprecation and Vulnerability Information";
+                                }
+                                else if (Model.IsPackageDeprecationEnabled)
+                                {
+                                    abbreviation = "Deprecation Information";
+                                }
+
+                                <th aria-hidden="true" abbr =@abbreviation />
                             }
                         </tr>
                     </thead>
@@ -753,15 +768,16 @@
                                             </td>
                                         }
                                     }
-                                    @if (Model.IsPackageDeprecationEnabled)
+
+                                    @if (Model.IsPackageDeprecationEnabled || Model.IsPackageVulnerabilitiesEnabled)
                                     {
-                                        if (packageVersion.DeprecationStatus == PackageDeprecationStatus.NotDeprecated)
+                                        var deprecationTitle = "";
+                                        var vulnerabilitiesTitle = "";
+                                        var useAlso = false;
+
+                                        if (Model.IsPackageDeprecationEnabled && packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
                                         {
-                                            <td class="package-icon-cell" aria-hidden="true"></td>
-                                        }
-                                        else
-                                        {
-                                            var deprecationTitle = packageVersion.Version;
+                                            deprecationTitle = packageVersion.Version;
                                             var isLegacy = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.Legacy);
                                             var hasCriticalBugs = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.CriticalBugs);
                                             if (hasCriticalBugs)
@@ -784,8 +800,31 @@
                                                 deprecationTitle += " is deprecated.";
                                             }
 
+                                            useAlso = true;
+                                        }
+
+                                        if (Model.IsPackageVulnerabilitiesEnabled && packageVersion.Vulnerabilities != null && packageVersion.Vulnerabilities.Any())
+                                        {
+                                            vulnerabilitiesTitle = useAlso ? "Also, " : "";
+                                            var severity = Enum.GetName(typeof(PackageVulnerabilitySeverity), packageVersion.MaxVulnerabilitySeverity).ToLowerInvariant();
+                                            vulnerabilitiesTitle += packageVersion.Version + " has at least one vulnerability with " + severity + " severity.";
+                                        }
+
+                                        if (deprecationTitle == "" && vulnerabilitiesTitle == "")
+                                        {
+                                            <td class="package-icon-cell" aria-hidden="true" />
+                                        }
+                                        else
+                                        {
+                                            if (deprecationTitle != "")
+                                            {
+                                                deprecationTitle += " ";
+                                            }
+
+                                            var iconTitle = deprecationTitle + vulnerabilitiesTitle;
+
                                             <td class="package-icon-cell">
-                                                <i class="ms-Icon ms-Icon--Warning package-icon" title="@deprecationTitle"></i>
+                                                <i class="ms-Icon ms-Icon--Warning package-icon" title="@iconTitle"></i>
                                             </td>
                                         }
                                     }

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageVulnerabilities.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageVulnerabilities.cshtml
@@ -1,0 +1,45 @@
+﻿@model DisplayPackageViewModel
+
+<div class="vulnerabilities-container">
+    <div class="icon-text alert alert-warning">
+        <div id="show-vulnerabilities-content-container" class="vulnerabilities-expander" tabindex="0" data-toggle="collapse" data-target="#vulnerabilities-content-container" aria-expanded="false" aria-controls="vulnerabilities-content-container" aria-labelledby="vulnerabilities-container-label" role="button">
+            <div class="vulnerabilities-expander" role="button">
+                <div class="vulnerabilities-expander-container">
+                    <i class="vulnerabilities-expander-icon ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
+
+                    <div id="vulnerabilities-container-label" class="vulnerabilities-expander-info-right">
+                        @{
+                            var severity = Enum.GetName(typeof(PackageVulnerabilitySeverity), Model.MaxVulnerabilitySeverity).ToLowerInvariant();
+                            @:This package has at least one <b>vulnerability</b> with <b>@severity</b> severity.
+                        }
+                    </div>
+                </div>
+
+                <div class="vulnerabilities-expander-container">
+                    <i id="vulnerabilities-expander-icon-right" class="vulnerabilities-expander-icon vulnerabilities-expander-info-right ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                </div>
+            </div>
+        </div>
+
+        <div class="vulnerabilities-content-container collapse" id="vulnerabilities-content-container">
+            <b>Details</b>
+            <table style="width:100%; border:none; border-collapse:unset">
+                @{
+                    foreach (var vulnerability in Model.Vulnerabilities)
+                    {
+                        var truncatedUrl = vulnerability.AdvisoryUrl;
+                        if (truncatedUrl.Length > 50)
+                        {
+                            truncatedUrl = truncatedUrl.Substring(0, 47) + "...";
+                        }
+
+                        <tr>
+                            <td>Advisory: <a href="@vulnerability.AdvisoryUrl" target="_blank">@truncatedUrl</a></td>
+                            <td>Severity: <span style="font-weight:bold">@Enum.GetName(typeof(PackageVulnerabilitySeverity), vulnerability.Severity)</span></td>
+                        </tr>
+                    }
+                }
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilityServiceVerifier.cs
+++ b/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilityServiceVerifier.cs
@@ -103,14 +103,14 @@ namespace VerifyGitHubVulnerabilities.Verify
 
                 var packages = _entitiesContext.Packages
                     .Where(p => p.PackageRegistration.Id == range.PackageId)
-                    .Include(p => p.Vulnerabilities)
+                    .Include(p => p.VulnerableVersionRanges)
                     .ToList();
 
                 var versionRange = VersionRange.Parse(range.PackageVersionRange);
                 foreach (var package in packages)
                 {
                     var version = NuGetVersion.Parse(package.NormalizedVersion);
-                    if (versionRange.Satisfies(version) != package.Vulnerabilities.Contains(existingRange))
+                    if (versionRange.Satisfies(version) != package.VulnerableVersionRanges.Contains(existingRange))
                     {
                         Console.Error.WriteLine(
                             $@"Vulnerability advisory {vulnerability.GitHubDatabaseKey

--- a/tests/NuGetGallery.Facts/Services/PackageVulnerabilityServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageVulnerabilityServiceFacts.cs
@@ -63,7 +63,7 @@ namespace NuGetGallery.Services
                 Service.ApplyExistingVulnerabilitiesToPackage(package);
 
                 // Assert
-                Assert.Single(package.Vulnerabilities, satisfiedRange);
+                Assert.Single(package.VulnerableVersionRanges, satisfiedRange);
                 Assert.Single(satisfiedRange.Packages, package);
             }
         }

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -822,6 +822,7 @@ namespace NuGetGallery.ViewModels
             Package package,
             User currentUser = null,
             Dictionary<int, PackageDeprecation> packageKeyToDeprecation = null,
+            Dictionary<int, IReadOnlyList<PackageVulnerability>> packageKeyToVulnerabilities = null,
             IReadOnlyList<PackageRename> packageRenames = null,
             string readmeHtml = null)
         {
@@ -832,6 +833,7 @@ namespace NuGetGallery.ViewModels
                 allVersions,
                 currentUser: currentUser,
                 packageKeyToDeprecation: packageKeyToDeprecation,
+                packageKeyToVulnerabilities: packageKeyToVulnerabilities,
                 packageRenames: packageRenames,
                 readmeResult: new RenderedMarkdownResult { Content = readmeHtml });
         }


### PR DESCRIPTION
First steps in addressing https://github.com/NuGet/NuGetGallery/issues/7650
In this PR we have:
- the feature flag
- initial changes to the view model
- initial changes to the view--we'll iterate on this in consultation with PM (for example, we don't yet have the distinction between a customer view and an owner view of the vulnerability expander, we will need to discuss tooltip and other language used, etc)--but we're under a feature flag in order to do this iteratively
- test coverage will need to be augmented (refactored, actually) and I want to do this in a different PR, as some class renames will affect vulnerability ingestion code--it will be noisy, so I'll separate it out for reviewing

Here is the current state of the view, highlights in red boxes:
![image](https://user-images.githubusercontent.com/14225979/101106161-33711d00-361b-11eb-80e9-40e734ec3e66.png)


Other notes:
- Because deprecations and vulnerabilities share the same bang icon, you'll see a combining of the logic in the view, and combination messages in the tooltip. These can be sweetened later as well, of course.
- I needed to separate out styles for deprecation and vulnerability for two reasons--we may wish to change the look of one or the other in future, and JS code that affects the expanders was having its operation polluted by reusing existing styles for the new expander.
- Colorizing severities can come in a future CSS tweak
- EF needed some attention as the join between Packages and VulnerablePackageVersionRanges wasn't functional (specifically the navigation properties in the m:m relationship)