### PR TITLE
Update the Gallery to reflect the latest validation database

### DIFF
--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -89,7 +89,7 @@
       <Version>4.3.0-dev-3612825</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -89,7 +89,7 @@
       <Version>4.3.0-dev-3612825</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -89,7 +89,7 @@
       <Version>4.3.0-dev-3612825</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -89,7 +89,7 @@
       <Version>4.3.0-dev-3612825</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -47,7 +47,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -56,13 +56,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -47,7 +47,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -56,13 +56,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -47,7 +47,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -56,13 +56,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -47,7 +47,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -56,13 +56,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -307,10 +307,10 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -307,10 +307,10 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -307,10 +307,10 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -307,10 +307,10 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
+++ b/src/NuGetGallery/Areas/Admin/Services/ValidationAdminService.cs
@@ -67,14 +67,16 @@ namespace NuGetGallery.Areas.Admin.Services
             var pendingPackages = _packages
                 .GetAll()
                 .Where(p => p.PackageStatusKey == PackageStatus.Validating)
-                .Select(p => p.Key)
+                .Select(p => (int?)p.Key)
                 .ToList();
             var pendingSymbolPackages = _symbolPackages
                 .GetAll()
                 .Where(s => s.StatusKey == PackageStatus.Validating)
-                .Select(s => s.Key)
+                .Select(s => (int?)s.Key)
                 .ToList();
 
+            // TODO: Add generic validation sets.
+            // Tracked by: https://github.com/NuGet/Engineering/issues/3587
             AddPendingValidationSets(pendingValidations, pendingPackages, ValidatingType.Package);
             AddPendingValidationSets(pendingValidations, pendingSymbolPackages, ValidatingType.SymbolPackage);
 
@@ -228,7 +230,7 @@ namespace NuGetGallery.Areas.Admin.Services
 
         private void AddPendingValidationSets(
             List<PackageValidationSet> validationSets,
-            IReadOnlyList<int> packageKeys,
+            IReadOnlyList<int?> packageKeys,
             ValidatingType type)
         {
             foreach (var packageKeyBatch in Batch(packageKeys, PendingValidationsBatchSize))
@@ -237,7 +239,7 @@ namespace NuGetGallery.Areas.Admin.Services
                     _validationSets
                         .GetAll()
                         .Where(v => v.ValidatingType == type)
-                        .Where(v => packageKeys.Contains(v.PackageKey)));
+                        .Where(v => packageKeyBatch.Contains(v.PackageKey)));
             }
         }
 

--- a/src/NuGetGallery/Areas/Admin/ViewModels/NuGetPackageValidationViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/NuGetPackageValidationViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Services.Validation;
@@ -8,12 +9,22 @@ using NuGetGallery.Areas.Admin.Models;
 
 namespace NuGetGallery.Areas.Admin.ViewModels
 {
-    public class ValidatedPackageViewModel : IPackageVersionModel
+    public class NuGetPackageValidationViewModel : IPackageVersionModel
     {
-        public ValidatedPackageViewModel(IReadOnlyList<PackageValidationSet> validationSets, PackageDeletedStatus deletedStatus, ValidatingType validatingType)
+        public NuGetPackageValidationViewModel(
+            IReadOnlyList<PackageValidationSet> validationSets,
+            PackageDeletedStatus deletedStatus,
+            ValidatingType validatingType)
         {
+            if (validatingType == ValidatingType.Generic)
+            {
+                throw new ArgumentException(
+                    $"Unsupported validation type of {validatingType}",
+                    nameof(validatingType));
+            }
+
             var first = validationSets.First();
-            PackageKey = first.PackageKey;
+            PackageKey = first.PackageKey.Value;
             Id = first.PackageId;
             NormalizedVersion = first.PackageNormalizedVersion;
             DeletedStatus = deletedStatus;

--- a/src/NuGetGallery/Areas/Admin/ViewModels/ValidationPageViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/ValidationPageViewModel.cs
@@ -11,10 +11,10 @@ namespace NuGetGallery.Areas.Admin.ViewModels
         {
         }
 
-        public ValidationPageViewModel(string query, IReadOnlyList<ValidatedPackageViewModel> packages)
+        public ValidationPageViewModel(string query, IReadOnlyList<NuGetPackageValidationViewModel> packages)
         {
             Query = query ?? string.Empty;
-            Packages = packages ?? new List<ValidatedPackageViewModel>();
+            Packages = packages ?? new List<NuGetPackageValidationViewModel>();
         }
 
         public string Query { get; }
@@ -23,6 +23,6 @@ namespace NuGetGallery.Areas.Admin.ViewModels
 
         public bool HasResults => Packages.Count > 0;
 
-        public IReadOnlyList<ValidatedPackageViewModel> Packages { get; }
+        public IReadOnlyList<NuGetPackageValidationViewModel> Packages { get; }
     }
 }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2241,13 +2241,13 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.84.0-loshar-uvp-db-4454369</Version>
+      <Version>2.84.0-loshar-uvp-db-4455697</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2241,13 +2241,13 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.84.0-loshar-uvp-db-4455697</Version>
+      <Version>2.84.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -190,7 +190,7 @@
     <Compile Include="Areas\Admin\ViewModels\ModifyFeatureFlagsFlightViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\ApiKeyRevokeViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\SiteAdminsViewModel.cs" />
-    <Compile Include="Areas\Admin\ViewModels\ValidatedPackageViewModel.cs" />
+    <Compile Include="Areas\Admin\ViewModels\NuGetPackageValidationViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\RevalidationPageViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\ValidationPageViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\DeleteAccountSearchResult.cs" />
@@ -2241,13 +2241,13 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.82.0</Version>
+      <Version>2.83.0-loshar-uvp-db-4434184</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2241,13 +2241,13 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.83.0-loshar-uvp-db-4434184</Version>
+      <Version>2.84.0-loshar-uvp-db-4454369</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>


### PR DESCRIPTION
Updates the Gallery to the latest validation database entities, which had breaking changes. Note that this change does not display generic validations, this will be added by https://github.com/NuGet/Engineering/issues/3587.

See: https://github.com/NuGet/ServerCommon/pull/357

Part of: https://github.com/NuGet/Engineering/issues/3576