### PR TITLE
Implementation of Cake tab with instructions for NuGet packages

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1228,6 +1228,7 @@ img.reserved-indicator-icon {
   -ms-user-select: all;
   user-select: all;
   vertical-align: middle;
+  word-break: break-word;
 }
 .page-package-details .install-tabs .tab-content .tab-pane .install-script-row .copy-button {
   height: 100%;

--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -1,6 +1,6 @@
 /*!
  * Bootstrap v3.4.1 (https://getbootstrap.com/)
- * Copyright 2011-2020 Twitter, Inc.
+ * Copyright 2011-2021 Twitter, Inc.
  * Licensed under the MIT license
  */
 

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -300,9 +300,12 @@
             // in high contrast mode (since borders are shown).
             border-color: @panel-footer-bg;
             border-style: solid;
-            border-width: 1px 0 1px 1px;
+            border-width: 1px;
+            border-radius: 0;
             user-select: all;
             vertical-align: middle;
+            padding: 10.5px;
+            margin: 0 0 11px;
           }
 
           .copy-button {

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -300,12 +300,10 @@
             // in high contrast mode (since borders are shown).
             border-color: @panel-footer-bg;
             border-style: solid;
-            border-width: 1px;
-            border-radius: 0;
+            border-width: 1px 0 1px 1px;
             user-select: all;
             vertical-align: middle;
-            padding: 10.5px;
-            margin: 0 0 11px;
+            word-break: break-word;
           }
 
           .copy-button {

--- a/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
+++ b/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Web;
+
+namespace NuGetGallery
+{
+    public static class CakeBuildManagerExtensions
+    {
+        public static string GetCakeInstallPackageCommand(this DisplayPackageViewModel model)
+        {
+            var reference = $"nuget:?package={model.Id}&version={model.Version}";
+
+            if (model.Prerelease)
+            {
+                reference += "&prerelease";
+            }
+
+            if (model.Tags.Contains("cake-addin", StringComparer.CurrentCultureIgnoreCase))
+            {
+                return $"#addin {reference}";
+            }
+
+            if (model.Tags.Contains("cake-module", StringComparer.CurrentCultureIgnoreCase))
+            {
+                return $"#module {reference}";
+            }
+
+            if (model.Tags.Contains("cake-recipe", StringComparer.CurrentCultureIgnoreCase))
+            {
+                return $"#load {reference}";
+            }
+
+            return string.Join(Environment.NewLine, new[]
+            {
+                $"// Install {model.Id} as a Cake Addin",
+                $"#addin {reference}",
+                "",
+                $"// Install {model.Id} as a Cake Tool",
+                $"#tool {reference}",
+            });
+
+        }
+    }
+}

--- a/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
+++ b/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Linq;
 
 namespace NuGetGallery

--- a/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
+++ b/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Web;
 
 namespace NuGetGallery
 {
@@ -10,11 +7,17 @@ namespace NuGetGallery
     {
         public static string GetCakeInstallPackageCommand(this DisplayPackageViewModel model)
         {
-            var reference = $"nuget:?package={model.Id}&version={model.Version}";
+            var scheme = model.IsDotnetToolPackageType ? "dotnet" : "nuget";
+            var reference = $"{scheme}:?package={model.Id}&version={model.Version}";
 
             if (model.Prerelease)
             {
                 reference += "&prerelease";
+            }
+
+            if (model.IsDotnetToolPackageType)
+            {
+                return $"#tool {reference}";
             }
 
             if (model.Tags.Contains("cake-addin", StringComparer.CurrentCultureIgnoreCase))

--- a/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
+++ b/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
@@ -8,6 +8,11 @@ namespace NuGetGallery
 {
     public static class CakeBuildManagerExtensions
     {
+        public static bool IsCakeExtension(this DisplayPackageViewModel model)
+        {
+            return IsCakeAddin(model) || IsCakeModule(model) || IsCakeRecipe(model);
+        }
+
         public static string GetCakeInstallPackageCommand(this DisplayPackageViewModel model)
         {
             var reference = $"nuget:?package={model.Id}&version={model.Version}";
@@ -17,29 +22,37 @@ namespace NuGetGallery
                 reference += "&prerelease";
             }
 
-            if (model.Tags.Contains("cake-addin", StringComparer.OrdinalIgnoreCase))
+            if (IsCakeAddin(model))
             {
                 return $"#addin {reference}";
             }
 
-            if (model.Tags.Contains("cake-module", StringComparer.OrdinalIgnoreCase))
+            if (IsCakeModule(model))
             {
                 return $"#module {reference}";
             }
 
-            if (model.Tags.Contains("cake-recipe", StringComparer.OrdinalIgnoreCase))
+            if (IsCakeRecipe(model))
             {
                 return $"#load {reference}";
             }
 
-            return string.Join(Environment.NewLine, new[]
-            {
+            return string.Join(Environment.NewLine,
                 $"// Install {model.Id} as a Cake Addin",
                 $"#addin {reference}",
                 "",
                 $"// Install {model.Id} as a Cake Tool",
-                $"#tool {reference}",
-            });
+                $"#tool {reference}"
+            );
         }
+
+        private static bool IsCakeAddin(ListPackageItemViewModel model) =>
+            model.Tags?.Contains("cake-addin", StringComparer.OrdinalIgnoreCase) ?? false;
+
+        private static bool IsCakeModule(ListPackageItemViewModel model) =>
+            model.Tags?.Contains("cake-module", StringComparer.OrdinalIgnoreCase) ?? false;
+
+        private static bool IsCakeRecipe(ListPackageItemViewModel model) =>
+            model.Tags?.Contains("cake-recipe", StringComparer.OrdinalIgnoreCase) ?? false;
     }
 }

--- a/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
+++ b/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
@@ -17,17 +17,17 @@ namespace NuGetGallery
                 reference += "&prerelease";
             }
 
-            if (model.Tags.Contains("cake-addin", StringComparer.CurrentCultureIgnoreCase))
+            if (model.Tags.Contains("cake-addin", StringComparer.OrdinalIgnoreCase))
             {
                 return $"#addin {reference}";
             }
 
-            if (model.Tags.Contains("cake-module", StringComparer.CurrentCultureIgnoreCase))
+            if (model.Tags.Contains("cake-module", StringComparer.OrdinalIgnoreCase))
             {
                 return $"#module {reference}";
             }
 
-            if (model.Tags.Contains("cake-recipe", StringComparer.CurrentCultureIgnoreCase))
+            if (model.Tags.Contains("cake-recipe", StringComparer.OrdinalIgnoreCase))
             {
                 return $"#load {reference}";
             }

--- a/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
+++ b/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
@@ -7,17 +7,11 @@ namespace NuGetGallery
     {
         public static string GetCakeInstallPackageCommand(this DisplayPackageViewModel model)
         {
-            var scheme = model.IsDotnetToolPackageType ? "dotnet" : "nuget";
-            var reference = $"{scheme}:?package={model.Id}&version={model.Version}";
+            var reference = $"nuget:?package={model.Id}&version={model.Version}";
 
             if (model.Prerelease)
             {
                 reference += "&prerelease";
-            }
-
-            if (model.IsDotnetToolPackageType)
-            {
-                return $"#tool {reference}";
             }
 
             if (model.Tags.Contains("cake-addin", StringComparer.CurrentCultureIgnoreCase))
@@ -43,7 +37,6 @@ namespace NuGetGallery
                 $"// Install {model.Id} as a Cake Tool",
                 $"#tool {reference}",
             });
-
         }
     }
 }

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -212,6 +212,7 @@
     <Compile Include="Controllers\ExperimentsController.cs" />
     <Compile Include="Controllers\ManageDeprecationJsonApiController.cs" />
     <Compile Include="ExtensionMethods.cs" />
