### PR TITLE
Adjust try blocks, repair empty TFM metadata case

### DIFF
--- a/src/GalleryTools/Commands/BackfillCommand.cs
+++ b/src/GalleryTools/Commands/BackfillCommand.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using GalleryTools.Utils;
+using Microsoft.IdentityModel.JsonWebTokens;
 using NuGet.Services.Sql;
 
 namespace GalleryTools.Commands
@@ -116,8 +117,7 @@ namespace GalleryTools.Commands
 
                 var repository = new EntityRepository<Package>(context);
 
-                var packages = repository.GetAll()
-                    .Include(p => p.PackageRegistration);
+                var packages = repository.GetAll().Include(p => p.PackageRegistration);
                 if (QueryIncludes != null)
                 {
                     packages = packages.Include(QueryIncludes);
@@ -233,6 +233,10 @@ namespace GalleryTools.Commands
                 var repository = new EntityRepository<Package>(context);
 
                 var packages = repository.GetAll().Include(p => p.PackageRegistration);
+                if (QueryIncludes != null)
+                {
+                    packages = packages.Include(QueryIncludes);
+                }
 
                 using (var csv = CreateCsvReader(fileName))
                 {
@@ -355,7 +359,9 @@ namespace GalleryTools.Commands
 
             var reader = new StreamReader(fileName);
 
-            return new CsvReader(reader, configuration);
+            var csvReader = new CsvReader(reader, configuration);
+            csvReader.Configuration.MissingFieldFound = null;
+            return csvReader;
         }
 
         private Configuration CreateCsvConfiguration()


### PR DESCRIPTION
Logic tweak--exceptions were still sneaking through because the try block for harvesting TFMs only surrounded the method call doing the extraction - it didn't surround the loop enumerating them. The collection is `IEnumerable`, so of course throwing can still take place while enumerating. The diffing isn't great here, but that's what's happening in `UpdatePackage`. Forcing another enumeration `ToList` is for the same reason.

Also, the case where no TFMs were being persisted to the metadata file was throwing on the update cycle. I needed to null the `MissingFieldFound` action on the csvReader (this instruction comes from the exception thrown by csvReader). The null case is covered in update code so this fixed the issue.