### PR TITLE
[Redesign] Add icons to tabs

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1481,8 +1481,12 @@ img.reserved-indicator-icon {
 .page-package-details-v2 .package-details-info .ms-Icon-ul li {
   margin-bottom: 18px;
 }
+.page-package-details-v2 .package-details-info .ms-Icon-ul .ms-Icon {
+  top: 1px;
+}
 .page-package-details-v2 .package-details-info .ms-Icon-ul img.icon {
   position: absolute;
+  top: 1px;
   left: -24px;
   width: 16px;
   height: 16px;
@@ -1650,6 +1654,10 @@ img.reserved-indicator-icon {
   font-size: 14px;
   font-family: 'Segoe UI', "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #323130;
+}
+.page-package-details-v2 .body-tabs .nav-tabs > li > a .ms-Icon {
+  position: relative;
+  top: 2px;
 }
 .page-package-details-v2 .body-tab-content {
   padding-top: 30px;

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -219,8 +219,13 @@
         margin-bottom: 18px;
       }
 
+      .ms-Icon {
+        top: 1px;
+      }
+
       img.icon {
         position: absolute;
+        top: 1px;
         left: -24px;
         width: 16px;
         height: 16px;
@@ -432,6 +437,11 @@
       font-size: 14px;
       font-family: @font-family-base;
       color: #323130;
+
+      .ms-Icon {
+        position: relative;
+        top: 2px;
+      }
     }
   }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -487,28 +487,43 @@
                 @if (!Model.Deleted)
                 {
                     <li role="presentation" class="active" id="show-readme-container">
-                        <a href="#readme-tab" aria-controls="readme-tab" role="tab" data-toggle="tab" id="readme-body-tab" class="body-tab">README</a>
+                        <a href="#readme-tab" aria-controls="readme-tab" role="tab" data-toggle="tab" id="readme-body-tab" class="body-tab">
+                            <i class="ms-Icon ms-Icon--Dictionary" aria-hidden="true"></i>
+                            README
+                        </a>
                     </li>
                     <li role="presentation">
-                        <a href="#dependencies-tab" aria-controls="dependencies-tab" role="tab" data-toggle="tab" id="dependencies-body-tab" class="body-tab">Dependencies</a>
+                        <a href="#dependencies-tab" aria-controls="dependencies-tab" role="tab" data-toggle="tab" id="dependencies-body-tab" class="body-tab">
+                            <i class="ms-Icon ms-Icon--Packages" aria-hidden="true"></i>
+                            Dependencies
+                        </a>
                     </li>
                 }
 
                 @if (!Model.IsDotnetToolPackageType && (Model.IsGitHubUsageEnabled || Model.IsPackageDependentsEnabled))
                 {
                     <li role="presentation">
-                        <a href="#usedby-tab" aria-controls="usedby-tab" role="tab" data-toggle="tab" id="usedby-body-tab" class="body-tab">Used By</a>
+                        <a href="#usedby-tab" aria-controls="usedby-tab" role="tab" data-toggle="tab" id="usedby-body-tab" class="body-tab">
+                            <i class="ms-Icon ms-Icon--BranchFork2" aria-hidden="true"></i>
+                            Used By
+                        </a>
                     </li>
                 }
 
                 <li role="presentation">
-                    <a href="#versions-tab" aria-controls="versions-tab" role="tab" data-toggle="tab" id="versions-body-tab" class="body-tab">Versions</a>
+                    <a href="#versions-tab" aria-controls="versions-tab" role="tab" data-toggle="tab" id="versions-body-tab" class="body-tab">
+                        <i class="ms-Icon ms-Icon--Stopwatch" aria-hidden="true"></i>
+                        Versions
+                    </a>
                 </li>
 
                 @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
                 {
                     <li role="presentation">
-                        <a href="#releasenotes-tab" aria-controls="releasenotes-tab" role="tab" data-toggle="tab" id="release-body-tab" class="body-tab">Release Notes</a>
+                        <a href="#releasenotes-tab" aria-controls="releasenotes-tab" role="tab" data-toggle="tab" id="release-body-tab" class="body-tab">
+                            <i class="ms-Icon ms-Icon--ReadingMode" aria-hidden="true"></i>
+                            Release Notes
+                        </a>
                     </li>
                 }
             </ul>


### PR DESCRIPTION
Add icons to tabs:

![image](https://user-images.githubusercontent.com/737941/131037102-8d286582-9244-4db9-88d8-0574f26a27a8.png)

This change also vertically centers the redesign's sidebar link icons:

![image](https://user-images.githubusercontent.com/737941/131037215-485250e9-f790-46c2-bd4c-27feddca0df0.png)

Here's what the overall page looks like:

![image](https://user-images.githubusercontent.com/737941/131037155-931f93c6-7db6-4b8b-9509-2409596c1de9.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/8761