### PR TITLE
Add bulk revalidate buttons to Validation admin panel

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -45,6 +45,9 @@ body h3 {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.form-inline-empty {
+  display: inline-block;
+}
 .footer {
   background-color: #002440;
   color: #e3ebf1;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -55,6 +55,10 @@ body {
   }
 }
 
+.form-inline-empty {
+  display: inline-block;
+}
+
 .footer {
   background-color: @panel-footer-bg;
   color: @panel-footer-color;

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -653,6 +653,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
     string controllerName,
     string role,
     string area = "",
+    string classes = null,
     Dictionary<string, string> formValues = null)
 {
     using (page.Html.BeginForm(
@@ -660,7 +661,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
         controllerName,
         new { area = area },
         FormMethod.Post,
-        new { id = formId }))
+        new { id = formId, @class = classes }))
     {
         @page.Html.AntiForgeryToken();
         if (formValues != null)
@@ -682,6 +683,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
     string controllerName,
     string role,
     string area = "",
+    string classes = null,
     Dictionary<string, string> formValues = null)
 {
     @PostLink(
@@ -692,6 +694,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
         controllerName,
         role,
         area,
+        classes,
         formValues);
 }
 

--- a/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
@@ -17,7 +17,37 @@
 <section role="main" class="container main-container">
     <h2>Package Validations</h2>
 
-    <p>Get <a href="@Url.Action(actionName:"Pending")">pending validations</a>.</p>
+    <div>
+        <a href="@Url.Action(actionName:"Pending")">Get pending validations</a>
+        |
+        @ViewHelpers.PostLink(
+            this,
+            formId: "revalidate-pending-packages",
+            linkText: "Revalidate pending packages",
+            actionName: "RevalidatePending",
+            controllerName: "Validation",
+            role: string.Empty,
+            area: "Admin",
+            classes: "form-inline-empty",
+            formValues: new Dictionary<string, string>
+            {
+                { "validatingType", ValidatingType.Package.ToString() },
+            })
+        |
+        @ViewHelpers.PostLink(
+            this,
+            formId: "revalidate-pending-symbol-packages",
+            linkText: "Revalidate pending symbol packages",
+            actionName: "RevalidatePending",
+            controllerName: "Validation",
+            role: string.Empty,
+            area: "Admin",
+            classes: "form-inline-empty",
+            formValues: new Dictionary<string, string>
+            {
+                { "validatingType", ValidatingType.SymbolPackage.ToString() },
+            })
+    </div>
 
     <form method="get" action="@Url.Action(actionName: "Search")">
         <p>
@@ -195,8 +225,21 @@
                         </table>
                     }
                 </div>
-                
+
             }
         </div>
     }
 </section>
+
+@section BottomScripts {
+    <script>
+    $(document).ready(function () {
+        $('#revalidate-pending-packages, #revalidate-pending-symbol-packages').submit(function (e) {
+            var operation = $(".post-link[data-form-id='" + e.target.id + "']").text().toLowerCase();
+            if (!operation || !confirm('Are you sure you want to ' + operation + '?')) {
+                e.preventDefault();
+            }
+        });
+    });
+    </script>
+}

--- a/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
@@ -87,6 +87,7 @@
                             {
                                 { "id", package.Id },
                                 { "version", package.NormalizedVersion },
+                                { "returnUrl", Url.Current() },
                             })
                         <br />
                     }
@@ -103,6 +104,7 @@
                             {
                                 { "id", package.Id },
                                 { "version", package.NormalizedVersion },
+                                { "returnUrl", Url.Current() },
                             })
                         <br />
                     }

