### PR TITLE
[Hotfix] Add missing resource

### DIFF
--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -35,6 +35,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Infrastructure\MigrateUserToOrganization.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Infrastructure\MigrateUserToOrganization.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="NuGet.Packaging">
       <Version>5.8.0</Version>
     </PackageReference>


### PR DESCRIPTION
This PR fixes the currently broken transform-user-to-organization flow: https://github.com/NuGet/NuGetGallery/issues/8344

This flow was broken by my move to .SDK-based projects. When converting NuGetGallery.Core.csproj to SDK-based, I missed an embedded resource item.

I have verified this on DEV. I'd like to take this to INT and PROD today to unblock our users.