### PR TITLE
Include jsdelivr CDN in the trusted image domains list

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
@@ -13,6 +13,7 @@
         "badges.gitter.im",
         "bettercodehub.com",
         "buildstats.info",
+        "cdn.jsdelivr.net",
         "ci.appveyor.com",
         "circleci.com",
         "codecov.io",


### PR DESCRIPTION
Closes https://github.com/NuGet/NuGetGallery/issues/8541
