### PR TITLE
Sidebar for New Display Package Page

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1448,6 +1448,9 @@ img.reserved-indicator-icon {
 .page-package-details-v2 .package-details-info .sidebar-links {
   font-size: 16px;
 }
+.page-package-details-v2 .package-details-info .pull-right {
+  float: right !important;
+}
 .page-package-details-v2 .package-details-info .title-links {
   font-size: 14px;
   font-weight: 400;
@@ -1455,7 +1458,7 @@ img.reserved-indicator-icon {
 }
 @media (min-width: 992px) {
   .page-package-details-v2 .package-details-info .title-links a {
-    float: right;
+    float: right !important;
   }
 }
 .page-package-details-v2 .package-details-info .sidebar-section {
@@ -1468,6 +1471,7 @@ img.reserved-indicator-icon {
   font-size: 14px;
   font-weight: 400;
   color: #666666;
+  margin-right: 12px;
 }
 .page-package-details-v2 .package-details-info .download-info .download-info-content {
   font-size: 16px;
@@ -1484,8 +1488,9 @@ img.reserved-indicator-icon {
   margin-right: 8px;
   border-radius: 5px;
 }
-.page-package-details-v2 .support-links {
-  margin-bottom: 24px;
+.page-package-details-v2 .support-links .report-link i {
+  color: #BE0151;
+  font-weight: bold;
 }
 .page-package-details-v2 .share-buttons img {
   margin-right: 8px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1430,7 +1430,7 @@ img.reserved-indicator-icon {
   text-align: right;
 }
 .page-package-details-v2 .package-details-info .ms-Icon-ul li {
-  margin-bottom: 15px;
+  margin-bottom: 18px;
 }
 .page-package-details-v2 .package-details-info .ms-Icon-ul img.icon {
   position: absolute;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1448,8 +1448,9 @@ img.reserved-indicator-icon {
 .page-package-details-v2 .package-details-info .sidebar-links {
   font-size: 16px;
 }
-.page-package-details-v2 .package-details-info .pull-right {
-  float: right !important;
+.page-package-details-v2 .package-details-info .links-first-section {
+  padding-bottom: 35px;
+  margin-bottom: 0px;
 }
 .page-package-details-v2 .package-details-info .title-links {
   font-size: 14px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1478,8 +1478,11 @@ img.reserved-indicator-icon {
   font-size: 16px;
   font-weight: 600;
 }
+.page-package-details-v2 .owner-list {
+  margin-bottom: 40px;
+}
 .page-package-details-v2 .owner-list li {
-  margin-bottom: 38px;
+  margin-bottom: 14px;
   display: block;
   overflow: hidden;
   white-space: nowrap;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1466,7 +1466,7 @@ img.reserved-indicator-icon {
   margin-top: 32px;
 }
 .page-package-details-v2 .package-details-info .download-info .download-info-row {
-  margin-bottom: 17px;
+  margin-bottom: 15px;
 }
 .page-package-details-v2 .package-details-info .download-info .download-info-header {
   font-size: 14px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1439,6 +1439,39 @@ img.reserved-indicator-icon {
   height: 16px;
   margin-top: 3px;
 }
+.page-package-details-v2 .package-details-info .sidebar-headers {
+  font-size: 16px;
+  font-weight: 600;
+  color: #666666;
+  margin-bottom: 12px;
+}
+.page-package-details-v2 .package-details-info .sidebar-links {
+  font-size: 16px;
+}
+.page-package-details-v2 .package-details-info #title-links {
+  font-size: 14px;
+  font-weight: 400;
+}
+.page-package-details-v2 .package-details-info .sidebar-section {
+  margin-bottom: 32px;
+}
+.page-package-details-v2 .package-details-info .sidebar-table {
+  margin-top: 8px;
+}
+.page-package-details-v2 .package-details-info .sidebar-table tr {
+  border-style: hidden;
+}
+.page-package-details-v2 .package-details-info .sidebar-table th {
+  text-align: center;
+  font-size: 14px;
+  font-weight: 400;
+  color: #666666;
+}
+.page-package-details-v2 .package-details-info .sidebar-table td {
+  font-size: 16px;
+  font-weight: 600;
+  text-align: center;
+}
 .page-package-details-v2 .owner-list li {
   margin-bottom: 8px;
   display: block;
@@ -1448,6 +1481,10 @@ img.reserved-indicator-icon {
 }
 .page-package-details-v2 .owner-list img {
   margin-right: 8px;
+  border-radius: 5px;
+}
+.page-package-details-v2 .support-links {
+  margin-bottom: 24px;
 }
 .page-package-details-v2 .share-buttons img {
   margin-right: 8px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1443,37 +1443,38 @@ img.reserved-indicator-icon {
   font-size: 16px;
   font-weight: 600;
   color: #666666;
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 .page-package-details-v2 .package-details-info .sidebar-links {
   font-size: 16px;
 }
-.page-package-details-v2 .package-details-info #title-links {
+.page-package-details-v2 .package-details-info .title-links {
   font-size: 14px;
   font-weight: 400;
+  padding-top: 2px;
+}
+@media (min-width: 992px) {
+  .page-package-details-v2 .package-details-info .title-links a {
+    float: right;
+  }
 }
 .page-package-details-v2 .package-details-info .sidebar-section {
-  margin-bottom: 32px;
+  margin-top: 32px;
 }
-.page-package-details-v2 .package-details-info .sidebar-table {
-  margin-top: 8px;
+.page-package-details-v2 .package-details-info .download-info .download-info-row {
+  margin-bottom: 17px;
 }
-.page-package-details-v2 .package-details-info .sidebar-table tr {
-  border-style: hidden;
-}
-.page-package-details-v2 .package-details-info .sidebar-table th {
-  text-align: center;
+.page-package-details-v2 .package-details-info .download-info .download-info-header {
   font-size: 14px;
   font-weight: 400;
   color: #666666;
 }
-.page-package-details-v2 .package-details-info .sidebar-table td {
+.page-package-details-v2 .package-details-info .download-info .download-info-content {
   font-size: 16px;
   font-weight: 600;
-  text-align: center;
 }
 .page-package-details-v2 .owner-list li {
-  margin-bottom: 8px;
+  margin-bottom: 38px;
   display: block;
   overflow: hidden;
   white-space: nowrap;

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -221,7 +221,7 @@
     .download-info {
 
       .download-info-row {
-        margin-bottom: 17px;
+        margin-bottom: 15px;
       }
 
       .download-info-header {

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -197,8 +197,9 @@
       font-size: 16px;
     }
 
-    .pull-right {
-      float: right !important;
+    .links-first-section {
+      padding-bottom: 35px;
+      margin-bottom: 0px;
     }
 
     .title-links {
@@ -208,7 +209,7 @@
 
       a {
         @media (min-width: @screen-md-min) {
-          .pull-right();
+          float: right !important;
         }
       }
     }

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -189,48 +189,52 @@
     .sidebar-headers {
       font-size: 16px;
       font-weight: 600;
-      color: #666666;
-      margin-bottom: 12px;
+      color: @gray-light;
+      margin-bottom: 14px;
     }
 
     .sidebar-links {
-      font-size: 16px; 
+      font-size: 16px;
     }
 
-    #title-links {
+    .title-links {
       font-size: 14px;
       font-weight: 400;
+      padding-top: 2px;
+
+      a {
+        @media (min-width: @screen-md-min) {
+          float: right;
+        }
+      }
     }
 
     .sidebar-section {
-      margin-bottom: 32px;
+      margin-top: 32px;
     }
 
-    .sidebar-table {
-      margin-top: 8px;
+    .download-info {
 
-      tr {
-        border-style: hidden;
+      .download-info-row {
+        margin-bottom: 17px; 
       }
 
-      th {
-        text-align: center;
+      .download-info-header {
         font-size: 14px;
         font-weight: 400;
-        color: #666666;
+        color: @gray-light;
       }
 
-      td {
+      .download-info-content {
         font-size: 16px;
         font-weight: 600;
-        text-align: center;
       }
     }
   }
 
   .owner-list {
     li {
-      margin-bottom: 8px;
+      margin-bottom: 38px;
       display: block;
       overflow: hidden;
       white-space: nowrap;

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -197,6 +197,10 @@
       font-size: 16px;
     }
 
+    .pull-right {
+      float: right !important;
+    }
+
     .title-links {
       font-size: 14px;
       font-weight: 400;
@@ -204,7 +208,7 @@
 
       a {
         @media (min-width: @screen-md-min) {
-          float: right;
+          .pull-right();
         }
       }
     }
@@ -216,13 +220,14 @@
     .download-info {
 
       .download-info-row {
-        margin-bottom: 17px; 
+        margin-bottom: 17px;
       }
 
       .download-info-header {
         font-size: 14px;
         font-weight: 400;
         color: @gray-light;
+        margin-right: 12px;
       }
 
       .download-info-content {
@@ -248,7 +253,13 @@
   }
 
   .support-links {
-    margin-bottom: 24px;
+
+    .report-link {
+      i {
+        color: #BE0151;
+        font-weight: bold;
+      }
+    }
   }
 
   .share-buttons {

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -239,8 +239,10 @@
   }
 
   .owner-list {
+    margin-bottom: 40px;
+
     li {
-      margin-bottom: 38px;
+      margin-bottom: 14px;
       display: block;
       overflow: hidden;
       white-space: nowrap;

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -174,7 +174,7 @@
   .package-details-info {
     .ms-Icon-ul {
       li {
-        margin-bottom: 15px;
+        margin-bottom: 18px;
       }
 
       img.icon {

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -185,6 +185,47 @@
         margin-top: 3px;
       }
     }
+
+    .sidebar-headers {
+      font-size: 16px;
+      font-weight: 600;
+      color: #666666;
+      margin-bottom: 12px;
+    }
+
+    .sidebar-links {
+      font-size: 16px; 
+    }
+
+    #title-links {
+      font-size: 14px;
+      font-weight: 400;
+    }
+
+    .sidebar-section {
+      margin-bottom: 32px;
+    }
+
+    .sidebar-table {
+      margin-top: 8px;
+
+      tr {
+        border-style: hidden;
+      }
+
+      th {
+        text-align: center;
+        font-size: 14px;
+        font-weight: 400;
+        color: #666666;
+      }
+
+      td {
+        font-size: 16px;
+        font-weight: 600;
+        text-align: center;
+      }
+    }
   }
 
   .owner-list {
@@ -198,7 +239,12 @@
 
     img {
       margin-right: 8px;
+      border-radius: 5px;
     }
+  }
+
+  .support-links {
+    margin-bottom: 24px;
   }
 
   .share-buttons {

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -1071,6 +1071,27 @@
                                     </a>
                                 </li>
                             }
+
+                            <div class="support-links">
+                                @if (Model.CanReportAsOwner)
+                                {
+                                    <li>
+                                        <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
+                                        <a href="@Url.ReportPackage(Model)" title="Contact the NuGet team for help with your package">
+                                            Contact support
+                                        </a>
+                                    </li>
+                                }
+                                else if (Model.Available)
+                                {
+                                    <li class="report-link">
+                                        <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
+                                        <a href="@Url.ReportAbuse(Model)" title="Report the package as abusive">
+                                            Report package
+                                        </a>
+                                    </li>
+                                }
+                            </div>
                         </ul>
                         @if (Model.LicenseNames.AnySafe())
                         {
@@ -1129,28 +1150,11 @@
                             </p>
                         }
 
-                        if (!String.IsNullOrEmpty(Model.Copyright))
+                        if (!string.IsNullOrEmpty(Model.Copyright))
                         {
                             <p>@Model.Copyright</p>
                         }
                     }
-                    <div class="support-links">
-                        @if (Model.CanReportAsOwner)
-                        {
-                            <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
-                            <a href="@Url.ReportPackage(Model)" title="Contact the NuGet team for help with your package">
-                                Contact support
-                            </a>
-                        }
-                        else if (Model.Available)
-                        {
-                            <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
-                            <a href="@Url.ReportAbuse(Model)" title="Report the package as abusive">
-                                Report
-                            </a>
-                        }
-                    </div>
-                   
 
                     @if (Model.Available)
                     {

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -854,7 +854,7 @@
                                 Downloads
                             </div>
                             <div class="col-md-6 title-links">
-                                @if (true @*StatisticsHelper.IsStatisticsPageAvailable*@) 
+                                @if (StatisticsHelper.IsStatisticsPageAvailable) 
                                 { 
                                     <a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics">Full stats →</a>
                                 }   

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -854,10 +854,10 @@
                                 Downloads
                             </div>
                             <div class="col-md-6 title-links">
-                                @if (StatisticsHelper.IsStatisticsPageAvailable) 
-                                { 
+                                @if (StatisticsHelper.IsStatisticsPageAvailable)
+                                {
                                     <a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics">Full stats →</a>
-                                }   
+                                }
                             </div>
                         </div>
                         <div class="download-info">
@@ -875,9 +875,10 @@
                             </div>
                         </div>
                     </div>
+
                     <div class="sidebar-section">
                         <div class="sidebar-headers">About Package</div>
-                        <ul class="list-unstyled ms-Icon-ul sidebar-links">
+                        <ul class="list-unstyled ms-Icon-ul sidebar-links links-first-section">
                             <li>
                                 <i class="ms-Icon ms-Icon--History" aria-hidden="true"></i>
                                 Last updated <span data-datetime="@Model.LastUpdated.ToString("O")">@Model.LastUpdated.ToNuGetShortDateString()</span>
@@ -952,8 +953,9 @@
                                     </li>
                                 }
                             }
-                            <br />
-
+                        </ul>
+                        
+                        <ul class="list-unstyled ms-Icon-ul sidebar-links">
                             @if (Model.Available)
                             {
                                 <li>
@@ -1082,6 +1084,7 @@
                                         </a>
                                     </li>
                                 }
+                                
                                 else if (Model.Available)
                                 {
                                     <li class="report-link">
@@ -1098,6 +1101,7 @@
                             <p>License info provided by <a href="http://sonatype.com/">Sonatype</a>.</p>
                         }
                     </div>
+
                     <div class="sidebar-section">
                         <div class="row sidebar-headers">
                             <div class="col-md-6">

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -520,7 +520,7 @@
                 </ul>
             </div>
             <div class="row">
-                <div class="col-sm-8">
+                <div class="col-sm-9">
                     <div class="tab-content body-tab-content">
                         @if (!Model.Deleted)
                         {
@@ -847,31 +847,33 @@
                     </div>
                 </div>
                 
-                <aside aria-label="Package details info" class="col-sm-4 package-details-info">
+                <aside aria-label="Package details info" class="col-sm-3 package-details-info">
                     <div class="sidebar-section">
-                        <div class="sidebar-headers">
-                            <span class="sidebar-headers">
+                        <div class="row sidebar-headers">
+                            <div class="col-md-6">
                                 Downloads
-                            </span>
-                            <span class="title-links pull-right">
-                                @if (StatisticsHelper.IsStatisticsPageAvailable) 
+                            </div>
+                            <div class="col-md-6 title-links">
+                                @if (true @*StatisticsHelper.IsStatisticsPageAvailable*@) 
                                 { 
-                                    <a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics" id="title-links">Full stats →</a>
+                                    <a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics">Full stats →</a>
                                 }   
-                            </span>
+                            </div>
                         </div>
-                        <table class="sidebar-table" style="width:100%">
-                            <tr>
-                                <th>Total</th>
-                                <th>Current version</th>
-                                <th>Per day average</th>
-                            </tr>
-                            <tr>
-                                <td>@Model.TotalDownloadCount.ToKiloFormat()</td>
-                                <td>@Model.DownloadCount.ToKiloFormat()</td>
-                                <td>@Model.DownloadsPerDay.ToKiloFormat()</td>
-                            </tr>
-                        </table>
+                        <div class="download-info">
+                            <div class="download-info-row">
+                                <span class="download-info-header">Total</span>
+                                <span class="download-info-content">@Model.TotalDownloadCount.ToKiloFormat()</span>
+                            </div>
+                            <div class="download-info-row">
+                                <span class="download-info-header">Current version</span>
+                                <span class="download-info-content">@Model.DownloadCount.ToKiloFormat()</span>
+                            </div>
+                            <div class="download-info-row">
+                                <span class="download-info-header">Per day average</span>
+                                <span class="download-info-content">@Model.DownloadsPerDay.ToKiloFormat()</span>
+                            </div>
+                        </div>
                     </div>
                     <div class="sidebar-section">
                         <div class="sidebar-headers">About Package</div>
@@ -889,6 +891,7 @@
                                     </a>
                                 </li>
                             }
+
                             @if (!Model.Deleted && Model.RepositoryUrl != null)
                             {
                                 <li>
@@ -908,27 +911,6 @@
                                     <a href="@Model.RepositoryUrl" data-track="outbound-repository-url" title="View the source code for this package" rel="nofollow">
                                         Source repository
                                     </a>
-                                </li>
-                            }
-
-                            @if (Model.Available)
-                            {
-                                <li>
-                                    <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
-                                    <a href="@Url.PackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw nupkg file." rel="nofollow">Download package</a>
-                                    &nbsp;(@Model.PackageFileSize.ToUserFriendlyBytesLabel())
-                                </li>
-                                if (hasSymbolsPackageAvailable)
-                                {
-                                    <li>
-                                        <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
-                                        <a href="@Url.SymbolPackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw snupkg file." rel="nofollow">Download symbols</a>
-                                        &nbsp;(@Model.LatestSymbolsPackage.FileSize.ToUserFriendlyBytesLabel())
-                                    </li>
-                                }
-                                <li class="no-clickonce">
-                                    <i class="ms-Icon ms-Icon--OpenInNewWindow" aria-hidden="true"></i>
-                                    <a href="@Url.ExplorerDeepLink(2, Model.Id, Model.Version)" title="Explore the nupkg with the NuGet Package Explorer (IE only)" rel="nofollow">Open in Package Explorer</a>
                                 </li>
                             }
 
@@ -969,6 +951,28 @@
                                         }
                                     </li>
                                 }
+                            }
+                            <br />
+
+                            @if (Model.Available)
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
+                                    <a href="@Url.PackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw nupkg file." rel="nofollow">Download package</a>
+                                    &nbsp;(@Model.PackageFileSize.ToUserFriendlyBytesLabel())
+                                </li>
+                                if (hasSymbolsPackageAvailable)
+                                {
+                                    <li>
+                                        <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
+                                        <a href="@Url.SymbolPackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw snupkg file." rel="nofollow">Download symbols</a>
+                                        &nbsp;(@Model.LatestSymbolsPackage.FileSize.ToUserFriendlyBytesLabel())
+                                    </li>
+                                }
+                                <li class="no-clickonce">
+                                    <i class="ms-Icon ms-Icon--OpenInNewWindow" aria-hidden="true"></i>
+                                    <a href="@Url.ExplorerDeepLink(2, Model.Id, Model.Version)" title="Explore the nupkg with the NuGet Package Explorer (IE only)" rel="nofollow">Open in Package Explorer</a>
+                                </li>
                             }
 
                             @if (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist)
@@ -1074,13 +1078,13 @@
                         }
                     </div>
                     <div class="sidebar-section">
-                        <div class="sidebar-headers">
-                            <span class="sidebar-headers">
+                        <div class="row sidebar-headers">
+                            <div class="col-md-6">
                                 Owners
-                            </span>
-                            <span class="title-links pull-right">
-                                <a href="@Url.ContactOwners(Model)" title="Ask the package owners a question" id="title-links">Contact owners →</a>
-                            </span>
+                            </div>
+                            <div class="col-md-6 title-links">
+                                <a href="@Url.ContactOwners(Model)" title="Ask the package owners a question">Contact owners →</a>
+                            </div>
                         </div>
 
                         <ul class="list-unstyled owner-list">

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -940,14 +940,7 @@
                                         {
                                             <a href="@Model.LicenseUrl"
                                                data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
-                                                @if (Model.LicenseNames.AnySafe())
-                                                {
-                                                    @(string.Join(", ", Model.LicenseNames.Select(x => x + " License")))
-                                                }
-                                                else
-                                                {
-                                                    @:License Info
-                                                }
+                                                License Info
                                             </a>
                                         }
                                     </li>

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -520,7 +520,7 @@
                 </ul>
             </div>
             <div class="row">
-                <div class="col-sm-9">
+                <div class="col-sm-8">
                     <div class="tab-content body-tab-content">
                         @if (!Model.Deleted)
                         {
@@ -846,194 +846,174 @@
                         }
                     </div>
                 </div>
-
-                <aside aria-label="Package details info" class="col-sm-3 package-details-info">
-                    <h2>Info</h2>
-                    <ul class="list-unstyled ms-Icon-ul">
-                        <li>
-                            <i class="ms-Icon ms-Icon--History" aria-hidden="true"></i>
-                            last updated <span data-datetime="@Model.LastUpdated.ToString("O")">@Model.LastUpdated.ToNuGetShortDateString()</span>
-                        </li>
-                        @if (!Model.Deleted && Model.ProjectUrl != null)
-                        {
+                
+                <aside aria-label="Package details info" class="col-sm-4 package-details-info">
+                    <div class="sidebar-section">
+                        <div class="sidebar-headers">
+                            <span class="sidebar-headers">
+                                Downloads
+                            </span>
+                            <span class="title-links pull-right">
+                                @if (StatisticsHelper.IsStatisticsPageAvailable) 
+                                { 
+                                    <a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics" id="title-links">Full stats →</a>
+                                }   
+                            </span>
+                        </div>
+                        <table class="sidebar-table" style="width:100%">
+                            <tr>
+                                <th>Total</th>
+                                <th>Current version</th>
+                                <th>Per day average</th>
+                            </tr>
+                            <tr>
+                                <td>@Model.TotalDownloadCount.ToKiloFormat()</td>
+                                <td>@Model.DownloadCount.ToKiloFormat()</td>
+                                <td>@Model.DownloadsPerDay.ToKiloFormat()</td>
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="sidebar-section">
+                        <div class="sidebar-headers">About Package</div>
+                        <ul class="list-unstyled ms-Icon-ul sidebar-links">
                             <li>
-                                <i class="ms-Icon ms-Icon--Globe" aria-hidden="true"></i>
-                                <a href="@Model.ProjectUrl" data-track="outbound-project-url" title="Visit the project site to learn more about this package" rel="nofollow">
-                                    @if (Model.ProjectUrl.Length <= 28)
-                                    {
-                                        @Model.ProjectUrl
-                                    }
-                                    else
-                                    {
-                                        @:Project Site
-                                    }
-                                </a>
+                                <i class="ms-Icon ms-Icon--History" aria-hidden="true"></i>
+                                Last updated <span data-datetime="@Model.LastUpdated.ToString("O")">@Model.LastUpdated.ToNuGetShortDateString()</span>
                             </li>
-                        }
-                        @if (!Model.Deleted && Model.RepositoryUrl != null)
-                        {
-                            <li>
-                                @switch (Model.RepositoryType)
-                                {
-                                    case DisplayPackageViewModel.RepositoryKind.GitHub:
-                                    case DisplayPackageViewModel.RepositoryKind.Git:
-                                        <img class="icon" aria-hidden="true" alt="Git logo"
-                                             src="@Url.Absolute("~/Content/gallery/img/git.svg")"
-                                             @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/git-32x32.png")) />
-                                        break;
-                                    default:
-                                        <i class="ms-Icon ms-Icon--Code" aria-hidden="true"></i>
-                                        break;
-                                }
-
-                                <a href="@Model.RepositoryUrl" data-track="outbound-repository-url" title="View the source code for this package" rel="nofollow">
-                                    Source repository
-                                </a>
-                            </li>
-                        }
-                        @if (!Model.Deleted && Model.LicenseUrl != null)
-                        {
-                            if (Model.EmbeddedLicenseType == EmbeddedLicenseFileType.Absent || !Model.Validating)
+                            @if (!Model.Deleted && Model.ProjectUrl != null)
                             {
                                 <li>
-                                    <i class="ms-Icon ms-Icon--Certificate" aria-hidden="true"></i>
-                                    @if (Model.LicenseExpressionSegments.AnySafe())
-                                    {
-                                        @:License:
-                                        foreach (var segment in Model.LicenseExpressionSegments)
-                                        {
-                                            if (@ViewHelpers.IsLicenseOrException(segment))
-                                            {
-                                                @MakeLicenseLink(segment);
-                                            }
-                                            else
-                                            {
-                                                @MakeLicenseSpan(segment);
-                                            }
-                                        }
-                                    }
-                                    else
-                                    {
-                                        <a href="@Model.LicenseUrl"
-                                           data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
-                                            @if (Model.LicenseNames.AnySafe())
-                                            {
-                                                @(string.Join(", ", Model.LicenseNames.Select(x => x + " License")))
-                                            }
-                                            else
-                                            {
-                                                @:License Info
-                                            }
-                                        </a>
-                                    }
+                                    <i class="ms-Icon ms-Icon--Globe" aria-hidden="true"></i>
+                                    <a href="@Model.ProjectUrl" data-track="outbound-project-url" title="Visit the project site to learn more about this package" rel="nofollow">
+                                        Project website
+                                    </a>
                                 </li>
                             }
-                        }
-                        <li>
-                            <i class="ms-Icon ms-Icon--Mail" aria-hidden="true"></i>
-                            <a href="@Url.ContactOwners(Model)" title="Ask the package owners a question">Contact owners</a>
-                        </li>
-                        @if (Model.CanReportAsOwner)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
-                                <a href="@Url.ReportPackage(Model)" title="Contact the NuGet team for help with your package">
-                                    Contact support
-                                </a>
-                            </li>
-                        }
-                        else if (Model.Available)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
-                                <a href="@Url.ReportAbuse(Model)" title="Report the package as abusive">
-                                    Report
-                                </a>
-                            </li>
-                        }
+                            @if (!Model.Deleted && Model.RepositoryUrl != null)
+                            {
+                                <li>
+                                    @switch (Model.RepositoryType)
+                                    {
+                                        case DisplayPackageViewModel.RepositoryKind.GitHub:
+                                        case DisplayPackageViewModel.RepositoryKind.Git:
+                                            <img class="icon" aria-hidden="true" alt="Git logo"
+                                                 src="@Url.Absolute("~/Content/gallery/img/git.svg")"
+                                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/git-32x32.png")) />
+                                            break;
+                                        default:
+                                            <i class="ms-Icon ms-Icon--Code" aria-hidden="true"></i>
+                                            break;
+                                    }
 
-                        @if (Model.Available)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
-                                <a href="@Url.PackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw nupkg file." rel="nofollow">Download package</a>
-                                &nbsp;(@Model.PackageFileSize.ToUserFriendlyBytesLabel())
-                            </li>
-                            if (hasSymbolsPackageAvailable)
+                                    <a href="@Model.RepositoryUrl" data-track="outbound-repository-url" title="View the source code for this package" rel="nofollow">
+                                        Source repository
+                                    </a>
+                                </li>
+                            }
+
+                            @if (Model.Available)
                             {
                                 <li>
                                     <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
-                                    <a href="@Url.SymbolPackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw snupkg file." rel="nofollow">Download symbols</a>
-                                    &nbsp;(@Model.LatestSymbolsPackage.FileSize.ToUserFriendlyBytesLabel())
+                                    <a href="@Url.PackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw nupkg file." rel="nofollow">Download package</a>
+                                    &nbsp;(@Model.PackageFileSize.ToUserFriendlyBytesLabel())
+                                </li>
+                                if (hasSymbolsPackageAvailable)
+                                {
+                                    <li>
+                                        <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
+                                        <a href="@Url.SymbolPackageDownload(2, Model.Id, Model.Version)" data-track="outbound-manual-download" title="Download the raw snupkg file." rel="nofollow">Download symbols</a>
+                                        &nbsp;(@Model.LatestSymbolsPackage.FileSize.ToUserFriendlyBytesLabel())
+                                    </li>
+                                }
+                                <li class="no-clickonce">
+                                    <i class="ms-Icon ms-Icon--OpenInNewWindow" aria-hidden="true"></i>
+                                    <a href="@Url.ExplorerDeepLink(2, Model.Id, Model.Version)" title="Explore the nupkg with the NuGet Package Explorer (IE only)" rel="nofollow">Open in Package Explorer</a>
                                 </li>
                             }
-                            <li class="no-clickonce">
-                                <i class="ms-Icon ms-Icon--OpenInNewWindow" aria-hidden="true"></i>
-                                <a href="@Url.ExplorerDeepLink(2, Model.Id, Model.Version)" title="Explore the nupkg with the NuGet Package Explorer (IE only)" rel="nofollow">Open in Package Explorer</a>
-                            </li>
-                        }
 
-                        @if (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
-                                <a href="@Url.ManagePackage(Model)">Manage package</a>
-                            </li>
-                        }
-                        @if (!Model.Deleted && hasSymbolsPackageAvailable && Model.CanDeleteSymbolsPackage)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
-                                <a href="@Url.DeleteSymbolsPackage(Model)" class="delete">Delete symbols</a>
-                            </li>
-                        }
+                            @if (!Model.Deleted && Model.LicenseUrl != null)
+                            {
+                                if (Model.EmbeddedLicenseType == EmbeddedLicenseFileType.Absent || !Model.Validating)
+                                {
+                                    <li>
+                                        <i class="ms-Icon ms-Icon--Certificate" aria-hidden="true"></i>
+                                        @if (Model.LicenseExpressionSegments.AnySafe())
+                                        {
+                                            foreach (var segment in Model.LicenseExpressionSegments)
+                                            {
+                                                if (@ViewHelpers.IsLicenseOrException(segment))
+                                                {
+                                                    @MakeLicenseLink(segment);
+                                                }
+                                                else
+                                                {
+                                                    @MakeLicenseSpan(segment);
+                                                }
+                                            }
+                                            @:license
+                                        }
+                                        else
+                                        {
+                                            <a href="@Model.LicenseUrl"
+                                               data-track="outbound-license-url" title="Make sure you agree with the license" rel="nofollow">
+                                                @if (Model.LicenseNames.AnySafe())
+                                                {
+                                                    @(string.Join(", ", Model.LicenseNames.Select(x => x + " License")))
+                                                }
+                                                else
+                                                {
+                                                    @:License Info
+                                                }
+                                            </a>
+                                        }
+                                    </li>
+                                }
+                            }
 
-                        @if (Model.Available && User.IsAdministrator())
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
-                                @ViewHelpers.PostLink(
-                                    this,
-                                    formId: "reflow-package-form",
-                                    linkText: "Reflow package",
-                                    actionName: "Reflow",
-                                    controllerName: "Packages",
-                                    role: "button",
-                                    formValues: new Dictionary<string, string>
-                                    {
-                                        { "id", Model.Id },
-                                        { "version", Model.Version },
-                                    })
-                            </li>
-                        }
+                            @if (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist)
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
+                                    <a href="@Url.ManagePackage(Model)">Manage package</a>
+                                </li>
+                            }
+                            @if (!Model.Deleted && hasSymbolsPackageAvailable && Model.CanDeleteSymbolsPackage)
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
+                                    <a href="@Url.DeleteSymbolsPackage(Model)" class="delete">Delete symbols</a>
+                                </li>
+                            }
 
-                        @if (!Model.Deleted && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
-                                @ViewHelpers.PostLink(
-                                    this,
-                                    formId: "revalidate-package-form",
-                                    linkText: "Revalidate package",
-                                    actionName: "Revalidate",
-                                    controllerName: "Packages",
-                                    role: string.Empty,
-                                    formValues: new Dictionary<string, string>
-                                    {
-                                        { "id", Model.Id },
-                                        { "version", Model.Version },
-                                    })
-                            </li>
-
-                            if (Model.LatestSymbolsPackage != null)
+                            @if (Model.Available && User.IsAdministrator())
                             {
                                 <li>
                                     <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
                                     @ViewHelpers.PostLink(
                                         this,
-                                        formId: "revalidate-symbols-form",
-                                        linkText: "Revalidate symbols",
-                                        actionName: "RevalidateSymbols",
+                                        formId: "reflow-package-form",
+                                        linkText: "Reflow package",
+                                        actionName: "Reflow",
+                                        controllerName: "Packages",
+                                        role: "button",
+                                        formValues: new Dictionary<string, string>
+                                        {
+                                            { "id", Model.Id },
+                                            { "version", Model.Version },
+                                        })
+                                </li>
+                            }
+
+                            @if (!Model.Deleted && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
+                                    @ViewHelpers.PostLink(
+                                        this,
+                                        formId: "revalidate-package-form",
+                                        linkText: "Revalidate package",
+                                        actionName: "Revalidate",
                                         controllerName: "Packages",
                                         role: string.Empty,
                                         formValues: new Dictionary<string, string>
@@ -1042,107 +1022,101 @@
                                             { "version", Model.Version },
                                         })
                                 </li>
+
+                                if (Model.LatestSymbolsPackage != null)
+                                {
+                                    <li>
+                                        <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
+                                        @ViewHelpers.PostLink(
+                                            this,
+                                            formId: "revalidate-symbols-form",
+                                            linkText: "Revalidate symbols",
+                                            actionName: "RevalidateSymbols",
+                                            controllerName: "Packages",
+                                            role: string.Empty,
+                                            formValues: new Dictionary<string, string>
+                                            {
+                                                { "id", Model.Id },
+                                                { "version", Model.Version },
+                                            })
+                                    </li>
+                                }
                             }
-                        }
 
-                        @if (User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Health" aria-hidden="true"></i>
-                                <a href="@Url.ViewValidations(Model)">View validations</a>
-                            </li>
-                        }
-
-                        @if (Model.IsFuGetLinksEnabled && !string.IsNullOrEmpty(Model.FuGetUrl))
-                        {
-                            var disclaimer = "fuget.org is a 3rd party website, not controlled by Microsoft. This link is made available to you per the NuGet Terms of Use.";
-
-                            <li>
-                                <img class="icon"
-                                     aria-label="@disclaimer" title="@disclaimer"
-                                     src="@Url.Absolute("~/Content/gallery/img/fuget.svg")"
-                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/fuget-32x32.png")) />
-                                <a href="@Model.FuGetUrl" data-track="outbound-repository-url"
-                                   aria-label="open in fuget.org explorer"
-                                   title="Explore additional package info on fuget.org" rel="nofollow">
-                                    Open in FuGet Package Explorer
-                                </a>
-                            </li>
-                        }
-                    </ul>
-                    @if (Model.LicenseNames.AnySafe())
-                    {
-                        <p>License info provided by <a href="http://sonatype.com/">Sonatype</a>.</p>
-                    }
-
-                    <h2>Statistics</h2>
-                    <ul class="list-unstyled ms-Icon-ul">
-                        <li>
-                            <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>
-                            @Model.TotalDownloadCount.ToNuGetNumberString() total @(Model.TotalDownloadCount == 1 ? "download" : "downloads")
-                        </li>
-                        <li>
-                            <i class="ms-Icon ms-Icon--Giftbox" aria-hidden="true"></i>
-                            @Model.DownloadCount.ToNuGetNumberString() @(Model.DownloadCount == 1 ? "download" : "downloads")
-                            of current version
-                        </li>
-                        <li>
-                            <i class="ms-Icon ms-Icon--Financial" aria-hidden="true"></i>
-                            @Model.DownloadsPerDayLabel @(Model.DownloadsPerDayLabel == "1" || Model.DownloadsPerDayLabel == "<1" ? "download" : "downloads")
-                            per day (avg)
-                        </li>
-                    </ul>
-                    @if (StatisticsHelper.IsStatisticsPageAvailable)
-                    {
-                        <a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics">View full stats</a>
-                    }
-
-                    <h2>Owners</h2>
-                    <ul class="list-unstyled owner-list">
-                        @if (!Model.Owners.Any())
-                        {
-                            @ViewHelpers.AlertWarning(@<text>This package has no owners and is not being actively maintained.</text>)
-                        }
-                        else
-                        {
-                            foreach (var owner in Model.Owners)
+                            @if (User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
                             {
                                 <li>
-                                    @if (!String.IsNullOrEmpty(owner.EmailAddress))
-                                    {
-                                        <a href="@Url.User(owner.Username)" title="@owner.Username">
-                                            @ViewHelpers.GravatarImage(
-                                                Url,
-                                                owner.EmailAddress,
-                                                owner.Username,
-                                                GalleryConstants.GravatarElementSize)
-                                        </a>
-                                    }
-                                    <a href="@Url.User(owner.Username)" title="@owner.Username">
-                                        @owner.Username
+                                    <i class="ms-Icon ms-Icon--Health" aria-hidden="true"></i>
+                                    <a href="@Url.ViewValidations(Model)">View validations</a>
+                                </li>
+                            }
+
+                            @if (Model.IsFuGetLinksEnabled && !string.IsNullOrEmpty(Model.FuGetUrl))
+                            {
+                                var disclaimer = "fuget.org is a 3rd party website, not controlled by Microsoft. This link is made available to you per the NuGet Terms of Use.";
+
+                                <li>
+                                    <img class="icon"
+                                         aria-label="@disclaimer" title="@disclaimer"
+                                         src="@Url.Absolute("~/Content/gallery/img/fuget.svg")"
+                                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/fuget-32x32.png")) />
+                                    <a href="@Model.FuGetUrl" data-track="outbound-repository-url"
+                                       aria-label="open in fuget.org explorer"
+                                       title="Explore additional package info on fuget.org" rel="nofollow">
+                                        Open in FuGet Package Explorer
                                     </a>
                                 </li>
                             }
+                        </ul>
+                        @if (Model.LicenseNames.AnySafe())
+                        {
+                            <p>License info provided by <a href="http://sonatype.com/">Sonatype</a>.</p>
                         }
-                    </ul>
+                    </div>
+                    <div class="sidebar-section">
+                        <div class="sidebar-headers">
+                            <span class="sidebar-headers">
+                                Owners
+                            </span>
+                            <span class="title-links pull-right">
+                                <a href="@Url.ContactOwners(Model)" title="Ask the package owners a question" id="title-links">Contact owners →</a>
+                            </span>
+                        </div>
 
+                        <ul class="list-unstyled owner-list">
+                            @if (!Model.Owners.Any())
+                            {
+                                @ViewHelpers.AlertWarning(@<text>This package has no owners and is not being actively maintained.</text>)
+                            }
+                            else
+                            {
+                                foreach (var owner in Model.Owners)
+                                {
+                                    <li>
+                                        @if (!String.IsNullOrEmpty(owner.EmailAddress))
+                                        {
+                                            <a href="@Url.User(owner.Username)" title="@owner.Username">
+                                                @ViewHelpers.GravatarImage(
+                                                    Url,
+                                                    owner.EmailAddress,
+                                                    owner.Username,
+                                                    GalleryConstants.GravatarElementSize)
+                                            </a>
+                                        }
+                                        <a href="@Url.User(owner.Username)" title="@owner.Username">
+                                            @owner.Username
+                                        </a>
+                                    </li>
+                                }
+                            }
+                        </ul>
+                    </div>
+                    
                     @if (!Model.Deleted)
                     {
-                        if (!String.IsNullOrEmpty(Model.Authors))
-                        {
-                            <h2>Authors</h2>
-                            <p>@Model.Authors</p>
-                        }
-
-                        if (!String.IsNullOrEmpty(Model.Copyright))
-                        {
-                            <h2>Copyright</h2>
-                            <p>@Model.Copyright</p>
-                        }
 
                         if (Model.Tags.AnySafe())
                         {
-                            <h2>Tags</h2>
                             <p>
                                 @foreach (var tag in Model.Tags)
                                 {
@@ -1150,11 +1124,32 @@
                                 }
                             </p>
                         }
+
+                        if (!String.IsNullOrEmpty(Model.Copyright))
+                        {
+                            <p>@Model.Copyright</p>
+                        }
                     }
+                    <div class="support-links">
+                        @if (Model.CanReportAsOwner)
+                        {
+                            <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
+                            <a href="@Url.ReportPackage(Model)" title="Contact the NuGet team for help with your package">
+                                Contact support
+                            </a>
+                        }
+                        else if (Model.Available)
+                        {
+                            <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
+                            <a href="@Url.ReportAbuse(Model)" title="Report the package as abusive">
+                                Report
+                            </a>
+                        }
+                    </div>
+                   
 
                     @if (Model.Available)
                     {
-                        <h2>Share</h2>
                         var encodedText = Url.Encode(string.Format("Check out {0} on #NuGet.", Model.Id));
                         <p class="share-buttons">
                             <a href="https://www.facebook.com/sharer/sharer.php?u=@absolutePackageUrl&t=@encodedText" target="_blank">

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -1096,10 +1096,6 @@
                                 }
                             </div>
                         </ul>
-                        @if (Model.LicenseNames.AnySafe())
-                        {
-                            <p>License info provided by <a href="http://sonatype.com/">Sonatype</a>.</p>
-                        }
                     </div>
 
                     <div class="sidebar-section">


### PR DESCRIPTION
# Solution 
I rearranged the information in the sidebar and got rid of Authors to match the redesign mockups. This included moving the download information to the top of the sidebar, moving report to above the tags, and adding the full stats and contact owners link to be across from their respective header. I then went into the .less files and added the necessary styling changes to match the mockups. This included rounding the owner icons, changing the color and spacing of the section headers, and changing the font size of all the text. 
Here is what it looks like now:
![image](https://user-images.githubusercontent.com/82480791/123164835-4e28a900-d428-11eb-9fa0-c177d76a4b23.png)

Here is what the whole page looks like:
![image](https://user-images.githubusercontent.com/82480791/123164861-541e8a00-d428-11eb-8a48-d9a2a48cfc2d.png)

# Testing 
In order to test my changes I checked the console to make sure nothing happened to the .js file. Inspected the elements to make sure that the corrected styling was being applied to them, and made sure all of the features worked with the feature flag on and off. 