### PR TITLE
Extend vulnerabilities verification to metadata

### DIFF
--- a/src/VerifyGitHubVulnerabilities/Configuration/VerifyGitHubVulnerabilitiesConfiguration.cs
+++ b/src/VerifyGitHubVulnerabilities/Configuration/VerifyGitHubVulnerabilitiesConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ServiceModel.Configuration;
 
 namespace VerifyGitHubVulnerabilities.Configuration
 {
@@ -16,5 +17,20 @@ namespace VerifyGitHubVulnerabilities.Configuration
         /// The personal access token to use to authenticate with GitHub.
         /// </summary>
         public string GitHubPersonalAccessToken { get; set; }
+
+        /// <summary>
+        /// The v3 index URI string for fetching registration metadata
+        /// </summary>
+        public string NuGetV3Index { get; set; }
+
+        /// <summary>
+        /// Whether to verify GitHubVulnerabilities in the gallery database
+        /// </summary>
+        public bool VerifyDatabase { get; set; } = true;
+
+        /// <summary>
+        /// Whether to verify GitHubVulnerabilities in the registration blobs
+        /// </summary>
+        public bool VerifyRegistrationMetadata { get; set; } = true;
     }
 }

--- a/src/VerifyGitHubVulnerabilities/Configuration/VerifyGitHubVulnerabilitiesConfiguration.cs
+++ b/src/VerifyGitHubVulnerabilities/Configuration/VerifyGitHubVulnerabilitiesConfiguration.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.ServiceModel.Configuration;
 
 namespace VerifyGitHubVulnerabilities.Configuration
 {

--- a/src/VerifyGitHubVulnerabilities/Job.cs
+++ b/src/VerifyGitHubVulnerabilities/Job.cs
@@ -34,7 +34,7 @@ namespace VerifyGitHubVulnerabilities
             Console.WriteLine($" FOUND {advisories.Count} advisories.");
 
             Console.WriteLine("Fetching vulnerabilities from DB...");
-            var verifier = new PackageVulnerabilitiesVerifier(_serviceProvider.GetRequiredService<IEntitiesContext>());
+            var verifier = new PackageVulnerabilitiesVerifier(_serviceProvider);
             var ingestor = new AdvisoryIngestor(verifier, new GitHubVersionRangeParser());
             await ingestor.IngestAsync(advisories);
 

--- a/src/VerifyGitHubVulnerabilities/Job.cs
+++ b/src/VerifyGitHubVulnerabilities/Job.cs
@@ -37,9 +37,7 @@ namespace VerifyGitHubVulnerabilities
             var ingestor = _serviceProvider.GetRequiredService<IAdvisoryIngestor>();
             await ingestor.IngestAsync(advisories);
 
-            var verifier =
-                _serviceProvider.GetRequiredService<IPackageVulnerabilitiesManagementService>() as
-                    PackageVulnerabilitiesVerifier;
+            var verifier = _serviceProvider.GetRequiredService<IPackageVulnerabilitiesVerifier>();
             Console.WriteLine(verifier.HasErrors ? 
                 "DB does not match GitHub API - see stderr output for details" :
                 "DB/metadata matches GitHub API!");
@@ -73,7 +71,9 @@ namespace VerifyGitHubVulnerabilities
 
             containerBuilder
                 .RegisterType<PackageVulnerabilitiesVerifier>()
-                .As<IPackageVulnerabilitiesManagementService>();
+                .As<IPackageVulnerabilitiesManagementService>()
+                .As<IPackageVulnerabilitiesVerifier>()
+                .SingleInstance();
         }
 
         protected void ConfigureGalleryServices(ContainerBuilder containerBuilder)

--- a/src/VerifyGitHubVulnerabilities/Verify/IPackageVulnerabilitiesVerifier.cs
+++ b/src/VerifyGitHubVulnerabilities/Verify/IPackageVulnerabilitiesVerifier.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Services.Entities;
+using NuGetGallery;
+
+namespace VerifyGitHubVulnerabilities.Verify
+{
+    /// <summary>
+    /// We need a <see cref=IPackageVulnerabilitiesManagementService" /> for inserting the verifier into the ingestion job,
+    /// so we extend for our extra reporting data.
+    /// </summary>
+    public interface IPackageVulnerabilitiesVerifier : IPackageVulnerabilitiesManagementService
+    {
+        /// <summary>
+        /// An error flag for verification
+        /// </summary>
+        bool HasErrors { get; }
+    }
+}

