### PR TITLE
Add vulnerability messaging to package details page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1038,6 +1038,48 @@ img.reserved-indicator-icon {
 .page-package-details .deprecation-container .deprecation-content-container p:last-of-type {
   margin-bottom: 0px;
 }
+.page-package-details .vulnerabilities-container .vulnerabilities-expander {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  vertical-align: middle;
+  width: 100%;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-expander .vulnerabilities-expander-container {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-expander .vulnerabilities-expander-container .vulnerabilities-expander-icon {
+  position: unset;
+  top: unset;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-expander .vulnerabilities-expander-container .vulnerabilities-expander-info-right {
+  padding-left: 15px;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-content-container {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid lightgray;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-content-container .vulnerabilities-list {
+  border-collapse: unset;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-severity-critical {
+  color: red;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-severity-high {
+  color: red;
+}
+.page-package-details .vulnerabilities-container .vulnerabilities-severity-moderate {
+  color: blue;
+}
 .page-package-details .failed-validation-alert-list {
   margin-top: 15px;
   margin-bottom: 15px;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -63,6 +63,50 @@
     }
   }
 
+  .vulnerabilities-container {
+    .vulnerabilities-expander {
+      display: flex;
+      justify-content: space-between;
+      vertical-align: middle;
+      width: 100%;
+
+      .vulnerabilities-expander-container {
+        display: flex;
+
+        .vulnerabilities-expander-icon {
+          position: unset;
+          top: unset;
+        }
+
+        .vulnerabilities-expander-info-right {
+          padding-left: 15px;
+        }
+      }
+    }
+
+    .vulnerabilities-content-container {
+      margin-top: 15px;
+      padding-top: 15px;
+      border-top: 1px solid lightgray;
+
+      .vulnerabilities-list {
+        border-collapse: unset;
+      }
+    }
+
+    .vulnerabilities-severity-critical {
+      color: red
+    }
+
+    .vulnerabilities-severity-high {
+      color: red
+    }
+
+    .vulnerabilities-severity-moderate {
+      color: blue
+    }
+  }
+
   .failed-validation-alert-list {
     margin-top: 15px;
     margin-bottom: 15px;

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -192,10 +192,17 @@ namespace NuGetGallery
                 viewModel.DeprecationStatus = PackageDeprecationStatus.NotDeprecated;
             }
 
-            if (packageKeyToVulnerabilities != null && packageKeyToVulnerabilities.TryGetValue(package.Key, out var vulnerabilities))
+            if (packageKeyToVulnerabilities != null 
+                && packageKeyToVulnerabilities.TryGetValue(package.Key, out var vulnerabilities)
+                && vulnerabilities != null && vulnerabilities.Any())
             {
                 viewModel.Vulnerabilities = vulnerabilities;
-                viewModel.MaxVulnerabilitySeverity = vulnerabilities.Max(v => v.Severity);
+                viewModel.MaxVulnerabilitySeverity = viewModel.Vulnerabilities.Max(v => v.Severity);
+            }
+            else
+            {
+                viewModel.Vulnerabilities = new List<PackageVulnerability>();
+                viewModel.MaxVulnerabilitySeverity = PackageVulnerabilitySeverity.Low;
             }
 
             return viewModel;

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -193,14 +193,14 @@ namespace NuGetGallery
                 viewModel.DeprecationStatus = PackageDeprecationStatus.NotDeprecated;
             }
 
-            PackageVulnerabilitySeverity? maxSeverity = null;
+            PackageVulnerabilitySeverity? maxVulnerabilitySeverity = null;
             if (packageKeyToVulnerabilities != null 
                 && packageKeyToVulnerabilities.TryGetValue(package.Key, out var vulnerabilities)
                 && vulnerabilities != null && vulnerabilities.Any())
             {
                 viewModel.Vulnerabilities = vulnerabilities;
-                maxSeverity = viewModel.Vulnerabilities.Max(v => v.Severity); // cache for messaging
-                viewModel.MaxVulnerabilitySeverity = maxSeverity.Value;
+                maxVulnerabilitySeverity = viewModel.Vulnerabilities.Max(v => v.Severity); // cache for messaging
+                viewModel.MaxVulnerabilitySeverity = maxVulnerabilitySeverity.Value;
             }
             else
             {
@@ -209,7 +209,7 @@ namespace NuGetGallery
             }
 
             viewModel.PackageWarningIconTitle =
-                GetWarningIconTitle(viewModel.Version, deprecation, maxSeverity);
+                GetWarningIconTitle(viewModel.Version, deprecation, maxVulnerabilitySeverity);
 
             return viewModel;
         }
@@ -217,10 +217,9 @@ namespace NuGetGallery
         private static string GetWarningIconTitle(
             string version, 
             PackageDeprecation deprecation,
-            PackageVulnerabilitySeverity? maxSeverity)
+            PackageVulnerabilitySeverity? maxVulnerabilitySeverity)
         {
             // We want a tooltip title for the warning icon, which concatenates deprecation and vulnerability information cleanly
-
             var deprecationTitle = "";
             if (deprecation != null)
             {
@@ -248,9 +247,9 @@ namespace NuGetGallery
                 }
             }
 
-            if (maxSeverity.HasValue)
+            if (maxVulnerabilitySeverity.HasValue)
             {
-                var severity = Enum.GetName(typeof(PackageVulnerabilitySeverity), maxSeverity)?.ToLowerInvariant() ?? "unknown";
+                var severity = Enum.GetName(typeof(PackageVulnerabilitySeverity), maxVulnerabilitySeverity)?.ToLowerInvariant() ?? "unknown";
                 var vulnerabilitiesTitle = $"{version} has at least one vulnerability with {severity} severity.";
 
                 return string.IsNullOrEmpty(deprecationTitle)

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2305,6 +2305,9 @@
   <ItemGroup>
     <Content Include="App_Data\Files\Content\Query-Hint-Configuration.json" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Packages\_DisplayPackageVulnerabilities.cshtml" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -5,22 +5,36 @@ $(function () {
     window.nuget.configureExpander("rename-content-container", "ChevronDown", null, "ChevronUp");
     configureExpanderWithEnterKeydown($('#show-rename-content-container'));
 
+    // Configure the vulnerability information container
+    var expanderAttributes = ['data-toggle', 'data-target', 'aria-expanded', 'aria-controls', 'tabindex'];
+    var vulnerabilitiesContainer = $('#show-vulnerabilities-content-container');
+    if ($('#vulnerabilities-content-container').children().length) {
+        // If the deprecation information container has content, configure it as an expander.
+        window.nuget.configureExpander("vulnerabilities-content-container", "ChevronDown", null, "ChevronUp");
+        configureExpanderWithEnterKeydown(vulnerabilitiesContainer);
+    } else {
+        // If the container does not have content, remove its expander attributes
+        expanderAttributes.forEach(attribute => vulnerabilitiesContainer.removeAttr(attribute));
+
+        // The expander should not be clickable when it doesn't have content
+        vulnerabilitiesContainer.find('.vulnerabilities-expander').removeAttr('role');
+
+        $('#vulnerabilities-expander-icon-right').hide();
+    }
+
     // Configure the deprecation information container
-    var container = $('#show-deprecation-content-container');
+    var deprecationContainer = $('#show-deprecation-content-container');
     if ($('#deprecation-content-container').children().length) {
         // If the deprecation information container has content, configure it as an expander.
         window.nuget.configureExpander("deprecation-content-container", "ChevronDown", null, "ChevronUp");
-        configureExpanderWithEnterKeydown(container)
+        configureExpanderWithEnterKeydown(deprecationContainer);
     }
     else {
         // If the container does not have content, remove its expander attributes
-        var expanderAttributes = ['data-toggle', 'data-target', 'aria-expanded', 'aria-controls', 'tabindex'];
-        for (var i in expanderAttributes) {
-            container.removeAttr(expanderAttributes[i]);
-        }
+        expanderAttributes.forEach(attribute => deprecationContainer.removeAttr(attribute));
 
         // The expander should not be clickable when it doesn't have content
-        container.find('.deprecation-expander').removeAttr('role');
+        deprecationContainer.find('.deprecation-expander').removeAttr('role');
 
         $('#deprecation-expander-icon-right').hide();
     }

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -4,12 +4,12 @@ $(function () {
     // Configure the rename information container
     window.nuget.configureExpander("rename-content-container", "ChevronDown", null, "ChevronUp");
     configureExpanderWithEnterKeydown($('#show-rename-content-container'));
+    var expanderAttributes = ['data-toggle', 'data-target', 'aria-expanded', 'aria-controls', 'tabindex'];
 
     // Configure the vulnerability information container
-    var expanderAttributes = ['data-toggle', 'data-target', 'aria-expanded', 'aria-controls', 'tabindex'];
     var vulnerabilitiesContainer = $('#show-vulnerabilities-content-container');
     if ($('#vulnerabilities-content-container').children().length) {
-        // If the deprecation information container has content, configure it as an expander.
+        // If the vulnerability information container has content, configure it as an expander.
         window.nuget.configureExpander("vulnerabilities-content-container", "ChevronDown", null, "ChevronUp");
         configureExpanderWithEnterKeydown(vulnerabilitiesContainer);
     } else {

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -87,6 +87,7 @@ namespace NuGetGallery
         public PackageDeprecationStatus DeprecationStatus { get; set; }
         public IReadOnlyCollection<PackageVulnerability> Vulnerabilities { get; set; }
         public PackageVulnerabilitySeverity MaxVulnerabilitySeverity { get; set; }
+        public string PackageWarningIconTitle { get; set; }
         public string AlternatePackageId { get; set; }
         public string AlternatePackageVersion { get; set; }
         public string CustomMessage { get; set; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -283,6 +283,11 @@
                 )
             }
 
+            @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities.Any())
+            {
+                @Html.Partial("_DisplayPackageVulnerabilities")
+            }
+
             @if (Model.IsPackageDeprecationEnabled && Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
             {
                 @Html.Partial("_DisplayPackageDeprecation")
@@ -359,7 +364,7 @@
 
                         @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
                         </text>
-                     )
+                    )
                 }
                 else if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.FailedValidation)
                 {
@@ -404,7 +409,7 @@
                     @ViewHelpers.AlertWarning(
                         @<text>
                             The owner has unlisted this package.
-                            This could mean that the package is deprecated or shouldn't be used anymore.
+                            This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
                         </text>
                     )
                 }
@@ -684,9 +689,9 @@
                             {
                                 <th aria-hidden="true" abbr="Signature Information"></th>
                             }
-                            @if (Model.IsPackageDeprecationEnabled)
+                            @if (Model.IsPackageDeprecationEnabled || Model.IsPackageVulnerabilitiesEnabled)
                             {
-                                <th aria-hidden="true" abbr="Deprecation Information"></th>
+                                <th aria-hidden="true" abbr ="Package Warnings" />
                             }
                         </tr>
                     </thead>
@@ -753,39 +758,55 @@
                                             </td>
                                         }
                                     }
-                                    @if (Model.IsPackageDeprecationEnabled)
+
+                                    @if (Model.IsPackageDeprecationEnabled || Model.IsPackageVulnerabilitiesEnabled)
                                     {
-                                        if (packageVersion.DeprecationStatus == PackageDeprecationStatus.NotDeprecated)
+                                        var deprecationTitle = "";
+                                        var vulnerabilitiesTitle = "";
+
+                                        if (Model.IsPackageDeprecationEnabled && packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
                                         {
-                                            <td class="package-icon-cell" aria-hidden="true"></td>
-                                        }
-                                        else
-                                        {
-                                            var deprecationTitle = packageVersion.Version;
+                                            deprecationTitle = packageVersion.Version;
                                             var isLegacy = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.Legacy);
                                             var hasCriticalBugs = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.CriticalBugs);
                                             if (hasCriticalBugs)
                                             {
                                                 if (isLegacy)
                                                 {
-                                                    deprecationTitle += " is deprecated because it's legacy and has critical bugs.";
+                                                    deprecationTitle += " is deprecated because it's legacy and has critical bugs";
                                                 }
                                                 else
                                                 {
-                                                    deprecationTitle += " is deprecated because it has critical bugs.";
+                                                    deprecationTitle += " is deprecated because it has critical bugs";
                                                 }
                                             }
                                             else if (isLegacy)
                                             {
-                                                deprecationTitle += " is deprecated because it's legacy and no longer maintained.";
+                                                deprecationTitle += " is deprecated because it's legacy and no longer maintained";
                                             }
                                             else
                                             {
-                                                deprecationTitle += " is deprecated.";
+                                                deprecationTitle += " is deprecated";
                                             }
+                                        }
+
+                                        if (Model.IsPackageVulnerabilitiesEnabled && packageVersion.Vulnerabilities.Any())
+                                        {
+                                            var severity = Enum.GetName(typeof(PackageVulnerabilitySeverity), packageVersion.MaxVulnerabilitySeverity).ToLowerInvariant();
+                                            vulnerabilitiesTitle = string.Format("{0} has at least one vulnerability with {1} severity.", packageVersion.Version, severity);
+                                        }
+
+                                        if (deprecationTitle == "" && vulnerabilitiesTitle == "")
+                                        {
+                                            <td class="package-icon-cell" aria-hidden="true" />
+                                        }
+                                        else
+                                        {
+                                            deprecationTitle += deprecationTitle != "" && vulnerabilitiesTitle != "" ? "; " : deprecationTitle != "" ? "." : "";
+                                            var iconTitle = deprecationTitle + vulnerabilitiesTitle;
 
                                             <td class="package-icon-cell">
-                                                <i class="ms-Icon ms-Icon--Warning package-icon" title="@deprecationTitle"></i>
+                                                <i class="ms-Icon ms-Icon--Warning package-icon" title="@iconTitle"></i>
                                             </td>
                                         }
                                     }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -283,7 +283,7 @@
                 )
             }
 
