### PR TITLE
Add icons to project to ensure bundling

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1339,6 +1339,8 @@
     <Content Include="Content\gallery\img\facebook.svg" />
     <Content Include="Content\gallery\img\git-32x32.png" />
     <Content Include="Content\gallery\img\git.svg" />
+    <Content Include="Content\gallery\img\fuget-32x32.png" />
+    <Content Include="Content\gallery\img\fuget.svg" />
     <Content Include="Content\gallery\img\github-32x32.png" />
     <Content Include="Content\gallery\img\github.svg" />
     <Content Include="Content\gallery\img\logo-footer-184x57.png" />

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1032,7 +1032,7 @@
                              @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/fuget-32x32.png")) />
                         <a href="@Model.FuGetUrl" data-track="outbound-repository-url"
                            aria-label="open in fuget.org explorer"
-                           title="Explore additional package info on fuget.org" rel="nofollow" target="_blank">
+                           title="Explore additional package info on fuget.org" rel="nofollow">
                             Open in FuGet Package Explorer
                         </a>
                     </li>


### PR DESCRIPTION
Despite the name of this branch, this change removes the target="_blank" attribute, because it's ignored by chromium browsers, and we don't do it in other anchors for 3rd party site.

But the important thing is that this change fixes a bug where the icons for the FuGet links aren't bundled--they weren't appearing on the deployed webapp. This completes this work: https://github.com/NuGet/NuGetGallery/issues/7850