### PR TITLE
Add role attributes to reserved checkmarks

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -261,7 +261,7 @@
                         <img class="reserved-indicator"
                              src="~/Content/gallery/img/reserved-indicator.svg"
                              @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
-                             data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"/>
+                             data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0" role="presentation"/>
                     }
                 </h1>
 

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -50,7 +50,7 @@
                     <img class="reserved-indicator"
                          src="~/Content/gallery/img/reserved-indicator.svg"
                          @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-20x20.png"))
-                         data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0" />
+                         data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0" role="presentation"/>
                 }
 
                 @if (showEditButton && (Model.CanEdit || Model.CanManageOwners || Model.CanUnlistOrRelist))


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8743

Behavior of the checkmarks is unchanged, attributes added (which may support screen readers that we don't test). We've tested Windows Narrator and NVDA. These new attributes satisfy compliance requirements.

Note that a lot of suggested compliance changes resulted in screen readers reading text twice--adding `role="presentation"` seems to be the cleanest fix.