-            @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities.Any())
+            @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities != null)
             {
                 @Html.Partial("_DisplayPackageVulnerabilities")
             }
@@ -691,7 +691,7 @@
                             }
                             @if (Model.IsPackageDeprecationEnabled || Model.IsPackageVulnerabilitiesEnabled)
                             {
-                                <th aria-hidden="true" abbr ="Package Warnings" />
+                                <th aria-hidden="true" abbr="Package Warnings"></th>
                             }
                         </tr>
                     </thead>
@@ -759,56 +759,15 @@
                                         }
                                     }
 
-                                    @if (Model.IsPackageDeprecationEnabled || Model.IsPackageVulnerabilitiesEnabled)
+                                    @if (string.IsNullOrEmpty(packageVersion.PackageWarningIconTitle))
                                     {
-                                        var deprecationTitle = "";
-                                        var vulnerabilitiesTitle = "";
-
-                                        if (Model.IsPackageDeprecationEnabled && packageVersion.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
-                                        {
-                                            deprecationTitle = packageVersion.Version;
-                                            var isLegacy = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.Legacy);
-                                            var hasCriticalBugs = packageVersion.DeprecationStatus.HasFlag(PackageDeprecationStatus.CriticalBugs);
-                                            if (hasCriticalBugs)
-                                            {
-                                                if (isLegacy)
-                                                {
-                                                    deprecationTitle += " is deprecated because it's legacy and has critical bugs";
-                                                }
-                                                else
-                                                {
-                                                    deprecationTitle += " is deprecated because it has critical bugs";
-                                                }
-                                            }
-                                            else if (isLegacy)
-                                            {
-                                                deprecationTitle += " is deprecated because it's legacy and no longer maintained";
-                                            }
-                                            else
-                                            {
-                                                deprecationTitle += " is deprecated";
-                                            }
-                                        }
-
-                                        if (Model.IsPackageVulnerabilitiesEnabled && packageVersion.Vulnerabilities.Any())
-                                        {
-                                            var severity = Enum.GetName(typeof(PackageVulnerabilitySeverity), packageVersion.MaxVulnerabilitySeverity).ToLowerInvariant();
-                                            vulnerabilitiesTitle = string.Format("{0} has at least one vulnerability with {1} severity.", packageVersion.Version, severity);
-                                        }
-
-                                        if (deprecationTitle == "" && vulnerabilitiesTitle == "")
-                                        {
-                                            <td class="package-icon-cell" aria-hidden="true" />
-                                        }
-                                        else
-                                        {
-                                            deprecationTitle += deprecationTitle != "" && vulnerabilitiesTitle != "" ? "; " : deprecationTitle != "" ? "." : "";
-                                            var iconTitle = deprecationTitle + vulnerabilitiesTitle;
-
-                                            <td class="package-icon-cell">
-                                                <i class="ms-Icon ms-Icon--Warning package-icon" title="@iconTitle"></i>
-                                            </td>
-                                        }
+                                        <td class="package-icon-cell" aria-hidden="true" />
+                                    }
+                                    else
+                                    {
+                                        <td class="package-icon-cell">
+                                            <i class="ms-Icon ms-Icon--Warning package-icon" title="@packageVersion.PackageWarningIconTitle"></i>
+                                        </td>
                                     }
                                 </tr>
                             }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -761,7 +761,7 @@
 
                                     @if (string.IsNullOrEmpty(packageVersion.PackageWarningIconTitle))
                                     {
-                                        <td class="package-icon-cell" aria-hidden="true" />
+                                        <td class="package-icon-cell" aria-hidden="true"></td>
                                     }
                                     else
                                     {

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageVulnerabilities.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageVulnerabilities.cshtml
@@ -1,0 +1,54 @@
+﻿@model DisplayPackageViewModel
+
+<div class="vulnerabilities-container">
+    <div class="icon-text alert alert-warning">
+        <div id="show-vulnerabilities-content-container" class="vulnerabilities-expander" tabindex="0" data-toggle="collapse" data-target="#vulnerabilities-content-container" aria-expanded="false" aria-controls="vulnerabilities-content-container" aria-labelledby="vulnerabilities-container-label" role="button">
+            <div class="vulnerabilities-expander" role="button">
+                <div class="vulnerabilities-expander-container">
+                    <i class="vulnerabilities-expander-icon ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
+
+                    <div id="vulnerabilities-container-label" class="vulnerabilities-expander-info-right">
+                        @{
+                            var maxSeverity = Enum.GetName(typeof(PackageVulnerabilitySeverity), Model.MaxVulnerabilitySeverity).ToLowerInvariant();
+                            if (Model.CanDisplayPrivateMetadata)
+                            {
+                                @:This package version has at least one vulnerability with a <span class="vulnerabilities-severity-@maxSeverity">@maxSeverity</span> severity. Please unlist, deprecate, and release a new package with a fix.
+                            }
+                            else
+                            {
+                                @:This package has at least one <b>vulnerability</b> with <b>@maxSeverity</b> severity. It may lead to specific problems in your project. Try updating the package version.
+                            }
+                        }
+                    </div>
+                </div>
+
+                <div class="vulnerabilities-expander-container">
+                    <i id="vulnerabilities-expander-icon-right" class="vulnerabilities-expander-icon vulnerabilities-expander-info-right ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                </div>
+            </div>
+        </div>
+
+        <div class="vulnerabilities-content-container collapse" id="vulnerabilities-content-container">
+            <b>Details</b>
+            <table width="100%" class="vulnerabilities-list">
+                @{
+                    foreach (var vulnerability in Model.Vulnerabilities)
+                    {
+                        var truncatedUrl = vulnerability.AdvisoryUrl;
+                        if (truncatedUrl.Length > 50)
+                        {
+                            truncatedUrl = truncatedUrl.Substring(0, 47) + "...";
+                        }
+
+                        var vulnerabilitySeverity = Enum.GetName(typeof(PackageVulnerabilitySeverity), vulnerability.Severity).ToLowerInvariant();
+
+                        <tr>
+                            <td>Advisory: <a href="@vulnerability.AdvisoryUrl" target="_blank">@truncatedUrl</a></td>
+                            <td>Severity: <span class="vulnerabilities-severity-@vulnerabilitySeverity">@vulnerabilitySeverity</span></td>
+                        </tr>
+                    }
+                }
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageVulnerabilities.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageVulnerabilities.cshtml
@@ -32,20 +32,17 @@
             <b>Details</b>
             <table width="100%" class="vulnerabilities-list">
                 @{
-                    foreach (var vulnerability in Model.Vulnerabilities)
+                    if (Model.Vulnerabilities != null)
                     {
-                        var truncatedUrl = vulnerability.AdvisoryUrl;
-                        if (truncatedUrl.Length > 50)
+                        foreach (var vulnerability in Model.Vulnerabilities)
                         {
-                            truncatedUrl = truncatedUrl.Substring(0, 47) + "...";
+                            var vulnerabilitySeverity = Enum.GetName(typeof(PackageVulnerabilitySeverity), vulnerability.Severity).ToLowerInvariant();
+
+                            <tr>
+                                <td>Advisory: <a href="@vulnerability.AdvisoryUrl" target="_blank">@vulnerability.AdvisoryUrl</a></td>
+                                <td>Severity: <span class="vulnerabilities-severity-@vulnerabilitySeverity">@vulnerabilitySeverity</span></td>
+                            </tr>
                         }
-
-                        var vulnerabilitySeverity = Enum.GetName(typeof(PackageVulnerabilitySeverity), vulnerability.Severity).ToLowerInvariant();
-
-                        <tr>
-                            <td>Advisory: <a href="@vulnerability.AdvisoryUrl" target="_blank">@truncatedUrl</a></td>
-                            <td>Severity: <span class="vulnerabilities-severity-@vulnerabilitySeverity">@vulnerabilitySeverity</span></td>
-                        </tr>
                     }
                 }
             </table>

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -463,8 +463,6 @@ namespace NuGetGallery
                 // Arrange
                 var id = "Test" + Guid.NewGuid().ToString();
                 var packageService = new Mock<IPackageService>();
-                var deprecationService = new Mock<IPackageDeprecationService>();
-                var vulnerabilitiesService = new Mock<IPackageVulnerabilitiesService>();
                 var diagnosticsService = new Mock<IDiagnosticsService>();
                 var searchClient = new Mock<ISearchClient>();
                 var searchService = new Mock<ExternalSearchService>(diagnosticsService.Object, searchClient.Object)
@@ -476,21 +474,9 @@ namespace NuGetGallery
                 var controller = CreateController(
                     GetConfigurationService(),
                     packageService: packageService,
-                    deprecationService: deprecationService,
-                    vulnerabilitiesService: vulnerabilitiesService,
                     searchService: searchService.As<ISearchService>(),
                     httpContext: httpContext);
                 controller.SetCurrentUser(TestUtility.FakeUser);
-
-                deprecationService
-                    .Setup(x => x.GetDeprecationsById(id))
-                    .Returns(new List<PackageDeprecation>())
-                    .Verifiable();
-
-                vulnerabilitiesService
-                    .Setup(x => x.GetVulnerabilitiesById(id))
-                    .Returns(new Dictionary<int, IReadOnlyList<PackageVulnerability>>())
-                    .Verifiable();
 
                 searchService
                     .Setup(x => x.RawSearch(It.IsAny<SearchFilter>()))
@@ -524,8 +510,6 @@ namespace NuGetGallery
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Equal(id, model.Id);
                 searchService.Verify(x => x.RawSearch(It.IsAny<SearchFilter>()), Times.Exactly(searchTimes));
-                deprecationService.Verify();
-                vulnerabilitiesService.Verify();
             }
 
             [Fact]
