### PR TITLE
return backfill to order by date, batch size 1000

### DIFF
--- a/src/GalleryTools/Commands/BackfillCommand.cs
+++ b/src/GalleryTools/Commands/BackfillCommand.cs
@@ -125,7 +125,7 @@ namespace GalleryTools.Commands
 
                 packages = packages
                     .Where(p => p.Created < lastCreateTime && p.Created > startTime)
-                    .Where(p => p.PackageStatusKey == PackageStatus.Available || p.PackageStatusKey == PackageStatus.Validating)
+                    .Where(p => p.PackageStatusKey == PackageStatus.Available)
                     .OrderBy(p => p.Created);
                 if (LimitTo > 0)
                 {

--- a/src/GalleryTools/Commands/BackfillCommand.cs
+++ b/src/GalleryTools/Commands/BackfillCommand.cs
@@ -122,10 +122,11 @@ namespace GalleryTools.Commands
                 {
                     packages = packages.Include(QueryIncludes);
                 }
-                
+
                 packages = packages
                     .Where(p => p.Created < lastCreateTime && p.Created > startTime)
-                    .OrderBy(p => p.PackageRegistration.Id);
+                    .Where(p => p.PackageStatusKey == PackageStatus.Available || p.PackageStatusKey == PackageStatus.Validating)
+                    .OrderBy(p => p.Created);
                 if (LimitTo > 0)
                 {
                     packages = packages.Take(LimitTo);

--- a/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
+++ b/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.Extensions.CommandLineUtils;
+using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
 using NuGetGallery;
@@ -30,10 +31,34 @@ namespace GalleryTools.Commands
         protected override List<string> ReadMetadata(IList<string> files, NuspecReader nuspecReader)
         {
             var supportedTFMs = new List<string>();
-            var supportedFrameworks = _packageService.GetSupportedFrameworks(nuspecReader, files);
+
+            // We wrap this int a try catch because fetching supported frameworks on existing packages can sometimes throw
+            // ArgumentExceptions due to format errors (usually portable TFM formatting). In this case we'll clear the TFMs.
+            var supportedFrameworks = Enumerable.Empty<NuGetFramework>();
+            try
+            {
+                supportedFrameworks = _packageService.GetSupportedFrameworks(nuspecReader, files);
+            }
+            catch (ArgumentException)
+            {
+                // do nothing--this is a known scenario and we'll skip this package quietly, which will give us a more useful error log file
+            }
+
             foreach (var tfm in supportedFrameworks)
             {
-                supportedTFMs.Add(tfm.GetShortFolderName());
+                // We wrap this in a try-catch because some poorly-crafted portable TFMs will make it through GetSupportedFrameworks and fail here, e.g. for a
+                // non-existent profile name like "Profile1", which will cause GetShortFolderName to throw. We want to fail silently for these as this is a known
+                // scenario (more useful error log) and not failing will allow us to  still capture all of the valid TFMs.
+                // See https://github.com/NuGet/NuGet.Client/blob/ba008e14611f4fa518c2d02ed78dfe5969e4a003/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs#L297
+                // See https://github.com/NuGet/NuGet.Client/blob/ba008e14611f4fa518c2d02ed78dfe5969e4a003/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs#L487                }
+                try
+                {
+                    supportedTFMs.Add(tfm.ToShortNameOrNull());
+                }
+                catch
+                {
+                    // skip this TFM and only collect well-formatted ones
+                }
             }
 
             return supportedTFMs;
@@ -48,9 +73,19 @@ namespace GalleryTools.Commands
 
         protected override void UpdatePackage(Package package, List<string> metadata, EntitiesContext context)
         {
-            var existingTFMs = package.SupportedFrameworks == null
-                ? Enumerable.Empty<string>()
-                : package.SupportedFrameworks.Select(f => f.FrameworkName.GetShortFolderName()).OrderBy(f => f);
+            // Note that extracting old TFMs may throw for formatting reasons. In this case we'll force a full replacement by leaving the collection empty.
+            var existingTFMs = Enumerable.Empty<string>();
+            if (package.SupportedFrameworks != null)
+            {
+                try
+                {
+                    existingTFMs = package.SupportedFrameworks.Select(f => f.FrameworkName.GetShortFolderName()).OrderBy(f => f);
+                }
+                catch
+                {
+                    // do nothing and replace in full
+                }
+            }
 
             var newTFMs = metadata == null || metadata.Count == 0
                 ? Enumerable.Empty<string>() 

--- a/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
+++ b/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
@@ -20,6 +20,8 @@ namespace GalleryTools.Commands
         
         protected override Expression<Func<Package, object>> QueryIncludes => p => p.SupportedFrameworks;
 
+        protected override int CollectBatchSize => 1000;
+
         public static void Configure(CommandLineApplication config)
         {
             Configure<BackfillTfmMetadataCommand>(config);


### PR DESCRIPTION
Backfill job was ordered in such a way as to not work with cursoring. There was a filtering condition removed which also needed to be reinstated. I also upped the batching size to 1000 for the TFM backfill.