### PR TITLE
Styled Header for new display package page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1285,8 +1285,9 @@ img.reserved-indicator-icon {
   margin-right: 14px;
 }
 .page-package-details-v2 .package-title h1 .package-icon {
-  height: 40px;
-  width: 40px;
+  height: 32px;
+  width: 32px;
+  margin-top: 8px;
   margin-right: 12px;
 }
 .page-package-details-v2 .package-title h1 .prefix-reserve-title {
@@ -1300,6 +1301,7 @@ img.reserved-indicator-icon {
   -ms-flex-align: center;
   align-items: center;
   border-radius: 100px;
+  vertical-align: bottom;
 }
 .page-package-details-v2 .package-title h1 .prefix-reserve-title .reserved-indicator {
   width: 18px;
@@ -1307,7 +1309,7 @@ img.reserved-indicator-icon {
   margin-left: 2px;
 }
 .page-package-details-v2 .package-title h1 .prefix-reserve-title .prefix-reserve-label {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 400;
   color: #2F6FA7;
   margin-top: 2px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1272,13 +1272,13 @@ img.reserved-indicator-icon {
 .page-package-details-v2 .package-title {
   margin-bottom: 30px;
 }
-.page-package-details-v2 .package-title h1 #title {
+.page-package-details-v2 .package-title h1 .title {
   font-size: 32px;
   margin-top: 40px;
   font-weight: 400;
   margin-right: 18px;
 }
-.page-package-details-v2 .package-title h1 #version-title {
+.page-package-details-v2 .package-title h1 .version-title {
   font-size: 16px;
   font-weight: 400;
   color: #666666;
@@ -1301,12 +1301,12 @@ img.reserved-indicator-icon {
   align-items: center;
   border-radius: 100px;
 }
-.page-package-details-v2 .package-title h1 .prefix-reserve-title #reserved-indicator {
+.page-package-details-v2 .package-title h1 .prefix-reserve-title .reserved-indicator {
   width: 18px;
   margin-right: 5px;
   margin-left: 2px;
 }
-.page-package-details-v2 .package-title h1 .prefix-reserve-title #prefix-reserve-label {
+.page-package-details-v2 .package-title h1 .prefix-reserve-title .prefix-reserve-label {
   font-size: 16px;
   font-weight: 400;
   color: #2F6FA7;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1283,6 +1283,7 @@ img.reserved-indicator-icon {
   font-weight: 400;
   color: #666666;
   margin-right: 14px;
+  vertical-align: middle;
 }
 .page-package-details-v2 .package-title h1 .package-icon {
   height: 32px;
@@ -1301,7 +1302,7 @@ img.reserved-indicator-icon {
   -ms-flex-align: center;
   align-items: center;
   border-radius: 100px;
-  vertical-align: bottom;
+  vertical-align: middle;
 }
 .page-package-details-v2 .package-title h1 .prefix-reserve-title .reserved-indicator {
   width: 18px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1266,7 +1266,7 @@ img.reserved-indicator-icon {
 .page-package-details-v2 tr {
   border-bottom: 1px solid lightgray;
 }
-.page-package-details-v2 .header {
+.page-package-details-v2 .package-header {
   margin-bottom: 36px;
 }
 .page-package-details-v2 .package-title {

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1266,14 +1266,56 @@ img.reserved-indicator-icon {
 .page-package-details-v2 tr {
   border-bottom: 1px solid lightgray;
 }
+.page-package-details-v2 .header {
+  margin-bottom: 36px;
+}
 .page-package-details-v2 .package-title {
-  margin-bottom: 24px;
+  margin-bottom: 30px;
+}
+.page-package-details-v2 .package-title h1 #title {
+  font-size: 32px;
+  margin-top: 40px;
+  font-weight: 400;
+  margin-right: 18px;
+}
+.page-package-details-v2 .package-title h1 #version-title {
+  font-size: 16px;
+  font-weight: 400;
+  color: #666666;
+  margin-right: 14px;
+}
+.page-package-details-v2 .package-title h1 .package-icon {
+  height: 40px;
+  width: 40px;
+  margin-right: 12px;
+}
+.page-package-details-v2 .package-title h1 .prefix-reserve-title {
+  background-color: #F3F2F1;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 100px;
+}
+.page-package-details-v2 .package-title h1 .prefix-reserve-title #reserved-indicator {
+  width: 18px;
+  margin-right: 5px;
+  margin-left: 2px;
+}
+.page-package-details-v2 .package-title h1 .prefix-reserve-title #prefix-reserve-label {
+  font-size: 16px;
+  font-weight: 400;
+  color: #2F6FA7;
+  margin-top: 2px;
+  margin-bottom: 2px;
+  margin-right: 10px;
 }
 .page-package-details-v2 .package-title div {
   margin-top: 2px;
-}
-.page-package-details-v2 .package-title .reserved-indicator {
-  width: 25px;
 }
 .page-package-details-v2 .deprecation-container .deprecation-expander {
   display: -webkit-box;
@@ -1371,10 +1413,6 @@ img.reserved-indicator-icon {
   padding-left: 0;
   padding-right: 0;
   text-align: right;
-}
-.page-package-details-v2 .package-details-main .package-icon-cell .package-icon {
-  padding-left: 6px;
-  padding-right: 6px;
 }
 .page-package-details-v2 .package-details-info .ms-Icon-ul li {
   margin-bottom: 15px;

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -32,6 +32,7 @@
         font-weight: 400;
         color: #666666;
         margin-right: 14px;
+        vertical-align: middle;
       }
 
       .package-icon {
@@ -46,7 +47,7 @@
         display: inline-flex;
         align-items: center;
         border-radius: 100px;
-        vertical-align: bottom;
+        vertical-align: middle;
 
         .reserved-indicator {
           width: 18px;

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -35,8 +35,9 @@
       }
 
       .package-icon {
-        height: 40px;
-        width: 40px;
+        height: 32px;
+        width: 32px;
+        margin-top: 8px;
         margin-right: 12px;
       }
 
@@ -45,6 +46,7 @@
         display: inline-flex;
         align-items: center;
         border-radius: 100px;
+        vertical-align: bottom;
 
         .reserved-indicator {
           width: 18px;
@@ -53,7 +55,7 @@
         }
 
         .prefix-reserve-label {
-          font-size: 16px;
+          font-size: 14px;
           font-weight: 400;
           color: #2F6FA7;
           margin-top: 2px;

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -11,15 +11,60 @@
     border-bottom: 1px solid lightgray;
   }
 
+  .header {
+    margin-bottom: 36px;
+  }
+
   .package-title {
-    margin-bottom: 24px;
+    margin-bottom: 30px;
+
+    h1 {
+
+      #title {
+        font-size: 32px;
+        margin-top: 40px;
+        font-weight: 400;
+        margin-right: 18px;
+      }
+
+      #version-title {
+        font-size: 16px;
+        font-weight: 400;
+        color: #666666;
+        margin-right: 14px;
+      }
+
+      .package-icon {
+        height: 40px;
+        width: 40px;
+        margin-right: 12px;
+      }
+
+      .prefix-reserve-title {
+        background-color: #F3F2F1;
+        display: inline-flex;
+        align-items: center;
+        border-radius: 100px;
+
+        #reserved-indicator {
+          width: 18px;
+          margin-right: 5px;
+          margin-left: 2px;
+        }
+
+        #prefix-reserve-label {
+          font-size: 16px;
+          font-weight: 400;
+          color: #2F6FA7;
+          margin-top: 2px;
+          margin-bottom: 2px;
+          margin-right: 10px;
+        }
+      }
+    }
 
     div {
       margin-top: 2px;
-    }
-
-    .reserved-indicator {
-      width: 25px;
     }
   }
 
@@ -120,11 +165,6 @@
       padding-left: 0;
       padding-right: 0;
       text-align: right;
-
-      .package-icon {
-        padding-left: 6px;
-        padding-right: 6px;
-      }
     }
   }
 

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -20,14 +20,14 @@
 
     h1 {
 
-      #title {
+      .title {
         font-size: 32px;
         margin-top: 40px;
         font-weight: 400;
         margin-right: 18px;
       }
 
-      #version-title {
+      .version-title {
         font-size: 16px;
         font-weight: 400;
         color: #666666;
@@ -46,13 +46,13 @@
         align-items: center;
         border-radius: 100px;
 
-        #reserved-indicator {
+        .reserved-indicator {
           width: 18px;
           margin-right: 5px;
           margin-left: 2px;
         }
 
-        #prefix-reserve-label {
+        .prefix-reserve-label {
           font-size: 16px;
           font-weight: 400;
           color: #2F6FA7;

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -30,7 +30,7 @@
       .version-title {
         font-size: 16px;
         font-weight: 400;
-        color: #666666;
+        color: @gray-light;
         margin-right: 14px;
         vertical-align: middle;
       }

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -11,7 +11,7 @@
     border-bottom: 1px solid lightgray;
   }
 
-  .header {
+  .package-header {
     margin-bottom: 36px;
   }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -243,7 +243,7 @@
 
 <section role="main" class="container main-container page-package-details-v2">
     <div class="row">
-        <article class="col-sm-12 package-details-main">
+        <div class="package-details-main">
             <div class="row">
                 <div class="package-header">
                     <div class="package-title">
@@ -1182,7 +1182,7 @@
                     }
                 </aside>
             </div>
-        </article>
+        </div>
     </div>
 </section>
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -244,283 +244,280 @@
 <section role="main" class="container main-container page-package-details-v2">
     <div class="row">
         <div class="package-details-main">
-            <div class="row">
-                <div class="package-header">
-                    <div class="package-title">
-                        <h1>
-                            <span class="pull-left">
-                                <img class="package-icon img-responsive" aria-hidden="true" alt=""
-                                     src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
-                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
+            <div class="package-header">
+                <div class="package-title">
+                    <h1>
+                        <span class="pull-left">
+                            <img class="package-icon img-responsive" aria-hidden="true" alt=""
+                                 src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
+                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
+                        </span>
+                        <span class="title">
+                            @Html.BreakWord(Model.Id)
+                        </span>
+                        <span class="version-title">
+                            @Model.Version
+                        </span>
+                        @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
+                        {
+                            <span class="prefix-reserve-title">
+                                <img class="reserved-indicator"
+                                     src="~/Content/gallery/img/reserved-indicator.svg"
+                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
+                                     title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                                <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
+                                    Prefix Reserved
+                                </a>
                             </span>
+                        }
+                    </h1>
+                </div>
 
-                            <span class="title">
-                                @Html.BreakWord(Model.Id)
-                            </span>
-                            <span class="version-title">
-                                @Model.Version
-                            </span>
-                            @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
-                            {
-                                <span class="prefix-reserve-title">
-                                    <img class="reserved-indicator"
-                                         src="~/Content/gallery/img/reserved-indicator.svg"
-                                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
-                                         title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
-                                    <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
-                                        Prefix Reserved
-                                    </a>
-                                </span>
-                            }
-                        </h1>
-                    </div>
-
-                    @if (Model.Validating)
+                @if (Model.Validating)
+                {
+                    @ViewHelpers.AlertWarning(
+                        @<text>
+                            <strong>This package has not been published yet.</strong> It will appear in search results and
+                            will be available for install/restore after both validation and indexing are complete. Package
+                            validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
+                        </text>
+                    )
+                    if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
                     {
                         @ViewHelpers.AlertWarning(
                             @<text>
-                                <strong>This package has not been published yet.</strong> It will appear in search results and
-                                will be available for install/restore after both validation and indexing are complete. Package
-                                validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
+                                The license link will become available once package validation has completed successfully.
                             </text>
                         )
-                        if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
-                        {
-                            @ViewHelpers.AlertWarning(
-                                @<text>
-                                    The license link will become available once package validation has completed successfully.
-                                </text>
-                            )
-                        }
-
-                        if (Model.ValidatingTooLong)
-                        {
-                            @ViewHelpers.AlertWarning(
-                                @<text>
-                                    <strong>Package validation is taking longer than expected.</strong> This is not normal, but we are on it!
-                                </text>
-                            )
-                        }
                     }
 
-                    @if (Model.FailedValidation)
+                    if (Model.ValidatingTooLong)
+                    {
+                        @ViewHelpers.AlertWarning(
+                            @<text>
+                                <strong>Package validation is taking longer than expected.</strong> This is not normal, but we are on it!
+                            </text>
+                        )
+                    }
+                }
+
+                @if (Model.FailedValidation)
+                {
+                    @ViewHelpers.AlertDanger(
+                        @<text>
+                            <strong>Package publishing failed.</strong> This package could not be published due to the following reason(s):
+                            <ul class="failed-validation-alert-list">
+                                @foreach (var issue in Model.PackageValidationIssues)
+                                {
+                                    <li>@Html.Partial("_ValidationIssue", issue)</li>
+                                }
+                            </ul>
+                            @if (!Model.PackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+                            {
+                                var issuePluralString = Model.PackageValidationIssues.Count > 1 ? "all the issues" : "the issue";
+                                <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
+                             }
+                             else
+                             {
+                                <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
+                             }
+                        </text>
+                    )
+                }
+
+                @if (Model.Deleted)
+                {
+                    @ViewHelpers.AlertDanger(
+                        @<text>
+                            <strong>This package has been deleted from the gallery.</strong> It is no longer available
+                            for install/restore.
+                        </text>
+                    )
+                }
+
+                @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities != null)
+                {
+                    @Html.Partial("_DisplayPackageVulnerabilities")
+                }
+
+                @if (Model.IsPackageDeprecationEnabled && Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                {
+                    @Html.Partial("_DisplayPackageDeprecation")
+                }
+
+                @if (Model.IsPackageRenamesEnabled && Model.PackageRenames != null && Model.PackageRenames.Count != 0)
+                {
+                    @Html.Partial("_DisplayPackageRenames")
+                }
+
+                @if (Model.Prerelease)
+                {
+                    @ViewHelpers.AlertInfo(
+                        @<text>
+                            This is a prerelease version of @(Model.Id).
+                        </text>
+                    )
+                }
+                @if (Model.NuGetVersion.HasMetadata)
+                {
+                    @ViewHelpers.AlertInfo(
+                        @<text>
+                            This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
+                        </text>
+                    )
+                }
+                @if (Model.VersionRequestedWasNotFound)
+                {
+                    @ViewHelpers.AlertWarning(
+                        @<text>
+                            The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
+                        </text>
+                    )
+                }
+                @if (Model.HasNewerRelease)
+                {
+                    @ViewHelpers.AlertInfo(
+                        @<text>
+                            There is a newer version of this package available.
+                            <br /> See the version list below for details.
+                        </text>
+                    )
+                }
+                else if (Model.HasNewerPrerelease)
+                {
+                    @ViewHelpers.AlertInfo(
+                        @<text>
+                            There is a newer prerelease version of this package available.
+                            <br /> See the version list below for details.
+                        </text>
+                    )
+                }
+
+                @if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
+                {
+                    @ViewHelpers.AlertWarning(
+                        @<text>
+                            <strong>This package has not been indexed yet.</strong> It will appear in search results
+                            and will be available for install/restore after indexing is complete.
+                        </text>
+                    )
+                }
+
+                @if (Model.HasEmbeddedIcon && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && (Model.Available || Model.Validating))
+                {
+                    @ViewHelpers.AlertWarning(
+                        @<text>
+                            The package icon will become available after this package is indexed.
+                        </text>
+                    )
+                }
+
+                @if (Model.CanDisplayPrivateMetadata && showSymbolsPackageStatus)
+                {
+                    if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.Validating)
+                    {
+                        @ViewHelpers.AlertWarning(
+                            @<text>
+                                <strong>The symbols for this package have not been indexed yet.</strong> They are not available
+                                for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
+                                Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
+
+                                @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
+                            </text>
+                        )
+                    }
+                    else if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.FailedValidation)
                     {
                         @ViewHelpers.AlertDanger(
                             @<text>
-                                <strong>Package publishing failed.</strong> This package could not be published due to the following reason(s):
+                                <strong>Symbols package publishing failed.</strong> The associated symbols package could not be published due to the following reason(s):
                                 <ul class="failed-validation-alert-list">
-                                    @foreach (var issue in Model.PackageValidationIssues)
+                                    @foreach (var issue in Model.SymbolsPackageValidationIssues)
                                     {
                                         <li>@Html.Partial("_ValidationIssue", issue)</li>
                                     }
                                 </ul>
-                                @if (!Model.PackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+                                @if (!Model.SymbolsPackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
                                 {
-                                    var issuePluralString = Model.PackageValidationIssues.Count > 1 ? "all the issues" : "the issue";
-                                    <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
+                                    var issuePluralString = Model.SymbolsPackageValidationIssues.Count() > 1 ? "all the issues" : "the issue";
+                                    <text>Once you've fixed @issuePluralString with your symbols package, you can re-upload it.</text>
                                 }
                                 else
                                 {
-                                    <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
+                                    <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
                                 }
+
+                                @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
                             </text>
                         )
                     }
+                }
 
-                    @if (Model.Deleted)
-                    {
-                        @ViewHelpers.AlertDanger(
-                            @<text>
-                                <strong>This package has been deleted from the gallery.</strong> It is no longer available
-                                for install/restore.
-                            </text>
-                        )
-                    }
-
-                    @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities != null)
-                    {
-                        @Html.Partial("_DisplayPackageVulnerabilities")
-                    }
-
-                    @if (Model.IsPackageDeprecationEnabled && Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
-                    {
-                        @Html.Partial("_DisplayPackageDeprecation")
-                    }
-
-                    @if (Model.IsPackageRenamesEnabled && Model.PackageRenames != null && Model.PackageRenames.Count != 0)
-                    {
-                        @Html.Partial("_DisplayPackageRenames")
-                    }
-
-                    @if (Model.Prerelease)
-                    {
-                        @ViewHelpers.AlertInfo(
-                            @<text>
-                                This is a prerelease version of @(Model.Id).
-                            </text>
-                        )
-                    }
-                    @if (Model.NuGetVersion.HasMetadata)
-                    {
-                        @ViewHelpers.AlertInfo(
-                            @<text>
-                                This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
-                            </text>
-                        )
-                    }
-                    @if (Model.VersionRequestedWasNotFound)
+                @if (!Model.Listed && Model.Available)
+                {
+                    if (Model.CanDisplayPrivateMetadata)
                     {
                         @ViewHelpers.AlertWarning(
                             @<text>
-                                The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
+                                This package is unlisted and hidden from package listings.
+                                You can see the package because you are one of its owners. To list the package again,
+                                <a href="@Url.ManagePackage(Model)">change its listing setting</a>.
                             </text>
                         )
                     }
-                    @if (Model.HasNewerRelease)
-                    {
-                        @ViewHelpers.AlertInfo(
-                            @<text>
-                                There is a newer version of this package available.
-                                <br /> See the version list below for details.
-                            </text>
-                        )
-                    }
-                    else if (Model.HasNewerPrerelease)
-                    {
-                        @ViewHelpers.AlertInfo(
-                            @<text>
-                                There is a newer prerelease version of this package available.
-                                <br /> See the version list below for details.
-                            </text>
-                        )
-                    }
-
-                    @if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
+                    else
                     {
                         @ViewHelpers.AlertWarning(
                             @<text>
-                                <strong>This package has not been indexed yet.</strong> It will appear in search results
-                                and will be available for install/restore after indexing is complete.
+                                The owner has unlisted this package.
+                                This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
                             </text>
                         )
                     }
+                }
 
-                    @if (Model.HasEmbeddedIcon && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && (Model.Available || Model.Validating))
-                    {
-                        @ViewHelpers.AlertWarning(
-                            @<text>
-                                The package icon will become available after this package is indexed.
-                            </text>
-                        )
-                    }
+                @if (!Model.Deleted && !String.IsNullOrEmpty(Model.MinClientVersion))
+                {
+                    <p>Requires NuGet @Model.MinClientVersion or higher.</p>
+                }
+                @if (Model.Available)
+                {
+                    <div class="install-tabs">
+                        <ul class="nav nav-tabs" role="tablist">
+                            @{ var firstPackageManager = true; }
+                            @foreach (var packageManager in packageManagers)
+                            {
+                                @CommandTab(packageManager, active: firstPackageManager)
 
-                    @if (Model.CanDisplayPrivateMetadata && showSymbolsPackageStatus)
-                    {
-                        if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.Validating)
-                        {
-                            @ViewHelpers.AlertWarning(
-                                @<text>
-                                    <strong>The symbols for this package have not been indexed yet.</strong> They are not available
-                                    for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
-                                    Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
+                                firstPackageManager = false;
+                            }
+                        </ul>
+                        <div class="tab-content">
+                            @{ firstPackageManager = true; }
+                            @foreach (var packageManager in packageManagers)
+                            {
+                                @CommandPanel(packageManager, active: firstPackageManager)
 
-                                    @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
-                                </text>
-                            )
-                        }
-                        else if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.FailedValidation)
-                        {
-                            @ViewHelpers.AlertDanger(
-                                @<text>
-                                    <strong>Symbols package publishing failed.</strong> The associated symbols package could not be published due to the following reason(s):
-                                    <ul class="failed-validation-alert-list">
-                                        @foreach (var issue in Model.SymbolsPackageValidationIssues)
-                                         {
-                                            <li>@Html.Partial("_ValidationIssue", issue)</li>
-                                         }
-                                    </ul>
-                                    @if (!Model.SymbolsPackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
-                                     {
-                                         var issuePluralString = Model.SymbolsPackageValidationIssues.Count() > 1 ? "all the issues" : "the issue";
-                                        <text>Once you've fixed @issuePluralString with your symbols package, you can re-upload it.</text>
-                                     }
-                                     else
-                                     {
-                                        <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
-                                     }
-
-                                    @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
-                                </text>
-                            )
-                        }
-                    }
-
-                    @if (!Model.Listed && Model.Available)
-                    {
-                        if (Model.CanDisplayPrivateMetadata)
-                        {
-                            @ViewHelpers.AlertWarning(
-                                @<text>
-                                    This package is unlisted and hidden from package listings.
-                                    You can see the package because you are one of its owners. To list the package again,
-                                    <a href="@Url.ManagePackage(Model)">change its listing setting</a>.
-                                </text>
-                            )
-                        }
-                        else
-                        {
-                            @ViewHelpers.AlertWarning(
-                                @<text>
-                                    The owner has unlisted this package.
-                                    This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
-                                </text>
-                            )
-                        }
-                    }
-
-                    @if (!Model.Deleted && !String.IsNullOrEmpty(Model.MinClientVersion))
-                    {
-                        <p>Requires NuGet @Model.MinClientVersion or higher.</p>
-                    }
-                    @if (Model.Available)
-                    {
-                        <div class="install-tabs">
-                            <ul class="nav nav-tabs" role="tablist">
-                                @{ var firstPackageManager = true; }
-                                @foreach (var packageManager in packageManagers)
-                                {
-                                    @CommandTab(packageManager, active: firstPackageManager)
-
-                                    firstPackageManager = false;
-                                }
-                            </ul>
-                            <div class="tab-content">
-                                @{ firstPackageManager = true; }
-                                @foreach (var packageManager in packageManagers)
-                                {
-                                    @CommandPanel(packageManager, active: firstPackageManager)
-
-                                    firstPackageManager = false;
-                                }
-                            </div>
+                                firstPackageManager = false;
+                            }
                         </div>
+                    </div>
+                }
+            </div>
+            <div class="body-tabs">
+                <ul class="nav nav-tabs" role="tablist">
+                    @if (!Model.Deleted)
+                    {
+                        <li role="presentation" class="active"><a href="#readme-tab" aria-controls="ReadMe" role="tab" data-toggle="tab" id="readme-body-tab" class="body-tab">README</a></li>
+                        <li role="presentation"><a href="#dependencies-tab" aria-controls="Dependencies" role="tab" data-toggle="tab" id="dependencies-body-tab" class="body-tab">Dependencies</a></li>
                     }
-                </div>
-                <div class="body-tabs">
-                    <ul class="nav nav-tabs" role="tablist">
-                        @if (!Model.Deleted)
-                        {
-                            <li role="presentation" class="active"><a href="#readme-tab" aria-controls="ReadMe" role="tab" data-toggle="tab" id="readme-body-tab" class="body-tab">README</a></li>
-                            <li role="presentation"><a href="#dependencies-tab" aria-controls="Dependencies" role="tab" data-toggle="tab" id="dependencies-body-tab" class="body-tab">Dependencies</a></li>
-                        }
-                        <li role="presentation"><a href="#usedby-tab" aria-controls="UsedBy" role="tab" data-toggle="tab" id="usedby-body-tab" class="body-tab">Used By</a></li>
-                        <li role="presentation"><a href="#versions-tab" aria-controls="Versions" role="tab" data-toggle="tab" id="versions-body-tab" class="body-tab">Versions</a></li>
-                        @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes)) 
-                        { 
-                            <li role="presentation"><a href="#releasenotes-tab" aria-controls="ReleaseNotes" role="tab" data-toggle="tab" id="release-body-tab" class="body-tab">Release Notes</a></li>
-                        }
-                    </ul>
-                </div>
+                    <li role="presentation"><a href="#usedby-tab" aria-controls="UsedBy" role="tab" data-toggle="tab" id="usedby-body-tab" class="body-tab">Used By</a></li>
+                    <li role="presentation"><a href="#versions-tab" aria-controls="Versions" role="tab" data-toggle="tab" id="versions-body-tab" class="body-tab">Versions</a></li>
+                    @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
+                    {
+                        <li role="presentation"><a href="#releasenotes-tab" aria-controls="ReleaseNotes" role="tab" data-toggle="tab" id="release-body-tab" class="body-tab">Release Notes</a></li>
+                    }
+                </ul>
             </div>
             <div class="row">
                 <div class="col-sm-9">
@@ -849,7 +846,7 @@
                         }
                     </div>
                 </div>
-                
+
                 <aside aria-label="Package details info" class="col-sm-3 package-details-info">
                     <h2>Info</h2>
                     <ul class="list-unstyled ms-Icon-ul">

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -254,23 +254,23 @@
                                      @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
                             </span>
 
-                            <span id="title">
+                            <span class="title">
                                 @Html.BreakWord(Model.Id)
                             </span>
-                            <span id="version-title">
+                            <span class="version-title">
                                 @Model.Version
                             </span>
                             @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
                             {
-                                <span class="prefix-reserve-title">
-                                    <img id="reserved-indicator"
-                                         src="~/Content/gallery/img/reserved-indicator.svg"
-                                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
-                                         title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
-                                    <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" id="prefix-reserve-label">
-                                        Prefix Reserved
-                                    </a>
-                                </span>
+                            <span class="prefix-reserve-title">
+                                <img class="reserved-indicator"
+                                     src="~/Content/gallery/img/reserved-indicator.svg"
+                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
+                                     title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                                <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
+                                    Prefix Reserved
+                                </a>
+                            </span>
                             }
                         </h1>
                     </div>

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -262,15 +262,15 @@
                             </span>
                             @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
                             {
-                            <span class="prefix-reserve-title">
-                                <img class="reserved-indicator"
-                                     src="~/Content/gallery/img/reserved-indicator.svg"
-                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
-                                     title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
-                                <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
-                                    Prefix Reserved
-                                </a>
-                            </span>
+                                <span class="prefix-reserve-title">
+                                    <img class="reserved-indicator"
+                                         src="~/Content/gallery/img/reserved-indicator.svg"
+                                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
+                                         title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                                    <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
+                                        Prefix Reserved
+                                    </a>
+                                </span>
                             }
                         </h1>
                     </div>

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -245,7 +245,7 @@
     <div class="row">
         <article class="col-sm-12 package-details-main">
             <div class="row">
-                <div class="header">
+                <div class="package-header">
                     <div class="package-title">
                         <h1>
                             <span class="pull-left">

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -243,261 +243,269 @@
 
 <section role="main" class="container main-container page-package-details-v2">
     <div class="row">
-        <aside aria-label="Package icon" class="col-sm-1">
-            <h3>
-                <img class="package-icon img-responsive" aria-hidden="true" alt=""
-                     src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
-                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
-            </h3>
-        </aside>
-        <article class="col-sm-11 package-details-main">
+        <article class="col-sm-12 package-details-main">
             <div class="row">
-                <div class="package-title">
-                    <h1>
-                        @Html.BreakWord(Model.Id)
-                        <small class="text-nowrap">@Model.Version</small>
+                <div class="header">
+                    <div class="package-title">
+                        <h1>
+                            <span class="pull-left">
+                                <img class="package-icon img-responsive" aria-hidden="true" alt=""
+                                     src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
+                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
+                            </span>
 
-                        @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
+                            <span id="title">
+                                @Html.BreakWord(Model.Id)
+                            </span>
+                            <span id="version-title">
+                                @Model.Version
+                            </span>
+                            @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
+                            {
+                                <span class="prefix-reserve-title">
+                                    <img id="reserved-indicator"
+                                         src="~/Content/gallery/img/reserved-indicator.svg"
+                                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
+                                         title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                                    <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" id="prefix-reserve-label">
+                                        Prefix Reserved
+                                    </a>
+                                </span>
+                            }
+                        </h1>
+                    </div>
+
+                    @if (Model.Validating)
+                    {
+                        @ViewHelpers.AlertWarning(
+                            @<text>
+                                <strong>This package has not been published yet.</strong> It will appear in search results and
+                                will be available for install/restore after both validation and indexing are complete. Package
+                                validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
+                            </text>
+                        )
+                        if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
                         {
-                            <img class="reserved-indicator"
-                                 src="~/Content/gallery/img/reserved-indicator.svg"
-                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
-                                 title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                            @ViewHelpers.AlertWarning(
+                                @<text>
+                                    The license link will become available once package validation has completed successfully.
+                                </text>
+                            )
                         }
-                    </h1>
 
-                </div>
-
-                @if (Model.Validating)
-                {
-                    @ViewHelpers.AlertWarning(
-                        @<text>
-                            <strong>This package has not been published yet.</strong> It will appear in search results and
-                            will be available for install/restore after both validation and indexing are complete. Package
-                            validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetPackageValidation">Read more</a>.
-                        </text>
-                    )
-                    if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
-                    {
-                        @ViewHelpers.AlertWarning(
-                            @<text>
-                                The license link will become available once package validation has completed successfully.
-                            </text>
-                        )
+                        if (Model.ValidatingTooLong)
+                        {
+                            @ViewHelpers.AlertWarning(
+                                @<text>
+                                    <strong>Package validation is taking longer than expected.</strong> This is not normal, but we are on it!
+                                </text>
+                            )
+                        }
                     }
 
-                    if (Model.ValidatingTooLong)
-                    {
-                        @ViewHelpers.AlertWarning(
-                            @<text>
-                                <strong>Package validation is taking longer than expected.</strong> This is not normal, but we are on it!
-                            </text>
-                        )
-                    }
-                }
-
-                @if (Model.FailedValidation)
-                {
-                    @ViewHelpers.AlertDanger(
-                        @<text>
-                            <strong>Package publishing failed.</strong> This package could not be published due to the following reason(s):
-                            <ul class="failed-validation-alert-list">
-                                @foreach (var issue in Model.PackageValidationIssues)
-                                {
-                                    <li>@Html.Partial("_ValidationIssue", issue)</li>
-                                }
-                            </ul>
-                            @if (!Model.PackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
-                            {
-                                var issuePluralString = Model.PackageValidationIssues.Count > 1 ? "all the issues" : "the issue";
-                                <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
-                            }
-                            else
-                            {
-                                <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
-                            }
-                        </text>
-                    )
-                }
-
-                @if (Model.Deleted)
-                {
-                    @ViewHelpers.AlertDanger(
-                        @<text>
-                            <strong>This package has been deleted from the gallery.</strong> It is no longer available
-                            for install/restore.
-                        </text>
-                    )
-                }
-
-                @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities != null)
-                {
-                    @Html.Partial("_DisplayPackageVulnerabilities")
-                }
-
-                @if (Model.IsPackageDeprecationEnabled && Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
-                {
-                    @Html.Partial("_DisplayPackageDeprecation")
-                }
-
-                @if (Model.IsPackageRenamesEnabled && Model.PackageRenames != null && Model.PackageRenames.Count != 0)
-                {
-                    @Html.Partial("_DisplayPackageRenames")
-                }
-
-                @if (Model.Prerelease)
-                {
-                    @ViewHelpers.AlertInfo(
-                        @<text>
-                            This is a prerelease version of @(Model.Id).
-                        </text>
-                    )
-                }
-                @if (Model.NuGetVersion.HasMetadata)
-                {
-                    @ViewHelpers.AlertInfo(
-                        @<text>
-                            This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
-                        </text>
-                    )
-                }
-                @if (Model.VersionRequestedWasNotFound)
-                {
-                    @ViewHelpers.AlertWarning(
-                        @<text>
-                            The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
-                        </text>
-                    )
-                }
-                @if (Model.HasNewerRelease)
-                {
-                    @ViewHelpers.AlertInfo(
-                        @<text>
-                            There is a newer version of this package available.
-                            <br /> See the version list below for details.
-                        </text>
-                    )
-                }
-                else if (Model.HasNewerPrerelease)
-                {
-                    @ViewHelpers.AlertInfo(
-                        @<text>
-                            There is a newer prerelease version of this package available.
-                            <br /> See the version list below for details.
-                        </text>
-                    )
-                }
-
-                @if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
-                {
-                    @ViewHelpers.AlertWarning(
-                        @<text>
-                            <strong>This package has not been indexed yet.</strong> It will appear in search results
-                            and will be available for install/restore after indexing is complete.
-                        </text>
-                    )
-                }
-
-                @if (Model.HasEmbeddedIcon && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && (Model.Available || Model.Validating))
-                {
-                    @ViewHelpers.AlertWarning(
-                        @<text>
-                            The package icon will become available after this package is indexed.
-                        </text>
-                    )
-                }
-
-                @if (Model.CanDisplayPrivateMetadata && showSymbolsPackageStatus)
-                {
-                    if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.Validating)
-                    {
-                        @ViewHelpers.AlertWarning(
-                            @<text>
-                                <strong>The symbols for this package have not been indexed yet.</strong> They are not available
-                                for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
-                                Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
-
-                                @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
-                            </text>
-                        )
-                    }
-                    else if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.FailedValidation)
+                    @if (Model.FailedValidation)
                     {
                         @ViewHelpers.AlertDanger(
                             @<text>
-                                <strong>Symbols package publishing failed.</strong> The associated symbols package could not be published due to the following reason(s):
+                                <strong>Package publishing failed.</strong> This package could not be published due to the following reason(s):
                                 <ul class="failed-validation-alert-list">
-                                    @foreach (var issue in Model.SymbolsPackageValidationIssues)
-                                     {
+                                    @foreach (var issue in Model.PackageValidationIssues)
+                                    {
                                         <li>@Html.Partial("_ValidationIssue", issue)</li>
-                                     }
+                                    }
                                 </ul>
-                                @if (!Model.SymbolsPackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
-                                 {
-                                     var issuePluralString = Model.SymbolsPackageValidationIssues.Count() > 1 ? "all the issues" : "the issue";
-                                    <text>Once you've fixed @issuePluralString with your symbols package, you can re-upload it.</text>
-                                 }
-                                 else
-                                 {
-                                    <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
-                                 }
-
-                                @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
+                                @if (!Model.PackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+                                {
+                                    var issuePluralString = Model.PackageValidationIssues.Count > 1 ? "all the issues" : "the issue";
+                                    <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
+                                }
+                                else
+                                {
+                                    <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
+                                }
                             </text>
                         )
                     }
-                }
 
-                @if (!Model.Listed && Model.Available)
-                {
-                    if (Model.CanDisplayPrivateMetadata)
+                    @if (Model.Deleted)
+                    {
+                        @ViewHelpers.AlertDanger(
+                            @<text>
+                                <strong>This package has been deleted from the gallery.</strong> It is no longer available
+                                for install/restore.
+                            </text>
+                        )
+                    }
+
+                    @if (Model.IsPackageVulnerabilitiesEnabled && Model.Vulnerabilities != null)
+                    {
+                        @Html.Partial("_DisplayPackageVulnerabilities")
+                    }
+
+                    @if (Model.IsPackageDeprecationEnabled && Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                    {
+                        @Html.Partial("_DisplayPackageDeprecation")
+                    }
+
+                    @if (Model.IsPackageRenamesEnabled && Model.PackageRenames != null && Model.PackageRenames.Count != 0)
+                    {
+                        @Html.Partial("_DisplayPackageRenames")
+                    }
+
+                    @if (Model.Prerelease)
+                    {
+                        @ViewHelpers.AlertInfo(
+                            @<text>
+                                This is a prerelease version of @(Model.Id).
+                            </text>
+                        )
+                    }
+                    @if (Model.NuGetVersion.HasMetadata)
+                    {
+                        @ViewHelpers.AlertInfo(
+                            @<text>
+                                This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
+                            </text>
+                        )
+                    }
+                    @if (Model.VersionRequestedWasNotFound)
                     {
                         @ViewHelpers.AlertWarning(
                             @<text>
-                                This package is unlisted and hidden from package listings.
-                                You can see the package because you are one of its owners. To list the package again,
-                                <a href="@Url.ManagePackage(Model)">change its listing setting</a>.
+                                The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
                             </text>
                         )
                     }
-                    else
+                    @if (Model.HasNewerRelease)
+                    {
+                        @ViewHelpers.AlertInfo(
+                            @<text>
+                                There is a newer version of this package available.
+                                <br /> See the version list below for details.
+                            </text>
+                        )
+                    }
+                    else if (Model.HasNewerPrerelease)
+                    {
+                        @ViewHelpers.AlertInfo(
+                            @<text>
+                                There is a newer prerelease version of this package available.
+                                <br /> See the version list below for details.
+                            </text>
+                        )
+                    }
+
+                    @if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
                     {
                         @ViewHelpers.AlertWarning(
                             @<text>
-                                The owner has unlisted this package.
-                                This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
+                                <strong>This package has not been indexed yet.</strong> It will appear in search results
+                                and will be available for install/restore after indexing is complete.
                             </text>
                         )
                     }
-                }
 
-                @if (!Model.Deleted && !String.IsNullOrEmpty(Model.MinClientVersion))
-                {
-                    <p>Requires NuGet @Model.MinClientVersion or higher.</p>
-                }
-                @if (Model.Available)
-                {
-                    <div class="install-tabs">
-                        <ul class="nav nav-tabs" role="tablist">
-                            @{ var firstPackageManager = true; }
-                            @foreach (var packageManager in packageManagers)
-                            {
-                                @CommandTab(packageManager, active: firstPackageManager)
+                    @if (Model.HasEmbeddedIcon && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && (Model.Available || Model.Validating))
+                    {
+                        @ViewHelpers.AlertWarning(
+                            @<text>
+                                The package icon will become available after this package is indexed.
+                            </text>
+                        )
+                    }
 
-                                firstPackageManager = false;
-                            }
-                        </ul>
-                        <div class="tab-content">
-                            @{ firstPackageManager = true; }
-                            @foreach (var packageManager in packageManagers)
-                            {
-                                @CommandPanel(packageManager, active: firstPackageManager)
+                    @if (Model.CanDisplayPrivateMetadata && showSymbolsPackageStatus)
+                    {
+                        if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.Validating)
+                        {
+                            @ViewHelpers.AlertWarning(
+                                @<text>
+                                    <strong>The symbols for this package have not been indexed yet.</strong> They are not available
+                                    for download from the NuGet.org symbol server. Symbols will be available for download after both validation and indexing are complete.
+                                    Symbols validation and indexing may take up to an hour. <a href="https://aka.ms/NuGetSymbolsPackageValidation">Read more</a>.
 
-                                firstPackageManager = false;
-                            }
+                                    @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
+                                </text>
+                            )
+                        }
+                        else if (Model.LatestSymbolsPackage.StatusKey == PackageStatus.FailedValidation)
+                        {
+                            @ViewHelpers.AlertDanger(
+                                @<text>
+                                    <strong>Symbols package publishing failed.</strong> The associated symbols package could not be published due to the following reason(s):
+                                    <ul class="failed-validation-alert-list">
+                                        @foreach (var issue in Model.SymbolsPackageValidationIssues)
+                                         {
+                                            <li>@Html.Partial("_ValidationIssue", issue)</li>
+                                         }
+                                    </ul>
+                                    @if (!Model.SymbolsPackageValidationIssues.Any(i => i.IssueCode == ValidationIssueCode.Unknown))
+                                     {
+                                         var issuePluralString = Model.SymbolsPackageValidationIssues.Count() > 1 ? "all the issues" : "the issue";
+                                        <text>Once you've fixed @issuePluralString with your symbols package, you can re-upload it.</text>
+                                     }
+                                     else
+                                     {
+                                        <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your symbols package.</text>
+                                     }
+
+                                    @AppendAvailableSymbolsMessage(hasSymbolsPackageAvailable)
+                                </text>
+                            )
+                        }
+                    }
+
+                    @if (!Model.Listed && Model.Available)
+                    {
+                        if (Model.CanDisplayPrivateMetadata)
+                        {
+                            @ViewHelpers.AlertWarning(
+                                @<text>
+                                    This package is unlisted and hidden from package listings.
+                                    You can see the package because you are one of its owners. To list the package again,
+                                    <a href="@Url.ManagePackage(Model)">change its listing setting</a>.
+                                </text>
+                            )
+                        }
+                        else
+                        {
+                            @ViewHelpers.AlertWarning(
+                                @<text>
+                                    The owner has unlisted this package.
+                                    This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used anymore.
+                                </text>
+                            )
+                        }
+                    }
+
+                    @if (!Model.Deleted && !String.IsNullOrEmpty(Model.MinClientVersion))
+                    {
+                        <p>Requires NuGet @Model.MinClientVersion or higher.</p>
+                    }
+                    @if (Model.Available)
+                    {
+                        <div class="install-tabs">
+                            <ul class="nav nav-tabs" role="tablist">
+                                @{ var firstPackageManager = true; }
+                                @foreach (var packageManager in packageManagers)
+                                {
+                                    @CommandTab(packageManager, active: firstPackageManager)
+
+                                    firstPackageManager = false;
+                                }
+                            </ul>
+                            <div class="tab-content">
+                                @{ firstPackageManager = true; }
+                                @foreach (var packageManager in packageManagers)
+                                {
+                                    @CommandPanel(packageManager, active: firstPackageManager)
+
+                                    firstPackageManager = false;
+                                }
+                            </div>
                         </div>
-                    </div>
-                }
+                    }
+                </div>
                 <div class="body-tabs">
                     <ul class="nav nav-tabs" role="tablist">
                         @if (!Model.Deleted)


### PR DESCRIPTION
# Solution 
This PR is all about styling the header of the new display package page. I changed the sizing, spacing, and colors of the header elements to match the redesign mock ups. I also added a "prefix reserved" label that links to the ID prefix reservation docs. The goal of this PR was do all the necessary changes in the header except for the installation instructions, so I have left them untouched and will do those changes in a later PR. Here is what the final product looks like 
![image](https://user-images.githubusercontent.com/82480791/122300053-a7865a80-ceb3-11eb-9b5c-1141bf40a5d0.png)

# Testing 
I tested all the links to make sure that they worked with the feature flag on and off, checked the console to make sure that there were no errors in the .js file, and resized the page to make sure the styling stayed the same. 
This addresses issue #8601