### PR TITLE
Adjust support request hint to include DMCA text

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Index.cshtml
@@ -76,7 +76,8 @@
                     <div class="form-field">
                         <label for="editIssueComment">Add comment</label>
                         <textarea id="editIssueComment" name="editIssueComment" data-bind="value: editIssueComment" rows="10"
-                                  placeholder="Add a comment..." autocomplete="off" autofocus></textarea>
+                                  placeholder="Add a comment. If resolving a DMCA request add offender account names (in single quotes, comma-delimited), offending package id, and resolution (no action, withdrawn, upheld). Example: accounts:'foo1','foo2' id:BarPkg resolution: upheld"
+                                  autocomplete="off" autofocus></textarea>
                     </div>
                 </fieldset>
             </form>


### PR DESCRIPTION
Addresses: https://github.com/NuGet/NuGetGallery/issues/8535

A text update for the hint of the text area in the support request edit dialog, prompting users to format their resolution to cover the  data we need for searches.