### PR TITLE
[A11Y] Screenreader does not read required keyword for the control “Package Owner".

### DIFF
--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -322,6 +322,7 @@
                 <label class="required" data-bind="attr: { for: PackageOwnerId,
                                             id: PackageOwnerId() + '-label' }">Package Owner</label>
                 <select class="form-control"
+                        aria-required="true"
                         data-bind="attr: { id: PackageOwnerId,
                                                     name: PackageOwnerId,
                                                     'aria-labelledby': PackageOwnerId() + '-label' },


### PR DESCRIPTION
* Added aria-required="true" to announce a required input.

Addresses https://github.com/NuGet/NuGetGallery/issues/8494