### PR TITLE
Re-add a11y to checkmarks and bangs in package details page

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package-v2.js
@@ -184,4 +184,7 @@
             }
         });
     }
+
+    $(".reserved-indicator").each(window.nuget.setPopovers);
+    $(".package-warning-icon").each(window.nuget.setPopovers);
 });

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -243,10 +243,10 @@
                                     src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
                         </span>
-                        <span class="title">
+                        <span class="title" tabindex="0">
                             @Html.BreakWord(Model.Id)
                         </span>
-                        <span class="version-title">
+                        <span class="version-title" tabindex="0">
                             @Model.Version
                         </span>
                         @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
@@ -255,7 +255,8 @@
                                 <img class="reserved-indicator"
                                         src="~/Content/gallery/img/reserved-indicator.svg"
                                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
-                                        title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                                        data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"
+                                        alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"/>
                                 <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
                                     Prefix Reserved
                                 </a>
@@ -812,7 +813,7 @@
                                         || (!packageVersion.Deleted && Model.CanDisplayPrivateMetadata))
                                     {
                                         <tr class="@(packageVersion.IsCurrent(Model) ? "bg-info" : null)">
-                                            <td tabindex="0">
+                                            <td>
                                                 <a href="@Url.Package(packageVersion)" title="@packageVersion.Version">
                                                     @packageVersion.Version.Abbreviate(30)
                                                 </a>
@@ -866,8 +867,11 @@
                                             }
                                             else
                                             {
-                                                <td tabindex="0" class="package-icon-cell">
-                                                    <i class="ms-Icon ms-Icon--Warning package-icon" title="@packageVersion.PackageWarningIconTitle"></i>
+                                                <td class="package-icon-cell">
+                                                    <span class="package-warning-icon" aria-label="@packageVersion.PackageWarningIconTitle"
+                                                          data-content="@packageVersion.PackageWarningIconTitle" tabindex="0">
+                                                        <i class="ms-Icon ms-Icon--Warning package-icon"></i>
+                                                    </span>
                                                 </td>
                                             }
                                         </tr>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8897

- Adds the popovers into the new v2 package details page for reserved checkmarks (including alt tag) and vulnerable/deprecated bangs. 
- Narrator support also restored.
- There needed to be tab stops added to ID and version at the top. 
- I also removed a double tab stop on the versions in the version table.

Here are the changes (I pause and point at them): 
![44leShd08k](https://user-images.githubusercontent.com/14225979/144372641-9bc76ea9-97ed-44c2-9621-578728ce0c0d.gif)
  