### PR TITLE
change condition

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -255,10 +255,10 @@
                 $(reportContainerElement).attr("data-bind", "template: { name: 'verify-metadata-template', data: data }");
                 $("#verify-package-container").append(reportContainerElement);
                 ko.applyBindings({ data: model }, reportContainerElement);
-                if (model.ReadmeFileContents.Content) {
-                    $('#import-readme-container').addClass('hidden');
-                } else {
+                if (model.ReadmeFileContents == null) {
                     $('#import-readme-container').removeClass('hidden');
+                } else if (model.ReadmeFileContents.Content) {
+                    $('#import-readme-container').addClass('hidden');
                 }
 
                 var submitContainerElement = document.createElement("div");


### PR DESCRIPTION
This is fix for bug I found  with PR https://github.com/NuGet/NuGetGallery/pull/8406

Expect legacy readme work when uploading package without embedded readme

Without changes: legacy readme container invisable at upload package page if we upload package without embedded readme
<img width="783" alt="wrongreadme" src="https://user-images.githubusercontent.com/64443925/110058365-0f56d200-7d17-11eb-8c25-a63eb4bd7bbf.PNG">

After changes:   legacy readme container display when package has legacy readme
<img width="845" alt="pic" src="https://user-images.githubusercontent.com/64443925/110058783-de2ad180-7d17-11eb-986e-f455d0131aa1.PNG">

No problem with embedded readme



Addresses https://github.com/NuGet/Engineering/issues/3507