+    <Compile Include="Extensions\CakeBuildManagerExtensions.cs" />
     <Compile Include="Extensions\ImageExtensions.cs" />
     <Compile Include="Helpers\ValidationHelper.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeleteAccountListPackageItemViewModelFactory.cs" />

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -103,6 +103,12 @@
                     "For F# scripts that support <a href=\"{0}\">#r syntax</a>, copy this into the source code to reference the package.",
                     "https://docs.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/#referencing-packages-in-f-interactive")
             },
+
+            new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/")
+            {
+                Id = "cake",
+                InstallPackageCommand = Model.GetCakeInstallPackageCommand()
+            },
         };
     }
 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -163,7 +163,7 @@
     <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty)" id="@packageManager.Id">
         <div>
             <div class="install-script-row">
-                <pre class="install-script" id="@packageManager.Id-text">@packageManager.InstallPackageCommand</pre>
+                <div class="install-script" id="@packageManager.Id-text">@packageManager.InstallPackageCommand</div>
                 <div class="copy-button">
                     <!--In order to statisfy the requirement to announce button status both on NVDA/Narrator, other screen reader like NVDA will
                         announce the data-content "Copied" everytime when we press button, however, it won't work with Narrator when we use bootstrap popover 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -106,7 +106,7 @@
 
             new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/support/nuget")
             {
-                Id = "cake",
+                Id = Model.IsCakeExtension() ? "cake-extension" : "cake",
                 InstallPackageCommand = Model.GetCakeInstallPackageCommand()
             },
         };

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -36,12 +36,6 @@
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET Core Global Tool</a> you can call from the shell/command line.",
             },
