### PR TITLE
[HOTFIX] Fix functional tests by reducing number of pushed duplicate packages

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
@@ -35,7 +35,9 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
             // Arrange
             var packageId = $"{nameof(DuplicatePushesAreRejectedAndNotDeleted)}.{Guid.NewGuid():N}";
 
-            int pushVersionCount = 10;
+            // TODO: Increase this back to 10.
+            // See: https://github.com/NuGet/NuGetGallery/issues/8368
+            int pushVersionCount = 1;
             var duplicatePushTasks = new List<Task>();
             for (var duplicateTaskIndex = 0; duplicateTaskIndex < pushVersionCount; duplicateTaskIndex++)
             {


### PR DESCRIPTION
Functional tests on PROD are currently failing repeatedly:

* https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=77508&view=results
* https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=77522&view=results
* https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=77526&view=results

The duplicate package push functional test pushes 160 packages in parallel. This is causing SQL timeouts. To unblock functional tests, we will temporarily reduce the number of duplicated packages we push to just 16. As part of https://github.com/NuGet/NuGetGallery/issues/8368, we will improve the SQL query used to push packages and revert this change.

Part of https://github.com/NuGet/NuGetGallery/issues/8368