### PR TITLE
update term used for .NET tools

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -34,7 +34,7 @@
                 CommandPrefix = "> ",
                 InstallPackageCommand = string.Format("dotnet tool install --global {0} --version {1}", Model.Id, Model.Version),
                 AlertLevel = AlertLevel.Info,
-                AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET Core Global Tool</a> you can call from the shell/command line.",
+                AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET tool</a> you can call from the shell/command line.",
             }
         };
     }


### PR DESCRIPTION
As per the [linked document](https://aka.ms/global-tools), these are now referred to as ".NET tools" —

> How to manage .NET tools
> 
> A .NET tool is a special NuGet package that contains a console application.