-
-            new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/support/nuget")
-            {
-                Id = "cake",
-                InstallPackageCommand = Model.GetCakeInstallPackageCommand()
-            },
         };
     }
     else if (Model.IsDotnetNewTemplatePackageType)

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -163,7 +163,7 @@
     <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty)" id="@packageManager.Id">
         <div>
             <div class="install-script-row">
-                <div class="install-script" id="@packageManager.Id-text">@packageManager.InstallPackageCommand</div>
+                <pre class="install-script" id="@packageManager.Id-text">@packageManager.InstallPackageCommand</pre>
                 <div class="copy-button">
                     <!--In order to statisfy the requirement to announce button status both on NVDA/Narrator, other screen reader like NVDA will
                         announce the data-content "Copied" everytime when we press button, however, it won't work with Narrator when we use bootstrap popover 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -37,7 +37,7 @@
                 AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET Core Global Tool</a> you can call from the shell/command line.",
             },
 
-            new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/")
+            new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/support/nuget")
             {
                 Id = "cake",
                 InstallPackageCommand = Model.GetCakeInstallPackageCommand()
@@ -110,7 +110,7 @@
                     "https://docs.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/#referencing-packages-in-f-interactive")
             },
 
-            new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/")
+            new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/support/nuget")
             {
                 Id = "cake",
                 InstallPackageCommand = Model.GetCakeInstallPackageCommand()

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -35,7 +35,13 @@
                 InstallPackageCommand = string.Format("dotnet tool install --global {0} --version {1}", Model.Id, Model.Version),
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET Core Global Tool</a> you can call from the shell/command line.",
-            }
+            },
+
+            new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/")
+            {
+                Id = "cake",
+                InstallPackageCommand = Model.GetCakeInstallPackageCommand()
+            },
         };
     }
     else if (Model.IsDotnetNewTemplatePackageType)

