### PR TITLE
Added mandatory styles to add organizations page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -732,6 +732,10 @@ img.reserved-indicator-icon {
   margin-top: 6px;
   margin-bottom: 6px;
 }
+.page-add-organization .required:after {
+  color: red;
+  content: " *";
+}
 .page-admin-index h2 {
   margin-bottom: 8px;
   margin-top: 32px;

--- a/src/Bootstrap/less/theme/page-add-organization.less
+++ b/src/Bootstrap/less/theme/page-add-organization.less
@@ -1,6 +1,11 @@
 .page-add-organization {
-    .owner-image {
-        margin-top: 6px;
-        margin-bottom: 6px;
-    }
+  .owner-image {
+    margin-top: 6px;
+    margin-bottom: 6px;
+  }
+
+  .required:after {
+    color: red;
+    content: " *";
+  }
 }

--- a/src/NuGetGallery/Views/Organizations/Add.cshtml
+++ b/src/NuGetGallery/Views/Organizations/Add.cshtml
@@ -46,14 +46,14 @@
                         @Html.AntiForgeryToken()
 
                         <div class="form-group @Html.HasErrorFor(m => m.OrganizationName)" id="@organizationNameTextGroupId">
-                            @Html.ShowLabelFor(m => m.OrganizationName)
+                            <span class="required">@Html.ShowLabelFor(m => m.OrganizationName)</span>
                             @Html.ShowTextBoxFor(m => m.OrganizationName)
                             <span class="ms-font-s">This will be your organization account on <i id="@organizationNameTextId">@Url.User("{username}", relativeUrl: false)</i>.</span>
                             @Html.ShowValidationMessagesFor(m => m.OrganizationName)
                         </div>
 
                         <div class="form-group @Html.HasErrorFor(m => m.OrganizationEmailAddress)" id="@emailBoxGroupId">
-                            @Html.ShowLabelFor(m => m.OrganizationEmailAddress)
+                            <span class="required">@Html.ShowLabelFor(m => m.OrganizationEmailAddress)</span>
                             @Html.ShowTextBoxFor(m => m.OrganizationEmailAddress)
                             <span class="ms-font-s">Users can contact your organization at this email address.</span>
                             @Html.ShowValidationMessagesFor(m => m.OrganizationEmailAddress)


### PR DESCRIPTION
Addresses: https://github.com/NuGet/NuGetGallery/issues/8492

Adds red asterisk to required fields on add organizations page

![image](https://user-images.githubusercontent.com/14225979/113675891-2cf4ce00-96ff-11eb-8b3e-44cce38fd974.png)

Note that the screen reader also reads "required" for these now.

This change is consistent with: https://github.com/NuGet/NuGetGallery/blob/main/src/Bootstrap/less/theme/page-manage-organizations.less#L46