--- a/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
+++ b/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
@@ -17,7 +17,7 @@ using VerifyGitHubVulnerabilities.Configuration;
 
 namespace VerifyGitHubVulnerabilities.Verify
 {
-    public class PackageVulnerabilitiesVerifier : IPackageVulnerabilitiesManagementService
+    public class PackageVulnerabilitiesVerifier : IPackageVulnerabilitiesVerifier
     {
         private readonly VerifyGitHubVulnerabilitiesConfiguration _configuration;
         private readonly IEntitiesContext _entitiesContext;
@@ -203,7 +203,6 @@ namespace VerifyGitHubVulnerabilities.Verify
         {
             // Fetch metadata from registration blobs for verification--a collection of all versions of the package Id
             var metadata = await GetPackageMetadataAsync(packageId);
-
             foreach (var versionMetadata in metadata)
             {
                 var matchingVulnerabilities = Enumerable.Empty<PackageVulnerabilityMetadata>();

--- a/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
+++ b/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
@@ -2,23 +2,40 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
 using NuGetGallery;
+using VerifyGitHubVulnerabilities.Configuration;
 
 namespace VerifyGitHubVulnerabilities.Verify
 {
     public class PackageVulnerabilitiesVerifier : IPackageVulnerabilitiesManagementService
     {
+        private readonly VerifyGitHubVulnerabilitiesConfiguration _configuration;
         private readonly IEntitiesContext _entitiesContext;
 
-        public PackageVulnerabilitiesVerifier(
-            IEntitiesContext entitiesContext)
+        private PackageMetadataResource _packageMetadataResource;
+        private Dictionary<string, IEnumerable<IPackageSearchMetadata>> _packageMetadata;
+
+        public PackageVulnerabilitiesVerifier(IServiceProvider serviceProvider)
         {
-            _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
+            _configuration = serviceProvider.GetRequiredService<VerifyGitHubVulnerabilitiesConfiguration>() ??
+                             throw new Exception(
+                                 $"{nameof(VerifyGitHubVulnerabilitiesConfiguration)} service cannot be null");
+            if (_configuration.VerifyDatabase)
+            {
+                _entitiesContext = serviceProvider.GetRequiredService<IEntitiesContext>() ??
+                                   throw new Exception($"{nameof(IEntitiesContext)} service cannot be null for database operations");
+            }
         }
 
         public bool HasErrors { get; private set; }
@@ -36,7 +53,26 @@ namespace VerifyGitHubVulnerabilities.Verify
                 return Task.CompletedTask;
             }
 
-            Console.WriteLine($"Verifying vulnerability {vulnerability.GitHubDatabaseKey}.");
+            if (_configuration.VerifyDatabase)
+            {
+                VerifyVulnerabilityInDatabase(vulnerability, withdrawn);
+            }
+
+            // Note: testing a withdrawn advisory isn't practical in registration metadata. We can only download
+            // metadata for a package, and would need to download all package/version blobs to determine an advisory
+            // is no longer present. Covering withdrawn advisory processing in the database will be adequate.
+            if (_configuration.VerifyRegistrationMetadata && !withdrawn)
+            {
+                return VerifyVulnerabilityInMetadata(vulnerability);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void VerifyVulnerabilityInDatabase(PackageVulnerability vulnerability, bool withdrawn)
+        {
+            Console.WriteLine($"[Database] Verifying vulnerability {vulnerability.GitHubDatabaseKey}.");
+
             var existingVulnerability = _entitiesContext.Vulnerabilities
                 .Include(v => v.AffectedRanges)
                 .SingleOrDefault(v => v.GitHubDatabaseKey == vulnerability.GitHubDatabaseKey);
@@ -46,25 +82,25 @@ namespace VerifyGitHubVulnerabilities.Verify
                 if (existingVulnerability != null)
                 {
                     Console.Error.WriteLine(withdrawn ?
-                        $@"Vulnerability advisory {vulnerability.GitHubDatabaseKey} was withdrawn and should not be in DB!" :
-                        $@"Vulnerability advisory {vulnerability.GitHubDatabaseKey} affects no packages and should not be in DB!");
+                        $@"[Database] Vulnerability advisory {vulnerability.GitHubDatabaseKey} was withdrawn and should not be in DB!" :
+                        $@"[Database] Vulnerability advisory {vulnerability.GitHubDatabaseKey} affects no packages and should not be in DB!");
                     HasErrors = true;
                 }
 
-                return Task.CompletedTask;
+                return;
             }
 
             if (existingVulnerability == null)
             {
-                Console.Error.WriteLine($"Cannot find vulnerability {vulnerability.GitHubDatabaseKey} in DB!");
+                Console.Error.WriteLine($"[Database] Cannot find vulnerability {vulnerability.GitHubDatabaseKey} in DB!");
                 HasErrors = true;
-                return Task.CompletedTask;
+                return;
             }
 
             if (existingVulnerability.Severity != vulnerability.Severity)
             {
                 Console.Error.WriteLine(
-                    $@"Vulnerability advisory {vulnerability.GitHubDatabaseKey
+                    $@"[Database] Vulnerability advisory {vulnerability.GitHubDatabaseKey
                     }, severity does not match! GitHub: {vulnerability.Severity}, DB: {existingVulnerability.Severity}");
                 HasErrors = true;
             }
@@ -72,21 +108,21 @@ namespace VerifyGitHubVulnerabilities.Verify
             if (existingVulnerability.AdvisoryUrl != vulnerability.AdvisoryUrl)
             {
                 Console.Error.WriteLine(
-                    $@"Vulnerability advisory {vulnerability.GitHubDatabaseKey
+                    $@"[Database] Vulnerability advisory {vulnerability.GitHubDatabaseKey
                     }, advisory URL does not match! GitHub: {vulnerability.AdvisoryUrl}, DB: { existingVulnerability.AdvisoryUrl}");
                 HasErrors = true;
             }
 
             foreach (var range in vulnerability.AffectedRanges)
             {
-                Console.WriteLine($"Verifying range affecting {range.PackageId} {range.PackageVersionRange}.");
+                Console.WriteLine($"[Database] Verifying range affecting {range.PackageId} {range.PackageVersionRange}.");
                 var existingRange = existingVulnerability.AffectedRanges
                     .SingleOrDefault(r => r.PackageId == range.PackageId && r.PackageVersionRange == range.PackageVersionRange);
 
                 if (existingRange == null)
                 {
                     Console.Error.WriteLine(
-                        $@"Vulnerability advisory {vulnerability.GitHubDatabaseKey
+                        $@"[Database] Vulnerability advisory {vulnerability.GitHubDatabaseKey
                         }, cannot find range {range.PackageId} {range.PackageVersionRange} in DB!");
                     HasErrors = true;
                     continue;
@@ -95,7 +131,7 @@ namespace VerifyGitHubVulnerabilities.Verify
                 if (existingRange.FirstPatchedPackageVersion != range.FirstPatchedPackageVersion)
                 {
                     Console.Error.WriteLine(
-                        $@"Vulnerability advisory {vulnerability.GitHubDatabaseKey
+                        $@"[Database] Vulnerability advisory {vulnerability.GitHubDatabaseKey
                         }, range {range.PackageId} {range.PackageVersionRange}, first patched version does not match! GitHub: {
                         range.FirstPatchedPackageVersion}, DB: {range.FirstPatchedPackageVersion}");
                     HasErrors = true;
@@ -113,15 +149,150 @@ namespace VerifyGitHubVulnerabilities.Verify
                     if (versionRange.Satisfies(version) != package.VulnerablePackageRanges.Contains(existingRange))
                     {
                         Console.Error.WriteLine(
-                            $@"Vulnerability advisory {vulnerability.GitHubDatabaseKey
+                            $@"[Database] Vulnerability advisory {vulnerability.GitHubDatabaseKey
                             }, range {range.PackageId} {range.PackageVersionRange}, package {package.NormalizedVersion
                             } is not properly marked vulnerable to vulnerability!");
                         HasErrors = true;
                     }
                 }
             }
+        }
 
-            return Task.CompletedTask;
+        private Task VerifyVulnerabilityInMetadata(PackageVulnerability gitHubAdvisory)
+        {
+            Console.WriteLine($"[Metadata] Verifying vulnerability {gitHubAdvisory.GitHubDatabaseKey}.");
+
+            if (gitHubAdvisory.AffectedRanges == null || !gitHubAdvisory.AffectedRanges.Any())
+            {
+                return Task.CompletedTask;
+            }
+
+            // Group ranges by id -- this makes testing metadata collections cleaner
+            var rangesById = new Dictionary<string, IList<string>>();
+            foreach (var range in gitHubAdvisory.AffectedRanges)
+            {
+                var id = range.PackageId.Trim(' '); // some incoming data needs cleaning
+                if (rangesById.TryGetValue(id, out var packageVersionRangeForId))
+                {
+                    packageVersionRangeForId.Add(range.PackageVersionRange);
+                }
+                else
+                {
+                    rangesById[id] = new List<string> {range.PackageVersionRange};
+                }
+            }
+
+            var verificationTasks = new List<Task>();
+            foreach (var rangeById in rangesById)
+            {
+                verificationTasks.Add(VerifyVulnerabilityForRangeAsync(
+                    packageId: rangeById.Key, 
+                    ranges: rangeById.Value, 
+                    gitHubAdvisory.AdvisoryUrl, 
+                    gitHubAdvisory.GitHubDatabaseKey, 
+                    gitHubAdvisory.Severity));
+            }
+
+            return Task.WhenAll(verificationTasks);
+        }
+
+        private async Task VerifyVulnerabilityForRangeAsync (
+            string packageId,
+            IList<string> ranges,
+            string advisoryUrl, 
+            int advisoryDatabaseKey, 
+            PackageVulnerabilitySeverity advisorySeverity)
+        {
+            // Fetch metadata from registration blobs for verification--a collection of all versions of the package Id
+            var metadata = await GetPackageMetadataAsync(packageId);
+
+            foreach (var versionMetadata in metadata)
+            {
+                var matchingVulnerabilities = Enumerable.Empty<PackageVulnerabilityMetadata>();
+                if (versionMetadata.Vulnerabilities != null)
+                {
+                    matchingVulnerabilities = versionMetadata.Vulnerabilities.Where(v => v.AdvisoryUrl.ToString() == advisoryUrl);
+                }
+
+                var hasTheVulnerability = matchingVulnerabilities.Any();
+
+                // Check whether a version range pertaining to this id in the github advisory is satisfied by this metadata version
+                var versionisInGitHubRange = false;
+                foreach (var range in ranges)
+                {
+                    var gitHubVersionRange = VersionRange.Parse(range);
+                    if (gitHubVersionRange.Satisfies(versionMetadata.Identity.Version, new VersionComparer()))
+                    {
+                        versionisInGitHubRange = true;
+                        break;
+                    }
+                }
+
+                if (versionisInGitHubRange)
+                {
+                    if (!hasTheVulnerability)
+                    {
+                        Console.Error.WriteLine(
+                            $@"[Metadata] Vulnerability advisory {advisoryDatabaseKey
+                                }, version {versionMetadata.Identity.Version} of package {packageId} is not marked vulnerable and is in a vulnerable range!");
+                        HasErrors = true;
+                    }
+
+                    // Test whether we have any severity mismatches
+                    var firstSeverityMismatch = matchingVulnerabilities
+                        .FirstOrDefault(v => v.Severity != (int)advisorySeverity);
+                    if (firstSeverityMismatch != null)
+                    {
+                        Console.Error.WriteLine(
+                            $@"[Metadata] Vulnerability advisory {advisoryDatabaseKey
+                                }, severities has at least one mismatch! GitHub: {advisorySeverity}, Metadata: {firstSeverityMismatch.Severity}");
+                        HasErrors = true;
+                    }
+                }
+                else
+                {
+                    if (hasTheVulnerability)
+                    {
+                        Console.Error.WriteLine(
+                            $@"[Metadata] Vulnerability advisory {advisoryDatabaseKey
+                                }, version {versionMetadata} of package {packageId} is marked vulnerable and is not in a vulnerable range!");
+                        HasErrors = true;
+                    }
+                }
+            }
+        }
+
+        private async Task<IEnumerable<IPackageSearchMetadata>> GetPackageMetadataAsync(string package)
+        {
+            if (_packageMetadataResource == null)
+            {
+                await InitializeMetadataResourceAsync();
+            }
+
+            if (!_packageMetadata.TryGetValue(package, out IEnumerable<IPackageSearchMetadata> metadata))
+            {
+                metadata = await _packageMetadataResource.GetMetadataAsync(
+                    package,
+                    includePrerelease: true,
+                    includeUnlisted: false,
+                    sourceCacheContext: new SourceCacheContext(),
+                    log: NuGet.Common.NullLogger.Instance,
+                    token: CancellationToken.None);
+                _packageMetadata[package] = metadata;
+            }
+
+            return metadata;
+        }
+
+        private async Task InitializeMetadataResourceAsync()
+        {
+            var providers = Repository.Provider.GetCoreV3();
+            var packageSource = new PackageSource(_configuration.NuGetV3Index, "NuGet Source", isEnabled: true);
+            var sourceRepository = Repository.CreateSource(providers, packageSource, FeedType.Undefined);
+            _packageMetadataResource =
+                await sourceRepository.GetResourceAsync<PackageMetadataResource>(CancellationToken.None);
+
+            _packageMetadata = new Dictionary<string, IEnumerable<IPackageSearchMetadata>>();
         }
     }
 }

--- a/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
+++ b/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Job.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Verify\IPackageVulnerabilitiesVerifier.cs" />
     <Compile Include="Verify\PackageVulnerabilitiesVerifier.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Addresses: https://github.com/NuGet/Engineering/issues/3623

The verification test already existed for doing a full set check of database vulnerabilities--this change adds the capability of downloading registration metadata blobs to determine that the pipeline has propagated incremental changes correctly.

The config file changes allow you to test either or both.