--- a/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
@@ -1,0 +1,169 @@
+﻿using Xunit;
+
+namespace NuGetGallery.Extensions
+{
+    public class CakeBuildManagerExtensionsFacts
+    {
+        public class GivenACakeAddin
+        {
+            [Fact]
+            public void ReturnsAnAddinDirective()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    Id = "Cake.7zip", 
+                    Version = "1.0.0",
+                    Tags = new[] { "cake-addin" }
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Equal("#addin nuget:?package=Cake.7zip&version=1.0.0", actual);
+            }
+
+            [Fact]
+            public void ReturnsAnAddinDirectiveWithPrerelease()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    Id = "Cake.7zip",
+                    Version = "1.0.0",
+                    Tags = new[] { "cake-addin" },
+                    Prerelease = true
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Equal("#addin nuget:?package=Cake.7zip&version=1.0.0&prerelease", actual);
+            }
+        }
+
+        public class GivenACakeModule
+        {
+            [Fact]
+            public void ReturnsAModuleDirective()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    Id = "Cake.BuildSystems.Module",
+                    Version = "1.0.0",
+                    Tags = new[] { "cake-module" }
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Equal("#module nuget:?package=Cake.BuildSystems.Module&version=1.0.0", actual);
+            }
+
+            [Fact]
+            public void ReturnsAModuleDirectiveWithPrerelease()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    Id = "Cake.BuildSystems.Module",
+                    Version = "1.0.0",
+                    Tags = new[] { "cake-module" },
+                    Prerelease = true
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Equal("#module nuget:?package=Cake.BuildSystems.Module&version=1.0.0&prerelease", actual);
+            }
+        }
+
+        public class GivenACakeRecipe
+        {
+            [Fact]
+            public void ReturnsALoadDirective()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    Id = "Cake.Recipe",
+                    Version = "1.0.0",
+                    Tags = new[] { "cake-recipe" }
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Equal("#load nuget:?package=Cake.Recipe&version=1.0.0", actual);
+            }
+
+            [Fact]
+            public void ReturnsALoadDirectiveWithPrerelease()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    Id = "Cake.Recipe",
+                    Version = "1.0.0",
+                    Tags = new[] { "cake-recipe" },
+                    Prerelease = true
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Equal("#load nuget:?package=Cake.Recipe&version=1.0.0&prerelease", actual);
+            }
+        }
+
+        public class GivenANonCakePackage
+        {
+            [Fact]
+            public void ReturnsMultipleDirectives()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    Id = "Polly",
+                    Version = "1.0.0",
+                    Tags = new[] { "" }
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Contains("#addin nuget:?package=Polly&version=1.0.0", actual);
+                Assert.Contains("#tool nuget:?package=Polly&version=1.0.0", actual);
+            }
+
+            [Fact]
+            public void ReturnsALoadDirectiveWithPrerelease()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    Id = "Polly",
+                    Version = "1.0.0",
+                    Tags = new[] { "" },
+                    Prerelease = true
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Contains("#addin nuget:?package=Polly&version=1.0.0&prerelease", actual);
+                Assert.Contains("#tool nuget:?package=Polly&version=1.0.0&prerelease", actual);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
@@ -4,6 +4,48 @@ namespace NuGetGallery.Extensions
 {
     public class CakeBuildManagerExtensionsFacts
     {
+        public class GivenADotNetTool
+        {
+            [Fact]
+            public void ReturnsAToolDotNetDirective()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    IsDotnetToolPackageType = true,
+                    Id = "dotnet-reportgenerator-globaltool",
+                    Version = "4.8.6",
+                    Tags = new string[0],
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Equal("#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=4.8.6", actual);
+            }
+
+            [Fact]
+            public void ReturnsAToolDotNetDirectiveWithPrerelease()
+            {
+                // Arrange
+                var model = new DisplayPackageViewModel
+                {
+                    IsDotnetToolPackageType = true,
+                    Id = "dotnet-reportgenerator-globaltool",
+                    Version = "4.8.6",
+                    Tags = new string[0],
+                    Prerelease = true,
+                };
+
+                // act
+                var actual = model.GetCakeInstallPackageCommand();
+
+                // assert
+                Assert.Equal("#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=4.8.6&prerelease", actual);
+            }
+        }
+
         public class GivenACakeAddin
         {
             [Fact]

--- a/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
 
 namespace NuGetGallery.Extensions
 {

--- a/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
@@ -1,172 +1,167 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections;
+using System.Collections.Generic;
 using Xunit;
 
 namespace NuGetGallery.Extensions
 {
     public class CakeBuildManagerExtensionsFacts
     {
-        public class GivenACakeAddin
+        public class TheMethodGetCakeInstallPackageCommand
         {
-            [Fact]
-            public void ReturnsAnAddinDirective()
+            public class GivenAPackageWithTheCakeAddinTag
             {
-                // Arrange
-                var model = new DisplayPackageViewModel
+                [Fact]
+                public void ReturnsAnAddinDirective()
                 {
-                    Id = "Cake.7zip", 
-                    Version = "1.0.0",
-                    Tags = new[] { "cake-addin" }
-                };
+                    var model = new DisplayPackageViewModel
+                    {
+                        Id = "Cake.7zip",
+                        Version = "1.0.0",
+                        Tags = new[] { "cake-addin" },
+                    };
 
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
+                    var actual = model.GetCakeInstallPackageCommand();
 
-                // assert
-                Assert.Equal("#addin nuget:?package=Cake.7zip&version=1.0.0", actual);
+                    Assert.Equal("#addin nuget:?package=Cake.7zip&version=1.0.0", actual);
+                }
+
+                [Fact]
+                public void ReturnsAnAddinDirectiveWithPrerelease()
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        Id = "Cake.7zip",
+                        Version = "1.0.0",
+                        Tags = new[] { "cake-addin" },
+                        Prerelease = true,
+                    };
+
+                    var actual = model.GetCakeInstallPackageCommand();
+
+                    Assert.Equal("#addin nuget:?package=Cake.7zip&version=1.0.0&prerelease", actual);
+                }
             }
 
-            [Fact]
-            public void ReturnsAnAddinDirectiveWithPrerelease()
+            public class GivenAPackageWithTheCakeModuleTag
             {
-                // Arrange
-                var model = new DisplayPackageViewModel
+                [Fact]
+                public void ReturnsAModuleDirective()
                 {
-                    Id = "Cake.7zip",
-                    Version = "1.0.0",
-                    Tags = new[] { "cake-addin" },
-                    Prerelease = true
-                };
+                    var model = new DisplayPackageViewModel
+                    {
+                        Id = "Cake.BuildSystems.Module",
+                        Version = "1.0.0",
+                        Tags = new[] {"cake-module"},
+                    };
 
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
+                    var actual = model.GetCakeInstallPackageCommand();
 
-                // assert
-                Assert.Equal("#addin nuget:?package=Cake.7zip&version=1.0.0&prerelease", actual);
+                    Assert.Equal("#module nuget:?package=Cake.BuildSystems.Module&version=1.0.0", actual);
+                }
+
+                [Fact]
+                public void ReturnsAModuleDirectiveWithPrerelease()
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        Id = "Cake.BuildSystems.Module",
+                        Version = "1.0.0",
+                        Tags = new[] { "cake-module" },
+                        Prerelease = true,
+                    };
+
+                    var actual = model.GetCakeInstallPackageCommand();
+
+                    Assert.Equal("#module nuget:?package=Cake.BuildSystems.Module&version=1.0.0&prerelease", actual);
+                }
+            }
+
+            public class GivenAPackageWithTheCakeRecipeTag
+            {
+                [Fact]
+                public void ReturnsALoadDirective()
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        Id = "Cake.Recipe",
+                        Version = "1.0.0",
+                        Tags = new[] { "cake-recipe" },
+                    };
+
+                    var actual = model.GetCakeInstallPackageCommand();
+
+                    Assert.Equal("#load nuget:?package=Cake.Recipe&version=1.0.0", actual);
+                }
+
+                [Fact]
+                public void ReturnsALoadDirectiveWithPrerelease()
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        Id = "Cake.Recipe",
+                        Version = "1.0.0",
+                        Tags = new[] { "cake-recipe" },
+                        Prerelease = true,
+                    };
+
+                    var actual = model.GetCakeInstallPackageCommand();
+
+                    Assert.Equal("#load nuget:?package=Cake.Recipe&version=1.0.0&prerelease", actual);
+                }
+            }
+
+            public class GivenAPackageWithoutAnyKnownCakeTags
+            {
+                [Theory]
+                [ClassData(typeof(PackageTagsNotKnownToBeCakeExtensions))]
+                public void ReturnsMultipleDirectives(string[] tags)
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        Id = "Polly",
+                        Version = "1.0.0",
+                        Tags = tags,
+                    };
+
+                    var actual = model.GetCakeInstallPackageCommand();
+
+                    Assert.Contains("#addin nuget:?package=Polly&version=1.0.0", actual);
+                    Assert.Contains("#tool nuget:?package=Polly&version=1.0.0", actual);
+                }
+
+                [Theory]
+                [ClassData(typeof(PackageTagsNotKnownToBeCakeExtensions))]
+                public void ReturnsMultipleDirectivesWithPrerelease(string[] tags)
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        Id = "Polly",
+                        Version = "1.0.0",
+                        Tags = tags,
+                        Prerelease = true,
+                    };
+
+                    var actual = model.GetCakeInstallPackageCommand();
+
+                    Assert.Contains("#addin nuget:?package=Polly&version=1.0.0&prerelease", actual);
+                    Assert.Contains("#tool nuget:?package=Polly&version=1.0.0&prerelease", actual);
+                }
             }
         }
 
