### PR TITLE
[A11y] Label the maintainers link

### DIFF
--- a/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
@@ -19,7 +19,8 @@ namespace NuGetGallery
         {
             ContactUrl = contactUrl;
             AlertLevel = AlertLevel.Warning;
-            AlertMessage = string.Format("The NuGet Team does not provide support for this client. Please contact its <a href=\"{0}\">maintainers</a> for support.", contactUrl);
+            AlertMessage = "The NuGet Team does not provide support for this client. Please contact its "
+                + $"<a href=\"{contactUrl}\" aria-label=\"Contact the maintainers of the {name} client\">maintainers</a> for support.";
         }
     }
 }


### PR DESCRIPTION
Screen reader will now announce `Contact the maintainers of the X client` after focusing the maintainers link:

![image](https://user-images.githubusercontent.com/737941/132577521-a05445e0-5ecd-41a8-914c-f984098e01a7.png)

Part of https://github.com/NuGet/NuGetGallery/issues/8790