### PR TITLE
Make package body tabs linkable

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -154,6 +154,8 @@
             storage.setItem(bodyStorageKey, e.target.id);
         }
 
+        window.history.replaceState("", "", "#" + e.target.id);
+
         clampUsedByDescriptions();
 
         window.nuget.sendMetric("ShowDisplayPackageTab", 1, {

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -93,12 +93,19 @@
     var storage = window['localStorage'];
     var packageManagerStorageKey = 'preferred_package_manager';
     var bodyStorageKey = 'preferred_body_tab';
-
-    // The V3 registration API links to the display package page's README using
-    // the 'show-readme-container' URL fragment.
     var restorePreferredBodyTab = true;
-    if (window.location.hash === '#show-readme-container') {
-        $('#readme-body-tab').focus();
+
+    var windowHash = window.location.hash;
+
+    if (windowHash ) {
+
+        // The V3 registration API links to the display package page's README using
+        // the 'show-readme-container' URL fragment.
+        if (windowHash === '#show-readme-container') {
+            windowHash = '#readme-tab';
+        }
+        $(windowHash).focus();
+        // don't restore body tab from storage then
         restorePreferredBodyTab = false;
     }
 

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -96,16 +96,16 @@
     var restorePreferredBodyTab = true;
 
     var windowHash = window.location.hash;
-
-    if (windowHash ) {
-
+    if (windowHash) {
         // The V3 registration API links to the display package page's README using
         // the 'show-readme-container' URL fragment.
         if (windowHash === '#show-readme-container') {
-            windowHash = '#readme-tab';
+            windowHash = '#readme-body-tab';
         }
+
         $(windowHash).focus();
-        // don't restore body tab from storage then
+        $(windowHash).tab('show');
+        // don't restore body tab given the window hash
         restorePreferredBodyTab = false;
     }
 


### PR DESCRIPTION
1. Read window hash param from url
2. Use passed hash to focus body tab
3. Replace window history on activate tab to
  - adjust current url (so you can copy and share it)
  - avoid navigating back through tabs


Addresses https://github.com/NuGet/NuGetGallery/issues/8822