### PR TITLE
Display NuGet Package Explorer link on details page.

### DIFF
--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -259,5 +259,10 @@ namespace GitHubVulnerabilities2Db.Fakes
         {
             throw new NotImplementedException();
         }
+
+        public bool IsDisplayNuGetPackageExplorerLinkEnabled()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -29,6 +29,7 @@ namespace NuGetGallery
         private const string DisplayVulnerabilitiesFeatureName = GalleryPrefix + "DisplayVulnerabilities";
         private const string ManagePackagesVulnerabilitiesFeatureName = GalleryPrefix + "ManagePackagesVulnerabilities";
         private const string DisplayFuGetLinksFeatureName = GalleryPrefix + "DisplayFuGetLinks";
+        private const string DisplayNuGetPackageExplorerLinkFeatureName = GalleryPrefix + "DisplayNuGetPackageExplorerLink";
         private const string ODataReadOnlyDatabaseFeatureName = GalleryPrefix + "ODataReadOnlyDatabase";
         private const string PackagesAtomFeedFeatureName = GalleryPrefix + "PackagesAtomFeed";
         private const string SearchSideBySideFlightName = GalleryPrefix + "SearchSideBySide";
@@ -153,6 +154,11 @@ namespace NuGetGallery
         public bool IsDisplayFuGetLinksEnabled()
         {
             return _client.IsEnabled(DisplayFuGetLinksFeatureName, defaultValue: false);
+        }
+
+        public bool IsDisplayNuGetPackageExplorerLinkEnabled()
+        {
+            return _client.IsEnabled(DisplayNuGetPackageExplorerLinkFeatureName, defaultValue: false);
         }
 
         public bool AreEmbeddedIconsEnabled(User user)

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -78,6 +78,11 @@ namespace NuGetGallery
         bool IsDisplayFuGetLinksEnabled();
 
         /// <summary>
+        /// Whether or not a nuget.info (NuGet Package Explorer) link is visible on a package's details page.
+        /// </summary>
+        bool IsDisplayNuGetPackageExplorerLinkEnabled();
+
+        /// <summary>
         /// Whether the user is allowed to publish packages with an embedded icon.
         /// </summary>
         bool AreEmbeddedIconsEnabled(User user);

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -25,6 +25,7 @@
     "NuGetGallery.DisplayVulnerabilities": "Enabled",
     "NuGetGallery.ManagePackagesVulnerabilities": "Enabled",
     "NuGetGallery.DisplayFuGetLinks": "Enabled",
+    "NuGetGallery.DisplayNuGetPackageExplorerLink": "Enabled",
     "NuGetGallery.PatternSetTfmHeuristics": "Enabled",
     "NuGetGallery.EmbeddedIcons": "Enabled",
     "NuGetGallery.MarkdigMdRendering": "Enabled",

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -937,6 +937,7 @@ namespace NuGetGallery
             model.IsPackageDeprecationEnabled = isPackageDeprecationEnabled;
             model.IsPackageVulnerabilitiesEnabled = isPackageVulnerabilitiesEnabled;
             model.IsFuGetLinksEnabled = _featureFlagService.IsDisplayFuGetLinksEnabled();
+            model.IsNuGetPackageExplorerLinkEnabled = _featureFlagService.IsDisplayNuGetPackageExplorerLinkEnabled();
             model.IsPackageRenamesEnabled = _featureFlagService.IsPackageRenamesEnabled(currentUser);
             model.IsPackageDependentsEnabled = _featureFlagService.IsPackageDependentsEnabled(currentUser);
            

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -171,6 +171,12 @@ namespace NuGetGallery
                 viewModel.FuGetUrl = fugetReadyUrl;
             }
 
