### PR TITLE
Switching httpRuntime to 4.7.2

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -340,7 +340,7 @@
         <add tagPrefix="ef" assembly="Microsoft.AspNet.EntityDataSource" namespace="Microsoft.AspNet.EntityDataSource"/>
       </controls>
     </pages>
-    <httpRuntime targetFramework="4.5" maxQueryStringLength="12000" maxRequestLength="256000" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" relaxedUrlToFileSystemMapping="true" enableVersionHeader="false"/>
+    <httpRuntime targetFramework="4.7.2" maxQueryStringLength="12000" maxRequestLength="256000" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" relaxedUrlToFileSystemMapping="true" enableVersionHeader="false"/>
     <httpModules>
       <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL"/>
       <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah, Version=1.2.14706.0, Culture=neutral, PublicKeyToken=57eac04b2e0f138e, processorArchitecture=MSIL"/>


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/4071

Differences between .Net 4.5 and 4.7.2: https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.5-4.7.2

Concerns:
- https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.5-4.7.2#allow-unicode-bidirectional-control-characters-in-uris (we don't allow non-printable characters neither in package IDs nor in versions nor in usernames, so it shouldn't affect us)
- https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.5-4.7.2#change-in-path-separator-character-in-fullname-property-of-ziparchiveentry-objects (we don't use `CreateFromDirectory` anywhere in Gallery, so shouldn't affect us)
- https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.5-4.7.2#deflatestream-uses-native-apis-for-decompression (we use `DeflateStream` in a single place in Gallery and I would imagine others would have notice if it was broken)
- https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.5-4.7.2#ensure-systemuri-uses-a-consistent-reserved-character-set (this might affect V2 endpoints, but those are covered by functional tests and they passed)
- https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.5-4.7.2#xmlwriter-throws-on-invalid-surrogate-pairs (we only use `XmlWriter` for producing an Atom feed, if anything breaks here, it was invalid in the first place and we can handle it on case-by-case basis).
- https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/retargeting/4.5-4.7.2#xsd-schema-validation-now-correctly-detects-violations-of-unique-constraints-if-compound-keys-are-used-and-one-key-is-empty (not validating XSD schemas in Gallery directly (client library might, but it should have been thoroughly tested already)).