### PR TITLE
show some content of readme if is too long

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -62,7 +62,7 @@ $(function () {
             "Show more");
 
         var showLess = $("#readme-less");
-        $clamp(showLess[0], { clamp: 10, useNativeClamp: false });
+        $clamp(showLess[0], { clamp: 30, useNativeClamp: false});
 
         $("#show-readme-more").click(function (e) {
             showLess.collapse("toggle");

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -62,7 +62,7 @@ $(function () {
             "Show more");
 
         var showLess = $("#readme-less");
-        $clamp(showLess[0], { clamp: 30, useNativeClamp: false});
+        $clamp(showLess[0], { clamp: 30, useNativeClamp: false });
 
         $("#show-readme-more").click(function (e) {
             showLess.collapse("toggle");


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

we are using clamp.js to cut off the html element.  Here we are going to increase the number of lines to cut off. 

clamp(): this controls where and when to clamp the text of an element. 

useNativeClamp (Boolean). Enables or disables using the native -webkit-line-clamp in a supported browser (ie. Webkit). It defaults to true if you're using Webkit, but it can behave wonky sometimes so you can set it to false to use the JavaScript- based solution.

```
            var height = getMaxHeight(clampValue);
            if (height <= element.clientHeight) {
                clampedText = truncate(getLastChild(element), height);
            }
```


before: 
![nugetcleaner.PNG](https://images.zenhubusercontent.com/5ea7662f8e9f163fb34aaf70/c25ed526-9ed5-4200-a9ca-d735bb531f72)


after : 
![readme0](https://user-images.githubusercontent.com/64443925/117193425-ac75cb80-ad97-11eb-87ef-762ce0bbaa2c.PNG)

Addresses https://github.com/NuGet/NuGetGallery/issues/8564