### PR TITLE
Update maxMdLengthByte to be consistent with validation 

### DIFF
--- a/src/NuGetGallery/Extensions/NumberExtensions.cs
+++ b/src/NuGetGallery/Extensions/NumberExtensions.cs
@@ -70,6 +70,40 @@ namespace NuGetGallery
         }
 
         /// <summary>
+        /// Format the number of bytes into a user-friendly display label.
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        public static string ToUserFriendlyBytesLabel(this int bytes)
+        {
+            if (bytes < 0)
+            {
+                throw new ArgumentOutOfRangeException("Negative values are not supported.", nameof(bytes));
+            }
+
+            if (bytes == 1)
+            {
+                return "1 byte";
+            }
+
+            const int scale = 1024;
+            string[] orders = { "GB", "MB", "KB", "bytes" };
+            var max = (long)Math.Pow(scale, orders.Length - 1);
+
+            foreach (var order in orders)
+            {
+                if (bytes >= max)
+                {
+                    return string.Format(CultureInfo.InvariantCulture, "{0:##.##} {1}", decimal.Divide(bytes, max), order);
+                }
+
+                max /= scale;
+            }
+
+            return "0 bytes";
+        }
+
+        /// <summary>
         /// Format the number to a 1 decimal precision plus a letter to represent the scale (K for kilo, M for mega, or B for billion)
         /// </summary>
         /// <param name="number">The number to format</param>

--- a/src/NuGetGallery/Extensions/NumberExtensions.cs
+++ b/src/NuGetGallery/Extensions/NumberExtensions.cs
@@ -75,33 +75,7 @@ namespace NuGetGallery
         /// <param name="bytes"></param>
         /// <returns></returns>
         public static string ToUserFriendlyBytesLabel(this int bytes)
-        {
-            if (bytes < 0)
-            {
-                throw new ArgumentOutOfRangeException("Negative values are not supported.", nameof(bytes));
-            }
-
-            if (bytes == 1)
-            {
-                return "1 byte";
-            }
-
-            const int scale = 1024;
-            string[] orders = { "GB", "MB", "KB", "bytes" };
-            var max = (long)Math.Pow(scale, orders.Length - 1);
-
-            foreach (var order in orders)
-            {
-                if (bytes >= max)
-                {
-                    return string.Format(CultureInfo.InvariantCulture, "{0:##.##} {1}", decimal.Divide(bytes, max), order);
-                }
-
-                max /= scale;
-            }
-
-            return "0 bytes";
-        }
+            => ToUserFriendlyBytesLabel((long)bytes);
 
         /// <summary>
         /// Format the number to a 1 decimal precision plus a letter to represent the scale (K for kilo, M for mega, or B for billion)

--- a/src/NuGetGallery/GalleryConstants.cs
+++ b/src/NuGetGallery/GalleryConstants.cs
@@ -27,6 +27,7 @@ namespace NuGetGallery
         public const int GravatarCacheDurationSeconds = 300;
 
         public const int MaxEmailSubjectLength = 255;
+        public const int MaxFileLengthBytes = 1024 * 1024; // 1MB for License, Icon, readme file
         internal static readonly NuGetVersion MaxSupportedMinClientVersion = new NuGetVersion("5.9.0.0");
         public const string PackageFileDownloadUriTemplate = "packages/{0}/{1}/download";
 

--- a/src/NuGetGallery/Services/PackageMetadataValidationService.cs
+++ b/src/NuGetGallery/Services/PackageMetadataValidationService.cs
@@ -304,7 +304,7 @@ namespace NuGetGallery
                         string.Format(
                             Strings.UploadPackage_FileTooLong,
                             Strings.UploadPackage_LicenseFileType,
-                            MaxAllowedLicenseLengthForUploading));
+                            MaxAllowedLicenseLengthForUploading.ToUserFriendlyBytesLabel()));
                 }
 
                 if (!await IsStreamLengthMatchesReportedAsync(nuGetPackage, licenseFilename, licenseFileEntry.Length))
@@ -396,7 +396,7 @@ namespace NuGetGallery
                     string.Format(
                         Strings.UploadPackage_FileTooLong,
                         Strings.UploadPackage_IconFileType,
-                        MaxAllowedLicenseLengthForUploading));
+                        MaxAllowedLicenseLengthForUploading.ToUserFriendlyBytesLabel()));
             }
 
             if (!await IsStreamLengthMatchesReportedAsync(nuGetPackage, iconFilePath, iconFileEntry.Length))
@@ -474,7 +474,7 @@ namespace NuGetGallery
                     string.Format(
                         Strings.UploadPackage_FileTooLong,
                         Strings.UploadPackage_ReadmeFileType,
-                        MaxAllowedReadmeLengthForUploading));
+                        MaxAllowedReadmeLengthForUploading.ToUserFriendlyBytesLabel()));
             }
 
             if (!await IsStreamLengthMatchesReportedAsync(nuGetPackage, readmeFilePath, readmeFileEntry.Length))