@@ -818,7 +802,6 @@ namespace NuGetGallery
             {
                 // Arrange
                 var packageService = new Mock<IPackageService>();
-                var deprecationService = new Mock<IPackageDeprecationService>();
                 var indexingService = new Mock<IIndexingService>();
                 var httpContext = new Mock<HttpContextBase>();
                 var httpCachePolicy = new Mock<HttpCachePolicyBase>();
@@ -826,8 +809,7 @@ namespace NuGetGallery
                     GetConfigurationService(),
                     packageService: packageService,
                     indexingService: indexingService,
-                    httpContext: httpContext,
-                    deprecationService: deprecationService);
+                    httpContext: httpContext);
                 controller.SetCurrentUser(currentUser);
                 httpContext.Setup(c => c.Response.Cache).Returns(httpCachePolicy.Object);
                 var title = "A test package!";
@@ -854,11 +836,6 @@ namespace NuGetGallery
                     .Setup(p => p.FilterExactPackage(packages, normalizedVersion))
                     .Returns(package);
 
-                deprecationService
-                    .Setup(x => x.GetDeprecationsById(id))
-                    .Returns(new List<PackageDeprecation>())
-                    .Verifiable();
-
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
 
                 // Act
@@ -868,8 +845,6 @@ namespace NuGetGallery
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Equal("Foo", model.Id);
                 Assert.Equal("1.1.1", model.Version);
