### PR TITLE
fixed missing flights for icons and readMes

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -82,6 +82,18 @@
       "SiteAdmins": false,
       "Accounts": [],
       "Domains": []
+    },
+    "NuGetGallery.EmbeddedIcons": {
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
+    },
+    "NuGetGallery.EmbeddedReadmes": {
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
     }
   }
 }


### PR DESCRIPTION
- currently cannot upload package with embedded readme or icons in local development enviroment as the features were disabled by default
- Found that both features were missing flights, so added them in and set to true for all

Addresses https://github.com/NuGet/NuGetGallery/issues/8557