### PR TITLE
Display version metadata only in an info box

### DIFF
--- a/src/NuGetGallery/Helpers/ViewModelExtensions/PackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/PackageViewModelFactory.cs
@@ -34,6 +34,7 @@ namespace NuGetGallery
             }
 
             viewModel.FullVersion = NuGetVersionFormatter.ToFullString(package.Version);
+            viewModel.NormalizedVersion = NuGetVersionFormatter.Normalize(package.Version);
 
             viewModel.Id = package.Id;
             viewModel.Version = String.IsNullOrEmpty(package.NormalizedVersion) ?

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/PackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/PackageViewModelFactory.cs
@@ -34,8 +34,6 @@ namespace NuGetGallery
             }
 
             viewModel.FullVersion = NuGetVersionFormatter.ToFullString(package.Version);
-            viewModel.NormalizedVersion = NuGetVersionFormatter.Normalize(package.Version);
-
             viewModel.Id = package.Id;
             viewModel.Version = String.IsNullOrEmpty(package.NormalizedVersion) ?
                 NuGetVersionFormatter.Normalize(package.Version) :

--- a/src/NuGetGallery/ViewModels/PackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageViewModel.cs
@@ -27,7 +27,6 @@ namespace NuGetGallery
         public string Id { get; set; }
         public string Version { get; set; }
         public string FullVersion { get; set; }
-        public string NormalizedVersion { get; set; }
         public PackageStatusSummary PackageStatusSummary { get; set; }
         public bool IsVulnerable { get; set; }
 

--- a/src/NuGetGallery/ViewModels/PackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageViewModel.cs
@@ -27,6 +27,7 @@ namespace NuGetGallery
         public string Id { get; set; }
         public string Version { get; set; }
         public string FullVersion { get; set; }
+        public string NormalizedVersion { get; set; }
         public PackageStatusSummary PackageStatusSummary { get; set; }
         public bool IsVulnerable { get; set; }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -247,7 +247,7 @@
             <div class="package-title">
                 <h1>
                     @Html.BreakWord(Model.Id)
-                    <small class="text-nowrap">@Model.FullVersion</small>
+                    <small class="text-nowrap">@Model.NormalizedVersion</small>
 
                     @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
                     {
@@ -346,6 +346,14 @@
                 @ViewHelpers.AlertInfo(
                     @<text>
                         This is a prerelease version of @(Model.Id).
+                    </text>
+                )
+            }
+            @if (Model.NuGetVersion.HasMetadata)
+            {
+                @ViewHelpers.AlertInfo(
+                    @<text>
+                        This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
                     </text>
                 )
             }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -247,7 +247,7 @@
             <div class="package-title">
                 <h1>
                     @Html.BreakWord(Model.Id)
-                    <small class="text-nowrap">@Model.NormalizedVersion</small>
+                    <small class="text-nowrap">@Model.Version</small>
 
                     @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
                     {
@@ -768,7 +768,7 @@
                                 @VersionListDivider(rowCount, versionsExpanded)
                                 <tr class="@(packageVersion.IsCurrent(Model) ? "bg-info" : null)">
                                     <td tabindex="0">
-                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.FullVersion">
+                                        <a href="@Url.Package(packageVersion)" title="@packageVersion.Version">
                                             @packageVersion.Version.Abbreviate(30)
                                         </a>
                                     </td>

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -88,7 +88,7 @@
                 <li>
                     <span class="icon-text">
                         <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
-                        Latest version: <span class="text-nowrap">@Model.NormalizedVersion @(Model.Prerelease ? "(prerelease)" : "")</span>
+                        Latest version: <span class="text-nowrap">@Model.Version @(Model.Prerelease ? "(prerelease)" : "")</span>
                     </span>
                 </li>
                 @if (Model.Tags.AnySafe())

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -88,7 +88,7 @@
                 <li>
                     <span class="icon-text">
                         <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
-                        Latest version: <span class="text-nowrap">@Model.FullVersion @(Model.Prerelease ? "(prerelease)" : "")</span>
+                        Latest version: <span class="text-nowrap">@Model.NormalizedVersion @(Model.Prerelease ? "(prerelease)" : "")</span>
                     </span>
                 </li>
                 @if (Model.Tags.AnySafe())


### PR DESCRIPTION
Minor changes to the UI so that the version metadata only appears inside an info box on the view package page. Before:

![image](https://user-images.githubusercontent.com/2829865/117590532-5035f180-b173-11eb-842a-01307204e841.png)

after:

![image](https://user-images.githubusercontent.com/2829865/116168613-2bd71f80-a746-11eb-8746-3167464cedf5.png)

The issue has a screenshot of a warning but it seems to be that an info box might be more appropriate, as version metadata isn't really cause for an alert.

The build metadata is also removed from the search page. Before:

![image](https://user-images.githubusercontent.com/2829865/117590547-5f1ca400-b173-11eb-9b2f-72fbbcb17836.png)

after:

![image](https://user-images.githubusercontent.com/2829865/116168621-32fe2d80-a746-11eb-8126-fadad01d9e77.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/7662