### PR TITLE
[Redesign] Fix registration's link to the README

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
@@ -56,6 +56,12 @@
     var packageManagerStorageKey = 'preferred_package_manager';
     var bodyStorageKey = 'preferred_body_tab';
 
+    var restorePreferredBodyTab = true;
+    if (window.location.hash === '#show-readme-container') {
+        $('#readme-body-tab').focus();
+        restorePreferredBodyTab = false;
+    }
+
     if (storage) {
         // Restore preferred package manager selection from localStorage.
         var preferredPackageManagerId = storage.getItem(packageManagerStorageKey);
@@ -64,9 +70,11 @@
         }
 
         // Restore preferred body tab selection from localStorage.
-        var preferredBodyTab = storage.getItem(bodyStorageKey);
-        if (preferredBodyTab) {
-            $('#' + preferredBodyTab).tab('show');
+        if (restorePreferredBodyTab) {
+            var preferredBodyTab = storage.getItem(bodyStorageKey);
+            if (preferredBodyTab) {
+                $('#' + preferredBodyTab).tab('show');
+            }
         }
 
         // Make sure we save the user's preferred body tab to localStorage.

--- a/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
@@ -56,6 +56,8 @@
     var packageManagerStorageKey = 'preferred_package_manager';
     var bodyStorageKey = 'preferred_body_tab';
 
+    // The V3 registration API links to the display package page's README using
+    // the 'show-readme-container' URL fragment.
     var restorePreferredBodyTab = true;
     if (window.location.hash === '#show-readme-container') {
         $('#readme-body-tab').focus();

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -494,14 +494,25 @@
                 <ul class="nav nav-tabs" role="tablist">
                     @if (!Model.Deleted)
                     {
-                        <li role="presentation" class="active"><a href="#readme-tab" aria-controls="ReadMe" role="tab" data-toggle="tab" id="readme-body-tab" class="body-tab">README</a></li>
-                        <li role="presentation"><a href="#dependencies-tab" aria-controls="Dependencies" role="tab" data-toggle="tab" id="dependencies-body-tab" class="body-tab">Dependencies</a></li>
+                        <li role="presentation" class="active" id="show-readme-container">
+                            <a href="#readme-tab" aria-controls="ReadMe" role="tab" data-toggle="tab" id="readme-body-tab" class="body-tab">README</a>
+                        </li>
+                        <li role="presentation">
+                            <a href="#dependencies-tab" aria-controls="Dependencies" role="tab" data-toggle="tab" id="dependencies-body-tab" class="body-tab">Dependencies</a>
+                        </li>
                     }
-                    <li role="presentation"><a href="#usedby-tab" aria-controls="UsedBy" role="tab" data-toggle="tab" id="usedby-body-tab" class="body-tab">Used By</a></li>
-                    <li role="presentation"><a href="#versions-tab" aria-controls="Versions" role="tab" data-toggle="tab" id="versions-body-tab" class="body-tab">Versions</a></li>
+                    <li role="presentation">
+                        <a href="#usedby-tab" aria-controls="UsedBy" role="tab" data-toggle="tab" id="usedby-body-tab" class="body-tab">Used By</a>
+                    </li>
+                    <li role="presentation">
+                        <a href="#versions-tab" aria-controls="Versions" role="tab" data-toggle="tab" id="versions-body-tab" class="body-tab">Versions</a>
+                    </li>
+
                     @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
                     {
-                        <li role="presentation"><a href="#releasenotes-tab" aria-controls="ReleaseNotes" role="tab" data-toggle="tab" id="release-body-tab" class="body-tab">Release Notes</a></li>
+                        <li role="presentation">
+                            <a href="#releasenotes-tab" aria-controls="ReleaseNotes" role="tab" data-toggle="tab" id="release-body-tab" class="body-tab">Release Notes</a>
+                        </li>
                     }
                 </ul>
             </div>

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -495,23 +495,23 @@
                     @if (!Model.Deleted)
                     {
                         <li role="presentation" class="active" id="show-readme-container">
-                            <a href="#readme-tab" aria-controls="ReadMe" role="tab" data-toggle="tab" id="readme-body-tab" class="body-tab">README</a>
+                            <a href="#readme-tab" aria-controls="readme-tab" role="tab" data-toggle="tab" id="readme-body-tab" class="body-tab">README</a>
                         </li>
                         <li role="presentation">
-                            <a href="#dependencies-tab" aria-controls="Dependencies" role="tab" data-toggle="tab" id="dependencies-body-tab" class="body-tab">Dependencies</a>
+                            <a href="#dependencies-tab" aria-controls="dependencies-tab" role="tab" data-toggle="tab" id="dependencies-body-tab" class="body-tab">Dependencies</a>
                         </li>
                     }
                     <li role="presentation">
-                        <a href="#usedby-tab" aria-controls="UsedBy" role="tab" data-toggle="tab" id="usedby-body-tab" class="body-tab">Used By</a>
+                        <a href="#usedby-tab" aria-controls="usedby-tab" role="tab" data-toggle="tab" id="usedby-body-tab" class="body-tab">Used By</a>
                     </li>
                     <li role="presentation">
-                        <a href="#versions-tab" aria-controls="Versions" role="tab" data-toggle="tab" id="versions-body-tab" class="body-tab">Versions</a>
+                        <a href="#versions-tab" aria-controls="versions-tab" role="tab" data-toggle="tab" id="versions-body-tab" class="body-tab">Versions</a>
                     </li>
 
                     @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
                     {
                         <li role="presentation">
-                            <a href="#releasenotes-tab" aria-controls="ReleaseNotes" role="tab" data-toggle="tab" id="release-body-tab" class="body-tab">Release Notes</a>
+                            <a href="#releasenotes-tab" aria-controls="releasenotes-tab" role="tab" data-toggle="tab" id="release-body-tab" class="body-tab">Release Notes</a>
                         </li>
                     }
                 </ul>


### PR DESCRIPTION
## Background

For packages with an embedded readme, registration's `readmeUrl` links to the display package page using the `#show-readme-container` URL fragment. For example: https://api.nuget.org/v3/registration5-gz-semver2/knapcode.torsharp/index.json:

<details>
<summary>Example registration JSON for package with embedded readme...</summary>

```json
{
  ...

  "items": [
    {
      ...

      "items": [
        {
          ...

          "@id": "https://api.nuget.org/v3/registration5-gz-semver2/knapcode.torsharp/2.7.0.json",
          "catalogEntry": {
            ...
            "licenseUrl": "https://www.nuget.org/packages/Knapcode.TorSharp/2.7.0/license",
            "readmeUrl": "https://www.nuget.org/packages/Knapcode.TorSharp/2.7.0#show-readme-container",
            ...
            "version": "2.7.0"
          },
          ...
        },

        ...
      ],

      ...
    }
  ]

  ...
}
```

</details>

## Fix

In the current design, this is implemented using Bootstrap 3's collapse component. The redesign broke this feature as it uses Bootstrap 3's tab component instead, which does not support opening using fragments. This change re-adds support for the `#show-readme-container` fragment link using Javascript.

I also fixed some ARIA attributes to improve accessibility.

Addresses https://github.com/NuGet/NuGetGallery/issues/8698