### PR TITLE
Set default flags in local environment 

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -26,7 +26,9 @@
     "NuGetGallery.ManagePackagesVulnerabilities": "Enabled",
     "NuGetGallery.DisplayFuGetLinks": "Enabled",
     "NuGetGallery.PatternSetTfmHeuristics": "Enabled",
-    "NuGetGallery.EmbeddedIcons": "Enabled"
+    "NuGetGallery.EmbeddedIcons": "Enabled",
+    "NuGetGallery.MarkdigMdRendering": "Enabled",
+    "NuGetGallery.ImageAllowlist": "Enabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {


### PR DESCRIPTION
enable NuGetGallery.ImageAllowlist and NuGetGallery.MarkdigMdRendering in local environment to alig with prod 