### PR TITLE
Rename vulnerability management service, add feature flag

### DIFF
--- a/src/GitHubVulnerabilities2Db/Ingest/AdvisoryIngestor.cs
+++ b/src/GitHubVulnerabilities2Db/Ingest/AdvisoryIngestor.cs
@@ -13,11 +13,11 @@ namespace GitHubVulnerabilities2Db.Ingest
 {
     public class AdvisoryIngestor : IAdvisoryIngestor
     {
-        private readonly IPackageVulnerabilityService _packageVulnerabilityService;
+        private readonly IPackageVulnerabilitiesManagementService _packageVulnerabilityService;
         private readonly IGitHubVersionRangeParser _gitHubVersionRangeParser;
 
         public AdvisoryIngestor(
-            IPackageVulnerabilityService packageVulnerabilityService,
+            IPackageVulnerabilitiesManagementService packageVulnerabilityService,
             IGitHubVersionRangeParser gitHubVersionRangeParser)
         {
             _packageVulnerabilityService = packageVulnerabilityService ?? throw new ArgumentNullException(nameof(packageVulnerabilityService));

--- a/src/GitHubVulnerabilities2Db/Job.cs
+++ b/src/GitHubVulnerabilities2Db/Job.cs
@@ -64,8 +64,8 @@ namespace GitHubVulnerabilities2Db
             ConfigureGalleryServices(containerBuilder);
 
             containerBuilder
-                .RegisterType<PackageVulnerabilityService>()
-                .As<IPackageVulnerabilityService>();
+                .RegisterType<PackageVulnerabilitiesManagementService>()
+                .As<IPackageVulnerabilitiesManagementService>();
 
             containerBuilder
                 .RegisterType<GitHubVersionRangeParser>()

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -25,6 +25,7 @@ namespace NuGetGallery
         private const string ManageDeprecationFeatureName = GalleryPrefix + "ManageDeprecation";
         private const string ManageDeprecationForManyVersionsFeatureName = GalleryPrefix + "ManageDeprecationMany";
         private const string ManageDeprecationApiFeatureName = GalleryPrefix + "ManageDeprecationApi";
+        private const string DisplayVulnerabilitiesFeatureName = GalleryPrefix + "DisplayVulnerabilities";
         private const string ODataReadOnlyDatabaseFeatureName = GalleryPrefix + "ODataReadOnlyDatabase";
         private const string PackagesAtomFeedFeatureName = GalleryPrefix + "PackagesAtomFeed";
         private const string SearchSideBySideFlightName = GalleryPrefix + "SearchSideBySide";
@@ -125,6 +126,11 @@ namespace NuGetGallery
         public bool IsManageDeprecationApiEnabled(User user)
         {
             return _client.IsEnabled(ManageDeprecationApiFeatureName, user, defaultValue: false);
+        }
+
+        public bool IsDisplayVulnerabilitiesEnabled()
+        {
+            return _client.IsEnabled(DisplayVulnerabilitiesFeatureName, defaultValue: false);
         }
 
         public bool AreEmbeddedIconsEnabled(User user)

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -57,6 +57,11 @@ namespace NuGetGallery
         bool IsManageDeprecationApiEnabled(User user);
 
         /// <summary>
+        /// Whether or not a package owner can view vulnerability advisory information on their package.
+        /// </summary>
+        bool IsDisplayVulnerabilitiesEnabled();
+
+        /// <summary>
         /// Whether the user is allowed to publish packages with an embedded icon.
         /// </summary>
         bool AreEmbeddedIconsEnabled(User user);

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -161,7 +161,7 @@
     <Compile Include="PackageManagement\IPackageOwnershipManagementService.cs" />
     <Compile Include="PackageManagement\IPackageService.cs" />
     <Compile Include="PackageManagement\IPackageUpdateService.cs" />
-    <Compile Include="PackageManagement\IPackageVulnerabilityService.cs" />
+    <Compile Include="PackageManagement\IPackageVulnerabilitiesManagementService.cs" />
     <Compile Include="PackageManagement\IReservedNamespaceService.cs" />
     <Compile Include="PackageManagement\PackageDeleteDecision.cs" />
     <Compile Include="PackageManagement\PackageFilter.cs" />
@@ -170,7 +170,7 @@
     <Compile Include="PackageManagement\PackageOwnerRequestService.cs" />
     <Compile Include="PackageManagement\PackageOwnershipManagementService.cs" />
     <Compile Include="PackageManagement\PackageService.cs" />
-    <Compile Include="PackageManagement\PackageVulnerabilityService.cs" />
+    <Compile Include="PackageManagement\PackageVulnerabilitiesManagementService.cs" />
     <Compile Include="PackageManagement\ReservedNamespaceService.cs" />
     <Compile Include="Permissions\ActionRequiringAccountPermissions.cs" />
     <Compile Include="Permissions\ActionRequiringEntityPermissions.cs" />

--- a/src/NuGetGallery.Services/PackageManagement/IPackageVulnerabilitiesManagementService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageVulnerabilitiesManagementService.cs
@@ -6,10 +6,10 @@ using NuGet.Services.Entities;
 
 namespace NuGetGallery
 {
-    public interface IPackageVulnerabilityService
+    public interface IPackageVulnerabilitiesManagementService
     {
         /// <summary>
-        /// Adds any <see cref="VulnerablePackageVersionRange"/>s to <see cref="Package.Vulnerabilities"/> that it is a part of.
+        /// Adds any <see cref="VulnerablePackageVersionRange"/>s to <see cref="Package.VulnerableVersionRanges"/> that it is a part of.
         /// </summary>
         /// <remarks>
         /// Does not commit changes. The caller is expected to commit any changes separately.

--- a/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilitiesManagementService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilitiesManagementService.cs
@@ -12,16 +12,16 @@ using NuGet.Versioning;
 
 namespace NuGetGallery
 {
-    public class PackageVulnerabilityService : IPackageVulnerabilityService
+    public class PackageVulnerabilitiesManagementService : IPackageVulnerabilitiesManagementService
     {
         private readonly IEntitiesContext _entitiesContext;
         private readonly IPackageUpdateService _packageUpdateService;
-        private readonly ILogger<PackageVulnerabilityService> _logger;
+        private readonly ILogger<PackageVulnerabilitiesManagementService> _logger;
 
-        public PackageVulnerabilityService(
+        public PackageVulnerabilitiesManagementService(
             IEntitiesContext entitiesContext,
             IPackageUpdateService packageUpdateService,
-            ILogger<PackageVulnerabilityService> logger)
+            ILogger<PackageVulnerabilitiesManagementService> logger)
         {
             _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
             _packageUpdateService = packageUpdateService ?? throw new ArgumentNullException(nameof(packageUpdateService));

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -22,7 +22,8 @@
     "NuGetGallery.ODataV2FindPackagesByIdNonHijacked": "Enabled",
     "NuGetGallery.ODataV2FindPackagesByIdCountNonHijacked": "Enabled",
     "NuGetGallery.ODataV2SearchNonHijacked": "Enabled",
-    "NuGetGallery.ODataV2SearchCountNonHijacked": "Enabled"
+    "NuGetGallery.ODataV2SearchCountNonHijacked": "Enabled",
+    "NuGetGallery.DisplayVulnerabilities": "Enabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -442,8 +442,8 @@ namespace NuGetGallery
                 .As<IIconUrlTemplateProcessor>()
                 .InstancePerLifetimeScope();
 
-            builder.RegisterType<PackageVulnerabilityService>()
-                .As<IPackageVulnerabilityService>()
+            builder.RegisterType<PackageVulnerabilitiesManagementService>()
+                .As<IPackageVulnerabilitiesManagementService>()
                 .InstancePerLifetimeScope();
 
             services.AddHttpClient();

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery
         private readonly IReservedNamespaceService _reservedNamespaceService;
         private readonly IValidationService _validationService;
         private readonly ICoreLicenseFileService _coreLicenseFileService;
-        private readonly IPackageVulnerabilityService _vulnerabilityService;
+        private readonly IPackageVulnerabilitiesManagementService _vulnerabilityService;
         private readonly IPackageMetadataValidationService _metadataValidationService;
 
         public PackageUploadService(
@@ -33,7 +33,7 @@ namespace NuGetGallery
             IValidationService validationService,
             ICoreLicenseFileService coreLicenseFileService,
             IDiagnosticsService diagnosticsService,
-            IPackageVulnerabilityService vulnerabilityService,
+            IPackageVulnerabilitiesManagementService vulnerabilityService,
             IPackageMetadataValidationService metadataValidationService)
         {
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));

--- a/src/VerifyGitHubVulnerabilities/Job.cs
+++ b/src/VerifyGitHubVulnerabilities/Job.cs
@@ -34,7 +34,7 @@ namespace VerifyGitHubVulnerabilities
             Console.WriteLine($" FOUND {advisories.Count} advisories.");
 
             Console.WriteLine("Fetching vulnerabilities from DB...");
-            var verifier = new PackageVulnerabilityServiceVerifier(_serviceProvider.GetRequiredService<IEntitiesContext>());
+            var verifier = new PackageVulnerabilitiesVerifier(_serviceProvider.GetRequiredService<IEntitiesContext>());
             var ingestor = new AdvisoryIngestor(verifier, new GitHubVersionRangeParser());
             await ingestor.IngestAsync(advisories);
 

--- a/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
+++ b/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
@@ -11,11 +11,11 @@ using NuGetGallery;
 
 namespace VerifyGitHubVulnerabilities.Verify
 {
-    public class PackageVulnerabilityServiceVerifier : IPackageVulnerabilityService
+    public class PackageVulnerabilitiesVerifier : IPackageVulnerabilitiesManagementService
     {
         private readonly IEntitiesContext _entitiesContext;
 
-        public PackageVulnerabilityServiceVerifier(
+        public PackageVulnerabilitiesVerifier(
             IEntitiesContext entitiesContext)
         {
             _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));

--- a/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
+++ b/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
@@ -49,7 +49,7 @@
     <Compile Include="Job.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Verify\PackageVulnerabilityServiceVerifier.cs" />
+    <Compile Include="Verify\PackageVulnerabilitiesVerifier.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
+++ b/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
@@ -132,14 +132,14 @@ namespace GitHubVulnerabilities2Db.Facts
         {
             public MethodFacts()
             {
-                PackageVulnerabilityServiceMock = new Mock<IPackageVulnerabilityService>();
+                PackageVulnerabilityServiceMock = new Mock<IPackageVulnerabilitiesManagementService>();
                 GitHubVersionRangeParserMock = new Mock<IGitHubVersionRangeParser>();
                 Ingestor = new AdvisoryIngestor(
                     PackageVulnerabilityServiceMock.Object,
                     GitHubVersionRangeParserMock.Object);
             }
 
-            public Mock<IPackageVulnerabilityService> PackageVulnerabilityServiceMock { get; }
+            public Mock<IPackageVulnerabilitiesManagementService> PackageVulnerabilityServiceMock { get; }
             public Mock<IGitHubVersionRangeParser> GitHubVersionRangeParserMock { get; }
             public AdvisoryIngestor Ingestor { get; }
         }

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -110,7 +110,7 @@
     <Compile Include="Services\PackageDeprecationManagementServiceFacts.cs" />
     <Compile Include="Services\PackageDeprecationServiceFacts.cs" />
     <Compile Include="Services\PackageRenameServiceFacts.cs" />
-    <Compile Include="Services\PackageVulnerabilityServiceFacts.cs" />
+    <Compile Include="Services\PackageVulnerabilitiesManagementServiceFacts.cs" />
     <Compile Include="Services\SearchSideBySideServiceFacts.cs" />
     <Compile Include="Services\PackageUpdateServiceFacts.cs" />
     <Compile Include="Services\StatusServiceFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageUploadServiceFacts.cs
@@ -32,7 +32,7 @@ namespace NuGetGallery
             Mock<IPackageService> packageService = null,
             Mock<IReservedNamespaceService> reservedNamespaceService = null,
             Mock<IValidationService> validationService = null,
-            Mock<IPackageVulnerabilityService> vulnerabilityService = null)
+            Mock<IPackageVulnerabilitiesManagementService> vulnerabilityService = null)
         {
             packageService = packageService ?? new Mock<IPackageService>();
 
@@ -64,7 +64,7 @@ namespace NuGetGallery
 
             if (vulnerabilityService == null)
             {
-                vulnerabilityService = new Mock<IPackageVulnerabilityService>();
+                vulnerabilityService = new Mock<IPackageVulnerabilitiesManagementService>();
             }
 
             validationService = validationService ?? new Mock<IValidationService>();
@@ -96,7 +96,7 @@ namespace NuGetGallery
                 var key = 0;
                 var packageService = new Mock<IPackageService>();
                 packageService.Setup(x => x.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
-                var vulnerabilityService = new Mock<IPackageVulnerabilityService>();
+                var vulnerabilityService = new Mock<IPackageVulnerabilitiesManagementService>();
 
                 var id = "Microsoft.Aspnet.Mvc";
                 var packageUploadService = CreateService(packageService, vulnerabilityService: vulnerabilityService);
@@ -151,7 +151,7 @@ namespace NuGetGallery
                     .Setup(r => r.GetReservedNamespacesForId(It.IsAny<string>()))
                     .Returns(testNamespaces.ToList().AsReadOnly());
 
-                var vulnerabilityService = new Mock<IPackageVulnerabilityService>();
+                var vulnerabilityService = new Mock<IPackageVulnerabilitiesManagementService>();
 
                 var packageUploadService = CreateService(
                     reservedNamespaceService: reservedNamespaceService, 
@@ -193,7 +193,7 @@ namespace NuGetGallery
                     .Setup(r => r.GetReservedNamespacesForId(It.IsAny<string>()))
                     .Returns(testNamespaces.ToList().AsReadOnly());
 
-                var vulnerabilityService = new Mock<IPackageVulnerabilityService>();
+                var vulnerabilityService = new Mock<IPackageVulnerabilitiesManagementService>();
 
                 var packageUploadService = CreateService(
                     reservedNamespaceService: reservedNamespaceService,
@@ -741,7 +741,7 @@ namespace NuGetGallery
             protected readonly Mock<ITelemetryService> _telemetryService;
             protected readonly Mock<ICoreLicenseFileService> _licenseFileService;
             protected readonly Mock<IDiagnosticsService> _diagnosticsService;
-            protected readonly Mock<IPackageVulnerabilityService> _vulnerabilityService;
+            protected readonly Mock<IPackageVulnerabilitiesManagementService> _vulnerabilityService;
             protected readonly Mock<IPackageMetadataValidationService> _metadataValidationService;
             protected Package _package;
             protected Stream _packageFile;
@@ -784,7 +784,7 @@ namespace NuGetGallery
                     .Setup(ds => ds.GetSource(It.IsAny<string>()))
                     .Returns(Mock.Of<IDiagnosticsSource>());
 
-                _vulnerabilityService = new Mock<IPackageVulnerabilityService>();
+                _vulnerabilityService = new Mock<IPackageVulnerabilitiesManagementService>();
 
                 _metadataValidationService = new Mock<IPackageMetadataValidationService>();
 

--- a/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesManagementServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesManagementServiceFacts.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace NuGetGallery.Services
 {
-    public class PackageVulnerabilityServiceFacts
+    public class PackageVulnerabilitiesManagementServiceFacts
     {
         public class TheApplyExistingVulnerabilitiesToPackageMethod : MethodFacts
         {
@@ -211,7 +211,7 @@ namespace NuGetGallery.Services
                         .Verifiable();
                 }
 
-                var service = GetService<PackageVulnerabilityService>();
+                var service = GetService<PackageVulnerabilitiesManagementService>();
 
                 // Act
                 await service.UpdateVulnerabilityAsync(vulnerability, true);
@@ -258,7 +258,7 @@ namespace NuGetGallery.Services
                         .Verifiable();
                 }
 
-                var service = GetService<PackageVulnerabilityService>();
+                var service = GetService<PackageVulnerabilitiesManagementService>();
 
                 // Act
                 await service.UpdateVulnerabilityAsync(vulnerability, false);
@@ -440,7 +440,7 @@ namespace NuGetGallery.Services
                         .Verifiable();
                 }
 
-                var service = GetService<PackageVulnerabilityService>();
+                var service = GetService<PackageVulnerabilitiesManagementService>();
 
                 // Act
                 await service.UpdateVulnerabilityAsync(vulnerability, false);
@@ -469,7 +469,7 @@ namespace NuGetGallery.Services
                 _databaseMock = new Mock<IDatabase>();
                 Context = GetFakeContext();
                 UpdateServiceMock = GetMock<IPackageUpdateService>();
-                Service = GetService<PackageVulnerabilityService>();
+                Service = GetService<PackageVulnerabilitiesManagementService>();
 
                 _transactionMock
                     .Setup(x => x.Commit())
@@ -487,7 +487,7 @@ namespace NuGetGallery.Services
             private Mock<IDatabase> _databaseMock { get; }
             protected FakeEntitiesContext Context { get; }
             protected Mock<IPackageUpdateService> UpdateServiceMock { get; }
-            protected PackageVulnerabilityService Service { get; }
+            protected PackageVulnerabilitiesManagementService Service { get; }
 
             protected void VerifyTransaction()
             {


### PR DESCRIPTION
Starts to address: https://github.com/nuget/nugetgallery/issues/7650

This is a rename of the existing vulnerability service to a vulnerability management service, and the vulnerability service verifier to a vulnerability verifier. Quite a few files in this PR, but it's very repetitive.

Also, I've introduced a feature flag here for use in vulnerability messaging.

This is all groundwork for the PRs to follow.