### PR TITLE
Add IsVulnerable to Manage Packages view model

### DIFF
--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -87,9 +87,9 @@ namespace NuGetGallery
         Package FilterLatestPackageBySuffix(IReadOnlyCollection<Package> packages,
             string version, bool prerelease);
 
-        IEnumerable<Package> FindPackagesByOwner(User user, bool includeUnlisted, bool includeVersions = false);
+        IEnumerable<Package> FindPackagesByOwner(User user, bool includeUnlisted, bool includeVersions = false, bool includeVulnerabilities = false);
 
-        IEnumerable<Package> FindPackagesByAnyMatchingOwner(User user, bool includeUnlisted, bool includeVersions = false);
+        IEnumerable<Package> FindPackagesByAnyMatchingOwner(User user, bool includeUnlisted, bool includeVersions = false, bool includeVulnerabilities = false);
 
         IQueryable<PackageRegistration> FindPackageRegistrationsByOwner(User user);
 

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -403,9 +403,12 @@ namespace NuGetGallery
             return package;
         }
 
-        public IEnumerable<Package> FindPackagesByOwner(User user, bool includeUnlisted, bool includeVersions = false)
+        public IEnumerable<Package> FindPackagesByOwner(User user, 
+            bool includeUnlisted, 
+            bool includeVersions = false,
+            bool includeVulnerabilities = false)
         {
-            return GetPackagesForOwners(new[] { user.Key }, includeUnlisted, includeVersions);
+            return GetPackagesForOwners(new[] { user.Key }, includeUnlisted, includeVersions, includeVulnerabilities);
         }
 
         /// <summary>
@@ -414,15 +417,17 @@ namespace NuGetGallery
         public IEnumerable<Package> FindPackagesByAnyMatchingOwner(
             User user,
             bool includeUnlisted,
-            bool includeVersions = false)
+            bool includeVersions = false,
+            bool includeVulnerabilities = false)
         {
             var ownerKeys = user.Organizations.Select(org => org.OrganizationKey).ToList();
             ownerKeys.Insert(0, user.Key);
 
-            return GetPackagesForOwners(ownerKeys, includeUnlisted, includeVersions);
+            return GetPackagesForOwners(ownerKeys, includeUnlisted, includeVersions, includeVulnerabilities);
         }
 
-        private IEnumerable<Package> GetPackagesForOwners(IEnumerable<int> ownerKeys, bool includeUnlisted, bool includeVersions)
+        private IEnumerable<Package> GetPackagesForOwners(IEnumerable<int> ownerKeys, bool includeUnlisted,
+            bool includeVersions, bool includeVulnerabilities)
         {
             IQueryable<Package> packages = _packageRepository.GetAll()
                 .Where(p => p.PackageRegistration.Owners.Any(o => ownerKeys.Contains(o.Key)));
@@ -434,7 +439,7 @@ namespace NuGetGallery
 
             if (!includeVersions)
             {
-                // Do a best effort of retrieving the latest version. Note that UpdateIsLatest has had concurrency issues
+                // Do a best effort of retrieving the latest versions. Note that UpdateIsLatest has had concurrency issues
                 // where sometimes packages no rows with IsLatest set. In this case, we'll just select the last inserted
                 // row (descending [Key]) as opposed to reading all rows into memory and sorting on NuGetVersion.
                 packages = packages
@@ -450,11 +455,17 @@ namespace NuGetGallery
                         .FirstOrDefault());
             }
 
-            return packages
+            var result = packages
                 .Include(p => p.PackageRegistration)
                 .Include(p => p.PackageRegistration.Owners)
