### PR TITLE
[online safety] Add safety categories to report abuse form

### DIFF
--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -205,6 +205,11 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
+        public bool IsShowReportAbuseSafetyChangesEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsPackageDependentsEnabled(User user)
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -49,6 +49,7 @@ namespace NuGetGallery
         private const string ImageAllowlistFlightName = GalleryPrefix + "ImageAllowlist";
         private const string DisplayBannerFlightName = GalleryPrefix + "Banner";
         private const string DisplayPackagePageV2FeatureName = GalleryPrefix + "DisplayPackagePageV2";
+        private const string ShowReportAbuseSafetyChanges = GalleryPrefix + "ShowReportAbuseSafetyChanges";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -317,6 +318,11 @@ namespace NuGetGallery
         public bool IsODataV2SearchCountNonHijackedEnabled()
         {
             return _client.IsEnabled(ODataV2SearchCountNonHijackedFeatureName, defaultValue: true);
+        }
+
+        public bool IsShowReportAbuseSafetyChangesEnabled()
+        {
+            return _client.IsEnabled(ShowReportAbuseSafetyChanges, defaultValue: false);
         }
 
         public bool IsMarkdigMdRenderingEnabled()

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -248,9 +248,15 @@ namespace NuGetGallery
         /// </summary>
         bool IsLicenseMdRenderingEnabled(User user);
 
+        /// <summary>
         /// Whether the /Search()/$count endpoint is enabled for non-hijacked queries for the V2 OData API.
         /// </summary>
         bool IsODataV2SearchCountNonHijackedEnabled();
+
+        /// <summary>
+        /// Whether the online safety changes to the report abuse form have been enabled
+        /// </summary>
+        bool IsShowReportAbuseSafetyChangesEnabled();
 
         /// <summary>
         /// Whether rendering Markdown content to HTML using Markdig is enabled

--- a/src/NuGetGallery.Services/Models/ReportPackageReason.cs
+++ b/src/NuGetGallery.Services/Models/ReportPackageReason.cs
@@ -24,5 +24,23 @@ namespace NuGetGallery
 
         [Description("The package was not intended to be published publicly on nuget.org")]
         ReleasedInPublicByAccident,
+
+        [Description("Child sexual exploitation or abuse")]
+        ChildSexualExploitationOrAbuse,
+
+        [Description("Terrorism or violent extremism")]
+        TerrorismOrViolentExtremism,
+
+        [Description("The package contains hate speech")]
+        HateSpeech,
+
+        [Description("The package contains content related to imminent harm")]
+        ImminentHarm,
+
+        [Description("The package contains non-consensual intimate imagery (i.e. \"revenge porn\")")]
+        RevengePorn,
+
+        [Description("Other nudity or pornography (not \"revenge porn\")")]
+        OtherNudityOrPornography,
     }
 }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -67,6 +67,20 @@ namespace NuGetGallery
             ReportPackageReason.Other
         };
 
