### PR TITLE
[A11y] Improve copy button accessibility

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
@@ -134,20 +134,22 @@
 
     // Configure package manager copy button
     var copyButton = $('.installation-instructions button');
-    copyButton.popover({ trigger: 'manual' });
+    copyButton.popover({
+        trigger: 'manual',
+        // Windows Narrator does not announce popovers' content. See: https://github.com/twbs/bootstrap/issues/18618
+        // We can force Narrator to announce the content by changing
+        // the popover's role from 'tooltip' to 'status'.
+        // Modified from: https://github.com/twbs/bootstrap/blob/f17f882df292b29323f1e1da515bd16f326cee4a/js/popover.js#L28
+        template: '<div class="popover" role="status"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>'
+    });
 
     copyButton.click(function () {
         var text = $('#' + currentPackageManagerId + '-text').text().trim();
         window.nuget.copyTextToClipboard(text, copyButton);
         copyButton.popover('show');
-        //This is workaround for Narrator announce the status changes of copy button to achieve accessibility.
-        copyButton.attr('aria-pressed', 'true');
         setTimeout(function () {
             copyButton.popover('destroy');
         }, 1000);
-        setTimeout(function () {
-            copyButton.attr('aria-pressed', 'false');
-        }, 1500);
         window.nuget.sendMetric("CopyInstallCommand", 1, {
             ButtonId: currentPackageManagerId,
             PackageId: packageId,

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -90,20 +90,22 @@ $(function () {
     // Configure package manager copy buttons
     function configureCopyButton(id) {
         var copyButton = $('#' + id + '-button');
-        copyButton.popover({ trigger: 'manual' });
+        copyButton.popover({
+            trigger: 'manual',
+            // Windows Narrator does not announce popovers' content. See: https://github.com/twbs/bootstrap/issues/18618
+            // We can force Narrator to announce the content by changing
+            // the popover's role from 'tooltip' to 'status'.
+            // Modified from: https://github.com/twbs/bootstrap/blob/f17f882df292b29323f1e1da515bd16f326cee4a/js/popover.js#L28
+            template: '<div class="popover" role="status"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>'
+        });
 
         copyButton.click(function () {
             var text = $('#' + id + '-text').text().trim();
             window.nuget.copyTextToClipboard(text, copyButton);
             copyButton.popover('show');
-            //This is workaround for Narrator announce the status changes of copy button to achieve accessibility.
-            copyButton.attr('aria-pressed', 'true');
             setTimeout(function () {
                 copyButton.popover('destroy');
             }, 1000);
-            setTimeout(function () {
-                copyButton.attr('aria-pressed', 'false');
-            }, 1500);  
             window.nuget.sendMetric("CopyInstallCommand", 1, {
                 ButtonId: id,
                 PackageId: packageId,

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -193,14 +193,9 @@
                 @* Writing out the install command must be on a single line to avoid undesired whitespace in the <pre> tag. *@
                 <pre class="install-script" id="@packageManager.Id-text">@foreach (var c in cs) {<span class="install-command-row">@c</span>}</pre>
                 <div class="copy-button">
-                    <!--In order to statisfy the requirement to announce button status both on NVDA/Narrator, other screen reader like NVDA will
-                        announce the data-content "Copied" everytime when we press button, however, it won't work with Narrator when we use bootstrap popover 
-                        because of known issue(https://github.com/twbs/bootstrap/issues/18618).
-                        We add aria-pressed to indicate the whether button is pressed or not, which is workaround only for Narrator announce the status change of button
-                    -->
                     <button id="@packageManager.Id-button" class="btn btn-default btn-warning" type="button"
                             data-toggle="popover" data-placement="bottom" data-content="Copied."
-                            aria-label="@packageManager.CopyLabel" aria-pressed="false" aria-live="polite" role="button">
+                            aria-label="@packageManager.CopyLabel" aria-live="polite" role="button">
                         <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
                     </button>
                 </div>

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -465,14 +465,9 @@
                             }
                         </select>
 
-                        <!--In order to statisfy the requirement to announce button status both on NVDA/Narrator, other screen reader like NVDA will
-                            announce the data-content "Copied" everytime when we press button, however, it won't work with Narrator when we use bootstrap popover
-                            because of known issue (https://github.com/twbs/bootstrap/issues/18618).
-                            We add aria-pressed to indicate the whether button is pressed or not, which is workaround only for Narrator announce the status change of button
-                        -->
                         <button class="btn btn-blue" type="button"
                                 data-toggle="popover" data-placement="bottom" data-content="Copied."
-                                aria-label="CopyLabel" aria-pressed="false" aria-live="polite" role="button">
+                                aria-label="CopyLabel" aria-live="polite" role="button">
                             <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
                         </button>
                     </div>


### PR DESCRIPTION
# Background
The Bootstrap 3 popover does not work well with Windows Narrator. Previously, we worked around this by "flashing" the button's pressed state (we set the button's `aria-pressed` to `true`, wait 1.5 seconds, then set it back to `false`). Now, we work around this by giving the popover a role of `status`, which causes Windows Narrator to read the content (Narrator refuses to announce labels with the `tooltip` role).

Addresses: https://github.com/NuGet/NuGetGallery/issues/8607
Addresses: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1061326

# Testing

This change passes Accessibility Insights FastPass:

![image](https://user-images.githubusercontent.com/737941/130879512-f3c2f832-6656-4ac5-af1b-276a1b87c4f2.png)

## Windows Narrator

Here is what Windows Narrator announces when you tab to the copy button:
* Before: `Table, Copy the package manager command, button, off`
* After: `Table, Copy the package manager command, button`

Here is what Windows Narrator announces when you press the copy button:
* Before: `Copy the package command, button, Copy the package command, button, on`
* After: `Copied, end of line`

## NVDA

Here is what NVDA announces when you tab to the copy button:
* Before: `Copy the package manager command, toggle, button, not pressed`
* After: `Copy the package manager command, button`

Here is what NVDA announces when you press the copy button:
* Before: `Copied, copied, pressed, not pressed` 
* After: `Copied, copied`
