### PR TITLE
[Redesign] Remove extra space on README warnings

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1665,6 +1665,10 @@ img.reserved-indicator-icon {
 .page-package-details-v2 .body-tab-content #usedby-tab h6:first-child {
   margin-top: 0px;
 }
+.page-package-details-v2 .body-tab-content #readme-tab div.alert:first-child,
+.page-package-details-v2 .body-tab-content #usedby-tab div.alert:first-child {
+  margin-top: 0px;
+}
 .page-package-details-v2 .body-tab-content #dependencies-tab li:first-child h4 {
   margin-top: 0px;
 }

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -450,6 +450,10 @@
       h6:first-child {
         margin-top: 0px;
       }
+
+      div.alert:first-child {
+        margin-top: 0px;
+      }
     }
 
     #dependencies-tab {


### PR DESCRIPTION
Without warning:

![image](https://user-images.githubusercontent.com/737941/127905994-c4109fae-d461-4e88-95e4-e8659c36ea52.png)


With warning (notice there is no extra space now and it is consistent as without warning):

![image](https://user-images.githubusercontent.com/737941/127905950-577ef994-3248-4444-a9cb-97f50fc93665.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/8729