### PR TITLE
Trying to create sync DB connection synchronously before doing async

### DIFF
--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-5066115</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-5066115</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-5066115</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-5066115</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -50,7 +50,7 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -59,13 +59,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -50,7 +50,7 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -59,13 +59,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -50,7 +50,7 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -59,13 +59,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -50,7 +50,7 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -59,13 +59,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
+++ b/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
@@ -39,7 +39,7 @@ namespace NuGetGallery.Configuration
             SettingPrefix + "SupportRequestSqlServer",
             SettingPrefix + "ValidationSqlServer" };
 
-        public ISecretInjector SecretInjector { get; set; }
+        public ICachingSecretInjector SecretInjector { get; set; }
 
         /// <summary>
         /// Initializes the configuration service and associates a secret injector based on the configured KeyVault
@@ -52,7 +52,7 @@ namespace NuGetGallery.Configuration
             var secretReader = secretReaderFactory.CreateSecretReader();
             var secretInjector = secretReaderFactory.CreateSecretInjector(secretReader);
 
-            configuration.SecretInjector = secretInjector;
+            configuration.SecretInjector = secretInjector as ICachingSecretInjector ?? throw new InvalidOperationException("Caching secret reader is required to run the service");
 
             return configuration;
         }

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -317,10 +317,10 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -317,10 +317,10 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -317,10 +317,10 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -317,10 +317,10 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -952,8 +952,7 @@ namespace NuGetGallery
 
         private static DbConnection CreateDbConnection(ISqlConnectionFactory connectionFactory)
         {
-            var connection = connectionFactory.TryCreate();
-            if (connection != null)
+            if (connectionFactory.TryCreate(out var connection))
             {
                 return connection;
             }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -944,7 +944,7 @@ namespace NuGetGallery
             ILoggerFactory loggerFactory,
             string name,
             string connectionString,
-            ISecretInjector secretInjector)
+            ICachingSecretInjector secretInjector)
         {
             var logger = loggerFactory.CreateLogger($"AzureSqlConnectionFactory-{name}");
             return new AzureSqlConnectionFactory(connectionString, secretInjector, logger);
@@ -952,6 +952,11 @@ namespace NuGetGallery
 
         private static DbConnection CreateDbConnection(ISqlConnectionFactory connectionFactory)
         {
+            var connection = connectionFactory.TryCreate();
+            if (connection != null)
+            {
+                return connection;
+            }
             return Task.Run(() => connectionFactory.CreateAsync()).Result;
         }
 
@@ -959,7 +964,7 @@ namespace NuGetGallery
             ContainerBuilder builder,
             ILoggerFactory loggerFactory,
             ConfigurationService configuration,
-            ISecretInjector secretInjector)
+            ICachingSecretInjector secretInjector)
         {
             var galleryDbReadOnlyReplicaConnectionFactory = CreateDbConnectionFactory(
                 loggerFactory,
@@ -980,7 +985,7 @@ namespace NuGetGallery
             ContainerBuilder builder,
             ILoggerFactory loggerFactory,
             ConfigurationService configuration,
-            ISecretInjector secretInjector)
+            ICachingSecretInjector secretInjector)
         {
             var validationDbConnectionFactory = CreateDbConnectionFactory(
                 loggerFactory,
@@ -1009,7 +1014,7 @@ namespace NuGetGallery
             ContainerBuilder builder,
             ILoggerFactory loggerFactory,
             ConfigurationService configuration,
-            ISecretInjector secretInjector)
+            ICachingSecretInjector secretInjector)
         {
             builder
                 .RegisterType<NuGet.Services.Validation.ServiceBusMessageSerializer>()

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -950,7 +950,7 @@ namespace NuGetGallery
             return new AzureSqlConnectionFactory(connectionString, secretInjector, logger);
         }
 
