### PR TITLE
[Hotfix] Registering admin panel routes when admin panel is not disabled.

### DIFF
--- a/src/NuGetGallery/App_Start/AppActivator.cs
+++ b/src/NuGetGallery/App_Start/AppActivator.cs
@@ -248,7 +248,7 @@ namespace NuGetGallery
             // Log unhandled exceptions
             GlobalConfiguration.Configuration.Services.Add(typeof(IExceptionLogger), new QuietExceptionLogger());
 
-            Routes.RegisterRoutes(RouteTable.Routes, configuration.FeedOnlyMode);
+            Routes.RegisterRoutes(RouteTable.Routes, configuration.FeedOnlyMode, configuration.AdminPanelEnabled);
             AreaRegistration.RegisterAllAreas();
 
             GlobalFilters.Filters.Add(new SendErrorsToTelemetryAttribute { View = "~/Views/Errors/InternalError.cshtml" });


### PR DESCRIPTION
Fixed incorrect call to `Routes.RegisterRoutes` which prevented admin access to some pages.