### PR TITLE
Add link for reserved namespace error during package upload 

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -518,7 +518,7 @@ namespace NuGetGallery
                 {
                     var version = nuspec.GetVersion().ToNormalizedString();
                     _telemetryService.TrackPackagePushNamespaceConflictEvent(id, version, currentUser, User.Identity);
-                    return Json(HttpStatusCode.Conflict, new[] { new JsonValidationMessage(Strings.UploadPackage_IdNamespaceConflict) });
+                    return Json(HttpStatusCode.Conflict, new[] { new JsonValidationMessage(new UploadPackageIdNamespaceConflict()) });
                 }
                 else if (result == PermissionsCheckResult.OwnerlessReservedNamespaceFailure)
                 {

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -310,6 +310,7 @@
     </Compile>
     <Compile Include="Modules\CookieComplianceHttpModule.cs" />
     <Compile Include="RequestModels\DeletePackagesApiRequest.cs" />
+    <Compile Include="Services\UploadPackageIdNamespaceConflict.cs" />
     <Compile Include="Services\ImageDomainValidator.cs" />
     <Compile Include="Services\IMarkdownService.cs" />
     <Compile Include="Services\IImageDomainValidator.cs" />

--- a/src/NuGetGallery/Services/UploadPackageIdNamespaceConflict.cs
+++ b/src/NuGetGallery/Services/UploadPackageIdNamespaceConflict.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// Represents a package ID reservation conflict
+    /// </summary>
+    public class UploadPackageIdNamespaceConflict : IValidationMessage
+    {
+        public bool HasRawHtmlRepresentation => true;
+        public string PlainTextMessage => Strings.UploadPackage_IdNamespaceConflict;
+        public string RawHtmlMessage => Strings.UploadPackage_IdNamespaceConflictHtml;
+    }
+}

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2535,11 +2535,20 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This package ID has been reserved. Please request access to upload to this reserved namespace from the owner of the reserved prefix, or re-upload the package with a different ID..
+        ///   Looks up a localized string similar to This package ID has been reserved. Please request access to upload to this reserved namespace from the owner of the reserved prefix, or re-upload the package with a different ID. Go to https://docs.microsoft.com/en-us/nuget/reference/id-prefix-reservation learn more about Package ID prefix reservation..
         /// </summary>
         public static string UploadPackage_IdNamespaceConflict {
             get {
                 return ResourceManager.GetString("UploadPackage_IdNamespaceConflict", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This package ID has been reserved. Please request access to upload to this reserved namespace from the owner of the reserved prefix, or re-upload the package with a different ID. Go to &lt;a href=&quot;https://docs.microsoft.com/en-us/nuget/reference/id-prefix-reservation&quot;&gt;https://docs.microsoft.com/en-us/nuget/reference/id-prefix-reservation&lt;/a&gt; learn more about Package ID prefix reservation..
+        /// </summary>
+        public static string UploadPackage_IdNamespaceConflictHtml {
+            get {
+                return ResourceManager.GetString("UploadPackage_IdNamespaceConflictHtml", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -515,7 +515,10 @@ For more information, please contact '{2}'.</value>
     <value>The ID prefix of this package has been reserved for one of the owners of this package by NuGet.org.</value>
   </data>
   <data name="UploadPackage_IdNamespaceConflict" xml:space="preserve">
-    <value>This package ID has been reserved. Please request access to upload to this reserved namespace from the owner of the reserved prefix, or re-upload the package with a different ID.</value>
+    <value>This package ID has been reserved. Please request access to upload to this reserved namespace from the owner of the reserved prefix, or re-upload the package with a different ID. Go to https://docs.microsoft.com/en-us/nuget/reference/id-prefix-reservation learn more about Package ID prefix reservation.</value>
+  </data>
+  <data name="UploadPackage_IdNamespaceConflictHtml" xml:space="preserve">
+    <value>This package ID has been reserved. Please request access to upload to this reserved namespace from the owner of the reserved prefix, or re-upload the package with a different ID. Go to &lt;a href=&quot;https://docs.microsoft.com/en-us/nuget/reference/id-prefix-reservation&quot;&gt;https://docs.microsoft.com/en-us/nuget/reference/id-prefix-reservation&lt;/a&gt; learn more about Package ID prefix reservation.</value>
   </data>
   <data name="PreviewReadMe_ConversionFailed" xml:space="preserve">
     <value>Conversion of Markdown to HTML failed with '{0}'.</value>


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Add link to message when there is conflict of namespace during uploading package 

After changes: 
![uploadWithName](https://user-images.githubusercontent.com/64443925/119746376-38ce5800-be45-11eb-9b3d-c4f6ed8faec5.PNG)


Addresses https://github.com/NuGet/NuGetGallery/issues/8397