### PR TITLE
[a11y] Add popovers to verification checkmarks

### DIFF
--- a/src/NuGetGallery/App_Start/AppActivator.cs
+++ b/src/NuGetGallery/App_Start/AppActivator.cs
@@ -170,6 +170,10 @@ namespace NuGetGallery
                 .Include("~/Scripts/gallery/clamp.js");
             BundleTable.Bundles.Add(displayPackageScriptBundle);
 
+            var listPackagesScriptBundle = new ScriptBundle("~/Scripts/gallery/page-list-packages.min.js")
+                .Include("~/Scripts/gallery/page-list-packages.js");
+            BundleTable.Bundles.Add(listPackagesScriptBundle);
+
             var managePackagesScriptBundle = new ScriptBundle("~/Scripts/gallery/page-manage-packages.min.js")
                 .Include("~/Scripts/gallery/page-manage-packages.js");
             BundleTable.Bundles.Add(managePackagesScriptBundle);

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1675,6 +1675,7 @@
     <Content Include="App_Data\Files\Content\Symbols-Configuration.json" />
     <Content Include="Scripts\gallery\instrumentation.js" />
     <Content Include="Scripts\gallery\knockout-3.5.1.js" />
+    <Content Include="Scripts\gallery\page-list-packages.js" />
     <Content Include="Views\Shared\SiteMenu.cshtml">
       <SubType>Code</SubType>
     </Content>

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -1,0 +1,22 @@
+$(function () {
+    'use strict';
+
+    for (var i = 0; i < listItemCount; i++) {
+        var id = "reserved-indicator-" + i;
+        configureCheckmarkImagePopover(id);
+    }
+
+    function configureCheckmarkImagePopover(id) {
+        var checkmarkImage = $('#' + id);
+        if (checkmarkImage.length == 1) {   // i.e. checkmark exists
+            checkmarkImage.popover({ trigger: 'hover focus' });
+            checkmarkImage.click(function() {
+                checkmarkImage.popover('show');
+                setTimeout(function() {
+                        checkmarkImage.popover('destroy');
+                    },
+                    1000);
+            });
+        }
+    }
+});

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -1,14 +1,9 @@
-$(function () {
+$(function() {
     'use strict';
 
-    for (var i = 0; i < listItemCount; i++) {
-        var id = "reserved-indicator-" + i;
-        configureCheckmarkImagePopover(id);
-    }
-
-    function configureCheckmarkImagePopover(id) {
-        var checkmarkImage = $('#' + id);
-        if (checkmarkImage.length == 1) {   // i.e. checkmark exists
+    $(".reserved-indicator").each(
+        function() {
+            var checkmarkImage = $(this);
             checkmarkImage.popover({ trigger: 'hover focus' });
             checkmarkImage.click(function() {
                 checkmarkImage.popover('show');
@@ -18,5 +13,5 @@ $(function () {
                     1000);
             });
         }
-    }
+    );
 });

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -244,5 +244,9 @@
         $('#reset-advanced-search').on('click', function () {
             location.href = '?q=@Uri.EscapeDataString(Model.SearchTerm)';
         });
+
+        var listItemCount = @Model.Items.Count;
     </script>
+
+    @Scripts.Render("~/Scripts/gallery/page-list-packages.min.js")
 }

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -244,8 +244,6 @@
         $('#reset-advanced-search').on('click', function () {
             location.href = '?q=@Uri.EscapeDataString(Model.SearchTerm)';
         });
-
-        var listItemCount = @Model.Items.Count;
     </script>
 
     @Scripts.Render("~/Scripts/gallery/page-list-packages.min.js")

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -50,8 +50,7 @@
                     <img class="reserved-indicator"
                          src="~/Content/gallery/img/reserved-indicator.svg"
                          @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-20x20.png"))
-                         data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip"
-                         id=@("reserved-indicator-" + ViewData["ItemIndex"]) tabindex="0" />
+                         data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0" />
                 }
 
                 @if (showEditButton && (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist))

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -50,7 +50,8 @@
                     <img class="reserved-indicator"
                          src="~/Content/gallery/img/reserved-indicator.svg"
                          @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-20x20.png"))
-                         title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                         data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip"
+                         id=@("reserved-indicator-" + ViewData["ItemIndex"]) tabindex="0" />
                 }
 
                 @if (showEditButton && (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist))


### PR DESCRIPTION
Addresses: https://github.com/NuGet/NuGetGallery/issues/8490

We need a tab stop on this checkmark (`tabindex='0'` means it won't mess with tab ordering), and an id that can be found by the popover code. This will respond to hover and focus events.

Screenreaders also read the text as written (tested on Narrator and NVDA).

Just realized how fast this popover flashes by in the below video. The text is the same as the current tooltip: 
```The ID prefix of this package has been reserved for one of the owners of this package by NuGet.org```

![popoverwithouttitle](https://user-images.githubusercontent.com/14225979/114630668-74321e80-9cfe-11eb-80ac-92bd044702b8.gif)