+            var nugetPackageExplorerUrl = $"https://nuget.info/packages/{package.Id}/{package.NormalizedVersion}";
+            if (PackageHelper.TryPrepareUrlForRendering(nugetPackageExplorerUrl, out string nugetPackageExplorerReadyUrl))
+            {
+                viewModel.NuGetPackageExplorerUrl = nugetPackageExplorerReadyUrl;
+            }
+
             viewModel.EmbeddedLicenseType = package.EmbeddedLicenseType;
             viewModel.LicenseExpression = package.LicenseExpression;
 

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -19,7 +19,6 @@ namespace NuGetGallery
     {
         private const string Area = "area";
         private static IGalleryConfigurationService _configuration;
-        private const string PackageExplorerDeepLink = @"https://npe.codeplex.com/releases/clickonce/NuGetPackageExplorer.application?url={0}&id={1}&version={2}";
 
         public static class Fragments
         {
@@ -322,25 +321,6 @@ namespace NuGetGallery
 
             // Ensure trailing slashes for versionless package URLs, as a fix for package filenames that look like known file extensions
             return version == null ? EnsureTrailingSlash(result) : result;
-        }
-        public static string ExplorerDeepLink(
-            this UrlHelper url,
-            int feedVersion,
-            string id,
-            string version)
-        {
-            var urlResult = GetRouteLink(
-                url,
-                routeName: $"v{feedVersion}{RouteName.DownloadPackage}",
-                relativeUrl: false,
-                routeValues: new RouteValueDictionary
-                {
-                    { "Id", id }
-                });
-
-            urlResult = EnsureTrailingSlash(urlResult);
-
-            return string.Format(CultureInfo.InvariantCulture, PackageExplorerDeepLink, urlResult, id, version);
         }
 
         public static string LogOn(this UrlHelper url, bool relativeUrl = true)

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -36,6 +36,7 @@ namespace NuGetGallery
         public bool IsPackageDeprecationEnabled { get; set; }
         public bool IsPackageVulnerabilitiesEnabled { get; set; }
         public bool IsFuGetLinksEnabled { get; set; }
+        public bool IsNuGetPackageExplorerLinkEnabled { get; set; }
         public bool IsPackageRenamesEnabled { get; set; }
         public bool IsGitHubUsageEnabled { get; set; }
         public bool IsPackageDependentsEnabled { get; set; }
@@ -80,6 +81,7 @@ namespace NuGetGallery
         public string ProjectUrl { get; set; }
         public string LicenseUrl { get; set; }
         public string FuGetUrl { get; set; }
+        public string NuGetPackageExplorerUrl { get; set; }
         public IReadOnlyCollection<string> LicenseNames { get; set; }
         public string LicenseExpression { get; set; }
         public IReadOnlyCollection<CompositeLicenseExpressionSegment> LicenseExpressionSegments { get; set; }
@@ -122,6 +124,16 @@ namespace NuGetGallery
                     RepositoryType = RepositoryKind.Git;
                 }
             }
+        }
+
+        public bool CanDisplayNuGetPackageExplorerLink()
+        {
+            return IsNuGetPackageExplorerLinkEnabled && !string.IsNullOrEmpty(NuGetPackageExplorerUrl) && Available;
+        }
+
+        public bool CanDisplayFuGetLink()
+        {
+            return IsFuGetLinksEnabled && !string.IsNullOrEmpty(FuGetUrl) && Available;
         }
 
         public enum RepositoryKind

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -999,10 +999,6 @@
                             &nbsp;(@Model.LatestSymbolsPackage.FileSize.ToUserFriendlyBytesLabel())
                         </li>
                     }
-                    <li class="no-clickonce">
-                        <i class="ms-Icon ms-Icon--OpenInNewWindow" aria-hidden="true"></i>
-                        <a href="@Url.ExplorerDeepLink(2, Model.Id, Model.Version)" title="Explore the nupkg with the NuGet Package Explorer (IE only)" rel="nofollow">Open in Package Explorer</a>
-                    </li>
                 }
 
                 @if (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist)
@@ -1085,7 +1081,21 @@
                     </li>
                 }
 
-                @if (Model.IsFuGetLinksEnabled && !string.IsNullOrEmpty(Model.FuGetUrl))
+                @if (Model.CanDisplayNuGetPackageExplorerLink())
+                {
+                    var disclaimer = "nuget.info is a 3rd party website, not controlled by Microsoft. This link is made available to you per the NuGet Terms of Use.";
+
+                    <li>
+                        <i class="ms-Icon ms-Icon--FabricFolderSearch" aria-hidden="true" aria-label="@disclaimer" title="@disclaimer"></i>
+                        <a href="@Model.NuGetPackageExplorerUrl" data-track="outbound-nugetpackageexplorer-url"
+                           aria-label="open in NuGet Package Explorer"
+                           title="Explore additional package info on NuGet Package Explorer" target="_blank" rel="nofollow">
+                            Open in NuGet Package Explorer
+                        </a>
+                    </li>
+                }
+
+                @if (Model.CanDisplayFuGetLink())
                 {
                     var disclaimer = "fuget.org is a 3rd party website, not controlled by Microsoft. This link is made available to you per the NuGet Terms of Use.";
 
@@ -1094,9 +1104,9 @@
                              aria-label="@disclaimer" title="@disclaimer"
                              src="@Url.Absolute("~/Content/gallery/img/fuget.svg")"
                              @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/fuget-32x32.png")) />
-                        <a href="@Model.FuGetUrl" data-track="outbound-repository-url"
+                        <a href="@Model.FuGetUrl" data-track="outbound-fuget-url"
                            aria-label="open in fuget.org explorer"
-                           title="Explore additional package info on fuget.org" rel="nofollow">
+                           title="Explore additional package info on fuget.org" target="_blank" rel="nofollow">
                             Open in FuGet Package Explorer
                         </a>
                     </li>

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -969,10 +969,6 @@
                                         &nbsp;(@Model.LatestSymbolsPackage.FileSize.ToUserFriendlyBytesLabel())
                                     </li>
                                 }
