### PR TITLE
[A11y] Prevent hidden text when increasing text spacing

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1527,24 +1527,13 @@ img.reserved-indicator-icon {
   font-size: 14px;
   color: #333333;
   margin: 4px 0 0 0;
-  width: auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
   line-height: 16px;
-  /* fallback */
-  max-height: 32px;
-  /* fallback */
-  -webkit-line-clamp: 2;
-  /* number of lines to show */
-  -webkit-box-orient: vertical;
 }
 .page-package-details-v2 .used-by-link {
   font-family: 'Segoe UI', "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 19px;
   color: #337ab7;
-  width: auto;
 }
 .page-package-details-v2 .gh-link,
 .page-package-details-v2 .ngp-link {

--- a/src/Bootstrap/less/theme/page-display-package-v2.less
+++ b/src/Bootstrap/less/theme/page-display-package-v2.less
@@ -274,17 +274,7 @@
     font-size: 14px;
     color: #333333;
     margin: 4px 0 0 0;
-    width: auto;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
     line-height: 16px;
-    /* fallback */
-    max-height: 32px;
-    /* fallback */
-    -webkit-line-clamp: 2;
-    /* number of lines to show */
-    -webkit-box-orient: vertical;
   }
 
   .used-by-link {
@@ -292,7 +282,6 @@
     font-size: 16px;
     line-height: 19px;
     color: @brand-primary;
-    width: auto;
   }
 
   .gh-link, .ngp-link {

--- a/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
@@ -119,7 +119,7 @@
         if (usedByClamped) return;
         if (!usedByTab.hasClass('active')) return;
 
-        for (let usedByDescription of $('.used-by-desc').get()) {
+        for (var usedByDescription of $('.used-by-desc').get()) {
             $clamp(usedByDescription, { clamp: 2, useNativeClamp: false });
         }
 

--- a/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
@@ -110,6 +110,24 @@
         }
     }
 
+    var usedByClamped = false;
+    var usedByTab = $('#usedby-tab');
+
+    function clampUsedByDescriptions() {
+        // Clamp long descriptions in the "used by" tab. Ensure this runs only once,
+        // otherwise clamp.js removes too much content.
+        if (usedByClamped) return;
+        if (!usedByTab.hasClass('active')) return;
+
+        for (let usedByDescription of $('.used-by-desc').get()) {
+            $clamp(usedByDescription, { clamp: 2, useNativeClamp: false });
+        }
+
+        usedByClamped = true;
+    }
+
+    clampUsedByDescriptions();
+
     // Make sure we save the user's preferred body tab to localStorage.
     $('.package-manager-tab').on('shown.bs.tab', function (e) {
         if (storage) {
@@ -128,17 +146,14 @@
             storage.setItem(bodyStorageKey, e.target.id);
         }
 
+        clampUsedByDescriptions();
+
         window.nuget.sendMetric("ShowDisplayPackageTab", 1, {
             TabId: e.target.id,
             PackageId: packageId,
             PackageVersion: packageVersion
         });
     });
-
-    // Clamp long descriptions in the "used by" tab
-    for (let usedByDescription of $('.used-by-desc').get()) {
-        $clamp(usedByDescription, { clamp: 2, useNativeClamp: false });
-    }
 
     if (window.nuget.isGaAvailable()) {
         // Emit a Google Analytics event when the user clicks on a repo link in the GitHub Repos area of the Used By section.

--- a/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
@@ -135,6 +135,12 @@
         });
     });
 
+    // Clamp long descriptions in the "used by" tab
+    for (let usedByDescription of $('.used-by-desc').get()) {
+        $clamp(usedByDescription, { clamp: 2, useNativeClamp: false });
+    }
+
+
     if (window.nuget.isGaAvailable()) {
         // Emit a Google Analytics event when the user clicks on a repo link in the GitHub Repos area of the Used By section.
         $(".gh-link").on('click', function (elem) {

--- a/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
@@ -140,7 +140,6 @@
         $clamp(usedByDescription, { clamp: 2, useNativeClamp: false });
     }
 
-
     if (window.nuget.isGaAvailable()) {
         // Emit a Google Analytics event when the user clicks on a repo link in the GitHub Repos area of the Used By section.
         $(".gh-link").on('click', function (elem) {

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -672,13 +672,11 @@
                                                         @if (item.IsVerified)
                                                         {
                                                             <img class="reserved-indicator"
-                                                                    src="~/Content/gallery/img/reserved-indicator.svg"
-                                                                    @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-14x14.png"))
-                                                                    title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                                                                 src="~/Content/gallery/img/reserved-indicator.svg"
+                                                                 @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-14x14.png"))
+                                                                 title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
                                                         }
-                                                        <div class="row used-by-desc">
-                                                            <span>@(item.Description)</span>
-                                                        </div>
+                                                        <p class="used-by-desc">@item.Description</p>
                                                     </td>
                                                     <td>
                                                         <i class="ms-Icon ms-Icon--Download used-by-download-icon" aria-hidden="true"></i> <label class="used-by-count">@(item.DownloadCount.ToKiloFormat())</label>


### PR DESCRIPTION
Content in the Used By section gets incorrectly hidden when increasing the spacing in text:

<details>
<summary>Screenshot of bug...</summary>

![image](https://user-images.githubusercontent.com/737941/132586012-48a799fe-892e-4e17-be5b-d92992d7568a.png)

</details>

This fixes the accessibility bug by using `clamp.js` to clamp text. Note that this bug affects both the old and new designs, however, this fix only targets the redesign.

<details>
<summary>Screenshot of fix with increased spacing disabled...</summary>

Notice there are no visible changes from the current design:

![image](https://user-images.githubusercontent.com/737941/132585603-4a21b504-ad37-4179-b363-68797d1c40b4.png)

</details>

<details>
<summary>Screenshot of fix with increased spacing enabled...</summary>

Notice how all text is properly visible:

![image](https://user-images.githubusercontent.com/737941/132585768-03029f9a-22e7-4a2e-b83a-e4d827a06264.png)

</details>

See WCAG 2.1 requirement: https://www.w3.org/TR/WCAG21/#text-spacing

Part of https://github.com/NuGet/NuGetGallery/issues/8790