### PR TITLE
[Stats]Faster stats refresh

### DIFF
--- a/src/NuGetGallery/Services/JsonStatisticsService.cs
+++ b/src/NuGetGallery/Services/JsonStatisticsService.cs
@@ -20,7 +20,7 @@ namespace NuGetGallery
         /// <summary>
         /// How often statistics reports should be refreshed using the <see cref="_reportService"/>.
         /// </summary>
-        private readonly TimeSpan _refreshInterval = TimeSpan.FromHours(1);
+        private readonly TimeSpan _refreshInterval = TimeSpan.FromMinutes(15);
 
         /// <summary>
         /// The last time the reports were loaded, or null.


### PR DESCRIPTION
Small change to speed up the stats refresh since pipeline updates should allow the report to generate fast enough for this.

In theory, this will quadruple the hits on storage through this, and performance impact of this has not been analyzed.
However, I do not expect the impact of hitting 6 files 4 times instead of once every hour to be major.

This is not a critical change for functionality, and I'm happy to defer it if we so desire.