### PR TITLE
[Redesign] Fix README alerts if package hasn't passed validation

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -289,11 +289,11 @@
                             {
                                 var issuePluralString = Model.PackageValidationIssues.Count > 1 ? "all the issues" : "the issue";
                                 <text>Once you've fixed @issuePluralString with your package, you can reupload it with the same ID and version.</text>
-                             }
-                             else
-                             {
+                            }
+                            else
+                            {
                                 <text>Please contact <a href="mailto:support@nuget.org">support@nuget.org</a> to help fix your package.</text>
-                             }
+                            }
                         </text>
                     )
                 }
@@ -523,7 +523,15 @@
                         @if (!Model.Deleted)
                         {
                             <div role="tabpanel" class="tab-pane active" id="readme-tab">
-                                @if (Model.ReadMeHtml != null)
+                                @if ((Model.Validating || Model.FailedValidation) && Model.HasEmbeddedReadmeFile)
+                                {
+                                    @ViewHelpers.AlertWarning(
+                                        @<text>
+                                            The readme will become available once package validation has completed successfully.
+                                        </text>
+                                    )
+                                }
+                                else if (Model.ReadMeHtml != null)
                                 {
                                     <div id="readme-container">
                                         @if (Model.ReadMeImagesRewritten && Model.CanDisplayPrivateMetadata)
@@ -539,7 +547,7 @@
                                         @Html.Raw(Model.ReadMeHtml)
                                     </div>
                                 }
-                                else if (!Model.Deleted && !String.IsNullOrWhiteSpace(Model.Description))
+                                else
                                 {
                                     if (Model.CanDisplayPrivateMetadata) 
                                     { 


### PR DESCRIPTION
When package with embedded README is uploaded:

![image](https://user-images.githubusercontent.com/737941/127559122-c9aef2d9-72d5-4981-be29-ad977805d3df.png)

If package fails validation and has an embedded README:

![image](https://user-images.githubusercontent.com/737941/127559011-473973f9-553f-4bf1-8a25-5f3f7cf0d22b.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/8716

Test build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5036467&view=results
Test release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1113856