### PR TITLE
Expand deprecations by default on display package page

### DIFF
--- a/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageDeprecation.cshtml
@@ -35,12 +35,12 @@
                 </div>
 
                 <div class="deprecation-expander-container">
-                    <i id="deprecation-expander-icon-right" class="deprecation-expander-icon deprecation-expander-info-right ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                    <i id="deprecation-expander-icon-right" class="deprecation-expander-icon deprecation-expander-info-right ms-Icon ms-Icon--ChevronUp" aria-hidden="true"></i>
                 </div>
             </div>
         </div>
 
-        <div class="deprecation-content-container collapse" id="deprecation-content-container">
+        <div class="deprecation-content-container collapse in" id="deprecation-content-container">
             @if (!string.IsNullOrEmpty(Model.AlternatePackageId))
             {
                 string alternateUrl;


### PR DESCRIPTION
Originally implemented by @fowl2, this adds some more fixes. Screenshot:

![image](https://user-images.githubusercontent.com/737941/131045730-03e42f0d-bc09-48bc-bb0d-58e0165f8233.png)

This affects both old and new designs of the display package page.

Addresses https://github.com/NuGet/NuGetGallery/issues/8618

Replaces: https://github.com/NuGet/NuGetGallery/pull/8619