-                .Include(p => p.PackageRegistration.RequiredSigners)
-                .ToList();
+                .Include(p => p.PackageRegistration.RequiredSigners);
+
+            if (includeVulnerabilities)
+            {
+                result = result.Include($"{nameof(Package.VulnerablePackageRanges)}.{nameof(VulnerablePackageVersionRange.Vulnerability)}");
+            }
+
+            return result.ToList();
         }
 
         public IQueryable<PackageRegistration> FindPackageRegistrationsByOwner(User user)

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemRequiredSignerViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemRequiredSignerViewModelFactory.cs
@@ -13,11 +13,16 @@ namespace NuGetGallery
     {
         private readonly ListPackageItemViewModelFactory _listPackageItemViewModelFactory;
         private readonly ISecurityPolicyService _securityPolicyService;
+        private readonly IPackageVulnerabilitiesService _packageVulnerabilitiesService;
 
-        public ListPackageItemRequiredSignerViewModelFactory(ISecurityPolicyService securityPolicyService, IIconUrlProvider iconUrlProvider)
+        public ListPackageItemRequiredSignerViewModelFactory(
+            ISecurityPolicyService securityPolicyService, 
+            IIconUrlProvider iconUrlProvider,
+            IPackageVulnerabilitiesService packageVulnerabilitiesService)
         {
             _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider);
             _securityPolicyService = securityPolicyService ?? throw new ArgumentNullException(nameof(securityPolicyService));
+            _packageVulnerabilitiesService = packageVulnerabilitiesService ?? throw new ArgumentNullException(nameof(packageVulnerabilitiesService));
         }
 
         // username must be an empty string because <select /> option values are based on username
@@ -124,6 +129,8 @@ namespace NuGetGallery
 
                 viewModel.CanEditRequiredSigner &= wasAADLoginOrMultiFactorAuthenticated;
             }
+
+            viewModel.IsVulnerable = _packageVulnerabilitiesService.PackageIsVulnerable(package);
 
             return viewModel;
         }

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemRequiredSignerViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemRequiredSignerViewModelFactory.cs
@@ -130,7 +130,7 @@ namespace NuGetGallery
                 viewModel.CanEditRequiredSigner &= wasAADLoginOrMultiFactorAuthenticated;
             }
 
-            viewModel.IsVulnerable = _packageVulnerabilitiesService.PackageIsVulnerable(package);
+            viewModel.IsVulnerable = _packageVulnerabilitiesService.IsPackageVulnerable(package);
 
             return viewModel;
         }

--- a/src/NuGetGallery/Services/IPackageVulnerabilitiesService.cs
+++ b/src/NuGetGallery/Services/IPackageVulnerabilitiesService.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using NuGet.Services.Entities;
 
 namespace NuGetGallery
@@ -14,5 +13,11 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="id">id of the package for this query</param>
         IReadOnlyDictionary<int, IReadOnlyList<PackageVulnerability>> GetVulnerabilitiesById(string id);
+
+        /// <summary>
+        /// Returns true if the package has a vulnerability
+        /// </summary>
+        /// <param name="package">package to examine</param>
+        bool PackageIsVulnerable(Package package);
     }
 }

--- a/src/NuGetGallery/Services/IPackageVulnerabilitiesService.cs
+++ b/src/NuGetGallery/Services/IPackageVulnerabilitiesService.cs
@@ -18,6 +18,6 @@ namespace NuGetGallery
         /// Returns true if the package has a vulnerability
         /// </summary>
         /// <param name="package">package to examine</param>
-        bool PackageIsVulnerable(Package package);
+        bool IsPackageVulnerable(Package package);
     }
 }

--- a/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
+++ b/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.IO;
 using System.Linq;
 using NuGet.Services.Entities;
 
@@ -48,8 +49,13 @@ namespace NuGetGallery
             {
                 throw new ArgumentNullException(nameof(package));
             }
-                
-            return package.VulnerablePackageRanges?.FirstOrDefault(vpr => vpr.Vulnerability != null) != null;
+
+            if (package.VulnerablePackageRanges == null)
+            {
+                throw new ArgumentException($"{nameof(package.VulnerablePackageRanges)} should be included in package query");
+            }
+
+            return package.VulnerablePackageRanges.FirstOrDefault(vpr => vpr.Vulnerability != null) != null;
         }
     }
 }

--- a/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
+++ b/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
@@ -41,5 +41,10 @@ namespace NuGetGallery
             return !result.Any() ? null :
                 result.ToDictionary(kv => kv.Key, kv => kv.Value as IReadOnlyList<PackageVulnerability>);
         }
+
+        public bool PackageIsVulnerable(Package package) =>
+            package != null
+            && package.VulnerablePackageRanges != null
+            && package.VulnerablePackageRanges.FirstOrDefault(vpr => vpr.Vulnerability != null) != null;
     }
 }

--- a/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
+++ b/src/NuGetGallery/Services/PackageVulnerabilitiesService.cs
@@ -42,9 +42,14 @@ namespace NuGetGallery
                 result.ToDictionary(kv => kv.Key, kv => kv.Value as IReadOnlyList<PackageVulnerability>);
         }
 
