### PR TITLE
Add vulnerabilities service

### DIFF
--- a/src/NuGet.Services.Entities/Package.cs
+++ b/src/NuGet.Services.Entities/Package.cs
@@ -24,7 +24,7 @@ namespace NuGet.Services.Entities
             SymbolPackages = new HashSet<SymbolPackage>();
             Deprecations = new HashSet<PackageDeprecation>();
             AlternativeOf = new HashSet<PackageDeprecation>();
-            Vulnerabilities = new HashSet<VulnerablePackageVersionRange>();
+            VulnerablePackageRanges = new HashSet<VulnerablePackageVersionRange>();
             Listed = true;
         }
 #pragma warning restore 618
@@ -289,9 +289,9 @@ namespace NuGet.Services.Entities
         public virtual ICollection<PackageDeprecation> AlternativeOf { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of vulnerabilites that this package has.
+        /// Gets or sets the list of vulnerable package ranges connecting this package to vulnerabilities.
         /// </summary>
-        public ICollection<VulnerablePackageVersionRange> Vulnerabilities { get; set; }
+        public ICollection<VulnerablePackageVersionRange> VulnerablePackageRanges { get; set; }
 
         /// <summary>
         /// A flag that indicates that the package metadata had an embedded icon specified.

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -482,7 +482,7 @@ namespace NuGetGallery
             modelBuilder.Entity<VulnerablePackageVersionRange>()
                 .HasKey(pv => pv.Key)
                 .HasMany(pv => pv.Packages)
-                .WithMany(p => p.Vulnerabilities);
+                .WithMany(p => p.VulnerablePackageRanges);
 
             modelBuilder.Entity<VulnerablePackageVersionRange>()
                 .HasIndex(pv => pv.PackageId);

--- a/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilitiesManagementService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilitiesManagementService.cs
@@ -45,7 +45,7 @@ namespace NuGetGallery
                 var versionRange = VersionRange.Parse(possibleRange.PackageVersionRange);
                 if (versionRange.Satisfies(version))
                 {
-                    package.Vulnerabilities.Add(possibleRange);
+                    package.VulnerablePackageRanges.Add(possibleRange);
                     possibleRange.Packages.Add(package);
                 }
             }
@@ -278,7 +278,7 @@ namespace NuGetGallery
                         package.NormalizedVersion,
                         range.PackageVersionRange);
 
-                    package.Vulnerabilities.Add(range);
+                    package.VulnerablePackageRanges.Add(range);
                     range.Packages.Add(package);
                     packagesToUpdate.Add(package);
                 }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -422,6 +422,10 @@ namespace NuGetGallery
                 .As<IPackageDeprecationService>()
                 .InstancePerLifetimeScope();
 
+            builder.RegisterType<PackageVulnerabilitiesService>()
+                .As<IPackageVulnerabilitiesService>()
+                .InstancePerLifetimeScope();
+
             builder.RegisterType<PackageRenameService>()
                 .As<IPackageRenameService>()
                 .InstancePerLifetimeScope();

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -121,6 +121,7 @@ namespace NuGetGallery
         private readonly ILicenseExpressionSplitter _licenseExpressionSplitter;
         private readonly IFeatureFlagService _featureFlagService;
         private readonly IPackageDeprecationService _deprecationService;
+        private readonly IPackageVulnerabilitiesService _vulnerabilitiesService;
         private readonly IPackageRenameService _renameService;
         private readonly IABTestService _abTestService;
         private readonly IMarkdownService _markdownService;
@@ -161,6 +162,7 @@ namespace NuGetGallery
             ILicenseExpressionSplitter licenseExpressionSplitter,
             IFeatureFlagService featureFlagService,
             IPackageDeprecationService deprecationService,
+            IPackageVulnerabilitiesService vulnerabilitiesService,
             IPackageRenameService renameService,
             IABTestService abTestService,
             IIconUrlProvider iconUrlProvider,
@@ -197,6 +199,7 @@ namespace NuGetGallery
             _licenseExpressionSplitter = licenseExpressionSplitter ?? throw new ArgumentNullException(nameof(licenseExpressionSplitter));
             _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
             _deprecationService = deprecationService ?? throw new ArgumentNullException(nameof(deprecationService));
+            _vulnerabilitiesService = vulnerabilitiesService ?? throw new ArgumentNullException(nameof(vulnerabilitiesService));
             _renameService = renameService ?? throw new ArgumentNullException(nameof(renameService));
             _abTestService = abTestService ?? throw new ArgumentNullException(nameof(abTestService));
             _iconUrlProvider = iconUrlProvider ?? throw new ArgumentNullException(nameof(iconUrlProvider));
