### PR TITLE
Fix break in githubvulnerabilities2db dependency injection

### DIFF
--- a/src/GitHubVulnerabilities2Db/Fakes/FakeContentService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeContentService.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using System.Web;
+using NuGetGallery;
+
+namespace GitHubVulnerabilities2Db.Fakes
+{
+    public class FakeContentService : IContentService
+    {
+        public void ClearCache()
+        {
+            //no-op
+        }
+
+        public Task<IHtmlString> GetContentItemAsync(string name, TimeSpan expiresIn)
+        {
+            // no-op
+            return Task.FromResult((IHtmlString)null);
+        }
+    }
+}

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -1,0 +1,248 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Services.Entities;
+using NuGetGallery;
+
+namespace GitHubVulnerabilities2Db.Fakes
+{
+    public class FakeFeatureFlagService : IFeatureFlagService
+    {
+        public bool AreDynamicODataCacheDurationsEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool AreEmbeddedIconsEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool AreEmbeddedReadmesEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ArePatternSetTfmHeuristicsEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsABTestingEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAdvancedSearchEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAlternateStatisticsSourceEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsAsyncAccountDeleteEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDeletePackageApiEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDisplayFuGetLinksEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDisplayVulnerabilitiesEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsForceFlatContainerIconsEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsGet2FADismissFeedbackEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsGitHubUsageEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsGravatarProxyEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsImageAllowlistEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsLicenseMdRenderingEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsManageDeprecationApiEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsManageDeprecationEnabled(User user, PackageRegistration registration)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsManageDeprecationEnabled(User user, IEnumerable<Package> allVersions)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsManagePackagesVulnerabilitiesEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsMarkdigMdRenderingEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataDatabaseReadOnlyEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV1FindPackagesByIdCountNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV1FindPackagesByIdNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV1GetAllCountEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV1GetAllEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV1GetSpecificNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV1SearchCountNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV1SearchNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV2FindPackagesByIdCountNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV2FindPackagesByIdNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV2GetAllCountNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV2GetAllNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV2GetSpecificNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV2SearchCountNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsODataV2SearchNonHijackedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPackageDependentsEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPackageRenamesEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPackagesAtomFeedEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsPreviewHijackEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSearchSideBySideEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSelfServiceAccountDeleteEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsShowEnable2FADialogEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsTyposquattingEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsTyposquattingEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ProxyGravatarEnSubdomain()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -51,6 +51,8 @@
     <Compile Include="Collector\IAdvisoryQueryBuilder.cs" />
     <Compile Include="Collector\IAdvisoryQueryService.cs" />
     <Compile Include="Configuration\GitHubVulnerabilities2DbConfiguration.cs" />
+    <Compile Include="Fakes\FakeContentService.cs" />
+    <Compile Include="Fakes\FakeFeatureFlagService.cs" />
     <Compile Include="Gallery\ThrowingAuditingService.cs" />
     <Compile Include="Gallery\ThrowingIndexingService.cs" />
     <Compile Include="Gallery\ThrowingSecurityPolicyService.cs" />

--- a/src/GitHubVulnerabilities2Db/Job.cs
+++ b/src/GitHubVulnerabilities2Db/Job.cs
@@ -5,14 +5,13 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using Autofac;
 using GitHubVulnerabilities2Db.Collector;
 using GitHubVulnerabilities2Db.Configuration;
+using GitHubVulnerabilities2Db.Fakes;
 using GitHubVulnerabilities2Db.Gallery;
 using GitHubVulnerabilities2Db.GraphQL;
 using GitHubVulnerabilities2Db.Ingest;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -24,7 +23,6 @@ using NuGet.Services.Storage;
 using NuGetGallery;
 using NuGetGallery.Auditing;
 using NuGetGallery.Configuration;
-using NuGetGallery.Diagnostics;
 using NuGetGallery.Security;
 
 namespace GitHubVulnerabilities2Db
@@ -101,6 +99,10 @@ namespace GitHubVulnerabilities2Db
             containerBuilder
                 .RegisterType<ThrowingSecurityPolicyService>()
                 .As<ISecurityPolicyService>();
+
+            containerBuilder
+                .RegisterType<FakeFeatureFlagService>()
+                .As<IFeatureFlagService>();
 
             containerBuilder
                 .RegisterType<PackageService>()
@@ -180,20 +182,6 @@ namespace GitHubVulnerabilities2Db
             var storageFactory = ctx.Resolve<IStorageFactory>();
             var storage = storageFactory.Create();
             return new DurableCursor(storage.ResolveUri(getBlobName(config)), storage, DateTimeOffset.MinValue);
-        }
-    }
-
-    public class FakeContentService : IContentService
-    {
-        public void ClearCache()
-        {
-            //no-op
-        }
-
-        public Task<IHtmlString> GetContentItemAsync(string name, TimeSpan expiresIn)
-        {
-            // no-op
-            return Task.FromResult((IHtmlString)null);
         }
     }
 }


### PR DESCRIPTION
Address: https://github.com/NuGet/NuGetGallery/issues/8515

Dependency injection was broken by the inclusion of the feature flag service in the package service constructor. Added a fake type for this and moved it and an additional fake into a fakes directory.

[this surfaced in BCDR analysis]