### PR TITLE
reject empty readme file & fix error message for invalid extension

### DIFF
--- a/src/NuGetGallery/Services/PackageMetadataValidationService.cs
+++ b/src/NuGetGallery/Services/PackageMetadataValidationService.cs
@@ -458,6 +458,16 @@ namespace NuGetGallery
             }
 
             var readmeFileEntry = nuGetPackage.GetEntry(readmeFilePath);
+
+            if (readmeFileEntry.Length == 0)
+            {
+                return PackageValidationResult.Invalid(
+                    string.Format(
+                        Strings.ReadmeErrorEmpty,
+                        Strings.UploadPackage_ReadmeFileType,
+                        readmeFilePath));
+            }
+
             if (readmeFileEntry.Length > MaxAllowedReadmeLengthForUploading)
             {
                 return PackageValidationResult.Invalid(

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1589,6 +1589,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The readme file &apos;{0}&apos; cannot be empty.
+        /// </summary>
+        public static string ReadmeErrorEmpty {
+            get {
+                return ResourceManager.GetString("ReadmeErrorEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid Markdown Documentation source type..
         /// </summary>
         public static string ReadMeInvalidSourceType {
@@ -2598,7 +2607,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The readme file has an invalid extension &apos;{0}&apos;. Extension must be one of the following: {1}..
+        ///   Looks up a localized string similar to The readme file has an invalid extension &apos;{0}&apos;. Extension must be end in: {1}..
         /// </summary>
         public static string UploadPackage_InvalidReadmeFileExtension {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1589,7 +1589,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The readme file &apos;{0}&apos; cannot be empty.
+        ///   Looks up a localized string similar to The readme file &apos;{0}&apos; cannot be empty..
         /// </summary>
         public static string ReadmeErrorEmpty {
             get {
@@ -2607,7 +2607,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The readme file has an invalid extension &apos;{0}&apos;. Extension must be end in: {1}..
+        ///   Looks up a localized string similar to The readme file has an invalid extension &apos;{0}&apos;. The extension must be: &apos;{1}&apos;..
         /// </summary>
         public static string UploadPackage_InvalidReadmeFileExtension {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1166,7 +1166,7 @@ The {1} Team</value>
     <value>The &lt;readme&gt; element is not currently supported.</value>
   </data>
   <data name="UploadPackage_InvalidReadmeFileExtension" xml:space="preserve">
-    <value>The readme file has an invalid extension '{0}'. Extension must be one of the following: {1}.</value>
+    <value>The readme file has an invalid extension '{0}'. Extension must be end in: {1}.</value>
     <comment>{0} is the readme file extension specified in the .nuspec, {1} is the list of allowed extensions</comment>
   </data>
   <data name="UploadPackage_ReadmeFileType" xml:space="preserve">
@@ -1214,5 +1214,8 @@ The {1} Team</value>
   </data>
   <data name="UploadPackage_OwnerlessIdNamespaceConflictHtml" xml:space="preserve">
     <value>The package ID is reserved. You can upload your package with a different package ID. Reach out to &lt;a href="mailto:support@nuget.org"&gt;support@nuget.org&lt;/a&gt; if you have questions.</value>
+  </data>
+  <data name="ReadmeErrorEmpty" xml:space="preserve">
+    <value>The readme file '{0}' cannot be empty</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1166,7 +1166,7 @@ The {1} Team</value>
     <value>The &lt;readme&gt; element is not currently supported.</value>
   </data>
   <data name="UploadPackage_InvalidReadmeFileExtension" xml:space="preserve">
-    <value>The readme file has an invalid extension '{0}'. Extension must be end in: {1}.</value>
+    <value>The readme file has an invalid extension '{0}'. The extension must be: '{1}'.</value>
     <comment>{0} is the readme file extension specified in the .nuspec, {1} is the list of allowed extensions</comment>
   </data>
   <data name="UploadPackage_ReadmeFileType" xml:space="preserve">
@@ -1216,6 +1216,6 @@ The {1} Team</value>
     <value>The package ID is reserved. You can upload your package with a different package ID. Reach out to &lt;a href="mailto:support@nuget.org"&gt;support@nuget.org&lt;/a&gt; if you have questions.</value>
   </data>
   <data name="ReadmeErrorEmpty" xml:space="preserve">
-    <value>The readme file '{0}' cannot be empty</value>
+    <value>The readme file '{0}' cannot be empty.</value>
   </data>
 </root>


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

reject empty readme file: 
<img width="1315" alt="emptyReadme" src="https://user-images.githubusercontent.com/64443925/112391295-e9d53c80-8cb4-11eb-96d4-649afb0c4c02.PNG">

correct error message for invalid extension: 
<img width="1225" alt="invalidextension" src="https://user-images.githubusercontent.com/64443925/112391337-fc4f7600-8cb4-11eb-8d29-59360053fec6.PNG">


Addresses https://github.com/NuGet/Engineering/issues/3707, https://github.com/NuGet/NuGetGallery/issues/8460