### PR TITLE
adjust backfill logic - remove redundant catch, process null TFMs

### DIFF
--- a/src/GalleryTools/Commands/BackfillCommand.cs
+++ b/src/GalleryTools/Commands/BackfillCommand.cs
@@ -308,22 +308,14 @@ namespace GalleryTools.Commands
         {
             var httpZipProvider = new HttpZipProvider(httpClient);
 
-            try
-            {
-                var zipDirectoryReader = await httpZipProvider.GetReaderAsync(new Uri(nupkgUri));
-                var zipDirectory = await zipDirectoryReader.ReadAsync();
-                var files = zipDirectory
-                    .Entries
-                    .Select(x => x.GetName())
-                    .ToList();
+            var zipDirectoryReader = await httpZipProvider.GetReaderAsync(new Uri(nupkgUri));
+            var zipDirectory = await zipDirectoryReader.ReadAsync();
+            var files = zipDirectory
+                .Entries
+                .Select(x => x.GetName())
+                .ToList();
 
-                return ReadMetadata(files, nuspecReader);
-            }
-            catch (Exception e)
-            {
-                await logger.LogPackageError(id, version, e);
-                return default;
-            }
+            return ReadMetadata(files, nuspecReader);
         }
 
         private static XDocument LoadDocument(Stream stream)

--- a/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
+++ b/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
@@ -53,7 +53,11 @@ namespace GalleryTools.Commands
                 // See https://github.com/NuGet/NuGet.Client/blob/ba008e14611f4fa518c2d02ed78dfe5969e4a003/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs#L487                }
                 try
                 {
-                    supportedTFMs.Add(tfm.ToShortNameOrNull());
+                    var tfmToAdd = tfm.ToShortNameOrNull();
+                    if (!string.IsNullOrEmpty(tfmToAdd))
+                    {
+                        supportedTFMs.Add(tfmToAdd);
+                    }
                 }
                 catch
                 {


### PR DESCRIPTION
Pivoting to use `ToShortNameOrNull` introduced the possibility of nulls (which are explicitly returned by this method for the `any` TFM), and these need to be excluded from the collection list--these packages were throwing.

Also removed a redundant catch, as the calling method has an identical catch which will log collection errors.