-        public bool PackageIsVulnerable(Package package) =>
-            package != null
-            && package.VulnerablePackageRanges != null
-            && package.VulnerablePackageRanges.FirstOrDefault(vpr => vpr.Vulnerability != null) != null;
+        public bool IsPackageVulnerable(Package package)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+                
+            return package.VulnerablePackageRanges?.FirstOrDefault(vpr => vpr.Vulnerability != null) != null;
+        }
     }
 }

--- a/src/NuGetGallery/ViewModels/ManagePackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ManagePackagesViewModel.cs
@@ -23,5 +23,7 @@ namespace NuGetGallery
         public bool WasMultiFactorAuthenticated { get; set; }
 
         public bool IsCertificatesUIEnabled { get; set; }
+
+        public bool IsPackageVulnerabilitiesEnabled { get; set; }
     }
 }

--- a/src/NuGetGallery/ViewModels/PackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageViewModel.cs
@@ -28,6 +28,7 @@ namespace NuGetGallery
         public string Version { get; set; }
         public string FullVersion { get; set; }
         public PackageStatusSummary PackageStatusSummary { get; set; }
+        public bool IsVulnerable { get; set; }
 
         public bool IsCurrent(IPackageVersionModel current)
         {

--- a/tests/AccountDeleter.Facts/EvaluatorFacts.cs
+++ b/tests/AccountDeleter.Facts/EvaluatorFacts.cs
@@ -31,7 +31,7 @@ namespace NuGetGallery.AccountDeleter.Facts
         public void NuGetDeleteevaluatorReturnsCorrectValueForUnconfirmed()
         {
             // Setup
-            _packageService.Setup(ps => ps.FindPackagesByOwner(It.IsAny<User>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            _packageService.Setup(ps => ps.FindPackagesByOwner(It.IsAny<User>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(() =>
                 {
                     return new List<Package>();
@@ -58,7 +58,7 @@ namespace NuGetGallery.AccountDeleter.Facts
         public void NuGetDeleteevaluatorReturnsCorrectValueForPackages(bool userHasPackages, bool expectedResult)
         {
             // Setup
-            _packageService.Setup(ps => ps.FindPackagesByOwner(It.IsAny<User>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            _packageService.Setup(ps => ps.FindPackagesByOwner(It.IsAny<User>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(() =>
                 {
                     if (userHasPackages)
@@ -94,7 +94,7 @@ namespace NuGetGallery.AccountDeleter.Facts
         public void NuGetDeleteevaluatorReturnsCorrectValueForOrganizations(bool userHasOrgs, bool userIsAdmin, bool expectedResult)
         {
             // Setup
-            _packageService.Setup(ps => ps.FindPackagesByOwner(It.IsAny<User>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            _packageService.Setup(ps => ps.FindPackagesByOwner(It.IsAny<User>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(() =>
                 {
                     return new List<Package>();

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -1665,7 +1665,7 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(testOrganization.Username, false))
                     .Returns(testOrganization);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testOrganization, It.IsAny<bool>(), false))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testOrganization, It.IsAny<bool>(), false, false))
                     .Returns(userPackages);
                 GetMock<IPackageService>()
                     .Setup(stub => stub.WillPackageBeOrphanedIfOwnerRemoved(packageRegistration, testOrganization))
@@ -1700,7 +1700,7 @@ namespace NuGetGallery
                 controller.SetCurrentUser(fakes.OrganizationOwnerAdmin);
 
                 GetMock<IPackageService>()
-                    .Setup(x => x.FindPackagesByAnyMatchingOwner(testOrganization, true, false))
+                    .Setup(x => x.FindPackagesByAnyMatchingOwner(testOrganization, true, false, false))
                     .Returns(new[] { new Package { Version = "1.0.0", PackageRegistration = new PackageRegistration { Owners = new[] { testOrganization } } } });
                 GetMock<IPackageService>()
                     .Setup(x => x.WillPackageBeOrphanedIfOwnerRemoved(It.IsAny<PackageRegistration>(), testOrganization))
@@ -2484,7 +2484,7 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(username, false))
                     .Returns(testUser);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>(), false))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>(), false, false))
                     .Returns(userPackages);
                 const string iconUrl = "https://icon.test/url";
                 GetMock<IIconUrlProvider>()

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -3842,7 +3842,7 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(userName, false))
                     .Returns(_testUser);
                 GetMock<IPackageVulnerabilitiesService>()
-                    .Setup(stub => stub.PackageIsVulnerable(It.IsAny<Package>()))
+                    .Setup(stub => stub.IsPackageVulnerable(It.IsAny<Package>()))
                     .Returns<Package>(package => (package?.Id ?? "") == "Company.ZebraPackage"); // this is the vulnerable package - true if this
                 GetMock<IPackageService>()
                     .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false, It.IsAny<bool>()))

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -1099,7 +1099,7 @@ namespace NuGetGallery
                     .Returns(owner);
 
                 GetMock<IPackageService>()
-                    .Setup(x => x.FindPackagesByOwner(owner, false, false))
+                    .Setup(x => x.FindPackagesByOwner(owner, false, false, false))
                     .Returns(new[] { package, invalidatedPackage, validatingPackage, deletedPackage });
 
                 var controller = GetController<UsersController>();
@@ -1153,7 +1153,7 @@ namespace NuGetGallery
                     .Returns(owner);
 
                 GetMock<IPackageService>()
-                    .Setup(x => x.FindPackagesByOwner(owner, false, false))
+                    .Setup(x => x.FindPackagesByOwner(owner, false, false, false))
                     .Returns(new[] { package1, package2 });
 
                 var controller = GetController<UsersController>();
@@ -1195,7 +1195,7 @@ namespace NuGetGallery
                     .Setup(x => x.FindByUsername(username, false))
                     .Returns(owner);
                 GetMock<IPackageService>()
-                    .Setup(x => x.FindPackagesByOwner(owner, false, false))
+                    .Setup(x => x.FindPackagesByOwner(owner, false, false, false))
                     .Returns(new[] { userPackage });
 
                 var controller = GetController<UsersController>();
@@ -2273,7 +2273,7 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(testUser.Username, false))
                     .Returns(testUser);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>(), false))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>(), false, It.IsAny<bool>()))
                     .Returns(userPackages);
                 GetMock<IPackageService>()
                     .Setup(stub => stub.WillPackageBeOrphanedIfOwnerRemoved(packageRegistration, testUser))
@@ -2356,7 +2356,7 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(userName, false))
                     .Returns(testUser);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>(), false))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>(), false, It.IsAny<bool>()))
                     .Returns(userPackages);
                 GetMock<ISupportRequestService>()
                    .Setup(stub => stub.GetIssues(null, null, null, userName))
