### PR TITLE
Use new TFM logic for package ingestion in backfill command

### DIFF
--- a/src/GalleryTools/Commands/BackfillCommand.cs
+++ b/src/GalleryTools/Commands/BackfillCommand.cs
@@ -136,6 +136,11 @@ namespace GalleryTools.Commands
                 using (var csv = CreateCsvWriter(fileName))
                 using (var http = new HttpClient())
                 {
+                    // We want these downloads ignored by stats pipelines - this user agent is automatically skipped.
+                    // See https://github.com/NuGet/NuGet.Jobs/blob/262da48ed05d0366613bbf1c54f47879aad96dcd/src/Stats.ImportAzureCdnStatistics/StatisticsParser.cs#L41
+                    http.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", 
+                        "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; AppInsights)   Backfill Job: NuGet.Gallery GalleryTools");
+
                     var counter = 0;
                     var lastCreatedDate = default(DateTime?);
 

--- a/src/GalleryTools/Commands/BackfillDevelopmentDependencyMetadataCommand.cs
+++ b/src/GalleryTools/Commands/BackfillDevelopmentDependencyMetadataCommand.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
+using NuGetGallery;
 
 namespace GalleryTools.Commands
 {
@@ -32,7 +33,7 @@ namespace GalleryTools.Commands
             map.Map(x => x.Metadata).Index(3);
         }
 
-        protected override void UpdatePackage(Package package, bool metadata)
+        protected override void UpdatePackage(Package package, bool metadata, EntitiesContext context)
         {
             package.DevelopmentDependency = metadata;
         }

--- a/src/GalleryTools/Commands/BackfillRepositoryMetadataCommand.cs
+++ b/src/GalleryTools/Commands/BackfillRepositoryMetadataCommand.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Services.Entities;
+using NuGetGallery;
 
 namespace GalleryTools.Commands
 {
@@ -38,7 +39,7 @@ namespace GalleryTools.Commands
             map.Map(x => x.Metadata.Commit).Index(6);
         }
 
