### PR TITLE
[Redesign] Fix Safari font issue

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1441,7 +1441,6 @@ img.reserved-indicator-icon {
 }
 .page-package-details-v2 .installation-instructions .instructions-displayed {
   background-color: #FAF9F8;
-  font-family: 'Segoe UI';
   font-size: 14px;
 }
 .page-package-details-v2 .installation-instructions .instructions-displayed pre {

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -174,7 +174,6 @@
 
     .instructions-displayed {
       background-color: #FAF9F8;
-      font-family: 'Segoe UI';
       font-size: 14px;
 
       pre {


### PR DESCRIPTION
Safari does not support the Segoe UI font and falls back to the next font. This does not affect Chrome, Firefox, Edge, Internet Explorer, Opera

Before 🤮
![image](https://user-images.githubusercontent.com/737941/127570196-770e12dc-25b7-4682-a127-117ffb0449a5.png)

After 💪 
![image](https://user-images.githubusercontent.com/737941/127570215-f9a072d2-e9b1-4ede-8868-c80ff2f663a0.png)


Addresses https://github.com/NuGet/NuGetGallery/issues/8722

Test build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5037774&view=results
Test release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1115031