-        public class GivenACakeModule
+        public class PackageTagsNotKnownToBeCakeExtensions : IEnumerable<object[]>
         {
-            [Fact]
-            public void ReturnsAModuleDirective()
+            public IEnumerator<object[]> GetEnumerator()
             {
-                // Arrange
-                var model = new DisplayPackageViewModel
-                {
-                    Id = "Cake.BuildSystems.Module",
-                    Version = "1.0.0",
-                    Tags = new[] { "cake-module" }
-                };
-
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
-
-                // assert
-                Assert.Equal("#module nuget:?package=Cake.BuildSystems.Module&version=1.0.0", actual);
+                yield return new object[] { null };
+                yield return new object[] { new string[0] };
+                yield return new object[] { new[] { "json" } };
             }
 
-            [Fact]
-            public void ReturnsAModuleDirectiveWithPrerelease()
-            {
-                // Arrange
-                var model = new DisplayPackageViewModel
-                {
-                    Id = "Cake.BuildSystems.Module",
-                    Version = "1.0.0",
-                    Tags = new[] { "cake-module" },
-                    Prerelease = true
-                };
-
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
-
-                // assert
-                Assert.Equal("#module nuget:?package=Cake.BuildSystems.Module&version=1.0.0&prerelease", actual);
-            }
-        }
-
-        public class GivenACakeRecipe
-        {
-            [Fact]
-            public void ReturnsALoadDirective()
-            {
-                // Arrange
-                var model = new DisplayPackageViewModel
-                {
-                    Id = "Cake.Recipe",
-                    Version = "1.0.0",
-                    Tags = new[] { "cake-recipe" }
-                };
-
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
-
-                // assert
-                Assert.Equal("#load nuget:?package=Cake.Recipe&version=1.0.0", actual);
-            }
-
-            [Fact]
-            public void ReturnsALoadDirectiveWithPrerelease()
-            {
-                // Arrange
-                var model = new DisplayPackageViewModel
-                {
-                    Id = "Cake.Recipe",
-                    Version = "1.0.0",
-                    Tags = new[] { "cake-recipe" },
-                    Prerelease = true
-                };
-
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
-
-                // assert
-                Assert.Equal("#load nuget:?package=Cake.Recipe&version=1.0.0&prerelease", actual);
-            }
-        }
-
-        public class GivenANonCakePackage
-        {
-            [Fact]
-            public void ReturnsMultipleDirectives()
-            {
-                // Arrange
-                var model = new DisplayPackageViewModel
-                {
-                    Id = "Polly",
-                    Version = "1.0.0",
-                    Tags = new[] { "" }
-                };
-
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
-
-                // assert
-                Assert.Contains("#addin nuget:?package=Polly&version=1.0.0", actual);
-                Assert.Contains("#tool nuget:?package=Polly&version=1.0.0", actual);
-            }
-
-            [Fact]
-            public void ReturnsALoadDirectiveWithPrerelease()
-            {
-                // Arrange
-                var model = new DisplayPackageViewModel
-                {
-                    Id = "Polly",
-                    Version = "1.0.0",
-                    Tags = new[] { "" },
-                    Prerelease = true
-                };
-
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
-
-                // assert
-                Assert.Contains("#addin nuget:?package=Polly&version=1.0.0&prerelease", actual);
-                Assert.Contains("#tool nuget:?package=Polly&version=1.0.0&prerelease", actual);
-            }
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
@@ -4,48 +4,6 @@ namespace NuGetGallery.Extensions
 {
     public class CakeBuildManagerExtensionsFacts
     {
-        public class GivenADotNetTool
-        {
-            [Fact]
-            public void ReturnsAToolDotNetDirective()
-            {
-                // Arrange
-                var model = new DisplayPackageViewModel
-                {
-                    IsDotnetToolPackageType = true,
-                    Id = "dotnet-reportgenerator-globaltool",
-                    Version = "4.8.6",
-                    Tags = new string[0],
-                };
-
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
-
-                // assert
-                Assert.Equal("#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=4.8.6", actual);
-            }
-
-            [Fact]
-            public void ReturnsAToolDotNetDirectiveWithPrerelease()
-            {
-                // Arrange
-                var model = new DisplayPackageViewModel
-                {
-                    IsDotnetToolPackageType = true,
-                    Id = "dotnet-reportgenerator-globaltool",
-                    Version = "4.8.6",
-                    Tags = new string[0],
-                    Prerelease = true,
-                };
-
-                // act
-                var actual = model.GetCakeInstallPackageCommand();
-
-                // assert
-                Assert.Equal("#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=4.8.6&prerelease", actual);
-            }
-        }
-
         public class GivenACakeAddin
         {
             [Fact]

--- a/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace NuGetGallery.Extensions
@@ -14,8 +14,8 @@ namespace NuGetGallery.Extensions
             public class GivenAPackageWithKnownCakeTags
             {
                 [Theory]
-                [ClassData(typeof(PackageTagsKnownToBeCakeExtensions))]
-                public void ReturnsFalse(string[] tags)
+                [MemberData(nameof(PackageTagsKnownToBeCakeExtensions), MemberType = typeof(CakeBuildManagerExtensionsFacts))]
+                public void ReturnsTrue(string[] tags)
                 {
                     var model = new DisplayPackageViewModel
                     {
@@ -31,7 +31,7 @@ namespace NuGetGallery.Extensions
             public class GivenAPackageWithoutAnyKnownCakeTags
             {
                 [Theory]
-                [ClassData(typeof(PackageTagsNotKnownToBeCakeExtensions))]
+                [MemberData(nameof(PackageTagsNotKnownToBeCakeExtensions), MemberType = typeof(CakeBuildManagerExtensionsFacts))]
                 public void ReturnsFalse(string[] tags)
                 {
                     var model = new DisplayPackageViewModel
@@ -153,7 +153,7 @@ namespace NuGetGallery.Extensions
             public class GivenAPackageWithoutAnyKnownCakeTags
             {
                 [Theory]
-                [ClassData(typeof(PackageTagsNotKnownToBeCakeExtensions))]
+                [MemberData(nameof(PackageTagsNotKnownToBeCakeExtensions), MemberType = typeof(CakeBuildManagerExtensionsFacts))]
                 public void ReturnsMultipleDirectives(string[] tags)
                 {
                     var model = new DisplayPackageViewModel
@@ -170,7 +170,7 @@ namespace NuGetGallery.Extensions
                 }
 
                 [Theory]
-                [ClassData(typeof(PackageTagsNotKnownToBeCakeExtensions))]
+                [MemberData(nameof(PackageTagsNotKnownToBeCakeExtensions), MemberType = typeof(CakeBuildManagerExtensionsFacts))]
                 public void ReturnsMultipleDirectivesWithPrerelease(string[] tags)
                 {
                     var model = new DisplayPackageViewModel
@@ -189,28 +189,19 @@ namespace NuGetGallery.Extensions
             }
         }
 
-        public class PackageTagsKnownToBeCakeExtensions : IEnumerable<object[]>
+        public static IEnumerable<object[]> PackageTagsKnownToBeCakeExtensions => new[]
         {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { new[] { "cake-addin" } };
-                yield return new object[] { new[] { "cake-module" } };
-                yield return new object[] { new[] { "cake-recipe" } };
-            }
+            new[] { "cake-addin" },
+            new[] { "cake-module" },
+            new[] { "cake-recipe" },
+        }.Select(tags => new object[] { tags });
 
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        public class PackageTagsNotKnownToBeCakeExtensions : IEnumerable<object[]>
+        public static IEnumerable<object[]> PackageTagsNotKnownToBeCakeExtensions => new[]
         {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                yield return new object[] { null };
-                yield return new object[] { new string[0] };
-                yield return new object[] { new[] { "json" } };
-            }
-
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
+            null,
+            new string[0],
+            new string[] { null },
+            new[] { "json" },
+        }.Select(tags => new object[] { tags });
     }
 }

--- a/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
@@ -9,6 +9,43 @@ namespace NuGetGallery.Extensions
 {
     public class CakeBuildManagerExtensionsFacts
     {
+        public class TheMethodIsCakeExtension
+        {
+            public class GivenAPackageWithKnownCakeTags
+            {
+                [Theory]
+                [ClassData(typeof(PackageTagsKnownToBeCakeExtensions))]
+                public void ReturnsFalse(string[] tags)
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        Tags = tags,
+                    };
+
+                    var actual = model.IsCakeExtension();
+
+                    Assert.True(actual);
+                }
+            }
+
+            public class GivenAPackageWithoutAnyKnownCakeTags
+            {
+                [Theory]
+                [ClassData(typeof(PackageTagsNotKnownToBeCakeExtensions))]
+                public void ReturnsFalse(string[] tags)
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        Tags = tags,
+                    };
+
+                    var actual = model.IsCakeExtension();
+
+                    Assert.False(actual);
+                }
+            }
+        }
+
         public class TheMethodGetCakeInstallPackageCommand
         {
             public class GivenAPackageWithTheCakeAddinTag
@@ -150,6 +187,18 @@ namespace NuGetGallery.Extensions
                     Assert.Contains("#tool nuget:?package=Polly&version=1.0.0&prerelease", actual);
                 }
             }
+        }
+
+        public class PackageTagsKnownToBeCakeExtensions : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] { new[] { "cake-addin" } };
+                yield return new object[] { new[] { "cake-module" } };
+                yield return new object[] { new[] { "cake-recipe" } };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
 
         public class PackageTagsNotKnownToBeCakeExtensions : IEnumerable<object[]>

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Authentication\AuthenticationServiceFacts.cs" />
     <Compile Include="Authentication\Providers\CommonAuth\AzureActiveDirectoryV2AuthenticatorFacts.cs" />
     <Compile Include="Authentication\TestCredentialHelper.cs" />
