### PR TITLE
Implementation of Cake tab with instructions for .NET Tool packages

### DIFF
--- a/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
+++ b/src/NuGetGallery/Extensions/CakeBuildManagerExtensions.cs
@@ -15,11 +15,17 @@ namespace NuGetGallery
 
         public static string GetCakeInstallPackageCommand(this DisplayPackageViewModel model)
         {
-            var reference = $"nuget:?package={model.Id}&version={model.Version}";
+            var scheme = model.IsDotnetToolPackageType ? "dotnet" : "nuget";
+            var reference = $"{scheme}:?package={model.Id}&version={model.Version}";
 
             if (model.Prerelease)
             {
                 reference += "&prerelease";
+            }
+
+            if (model.IsDotnetToolPackageType)
+            {
+                return $"#tool {reference}";
             }
 
             if (IsCakeAddin(model))

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -36,6 +36,12 @@
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET Core Global Tool</a> you can call from the shell/command line.",
             },
+
+            new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/support/nuget")
+            {
+                Id = "cake-dotnet-tool",
+                InstallPackageCommand = Model.GetCakeInstallPackageCommand(),
+            },
         };
     }
     else if (Model.IsDotnetNewTemplatePackageType)

--- a/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/CakeBuildManagerExtensionsFacts.cs
@@ -48,6 +48,40 @@ namespace NuGetGallery.Extensions
 
         public class TheMethodGetCakeInstallPackageCommand
         {
+            public class GivenADotnetToolPackage
+            {
+                [Fact]
+                public void ReturnsADotNetToolDirective()
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        IsDotnetToolPackageType = true,
+                        Id = "dotnet-reportgenerator-globaltool",
+                        Version = "1.0.0",
+                    };
+
+                    var actual = model.GetCakeInstallPackageCommand();
+
+                    Assert.Equal("#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=1.0.0", actual);
+                }
+
+                [Fact]
+                public void ReturnsADotNetToolDirectiveWithPrerelease()
+                {
+                    var model = new DisplayPackageViewModel
+                    {
+                        IsDotnetToolPackageType = true,
+                        Id = "dotnet-reportgenerator-globaltool",
+                        Version = "1.0.0-preview",
+                        Prerelease = true,
+                    };
+
+                    var actual = model.GetCakeInstallPackageCommand();
+
+                    Assert.Equal("#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=1.0.0-preview&prerelease", actual);
+                }
+            }
+
             public class GivenAPackageWithTheCakeAddinTag
             {
                 [Fact]


### PR DESCRIPTION
This PR adds the Cake tab for `PackageType=DotnetTool`, which was not included in the [initial proposal](https://github.com/NuGet/NuGetGallery/issues/8381) because at the time of the proposal support for .NET Tools in Cake was provided by a community package.

Since then this feature has been added to the Cake core codebase and now Cake supports installing .NET tools directly from within Cake scripts through the `#tool` directive & `dotnet` scheme as shown in the screenshot below.

| :hammer_and_wrench: | Packages identified as .NET tool (via PackageType) |
|:---: | --- |
| | ![image](https://user-images.githubusercontent.com/177608/109409586-5dac4f80-796a-11eb-862a-f0b0a84a4df8.png) |
| | Packages of type `DotnetTool` |

---

/cc @joelverhagen

Addresses https://github.com/NuGet/NuGetGallery/issues/8381
Relates to https://github.com/NuGet/NuGetGallery/pull/8434
