### PR TITLE
Ingest withdrawn data in GitHub GraphQL

### DIFF
--- a/src/GitHubVulnerabilities2Db/Collector/AdvisoryQueryBuilder.cs
+++ b/src/GitHubVulnerabilities2Db/Collector/AdvisoryQueryBuilder.cs
@@ -23,6 +23,7 @@ namespace GitHubVulnerabilities2Db.Collector
         databaseId
         permalink
         severity
+        withdrawnAt
         updatedAt
         " + CreateVulnerabilitiesConnectionQuery() + @"
       }

--- a/src/GitHubVulnerabilities2Db/GraphQL/SecurityVulnerability.cs
+++ b/src/GitHubVulnerabilities2Db/GraphQL/SecurityVulnerability.cs
@@ -13,6 +13,7 @@ namespace GitHubVulnerabilities2Db.GraphQL
         public SecurityVulnerabilityPackage Package { get; set; }
         public string VulnerableVersionRange { get; set; }
         public SecurityVulnerabilityPackageVersion FirstPatchedVersion { get; set; }
+        public DateTimeOffset? WithdrawnAt { get; set; }
         public DateTimeOffset UpdatedAt { get; set; }
         public SecurityAdvisory Advisory { get; set; }
     }

--- a/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
+++ b/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
@@ -52,6 +52,7 @@ namespace GitHubVulnerabilities2Db.Facts
                         Assert.Equal(advisory.DatabaseId, vulnerability.GitHubDatabaseKey);
                         Assert.Equal(PackageVulnerabilitySeverity.Moderate, vulnerability.Severity);
                         Assert.Equal(advisory.Permalink, vulnerability.AdvisoryUrl);
+                        Assert.Equal(withdrawn, advisory.WithdrawnAt != null);
                     })
                     .Returns(Task.CompletedTask)
                     .Verifiable();


### PR DESCRIPTION
Addresses: https://github.com/NuGet/NuGetGallery/issues/8474

All of the logic exists in the service and UTs for processing the withdrawn field, but it needs to be added to the query.

Note that there are no withdrawn advisories for NuGet packages at this time, but we need this in place.