### PR TITLE
Fixed ImageDomainValidator for GitHub URLs

### DIFF
--- a/src/NuGetGallery/Services/ImageDomainValidator.cs
+++ b/src/NuGetGallery/Services/ImageDomainValidator.cs
@@ -13,7 +13,7 @@ namespace NuGetGallery
     public class ImageDomainValidator: IImageDomainValidator
     {
         private static readonly TimeSpan RegexTimeout = TimeSpan.FromMinutes(1);
-        private static readonly Regex GithubBadgeUrlRegEx = new Regex("^(https|http):\\/\\/github\\.com\\/[^/]+\\/[^/]+\\/workflows\\/.*badge\\.svg", RegexOptions.IgnoreCase, RegexTimeout);
+        private static readonly Regex GithubBadgeUrlRegEx = new Regex("^(https|http):\\/\\/github\\.com\\/[^/]+\\/[^/]+(\\/actions)?\\/workflows\\/.*badge\\.svg", RegexOptions.IgnoreCase, RegexTimeout);
 
         private readonly IContentObjectService _contentObjectService;
         public ImageDomainValidator (IContentObjectService contentObjectService)

--- a/tests/NuGetGallery.Facts/Services/ImageDomainValidatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ImageDomainValidatorFacts.cs
@@ -30,8 +30,10 @@ namespace NuGetGallery.Services
             [InlineData("https://api.bintray.com/example/image.svg", true, "https://api.bintray.com/example/image.svg", true)]
             [InlineData("http://api.bintray.com/example/image.svg", true, "https://api.bintray.com/example/image.svg", true)]
             [InlineData("https://travis-ci.org/Azure/azure-relay-aspnetserver.svg?branch=dev", false, null, false)]
-            [InlineData("https://github.com/cedx/where.dart/workflows/.github/workflows/ci.yaml/badge.svg?branch=feature-1", false, "https://github.com/cedx/where.dart/workflows/.github/workflows/ci.yaml/badge.svg?branch=feature-1", true)]
-            [InlineData("https://git@github.com/peaceiris/actions-gh-pages/workflows/docker-image-ci/something/badge.svg", false, null, false)]
+            [InlineData("https://github.com/cedx/where.dart/actions/workflows/build.yaml/badge.svg?branch=develop", false, "https://github.com/cedx/where.dart/actions/workflows/build.yaml/badge.svg?branch=develop", true)]
+            [InlineData("https://git@github.com/peaceiris/actions-gh-pages/actions/workflows/dev-image.yml/something/badge.svg", false, null, false)]
+            [InlineData("https://github.com/cedx/where.dart/workflows/build.yaml/badge.svg?branch=develop", false, "https://github.com/cedx/where.dart/workflows/build.yaml/badge.svg?branch=develop", true)]
+            [InlineData("https://git@github.com/peaceiris/actions-gh-pages/workflows/dev-image.yml/something/badge.svg", false, null, false)]
             public void TryPrepareImageUrlForRendering(string input, bool istrusted,  string expectedOutput, bool expectConversion)
             {
                 _contentObjectService


### PR DESCRIPTION
by adding the missing `/actions/` segment into the URL regex
`GithubBadgeUrlRegEx`.

Addresses https://github.com/NuGet/NuGetGallery/issues/8645