### PR TITLE
New TFM logic for package ingestion

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
@@ -111,6 +113,8 @@ namespace NuGetGallery
         Task<Package> CreatePackageAsync(PackageArchiveReader nugetPackage, PackageStreamMetadata packageStreamMetadata, User owner, User currentUser, bool isVerified);
 
         Package EnrichPackageFromNuGetPackage(Package package, PackageArchiveReader packageArchive, PackageMetadata packageMetadata, PackageStreamMetadata packageStreamMetadata, User user);
+
+        IEnumerable<NuGetFramework> GetSupportedFrameworks(NuspecReader nuspecReader, IList<string> packageFiles);
 
         Task PublishPackageAsync(string id, string version, bool commitChanges = true);
         Task PublishPackageAsync(Package package, bool commitChanges = true);

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -708,8 +708,8 @@ namespace NuGetGallery
         /// <summary>
         /// This method combines the logic used in restore operations to make a determination about the TFM supported by the package.
         /// We have curated a set of compatibility requirements for our needs in NuGet.org. The client logic can be found here:
-        /// https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs#L252-L291
-        /// https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs#L439-L442
+        /// https://github.com/NuGet/NuGet.Client/blob/63255047fe7052cc33b763356ff995d9166f719e/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs#L252-L294
+        /// https://github.com/NuGet/NuGet.Client/blob/63255047fe7052cc33b763356ff995d9166f719e/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs#L439-L442
         /// ...and our combination of these elements is below.
         /// The logic is essentially this:
         /// - Determine whether we're looking at a tools package. In this case we will use tools "pattern sets" (collections of file patterns

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.Entity;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using Moq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
@@ -969,6 +969,207 @@ namespace NuGetGallery
 
                 Assert.Empty(package.SupportedFrameworks);
             }
