### PR TITLE
improved the #r directive instructions

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -93,14 +93,14 @@
                 InstallPackageCommand = string.Format("paket add {0} --version {1}", Model.Id, Model.Version),
             },
 
-            new PackageManagerViewModel("F# Interactive")
+            new PackageManagerViewModel(".NET Interactive")
             {
-                Id = "fsharp-interactive",
+                Id = "net-interactive",
                 CommandPrefix = "> ",
                 InstallPackageCommand = string.Format("#r \"nuget: {0}, {1}\"", Model.Id, Model.Version),
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = string.Format(
-                    "For F# scripts that support <a href=\"{0}\">#r syntax</a>, copy this into the source code to reference the package.",
+                    "For C# and F# scripts that support <a href=\"{0}\">#r syntax</a>, copy this into the source code to reference the package.",
                     "https://docs.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/#referencing-packages-in-f-interactive")
             },
         };

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -99,9 +99,7 @@
                 CommandPrefix = "> ",
                 InstallPackageCommand = string.Format("#r \"nuget: {0}, {1}\"", Model.Id, Model.Version),
                 AlertLevel = AlertLevel.Info,
-                AlertMessage = string.Format(
-                    "For C# and F# scripts that support <a href=\"{0}\">#r syntax</a>, copy this into the source code to reference the package.",
-                    "https://docs.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/#referencing-packages-in-f-interactive")
+                AlertMessage = "#r directive can be used in F# Interactive, C# scripting and .NET Interactive. Copy this into the interactive tool or source code of the script to reference the package."
             },
         };
     }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -93,9 +93,9 @@
                 InstallPackageCommand = string.Format("paket add {0} --version {1}", Model.Id, Model.Version),
             },
 
-            new PackageManagerViewModel(".NET Interactive")
+            new PackageManagerViewModel("Script & Interactive")
             {
-                Id = "net-interactive",
+                Id = "script-interactive",
                 CommandPrefix = "> ",
                 InstallPackageCommand = string.Format("#r \"nuget: {0}, {1}\"", Model.Id, Model.Version),
                 AlertLevel = AlertLevel.Info,


### PR DESCRIPTION
This is a follow up to https://github.com/NuGet/NuGetGallery/pull/8375

Since `#r` is not exclusive to F#, it is a bit inaccurate to use the current header for the instructions - it would make sense to use a more generic name for it. 
Therefore I propose to rename `F# Interactive` to `.NET Interactive` as it then correctly captures both C# and F#.