### PR TITLE
Add Knapcode.MiniZip to 3rd party signing

### DIFF
--- a/sign.thirdparty.props
+++ b/sign.thirdparty.props
@@ -15,6 +15,7 @@
     <ThirdPartyBinaries Include="DynamicData.EFCodeFirstProvider.dll" />
     <ThirdPartyBinaries Include="Elmah.dll" />
     <ThirdPartyBinaries Include="ICSharpCode.SharpZipLib.dll" />
+    <ThirdPartyBinaries Include="Knapcode.MiniZip.dll" />
     <ThirdPartyBinaries Include="Lucene.Net.Contrib.Analyzers.dll" />
     <ThirdPartyBinaries Include="Lucene.Net.Contrib.Core.dll" />
     <ThirdPartyBinaries Include="Lucene.Net.Contrib.FastVectorHighlighter.dll" />


### PR DESCRIPTION
Build broken due to Knapcode.MiniZip.dll not being 3rd party signed. Added.