+
+            [Theory]
+            [MemberData(nameof(TargetFrameworkCases))]
+            private void DeterminesCorrectSupportedFrameworksFromFileList(bool isTools, List<string> files, List<string> expectedSupportedFrameworks)
+            {
+                // arrange
+                var nuspec = isTools
+                    ? @"<?xml version=""1.0""?>
+                        <package xmlns = ""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                            <metadata>
+                                <id>Foo</id>
+                                <packageTypes>
+                                    <packageType name=""DotnetTool""/>
+                                </packageTypes>
+                            </metadata>
+                        </package>"
+                    : @"<?xml version=""1.0""?>
+                        <package xmlns = ""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                            <metadata>
+                                <id>Foo</id>
+                            </metadata>
+                        </package>";
+                var xml = XDocument.Parse(nuspec);
+
+                var nuspecReader = new NuspecReader(xml);
+
+                // act
+                var supportedFrameworks = CreateService().GetSupportedFrameworks(nuspecReader, files)
+                    .Select(f => f.GetShortFolderName())
+                    .OrderBy(f => f)
+                    .ToList();
+
+                // assert
+                Assert.Equal<string>(expectedSupportedFrameworks, supportedFrameworks);
+            }
+
+            /// <summary>
+            /// These cases use the guidance laid out here:
+            /// https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package
+            /// https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks
+            /// https://docs.microsoft.com/en-us/nuget/reference/target-frameworks
+            /// https://docs.microsoft.com/en-us/dotnet/standard/frameworks
+            /// </summary>
+            public static IEnumerable<object[]> TargetFrameworkCases =>
+                new List<object[]>
+                {
+                    // Runtimes
+                    // - note that without "runtimes/" we don't use runtime ids (RIDs).
+                    new object[] {false, new List<string> {"lib/net40/_._", "lib/net45/_._"}, new List<string> {"net40", "net45"}},
+                    new object[] {false, new List<string> {"lib/net40/_._", "lib/net471/_._"}, new List<string> {"net40", "net471"}},
+                    new object[] {false, new List<string> {"lib/net40/_._", "lib/net4.7.1/_._"}, new List<string> {"net40", "net471"}},
+                    new object[] {false, new List<string> {"lib/netcoreapp31/_._", "lib/netstandard20/_._"}, new List<string> {"netcoreapp3.1", "netstandard2.0"}},
+                    new object[] {false, new List<string> {"lib/_._"}, new List<string> {"net"}},        // no version
+                    new object[] {false, new List<string> {"lib/win/_._"}, new List<string> {"win"}},    // note that this is "win" the TFM (i.e. dep'd/replaced by netcore45), not "win" the RID.
+                    new object[] {false, new List<string> {"lib/foo/_._"}, new List<string> {"foo"}},    // this will be generated as a TFM if users use it, but it's meaningless to us
+                    new object[] {false, new List<string> {"lib/any/_._"}, new List<string> {"dotnet"}}, // "dotnet" is deprecated but is still discernable through this pattern
+                    // - resources
+                    new object[] {false, new List<string> {"lib/netcoreapp31/zh-hant/_._", "lib/netstandard20/zh_hant_._"}, new List<string> {"netcoreapp3.1", "netstandard2.0"}},
+                    new object[] {false, new List<string> {"lib/netcoreapp31/fr-fr/_._", "lib/netstandard20/zh_hans_._"}, new List<string> {"netcoreapp3.1", "netstandard2.0"}},
+                    // - portables
+                    new object[] {false, new List<string> {"lib/portable-net45+sl40+win+wp71/_._", "lib/portable-net45+sl50+win+wp71+wp80/_._"},
+                        new List<string> {"portable-net45+sl4+win+wp71", "portable-net45+sl5+win+wp71+wp8"}},
+                    new object[] {false, new List<string> {"lib/portable-profile14/_._", "lib/portable-profile154/_._", "lib/portable-profile7/_._"},
+                        new List<string> {"portable-net40+sl5", "portable-net45+sl4+win8+wp8", "portable-net45+win8"}},
+                    new object[] {false, new List<string> {"lib/portable-net45+sl50+foo50+wp71+wp80/_._", "lib/portable-net45+foo40+win+wp71/_._"},
+                        new List<string> {"portable-net45+sl5+unsupported+wp71+wp8", "portable-net45+unsupported+win+wp71"}},
+                    new object[] {false, new List<string> {"lib/portable-net45+monotouch+monoandroid10+xamarintvos/_._"}, new List<string> { "portable-monoandroid10+monotouch+net45+xamarintvos"}},
+                    // - including "runtimes/" gives us the option of runtime ids (RIDs) but these won't affect TFM determination
+                    new object[] {false, new List<string> {"runtimes/win/net40/_._", "runtimes/win/net471/_._"}, new List<string>()},                   // no "lib" dir
+                    new object[] {false, new List<string> {"runtimes/win/foostuff/net40/_._", "runtimes/win/foostuff/net471/_._"}, new List<string>()}, // no "lib" dir
+                    new object[] {false, new List<string> {"runtimes/win/lib/net40/_._", "runtimes/win/lib/net471/_._"}, new List<string> {"net40", "net471"}},
+                    new object[] {false, new List<string> {"runtimes/win/lib/net40/", "runtimes/win/lib/net471/_._"}, new List<string> {"net471"}},     // no file in "net40" dir
+                    // - resources
+                    new object[] {false, new List<string> {"runtimes/win/lib/net471/_._", "runtimes/win/lib/net472/fr-fr/_._"}, new List<string> {"net471", "net472"}},
+                    // - supporting different TFMs for different RIDs won't be exposed here--we just want the union set of all supported TFMs
+                    new object[] {false, new List<string> {"runtimes/win10-x64/lib/net40/_._", "runtimes/win10-arm/lib/net471/_._"}, new List<string> {"net40", "net471"}},
+                    // - net5.0+ runtimes
+                    new object[] {false, new List<string> {"lib/net5.0/_._", "lib/net5.0/_._"}, new List<string> {"net5.0"}},
+                    new object[] {false, new List<string> {"lib/net5.0-tvos/_._", "lib/net5.0-ios/_._"}, new List<string> {"net5.0-ios", "net5.0-tvos"}},
+                    new object[] {false, new List<string> {"lib/net5.0-tvos/_._", "lib/net5.0-ios13.0/_._"}, new List<string> {"net5.0-ios13.0", "net5.0-tvos"}},
+                    new object[] {false, new List<string> {"lib/net5.1-tvos/_._", "lib/net5.1/_._", "lib/net5.0-tvos/_._"}, new List<string> {"net5.0-tvos", "net5.1", "net5.1-tvos"}},
+                    new object[] {false, new List<string> {"lib/net5.0/_1._", "lib/net5.0/_2._", "lib/native/_._"}, new List<string> {"native", "net5.0" }},
+
+                    // Compile time refs
+                    new object[] {false, new List<string> {"ref/_._"}, new List<string>()},
+                    new object[] {false, new List<string> {"ref/net40/_._", "ref/net451/_._"}, new List<string> {"net40", "net451"}},
+                    new object[] {false, new List<string> {"ref/net5.0-watchos/_1._", "ref/net5.0-watchos/_2._" }, new List<string> {"net5.0-watchos"}},
+                    new object[] {false, new List<string> {"ref/net5.0-macos/_1._", "ref/net5.0-windows/_2._" }, new List<string> {"net5.0-macos", "net5.0-windows"}},
+
+                    // Build props/targets
+                    // - only if a props or target file is present of the name {id}.props|targets ({id} is "Foo" in our case) will the TFM be supported
+                    new object[] {false, new List<string> {"build/net40/Foo.props", "build/net42/Foo.targets"}, new List<string> {"net40", "net42"}},
+                    new object[] {false, new List<string> {"build/net40/Bar.props", "build/net42/Foo.targets"}, new List<string> {"net42"}},
+                    new object[] {false, new List<string> {"build/net40/Bar.props", "build/net42/Bar.targets"}, new List<string>()},
+                    new object[] {false, new List<string> {"build/net5.0/Foo.props", "build/net42/Foo.targets"}, new List<string> {"net42", "net5.0"}},
+                    // - "any" is a special case for build, where having no specific TFM is valid
+                    new object[] {false, new List<string> {"build/Foo.props", "build/Foo.targets"}, new List<string> {"any"}},
+                    new object[] {false, new List<string> {"build/Bar.props", "build/Foo.targets"}, new List<string> {"any"}},
+                    new object[] {false, new List<string> {"build/Bar.props", "build/Bar.targets"}, new List<string>()},
+
+                    // Tools
+                    // - a special case where we will only assess tools TFMs when the nuspec indicates it is a tools (and only a tools) package - hence the true bool
+                    // - also, a file in the TFM root doesn't qualify a TFM-supported tool - an RID or "any" must be provided
+                    // - see this: https://github.com/NuGet/Home/issues/6197#issuecomment-349495271 - "any" covers portables.
+                    new object[] {true, new List<string> {"tools/netcoreapp3.1/_._"}, new List<string>()},
+                    new object[] {true, new List<string> {"tools/netcoreapp3.1/win10-x86/_._"}, new List<string> {"netcoreapp3.1"}},
+                    new object[] {true, new List<string> {"tools/netcoreapp3.1/win10-x86/tool1/_._", "tools/netcoreapp3.1/win10-x86/tool2/_._" }, 
+                        new List<string> {"netcoreapp3.1"}},
+                    new object[] {true, new List<string> {"tools/netcoreapp3.1/any/_._"}, new List<string> {"netcoreapp3.1"}},
+                    new object[] {true, new List<string> {"tools/netcoreapp3.1/win/tool1/_._"}, new List<string> {"netcoreapp3.1"}},
+                    new object[] {true, new List<string> {"tools/netcoreapp3.1/win/any/_._"}, new List<string> {"netcoreapp3.1"}},
+                    new object[] {false, new List<string> {"tools/netcoreapp3.1/any/_._"}, new List<string>()}, // not a tools package, no supported TFMs
+
+                    // Content
+                    new object[] {false, new List<string> {"contentFiles/css/_._"}, new List<string>()},
+                    new object[] {false, new List<string> {"contentFiles/any/_._"}, new List<string>()},
+                    new object[] {false, new List<string> {"contentFiles/cs/netstandard2.0/_._"}, new List<string>{"netstandard2.0"}},
+                    new object[] {false, new List<string> {"contentFiles/any/netstandard2.0/_._"}, new List<string>{"netstandard2.0"}},
+                    new object[] {false, new List<string> {"contentFiles/cs/any/_._"}, new List<string>{"any"}},
+                    new object[] {false, new List<string> {"contentFiles/vb/net45/_._", "contentFiles/cs/netcoreapp3.1/_._"},
+                        new List<string>{"net45", "netcoreapp3.1"}},
+
+                    // Combinations
+                    new object[] 
+                    {
+                        false,
+                        new List<string>
+                        {
+                            "Foo.nuspec",
+                            "runtimes/win10-x86/lib/net40/_._",
+                            "runtimes/win10-x86/lib/net471/_._",
+                            "ref/net5.0-watchos/_1._",
+                            "ref/net5.0-watchos/_2._",
+                            "build/netstandard21/Foo.props",
+                            "build/netstandard20/Foo.targets",
+                            "tools/netcoreapp3.1/win10-x86/tool1/_._",
+                            "tools/netcoreapp3.1/win10-x86/tool2/_._"
+                        }, 
+                        new List<string>{"net40", "net471", "net5.0-watchos", "netstandard2.0", "netstandard2.1"}
+                    },
+                    // - note that a tools package (true below) is *only* a tools package when evaluating TFM support
+                    new object[] 
+                    {
+                        true, // tools package
+                        new List<string>
+                        {
+                            "Foo.nuspec",
+                            "runtimes/win10-x86/lib/net40/_._",
+                            "runtimes/win10-x86/lib/net471/_._",
+                            "ref/net5.0-watchos/_1._",
+                            "ref/net5.0-watchos/_2._",
+                            "build/netstandard21/Foo.props",
+                            "build/netstandard20/Foo.targets",
+                            "tools/netcoreapp3.1/win10-x86/tool1/_._",
+                            "tools/netcoreapp3.1/win10-x86/tool2/_._"
+                        }, 
+                        new List<string> {"netcoreapp3.1"}
+                    },
+                    new object[]
+                    {
+                        false,
+                        new List<string>
+                        {
+                            "Foo.nuspec",
+                            "runtimes/win10-x86/lib/xamarinios/_._",
+                            "runtimes/win10-x64/lib/xamarinios/_._",
+                            "ref/xamarinios/_1._",
+                            "ref/xamarinios/_2._",
+                            "build/netstandard21/Foo.props",
+                            "build/netstandard21/Foo.targets",
+                            "contentFiles/vb/net45/_._", 
+                            "contentFiles/cs/netstandard2.1/_._"
+                        },
+                        new List<string>{"net45", "netstandard2.1", "xamarinios"}
+                    },
+                    new object[]
+                    {
+                        false, 
+                        new List<string>
+                        {
+                            ".signature.p7s",
+                            "LICENSE.md",
+                            "Foo.nuspec",
+                            "fooIcon.png",
+                            "[Content_Types].xml",
+                            "_rels/.rels",
+                            "package/service/metadata/core-properties/foo1234.psmdcp",
+                            "lib/net20/Foo.dll",
+                            "lib/net35/Foo.dll",
+                            "lib/net40/Foo.dll",
+                            "lib/net45/Foo.dll",
+                            "lib/netstandard1.0/Foo.dll",
+                            "lib/netstandard1.3/Foo.dll",
+                            "lib/netstandard2.0/Foo.dll",
+                            "lib/portable-net40+sl5+win8+wp8+wpa81/Foo.dll",
+                            "lib/portable-net45+win8+wp8+wpa81/Foo.dll"
+                        },
+                        new List<string> {"net20", "net35", "net40", "net45", "netstandard1.0", "netstandard1.3", "netstandard2.0",
+                            "portable-net40+sl5+win8+wp8+wpa81", "portable-net45+win8+wp8+wpa81"}
+                    }
+                };
 
             [Fact]
             private async Task WillThrowIfTheRepositoryTypeIsLongerThan100()


