### PR TITLE
Show vulnerability alerts on manage packages page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1618,6 +1618,17 @@ img.reserved-indicator-icon {
 .page-manage-packages .inner-table {
   margin-bottom: 0px;
 }
+.page-manage-packages .inner-table .package-icon-cell {
+  cursor: default;
+  padding-left: 0;
+  padding-right: 0;
+  text-align: right;
+}
+.page-manage-packages .inner-table .package-icon-cell .package-icon {
+  padding-left: 6px;
+  padding-right: 6px;
+  padding-top: 6px;
+}
 .page-manage-packages .required-signer {
   width: 100%;
   max-width: 90%;

--- a/src/Bootstrap/less/theme/page-manage-packages.less
+++ b/src/Bootstrap/less/theme/page-manage-packages.less
@@ -60,6 +60,19 @@
 
   .inner-table {
     margin-bottom: 0px;
+
+    .package-icon-cell {
+      cursor: default;
+      padding-left: 0;
+      padding-right: 0;
+      text-align: right;
+
+      .package-icon {
+        padding-left: 6px;
+        padding-right: 6px;
+        padding-top: 6px;
+      }
+    }
   }
 
   .required-signer {

--- a/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
+++ b/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
@@ -365,5 +365,10 @@ namespace GitHubVulnerabilities2Db.Gallery
         {
             throw new NotImplementedException();
         }
+
+        public void TrackManagePackagesQueryPerformance(long milliseconds, int packageIdCount)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -402,5 +402,15 @@ namespace NuGetGallery
             bool isAuthenticated,
             int testBucket,
             int testPercentage);
+
+        /// <summary>
+        /// Track query and viewmodel setup time for manage packages page.
+        /// </summary>
+        /// <param name="milliseconds">How long the queries and transforms took</param>
+        /// <param name="packageIdCount">The number of unique package ids represented on page</param>
+        void TrackManagePackagesQueryPerformance(
+            long milliseconds, 
+            int packageIdCount
+        );
     }
 }

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Principal;
 using System.Web;
+using Microsoft.Owin.Security.MicrosoftAccount;
 using Newtonsoft.Json;
 using NuGet.Services.Entities;
 using NuGet.Services.FeatureFlags;
@@ -89,6 +90,7 @@ namespace NuGetGallery
             public const string ABTestEvaluated = "ABTestEvaluated";
             public const string PackagePushDisconnect = "PackagePushDisconnect";
             public const string SymbolPackagePushDisconnect = "SymbolPackagePushDisconnect";
+            public const string ManagePackagesQueryPerformance = "ManagePackagesQueryPerformance";
         }
 
         private readonly IDiagnosticsSource _diagnosticsSource;
@@ -224,6 +226,9 @@ namespace NuGetGallery
         public const string IsActive = "IsActive";
         public const string TestBucket = "TestBucket";
         public const string TestPercentage = "TestPercentage";
+
+        // Manage package query performance properties
+        public const string PackageIdCount = "PackageIdCount";
 
         public TelemetryService(IDiagnosticsSource diagnosticsSource, ITelemetryClient telemetryClient)
         {
@@ -1083,6 +1088,14 @@ namespace NuGetGallery
                 properties.Add(IsAuthenticated, isAuthenticated.ToString());
                 properties.Add(TestBucket, testBucket.ToString());
                 properties.Add(TestPercentage, testPercentage.ToString());
+            });
+        }
+
+        public void TrackManagePackagesQueryPerformance(long milliseconds, int packageIdCount)
+        {
+            TrackMetric(Events.ManagePackagesQueryPerformance, milliseconds, properties =>
+            {
+                properties.Add(PackageIdCount, packageIdCount.ToString());
             });
         }
 

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -512,6 +513,8 @@ namespace NuGetGallery
         [UIAuthorize]
         public virtual ActionResult Packages()
         {
+            var stopwatch = Stopwatch.StartNew();
+
             var currentUser = GetCurrentUser();
 
             var owners = new List<ListPackageOwnerViewModel> {
@@ -568,6 +571,9 @@ namespace NuGetGallery
                 IsPackageVulnerabilitiesEnabled = _featureFlagService.IsDisplayVulnerabilitiesEnabled()
             };
 
+            stopwatch.Stop();
+            TelemetryService.TrackManagePackagesQueryPerformance(stopwatch.ElapsedMilliseconds, (listedPackages?.Count ?? 0) + unlistedPackages?.Count ?? 0);
+            
             return View(model);
         }
 