-        private static DbConnection CreateDbConnection(ISqlConnectionFactory connectionFactory)
+        public static DbConnection CreateDbConnection(ISqlConnectionFactory connectionFactory)
         {
             if (connectionFactory.TryCreate(out var connection))
             {

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2252,13 +2252,13 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
+      <Version>2.91.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2252,13 +2252,13 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5374589</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2252,13 +2252,13 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.90.0</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2252,13 +2252,13 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.91.0-agr-sync-sql-connect-5368013</Version>
+      <Version>2.91.0-agr-sync-sql-connect-5372845</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/tests/NuGetGallery.Facts/App_Start/ConfigurationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/App_Start/ConfigurationServiceFacts.cs
@@ -27,7 +27,7 @@ namespace NuGetGallery.App_Start
                     StubRequest.Setup(stub => stub.IsLocal).Returns(false);
 
                     var secretReaderFactory = new EmptySecretReaderFactory();
-                    SecretInjector = secretReaderFactory.CreateSecretInjector(secretReaderFactory.CreateSecretReader());
+                    SecretInjector = secretReaderFactory.CreateSecretInjector(secretReaderFactory.CreateSecretReader()) as ICachingSecretInjector;
                 }
 
                 public string StubConfiguredSiteRoot { get; set; }
@@ -106,7 +106,7 @@ namespace NuGetGallery.App_Start
         {
             private class TestableConfigurationService : ConfigurationService
             {
-                public TestableConfigurationService(ISecretInjector secretInjector = null)
+                public TestableConfigurationService(ICachingSecretInjector secretInjector = null)
                 {
                     SecretInjector = secretInjector ?? CreateDefaultSecretInjector();
                 }
@@ -132,10 +132,10 @@ namespace NuGetGallery.App_Start
                     return AppSettingStub;
                 }
 
-                private static ISecretInjector CreateDefaultSecretInjector()
+                private static ICachingSecretInjector CreateDefaultSecretInjector()
                 {
                     var secretReaderFactory = new EmptySecretReaderFactory();
-                    return secretReaderFactory.CreateSecretInjector(secretReaderFactory.CreateSecretReader());
+                    return secretReaderFactory.CreateSecretInjector(secretReaderFactory.CreateSecretReader()) as ICachingSecretInjector;
                 }
             }
 
@@ -175,7 +175,7 @@ namespace NuGetGallery.App_Start
             public async Task WhenSettingIsNotEmptySecretInjectorIsRan()
             {
                 // Arrange
-                var secretInjectorMock = new Mock<ISecretInjector>();
+                var secretInjectorMock = new Mock<ICachingSecretInjector>();
                 secretInjectorMock.Setup(x => x.InjectAsync(It.IsAny<string>()))
                                   .Returns<string>(s => Task.FromResult(s + "parsed"));
                 
@@ -201,7 +201,7 @@ namespace NuGetGallery.App_Start
             public async Task GivenNotInjectedSettingNameSecretInjectorIsNotRan(string settingName)
             {
                 // Arrange
-                var secretInjectorMock = new Mock<ISecretInjector>();
+                var secretInjectorMock = new Mock<ICachingSecretInjector>();
                 secretInjectorMock.Setup(x => x.InjectAsync(It.IsAny<string>()))
                     .Returns<string>(s => Task.FromResult(s + "parsed"));
 

--- a/tests/NuGetGallery.Facts/Framework/TestGalleryConfigurationService.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestGalleryConfigurationService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using NuGet.Services.KeyVault;
 using NuGetGallery.Configuration;
 using NuGetGallery.Configuration.SecretReader;
 
@@ -14,7 +15,7 @@ namespace NuGetGallery.Framework
         public TestGalleryConfigurationService()
         {
             var secretReaderFactory = new EmptySecretReaderFactory();
-            SecretInjector = secretReaderFactory.CreateSecretInjector(secretReaderFactory.CreateSecretReader());
+            SecretInjector = secretReaderFactory.CreateSecretInjector(secretReaderFactory.CreateSecretReader()) as ICachingSecretInjector;
         }
 
         protected override string GetAppSetting(string settingName)


### PR DESCRIPTION
Addresses #8858 

All the changes are in https://github.com/NuGet/ServerCommon/pull/374

This just applies the API change to Gallery. `CreateDbConnection` method was updated to call sync version that tries to use cache and simply fails if any required information is not cached, then it falls back to the old behavior.

Some basic tests in dev indicate that the change reduces the amount of `Task.Result` calls in `CreateDbConnection` by a factor of more than 100x.