-
-                deprecationService.Verify();
             }
 
             [Fact]
@@ -878,12 +853,10 @@ namespace NuGetGallery
                 // Arrange
                 var packageService = new Mock<IPackageService>();
                 var indexingService = new Mock<IIndexingService>();
-                var deprecationService = new Mock<IPackageDeprecationService>();
                 var controller = CreateController(
                     GetConfigurationService(),
                     packageService: packageService,
-                    indexingService: indexingService,
-                    deprecationService: deprecationService);
+                    indexingService: indexingService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
 
                 var id = "Foo";
@@ -930,11 +903,6 @@ namespace NuGetGallery
                     .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
                     .Returns(new[] { notLatestPackage, latestPackage, latestButNotPackage });
 
-                deprecationService
-                    .Setup(x => x.GetDeprecationsById(id))
-                    .Returns(new List<PackageDeprecation>())
-                    .Verifiable();
-
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
 
                 // Act
@@ -948,8 +916,6 @@ namespace NuGetGallery
                 Assert.Equal(latestPackage.NormalizedVersion, model.Version);
                 Assert.True(model.LatestVersionSemVer2);
                 Assert.False(model.VersionRequestedWasNotFound);
-
-                deprecationService.Verify();
             }
 
             [Fact]
@@ -958,12 +924,10 @@ namespace NuGetGallery
                 // Arrange
                 var packageService = new Mock<IPackageService>();
                 var indexingService = new Mock<IIndexingService>();
