### PR TITLE
[Redesign] Update installation instructions

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1445,20 +1445,19 @@ img.reserved-indicator-icon {
   font-size: 14px;
 }
 .page-package-details-v2 .installation-instructions .instructions-displayed pre {
+  background-color: #FAF9F8;
   border: 0px;
 }
-.page-package-details-v2 .installation-instructions-buttons {
-  background-color: #0078D4;
+.page-package-details-v2 button {
   width: 32px;
   height: 32px;
   float: right;
   padding: 0px;
 }
-.page-package-details-v2 .installation-instructions-buttons .ms-Icon--Copy {
+.page-package-details-v2 button .ms-Icon--Copy {
   color: #FFFFFF;
   width: 16px;
   height: 16px;
-  display: contents;
 }
 .page-package-details-v2 .package-details-main {
   overflow-wrap: break-word;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1290,7 +1290,7 @@ img.reserved-indicator-icon {
   border-bottom: 1px solid lightgray;
 }
 .page-package-details-v2 .package-header {
-  margin-bottom: 36px;
+  margin-bottom: 35px;
 }
 .page-package-details-v2 .package-title {
   margin-bottom: 30px;
@@ -1427,6 +1427,38 @@ img.reserved-indicator-icon {
 .page-package-details-v2 .failed-validation-alert-list {
   margin-top: 15px;
   margin-bottom: 15px;
+}
+.page-package-details-v2 .installation-instructions {
+  background-color: #F3F2F1;
+}
+.page-package-details-v2 .installation-instructions .installation-instructions-dropdown {
+  font-size: 14px;
+  background-color: #F3F2F1;
+  height: 31px;
+  border-left: 0px;
+  border-top: 0px;
+  border-right: 0px;
+}
+.page-package-details-v2 .installation-instructions .instructions-displayed {
+  background-color: #FAF9F8;
+  font-family: 'Segoe UI';
+  font-size: 14px;
+}
+.page-package-details-v2 .installation-instructions .instructions-displayed pre {
+  border: 0px;
+}
+.page-package-details-v2 .installation-instructions-buttons {
+  background-color: #0078D4;
+  width: 32px;
+  height: 32px;
+  float: right;
+  padding: 0px;
+}
+.page-package-details-v2 .installation-instructions-buttons .ms-Icon--Copy {
+  color: #FFFFFF;
+  width: 16px;
+  height: 16px;
+  display: contents;
 }
 .page-package-details-v2 .package-details-main {
   overflow-wrap: break-word;
@@ -1647,6 +1679,7 @@ img.reserved-indicator-icon {
   border-bottom-color: #0078D4;
   border-bottom-width: 2px;
   font-weight: bold;
+  margin-bottom: -1px;
 }
 .page-package-details-v2 .body-tabs .nav-tabs > li > a {
   border-left: 0px;

--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -2687,6 +2687,59 @@ fieldset[disabled] .btn-danger.focus {
   color: #df001e;
   background-color: #fff;
 }
+.btn-blue {
+  color: #333;
+  background-color: #0078D4;
+  border-color: #7f7f7f;
+}
+.btn-blue:focus,
+.btn-blue.focus {
+  color: #333;
+  background-color: #005ba1;
+  border-color: #3f3f3f;
+}
+.btn-blue:hover {
+  color: #333;
+  background-color: #005ba1;
+  border-color: #606060;
+}
+.btn-blue:active,
+.btn-blue.active,
+.open > .dropdown-toggle.btn-blue {
+  color: #333;
+  background-color: #005ba1;
+  background-image: none;
+  border-color: #606060;
+}
+.btn-blue:active:hover,
+.btn-blue.active:hover,
+.open > .dropdown-toggle.btn-blue:hover,
+.btn-blue:active:focus,
+.btn-blue.active:focus,
+.open > .dropdown-toggle.btn-blue:focus,
+.btn-blue:active.focus,
+.btn-blue.active.focus,
+.open > .dropdown-toggle.btn-blue.focus {
+  color: #333;
+  background-color: #00477d;
+  border-color: #3f3f3f;
+}
+.btn-blue.disabled:hover,
+.btn-blue[disabled]:hover,
+fieldset[disabled] .btn-blue:hover,
+.btn-blue.disabled:focus,
+.btn-blue[disabled]:focus,
+fieldset[disabled] .btn-blue:focus,
+.btn-blue.disabled.focus,
+.btn-blue[disabled].focus,
+fieldset[disabled] .btn-blue.focus {
+  background-color: #0078D4;
+  border-color: #7f7f7f;
+}
+.btn-blue .badge {
+  color: #0078D4;
+  background-color: #333;
+}
 .btn-link {
   font-weight: 400;
   color: #337ab7;

--- a/src/Bootstrap/less/buttons.less
+++ b/src/Bootstrap/less/buttons.less
@@ -87,6 +87,10 @@
 .btn-danger {
   .button-variant(@btn-danger-color; @btn-danger-bg; @btn-danger-border);
 }
+// Blue button for installation instructions
+.btn-blue {
+  .button-variant(@btn-default-color; #0078D4; @btn-default-border);
+}
 
 
 // Link buttons

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -12,7 +12,7 @@
   }
 
   .package-header {
-    margin-bottom: 36px;
+    margin-bottom: 35px;
   }
 
   .package-title {
@@ -158,6 +158,44 @@
   .failed-validation-alert-list {
     margin-top: 15px;
     margin-bottom: 15px;
+  }
+
+  .installation-instructions {
+    background-color: #F3F2F1;
+
+    .installation-instructions-dropdown {
+      font-size: 14px;
+      background-color: #F3F2F1;
+      height: 31px;
+      border-left: 0px;
+      border-top: 0px;
+      border-right: 0px;
+    }
+
+    .instructions-displayed {
+      background-color: #FAF9F8;
+      font-family: 'Segoe UI';
+      font-size: 14px;
+
+      pre {
+        border: 0px;
+      }
+    }
+  }
+
+  .installation-instructions-buttons {
+    background-color: #0078D4;
+    width: 32px;
+    height: 32px;
+    float: right;
+    padding: 0px;
+
+    .ms-Icon--Copy {
+      color: #FFFFFF;
+      width: 16px;
+      height: 16px;
+      display: contents;
+    }
   }
 
   .package-details-main {
@@ -438,6 +476,7 @@
       border-bottom-color: #0078D4;
       border-bottom-width: 2px;
       font-weight: bold;
+      margin-bottom: -1px;
     }
 
     .nav-tabs > li > a {

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -178,13 +178,13 @@
       font-size: 14px;
 
       pre {
+        background-color: #FAF9F8;
         border: 0px;
       }
     }
   }
 
-  .installation-instructions-buttons {
-    background-color: #0078D4;
+  button {
     width: 32px;
     height: 32px;
     float: right;
@@ -194,7 +194,6 @@
       color: #FFFFFF;
       width: 16px;
       height: 16px;
-      display: contents;
     }
   }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -187,15 +187,15 @@
             {
                 case AlertLevel.Info:
                     @ViewHelpers.AlertInfo(
-                            @<text>
-                                @Html.Raw(packageManager.AlertMessage)
-                            </text>);
+                        @<text>
+                            @Html.Raw(packageManager.AlertMessage)
+                        </text>);
                     break;
                 case AlertLevel.Warning:
                     @ViewHelpers.AlertWarning(
-                            @<text>
-                                @Html.Raw(packageManager.AlertMessage)
-                            </text>);
+                        @<text>
+                            @Html.Raw(packageManager.AlertMessage)
+                        </text>);
                     break;
                 default:
                     break;
@@ -460,20 +460,26 @@
                 @if (Model.Available)
                 {
                     <div class="installation-instructions">
-                        <div class="top-content-instructions">
+                        <div>
                             <select name="installation-instructions" class="installation-instructions-dropdown">
                                 @foreach (var packageManager in packageManagers)
                                 {
-                                    <option value=@packageManager.Id>@packageManager.Name</option>
+                                    <option value="@packageManager.Id">@packageManager.Name</option>
                                 }
                             </select>
-                            <button class="btn btn-default installation-instructions-buttons" type="button"
+
+                            <!--In order to statisfy the requirement to announce button status both on NVDA/Narrator, other screen reader like NVDA will
+                                announce the data-content "Copied" everytime when we press button, however, it won't work with Narrator when we use bootstrap popover
+                                because of known issue (https://github.com/twbs/bootstrap/issues/18618).
+                                We add aria-pressed to indicate the whether button is pressed or not, which is workaround only for Narrator announce the status change of button
+                            -->
+                            <button class="btn btn-blue" type="button"
                                     data-toggle="popover" data-placement="bottom" data-content="Copied."
                                     aria-label="CopyLabel" aria-pressed="false" aria-live="polite" role="button">
                                 <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
                             </button>
                         </div>
-                       
+
                         @{ var firstPackageManager = true; }
                         @foreach (var packageManager in packageManagers)
                         {

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -167,63 +167,40 @@
     }
 }
 
-@helper CommandTab(PackageManagerViewModel packageManager, bool active)
-{
-    <li role="presentation" class="@(active ? "active" : string.Empty)">
-        <a href="#@packageManager.Id" aria-expanded="@(active ? "true" : "false")"
-           id="@packageManager.Id-tab" class="package-manager-tab"
-           aria-selected="@(active ? "true" : "false")"
-           aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
-           title="Switch to tab panel which contains package installation command for @packageManager.Name">
-            @packageManager.Name
-        </a>
-    </li>
-}
-
 @helper CommandPanel(PackageManagerViewModel packageManager, bool active)
 {
     var thirdPartyPackageManager = packageManager as ThirdPartyPackageManagerViewModel;
-    <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty)" id="@packageManager.Id">
-        <div>
-            <div class="install-script-row">
-                @{
-                    var lastIndex = packageManager.InstallPackageCommands.Length - 1;
-                    var cs = packageManager.InstallPackageCommands.Select((c, i) => i < lastIndex ? c + Environment.NewLine : c);
-                }
-                @* Writing out the install command must be on a single line to avoid undesired whitespace in the <pre> tag. *@
-                <pre class="install-script" id="@packageManager.Id-text">@foreach (var c in cs) {<span class="install-command-row">@c</span>}</pre>
-                <div class="copy-button">
-                    <!--In order to statisfy the requirement to announce button status both on NVDA/Narrator, other screen reader like NVDA will
-                        announce the data-content "Copied" everytime when we press button, however, it won't work with Narrator when we use bootstrap popover 
-                        because of known issue(https://github.com/twbs/bootstrap/issues/18618).
-                        We add aria-pressed to indicate the whether button is pressed or not, which is workaround only for Narrator announce the status change of button
-                    -->
-                    <button id="@packageManager.Id-button" class="btn btn-default btn-warning" type="button"
-                            data-toggle="popover" data-placement="bottom" data-content="Copied."
-                            aria-label="@packageManager.CopyLabel" aria-pressed="false" aria-live="polite" role="button">
-                        <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
-                    </button>
+    <div class="instructions-displayed @(active ? string.Empty : "hidden")" id="@packageManager.Id-instructions">
+        <div id="@packageManager.Id">
+            <div>
+                <div class="install-script-row">
+                    @{
+                        var lastIndex = packageManager.InstallPackageCommands.Length - 1;
+                        var cs = packageManager.InstallPackageCommands.Select((c, i) => i < lastIndex ? c + Environment.NewLine : c);
+                    }
+                    @* Writing out the install command must be on a single line to avoid undesired whitespace in the <pre> tag. *@
+                    <pre class="install-script" id="@packageManager.Id-text">@foreach (var c in cs) {<span class="install-command-row">@c</span>}</pre>
                 </div>
             </div>
-        </div>
 
-        @switch (packageManager.AlertLevel)
-        {
-            case AlertLevel.Info: 
-                @ViewHelpers.AlertInfo(
-                    @<text>
-                        @Html.Raw(packageManager.AlertMessage)
-                    </text>);
-                break;
-            case AlertLevel.Warning:
-                @ViewHelpers.AlertWarning(
-                    @<text>
-                        @Html.Raw(packageManager.AlertMessage)
-                    </text>);
-                break;
-            default:
-                break;
-        }
+            @switch (packageManager.AlertLevel)
+            {
+                case AlertLevel.Info:
+                    @ViewHelpers.AlertInfo(
+                            @<text>
+                                @Html.Raw(packageManager.AlertMessage)
+                            </text>);
+                    break;
+                case AlertLevel.Warning:
+                    @ViewHelpers.AlertWarning(
+                            @<text>
+                                @Html.Raw(packageManager.AlertMessage)
+                            </text>);
+                    break;
+                default:
+                    break;
+            }
+        </div>   
     </div>
 }
 
@@ -482,25 +459,28 @@
                 }
                 @if (Model.Available)
                 {
-                    <div class="install-tabs">
-                        <ul class="nav nav-tabs" role="tablist">
-                            @{ var firstPackageManager = true; }
-                            @foreach (var packageManager in packageManagers)
-                            {
-                                @CommandTab(packageManager, active: firstPackageManager)
-
-                                firstPackageManager = false;
-                            }
-                        </ul>
-                        <div class="tab-content">
-                            @{ firstPackageManager = true; }
-                            @foreach (var packageManager in packageManagers)
-                            {
-                                @CommandPanel(packageManager, active: firstPackageManager)
-
-                                firstPackageManager = false;
-                            }
+                    <div class="installation-instructions">
+                        <div class="top-content-instructions">
+                            <select name="installation-instructions" class="installation-instructions-dropdown">
+                                @foreach (var packageManager in packageManagers)
+                                {
+                                    <option value=@packageManager.Id>@packageManager.Name</option>
+                                }
+                            </select>
+                            <button class="btn btn-default installation-instructions-buttons" type="button"
+                                    data-toggle="popover" data-placement="bottom" data-content="Copied."
+                                    aria-label="CopyLabel" aria-pressed="false" aria-live="polite" role="button">
+                                <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
+                            </button>
                         </div>
+                       
+                        @{ var firstPackageManager = true; }
+                        @foreach (var packageManager in packageManagers)
+                        {
+                            @CommandPanel(packageManager, active: firstPackageManager)
+
+                            firstPackageManager = false;
+                        }
                     </div>
                 }
             </div>


### PR DESCRIPTION
Addresses https://github.com/nuget/nugetgallery/issues/8602

## Screenshots

<details>
<summary>Default screenshot...</summary>

![image](https://user-images.githubusercontent.com/737941/126011290-82044fec-a12d-4ded-8685-670404b81b90.png)

Package with long ID:

![image](https://user-images.githubusercontent.com/737941/126014015-0cebbf54-09a2-4d25-a2c8-89f4fdcff0e5.png)

</details>

<details>
<summary>Installation instructions with banners below...</summary>

![image](https://user-images.githubusercontent.com/737941/126011367-6cb9df7d-6cab-4e65-a62e-02d9483c0864.png)

![image](https://user-images.githubusercontent.com/737941/126011382-a6eb46bb-410c-4715-a125-0434e9335dfa.png)

</details>

<details>
<summary>Multi-line installation instructions...</summary>

![image](https://user-images.githubusercontent.com/737941/126011395-963edb09-e8e3-4010-ba76-9a024185c863.png)

![image](https://user-images.githubusercontent.com/737941/126013822-513961bf-e80d-43e1-8ddf-4cf34e2c62b5.png)

</details>

<details>
<summary>.NET Tools...</summary>

![image](https://user-images.githubusercontent.com/737941/126013418-9d8c7d79-1bfe-41c3-9747-11e1352a7f7f.png)

</details>

<details>
<summary> ⚠ .NET Template...</summary>

![image](https://user-images.githubusercontent.com/737941/126013715-aef3d7ac-388e-4de2-94cd-5d77f04b49bf.png)

⚠ NOTE: There is only one package manager that supports .NET Templates today. The UI has a dropdown with only a single option.

</details>

<details>
<summary>Mobile...</summary>

FYI the installation instructions are sideways scrollable. You can swipe (or is it pan?) to see the text:

![image](https://user-images.githubusercontent.com/737941/126014178-e03074a4-9e3a-4314-9423-55a050713a81.png)

![image](https://user-images.githubusercontent.com/737941/126014278-696343de-ae7a-4ce9-863a-8f286d36ceb6.png)

</details>
