### PR TITLE
Fix condition with readme container & remove dev.azure from allowlist

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
@@ -17,7 +17,6 @@
         "codecov.io",
         "codefactor.io",
         "coveralls.io",
-        "dev.azure.com",
         "gitlab.com",
         "img.shields.io",
         "isitmaintained.com",

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -255,10 +255,10 @@
                 $(reportContainerElement).attr("data-bind", "template: { name: 'verify-metadata-template', data: data }");
                 $("#verify-package-container").append(reportContainerElement);
                 ko.applyBindings({ data: model }, reportContainerElement);
-                if (model.ReadmeFileContents.Content) {
-                    $('#import-readme-container').addClass('hidden');
-                } else {
+                if (model.ReadmeFileContents == null) {
                     $('#import-readme-container').removeClass('hidden');
+                } else if (model.ReadmeFileContents.Content) {
+                    $('#import-readme-container').addClass('hidden');
                 }
 
                 var submitContainerElement = document.createElement("div");

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -255,6 +255,9 @@
                 $(reportContainerElement).attr("data-bind", "template: { name: 'verify-metadata-template', data: data }");
                 $("#verify-package-container").append(reportContainerElement);
                 ko.applyBindings({ data: model }, reportContainerElement);
+                //Content of ReadmeFileContents indicates if embedded readme exists in the package.
+                //Support legacy readme by displaying readme container if ReadmeFileContents is null.
+                //Disable legacy readme by hiding readme container only if embedded readme content is not null.
                 if (model.ReadmeFileContents == null) {
                     $('#import-readme-container').removeClass('hidden');
                 } else if (model.ReadmeFileContents.Content) {


### PR DESCRIPTION
This is fix for bug I found  with PR https://github.com/NuGet/NuGetGallery/pull/8406

Expect legacy readme work when uploading package without embedded readme

Without changes: legacy readme container invisable at upload package page if we upload package without embedded readme
<img width="783" alt="wrongreadme" src="https://user-images.githubusercontent.com/64443925/110058365-0f56d200-7d17-11eb-8c25-a63eb4bd7bbf.PNG">

After changes:   legacy readme container display when package has legacy readme

<img width="949" alt="uploadPage" src="https://user-images.githubusercontent.com/64443925/110154947-b7ad7a80-7d99-11eb-8d4d-dcb46ea51bd0.PNG">


No problem with embedded readme



Addresses https://github.com/NuGet/Engineering/issues/3507