### PR TITLE
Restrict package sources

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,6 +8,7 @@
     <add key="automatic" value="True" />
   </packageRestore>
   <packageSources>
+    <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
Restrict package sources to those explicitly listed in the `nuget.config` file. This prevents build issues where packages may come from unexpected package sources due to other `nuget.config` files (see [this](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior#config-file-locations-and-uses)).

Part of https://github.com/NuGet/Engineering/issues/3525