### PR TITLE
Fixing the vulnerability order inside the dictionary cache

### DIFF
--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -206,7 +206,7 @@ namespace NuGetGallery
                 && packageKeyToVulnerabilities.TryGetValue(package.Key, out var vulnerabilities)
                 && vulnerabilities != null && vulnerabilities.Any())
             {
-                viewModel.Vulnerabilities = vulnerabilities;
+                viewModel.Vulnerabilities = vulnerabilities.OrderByDescending(vul => vul.Severity).ToList().AsReadOnly();
                 maxVulnerabilitySeverity = viewModel.Vulnerabilities.Max(v => v.Severity); // cache for messaging
                 viewModel.MaxVulnerabilitySeverity = maxVulnerabilitySeverity.Value;
             }

--- a/src/NuGetGallery/Services/PackageVulnerabilitiesCacheService.cs
+++ b/src/NuGetGallery/Services/PackageVulnerabilitiesCacheService.cs
@@ -86,7 +86,7 @@ namespace NuGetGallery
                                     ikv.GroupBy(kv => kv.PackageKey, kv => kv.Vulnerability)
                                         // - build the inner dictionaries, all under the same <id>, each keyed by <package key>
                                         .ToDictionary(kv => kv.Key,
-                                            kv => kv.ToList().AsReadOnly() as IReadOnlyList<PackageVulnerability>));
+                                            kv => kv.OrderByDescending(x => x.Severity).ToList().AsReadOnly() as IReadOnlyList<PackageVulnerability>));
                     }
 
                     stopwatch.Stop();

--- a/src/NuGetGallery/Services/PackageVulnerabilitiesCacheService.cs
+++ b/src/NuGetGallery/Services/PackageVulnerabilitiesCacheService.cs
@@ -86,7 +86,7 @@ namespace NuGetGallery
                                     ikv.GroupBy(kv => kv.PackageKey, kv => kv.Vulnerability)
                                         // - build the inner dictionaries, all under the same <id>, each keyed by <package key>
                                         .ToDictionary(kv => kv.Key,
-                                            kv => kv.OrderByDescending(x => x.Severity).ToList().AsReadOnly() as IReadOnlyList<PackageVulnerability>));
+                                            kv => kv.ToList().AsReadOnly() as IReadOnlyList<PackageVulnerability>));
                     }
 
                     stopwatch.Stop();

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -924,6 +924,36 @@ namespace NuGetGallery.ViewModels
             Assert.Null(versionModel.CustomMessage);
         }
 
+        [Fact]
+        public void VulnerabilitiesDisplayedInOrder()
+        {
+            var package = CreateTestPackage("1.0.0");
+
+            var packageKeyToVulnerabilities = new Dictionary<int, IReadOnlyList<PackageVulnerability>>
+            {
+                { package.Key, new List<PackageVulnerability>
+                    {
+                        new PackageVulnerability { Key = 1, Severity = PackageVulnerabilitySeverity.High },
+                        new PackageVulnerability { Key = 2, Severity = PackageVulnerabilitySeverity.Low },
+                        new PackageVulnerability { Key = 3, Severity = PackageVulnerabilitySeverity.Critical },
+                    }
+                }
+            };
+
+            // Act
+            var model = CreateDisplayPackageViewModel(
+                package,
+                currentUser: null,
+                packageKeyToVulnerabilities: packageKeyToVulnerabilities,
+                readmeHtml: null);
+
+            // Assert
+            var versionModel = model.PackageVersions.Single();
+            Assert.Null(versionModel.CustomMessage);
+            Assert.NotNull(model.Vulnerabilities);
+            Assert.Equal(model.Vulnerabilities, packageKeyToVulnerabilities[package.Key].OrderByDescending(p => p.Severity).ToList().AsReadOnly());
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -951,7 +951,9 @@ namespace NuGetGallery.ViewModels
             var versionModel = model.PackageVersions.Single();
             Assert.Null(versionModel.CustomMessage);
             Assert.NotNull(model.Vulnerabilities);
-            Assert.Equal(model.Vulnerabilities, packageKeyToVulnerabilities[package.Key].OrderByDescending(p => p.Severity).ToList().AsReadOnly());
+            Assert.Equal(PackageVulnerabilitySeverity.Critical, model.Vulnerabilities.ElementAt(0).Severity);
+            Assert.Equal(PackageVulnerabilitySeverity.High, model.Vulnerabilities.ElementAt(1).Severity);
+            Assert.Equal(PackageVulnerabilitySeverity.Low, model.Vulnerabilities.ElementAt(2).Severity);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #8703
I'm not sure how much this will impact the performance. Do we have an environment to do any kind of performance test?

I've tried to put the order inside the query but without success.
Accept any tips on this ❤