### PR TITLE
[A11y] Remove collapse from cancel button in ApiKey page.

### DIFF
--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -499,7 +499,7 @@
                                            id: CancelEditId },
                                    enable: SelectPackagesEnabled() && !PendingCreateOrEdit(),
                                    click: CancelEdit"
-                        class="btn btn-default btn-block" data-toggle="collapse">
+                        class="btn btn-default btn-block">
                     Cancel
                 </button>
             </div>


### PR DESCRIPTION
The cancel button is announced as expanded when it's clickable (you don't know it's collapse because it's disabled), but since that button doesn't actually expands data we got a bug for that behavior.
* removed collapse from cancel button.

Addresses https://github.com/NuGet/NuGetGallery/issues/8496.