### PR TITLE
[Hotfix] Update test to use Newtonsoft.Json instead of jQuery.

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedTests.cs
@@ -52,13 +52,13 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         }
 
         [Fact]
-        [Description("Verify the webresponse from top30 packages feed contains jQuery")]
+        [Description("Verify the webresponse from top30 packages feed contains Newtonsoft.Json")]
         [Priority(0)]
         [Category("P0Tests")]
         public async Task Top30PackagesFeedTest()
         {
             string url = UrlHelper.V2FeedRootUrl + @"/Search()?$filter=IsAbsoluteLatestVersion&$orderby=DownloadCount%20desc,Id&$skip=0&$top=30&searchTerm=''&targetFramework='net45'&includePrerelease=true";
-            bool containsResponseText = await _odataHelper.ContainsResponseText(url, "jQuery");
+            bool containsResponseText = await _odataHelper.ContainsResponseText(url, "Newtonsoft.Json");
             Assert.True(containsResponseText);
         }
 


### PR DESCRIPTION
Currently gallery releases are blocked by this issue, just changed jQuery for Newtonsoft.Json when searching for a package that is part of the top30.