### PR TITLE
Updating the client libraries to 5.9

### DIFF
--- a/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
+++ b/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
@@ -15,7 +15,7 @@
       <Version>10.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>5.8.0</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -44,7 +44,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Packaging">
-      <Version>5.8.0</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
       <Version>2.84.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -301,10 +301,10 @@
       <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>5.8.0</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
-      <Version>5.8.0</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.84.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2234,10 +2234,10 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Configuration">
-      <Version>5.8.0</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
-      <Version>5.8.0</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
       <Version>2.84.0</Version>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -575,7 +575,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6823" newVersion="5.8.0.6823"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.9.0.7134" newVersion="5.9.0.7134"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -595,11 +595,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6823" newVersion="5.8.0.6823"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.9.0.7134" newVersion="5.9.0.7134"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6823" newVersion="5.8.0.6823"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.9.0.7134" newVersion="5.9.0.7134"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>

--- a/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
+++ b/tests/NuGetGallery.Facts/ExtensionMethodsFacts.cs
@@ -23,8 +23,8 @@ namespace NuGetGallery
             [InlineData("net5.0-windows", "net5.0-windows")]
             [InlineData("net5.0-windows9.0", "net5.0-windows9")]
             [InlineData("net5.0-ios14.0", "net5.0-ios14.0")]
-            [InlineData("net5.0", "netcoreapp5.0-windows")] // See: https://github.com/NuGet/Home/issues/10177
-            [InlineData("net5.0", "netcoreapp5.0-windows9")] // See: https://github.com/NuGet/Home/issues/10177
+            [InlineData("net5.0-windows", "netcoreapp5.0-windows")]
+            [InlineData("net5.0-windows9.0", "netcoreapp5.0-windows9")]
             [InlineData("net6.0", "net6.0")]
             [InlineData("net10.0", "net10.0")]
             [InlineData(".NETFramework 4.0", "net40")]

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -91,7 +91,7 @@
       <Version>1.0.0.10</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>5.8.0</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>


### PR DESCRIPTION
Finally addresses https://github.com/NuGet/NuGetGallery/issues/8280.

Mostly brings support for `MIT-0` license in license expressions. Techincally, we only needed to update `NuGet.Packaging` to get it, but I had all client libraries updated to have their versions aligned.

Had to update some tests due to a [bugfix](https://github.com/NuGet/Home/issues/10177) in the client library.