@@ -3690,7 +3690,7 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(userName, false))
                     .Returns(testUser);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>(), false))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(testUser, It.IsAny<bool>(), false, It.IsAny<bool>()))
                     .Returns(userPackages);
                 GetMock<ISupportRequestService>()
                     .Setup(stub => stub.GetIssues(null, null, null, null))
@@ -3729,7 +3729,7 @@ namespace NuGetGallery
                 packageRegistration.Id = Id;
                 packageRegistration.Owners.Add(_testUser);
 
-                var userPackage1 = new Package()
+                var userPackage1 = new Package
                 {
                     Key = Key,
                     Version = Version,
@@ -3747,8 +3747,8 @@ namespace NuGetGallery
                 PackageRegistration packageRegistration2 = CreatePackageRegistration("Company.AlphaPackage", 1, "1.0.0", "first");
                 PackageRegistration packageRegistration3 = CreatePackageRegistration("Company.NormalPackage", 1, "1.0.0", "middle");
 
-                var userPackages = new List<Package>() { 
-                    packageRegistration1.Packages.First() ,
+                var userPackages = new List<Package> { 
+                    packageRegistration1.Packages.First(),
                     packageRegistration2.Packages.First(),
                     packageRegistration3.Packages.First()
                 };
@@ -3758,7 +3758,7 @@ namespace NuGetGallery
                     .Returns(_testUser);
 
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false, It.IsAny<bool>()))
                     .Returns(userPackages);
 
                 var model = ResultAssert.IsView<ManagePackagesViewModel>(_testController.Packages());
@@ -3775,8 +3775,8 @@ namespace NuGetGallery
                 PackageRegistration packageRegistration2 = CreatePackageRegistration("Company.NormalPackage", 1, "0.0.1", "first");
                 PackageRegistration packageRegistration3 = CreatePackageRegistration("Company.AlphaPackage", 1, "1.1.0", "last");
 