--- a/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-packages.js
@@ -35,6 +35,7 @@
             this.ShowRequiredSigner = packageItem.ShowRequiredSigner;
             this.ShowTextBox = packageItem.ShowTextBox;
             this.CanEditRequiredSigner = packageItem.CanEditRequiredSigner;
+            this.IsVulnerable = packageItem.IsVulnerable;
             this.CanEdit = packageItem.CanEdit;
             this.CanManageOwners = packageItem.CanManageOwners;
             this.CanDelete = packageItem.CanDelete;

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -116,10 +116,14 @@
                         <th class="sortable">Owners</th>
                     @if (Model.IsCertificatesUIEnabled)
                     {
-                        <th  class="sortable">Signing Owner</th>
+                        <th class="sortable">Signing Owner</th>
                     }
-                        <th  class="sortable">Downloads</th>
-                        <th  class="sortable">Latest Version</th>
+                        <th class="sortable">Downloads</th>
+                        <th class="sortable">Latest Version</th>
+                    @if (Model.IsPackageVulnerabilitiesEnabled)
+                    {
+                        <th><span class="hidden">Package warnings</span></th>
+                    }
                         <th><span class="hidden">Icon</span></th>
                     </tr>
                 </thead>
@@ -171,6 +175,12 @@
                         <td class="align-middle text-nowrap" data-bind="attr: { 'data-sortby': VersionSortOrder }">
                             <span data-bind="text: LatestVersion"></span>
                         </td>
+                    @if (Model.IsPackageVulnerabilitiesEnabled)
+                    {
+                        <td class="package-icon-cell">
+                            <i class="ms-Icon ms-Icon--Warning package-icon" data-bind="visible: IsVulnerable" title="This package has at least one known vulnerability. Details on package details page."></i>
+                        </td>
+                    }
                         <td class="text-right align-middle package-controls">
                             <span data-bind="visible: CanEdit || CanManageOwners || CanDelete">
                                 <a class="btn" title="Manage Package" data-bind="attr: { href: ManageUrl,
@@ -353,7 +363,8 @@
             p.CanEditRequiredSigner,
             p.ShowRequiredSigner,
             p.ShowTextBox,
-            p.VersionSortOrder
+            p.VersionSortOrder,
+            p.IsVulnerable
         };
     }
 

--- a/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
@@ -367,5 +367,10 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         {
             throw new NotImplementedException();
         }
+
+        public void TrackManagePackagesQueryPerformance(long milliseconds, int packageIdCount)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -339,6 +339,10 @@ namespace NuGetGallery
                     yield return new object[] { "SymbolPackagePushDisconnect",
                         (TrackAction)(s => s.TrackSymbolPackagePushDisconnectEvent())
                     };
+
+                    yield return new object[] { "ManagePackagesQueryPerformance",
+                        (TrackAction)(s => s.TrackManagePackagesQueryPerformance(1, 1))
+                    };
                 }
             }
 


### PR DESCRIPTION
Note: this PR must be merged first: https://github.com/NuGet/NuGetGallery/pull/8362

Addresses remainder of https://github.com/NuGet/NuGetGallery/issues/8361

This change decorates all packages, of which any version is vulnerable, in the manage packages view with a bang and tooltip indicating to go to the details page. This applies to listed and unlisted groups of packages.

![image](https://user-images.githubusercontent.com/14225979/102944030-59e0f480-4505-11eb-8798-915d27807607.png)