+        private static readonly IReadOnlyList<ReportPackageReason> ReportAbuseWithSafetyReasons = new[]
+        {
+            ReportPackageReason.ViolatesALicenseIOwn,
+            ReportPackageReason.ContainsMaliciousCode,
+            ReportPackageReason.HasABugOrFailedToInstall,
+            ReportPackageReason.ChildSexualExploitationOrAbuse,
+            ReportPackageReason.TerrorismOrViolentExtremism,
+            ReportPackageReason.HateSpeech,
+            ReportPackageReason.ImminentHarm,
+            ReportPackageReason.RevengePorn,
+            ReportPackageReason.OtherNudityOrPornography,
+            ReportPackageReason.Other
+        };
+
         private static readonly IReadOnlyList<ReportPackageReason> ReportMyPackageReasons = new[]
         {
             ReportPackageReason.ContainsPrivateAndConfidentialData,
@@ -1336,7 +1350,9 @@ namespace NuGetGallery
 
             var model = new ReportAbuseViewModel
             {
-                ReasonChoices = ReportAbuseReasons,
+                ReasonChoices = _featureFlagService.IsShowReportAbuseSafetyChangesEnabled() 
+                    ? ReportAbuseWithSafetyReasons
+                    : ReportAbuseReasons,
                 PackageId = id,
                 PackageVersion = package.Version,
                 CopySender = true,

--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -25,13 +25,13 @@
                 </text>
             )
 
-            <p>
+            <p tabindex="0">
                 Please provide a detailed abuse report with evidence to support your claim! We cannot delete packages without evidence that they exhibit malicious behavior.
             </p>
 
             @if (!Model.ConfirmedUser)
             {
-                <p>
+                <p tabindex="0">
                     Note: If this is your package and you would like to contact support, please
                     <a href="@Url.LogOn(returnUrl)">sign in.</a>
                 </p>
@@ -42,7 +42,7 @@
 
                 <div id="form-field-reason" class="form-group @Html.HasErrorFor(m => m.Reason)">
                     @Html.ShowLabelFor(m => m.Reason)
-                    <p>Please select the reason for contacting support about this package.</p>
+                    <p tabindex="0">Please select the reason for contacting support about this package.</p>
                     @Html.ShowEnumDropDownListFor(m => m.Reason, Model.ReasonChoices, "<Choose a Reason>")
                     @Html.ShowValidationMessagesFor(m => m.Reason)
                 </div>
@@ -53,14 +53,47 @@
                         @Html.ShowTextBoxFor(m => m.Email)
                         @Html.ShowValidationMessagesFor(m => m.Email)
                     </div>
-                    <div class="form-group @Html.HasErrorFor(m => m.AlreadyContactedOwner)">
+                    <div class="form-group already-contacted-owner @Html.HasErrorFor(m => m.AlreadyContactedOwner)">
                         @Html.ShowCheckboxFor(m => m.AlreadyContactedOwner)
                         @Html.ShowLabelFor(m => m.AlreadyContactedOwner)
                         @Html.ShowValidationMessagesFor(m => m.AlreadyContactedOwner)
                     </div>
                     <div class="form-group @Html.HasErrorFor(m => m.Message)">
                         @Html.ShowLabelFor(m => m.Message)
-                        <p>Please provide a detailed description of the problem.<span class="infringement-claim-requirements"> If you are reporting copyright infringement, please describe the copyrighted material with particularity and provide us with information about your copyright (i.e. title of copyrighted work, URL where to view your copyrighted work, description of your copyrighted work, and any copyright registrations you may have, etc.). For trademark infringement, include the name of your trademark, registration number, and country where registered.</span></p>
+                        <p tabindex="0">
+                            Please provide a detailed description of the problem.
+                        <p>
+                        <div class="infringement-claim-requirements" tabindex="0">
+                            <p>
+                                If you are reporting copyright infringement, please describe the copyrighted material with particularity and provide us with information about your copyright (i.e. title of copyrighted work, URL where to view your copyrighted work, description of your copyrighted work, and any copyright registrations you may have, etc.). For trademark infringement, include the name of your trademark, registration number, and country where registered.
+                            </p>
+                        </div>
+                        <div class="child-sexual-exploitation" tabindex="0">
+                            <p>
+                                Note: Please complete this form and submit it so we can proceed with an appropriate response regarding the NuGet package (e.g. removing it). In addition, please proceed to <a href="https://report.cybertip.org">https://report.cybertip.org</a> to report the matter in more detail.
+                            </p>
+                        </div>
+                        <div class="terrorism-or-violent-extremism" tabindex="0">
+                            <p>
+                                Note: Please complete this form and submit it so we can proceed with an appropriate response regarding the NuGet package (e.g. removing it). In addition, please proceed to <a href="https://www.microsoft.com/en-au/concern/terroristcontent">https://www.microsoft.com/en-au/concern/terroristcontent</a> to report the matter in more detail.
+                            </p>
+                        </div>
+                        <div class="imminent-harm" tabindex="0">
+                            <p>
+                                Note: please ensure when reporting this type of abuse that you've considered whether the following are present:
+                                <ul>
+                                    <li>A targeted person or group (including self)</li>
+                                    <li>An identified actor--i.e. person intending to commit the offense</li>
+                                    <li>Details of the threat</li>
+                                    <li>Time and/or place where the act will be carried out</li>
+                                </ul>
+                            </p>
+                        </div>
+                        <div class="revenge-porn" tabindex="0">
+                            <p>
+                                Note: Please complete this form and submit it so we can proceed with an appropriate response regarding the NuGet package (e.g. removing it). In addition, please proceed to <a href="https://www.microsoft.com/en-us/concern/revengeporn">https://www.microsoft.com/en-us/concern/revengeporn</a> to report the matter in more detail.
+                            </p>
+                        </div>
                         @Html.ShowTextAreaFor(m => m.Message, 10, 50)
                         @Html.ShowValidationMessagesFor(m => m.Message)
                     </div>
@@ -110,6 +143,42 @@
                 $('#report-abuse-form').hide();
             } else {
                 $('#report-abuse-form').show();
+            }
+
+            // We don't suggest the customer contact the owner in the case of safety violations
+            if (val === 'ChildSexualExploitationOrAbuse'
+                || val === 'TerrorismOrViolentExtremism'
+                || val === 'HateSpeech'
+                || val === 'ImminentHarm'
+                || val === 'RevengePorn'
+                || val === 'OtherNudityOrPornography') {
+                $form.find('.already-contacted-owner').hide();
+            } else {
+                $form.find('.already-contacted-owner').show();
+            }
+
+            if (val === 'ChildSexualExploitationOrAbuse') {
+                $form.find('.child-sexual-exploitation').show();
+            } else {
+                $form.find('.child-sexual-exploitation').hide();
+            }
+
+            if (val === 'TerrorismOrViolentExtremism') {
+                $form.find('.terrorism-or-violent-extremism').show();
+            } else {
+                $form.find('.terrorism-or-violent-extremism').hide();
+            }
+
+            if (val === 'ImminentHarm') {
+                $form.find('.imminent-harm').show();
+            } else {
+                $form.find('.imminent-harm').hide();
+            }
+
+            if (val === 'RevengePorn') {
+                $form.find('.revenge-porn').show();
+            } else {
+                $form.find('.revenge-porn').hide();
             }
 
             if (val == 'ViolatesALicenseIOwn') {

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -103,6 +103,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsODataV2SearchCountNonHijackedEnabled() => throw new NotImplementedException();
 
+        public bool IsShowReportAbuseSafetyChangesEnabled() => throw new NotImplementedException();
+
         public bool IsMarkdigMdRenderingEnabled() => throw new NotImplementedException();
 
         public bool IsDeletePackageApiEnabled(User user) => throw new NotImplementedException();


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8590
Spec: https://github.com/NuGet/Home/blob/dev/proposed/2021/NuGetOrgReportForm-SafetyChanges.md

- Adds online safety categories and associated text to form
- Adds tab indexes for a11y to other text (more a11y work is needed for this form, but this was a quick win for now)
- Removed contacted owner checkbox for safety categories - we don't want customers to feel they should do this
- All under a feature flag for now

[note that the gif below shows inconsistent "the" and "this" in dropdown. Since fixed.]

![reportabuseform](https://user-images.githubusercontent.com/14225979/121983676-0c1eb800-cdd5-11eb-9f6f-316a8016c10f.gif)