--- a/src/NuGetGallery/Services/PackageMetadataValidationService.cs
+++ b/src/NuGetGallery/Services/PackageMetadataValidationService.cs
@@ -54,11 +54,11 @@ namespace NuGetGallery
         /// in plain text and small enough to not cause issues with scanning through such file a few times
         /// during the package validation.
         /// </remarks>
-        private const long MaxAllowedLicenseLengthForUploading = 1024 * 1024; // 1 MB
-        private const long MaxAllowedIconLengthForUploading = 1024 * 1024; // 1 MB
+        private const int MaxAllowedLicenseLengthForUploading = GalleryConstants.MaxFileLengthBytes;
+        private const int MaxAllowedIconLengthForUploading = GalleryConstants.MaxFileLengthBytes;
         private const int MaxAllowedLicenseNodeValueLength = 500;
         // 1 MB Keep consistent with icon, license for now, change value later once we define the size
-        private const long MaxAllowedReadmeLengthForUploading = 1024 * 1024;
+        private const int MaxAllowedReadmeLengthForUploading = GalleryConstants.MaxFileLengthBytes;
         private const string LicenseNodeName = "license";
         private const string IconNodeName = "icon";
         private const string AllowedLicenseVersion = "1.0.0";
@@ -304,7 +304,7 @@ namespace NuGetGallery
                         string.Format(
                             Strings.UploadPackage_FileTooLong,
                             Strings.UploadPackage_LicenseFileType,
-                            MaxAllowedLicenseLengthForUploading.ToUserFriendlyBytesLabel()));
+                            MaxAllowedLicenseLengthForUploading));
                 }
 
                 if (!await IsStreamLengthMatchesReportedAsync(nuGetPackage, licenseFilename, licenseFileEntry.Length))
@@ -396,7 +396,7 @@ namespace NuGetGallery
                     string.Format(
                         Strings.UploadPackage_FileTooLong,
                         Strings.UploadPackage_IconFileType,
-                        MaxAllowedLicenseLengthForUploading.ToUserFriendlyBytesLabel()));
+                        MaxAllowedLicenseLengthForUploading));
             }
 
             if (!await IsStreamLengthMatchesReportedAsync(nuGetPackage, iconFilePath, iconFileEntry.Length))
@@ -474,7 +474,7 @@ namespace NuGetGallery
                     string.Format(
                         Strings.UploadPackage_FileTooLong,
                         Strings.UploadPackage_ReadmeFileType,
-                        MaxAllowedReadmeLengthForUploading.ToUserFriendlyBytesLabel()));
+                        MaxAllowedReadmeLengthForUploading));
             }
 
             if (!await IsStreamLengthMatchesReportedAsync(nuGetPackage, readmeFilePath, readmeFileEntry.Length))

--- a/src/NuGetGallery/Services/ReadMeService.cs
+++ b/src/NuGetGallery/Services/ReadMeService.cs
@@ -21,7 +21,7 @@ namespace NuGetGallery
         internal const string TypeFile = "File";
         internal const string TypeWritten = "Written";
 
-        internal const int MaxMdLengthBytes = 8000;
+        internal const int MaxAllowedReadmeLength = GalleryConstants.MaxFileLengthBytes;
         private const string UrlHostRequirement = "raw.githubusercontent.com";
 
         private static readonly TimeSpan UrlTimeout = TimeSpan.FromSeconds(10);
@@ -235,10 +235,10 @@ namespace NuGetGallery
 
             if (TypeWritten.Equals(readMeType, StringComparison.InvariantCultureIgnoreCase))
             {
-                if (encoding.GetByteCount(readMeRequest.SourceText) > MaxMdLengthBytes)
+                if (encoding.GetByteCount(readMeRequest.SourceText) > MaxAllowedReadmeLength)
                 {
                     throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
-                        Strings.ReadMeMaxLengthExceeded, MaxMdLengthBytes));
+                        Strings.ReadMeMaxLengthExceeded, MaxAllowedReadmeLength));
                 }
                 return readMeRequest.SourceText;
             }
@@ -272,7 +272,7 @@ namespace NuGetGallery
 
             using (var readMeMdStream = readMeMdPostedFile.InputStream)
             {
-                return await ReadMaxAsync(readMeMdStream, MaxMdLengthBytes, encoding);
+                return await ReadMaxAsync(readMeMdStream, MaxAllowedReadmeLength, encoding);
             }
         }
 
@@ -292,7 +292,7 @@ namespace NuGetGallery
             {
                 using (var httpStream = await client.GetStreamAsync(readMeMdUrl))
                 {
-                    return await ReadMaxAsync(httpStream, MaxMdLengthBytes, encoding);
+                    return await ReadMaxAsync(httpStream, MaxAllowedReadmeLength, encoding);
                 }
             }
         }