-                var deprecationService = new Mock<IPackageDeprecationService>();
                 var controller = CreateController(
                     GetConfigurationService(),
                     packageService: packageService,
-                    indexingService: indexingService,
-                    deprecationService: deprecationService);
+                    indexingService: indexingService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
 
                 var id = "Foo";
@@ -988,11 +952,6 @@ namespace NuGetGallery
                     .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
                     .Returns(notLatestPackage);
 
-                deprecationService
-                    .Setup(x => x.GetDeprecationsById(id))
-                    .Returns(new List<PackageDeprecation>())
-                    .Verifiable();
-
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
 
                 // Act
@@ -1004,8 +963,6 @@ namespace NuGetGallery
                 Assert.Equal(id, model.Id);
                 Assert.Equal(notLatestPackage.NormalizedVersion, model.Version);
                 Assert.False(model.LatestVersionSemVer2);
-
-                deprecationService.Verify();
             }
 
             [Fact]
@@ -1014,12 +971,10 @@ namespace NuGetGallery
                 // Arrange
                 var packageService = new Mock<IPackageService>();
                 var indexingService = new Mock<IIndexingService>();
-                var deprecationService = new Mock<IPackageDeprecationService>();
                 var controller = CreateController(
                     GetConfigurationService(),
                     packageService: packageService,
-                    indexingService: indexingService,
-                    deprecationService: deprecationService);
+                    indexingService: indexingService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
 
                 var package = new Package()
