### PR TITLE
[Redesign] Address sidebar feedback

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1494,10 +1494,6 @@ img.reserved-indicator-icon {
 .page-package-details-v2 .package-details-info .sidebar-links {
   font-size: 16px;
 }
-.page-package-details-v2 .package-details-info .links-first-section {
-  padding-bottom: 35px;
-  margin-bottom: 0px;
-}
 .page-package-details-v2 .package-details-info .title-links {
   font-size: 14px;
   font-weight: 400;

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -239,11 +239,6 @@
       font-size: 16px;
     }
 
-    .links-first-section {
-      padding-bottom: 35px;
-      margin-bottom: 0px;
-    }
-
     .title-links {
       font-size: 14px;
       font-weight: 400;

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -844,7 +844,7 @@
                     }
                 </div>
             </div>
-            
+
             <aside aria-label="Package details info" class="col-sm-3 package-details-info">
                 <div class="sidebar-section">
                     <div class="row sidebar-headers">
@@ -875,8 +875,8 @@
                 </div>
 
                 <div class="sidebar-section">
-                    <div class="sidebar-headers">About Package</div>
-                    <ul class="list-unstyled ms-Icon-ul sidebar-links links-first-section">
+                    <div class="sidebar-headers">About</div>
+                    <ul class="list-unstyled ms-Icon-ul sidebar-links">
                         <li>
                             <i class="ms-Icon ms-Icon--History" aria-hidden="true"></i>
                             Last updated <span data-datetime="@Model.LastUpdated.ToString("O")">@Model.LastUpdated.ToNuGetShortDateString()</span>
@@ -944,9 +944,7 @@
                                 </li>
                             }
                         }
-                    </ul>
-                    
-                    <ul class="list-unstyled ms-Icon-ul sidebar-links">
+
                         @if (Model.Available)
                         {
                             <li>
@@ -962,86 +960,6 @@
                                     &nbsp;(@Model.LatestSymbolsPackage.FileSize.ToUserFriendlyBytesLabel())
                                 </li>
                             }
-                        }
-
-                        @if (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
-                                <a href="@Url.ManagePackage(Model)">Manage package</a>
-                            </li>
-                        }
-                        @if (!Model.Deleted && hasSymbolsPackageAvailable && Model.CanDeleteSymbolsPackage)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
-                                <a href="@Url.DeleteSymbolsPackage(Model)" class="delete">Delete symbols</a>
-                            </li>
-                        }
-
-                        @if (Model.Available && User.IsAdministrator())
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
-                                @ViewHelpers.PostLink(
-                                    this,
-                                    formId: "reflow-package-form",
-                                    linkText: "Reflow package",
-                                    actionName: "Reflow",
-                                    controllerName: "Packages",
-                                    role: "button",
-                                    formValues: new Dictionary<string, string>
-                                    {
-                                        { "id", Model.Id },
-                                        { "version", Model.Version },
-                                    })
-                            </li>
-                        }
-
-                        @if (!Model.Deleted && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
-                                @ViewHelpers.PostLink(
-                                    this,
-                                    formId: "revalidate-package-form",
-                                    linkText: "Revalidate package",
-                                    actionName: "Revalidate",
-                                    controllerName: "Packages",
-                                    role: string.Empty,
-                                    formValues: new Dictionary<string, string>
-                                    {
-                                        { "id", Model.Id },
-                                        { "version", Model.Version },
-                                    })
-                            </li>
-
-                            if (Model.LatestSymbolsPackage != null)
-                            {
-                                <li>
-                                    <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
-                                    @ViewHelpers.PostLink(
-                                        this,
-                                        formId: "revalidate-symbols-form",
-                                        linkText: "Revalidate symbols",
-                                        actionName: "RevalidateSymbols",
-                                        controllerName: "Packages",
-                                        role: string.Empty,
-                                        formValues: new Dictionary<string, string>
-                                        {
-                                            { "id", Model.Id },
-                                            { "version", Model.Version },
-                                        })
-                                </li>
-                            }
-                        }
-
-                        @if (User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Health" aria-hidden="true"></i>
-                                <a href="@Url.ViewValidations(Model)">View validations</a>
-                            </li>
                         }
 
                         @if (Model.CanDisplayNuGetPackageExplorerLink())
@@ -1075,17 +993,7 @@
                             </li>
                         }
 
-                        @if (Model.CanReportAsOwner)
-                        {
-                            <li>
-                                <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
-                                <a href="@Url.ReportPackage(Model)" title="Contact the NuGet team for help with your package">
-                                    Contact support
-                                </a>
-                            </li>
-                        }
-
-                        else if (Model.Available)
+                        @if (!Model.CanReportAsOwner && Model.Available)
                         {
                             <li class="report-link">
                                 <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
@@ -1096,6 +1004,104 @@
                         }
                     </ul>
                 </div>
