### PR TITLE
Improve accessibility for redesigned installation instructions

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -456,7 +456,9 @@
             {
                 <div class="installation-instructions">
                     <div>
-                        <select name="installation-instructions" class="installation-instructions-dropdown">
+                        <select name="installation-instructions"
+                                class="installation-instructions-dropdown"
+                                aria-label="Select a package manager">
                             @foreach (var packageManager in packageManagers)
                             {
                                 <option value="@packageManager.Id">@packageManager.Name</option>


### PR DESCRIPTION
Adds a missing ARIA label to pass Accessibility Insight's FastPass:

![image](https://user-images.githubusercontent.com/737941/130669600-691e2013-dae7-4061-9a7e-185ed41aad27.png)

I'm not sure why FastPass didn't report this before ¯\_(ツ)_/¯

Addresses https://github.com/nuget/nugetgallery/issues/8737