### PR TITLE
Optimize the push package API

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
+using NuGet.Versioning;
 using NuGetGallery.Packaging;
 
 namespace NuGetGallery
@@ -155,5 +156,13 @@ namespace NuGetGallery
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="registration" />
         /// is <c>null</c>.</exception>
         Task SetRequiredSignerAsync(PackageRegistration registration, User signer, bool commitChanges = true);
+
+        /// <summary>
+        /// Get a package's status, or <c>null</c> if the package does not exist.
+        /// </summary>
+        /// <param name="packageId">The package's ID.</param>
+        /// <param name="packageVersion">The package's version.</param>
+        /// <returns>The package's status, or <c>null</c> is the package does not exist.</returns>
+        PackageStatus? GetPackageStatus(string packageId, NuGetVersion packageVersion);
     }
 }

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -950,11 +950,14 @@ namespace NuGetGallery
         {
             var normalizedVersion = packageVersion.ToNormalizedString();
 
+            // Note the casting to a nullable enum in the "Select". This is required to
+            // return "null" if there are no rows. Otherwise, "FirstOrDefault" would return
+            // "PackageStatus.Available" as the default value.
             return _packageRepository
                 .GetAll()
                 .Where(p => p.PackageRegistration.Id == packageId)
                 .Where(p => p.Version == normalizedVersion)
-                .Select(p => p.PackageStatusKey)
+                .Select(p => (PackageStatus?)p.PackageStatusKey)
                 .FirstOrDefault();
         }
     }

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -945,5 +945,17 @@ namespace NuGetGallery
                 _telemetryService.TrackRequiredSignerSet(registration.Id);
             }
         }
+
+        public PackageStatus? GetPackageStatus(string packageId, NuGetVersion packageVersion)
+        {
+            var normalizedVersion = packageVersion.ToNormalizedString();
+
+            return _packageRepository
+                .GetAll()
+                .Where(p => p.PackageRegistration.Id == packageId)
+                .Where(p => p.Version == normalizedVersion)
+                .Select(p => p.PackageStatusKey)
+                .FirstOrDefault();
+        }
     }
 }

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -658,12 +658,14 @@ namespace NuGetGallery
                                 }
 
                                 // A package can only be reuploaded if it never passed validation.
-                                // We try to avoid loading the package's full entity as it is expensive.
                                 var existingStatus = PackageService.GetPackageStatus(id, version);
                                 if (existingStatus != null)
                                 {
                                     if (existingStatus == PackageStatus.FailedValidation)
                                     {
+                                        // Allow this new upload to replace the existing package.
+                                        // We avoided loading the full package entity until now as it is
+                                        // a relatively expensive operation and this path is uncommon.
                                         var existingPackage = PackageService.FindPackageByIdAndVersionStrict(id, version.ToStringSafe());
 
                                         TelemetryService.TrackPackageReupload(existingPackage);

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -657,6 +657,8 @@ namespace NuGetGallery
                                         string.Format(CultureInfo.CurrentCulture, Strings.PackageIsLocked, packageRegistration.Id));
                                 }
 
+                                // A package can only be reuploaded if it never passed validation.
+                                // We try to avoid loading the package's full entity as it is expensive.
                                 var existingStatus = PackageService.GetPackageStatus(id, version);
                                 if (existingStatus != null)
                                 {

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -657,11 +657,13 @@ namespace NuGetGallery
                                         string.Format(CultureInfo.CurrentCulture, Strings.PackageIsLocked, packageRegistration.Id));
                                 }
 
-                                var existingPackage = PackageService.FindPackageByIdAndVersionStrict(id, version.ToStringSafe());
-                                if (existingPackage != null)
+                                var existingStatus = PackageService.GetPackageStatus(id, version);
+                                if (existingStatus != null)
                                 {
-                                    if (existingPackage.PackageStatusKey == PackageStatus.FailedValidation)
+                                    if (existingStatus == PackageStatus.FailedValidation)
                                     {
+                                        var existingPackage = PackageService.FindPackageByIdAndVersionStrict(id, version.ToStringSafe());
+
                                         TelemetryService.TrackPackageReupload(existingPackage);
 
                                         await PackageDeleteService.HardDeletePackagesAsync(

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -850,7 +850,13 @@ namespace NuGetGallery
                 var controller = new TestableApiController(GetConfigurationService());
                 controller.SetCurrentUser(new User() { EmailAddress = "confirmed2@email.com" });
                 controller.MockPackageService.Setup(x => x.FindPackageRegistrationById(id)).Returns(packageRegistration);
-                controller.MockPackageService.Setup(x => x.FindPackageByIdAndVersionStrict(id, version)).Returns(conflictingPackage);
+                controller
+                    .MockPackageService
+                    .Setup(x => x.GetPackageStatus(
+                        id,
+                        It.Is<NuGetVersion>(v => v.ToNormalizedString() == version)))
+                    .Returns(status);
+
                 controller.SetupPackageFromInputStream(nuGetPackage);
 
                 // Act
@@ -897,8 +903,16 @@ namespace NuGetGallery
 
                 var controller = new TestableApiController(GetConfigurationService());
                 controller.SetCurrentUser(currentUser);
+
                 controller.MockPackageService.Setup(x => x.FindPackageRegistrationById(id)).Returns(packageRegistration);
                 controller.MockPackageService.Setup(x => x.FindPackageByIdAndVersionStrict(id, version)).Returns(conflictingPackage);
+                controller
+                    .MockPackageService
+                    .Setup(x => x.GetPackageStatus(
+                        id,
+                        It.Is<NuGetVersion>(v => v.ToNormalizedString() == version)))
+                    .Returns(PackageStatus.FailedValidation);
+
                 controller.SetupPackageFromInputStream(nuGetPackage);
 
                 // Act

--- a/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/PackageCreation/ApiPushTests.cs
@@ -35,9 +35,7 @@ namespace NuGetGallery.FunctionalTests.PackageCreation
             // Arrange
             var packageId = $"{nameof(DuplicatePushesAreRejectedAndNotDeleted)}.{Guid.NewGuid():N}";
 
-            // TODO: Increase this back to 10.
-            // See: https://github.com/NuGet/NuGetGallery/issues/8368
-            int pushVersionCount = 1;
+            int pushVersionCount = 10;
             var duplicatePushTasks = new List<Task>();
             for (var duplicateTaskIndex = 0; duplicateTaskIndex < pushVersionCount; duplicateTaskIndex++)
             {


### PR DESCRIPTION
## Background

Previously, the functional tests on PROD failed repeatedly:

* https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=77508&view=results
* https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=77522&view=results
* https://nuget.visualstudio.com/NuGetBuild/_build/results?buildId=77526&view=results

The functional tests push many packages in parallel, which caused an expensive SQL query to time out.

## Fix

This improves the push package API performance by avoiding a costly SQL query on the "hot" path.

<details>
<summary>Verification...</summary>

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4362696&view=results
Release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=923920

Test plan:
* [x] Upload package
* [x] Reupload package that previously failed validation
* [x] Reupload package that previously passed validation 

</details>


Addresses https://github.com/NuGet/NuGetGallery/issues/8368