+
+                @if (Model.CanDisplayPrivateMetadata)
+                {
+                    <div class="sidebar-section">
+                        <div class="sidebar-headers">Manage</div>
+                        <ul class="list-unstyled ms-Icon-ul sidebar-links">
+                            @if (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist)
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Edit" aria-hidden="true"></i>
+                                    <a href="@Url.ManagePackage(Model)">Manage package</a>
+                                </li>
+                            }
+                            @if (!Model.Deleted && hasSymbolsPackageAvailable && Model.CanDeleteSymbolsPackage)
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Delete" aria-hidden="true"></i>
+                                    <a href="@Url.DeleteSymbolsPackage(Model)" class="delete">Delete symbols</a>
+                                </li>
+                            }
+
+                            @if (Model.Available && User.IsAdministrator())
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
+                                    @ViewHelpers.PostLink(
+                                        this,
+                                        formId: "reflow-package-form",
+                                        linkText: "Reflow package",
+                                        actionName: "Reflow",
+                                        controllerName: "Packages",
+                                        role: "button",
+                                        formValues: new Dictionary<string, string>
+                                        {
+                                            { "id", Model.Id },
+                                            { "version", Model.Version },
+                                        })
+                                </li>
+                            }
+
+                            @if (!Model.Deleted && User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
+                                    @ViewHelpers.PostLink(
+                                        this,
+                                        formId: "revalidate-package-form",
+                                        linkText: "Revalidate package",
+                                        actionName: "Revalidate",
+                                        controllerName: "Packages",
+                                        role: string.Empty,
+                                        formValues: new Dictionary<string, string>
+                                        {
+                                            { "id", Model.Id },
+                                            { "version", Model.Version },
+                                        })
+                                </li>
+
+                                if (Model.LatestSymbolsPackage != null)
+                                {
+                                    <li>
+                                        <i class="ms-Icon ms-Icon--Refresh" aria-hidden="true"></i>
+                                        @ViewHelpers.PostLink(
+                                            this,
+                                            formId: "revalidate-symbols-form",
+                                            linkText: "Revalidate symbols",
+                                            actionName: "RevalidateSymbols",
+                                            controllerName: "Packages",
+                                            role: string.Empty,
+                                            formValues: new Dictionary<string, string>
+                                            {
+                                                { "id", Model.Id },
+                                                { "version", Model.Version },
+                                            })
+                                    </li>
+                                }
+                            }
+
+                            @if (User.IsAdministrator() && Config.Current.AsynchronousPackageValidationEnabled)
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Health" aria-hidden="true"></i>
+                                    <a href="@Url.ViewValidations(Model)">View validations</a>
+                                </li>
+                            }
+
+                            @if (Model.CanReportAsOwner)
+                            {
+                                <li>
+                                    <i class="ms-Icon ms-Icon--Help" aria-hidden="true"></i>
+                                    <a href="@Url.ReportPackage(Model)" title="Contact the NuGet team for help with your package">
+                                        Contact support
+                                    </a>
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                }
 
                 <div class="sidebar-section">
                     <div class="row sidebar-headers">


### PR DESCRIPTION
I recommend reviewing without whitespace changes:

![image](https://user-images.githubusercontent.com/737941/127714824-b2607a5b-96f2-4ffa-8117-b82715071147.png)

Here is a summary of the changes:

```diff
-* "About package" section
+* "About" section
    * Last updated date
    * Project website
    * Source repository
    * License info
-  
-    <whitespace>
- 
    * Download package
    * Download symbols
+   * "Open in NuGet package explorer" link
+   * "Open in FuGet package explorer" link
+   * "Report package" link
+
+* "Manage" section
    * "Manage package" link
    * "Delete symbols" link
    * "Reflow package" link
    * "Revalidate package" link
    * "Revalidate symbols" link
    * "View validations" link
+   * "Contact support" link 
-   * "Open in NuGet package explorer" link
-   * "Open in FuGet package explorer" link
-   * "Contact support" or "Report package" link
```

<details>
<summary>Screenshot if logged out...</summary>

![image](https://user-images.githubusercontent.com/737941/127901226-fc3ba143-bc1e-461e-94be-46365bc8c64f.png)

</details>

<details>
<summary>Screenshot if logged in as owner...</summary>

![image](https://user-images.githubusercontent.com/737941/127902798-31024ee0-88b5-483a-8103-bd59b79c1bc1.png)

</details>

<details>
<summary>Screenshot if logged in as admin...</summary>

![image](https://user-images.githubusercontent.com/737941/127901155-ab113555-5a34-46f7-a9a3-fd8a3c889def.png)

</details>

Addresses https://github.com/nuget/nugetgallery/issues/8717