--- a/src/NuGetGallery/Services/ReadMeService.cs
+++ b/src/NuGetGallery/Services/ReadMeService.cs
@@ -21,7 +21,7 @@ namespace NuGetGallery
         internal const string TypeFile = "File";
         internal const string TypeWritten = "Written";
 
-        internal const int MaxAllowedReadmeLength = GalleryConstants.MaxFileLengthBytes;
+        internal const int MaxAllowedReadmeBytes = GalleryConstants.MaxFileLengthBytes;
         private const string UrlHostRequirement = "raw.githubusercontent.com";
 
         private static readonly TimeSpan UrlTimeout = TimeSpan.FromSeconds(10);
@@ -235,10 +235,10 @@ namespace NuGetGallery
 
             if (TypeWritten.Equals(readMeType, StringComparison.InvariantCultureIgnoreCase))
             {
-                if (encoding.GetByteCount(readMeRequest.SourceText) > MaxAllowedReadmeLength)
+                if (encoding.GetByteCount(readMeRequest.SourceText) > MaxAllowedReadmeBytes)
                 {
                     throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
-                        Strings.ReadMeMaxLengthExceeded, MaxAllowedReadmeLength));
+                        Strings.ReadMeMaxLengthExceeded, MaxAllowedReadmeBytes));
                 }
                 return readMeRequest.SourceText;
             }
@@ -272,7 +272,7 @@ namespace NuGetGallery
 
             using (var readMeMdStream = readMeMdPostedFile.InputStream)
             {
-                return await ReadMaxAsync(readMeMdStream, MaxAllowedReadmeLength, encoding);
+                return await ReadMaxAsync(readMeMdStream, MaxAllowedReadmeBytes, encoding);
             }
         }
 
@@ -292,7 +292,7 @@ namespace NuGetGallery
             {
                 using (var httpStream = await client.GetStreamAsync(readMeMdUrl))
                 {
-                    return await ReadMaxAsync(httpStream, MaxAllowedReadmeLength, encoding);
+                    return await ReadMaxAsync(httpStream, MaxAllowedReadmeBytes, encoding);
                 }
             }
         }

--- a/tests/NuGetGallery.Facts/Extensions/NumberExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/Extensions/NumberExtensionsFacts.cs
@@ -22,7 +22,19 @@ namespace NuGetGallery.Extensions
             [InlineData(1024, "1 KB")]
             [InlineData(1024*1024, "1 MB")]
             [InlineData(1024 * 1024 * 1024, "1 GB")]
-            public void FormatsUsingExpectedUnit(long bytes, string expected)
+            public void FormatsUsingExpectedUnitWithLong(long bytes, string expected)
+            {
+                var actual = NumberExtensions.ToUserFriendlyBytesLabel(bytes);
+
+                Assert.Equal(expected, actual);
+            }
+
+            [Theory]
+            [InlineData(1, "1 byte")]
+            [InlineData(512, "512 bytes")]
+            [InlineData(1024, "1 KB")]
+            [InlineData(1024 * 1024, "1 MB")]
+            public void FormatsUsingExpectedUnitWithInt(int bytes, string expected)
             {
                 var actual = NumberExtensions.ToUserFriendlyBytesLabel(bytes);
 

--- a/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
@@ -278,7 +278,7 @@ namespace NuGetGallery
 
         public class TheGetReadMeMdAsyncMethod
         {
-            private readonly string LargeMarkdown = new string('x', ReadMeService.MaxMdLengthBytes + 1);
+            private readonly string LargeMarkdown = new string('x', ReadMeService.MaxAllowedReadmeLength + 1);
 
             [Theory]
             [InlineData("")]

--- a/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/ReadMeServiceFacts.cs
@@ -278,7 +278,7 @@ namespace NuGetGallery
 
         public class TheGetReadMeMdAsyncMethod
         {
-            private readonly string LargeMarkdown = new string('x', ReadMeService.MaxAllowedReadmeLength + 1);
+            private readonly string LargeMarkdown = new string('x', ReadMeService.MaxAllowedReadmeBytes + 1);
 
             [Theory]
             [InlineData("")]


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Issue: inconsistent max readme file size between validation during upload and preview readme at manage package page

validation readme max size:
https://github.com/NuGet/NuGetGallery/blob/c71e12429b108c4d87e2da41790b164149a43389/src/NuGetGallery/Services/PackageMetadataValidationService.cs#L61
Preview at manage package: 
https://github.com/NuGet/NuGetGallery/blob/db62de43e24b704e9ab16d8abc39bdfa3e73260b/src/NuGetGallery/Services/ReadMeService.cs#L24

Fix: Make maxmdreadme length to be consistent while uploading and preview

Before:
![reamdbug](https://user-images.githubusercontent.com/64443925/132561568-d7e57f0e-0a20-49a8-9003-738985b82366.PNG)


After: 
![bugafter](https://user-images.githubusercontent.com/64443925/132561611-30b9d2cd-0d3b-42cf-b29e-6d2c99977120.PNG)


Addresses https://github.com/NuGet/NuGetGallery/issues/8771