@@ -875,6 +878,8 @@ namespace NuGetGallery
                 .GroupBy(d => d.PackageKey)
                 .ToDictionary(g => g.Key, g => g.First());
 
+            var packageKeyToVulnerabilities = _vulnerabilitiesService.GetVulnerabilitiesById(id);
+
             IReadOnlyList<PackageRename> packageRenames = null;
             if (_featureFlagService.IsPackageRenamesEnabled(currentUser))
             {
@@ -886,6 +891,7 @@ namespace NuGetGallery
                 allVersions,
                 currentUser,
                 packageKeyToDeprecation,
+                packageKeyToVulnerabilities,
                 packageRenames,
                 readme);
 
@@ -895,6 +901,7 @@ namespace NuGetGallery
             model.IsCertificatesUIEnabled = _contentObjectService.CertificatesConfiguration?.IsUIEnabledForUser(currentUser) ?? false;
             model.IsAtomFeedEnabled = _featureFlagService.IsPackagesAtomFeedEnabled();
             model.IsPackageDeprecationEnabled = _featureFlagService.IsManageDeprecationEnabled(currentUser, allVersions);
+            model.IsPackageVulnerabilitiesEnabled = _featureFlagService.IsDisplayVulnerabilitiesEnabled();
             model.IsPackageRenamesEnabled = _featureFlagService.IsPackageRenamesEnabled(currentUser);
             model.IsPackageDependentsEnabled = _featureFlagService.IsPackageDependentsEnabled(currentUser);
            

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
@@ -39,6 +39,7 @@ namespace NuGetGallery
                 allVersions,
                 currentUser,
                 packageKeyToDeprecation: null,
+                packageKeyToVulnerabilities: null,
                 packageRenames: null,
                 readmeResult: null);
 

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -305,8 +305,10 @@
     <Compile Include="Modules\CookieComplianceHttpModule.cs" />
     <Compile Include="RequestModels\DeletePackagesApiRequest.cs" />
     <Compile Include="Services\IMarkdownService.cs" />
+    <Compile Include="Services\IPackageVulnerabilitiesService.cs" />
     <Compile Include="Services\IPackageMetadataValidationService.cs" />
     <Compile Include="Services\MarkdownService.cs" />
+    <Compile Include="Services\PackageVulnerabilitiesService.cs" />
     <Compile Include="Services\PackageMetadataValidationService.cs" />
     <Compile Include="Services\ConfigurationIconFileProvider.cs" />
     <Compile Include="Services\IconUrlDeprecationValidationMessage.cs" />

--- a/src/NuGetGallery/Services/IPackageVulnerabilitiesService.cs
+++ b/src/NuGetGallery/Services/IPackageVulnerabilitiesService.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Services.Entities;
+
+namespace NuGetGallery
+{
+    public interface IPackageVulnerabilitiesService
+    {
+        /// <summary>
+        /// Returns a dictionary mapping package keys to collections of vulnerabilities for that package/version
+        /// </summary>
+        /// <param name="id">id of the package for this query</param>
+        IReadOnlyDictionary<int, IReadOnlyList<PackageVulnerability>> GetVulnerabilitiesById(string id);
+    }
+}

--- a/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
+++ b/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using NuGet.Services.Entities;
+
+namespace NuGetGallery
+{
+    public class PackageVulnerabilitiesService : IPackageVulnerabilitiesService
+    {
+        private readonly IEntitiesContext _entitiesContext;
+
+        public PackageVulnerabilitiesService(IEntitiesContext entitiesContext)
+        {
+            _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
+        }
+
+        public IReadOnlyDictionary<int, IReadOnlyList<PackageVulnerability>> GetVulnerabilitiesById(string id)
+        {
+            var result = new Dictionary<int, List<PackageVulnerability>>();
+            var packagesMatchingId = _entitiesContext.Packages
+                .Where(p => p.PackageRegistration != null && p.PackageRegistration.Id == id)
+                .Include($"{nameof(Package.VulnerablePackageRanges)}.{nameof(VulnerablePackageVersionRange.Vulnerability)}");
+            foreach (var package in packagesMatchingId)
+            {
+                if (package.VulnerablePackageRanges == null)
+                {
+                    continue;
+                }
+
+                if (package.VulnerablePackageRanges.Any())
+                {
+                    result.Add(package.Key,
+                        package.VulnerablePackageRanges.Select(vr => vr.Vulnerability).ToList());
+                }
+            }
+
+            return !result.Any() ? null :
+                result.ToDictionary(kv => kv.Key, kv => kv.Value as IReadOnlyList<PackageVulnerability>);
+        }
+    }
+}

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -33,6 +33,7 @@ namespace NuGetGallery
         public bool IsDotnetNewTemplatePackageType { get; set; }
         public bool IsAtomFeedEnabled { get; set; }
         public bool IsPackageDeprecationEnabled { get; set; }
