### PR TITLE
Adding an option to disable admin panel

### DIFF
--- a/src/AccountDeleter/Configuration/GalleryConfiguration.cs
+++ b/src/AccountDeleter/Configuration/GalleryConfiguration.cs
@@ -37,6 +37,7 @@ namespace NuGetGallery.AccountDeleter
         public string AzureStorage_Revalidation_ConnectionString { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public bool AzureStorageReadAccessGeoRedundant { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public TimeSpan FeatureFlagsRefreshInterval { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public bool AdminPanelEnabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public bool AdminPanelDatabaseAccessEnabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public bool AsynchronousPackageValidationEnabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public bool BlockingAsynchronousPackageValidationEnabled { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
@@ -76,6 +76,9 @@ namespace NuGetGallery.Configuration
 
         public TimeSpan FeatureFlagsRefreshInterval { get; set; }
 
+        [DefaultValue(true)]
+        public bool AdminPanelEnabled { get; set; }
+
         public bool AdminPanelDatabaseAccessEnabled { get; set; }
 
         public bool AsynchronousPackageValidationEnabled { get; set; }

--- a/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
@@ -101,6 +101,11 @@ namespace NuGetGallery.Configuration
         TimeSpan FeatureFlagsRefreshInterval { get; set; }
 
         /// <summary>
+        /// Indicates whether Admin panel pages exist on this instance.
+        /// </summary>
+        bool AdminPanelEnabled { get; set; }
+
+        /// <summary>
         /// Gets a boolean indicating whether DB admin through web UI should be accesible.
         /// </summary>
         bool AdminPanelDatabaseAccessEnabled { get; set; }

--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -271,20 +271,28 @@ namespace NuGetGallery
                 new { controller = "Packages", action = "SetLicenseReportVisibility", visible = false },
                 new { version = new VersionRouteConstraint() });
 
-            routes.MapRoute(
-                RouteName.PackageReflowAction,
-                "packages/manage/reflow",
-                new { controller = "Packages", action = nameof(PackagesController.Reflow) });
+            if (adminPanelEnabled)
+            {
+                routes.MapRoute(
+                    RouteName.PackageReflowAction,
+                    "packages/manage/reflow",
+                    new { controller = "Packages", action = nameof(PackagesController.Reflow) });
 
-            routes.MapRoute(
-                RouteName.PackageRevalidateAction,
-                "packages/manage/revalidate",
-                new { controller = "Packages", action = nameof(PackagesController.Revalidate) });
+                routes.MapRoute(
+                    RouteName.PackageRevalidateAction,
+                    "packages/manage/revalidate",
+                    new { controller = "Packages", action = nameof(PackagesController.Revalidate) });
 
-            routes.MapRoute(
-                RouteName.PackageRevalidateSymbolsAction,
-                "packages/manage/revalidate-symbols",
-                new { controller = "Packages", action = nameof(PackagesController.RevalidateSymbols) });
+                routes.MapRoute(
+                    RouteName.PackageRevalidateSymbolsAction,
+                    "packages/manage/revalidate-symbols",
+                    new { controller = "Packages", action = nameof(PackagesController.RevalidateSymbols) });
+
+                routes.MapRoute(
+                    RouteName.PackageDeleteAction,
+                    "packages/manage/delete",
+                    new { controller = "Packages", action = "Delete" });
+            }
 
             var packageVersionActionRoute = routes.MapRoute(
                 RouteName.PackageVersionAction,
@@ -296,11 +304,6 @@ namespace NuGetGallery
                 RouteName.PackageAction,
                 "packages/{id}/{action}",
                 new { controller = "Packages" });
-
-            var packageDeleteRoute = routes.MapRoute(
-                RouteName.PackageDeleteAction,
-                "packages/manage/delete",
-                new { controller = "Packages", action = "Delete" });
 
             var confirmationRequiredRoute = routes.MapRoute(
                 "ConfirmationRequired",

--- a/src/NuGetGallery/App_Start/Routes.cs
+++ b/src/NuGetGallery/App_Start/Routes.cs
@@ -10,11 +10,11 @@ namespace NuGetGallery
 {
     public static class Routes
     {
-        public static void RegisterRoutes(RouteCollection routes, bool feedOnlyMode = false)
+        public static void RegisterRoutes(RouteCollection routes, bool feedOnlyMode = false, bool adminPanelEnabled = false)
         {
             if (!feedOnlyMode)
             {
-                RegisterUIRoutes(routes);
+                RegisterUIRoutes(routes, adminPanelEnabled);
             }
             else
             {
@@ -29,7 +29,7 @@ namespace NuGetGallery
             RegisterApiV2Routes(routes);
         }
 
-        public static void RegisterUIRoutes(RouteCollection routes)
+        public static void RegisterUIRoutes(RouteCollection routes, bool adminPanelEnabled)
         {
             routes.MapRoute(
                 RouteName.Home,
@@ -449,11 +449,14 @@ namespace NuGetGallery
                 "account/changeMultiFactorAuthentication",
                 new { controller = "Users", action = "ChangeMultiFactorAuthentication" });
 
-            routes.MapRoute(
-                RouteName.AdminDeleteAccount,
-                "account/delete/{accountName}",
-                new { controller = "Users", action = "Delete" },
-                new RouteExtensions.ObfuscatedPathMetadata(2, Obfuscator.DefaultTelemetryUserName));
+            if (adminPanelEnabled)
+            {
+                routes.MapRoute(
+                    RouteName.AdminDeleteAccount,
+                    "account/delete/{accountName}",
+                    new { controller = "Users", action = "Delete" },
+                    new RouteExtensions.ObfuscatedPathMetadata(2, Obfuscator.DefaultTelemetryUserName));
+            }
 
             routes.MapRoute(
                 RouteName.UserDeleteAccount,

--- a/src/NuGetGallery/Areas/Admin/AdminAreaRegistration.cs
+++ b/src/NuGetGallery/Areas/Admin/AdminAreaRegistration.cs
@@ -18,6 +18,11 @@ namespace NuGetGallery.Areas.Admin
         {
             var galleryConfigurationService = DependencyResolver.Current.GetService<IGalleryConfigurationService>();
 
+            if (!galleryConfigurationService.Current.AdminPanelEnabled)
+            {
+                return;
+            }
+
             if (galleryConfigurationService.Current.AdminPanelDatabaseAccessEnabled)
             {
                 var galleryDbConnectionFactory = DependencyResolver.Current.GetService<ISqlConnectionFactory>();

--- a/src/NuGetGallery/Areas/Admin/DynamicData/Site.master.cs
+++ b/src/NuGetGallery/Areas/Admin/DynamicData/Site.master.cs
@@ -17,7 +17,7 @@ namespace NuGetGallery.Areas.Admin.DynamicData
                 Response.End();
             }
 
-            if (!Request.IsLocal && !Page.User.IsAdministrator())
+            if ((!Request.IsLocal && !Page.User.IsAdministrator()) || !AdminHelper.IsAdminPanelEnabled)
             {
                 Response.StatusCode = (int)HttpStatusCode.Forbidden;
                 Response.End();

--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -338,7 +338,7 @@ namespace NuGetGallery
         }
 
         [HttpGet]
-        [UIAuthorize(Roles = "Admins")]
+        [AdminAction()]
         public virtual ActionResult Delete(string accountName)
         {
             var accountToDelete = UserService.FindByUsername(accountName) as TUser;
@@ -351,7 +351,7 @@ namespace NuGetGallery
         }
 
         [HttpDelete]
-        [UIAuthorize(Roles = "Admins")]
+        [AdminAction()]
         [RequiresAccountConfirmation("Delete account")]
         [ValidateAntiForgeryToken]
         public virtual async Task<ActionResult> Delete(DeleteAccountAsAdminViewModel model)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1850,7 +1850,7 @@ namespace NuGetGallery
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        [UIAuthorize(Roles = "Admins")]
+        [AdminAction()]
         [RequiresAccountConfirmation("reflow a package")]
         public virtual async Task<ActionResult> Reflow(string id, string version)
         {
@@ -1887,7 +1887,7 @@ namespace NuGetGallery
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        [UIAuthorize(Roles = "Admins")]
+        [AdminAction()]
         [RequiresAccountConfirmation("revalidate a package")]
         public virtual async Task<ActionResult> Revalidate(string id, string version)
         {
@@ -1916,7 +1916,7 @@ namespace NuGetGallery
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        [UIAuthorize(Roles = "Admins")]
+        [AdminAction()]
         [RequiresAccountConfirmation("revalidate a symbols package")]
         public virtual async Task<ActionResult> RevalidateSymbols(string id, string version)
         {
@@ -1981,7 +1981,7 @@ namespace NuGetGallery
             return RedirectToActionPermanent(nameof(Manage));
         }
 
-        [UIAuthorize(Roles = "Admins")]
+        [AdminAction()]
         [HttpPost]
         [RequiresAccountConfirmation("delete a package")]
         [ValidateAntiForgeryToken]

--- a/src/NuGetGallery/Filters/AdminActionAttribute.cs
+++ b/src/NuGetGallery/Filters/AdminActionAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Web;
+using System.Web.Mvc;
+
+namespace NuGetGallery.Filters
+{
+    public class AdminActionAttribute : UIAuthorizeAttribute
+    {
+        public override void OnAuthorization(AuthorizationContext filterContext)
+        {
+            if (!AdminHelper.IsAdminPanelEnabled)
+            {
+                filterContext.Result = new HttpStatusCodeResult(HttpStatusCode.Forbidden);
+            }
+
+            Roles = "Admins";
+
+            base.OnAuthorization(filterContext);
+        }
+    }
+}

--- a/src/NuGetGallery/Filters/UiAuthorizeAttribute.cs
+++ b/src/NuGetGallery/Filters/UiAuthorizeAttribute.cs
@@ -8,7 +8,7 @@ using AuthorizationContext = System.Web.Mvc.AuthorizationContext;
 
 namespace NuGetGallery.Filters
 {
-    public sealed class UIAuthorizeAttribute : AuthorizeAttribute
+    public class UIAuthorizeAttribute : AuthorizeAttribute
     {
         public bool AllowDiscontinuedLogins { get; }
 

--- a/src/NuGetGallery/Helpers/AdminHelper.cs
+++ b/src/NuGetGallery/Helpers/AdminHelper.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Web.Mvc;
+using NuGetGallery.Configuration;
+
+namespace NuGetGallery
+{
+    public static class AdminHelper
+    {
+        private static Lazy<bool> AdminPanelEnabled = new Lazy<bool>(() =>  
+            DependencyResolver.Current.GetService<IGalleryConfigurationService>()
+                .Current.AdminPanelEnabled);
+
+        public static bool IsAdminPanelEnabled => AdminPanelEnabled.Value;
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -214,6 +214,7 @@
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="Extensions\CakeBuildManagerExtensions.cs" />
     <Compile Include="Extensions\ImageExtensions.cs" />
+    <Compile Include="Helpers\AdminHelper.cs" />
     <Compile Include="Helpers\ValidationHelper.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeleteAccountListPackageItemViewModelFactory.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeletePackageViewModelFactory.cs" />

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -214,6 +214,7 @@
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="Extensions\CakeBuildManagerExtensions.cs" />
     <Compile Include="Extensions\ImageExtensions.cs" />
+    <Compile Include="Filters\AdminActionAttribute.cs" />
     <Compile Include="Helpers\AdminHelper.cs" />
     <Compile Include="Helpers\ValidationHelper.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeleteAccountListPackageItemViewModelFactory.cs" />

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -1387,6 +1387,7 @@ namespace NuGetGallery
 
         public static string Admin(this UrlHelper url, bool relativeUrl = true)
         {
+            // TODO: change to something when admin panel is disabled?
             return GetActionLink(
                 url,
                 "Index",

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1020,7 +1020,7 @@
                     </li>
                 }
 
-                @if (Model.Available && User.IsAdministrator())
+                @if (AdminHelper.IsAdminPanelEnabled && Model.Available && User.IsAdministrator())
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
@@ -1039,7 +1039,7 @@
                     </li>
                 }
 
-                @if (!Model.Deleted && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
+                @if (AdminHelper.IsAdminPanelEnabled && !Model.Deleted && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
@@ -1077,7 +1077,7 @@
                     }
                 }
 
-                @if (User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
+                @if (AdminHelper.IsAdminPanelEnabled && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
                 {
                     <li>
                         <i class="ms-Icon ms-Icon--Health" aria-hidden="true"></i>

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -990,7 +990,7 @@
                                 </li>
                             }
 
-                            @if (Model.Available && User.IsAdministrator())
+                            @if (AdminHelper.IsAdminPanelEnabled && Model.Available && User.IsAdministrator())
                             {
                                 <li>
                                     <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
@@ -1009,7 +1009,7 @@
                                 </li>
                             }
 
-                            @if (!Model.Deleted && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
+                            @if (AdminHelper.IsAdminPanelEnabled && !Model.Deleted && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
                             {
                                 <li>
                                     <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
@@ -1047,7 +1047,7 @@
                                 }
                             }
 
-                            @if (User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
+                            @if (AdminHelper.IsAdminPanelEnabled && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
                             {
                                 <li>
                                     <i class="ms-Icon ms-Icon--Health" aria-hidden="true"></i>

--- a/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Header.cshtml
@@ -82,7 +82,7 @@
                         {
                             @DisplayNavigationItem("Statistics", Url.Statistics())
                         }
-                        @if (Request.IsAuthenticated && User.IsInRole(CoreConstants.AdminRoleName))
+                        @if (Request.IsAuthenticated && AdminHelper.IsAdminPanelEnabled && User.IsInRole(CoreConstants.AdminRoleName))
                         {
                             @DisplayNavigationItem("Admin", Url.Admin())
                         }
@@ -126,7 +126,7 @@
                                                 <span class="dropdown-email">@CurrentUser.EmailAddress.Abbreviate(25)</span>
                                             </div>
                                         </li>
-                                        @if (Request.IsAuthenticated && User.IsInRole(CoreConstants.AdminRoleName))
+                                        @if (Request.IsAuthenticated && AdminHelper.IsAdminPanelEnabled && User.IsInRole(CoreConstants.AdminRoleName))
                                         {
                                             <li class="divider"></li>
                                             <li role="presentation"><a href="@Url.Admin()" role="menuitem">Admin</a></li>

--- a/src/NuGetGallery/Views/Shared/SiteMenu.cshtml
+++ b/src/NuGetGallery/Views/Shared/SiteMenu.cshtml
@@ -14,7 +14,7 @@
     {
         <li class="@classes["Statistics"]"><a href="@Url.Statistics()">Statistics</a></li>
     }
-    @if (Request.IsAuthenticated && User.IsInRole(CoreConstants.AdminRoleName))
+    @if (Request.IsAuthenticated && AdminHelper.IsAdminPanelEnabled && User.IsInRole(CoreConstants.AdminRoleName))
     {
         <li class="@classes["Admin"]"><a href="@Url.Admin()">Admin</a></li>
     }

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -28,7 +28,7 @@
                     <div class="description">Total @(Model.TotalPackageDownloadCount == 1 ? "download" : "downloads") of packages</div>
                 </div>
             </div>
-            @if (User.IsAdministrator())
+            @if (AdminHelper.IsAdminPanelEnabled && User.IsAdministrator())
             {
                 <div class="additional-info">
                     <dl>
@@ -53,7 +53,7 @@
                     {
                         <a href="@(Model.UserIsOrganization ? Url.ManageMyOrganization(Model.Username) : Url.AccountSettings())" aria-label="Manage this account"><i class="ms-Icon ms-Icon--Edit ms-font-xl"></i></a>
                     }
-                    @if (User.IsAdministrator())
+                    @if (AdminHelper.IsAdminPanelEnabled && User.IsAdministrator())
                     {
                         var deleteUrl = Model.UserIsOrganization ? Url.AdminDeleteOrganization(Model.Username) : Url.AdminDeleteAccount(Model.Username);
                         <a href="@deleteUrl" aria-label="Delete this account"><i class="ms-Icon ms-Icon--Delete ms-font-xl" aria-hidden="true"></i></a>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -44,6 +44,7 @@
     <add key="Gallery.AzureStorageReadAccessGeoRedundant" value="false"/>
     <!-- If the storage account has to fall-back to a secondary (when Read Access Geo Redundant is enabled in Azure storage), change Gallery.AzureStorageReadAccessGeoRedundant to true -->
     <add key="Gallery.FeatureFlagsRefreshInterval" value="00:01:00"/>
+    <add key="Gallery.AdminPanelEnabled" value="true"/>
     <add key="Gallery.AdminPanelDatabaseAccessEnabled" value="false"/>
     <add key="Gallery.AsynchronousPackageValidationEnabled" value="false"/>
     <add key="Gallery.BlockingAsynchronousPackageValidationEnabled" value="false"/>

--- a/tests/NuGetGallery.Facts/Helpers/ObfuscationHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/ObfuscationHelperFacts.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery.Helpers
                 {
                     _currentRoutes = new RouteCollection();
                     Routes.RegisterApiV2Routes(_currentRoutes);
-                    Routes.RegisterUIRoutes(_currentRoutes);
+                    Routes.RegisterUIRoutes(_currentRoutes, false);
                 }
             }
 

--- a/tests/NuGetGallery.Facts/Helpers/ObfuscationHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/ObfuscationHelperFacts.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery.Helpers
                 {
                     _currentRoutes = new RouteCollection();
                     Routes.RegisterApiV2Routes(_currentRoutes);
-                    Routes.RegisterUIRoutes(_currentRoutes, false);
+                    Routes.RegisterUIRoutes(_currentRoutes, true);
                 }
             }
 

--- a/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery.Telemetry
             {
                 _currentRoutes = new RouteCollection();
                 Routes.RegisterApiV2Routes(_currentRoutes);
-                Routes.RegisterUIRoutes(_currentRoutes, false);
+                Routes.RegisterUIRoutes(_currentRoutes, true);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/ClientTelemetryPIIProcessorTests.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery.Telemetry
             {
                 _currentRoutes = new RouteCollection();
                 Routes.RegisterApiV2Routes(_currentRoutes);
-                Routes.RegisterUIRoutes(_currentRoutes);
+                Routes.RegisterUIRoutes(_currentRoutes, false);
             }
         }
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/3418

Adds an `AdminPanelEnabled` option to the configuration (defaulted to `true`) that controls whether `Admin` area of the site gets registered as well as some admin routes not directly under `/Admin`.

`AdminHelper` was added for ease of checking and caching the results. `AdminAction` replaced the `UIAuthorize(Roles = "Admins")` to contain the check.