### PR DESCRIPTION
Addresses: https://github.com/NuGet/NuGetGallery/issues/8386

The existing logic in `PackageService` relies on `package.GetSupportedFrameworks`, which while giving (largely) correct data, doesn't give enough of it--~85% with this change increasing it to ~93%. The new method in `PackageService` utilizes the restore logic employed by restore, gathering it into a single location for easy and robust maintenance. This logic will give us the supported frameworks for packages whose anatomy follows our guidelines, e.g. https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks. Some notes on this:
- Pattern set matching is our heuristic here--the only time we use the nuspec (which has misled us in the prior approach) is to determine package type, specifically answering one question: is this a _tools_ package and nothing else? If it is a tools package _only_, we will look to match tools pattern sets _only_ in order to list supported TFMs. Other pattern sets don't exist. This matches client restore behavior.
- Packages of type _build_ will only match build pattern sets when a `{id}.props|targets` file exists in a directory named for the TFM (in an appropriate pattern sets for build)
- See unit tests for cases - I've tried to cover as much as is reasonable there.

I've split the file list from the nuspec reader in this method, so that it can be called by existing logic in the `PackageService`, as well as by the new backfill job `BackfillTfmMetadataCommand`. (see https://github.com/NuGet/NuGetGallery/pull/8431, which should be merged _after_ this PR).