### PR TITLE
workaround for narrator announce the status changes of copy button

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -97,16 +97,7 @@ $(function () {
             window.nuget.copyTextToClipboard(text, copyButton);
             copyButton.popover('show');
             //This is workaround for Narrator announce the status changes of copy button to achieve accessibility.
-            switch (copyButton.attr('aria-pressed')) {
-                case 'false':
-                    copyButton.attr('aria-pressed', 'true');
-                    break;
-                case 'true':
-                    copyButton.attr('aria-pressed', 'true');
-                    break;
-                default:
-                    copyButton.attr('aria-pressed', 'false');
-            }
+            copyButton.attr('aria-pressed', 'true');
             setTimeout(function () {
                 copyButton.popover('destroy');
             }, 1000);

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -96,9 +96,23 @@ $(function () {
             var text = $('#' + id + '-text').text().trim();
             window.nuget.copyTextToClipboard(text, copyButton);
             copyButton.popover('show');
+            //This is workaround for Narrator announce the status changes of copy button to achieve accessibility.
+            switch (copyButton.attr('aria-pressed')) {
+                case 'false':
+                    copyButton.attr('aria-pressed', 'true');
+                    break;
+                case 'true':
+                    copyButton.attr('aria-pressed', 'true');
+                    break;
+                default:
+                    copyButton.attr('aria-pressed', 'false');
+            }
             setTimeout(function () {
                 copyButton.popover('destroy');
             }, 1000);
+            setTimeout(function () {
+                copyButton.attr('aria-pressed', 'false');
+            }, 1500);  
             window.nuget.sendMetric("CopyInstallCommand", 1, {
                 ButtonId: id,
                 PackageId: packageId,

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -159,9 +159,14 @@
             <div class="install-script-row">
                 <pre class="install-script" id="@packageManager.Id-text">@packageManager.InstallPackageCommand</pre>
                 <div class="copy-button">
+                    <!--In order to statisfy the requirement to announce button status both on NVDA/Narrator, other screen reader like NVDA will
+                        announce the data-content "Copied" everytime when we press button, however, it won't work with Narrator when we use bootstrap popover 
+                        because of known issue(https://github.com/twbs/bootstrap/issues/18618).
+                        We add aria-pressed to indicate the whether button is pressed or not, which is workaround only for Narrator announce the status change of button
+                    -->
                     <button id="@packageManager.Id-button" class="btn btn-default btn-warning" type="button"
                             data-toggle="popover" data-placement="bottom" data-content="Copied."
-                            aria-label="@packageManager.CopyLabel" aria-live="polite" role="status">
+                            aria-label="@packageManager.CopyLabel" aria-pressed="false" aria-live="polite" role="button">
                         <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
                     </button>
                 </div>


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

We currently are using bootstrap popover in nuget gallery, tooltips uses aria-describedby which is dynamically added once the tooltip is triggered 
in aria-describedby, it doesn't have aria attribute also it won't focus on the tooltip, what’s why Narrator would not read status. Besides that Narrator doesn’t read data content attribute as well.  For other screen readers like NVDA, they would read data content. That’s why our current fix in gallery work with NVDA, not Narrator.
 
This is common issue that existing in bootstrap community.(https://github.com/twbs/bootstrap/issues/28446)

This is workaround for narrator announce the staus of copy button to statisfy accessibility requirement

expected behavior with current changes: Narrator will announce that content is copied button is click at first time, it won't announce the status if click is made within 1500milisecond, it will continue to announce after 1500milisecond
