### PR TITLE
update maxMdLengthByte to be consistent with validation 

### DIFF
--- a/src/NuGetGallery/Services/ReadMeService.cs
+++ b/src/NuGetGallery/Services/ReadMeService.cs
@@ -21,7 +21,7 @@ namespace NuGetGallery
         internal const string TypeFile = "File";
         internal const string TypeWritten = "Written";
 
-        internal const int MaxMdLengthBytes = 8000;
+        internal const int MaxMdLengthBytes = 1024 * 1024;
         private const string UrlHostRequirement = "raw.githubusercontent.com";
 
         private static readonly TimeSpan UrlTimeout = TimeSpan.FromSeconds(10);

--- a/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ODataFeeds/V2FeedTests.cs
@@ -52,13 +52,13 @@ namespace NuGetGallery.FunctionalTests.ODataFeeds
         }
 
         [Fact]
-        [Description("Verify the webresponse from top30 packages feed contains jQuery")]
+        [Description("Verify the webresponse from top30 packages feed contains Newtonsoft.Json")]
         [Priority(0)]
         [Category("P0Tests")]
         public async Task Top30PackagesFeedTest()
         {
             string url = UrlHelper.V2FeedRootUrl + @"/Search()?$filter=IsAbsoluteLatestVersion&$orderby=DownloadCount%20desc,Id&$skip=0&$top=30&searchTerm=''&targetFramework='net45'&includePrerelease=true";
-            bool containsResponseText = await _odataHelper.ContainsResponseText(url, "jQuery");
+            bool containsResponseText = await _odataHelper.ContainsResponseText(url, "Newtonsoft.Json");
             Assert.True(containsResponseText);
         }
 

--- a/tests/NuGetGallery.LoadTests/LoadTests.cs
+++ b/tests/NuGetGallery.LoadTests/LoadTests.cs
@@ -128,13 +128,13 @@ namespace NuGetGallery.LoadTests
         }
 
         [TestMethod]
-        [Description("Verify the webresponse from top30 packages feed contains jQuery")]
+        [Description("Verify the webresponse from top30 packages feed contains Newtonsoft.Json")]
         [TestCategory("P0Tests")]
         public async Task Top30PackagesFeedTest()
         {
             string url = UrlHelper.V2FeedRootUrl + @"/Search()?$filter=IsAbsoluteLatestVersion&$orderby=DownloadCount%20desc,Id&$skip=0&$top=30&searchTerm=''&targetFramework='net45'&includePrerelease=true";
             var odataHelper = new ODataHelper();
-            bool containsResponseText = await odataHelper.ContainsResponseText(url, "jQuery");
+            bool containsResponseText = await odataHelper.ContainsResponseText(url, "Newtonsoft.Json");
             Assert.IsTrue(containsResponseText);
         }
 


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Issue: inconsistent max readme file size between validation during upload and preview readme at manage package page

validation readme max size:
https://github.com/NuGet/NuGetGallery/blob/c71e12429b108c4d87e2da41790b164149a43389/src/NuGetGallery/Services/PackageMetadataValidationService.cs#L61
Preview at manage package: 
https://github.com/NuGet/NuGetGallery/blob/db62de43e24b704e9ab16d8abc39bdfa3e73260b/src/NuGetGallery/Services/ReadMeService.cs#L24

Fix: Make maxmdreadme length to be consistent while uploading and preview

Before:
![reamdbug](https://user-images.githubusercontent.com/64443925/132561568-d7e57f0e-0a20-49a8-9003-738985b82366.PNG)


After: 
![bugafter](https://user-images.githubusercontent.com/64443925/132561611-30b9d2cd-0d3b-42cf-b29e-6d2c99977120.PNG)


Addresses https://github.com/NuGet/NuGetGallery/issues/8771