### PR TITLE
[Statistics]Adding Support for other reports from alternate container

### DIFF
--- a/src/NuGetGallery/Services/CloudReportService.cs
+++ b/src/NuGetGallery/Services/CloudReportService.cs
@@ -1,23 +1,30 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
+using NuGetGallery.Services;
 
 namespace NuGetGallery
 {
     public class CloudReportService : IReportService
     {
         private const string _statsContainerName = "nuget-cdnstats";
-        private readonly string _connectionString;
-        private readonly bool _readAccessGeoRedundant;
+        private readonly IFeatureFlagService _featureFlagService;
+        private readonly IBlobStorageConfiguration _primaryStorageConfiguration;
+        private readonly IBlobStorageConfiguration _alternateBlobStorageConfiguration;
 
-        public CloudReportService(string connectionString, bool readAccessGeoRedundant)
+        public CloudReportService(
+            IFeatureFlagService featureFlagService,
+            IBlobStorageConfiguration primaryBlobStorageConfiguration,
+            IBlobStorageConfiguration alternateBlobStorageConfiguration)
         {
-            _connectionString = connectionString;
-            _readAccessGeoRedundant = readAccessGeoRedundant;
+            _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
+            _primaryStorageConfiguration = primaryBlobStorageConfiguration ?? throw new ArgumentNullException(nameof(primaryBlobStorageConfiguration));
+            _alternateBlobStorageConfiguration = alternateBlobStorageConfiguration;
         }
 
         public async Task<StatisticsReport> Load(string reportName)
@@ -42,10 +49,19 @@ namespace NuGetGallery
 
         private CloudBlobContainer GetCloudBlobContainer()
         {
-            var storageAccount = CloudStorageAccount.Parse(_connectionString);
+            var connectionString = _primaryStorageConfiguration.ConnectionString;
+            var readAccessGeoRedundant = _primaryStorageConfiguration.ReadAccessGeoRedundant;
+
+            if(_alternateBlobStorageConfiguration != null && _featureFlagService.IsAlternateStatisticsSourceEnabled())
+            {
+                connectionString = _alternateBlobStorageConfiguration.ConnectionString;
+                readAccessGeoRedundant = _alternateBlobStorageConfiguration.ReadAccessGeoRedundant;
+            }
+
+            var storageAccount = CloudStorageAccount.Parse(connectionString);
             var blobClient = storageAccount.CreateCloudBlobClient();
 
-            if (_readAccessGeoRedundant)
+            if (readAccessGeoRedundant)
             {
                 blobClient.DefaultRequestOptions.LocationMode = LocationMode.PrimaryThenSecondary;
             }


### PR DESCRIPTION
Adds support for sourcing other reports from the alternate stats container.
Currently, feature flagging is all-or-nothing.