### PR TITLE
Give the manage packages page its own PVA flag

### DIFF
--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -27,6 +27,7 @@ namespace NuGetGallery
         private const string ManageDeprecationForManyVersionsFeatureName = GalleryPrefix + "ManageDeprecationMany";
         private const string ManageDeprecationApiFeatureName = GalleryPrefix + "ManageDeprecationApi";
         private const string DisplayVulnerabilitiesFeatureName = GalleryPrefix + "DisplayVulnerabilities";
+        private const string ManagePackagesVulnerabilitiesFeatureName = GalleryPrefix + "ManagePackagesVulnerabilities";
         private const string DisplayFuGetLinksFeatureName = GalleryPrefix + "DisplayFuGetLinks";
         private const string ODataReadOnlyDatabaseFeatureName = GalleryPrefix + "ODataReadOnlyDatabase";
         private const string PackagesAtomFeedFeatureName = GalleryPrefix + "PackagesAtomFeed";
@@ -139,6 +140,11 @@ namespace NuGetGallery
         public bool IsDisplayVulnerabilitiesEnabled()
         {
             return _client.IsEnabled(DisplayVulnerabilitiesFeatureName, defaultValue: false);
+        }
+
+        public bool IsManagePackagesVulnerabilitiesEnabled()
+        {
+            return _client.IsEnabled(ManagePackagesVulnerabilitiesFeatureName, defaultValue: false);
         }
 
         public bool IsDisplayFuGetLinksEnabled()

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -68,6 +68,11 @@ namespace NuGetGallery
         bool IsDisplayVulnerabilitiesEnabled();
 
         /// <summary>
+        /// Whether or not a package owner can view vulnerability advisory information on the Manage Packages page.
+        /// </summary>
+        bool IsManagePackagesVulnerabilitiesEnabled();
+
+        /// <summary>
         /// Whether or not a fuget.org link is visible on a package's details page.
         /// </summary>
         bool IsDisplayFuGetLinksEnabled();

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -463,7 +463,7 @@ namespace NuGetGallery
                 .Include(p => p.PackageRegistration.Owners)
                 .Include(p => p.PackageRegistration.RequiredSigners);
 
-            if (includeVulnerabilities)
+            if (includeVulnerabilities && _featureFlagService.IsManagePackagesVulnerabilitiesEnabled())
             {
                 result = result.Include($"{nameof(Package.VulnerablePackageRanges)}.{nameof(VulnerablePackageVersionRange.Vulnerability)}");
             }

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -23,6 +23,7 @@
     "NuGetGallery.ODataV2SearchNonHijacked": "Enabled",
     "NuGetGallery.ODataV2SearchCountNonHijacked": "Enabled",
     "NuGetGallery.DisplayVulnerabilities": "Enabled",
+    "NuGetGallery.ManagePackagesVulnerabilities": "Enabled",
     "NuGetGallery.DisplayFuGetLinks": "Enabled",
     "NuGetGallery.PatternSetTfmHeuristics": "Enabled"
   },

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -566,7 +566,7 @@ namespace NuGetGallery
                 ReservedNamespaces = reservedPrefixes,
                 WasMultiFactorAuthenticated = User.WasMultiFactorAuthenticated(),
                 IsCertificatesUIEnabled = ContentObjectService.CertificatesConfiguration?.IsUIEnabledForUser(currentUser) ?? false,
-                IsPackageVulnerabilitiesEnabled = _featureFlagService.IsDisplayVulnerabilitiesEnabled()
+                IsManagePackagesVulnerabilitiesEnabled = _featureFlagService.IsManagePackagesVulnerabilitiesEnabled()
             };
 
             return View(model);

--- a/src/NuGetGallery/ViewModels/ManagePackagesViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ManagePackagesViewModel.cs
@@ -24,6 +24,6 @@ namespace NuGetGallery
 
         public bool IsCertificatesUIEnabled { get; set; }
 
-        public bool IsPackageVulnerabilitiesEnabled { get; set; }
+        public bool IsManagePackagesVulnerabilitiesEnabled { get; set; }
     }
 }

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -120,7 +120,7 @@
                     }
                         <th class="sortable">Downloads</th>
                         <th class="sortable">Latest Version</th>
-                    @if (Model.IsPackageVulnerabilitiesEnabled)
+                    @if (Model.IsManagePackagesVulnerabilitiesEnabled)
                     {
                         <th><span class="hidden">Package warnings</span></th>
                     }
@@ -175,7 +175,7 @@
                         <td class="align-middle text-nowrap" data-bind="attr: { 'data-sortby': VersionSortOrder }">
                             <span data-bind="text: LatestVersion"></span>
                         </td>
-                    @if (Model.IsPackageVulnerabilitiesEnabled)
+                    @if (Model.IsManagePackagesVulnerabilitiesEnabled)
                     {
                         <td class="package-icon-cell">
                             <i class="ms-Icon ms-Icon--Warning package-icon" data-bind="visible: IsVulnerable" title="This version has at least one known vulnerability. Click on the package name for details."></i>

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -33,6 +33,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsDisplayVulnerabilitiesEnabled() => throw new NotImplementedException();
 
+        public bool IsManagePackagesVulnerabilitiesEnabled() => throw new NotImplementedException();
+
         public bool IsDisplayFuGetLinksEnabled() => throw new NotImplementedException();
 
         public bool AreEmbeddedIconsEnabled(User user) => throw new NotImplementedException();


### PR DESCRIPTION
I've done some perf testing in DEV, and it's a slight regression, so I want to release this specific page under its own flag. 

Part of this work: https://github.com/NuGet/NuGetGallery/issues/8361

...and a follow on from https://github.com/NuGet/NuGetGallery/pull/8436 and https://github.com/NuGet/NuGetGallery/pull/8435

The regression on this page is around 50% in DEV, but it's only a matter of 2 seconds so unsure how it will scale. Would like to see it on PROD data with the ability to disable it.