@@ -1043,11 +998,6 @@ namespace NuGetGallery
                     .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
                     .Returns(package);
 
-                deprecationService
-                    .Setup(x => x.GetDeprecationsById("Foo"))
-                    .Returns(new List<PackageDeprecation>())
-                    .Verifiable();
-
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
 
                 // Act
@@ -1058,8 +1008,6 @@ namespace NuGetGallery
                 Assert.Equal("Foo", model.Id);
                 Assert.Equal("1.1.1", model.Version);
                 Assert.Null(model.ReadMeHtml);
-
-                deprecationService.Verify();
             }
 
             [Fact]
@@ -1118,14 +1066,12 @@ namespace NuGetGallery
             {
                 var packageService = new Mock<IPackageService>();
                 var indexingService = new Mock<IIndexingService>();
-                var deprecationService = new Mock<IPackageDeprecationService>();
                 var fileService = new Mock<IPackageFileService>();
                 var controller = CreateController(
                     GetConfigurationService(),
                     packageService: packageService,
                     indexingService: indexingService,
-                    packageFileService: fileService,
-                    deprecationService: deprecationService);
+                    packageFileService: fileService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
 
                 var id = "Foo";
@@ -1151,11 +1097,6 @@ namespace NuGetGallery
                     .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
                     .Returns(package);
 
-                deprecationService
-                    .Setup(x => x.GetDeprecationsById(id))
-                    .Returns(new List<PackageDeprecation>())
-                    .Verifiable();
-
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
 
                 if (hasReadMe)
@@ -1163,11 +1104,7 @@ namespace NuGetGallery
                     fileService.Setup(f => f.DownloadReadMeMdFileAsync(It.IsAny<Package>())).Returns(Task.FromResult(readMeHtml));
                 }
 
-                var result = await controller.DisplayPackage(id, /*version*/null);
-
-                deprecationService.Verify();
-
-                return result;
+                return await controller.DisplayPackage(id, /*version*/null);
             }
 
             [Fact]
@@ -1175,7 +1112,6 @@ namespace NuGetGallery
             {
                 // Arrange
                 var packageService = new Mock<IPackageService>();
-                var deprecationService = new Mock<IPackageDeprecationService>();
                 var indexingService = new Mock<IIndexingService>();
                 var fileService = new Mock<IPackageFileService>();
                 var validationService = new Mock<IValidationService>();
@@ -1185,8 +1121,7 @@ namespace NuGetGallery
                     packageService: packageService,
                     indexingService: indexingService,
                     packageFileService: fileService,
-                    validationService: validationService,
-                    deprecationService: deprecationService);
+                    validationService: validationService);
                 controller.SetCurrentUser(TestUtility.FakeUser);
 
                 var package = new Package()
@@ -1208,11 +1143,6 @@ namespace NuGetGallery
                 packageService.Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
                     .Returns(package);
 
-                deprecationService
-                    .Setup(x => x.GetDeprecationsById("Foo"))
-                    .Returns(new List<PackageDeprecation>())
-                    .Verifiable();
-
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
 
                 var expectedIssues = new[]
@@ -1231,8 +1161,6 @@ namespace NuGetGallery
                 // Assert
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Equal(model.PackageValidationIssues, expectedIssues);
-
-                deprecationService.Verify();
             }
 
             [Theory]
@@ -1278,8 +1206,7 @@ namespace NuGetGallery
 
                 deprecationService
                     .Setup(x => x.GetDeprecationsById(id))
-                    .Returns(new List<PackageDeprecation>())
-                    .Verifiable();
+                    .Returns(new List<PackageDeprecation>());
 
                 // Arrange and Act
                 var result = await controller.DisplayPackage(id, version: null);
@@ -1287,8 +1214,6 @@ namespace NuGetGallery
                 // Assert
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Equal(isAtomFeedEnabled, model.IsAtomFeedEnabled);
-
-                deprecationService.Verify();
             }
 
             [Theory]
@@ -1343,7 +1268,10 @@ namespace NuGetGallery
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Equal(isDeprecationEnabled, model.IsPackageDeprecationEnabled);
 
-                deprecationService.Verify();
+                if (isDeprecationEnabled)
+                {
+                    deprecationService.Verify();
+                }
             }
 
             [Theory]
@@ -1399,7 +1327,10 @@ namespace NuGetGallery
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Equal(isDeprecationEnabled, model.IsPackageDeprecationEnabled);
 