-                var userPackages = new List<Package>() {
-                    packageRegistration1.Packages.First() ,
+                var userPackages = new List<Package> {
+                    packageRegistration1.Packages.First(),
                     packageRegistration2.Packages.First(),
                     packageRegistration3.Packages.First()
                 };
@@ -3786,7 +3786,7 @@ namespace NuGetGallery
                     .Returns(_testUser);
 
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false, It.IsAny<bool>()))
                     .Returns(userPackages);
 
                 var model = ResultAssert.IsView<ManagePackagesViewModel>(_testController.Packages());
@@ -3813,7 +3813,7 @@ namespace NuGetGallery
                     .Setup(stub => stub.FindByUsername(userName, false))
                     .Returns(_testUser);
                 GetMock<IPackageService>()
-                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false))
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false, It.IsAny<bool>()))
                     .Returns(userPackages);
 
                 var model = ResultAssert.IsView<ManagePackagesViewModel>(_testController.Packages());
@@ -3821,6 +3821,37 @@ namespace NuGetGallery
                 GetMock<IIconUrlProvider>()
                     .Verify(iup => iup.GetIconUrlString(userPackage), Times.AtLeastOnce);
                 Assert.Equal(iconUrl, model.ListedPackages.Single().IconUrl);
+            }
+
+            [Fact]
+            public void AssessesVulnerabilities()
+            {
+                PackageRegistration zebraRegistration = CreatePackageRegistration("Company.ZebraPackage", 1, "1.0.0", "test zebra vulnerable");
+                PackageRegistration alphaRegistration = CreatePackageRegistration("Company.AlphaPackage", 1, "1.1.1", "test alpha clean");
+                var versionRange = new VulnerablePackageVersionRange
+                {
+                    PackageVersionRange = "1.0.0"
+                };
+                var zebraPackage = zebraRegistration.Packages.First();
+                var alphaPackage = alphaRegistration.Packages.First();
+                zebraPackage.VulnerablePackageRanges = new List<VulnerablePackageVersionRange> { versionRange };
+                versionRange.Vulnerability = new PackageVulnerability();
+                var latestPackages = new List<Package> { zebraPackage, alphaPackage };
+
+                GetMock<IUserService>()
+                    .Setup(stub => stub.FindByUsername(userName, false))
+                    .Returns(_testUser);
+                GetMock<IPackageVulnerabilitiesService>()
+                    .Setup(stub => stub.PackageIsVulnerable(It.IsAny<Package>()))
+                    .Returns<Package>(package => (package?.Id ?? "") == "Company.ZebraPackage"); // this is the vulnerable package - true if this
+                GetMock<IPackageService>()
+                    .Setup(stub => stub.FindPackagesByAnyMatchingOwner(_testUser, It.IsAny<bool>(), false, It.IsAny<bool>()))
+                    .Returns(latestPackages);
+
+                var model = ResultAssert.IsView<ManagePackagesViewModel>(_testController.Packages());
+
+                Assert.False(model.ListedPackages.ToArray()[0].IsVulnerable);  // alpha
+                Assert.True(model.ListedPackages.ToArray()[1].IsVulnerable);   // zebra
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/DeleteAccountServiceFacts.cs
@@ -805,7 +805,8 @@ namespace NuGetGallery.Services
                 var packageService = new Mock<IPackageService>();
                 if (_user != null)
                 {
-                    packageService.Setup(m => m.FindPackagesByAnyMatchingOwner(_user, true, It.IsAny<bool>())).Returns(_userPackages);
+                    packageService.Setup(m => m.FindPackagesByAnyMatchingOwner(
+                        _user, true, It.IsAny<bool>(), It.IsAny<bool>())).Returns(_userPackages);
                     var packageRegistraionList = new List<PackageRegistration>();
                     if(_userPackagesRegistration != null)
                     {

--- a/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesServiceFacts.cs
@@ -1,13 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Moq;
 using NuGet.Services.Entities;
-using NuGetGallery.Auditing;
 using NuGetGallery.Framework;
 using Xunit;
 
@@ -62,6 +58,23 @@ namespace NuGetGallery.Services
             Assert.Equal(_vulnerabilityCritical, vulnerabilitiesFor111[1]);
 
             Assert.Null(notVulnerableResult);
+        }
+
+        [Fact]
+        public void GetsVulnerableStatusOfPackage()
+        {
+            // Arrange
+            SetUp();
+            var context = GetFakeContext();
+            var target = Get<PackageVulnerabilitiesService>();
+
+            // Act
+            var shouldBeVulnerable = target.PackageIsVulnerable(_packageVulnerable100);
+            var shouldNotBeVulnerable = target.PackageIsVulnerable(_packageNotVulnerable);
+
+            // Assert
+            Assert.True(shouldBeVulnerable);
+            Assert.False(shouldNotBeVulnerable);
         }
 
         private void SetUp()

--- a/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesServiceFacts.cs
@@ -143,13 +143,13 @@ namespace NuGetGallery.Services
                 Key = 2, // simulate a different order in db  - create a non-contiguous range of rows, even if the range is contiguous
                 PackageRegistration = _registrationVulnerable,
                 Version = "1.1.2",
-                VulnerablePackageRanges = null
+                VulnerablePackageRanges = new List<VulnerablePackageVersionRange>()
             };
             _packageNotVulnerable = new Package
             {
                 Key = 4,
                 PackageRegistration = new PackageRegistration { Id = "NotVulnerable" },
-                VulnerablePackageRanges = null
+                VulnerablePackageRanges = new List<VulnerablePackageVersionRange>()
             };
         }
     }