+    <Compile Include="Extensions\CakeBuildManagerExtensionsFacts.cs" />
     <Compile Include="Helpers\ValidationHelperFacts.cs" />
     <Compile Include="Infrastructure\ODataCacheOutputAttributeFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageIdsQueryFacts.cs" />


### PR DESCRIPTION
Add installation instructions of NuGet packages in Cake scripts.

Credits to Nils Andresen ( @nils-a ), member of the Cake team, who did all the hard work :muscle:

| :jigsaw: | Packages identified as Cake extension of type "Addin" (via tags) |
|:---: | --- |
| | ![image](https://user-images.githubusercontent.com/177608/109409604-86344980-796a-11eb-8f93-c147eabf07ac.png) |
| | Packages of type `Dependency` that have the tag `cake-addin` |

---

| :jigsaw: | Packages identified as Cake extension of type "Module" (via tags) |
|:---: | --- |
| | ![image](https://user-images.githubusercontent.com/177608/109409748-a0baf280-796b-11eb-8b8b-eef7d283b870.png) |
| | Packages of type `Dependency` that have the tag `cake-module` |

---

| :jigsaw: | Packages identified as Cake extension of type "Recipe" (via tags) |
|:---: | --- |
| | ![image](https://user-images.githubusercontent.com/177608/109409832-4ec69c80-796c-11eb-91c5-68e2739689dd.png) |
| | Packages of type `Dependency` that have the tag `cake-recipe` |

---

| :package: | Packages identified as Dependency (via PackageType) |
|:---: | --- |
| | ![image](https://user-images.githubusercontent.com/177608/109409850-73227900-796c-11eb-8dd1-b03e93939255.png) |
| | Packages of type `Dependency` |

---

/cc @joelverhagen

Addresses https://github.com/NuGet/NuGetGallery/issues/8381