-                                <li class="no-clickonce">
-                                    <i class="ms-Icon ms-Icon--OpenInNewWindow" aria-hidden="true"></i>
-                                    <a href="@Url.ExplorerDeepLink(2, Model.Id, Model.Version)" title="Explore the nupkg with the NuGet Package Explorer (IE only)" rel="nofollow">Open in Package Explorer</a>
-                                </li>
                             }
 
                             @if (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist)
@@ -1055,7 +1051,21 @@
                                 </li>
                             }
 
-                            @if (Model.IsFuGetLinksEnabled && !string.IsNullOrEmpty(Model.FuGetUrl))
+                            @if (Model.CanDisplayNuGetPackageExplorerLink())
+                            {
+                                var disclaimer = "nuget.info is a 3rd party website, not controlled by Microsoft. This link is made available to you per the NuGet Terms of Use.";
+
+                                <li>
+                                    <i class="ms-Icon ms-Icon--FabricFolderSearch" aria-hidden="true" aria-label="@disclaimer" title="@disclaimer"></i>
+                                    <a href="@Model.NuGetPackageExplorerUrl" data-track="outbound-nugetpackageexplorer-url"
+                                       aria-label="open in NuGet Package Explorer"
+                                       title="Explore additional package info on NuGet Package Explorer" target="_blank" rel="nofollow">
+                                        Open in NuGet Package Explorer
+                                    </a>
+                                </li>
+                            }
+
+                            @if (Model.CanDisplayFuGetLink())
                             {
                                 var disclaimer = "fuget.org is a 3rd party website, not controlled by Microsoft. This link is made available to you per the NuGet Terms of Use.";
 
@@ -1064,9 +1074,9 @@
                                          aria-label="@disclaimer" title="@disclaimer"
                                          src="@Url.Absolute("~/Content/gallery/img/fuget.svg")"
                                          @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/fuget-32x32.png")) />
-                                    <a href="@Model.FuGetUrl" data-track="outbound-repository-url"
+                                    <a href="@Model.FuGetUrl" data-track="outbound-fuget-url"
                                        aria-label="open in fuget.org explorer"
-                                       title="Explore additional package info on fuget.org" rel="nofollow">
+                                       title="Explore additional package info on fuget.org" target="_blank" rel="nofollow">
                                         Open in FuGet Package Explorer
                                     </a>
                                 </li>
@@ -1075,24 +1085,24 @@
                             <div class="support-links">
                                 @if (Model.CanReportAsOwner)
                                 {
-                                    <li>
-                                        <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
-                                        <a href="@Url.ReportPackage(Model)" title="Contact the NuGet team for help with your package">
-                                            Contact support
-                                        </a>
-                                    </li>
-                                }
-                                
-                                else if (Model.Available)
-                                {
-                                    <li class="report-link">
-                                        <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
-                                        <a href="@Url.ReportAbuse(Model)" title="Report the package as abusive">
-                                            Report package
-                                        </a>
-                                    </li>
-                                }
-                            </div>
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
+                                    <a href="@Url.ReportPackage(Model)" title="Contact the NuGet team for help with your package">
+                                        Contact support
+                                    </a>
+                                </li>
+                            }
+
+                            else if (Model.Available)
+                            {
+                                <li class="report-link">
+                                    <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
+                                    <a href="@Url.ReportAbuse(Model)" title="Report the package as abusive">
+                                        Report package
+                                    </a>
+                                </li>
+                            }
+</div>
                         </ul>
                     </div>
 

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -112,5 +112,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public bool IsImageAllowlistEnabled() => throw new NotImplementedException();
 
         public bool IsDisplayBannerEnabled() => throw new NotImplementedException();
+
+        public bool IsDisplayNuGetPackageExplorerLinkEnabled() => throw new NotImplementedException();
     }
 }

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -105,6 +105,79 @@ namespace NuGetGallery.ViewModels
         }
 
         [Theory]