+        public bool IsPackageVulnerabilitiesEnabled { get; set; }
         public bool IsPackageRenamesEnabled { get; set; }
         public bool IsGitHubUsageEnabled { get; set; }
         public bool IsPackageDependentsEnabled { get; set; }
@@ -82,6 +83,8 @@ namespace NuGetGallery
         public EmbeddedLicenseFileType EmbeddedLicenseType { get; set; }
 
         public PackageDeprecationStatus DeprecationStatus { get; set; }
+        public IReadOnlyCollection<PackageVulnerability> Vulnerabilities { get; set; }
+        public PackageVulnerabilitySeverity MaxVulnerabilitySeverity { get; set; }
         public string AlternatePackageId { get; set; }
         public string AlternatePackageVersion { get; set; }
         public string CustomMessage { get; set; }

--- a/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
+++ b/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
@@ -103,14 +103,14 @@ namespace VerifyGitHubVulnerabilities.Verify
 
                 var packages = _entitiesContext.Packages
                     .Where(p => p.PackageRegistration.Id == range.PackageId)
-                    .Include(p => p.Vulnerabilities)
+                    .Include(p => p.VulnerablePackageRanges)
                     .ToList();
 
                 var versionRange = VersionRange.Parse(range.PackageVersionRange);
                 foreach (var package in packages)
                 {
                     var version = NuGetVersion.Parse(package.NormalizedVersion);
-                    if (versionRange.Satisfies(version) != package.Vulnerabilities.Contains(existingRange))
+                    if (versionRange.Satisfies(version) != package.VulnerablePackageRanges.Contains(existingRange))
                     {
                         Console.Error.WriteLine(
                             $@"Vulnerability advisory {vulnerability.GitHubDatabaseKey

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Infrastructure\Mail\Messages\SearchSideBySideMessageFacts.cs" />
     <Compile Include="Infrastructure\SearchServiceFactoryFacts.cs" />
     <Compile Include="Services\MarkdownServiceFacts.cs" />
+    <Compile Include="Services\PackageVulnerabilitiesServiceFacts.cs" />
     <Compile Include="Services\PackageMetadataValidationServiceFacts.cs" />
     <Compile Include="Services\ConfigurationIconFileProviderFacts.cs" />
     <Compile Include="Services\AsynchronousDeleteAccountServiceFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesManagementServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesManagementServiceFacts.cs
@@ -63,7 +63,7 @@ namespace NuGetGallery.Services
                 Service.ApplyExistingVulnerabilitiesToPackage(package);
 
                 // Assert
-                Assert.Single(package.Vulnerabilities, satisfiedRange);
+                Assert.Single(package.VulnerablePackageRanges, satisfiedRange);
                 Assert.Single(satisfiedRange.Packages, package);
             }
         }

--- a/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesServiceFacts.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Services.Entities;
+using NuGetGallery.Auditing;
+using NuGetGallery.Framework;
+using Xunit;
+
+namespace NuGetGallery.Services
+{
+    public class PackageVulnerabilitiesServiceFacts : TestContainer
+    {
+        private PackageRegistration _registrationVulnerable;
+
+        private PackageVulnerability _vulnerabilityCritical;
+        private PackageVulnerability _vulnerabilityModerate;
+
+        private VulnerablePackageVersionRange _versionRangeCritical;
+        private VulnerablePackageVersionRange _versionRangeModerate;
+
+        private Package _packageVulnerable100;
+        private Package _packageVulnerable110;
+        private Package _packageVulnerable111;
+        private Package _packageVulnerable112;
+
+        private Package _packageNotVulnerable;
+
+        [Fact]
+        public void GetsVulnerabilitiesOfPackage()
+        {
+            // Arrange
+            SetUp();
+            var packages = new[]
+            {
+                _packageVulnerable100,
+                _packageVulnerable110,
+                _packageVulnerable111,
+                _packageVulnerable112,
+                _packageNotVulnerable
+            };
+            var context = GetFakeContext();
+            context.Packages.AddRange(packages);
+            var target = Get<PackageVulnerabilitiesService>();
+
+            // Act
+            var vulnerableResult = target.GetVulnerabilitiesById("Vulnerable");
+            var notVulnerableResult = target.GetVulnerabilitiesById("NotVulnerable");
+
+            // Assert
+            Assert.Equal(3, vulnerableResult.Count);
+            var vulnerabilitiesFor100 = vulnerableResult[_packageVulnerable100.Key];
+            var vulnerabilitiesFor110 = vulnerableResult[_packageVulnerable110.Key];
+            var vulnerabilitiesFor111 = vulnerableResult[_packageVulnerable111.Key];
+            Assert.Equal(_vulnerabilityModerate, vulnerabilitiesFor100[0]);
+            Assert.Equal(_vulnerabilityModerate, vulnerabilitiesFor110[0]);
+            Assert.Equal(_vulnerabilityModerate, vulnerabilitiesFor111[0]);
+            Assert.Equal(_vulnerabilityCritical, vulnerabilitiesFor111[1]);
+
+            Assert.Null(notVulnerableResult);
+        }
+
+        private void SetUp()
+        {
+            _registrationVulnerable = new PackageRegistration { Id = "Vulnerable" };
+
+            _vulnerabilityCritical = new PackageVulnerability
+            {
+                AdvisoryUrl = "http://theurl/1234",
+                GitHubDatabaseKey = 1234,
+                Severity = PackageVulnerabilitySeverity.Critical
+            };
+            _vulnerabilityModerate = new PackageVulnerability
+            {
+                AdvisoryUrl = "http://theurl/5678",
+                GitHubDatabaseKey = 5678,
+                Severity = PackageVulnerabilitySeverity.Moderate
+            };
+
+            _versionRangeCritical = new VulnerablePackageVersionRange
+            {
+                Vulnerability = _vulnerabilityCritical,
+                PackageVersionRange = "1.1.1",
+                FirstPatchedPackageVersion = "1.1.2"
+            };
+            _versionRangeModerate = new VulnerablePackageVersionRange
+            {
+                Vulnerability = _vulnerabilityModerate,
+                PackageVersionRange = "<=1.1.1",
+                FirstPatchedPackageVersion = "1.1.2"
+            };
+
+            _packageVulnerable100 = new Package
+            {
+                Key = 0,
+                PackageRegistration = _registrationVulnerable,
+                Version = "1.0.0",
+                VulnerablePackageRanges = new List<VulnerablePackageVersionRange>
+                {
+                    _versionRangeModerate
+                }
+            };
+            _packageVulnerable110 = new Package
+            {
+                Key = 1,
+                PackageRegistration = _registrationVulnerable,
+                Version = "1.1.0",
+                VulnerablePackageRanges = new List<VulnerablePackageVersionRange>
+                {
+                    _versionRangeModerate
+                }
+            };
+            _packageVulnerable111 = new Package
+            {
+                Key = 3, // simulate a different order in db - create a non-contiguous range of rows, even if the range is contiguous
+                PackageRegistration = _registrationVulnerable,
+                Version = "1.1.1",
+                VulnerablePackageRanges = new List<VulnerablePackageVersionRange>
+                {
+                    _versionRangeModerate,
+                    _versionRangeCritical
+                }
+            };
+            _packageVulnerable112 = new Package
+            {
+                Key = 2, // simulate a different order in db  - create a non-contiguous range of rows, even if the range is contiguous
+                PackageRegistration = _registrationVulnerable,
+                Version = "1.1.2",
+                VulnerablePackageRanges = null
+            };
+            _packageNotVulnerable = new Package
+            {
+                Key = 4,
+                PackageRegistration = new PackageRegistration { Id = "NotVulnerable" },
+                VulnerablePackageRanges = null
+            };
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -822,6 +822,7 @@ namespace NuGetGallery.ViewModels
             Package package,
             User currentUser = null,
             Dictionary<int, PackageDeprecation> packageKeyToDeprecation = null,
+            Dictionary<int, IReadOnlyList<PackageVulnerability>> packageKeyToVulnerabilities = null,
             IReadOnlyList<PackageRename> packageRenames = null,
             string readmeHtml = null)
         {
@@ -832,6 +833,7 @@ namespace NuGetGallery.ViewModels
                 allVersions,
                 currentUser: currentUser,
                 packageKeyToDeprecation: packageKeyToDeprecation,
+                packageKeyToVulnerabilities: packageKeyToVulnerabilities,
                 packageRenames: packageRenames,
                 readmeResult: new RenderedMarkdownResult { Content = readmeHtml });
         }


### PR DESCRIPTION
Starts to address: https://github.com/nuget/nugetgallery/issues/7650.

PR https://github.com/NuGet/NuGetGallery/pull/8356 must be merged before this one.

Here I introduce the new package vulnerability service. This service's job is simple at this point--return a dictionary of package keys with a list of vulnerabilities for each. Some plumbing is also added to make those values available to view models.

There is also the renaming of an EF navigation property Vulnerabilities to VulnerablePackageRanges, which is more representative.

Again, a few files here, but there's quite a bit of repetition for the rename and plumbing.