-        protected override void UpdatePackage(Package package, RepositoryMetadata metadata)
+        protected override void UpdatePackage(Package package, RepositoryMetadata metadata, EntitiesContext context)
         {
             package.RepositoryUrl = metadata.Url;
 

--- a/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
+++ b/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.Packaging;
+using NuGet.Services.Entities;
+using NuGetGallery;
+
+namespace GalleryTools.Commands
+{
+    public sealed class BackfillTfmMetadataCommand : BackfillCommand<string>
+    {
+        protected override string MetadataFileName => "tfmMetadata.txt";
+        
+        protected override MetadataSourceType SourceType => MetadataSourceType.Entities;
+        
+        protected override string QueryIncludes => $"{nameof(Package.SupportedFrameworks)}";
+
+        protected override int LimitTo => 100000;
+
+        protected override bool UpdateNeedsContext => true;
+
+        public static void Configure(CommandLineApplication config)
+        {
+            Configure<BackfillTfmMetadataCommand>(config);
+        }
+
+        protected override string ReadMetadata(IList<string> files, NuspecReader nuspecReader)
+        {
+            var supportedTFMs = string.Empty;
+            if (_packageService == null)
+            {
+                return supportedTFMs;
+            }
+
+            var supportedFrameworks = _packageService.GetSupportedFrameworks(nuspecReader, files);
+            foreach (var tfm in supportedFrameworks)
+            {
+                supportedTFMs += supportedTFMs == string.Empty
+                    ? tfm.GetShortFolderName()
+                    : $";{tfm.GetShortFolderName()}";
+            }
+
+            return supportedTFMs;
+        }
+
+        protected override bool ShouldWriteMetadata(string metadata) => true;
+
+        protected override void ConfigureClassMap(PackageMetadataClassMap map)
+        {
+            map.Map(x => x.Metadata).Index(3);
+        }
+
+        protected override void UpdatePackage(EntitiesContext context, Package package, string metadata)
+        {
+            var existingTFMs = package.SupportedFrameworks == null
+                ? Enumerable.Empty<string>()
+                : package.SupportedFrameworks.Select(f => f.FrameworkName.GetShortFolderName()).OrderBy(f => f);
+
+            var newTFMs = string.IsNullOrEmpty(metadata)
+                ? Enumerable.Empty<string>() 
+                : metadata.Split(';').OrderBy(f => f);
+
+            if (Enumerable.SequenceEqual(existingTFMs, newTFMs))
+            {
+                return; // nothing to change
+            }
+
+            // clean out the old (which will be left unattached in table otherwise) before adding new
+            foreach (var supportedFramework in package.SupportedFrameworks.ToList())
+            {
+                package.SupportedFrameworks.Remove(supportedFramework);
+                context.PackageFrameworks.Remove(supportedFramework);
+            }
+
+            package.SupportedFrameworks = newTFMs.Select(f => new PackageFramework {Package = package, TargetFramework = f}).ToList();
+        }
+    }
+}

--- a/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
+++ b/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Microsoft.Extensions.CommandLineUtils;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
@@ -16,9 +18,7 @@ namespace GalleryTools.Commands
         
         protected override MetadataSourceType SourceType => MetadataSourceType.Nupkg;
         
-        protected override string QueryIncludes => $"{nameof(Package.SupportedFrameworks)}";
-
-        protected override bool UpdateNeedsContext => true;
+        protected override Expression<Func<Package, object>> QueryIncludes => p => p.SupportedFrameworks;
 
         public static void Configure(CommandLineApplication config)
         {
@@ -28,11 +28,6 @@ namespace GalleryTools.Commands
         protected override List<string> ReadMetadata(IList<string> files, NuspecReader nuspecReader)
         {
             var supportedTFMs = new List<string>();
-            if (_packageService == null)
-            {
-                return supportedTFMs;
-            }
-
             var supportedFrameworks = _packageService.GetSupportedFrameworks(nuspecReader, files);
             foreach (var tfm in supportedFrameworks)
             {
@@ -49,7 +44,7 @@ namespace GalleryTools.Commands
             map.Map(x => x.Metadata).Index(3);
         }
 
-        protected override void UpdatePackage(EntitiesContext context, Package package, List<string> metadata)
+        protected override void UpdatePackage(Package package, List<string> metadata, EntitiesContext context)
         {
             var existingTFMs = package.SupportedFrameworks == null
                 ? Enumerable.Empty<string>()

--- a/src/GalleryTools/GalleryTools.csproj
+++ b/src/GalleryTools/GalleryTools.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Commands\BackfillCommand.cs" />
+    <Compile Include="Commands\BackfillTfmMetadataCommand.cs" />
     <Compile Include="Commands\BackfillDevelopmentDependencyMetadataCommand.cs" />
     <Compile Include="Commands\BackfillRepositoryMetadataCommand.cs" />
     <Compile Include="Commands\HashCommand.cs" />
@@ -84,6 +85,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Knapcode.MiniZip">
+      <Version>0.15.0</Version>
+    </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/GalleryTools/GalleryTools.csproj
+++ b/src/GalleryTools/GalleryTools.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Knapcode.MiniZip">
-      <Version>0.15.0</Version>
+      <Version>0.16.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/GalleryTools/Program.cs
+++ b/src/GalleryTools/Program.cs
@@ -19,6 +19,7 @@ namespace GalleryTools
             commandLineApplication.Command("applyTenantPolicy", ApplyTenantPolicyCommand.Configure);
             commandLineApplication.Command("fillrepodata", BackfillRepositoryMetadataCommand.Configure);
             commandLineApplication.Command("filldevdeps", BackfillDevelopmentDependencyCommand.Configure);
+            commandLineApplication.Command("filltfms", BackfillTfmMetadataCommand.Configure);
             commandLineApplication.Command("verifyapikey", VerifyApiKeyCommand.Configure);
             commandLineApplication.Command("updateIsLatest", UpdateIsLatestCommand.Configure);
             commandLineApplication.Command("reservenamespaces", ReserveNamespacesCommand.Configure);

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -72,6 +72,7 @@ namespace NuGetGallery
         public DbSet<PackageDeprecation> Deprecations { get; set; }
         public DbSet<PackageRegistration> PackageRegistrations { get; set; }
         public DbSet<PackageDependency> PackageDependencies { get; set; }
+        public DbSet<PackageFramework> PackageFrameworks { get; set; }
         public DbSet<Credential> Credentials { get; set; }
         public DbSet<Scope> Scopes { get; set; }
         public DbSet<UserSecurityPolicy> UserSecurityPolicies { get; set; }

--- a/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
@@ -13,6 +13,7 @@ namespace NuGetGallery
         DbSet<PackageDeprecation> Deprecations { get; set; }
         DbSet<PackageRegistration> PackageRegistrations { get; set; }
         DbSet<PackageDependency> PackageDependencies { get; set; }
+        DbSet<PackageFramework> PackageFrameworks { get; set; }
         DbSet<Credential> Credentials { get; set; }
         DbSet<Scope> Scopes { get; set; }
         DbSet<User> Users { get; set; }

--- a/src/VerifyMicrosoftPackage/Fakes/FakeEntitiesContext.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeEntitiesContext.cs
@@ -14,7 +14,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public DbSet<Certificate> Certificates { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DbSet<PackageDeprecation> Deprecations { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DbSet<PackageRegistration> PackageRegistrations { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public DbSet<PackageDependency> PackageDependencies  { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public DbSet<PackageDependency> PackageDependencies { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public DbSet<PackageFramework> PackageFrameworks { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DbSet<Credential> Credentials { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DbSet<Scope> Scopes { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public DbSet<User> Users { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
@@ -20,193 +20,104 @@ namespace NuGetGallery
 
         public DbSet<PackageRegistration> PackageRegistrations
         {
-            get
-            {
-                return Set<PackageRegistration>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<PackageRegistration>();
+            set => throw new NotSupportedException();
         }
+
         public DbSet<PackageDependency> PackageDependencies
         {
-            get
-            {
-                return Set<PackageDependency>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<PackageDependency>();
+            set => throw new NotSupportedException();
+        }
+
+        public DbSet<PackageFramework> PackageFrameworks
+        {
+            get => Set<PackageFramework>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<Package> Packages
         {
-            get
-            {
-                return Set<Package>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<Package>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<PackageDeprecation> Deprecations
         {
-            get
-            {
-                return Set<PackageDeprecation>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<PackageDeprecation>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<Credential> Credentials
         {
-            get
-            {
-                return Set<Credential>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<Credential>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<Scope> Scopes
         {
-            get
-            {
-                return Set<Scope>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<Scope>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<User> Users
         {
-            get
-            {
-                return Set<User>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<User>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<Organization> Organizations
         {
-            get
-            {
-                return Set<Organization>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<Organization>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<UserSecurityPolicy> UserSecurityPolicies
         {
-            get
-            {
-                return Set<UserSecurityPolicy>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<UserSecurityPolicy>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<ReservedNamespace> ReservedNamespaces
         {
-            get
-            {
-                return Set<ReservedNamespace>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<ReservedNamespace>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<Certificate> Certificates
         {
-            get
-            {
-                return Set<Certificate>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<Certificate>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<UserCertificate> UserCertificates
         {
-            get
-            {
-                return Set<UserCertificate>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<UserCertificate>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<SymbolPackage> SymbolPackages
         {
-            get
-            {
-                return Set<SymbolPackage>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<SymbolPackage>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<PackageVulnerability> Vulnerabilities
         {
-            get
-            {
-                return Set<PackageVulnerability>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<PackageVulnerability>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<VulnerablePackageVersionRange> VulnerableRanges
         {
-            get
-            {
-                return Set<VulnerablePackageVersionRange>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<VulnerablePackageVersionRange>();
+            set => throw new NotSupportedException();
         }
 
         public DbSet<PackageRename> PackageRenames
         {
-            get
-            {
-                return Set<PackageRename>();
-            }
-            set
-            {
-                throw new NotSupportedException();
-            }
+            get => Set<PackageRename>();
+            set => throw new NotSupportedException();
         }
 
         public virtual string QueryHint => throw new NotImplementedException();


### PR DESCRIPTION
Please address https://github.com/NuGet/NuGetGallery/pull/8432 first (this PR depends on it).

Addresses: https://github.com/NuGet/Engineering/issues/3605

This adds a new backfill command to update TFM details in packages, using the improved logic in the abope PR's branch. Some notes on this:
- In order to get a file list efficiently from the flat container blob, I've used @joelverhagen's Knapcode.MiniZip utility to extract from the stream the file list--this circumvents the needs to download the whole nupkg.
- Backfill commands all extend `BackfillCommand`, and while the structure of the type is appropriate for use here, I needed to make it more flexible while not compromising other backfill jobs. For example, specifying includes and limits in query sets, and providing the above file list for metadata extraction when needed.
- The SQL connections used by backfill jobs were not using managed identity, and this is corrected here.

Once the other PR is merged and operational in Gallery code, I will run the backfill on the PROD database to bring old TFMs up to speed. then we can address UX changes still under discussion here: https://github.com/NuGet/Home/pull/10573

/cc @anangaur @jcjiang @nkolev92 