### PR TITLE
[SAS Token] Create get only uri methods for files.

### DIFF
--- a/src/NuGetGallery.Core/Services/CorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageFileService.cs
@@ -44,6 +44,12 @@ namespace NuGetGallery
             return _fileStorageService.GetFileAsync(_metadata.FileFolderName, fileName);
         }
 
+        public Task<Uri> GetPackageUriAsync(Package package)
+        {
+            var fileName = FileNameHelper.BuildFileName(package, _metadata.FileSavePathTemplate, _metadata.FileExtension);
+            return _fileStorageService.GetFileUriAsync(_metadata.FileFolderName, fileName);
+        }
+
         public Task<Uri> GetPackageReadUriAsync(Package package)
         {
             var fileName = FileNameHelper.BuildFileName(package, _metadata.FileSavePathTemplate, _metadata.FileExtension);

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -25,6 +25,14 @@ namespace NuGetGallery
         /// <param name="ifNoneMatch">The <see cref="IFileReference.ContentId"/> value to use in an If-None-Match request</param>
         /// <returns>A <see cref="IFileReference"/> representing the file reference</returns>
         Task<IFileReference> GetFileReferenceAsync(string folderName, string fileName, string ifNoneMatch = null);
+        
+        /// <summary>
+        /// Gets a file URI.
+        /// </summary>
+        /// <param name="folderName">The folder containing the file.</param>
+        /// <param name="fileName">The file within the <paramref name="folderName"/>.</param>
+        /// <returns>A <see cref="Uri"/> for the specified file.</returns>
+        Task<Uri> GetFileUriAsync(string folderName, string fileName);
 
         /// <summary>
         /// Generates the storage file URI (which is optionally time limited)

--- a/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
@@ -26,7 +26,7 @@ namespace NuGetGallery
         Task<Stream> DownloadPackageFileAsync(Package package);
 
         /// <summary>
-        /// Generates the URL for the specified package in the public container for available packages.
+        /// Generates the URL for the specified package.
         /// </summary>
         /// <param name="package">The package metadata.</param>
         /// <returns>Package URL</returns>

--- a/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
+++ b/src/NuGetGallery.Core/Services/ICorePackageFileService.cs
@@ -29,6 +29,13 @@ namespace NuGetGallery
         /// Generates the URL for the specified package in the public container for available packages.
         /// </summary>
         /// <param name="package">The package metadata.</param>
+        /// <returns>Package URL</returns>
+        Task<Uri> GetPackageUriAsync(Package package);
+
+        /// <summary>
+        /// Generates the URL for the specified package in the public container for available packages.
+        /// </summary>
+        /// <param name="package">The package metadata.</param>
         /// <returns>Package download URL</returns>
         /// <remarks>
         /// The returned URL is only intended to be used by the internal tooling and not for the user:

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -237,6 +237,12 @@ namespace NuGetGallery
             return Task.FromResult(Directory.Exists(_configuration.FileStorageDirectory));
         }
 
+        public Task<Uri> GetFileUriAsync(string folderName, string fileName)
+        {
+            /// Not implemented for the same reason as <see cref="GetFileReadUriAsync(string, string, DateTimeOffset?)"/>.
+            throw new NotImplementedException();
+        }
+
         public Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess)
         {
             // technically, we would be able to generate the file:/// url here, but we don't need it right now

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -419,6 +419,31 @@ namespace NuGetGallery
             }
         }
 
+        public class TheGetPackageUriMethod : FactsBase
+        {
+            [Fact]
+            public async Task WillThrowIfPackageIsNull()
+            {
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _service.GetPackageUriAsync(null));
+                Assert.Equal("package", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task WillUseFileStorageService()
+            {
+                await _service.GetPackageUriAsync(_package);
+
+                string filename = BuildFileName(_package.PackageRegistration.Id, _package.NormalizedVersion, CoreConstants.NuGetPackageFileExtension, CoreConstants.PackageFileSavePathTemplate);
+
+                _fileStorageService.Verify(
+                    x => x.GetFileUriAsync(PackagesFolderName, filename),
+                    Times.Once());
+                _fileStorageService.Verify(
+                    x => x.GetFileUriAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once());
+            }
+        }
+
         public class TheGetPackageReadUriMethod : FactsBase
         {
             [Fact]


### PR DESCRIPTION
Added new methods to retrieve the file/package uri. This will help us support sas tokens that are not generated on methods that returns an uri with the sas token embeded.