--- a/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
@@ -78,7 +78,7 @@
                     {
                         @ViewHelpers.PostLink(
                             this,
-                            formId: "revalidate-package-form",
+                            formId: "revalidate-package-form-" + package.PackageKey,
                             linkText: "Revalidate package",
                             actionName: "Revalidate",
                             controllerName: "Packages",
@@ -94,7 +94,7 @@
                     {
                         @ViewHelpers.PostLink(
                             this,
-                            formId: "revalidate-symbols-form",
+                            formId: "revalidate-symbols-form-" + package.PackageKey,
                             linkText: "Revalidate symbols",
                             actionName: "RevalidateSymbols",
                             controllerName: "Packages",

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1911,7 +1911,7 @@ namespace NuGetGallery
         [ValidateAntiForgeryToken]
         [UIAuthorize(Roles = "Admins")]
         [RequiresAccountConfirmation("revalidate a package")]
-        public virtual async Task<ActionResult> Revalidate(string id, string version)
+        public virtual async Task<ActionResult> Revalidate(string id, string version, string returnUrl = null)
         {
             var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
 
@@ -1933,14 +1933,21 @@ namespace NuGetGallery
                 TempData["Message"] = $"An error occurred while revalidating the package. {ex.Message}";
             }
 
-            return SafeRedirect(Url.Package(id, version));
+            if (string.IsNullOrEmpty(returnUrl))
+            {
+                return SafeRedirect(Url.Package(id, version));
+            }
+            else
+            {
+                return SafeRedirect(returnUrl);
+            }
         }
 
         [HttpPost]
         [ValidateAntiForgeryToken]
         [UIAuthorize(Roles = "Admins")]
         [RequiresAccountConfirmation("revalidate a symbols package")]
-        public virtual async Task<ActionResult> RevalidateSymbols(string id, string version)
+        public virtual async Task<ActionResult> RevalidateSymbols(string id, string version, string returnUrl = null)
         {
             var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
 
@@ -1988,7 +1995,14 @@ namespace NuGetGallery
                 TempData["Message"] = $"An error occurred while revalidating the symbols package. {ex.Message}";
             }
 
-            return SafeRedirect(Url.Package(id, version));
+            if (string.IsNullOrEmpty(returnUrl))
+            {
+                return SafeRedirect(Url.Package(id, version));
+            }
+            else
+            {
+                return SafeRedirect(returnUrl);
+            }
         }
 
         /// <summary>

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -9174,6 +9174,21 @@ namespace NuGetGallery
             }
 
             [Fact]
+            public async Task RedirectsToCustomReturnUrl()
+            {
+                // Arrange & Act
+                var result = await _target.Revalidate(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    "/Admin");
+
+                // Assert
+                var redirect = Assert.IsType<SafeRedirectResult>(result);
+                Assert.Equal("/Admin", redirect.Url);
+                Assert.Equal("/", redirect.SafeUrl);
+            }
+
+            [Fact]
             public async Task RedirectsAfterRevalidatingPackage()
             {
                 // Arrange & Act
@@ -9259,6 +9274,21 @@ namespace NuGetGallery
                 _validationService.Verify(
                     x => x.RevalidateAsync(_symbolPacakge),
                     Times.Once);
+            }
+
+            [Fact]
+            public async Task RedirectsToCustomReturnUrl()
+            {
+                // Arrange & Act
+                var result = await _target.RevalidateSymbols(
+                    _package.PackageRegistration.Id,
+                    _package.Version,
+                    "/Admin");
+
+                // Assert
+                var redirect = Assert.IsType<SafeRedirectResult>(result);
+                Assert.Equal("/Admin", redirect.Url);
+                Assert.Equal("/", redirect.SafeUrl);
             }
 
             [Theory]


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/8702.

This PR makes three changes to the Validation admin panel

1. **Polish:** Redirect back to admin panel when clicking an individual revalidate (feedback in retrospective from @loic-sharma)
1. **Bug fix:** Fix the individual revalidate link. Previously, only the first form on the page worked due to duplicate IDs 😨
1. **Feature:** Adds two links to the Validation admin panel
    - Revalidate pending packages
    - Revalidate pending symbol packages

Each link queries for all entities of the respective type that are in the `Validating` state then enqueues a validation for each entity.

Each link has a confirmation dialog to avoid accidental clicks.

![revall](https://user-images.githubusercontent.com/94054/128436976-23eeda02-8e73-420c-927b-658c12f792cf.gif)
