### PR TITLE
show more link jumps problem

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -67,6 +67,7 @@ $(function () {
         $("#show-readme-more").click(function (e) {
             showLess.collapse("toggle");
             e.preventDefault();
+            return false;
         });
         showLess.on('hide.bs.collapse', function (e) {
             e.stopPropagation();
@@ -74,7 +75,6 @@ $(function () {
         showLess.on('show.bs.collapse', function (e) {
             e.stopPropagation();
         });
-        return false;
     }
 
     // Configure expanders

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -74,6 +74,7 @@ $(function () {
         showLess.on('show.bs.collapse', function (e) {
             e.stopPropagation();
         });
+        return false;
     }
 
     // Configure expanders

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -517,7 +517,7 @@
                             @Html.Raw(Model.ReadMeHtml)
                         </div>
 
-                        <a href="#show-readme-container" role="button" data-toggle="collapse" class="icon-link" data-target="#readme-more"
+                        <a href="#" role="button" data-toggle="collapse" class="icon-link" data-target="#readme-more"
                            aria-expanded="false" aria-controls="#readme-more, #readme-less"
                            id="show-readme-more" data-track="show-package-documentation">
                             <i class="ms-Icon ms-Icon--CalculatorAddition" aria-hidden="true"></i>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -517,7 +517,7 @@
                             @Html.Raw(Model.ReadMeHtml)
                         </div>
 
-                        <a href="#" role="button" data-toggle="collapse" class="icon-link" data-target="#readme-more"
+                        <a href="#show-readme-container" role="button" data-toggle="collapse" class="icon-link" data-target="#readme-more"
                            aria-expanded="false" aria-controls="#readme-more, #readme-less"
                            id="show-readme-more" data-track="show-package-documentation">
                             <i class="ms-Icon ms-Icon--CalculatorAddition" aria-hidden="true"></i>


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

before changes: 
Clicking the Show More link clears the URL fragment and goes to the top of the page.

after changes: 
The README should expand but the viewport should stay where it is.


Addresses https://github.com/NuGet/NuGetGallery/issues/8461