+        [InlineData("foo", "1.0.0", "https://nuget.info/packages/foo/1.0.0")]
+        [InlineData("foo", "1.1.0", "https://nuget.info/packages/foo/1.1.0")]
+        [InlineData("Foo.Bar", "1.1.0-bETa", "https://nuget.info/packages/Foo.Bar/1.1.0-bETa")]
+        public void ItInitializesNuGetPackageExplorerUrl(string packageId, string packageVersion, string expected)
+        {
+            var package = new Package
+            {
+                Version = packageVersion,
+                NormalizedVersion = packageVersion,
+                PackageRegistration = new PackageRegistration
+                {
+                    Id = packageId,
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
+            };
+
+            var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
+            Assert.Equal(expected, model.NuGetPackageExplorerUrl);
+        }
+
+        [Theory]
+        [InlineData(false, "https://nuget.info/packages/foo/1.0.0", true)]
+        [InlineData(true, "", true)]
+        [InlineData(true, null, true)]
+        [InlineData(true, "https://nuget.info/packages/foo/1.0.0", false)]
+        public void CannotDisplayNuGetPackageExplorerLinkWhenInvalid(bool isEnabled, string url, bool isAvailable)
+        {
+            var package = new Package
+            {
+                Version = "1.0.0",
+                NormalizedVersion = "1.0.0",
+                PackageRegistration = new PackageRegistration
+                {
+                    Id = "foo",
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
+            };
+
+            var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
+
+            model.IsNuGetPackageExplorerLinkEnabled = isEnabled;
+            model.NuGetPackageExplorerUrl = url;
+            model.Available = isAvailable;
+
+            Assert.False(model.CanDisplayNuGetPackageExplorerLink());
+        }
+
+        [Fact]
+        public void CanDisplayNuGetPackageExplorerLinkWhenValid()
+        {
+            var package = new Package
+            {
+                Version = "1.0.0",
+                NormalizedVersion = "1.0.0",
+                PackageRegistration = new PackageRegistration
+                {
+                    Id = "foo",
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
+            };
+
+            var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
+
+            model.IsNuGetPackageExplorerLinkEnabled = true;
+            model.Available = true;
+
+            Assert.True(model.CanDisplayNuGetPackageExplorerLink());
+        }
+
+        [Theory]
         [InlineData("foo", "1.0.0", "https://www.fuget.org/packages/foo/1.0.0")]
         [InlineData("foo", "1.1.0", "https://www.fuget.org/packages/foo/1.1.0")]
         [InlineData("Foo.Bar", "1.1.0-bETa", "https://www.fuget.org/packages/Foo.Bar/1.1.0-bETa")]
@@ -124,6 +197,34 @@ namespace NuGetGallery.ViewModels
 
             var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
             Assert.Equal(expected, model.FuGetUrl);
+        }
+
+        [Theory]
+        [InlineData(false, "https://www.fuget.org/packages/foo/1.0.0", true)]
+        [InlineData(true, "", true)]
+        [InlineData(true, null, true)]
+        [InlineData(true, "https://www.fuget.org/packages/foo/1.0.0", false)]
+        public void CannotDisplayFuGetLinkWhenInvalid(bool isEnabled, string url, bool isAvailable)
+        {
+            var package = new Package
+            {
+                Version = "1.0.0",
+                NormalizedVersion = "1.0.0",
+                PackageRegistration = new PackageRegistration
+                {
+                    Id = "foo",
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
+            };
+
+            var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
+
+            model.IsFuGetLinksEnabled = isEnabled;
+            model.FuGetUrl = url;
+            model.Available = isAvailable;
+
+            Assert.False(model.CanDisplayFuGetLink());
         }
 
         [Theory]


### PR DESCRIPTION
Summary of the changes:

* A link was added for both detail page versions (current, tabs).
* The link sends you to a nuget.info page where you can see the package assets.
* The link will only be displayed when the package is "Available", to avoid sending the user to a broken/non ready page.
* When you click the link it goes to a new page instead of using the current one.
* Minor refactor to the FuGet link to behave like this one.

### DisplayPackage page:
![DisplayPackage](https://user-images.githubusercontent.com/17834924/126389531-35d199c6-46e9-4450-9e25-22b4d61f5c7b.png)

### DisplayPackageV2 page:
![DisplayPackageV2](https://user-images.githubusercontent.com/17834924/126389539-b6f6ede7-c071-4264-ae21-5eeecd94cba1.png)

Addresses https://github.com/nuget/nugetgallery/issues/8428