### PR TITLE
Use throw instead of throw ex to preserve call stack

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -528,7 +528,7 @@ namespace NuGetGallery
             {
                 ex.Log();
                 TelemetryService.TrackSymbolPackagePushFailureEvent(id, normalizedVersion);
-                throw ex;
+                throw;
             }
         }
 

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -2426,6 +2426,7 @@ namespace NuGetGallery
             }
             catch (Exception ex)
             {
+                ex.Log();
                 _telemetryService.TrackPackagePushFailureEvent(id: null, version: null);
                 throw;
             }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -2427,7 +2427,7 @@ namespace NuGetGallery
             catch (Exception ex)
             {
                 _telemetryService.TrackPackagePushFailureEvent(id: null, version: null);
-                throw ex;
+                throw;
             }
         }
 

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -264,17 +264,24 @@ namespace NuGetGallery
                         package.NormalizedVersion);
                 }
 
-                return ReturnConflictOrThrow(ex);
+                if (IsConflict(ex))
+                {
+                    return PackageCommitResult.Conflict;
+                }
+                else
+                {
+                    throw;
+                }
             }
 
             return PackageCommitResult.Success;
         }
 
-        private PackageCommitResult ReturnConflictOrThrow(Exception ex)
+        private bool IsConflict(Exception ex)
         {
             if (ex is DbUpdateConcurrencyException concurrencyEx)
             {
-                return PackageCommitResult.Conflict;
+                return true;
             }
             else if (ex is DbUpdateException dbUpdateEx)
             {
@@ -287,13 +294,13 @@ namespace NuGetGallery
                             case 547:   // Constraint check violation
                             case 2601:  // Duplicated key row error
                             case 2627:  // Unique constraint error
-                                return PackageCommitResult.Conflict;
+                                return true;
                         }
                     }
                 }
             }
 
-            throw ex;
+            return false;
         }
     }
 }

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -241,7 +241,7 @@ namespace NuGetGallery
                             package.Version);
                     }
 
-                    throw ex;
+                    throw;
                 }
             }
             catch (FileAlreadyExistsException ex)

--- a/tests/NuGetGallery.Facts/Infrastructure/Lucene/SearchPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Lucene/SearchPolicyFacts.cs
@@ -479,7 +479,7 @@ namespace NuGetGallery.Infrastructure.Search
                 catch (Exception ex)
                 {
                     _logger.LogError(0, ex, "[{Type}] EXCEPTION", nameof(TestSearchHttpClient));
-                    throw ex;
+                    throw;
                 }
             }
         }


### PR DESCRIPTION
This will allow us to debug a strange push failure that I've seen.