### PR TITLE
Preparing ErrorLog for secret refresh.

### DIFF
--- a/src/NuGetGallery.Core/Infrastructure/TableErrorLog.cs
+++ b/src/NuGetGallery.Core/Infrastructure/TableErrorLog.cs
@@ -141,13 +141,11 @@ namespace NuGetGallery.Infrastructure
     {
         public const string TableName = "ElmahErrors";
 
-        private readonly string _connectionString;
         private readonly AzureEntityList<ErrorEntity> _entityList;
 
-        public TableErrorLog(string connectionString, bool readAccessGeoRedundant)
+        public TableErrorLog(Func<string> connectionStringFactory, bool readAccessGeoRedundant)
         {
-            _connectionString = connectionString;
-            _entityList = new AzureEntityList<ErrorEntity>(connectionString, TableName, readAccessGeoRedundant);
+            _entityList = new AzureEntityList<ErrorEntity>(connectionStringFactory, TableName, readAccessGeoRedundant);
         }
 
         public override ErrorLogEntry GetError(string id)

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -1436,7 +1436,11 @@ namespace NuGetGallery
 
             RegisterStatisticsServices(builder, configuration, telemetryService);
 
-            builder.RegisterInstance(new TableErrorLog(configuration.Current.AzureStorage_Errors_ConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant))
+            builder.Register(c =>
+                {
+                    var configurationFactory = c.Resolve<Func<IAppConfiguration>>();
+                    return new TableErrorLog(() => configurationFactory().AzureStorage_Errors_ConnectionString, configurationFactory().AzureStorageReadAccessGeoRedundant);
+                })
                 .As<ErrorLog>()
                 .SingleInstance();
 


### PR DESCRIPTION
Using connection string factory in `AzureEntityList`  instead of explicit connection string. Allows singleton to refresh connection string.