--- a/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesServiceFacts.cs
@@ -69,8 +69,8 @@ namespace NuGetGallery.Services
             var target = Get<PackageVulnerabilitiesService>();
 
             // Act
-            var shouldBeVulnerable = target.PackageIsVulnerable(_packageVulnerable100);
-            var shouldNotBeVulnerable = target.PackageIsVulnerable(_packageNotVulnerable);
+            var shouldBeVulnerable = target.IsPackageVulnerable(_packageVulnerable100);
+            var shouldNotBeVulnerable = target.IsPackageVulnerable(_packageNotVulnerable);
 
             // Assert
             Assert.True(shouldBeVulnerable);

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemRequiredSignerViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemRequiredSignerViewModelFacts.cs
@@ -37,7 +37,8 @@ namespace NuGetGallery.ViewModels
         [Fact]
         public void WhenPackageIsNull_Throws()
         {
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
             var exception = Assert.Throws<ArgumentNullException>(() => target.Create(
                 package: null,
                 currentUser: _currentUser,
@@ -54,7 +55,8 @@ namespace NuGetGallery.ViewModels
                 PackageRegistration = new PackageRegistration(),
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             var exception = Assert.Throws<ArgumentNullException>(
                 () => target.Create(
@@ -74,7 +76,8 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
 
-            var exception = Assert.Throws<ArgumentNullException>(() => new ListPackageItemRequiredSignerViewModelFactory(null, Mock.Of<IIconUrlProvider>()));
+            var exception = Assert.Throws<ArgumentNullException>(() => new ListPackageItemRequiredSignerViewModelFactory(
+                null, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>()));
 
             Assert.Equal("securityPolicyService", exception.ParamName);
         }
@@ -95,7 +98,8 @@ namespace NuGetGallery.ViewModels
                     It.Is<User>(user => user == _currentUser),
                     It.Is<string>(policyName => policyName == ControlRequiredSignerPolicy.PolicyName)))
                 .Returns(false);
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             var viewModel = target.Create(
                 package,
@@ -125,7 +129,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(x => x.IsSubscribed(
                     It.Is<User>(user => user == _currentUser),
@@ -160,7 +165,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(x => x.IsSubscribed(
                     It.Is<User>(user => user == _currentUser),
@@ -194,7 +200,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -229,7 +236,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -279,7 +287,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -315,7 +324,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -351,7 +361,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -414,7 +425,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -450,7 +462,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -486,7 +499,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -533,7 +547,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -591,7 +606,8 @@ namespace NuGetGallery.ViewModels
                 },
                 Version = "1.0.0"
             };
-            var target = new ListPackageItemRequiredSignerViewModelFactory(_securityPolicyService.Object, Mock.Of<IIconUrlProvider>());
+            var target = new ListPackageItemRequiredSignerViewModelFactory(
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(


### PR DESCRIPTION
Addresses view model portion of https://github.com/NuGet/NuGetGallery/issues/8361.

The intent is to add an `IsVulnerable` field to the packages listed in the Manage Packages view. The packages listed (in both the listed and unlisted lists) are the latest versions of those packages. If those latest versions are vulnerable, we want to display a warning, indicating that something needs to be done. It will be generic and will direct customers to the Package Details page for more information.