### PR TITLE
Additional online safety instructions in report package page

### DIFF
--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -92,6 +92,15 @@
                         <p tabindex="0">
                             Please provide a detailed description of the problem.
                         <p>
+                        <div class="online-safety-extras" tabindex="0">
+                            <p>
+                                Please also describe where in the package the problem was found. Be sure to include:
+                                <ul>
+                                    <li>Whether the problem is in graphics, video, readme, scripts, libraries, nuspec, other metadata, other file(s)</li>
+                                    <li>The exact names of the offending file(s)</li>
+                                </ul>
+                            </p>
+                        </div>
                         <div class="infringement-claim-requirements" tabindex="0">
                             <p>
                                 If you are reporting copyright infringement, please describe the copyrighted material with particularity and provide us with information about your copyright (i.e. title of copyrighted work, URL where to view your copyrighted work, description of your copyrighted work, and any copyright registrations you may have, etc.). For trademark infringement, include the name of your trademark, registration number, and country where registered.
@@ -193,8 +202,10 @@
                 || val === 'RevengePorn'
                 || val === 'OtherNudityOrPornography') {
                 $form.find('.already-contacted-owner').hide();
+                $form.find('.online-safety-extras').show();
             } else {
                 $form.find('.already-contacted-owner').show();
+                $form.find('.online-safety-extras').hide();
             }
 
             if (val === 'ChildSexualExploitationOrAbuse') {


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8899

This change instructs the reporter of abuse to include specifics that will help us address the problem quickly. The other accommodations for online safety reporting (no contact checkbox, additional detail for imminent harm reporting, revenge porn portal directions) are all preserved.

![kBIKcd1FzY](https://user-images.githubusercontent.com/14225979/144378864-5f4ee6cb-9eb1-4010-96f6-897488b74cf5.gif)


