### PR TITLE
CloudAuditService preparing for secret refresh

### DIFF
--- a/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
+++ b/src/NuGetGallery.Core/Auditing/CloudAuditingService.cs
@@ -75,8 +75,7 @@ namespace NuGetGallery.Auditing
             {
                 // Create the container and try again,
                 // this time we let exceptions bubble out
-                var permissions = new BlobContainerPermissions { PublicAccess = BlobContainerPublicAccessType.Off };
-                await container.CreateIfNotExistAsync(permissions);
+                await container.CreateIfNotExistAsync(permissions: null);
                 await WriteBlob(auditData, fullPath, blob);
             }
         }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -468,24 +468,20 @@ namespace NuGetGallery
                 .As<IPrincipal>()
                 .InstancePerLifetimeScope();
 
-            IAuditingService defaultAuditingService = null;
-
             switch (configuration.Current.StorageType)
             {
                 case StorageType.FileSystem:
                 case StorageType.NotSpecified:
                     ConfigureForLocalFileSystem(builder, configuration);
-                    defaultAuditingService = GetAuditingServiceForLocalFileSystem(configuration);
                     break;
                 case StorageType.AzureStorage:
                     ConfigureForAzureStorage(builder, configuration, telemetryService);
-                    defaultAuditingService = GetAuditingServiceForAzureStorage(builder, configuration);
                     break;
             }
 
             RegisterAsynchronousValidation(builder, loggerFactory, configuration, secretInjector);
 
-            RegisterAuditingServices(builder, defaultAuditingService);
+            RegisterAuditingServices(builder, configuration.Current.StorageType);
 
             RegisterCookieComplianceService(configuration, loggerFactory);
 
@@ -1376,10 +1372,10 @@ namespace NuGetGallery
                 .SingleInstance();
         }
 
-        private static IAuditingService GetAuditingServiceForLocalFileSystem(IGalleryConfigurationService configuration)
+        private static IAuditingService GetAuditingServiceForLocalFileSystem(IAppConfiguration configuration)
         {
             var auditingPath = Path.Combine(
-                FileSystemFileStorageService.ResolvePath(configuration.Current.FileStorageDirectory),
+                FileSystemFileStorageService.ResolvePath(configuration.FileStorageDirectory),
                 FileSystemAuditingService.DefaultContainerName);
 
             return new FileSystemAuditingService(auditingPath, AuditActor.GetAspNetOnBehalfOfAsync);
@@ -1445,17 +1441,6 @@ namespace NuGetGallery
                 .SingleInstance();
         }
 
-        private static IAuditingService GetAuditingServiceForAzureStorage(ContainerBuilder builder, IGalleryConfigurationService configuration)
-        {
-            var service = new CloudAuditingService(configuration.Current.AzureStorage_Auditing_ConnectionString, configuration.Current.AzureStorageReadAccessGeoRedundant, AuditActor.GetAspNetOnBehalfOfAsync);
-
-            builder.RegisterInstance(service)
-                .As<ICloudStorageStatusDependency>()
-                .SingleInstance();
-
-            return service;
-        }
-
         private static IAuditingService CombineAuditingServices(IEnumerable<IAuditingService> services)
         {
             if (!services.Any())
@@ -1487,19 +1472,46 @@ namespace NuGetGallery
             }
         }
 
-        private static void RegisterAuditingServices(ContainerBuilder builder, IAuditingService defaultAuditingService)
+        private static void RegisterAuditingServices(ContainerBuilder builder, string storageType)
         {
-            var auditingServices = GetAddInServices<IAuditingService>();
-            var services = new List<IAuditingService>(auditingServices);
-
-            if (defaultAuditingService != null)
+            if (storageType == StorageType.AzureStorage)
             {
-                services.Add(defaultAuditingService);
+                builder.Register(c =>
+                    {
+                        var configuration = c.Resolve<IAppConfiguration>();
+                        return new CloudAuditingService(configuration.AzureStorage_Auditing_ConnectionString, configuration.AzureStorageReadAccessGeoRedundant, AuditActor.GetAspNetOnBehalfOfAsync);
+                    })
+                    .SingleInstance()
+                    .AsSelf()
+                    .As<ICloudStorageStatusDependency>();
             }
 
-            var service = CombineAuditingServices(services);
+            builder.Register(c =>
+                {
+                    var configuration = c.Resolve<IAppConfiguration>();
+                    IAuditingService defaultAuditingService = null;
+                    switch (storageType)
+                    {
+                        case StorageType.FileSystem:
+                        case StorageType.NotSpecified:
+                            defaultAuditingService = GetAuditingServiceForLocalFileSystem(configuration);
+                            break;
 
-            builder.RegisterInstance(service)
+                        case StorageType.AzureStorage:
+                            defaultAuditingService = c.Resolve<CloudAuditingService>();
+                            break;
+                    }
+
+                    var auditingServices = GetAddInServices<IAuditingService>();
+                    var services = new List<IAuditingService>(auditingServices);
+
+                    if (defaultAuditingService != null)
+                    {
+                        services.Add(defaultAuditingService);
+                    }
+
+                    return CombineAuditingServices(services);
+                })
                 .AsSelf()
                 .As<IAuditingService>()
                 .SingleInstance();

--- a/tests/NuGetGallery.Core.Facts/Auditing/CloudAuditingServiceTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/CloudAuditingServiceTests.cs
@@ -17,8 +17,8 @@ namespace NuGetGallery.Auditing
         public void CloudAuditServiceObfuscateAuditRecord()
         {
             // Arrange
-            CloudBlobContainer nullBlobContainer = null;
-            var service = new CloudAuditingService(nullBlobContainer, AuditActor.GetCurrentMachineActorAsync);
+            ICloudBlobContainer nullBlobContainer = null;
+            var service = new CloudAuditingService(() => nullBlobContainer, AuditActor.GetCurrentMachineActorAsync);
 
             AuditActor onBehalfOf = new AuditActor("machineName", "3.3.3.3", "userName1", "NoAuthentication", "someKey", DateTime.Now, null);
             AuditActor auditActor = new AuditActor("machineName", "2.2.2.2", "userName1", "NoAuthentication", "someKey", DateTime.Now, onBehalfOf);
@@ -56,8 +56,8 @@ namespace NuGetGallery.Auditing
         public void OnlyPackageAuditRecordsWillBeSaved(AuditRecord record, bool expectedResult)
         {
             // Arrange
-            CloudBlobContainer nullBlobContainer = null;
-            var service = new CloudAuditingService(nullBlobContainer, AuditActor.GetCurrentMachineActorAsync);
+            ICloudBlobContainer nullBlobContainer = null;
+            var service = new CloudAuditingService(() => nullBlobContainer, AuditActor.GetCurrentMachineActorAsync);
 
             // Act + Assert
             Assert.Equal<bool>(expectedResult, service.RecordWillBePersisted(record));


### PR DESCRIPTION
Changed `CloudAuditService` to use `ICloudBlobClient` to access blob storage instead of using SDK classes directly, so it is ready for secret refresh changes. Also, DI registration was updated to resolve all dependencies within DI container instead of pulling in values from closures, which should help with secret refresh, too.