-                deprecationService.Verify();
+                if (isDeprecationEnabled)
+                {
+                    deprecationService.Verify();
+                }
             }
 
             [Fact]
@@ -1473,6 +1404,225 @@ namespace NuGetGallery
                 Assert.Equal("Hello", model.CustomMessage);
 
                 deprecationService.Verify();
+            }
+
+            [Theory]
+            [InlineData(PackageDeprecationStatus.NotDeprecated, PackageDeprecationStatus.NotDeprecated, "")]
+            [InlineData(PackageDeprecationStatus.CriticalBugs, PackageDeprecationStatus.NotDeprecated, 
+                "{0} is deprecated because it has critical bugs.")]
+            [InlineData(PackageDeprecationStatus.Legacy, PackageDeprecationStatus.NotDeprecated, 
+                "{0} is deprecated because it's legacy and no longer maintained.")]
+            [InlineData(PackageDeprecationStatus.Legacy, PackageDeprecationStatus.CriticalBugs, 
+                "{0} is deprecated because it's legacy and has critical bugs.")]
+            [InlineData(PackageDeprecationStatus.Other, PackageDeprecationStatus.NotDeprecated, "{0} is deprecated.")]
+            public async Task ShowsCorrectDeprecationIconTitle(
+                PackageDeprecationStatus deprecationStatus,
+                PackageDeprecationStatus deprecationStatusSecondFlag,
+                string expectedIconTitle)
+            {
+                deprecationStatus |= deprecationStatusSecondFlag; // this is to address a bug in xunit, where or'ing in the inlinedata returns 0
+
+                var featureFlagService = new Mock<IFeatureFlagService>();
+                var packageService = new Mock<IPackageService>();
+                var deprecationService = new Mock<IPackageDeprecationService>();
+                var vulnerabilitiesService = new Mock<IPackageVulnerabilitiesService>();
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService,
+                    featureFlagService: featureFlagService,
+                    deprecationService: deprecationService,
+                    vulnerabilitiesService: vulnerabilitiesService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var id = "Foo";
+                var version = "1.1.1";
+                var package = new Package()
+                {
+                    Key = 1,
+                    PackageRegistration = new PackageRegistration()
+                    {
+                        Id = id,
+                        Owners = new List<User>()
+                    },
+                    Version = "01.1.01",
+                    NormalizedVersion = version,
+                    Title = "A test package!"
+                };
+
+                List<PackageDeprecation> deprecations = default;
+                if (deprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                {
+                    var deprecation = new PackageDeprecation
+                    {
+                        PackageKey = 1,
+                        Status = deprecationStatus
+                    };
+
+                    deprecations = new List<PackageDeprecation> {deprecation};
+
+                }
+                else
+                {
+                    deprecations = new List<PackageDeprecation>();
+                }
+
+                package.Deprecations = deprecations;
+
+
+                var packages = new[] { package };
+                packageService
+                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Returns(packages);
+
+                packageService
+                    .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
+                    .Returns(package);
+
+                featureFlagService
+                    .Setup(x => x.IsManageDeprecationEnabled(TestUtility.FakeUser, packages))
+                    .Returns(true);
+
+                featureFlagService
+                    .Setup(x => x.IsDisplayVulnerabilitiesEnabled())
+                    .Returns(false);
+
+                deprecationService
+                    .Setup(x => x.GetDeprecationsById(id))
+                    .Returns(deprecations)
+                    .Verifiable();
+
+                // Arrange and Act
+                var result = await controller.DisplayPackage(id, version: null);
+
+                // Assert
+                var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
+                Assert.Equal(string.Format(expectedIconTitle, version), model.PackageWarningIconTitle);
+
+                deprecationService.Verify();
+            }
+
+            [Theory]
+            [InlineData(false, false, "")]
+            [InlineData(true, false, "{0} is deprecated because it's legacy and no longer maintained.")]
+            [InlineData(false, true, "{0} has at least one vulnerability with {1} severity.")]
+            [InlineData(true, true, "{0} is deprecated because it's legacy and no longer maintained; {0} has at least one vulnerability with {1} severity.")]
+            public async Task ShowsCombinedDeprecationAndVulnerabilitiesIconTitle(
+                bool isDeprecationEnabled,
+                bool isVulnerabilitiesEnabled,
+                string expectedIconTitle)
+            {
+                var featureFlagService = new Mock<IFeatureFlagService>();
+                var packageService = new Mock<IPackageService>();
+                var deprecationService = new Mock<IPackageDeprecationService>();
+                var vulnerabilitiesService = new Mock<IPackageVulnerabilitiesService>();
+                var controller = CreateController(
+                    GetConfigurationService(),
+                    packageService: packageService,
+                    featureFlagService: featureFlagService,
+                    deprecationService: deprecationService,
+                    vulnerabilitiesService: vulnerabilitiesService);
+                controller.SetCurrentUser(TestUtility.FakeUser);
+
+                var id = "Foo";
+                var vulnerabilityModerate = new PackageVulnerability
+                {
+                    AdvisoryUrl = "https://theurl/advisory01",
+                    GitHubDatabaseKey = 1,
+                    Severity = PackageVulnerabilitySeverity.Moderate
+                };
+                var vulnerabilityLow = new PackageVulnerability
+                {
+                    AdvisoryUrl = "https://theurl/advisory05",
+                    GitHubDatabaseKey = 5,
+                    Severity = PackageVulnerabilitySeverity.Low
+                };
+                var version = "1.1.1";
+
+                var deprecation = new PackageDeprecation
+                {
+                    PackageKey = 1,
+                    Status = PackageDeprecationStatus.Legacy
+                };
+
+                var package = new Package()
+                {
+                    Key = 1,
+                    PackageRegistration = new PackageRegistration()
+                    {
+                        Id = id,
+                        Owners = new List<User>()
+                    },
+                    VulnerablePackageRanges = new List<VulnerablePackageVersionRange>
+                    {
+                        new VulnerablePackageVersionRange
+                        {
+                            PackageVersionRange = "1.1.1",
+                            FirstPatchedPackageVersion = "1.1.2",
+                            PackageId = id,
+                            Vulnerability = vulnerabilityModerate
+                        },
+                        new VulnerablePackageVersionRange
+                        {
+                            PackageVersionRange = "<=1.1.1",
+                            FirstPatchedPackageVersion = "1.1.2",
+                            PackageId = id,
+                            Vulnerability = vulnerabilityLow
+                        }
+                    },
+                    Deprecations = new List<PackageDeprecation> { deprecation },
+                    Version = "01.1.01",
+                    NormalizedVersion = version,
+                    Title = "A test package!"
+                };
+
+                var packages = new[] { package };
+                packageService
+                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Returns(packages);
+
+                packageService
+                    .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
+                    .Returns(package);
+
+                featureFlagService
+                    .Setup(x => x.IsManageDeprecationEnabled(TestUtility.FakeUser, packages))
+                    .Returns(isDeprecationEnabled);
+
+                featureFlagService
+                    .Setup(x => x.IsDisplayVulnerabilitiesEnabled())
+                    .Returns(isVulnerabilitiesEnabled);
+
+                deprecationService
+                    .Setup(x => x.GetDeprecationsById(id))
+                    .Returns(new List<PackageDeprecation> { deprecation })
+                    .Verifiable();
+
+                vulnerabilitiesService
+                    .Setup(x => x.GetVulnerabilitiesById(id))
+                    .Returns(new Dictionary<int, IReadOnlyList<PackageVulnerability>>
+                    {
+                        { 1, new List<PackageVulnerability> { vulnerabilityModerate, vulnerabilityLow } }
+                    })
+                    .Verifiable();
+
+                // Arrange and Act
+                var result = await controller.DisplayPackage(id, version: null);
+
+                // Assert
+                var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
+                Assert.Equal(isDeprecationEnabled, model.IsPackageDeprecationEnabled);
+                Assert.Equal(isVulnerabilitiesEnabled, model.IsPackageVulnerabilitiesEnabled);
+                Assert.Equal(string.Format(expectedIconTitle, version, "moderate"), model.PackageWarningIconTitle);
+
+                if (isDeprecationEnabled)
+                {
+                    deprecationService.Verify();
+                }
+
+                if (isVulnerabilitiesEnabled)
+                {
+                    vulnerabilitiesService.Verify();
+                }
             }
 
             [Theory]
@@ -1555,7 +1705,6 @@ namespace NuGetGallery
                 var splitterMock = new Mock<ILicenseExpressionSplitter>();
                 var packageService = new Mock<IPackageService>();
                 var indexingService = new Mock<IIndexingService>();
-                var deprecationService = new Mock<IPackageDeprecationService>();
 
                 var segments = new List<CompositeLicenseExpressionSegment>();
                 splitterMock
@@ -1585,19 +1734,13 @@ namespace NuGetGallery
                     .Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
                     .Returns(package);
 
-                deprecationService
-                    .Setup(x => x.GetDeprecationsById(id))
-                    .Returns(new List<PackageDeprecation>())
-                    .Verifiable();
-
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
 
                 var controller = CreateController(
                     GetConfigurationService(),
                     packageService: packageService,
                     indexingService: indexingService,
-                    licenseExpressionSplitter: splitterMock,
-                    deprecationService: deprecationService);
+                    licenseExpressionSplitter: splitterMock);
 
                 var result = await controller.DisplayPackage(id, version: null);
 
