### PR TITLE
Gallery instance uptime tracking

### DIFF
--- a/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
+++ b/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
@@ -86,6 +86,11 @@ namespace GitHubVulnerabilities2Db.Gallery
             throw new NotImplementedException();
         }
 
+        public void TrackInstanceUptime(TimeSpan uptime)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackInvalidLicenseMetadata(string licenseValue)
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -404,5 +404,11 @@ namespace NuGetGallery
             bool isAuthenticated,
             int testBucket,
             int testPercentage);
+
+        /// <summary>
+        /// Tracks the current process uptime.
+        /// </summary>
+        /// <param name="uptime">The uptime to report.</param>
+        void TrackInstanceUptime(TimeSpan uptime);
     }
 }

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -91,6 +91,7 @@ namespace NuGetGallery
             public const string ABTestEvaluated = "ABTestEvaluated";
             public const string PackagePushDisconnect = "PackagePushDisconnect";
             public const string SymbolPackagePushDisconnect = "SymbolPackagePushDisconnect";
+            public const string InstanceUptime = "InstanceUptimeInDays";
         }
 
         private readonly IDiagnosticsSource _diagnosticsSource;
@@ -1095,12 +1096,17 @@ namespace NuGetGallery
 
         public void TrackPackagePushDisconnectEvent()
         {
-            TrackMetric(Events.PackagePushDisconnect, 1, p => { });
+            TrackMetric(Events.PackagePushDisconnect, 1, _ => { });
         }
 
         public void TrackSymbolPackagePushDisconnectEvent()
         {
-            TrackMetric(Events.SymbolPackagePushDisconnect, 1, p => { });
+            TrackMetric(Events.SymbolPackagePushDisconnect, 1, _ => { });
+        }
+
+        public void TrackInstanceUptime(TimeSpan uptime)
+        {
+            TrackMetric(Events.InstanceUptime, uptime.TotalDays, _ => { });
         }
 
         /// <summary>

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -214,7 +214,7 @@ namespace NuGetGallery
                     while (!token.IsCancellationRequested)
                     {
                         telemetryService.TrackInstanceUptime(DateTime.UtcNow - startTime);
-                        await Task.Delay(TimeSpan.FromHours(1), token);
+                        await Task.Delay(TimeSpan.FromMinutes(1), token);
                     }
                 });
             }

--- a/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
@@ -83,6 +83,11 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
+        public void TrackInstanceUptime(TimeSpan uptime)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackInvalidLicenseMetadata(string licenseValue)
         {
             throw new NotImplementedException();

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -343,6 +343,10 @@ namespace NuGetGallery
                     yield return new object[] { "SymbolPackagePushDisconnect",
                         (TrackAction)(s => s.TrackSymbolPackagePushDisconnectEvent())
                     };
+
+                    yield return new object[] { "InstanceUptimeInDays",
+                        (TrackAction)(s => s.TrackInstanceUptime(TimeSpan.FromSeconds(1)))
+                    };
                 }
             }
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/3718.

Since transient configuration objects have too much of a performance impact, instead of going that way, we'll track the Gallery instance uptime so we could make an alert that would tell us that we hadn't deployed for a while.