### PR TITLE
[Readme]Add message for readme during validation

### DIFF
--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -135,6 +135,7 @@ namespace NuGetGallery
             viewModel.ReadMeImagesRewritten = readmeResult != null ? readmeResult.ImagesRewritten : false;
             viewModel.ReadmeImageSourceDisallowed = readmeResult != null ? readmeResult.ImageSourceDisallowed : false;
             viewModel.HasEmbeddedIcon = package.HasEmbeddedIcon;
+            viewModel.HasEmbeddedReadmeFile = package.HasEmbeddedReadme;
 
             return viewModel;
         }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -282,6 +282,14 @@
                         </text>
                     )
                 }
+                if (Model.HasEmbeddedReadmeFile)
+                {
+                    @ViewHelpers.AlertWarning(
+                        @<text>
+                            The readme will become available once package validation has completed successfully.
+                        </text>
+                    )
+                }
 
                 if (Model.ValidatingTooLong)
                 {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -282,6 +282,7 @@
                         </text>
                     )
                 }
+
                 if (Model.HasEmbeddedReadmeFile)
                 {
                     @ViewHelpers.AlertWarning(

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -570,6 +570,58 @@ namespace NuGetGallery.ViewModels
             Assert.False(hasNewerRelease);
         }
 
+        [Fact]
+        public void HasEmbeddedReadmeFileTrueIfPackageHasEmbeddedReadme()
+        {
+            var package = new Package
+            {
+                Key = 123,
+                Version = "1.0.0",
+                HasReadMe = true,
+                EmbeddedReadmeType = EmbeddedReadmeFileType.Markdown,
+                PackageRegistration = new PackageRegistration
+                {
+                    Owners = Enumerable.Empty<User>().ToList(),
+                }
+            };
+
+            package.PackageRegistration.Packages = new[] { package };
+
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
+
+            //Act
+            var hasEmbeddedReadmeFile = viewModel.HasEmbeddedReadmeFile;
+
+            //Assert
+            Assert.True(hasEmbeddedReadmeFile);
+        }
+
+        [Fact]
+        public void HasEmbeddedReadmeFileFalseIfPackageHasLegacyReadme()
+        {
+            var package = new Package
+            {
+                Key = 123,
+                Version = "1.0.0",
+                HasReadMe = true,
+                EmbeddedReadmeType = EmbeddedReadmeFileType.Absent,
+                PackageRegistration = new PackageRegistration
+                {
+                    Owners = Enumerable.Empty<User>().ToList(),
+                }
+            };
+
+            package.PackageRegistration.Packages = new[] { package };
+
+            var viewModel = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
+
+            //Act
+            var hasEmbeddedReadmeFile = viewModel.HasEmbeddedReadmeFile;
+
+            //Assert
+            Assert.False(hasEmbeddedReadmeFile);
+        }
+
         private Package CreateTestPackage(string version, string dependencyVersion = null)
         {
             var package = new Package


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Add message about embedded readme available after validation 

after: 
![ReadmeMessage](https://user-images.githubusercontent.com/64443925/119939569-ec694200-bf42-11eb-9504-4a47066b0c0f.PNG)


Addresses: https://github.com/NuGet/NuGetGallery/issues/8507