@@ -1605,8 +1748,6 @@ namespace NuGetGallery
                     .Verify(les => les.SplitExpression(expression), Times.Once);
                 splitterMock
                     .Verify(les => les.SplitExpression(It.IsAny<string>()), Times.Once);
-
-                deprecationService.Verify();
 
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
                 Assert.Same(segments, model.LicenseExpressionSegments);


### PR DESCRIPTION
Completes: https://github.com/nuget/nugetgallery/issues/7650

Here we change the view to include a vulnerabilities panel for an affected package version.

Non-owner view, not expanded:
![image](https://user-images.githubusercontent.com/14225979/102730979-41949c80-4382-11eb-809e-7bea5218892e.png)

Owner view, expanded:
![image](https://user-images.githubusercontent.com/14225979/102730999-4d805e80-4382-11eb-8b5b-f5a09f86f3cc.png)

- bangs and tooltips in the version list (combined for deprecations and vulnerabilities). Again, formats and icons may be tweaked going forward. 

Vulnerability only:
![image](https://user-images.githubusercontent.com/14225979/102547237-a4790000-4104-11eb-9ec6-bfbbf3a801a8.png)

Vulnerability + deprecation:
![image](https://user-images.githubusercontent.com/14225979/102547326-c4102880-4104-11eb-8bc4-85e2c16eea40.png)
