### PR TITLE
Gallery API request count tracking by endpoint as metric

### DIFF
--- a/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
+++ b/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
@@ -376,6 +376,11 @@ namespace GitHubVulnerabilities2Db.Gallery
             throw new NotImplementedException();
         }
 
+        public void TrackApiRequest(string endpoint)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackVerifyPackageKeyEvent(string packageId, string packageVersion, User user, IIdentity identity, int statusCode)
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryClient.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryClient.cs
@@ -16,6 +16,8 @@ namespace NuGetGallery
 
         void TrackMetric(string metricName, double value, IDictionary<string, string> properties = null);
 
+        void TrackAggregatedMetric(string metricName, double value, Action<Action<string, string>> addDimensions);
+
         void TrackException(Exception exception, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null);
 
         void TrackDependency(string dependencyTypeName,

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -418,5 +418,11 @@ namespace NuGetGallery
         /// </summary>
         /// <param name="uptime">The uptime to report.</param>
         void TrackInstanceUptime(TimeSpan uptime);
+
+        /// <summary>
+        /// Tracks API request count by endpoint.
+        /// </summary>
+        /// <param name="endpoint"></param>
+        void TrackApiRequest(string endpoint);
     }
 }

--- a/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Metrics;
 using Microsoft.Extensions.Logging;
 
 namespace NuGetGallery
@@ -54,6 +56,62 @@ namespace NuGetGallery
             catch
             {
                 // logging failed, don't allow exception to escape
+            }
+        }
+
+        public void TrackAggregatedMetric(string metricName, double value, Action<Action<string, string>> addDimensions)
+        {
+            try
+            {
+                var dimensionNames = new List<string>();
+                var dimensionValues = new List<string>();
+                addDimensions((name, dvalue) =>
+                {
+                    dimensionNames.Add(name);
+                    dimensionValues.Add(dvalue);
+                });
+                var metricIdentifier = new MetricIdentifier("Gallery", metricName, dimensionNames);
+                var metric = UnderlyingClient.GetMetric(metricIdentifier);
+                switch (dimensionValues.Count)
+                {
+                    case 0:
+                        metric.TrackValue(value);
+                        break;
+                    case 1:
+                        metric.TrackValue(value, dimensionValues[0]);
+                        break;
+                    case 2:
+                        metric.TrackValue(value, dimensionValues[0], dimensionValues[1]);
+                        break;
+                    case 3:
+                        metric.TrackValue(value, dimensionValues[0], dimensionValues[1], dimensionValues[2]);
+                        break;
+                    case 4:
+                        metric.TrackValue(value, dimensionValues[0], dimensionValues[1], dimensionValues[2], dimensionValues[3]);
+                        break;
+                    case 5:
+                        metric.TrackValue(value, dimensionValues[0], dimensionValues[1], dimensionValues[2], dimensionValues[3], dimensionValues[4]);
+                        break;
+                    case 6:
+                        metric.TrackValue(value, dimensionValues[0], dimensionValues[1], dimensionValues[2], dimensionValues[3], dimensionValues[4], dimensionValues[5]);
+                        break;
+                    case 7:
+                        metric.TrackValue(value, dimensionValues[0], dimensionValues[1], dimensionValues[2], dimensionValues[3], dimensionValues[4], dimensionValues[5], dimensionValues[6]);
+                        break;
+                    case 8:
+                        metric.TrackValue(value, dimensionValues[0], dimensionValues[1], dimensionValues[2], dimensionValues[3], dimensionValues[4], dimensionValues[5], dimensionValues[6], dimensionValues[7]);
+                        break;
+                    case 9:
+                        metric.TrackValue(value, dimensionValues[0], dimensionValues[1], dimensionValues[2], dimensionValues[3], dimensionValues[4], dimensionValues[5], dimensionValues[6], dimensionValues[7], dimensionValues[8]);
+                        break;
+                    case 10:
+                        metric.TrackValue(value, dimensionValues[0], dimensionValues[1], dimensionValues[2], dimensionValues[3], dimensionValues[4], dimensionValues[5], dimensionValues[6], dimensionValues[7], dimensionValues[8], dimensionValues[9]);
+                        break;
+                }
+            }
+            catch
+            {
+
             }
         }
 

--- a/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
@@ -70,7 +70,7 @@ namespace NuGetGallery
                     dimensionNames.Add(name);
                     dimensionValues.Add(dvalue);
                 });
-                var metricIdentifier = new MetricIdentifier("Gallery", metricName, dimensionNames);
+                var metricIdentifier = new MetricIdentifier(metricNamespace: "Gallery", metricId: metricName, dimensionNames: dimensionNames);
                 var metric = UnderlyingClient.GetMetric(metricIdentifier);
                 switch (dimensionValues.Count)
                 {

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -94,6 +94,7 @@ namespace NuGetGallery
             public const string SymbolPackagePushDisconnect = "SymbolPackagePushDisconnect";
             public const string VulnerabilitiesCacheRefreshDurationMs = "VulnerabilitiesCacheRefreshDurationMs";
             public const string InstanceUptime = "InstanceUptimeInDays";
+            public const string ApiRequest = "ApiRequest";
         }
 
         private readonly IDiagnosticsSource _diagnosticsSource;
@@ -232,6 +233,8 @@ namespace NuGetGallery
         public const string IsActive = "IsActive";
         public const string TestBucket = "TestBucket";
         public const string TestPercentage = "TestPercentage";
+
+        public const string Endpoint = "Endpoint";
 
         public TelemetryService(IDiagnosticsSource diagnosticsSource, ITelemetryClient telemetryClient)
         {
@@ -1128,6 +1131,14 @@ namespace NuGetGallery
         public void TrackVulnerabilitiesCacheRefreshDuration(TimeSpan duration)
         {
             TrackMetric(Events.VulnerabilitiesCacheRefreshDurationMs, duration.TotalMilliseconds, properties => { });
+        }
+
+        public void TrackApiRequest(string endpoint)
+        {
+            _telemetryClient.TrackAggregatedMetric(Events.ApiRequest, 1, addDimension =>
+            {
+                addDimension(Endpoint, endpoint);
+            });
         }
 
         /// <summary>

--- a/src/NuGetGallery/Controllers/ODataV1FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV1FeedController.cs
@@ -56,6 +56,7 @@ namespace NuGetGallery.Controllers
         [CacheOutput(NoCache = true)]
         public IHttpActionResult Get(ODataQueryOptions<V1FeedPackage> options)
         {
+            _telemetryService.TrackApiRequest("/api/v1/Packages");
             return Get(options, _featureFlagService.IsODataV1GetAllEnabled());
         }
 
@@ -64,6 +65,7 @@ namespace NuGetGallery.Controllers
         [CacheOutput(NoCache = true)]
         public IHttpActionResult GetCount(ODataQueryOptions<V1FeedPackage> options)
         {
+            _telemetryService.TrackApiRequest("/api/v1/Packages/$count");
             return Get(options, _featureFlagService.IsODataV1GetAllCountEnabled())
                 .FormattedAsCountResult<V1FeedPackage>();
         }
@@ -107,6 +109,7 @@ namespace NuGetGallery.Controllers
             ClientTimeSpan = ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds)]
         public async Task<IHttpActionResult> Get(ODataQueryOptions<V1FeedPackage> options, string id, string version)
         {
+            _telemetryService.TrackApiRequest("/api/v1/Packages(Id=,Version=)");
             var result = await GetCoreAsync(
                 options,
                 id,
@@ -126,6 +129,7 @@ namespace NuGetGallery.Controllers
             ClientTimeSpan = ODataCacheConfiguration.DefaultGetByIdAndVersionCacheTimeInSeconds)]
         public async Task<IHttpActionResult> FindPackagesById(ODataQueryOptions<V1FeedPackage> options, [FromODataUri]string id)
         {
+            _telemetryService.TrackApiRequest("/api/v1/FindPackagesById()?id=");
             return await FindPackagesByIdAsync(
                 options,
                 id,
@@ -140,6 +144,7 @@ namespace NuGetGallery.Controllers
             NoCache = true)]
         public async Task<IHttpActionResult> FindPackagesByIdCount(ODataQueryOptions<V1FeedPackage> options, [FromODataUri] string id)
         {
+            _telemetryService.TrackApiRequest("/api/v1/FindPackagesById()/$count?id=");
             return (await FindPackagesByIdAsync(
                 options,
                 id,
@@ -255,6 +260,7 @@ namespace NuGetGallery.Controllers
         [HttpGet]
         public IHttpActionResult GetPropertyFromPackages(string propertyName, string id, string version)
         {
+            _telemetryService.TrackApiRequest("/api/v1/Packages(Id=,Version=)/propertyName");
             switch (propertyName.ToLowerInvariant())
             {
                 case "id": return Ok(id);
@@ -276,6 +282,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]string searchTerm = "",
             [FromODataUri]string targetFramework = "")
         {
+            _telemetryService.TrackApiRequest("/api/v1/Search()?searchTerm=&targetFramework=&includePrerelease=");
             return await SearchAsync(
                 options,
                 searchTerm,
@@ -294,6 +301,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]string searchTerm = "",
             [FromODataUri]string targetFramework = "")
         {
+            _telemetryService.TrackApiRequest("/api/v1/Search()/$count?searchTerm=&targetFramework=&includePrerelease=");
             return (await SearchAsync(
                 options,
                 searchTerm,

--- a/src/NuGetGallery/Controllers/ODataV2FeedController.cs
+++ b/src/NuGetGallery/Controllers/ODataV2FeedController.cs
@@ -61,6 +61,7 @@ namespace NuGetGallery.Controllers
             ODataQueryOptions<V2FeedPackage> options,
             [FromUri]string semVerLevel = null)
         {
+            _telemetryService.TrackApiRequest("/api/v2/Packages?semVerLevel=");
             return await GetAsync(
                 options,
                 semVerLevel,
@@ -74,6 +75,7 @@ namespace NuGetGallery.Controllers
             ODataQueryOptions<V2FeedPackage> options,
             [FromUri] string semVerLevel = null)
         {
+            _telemetryService.TrackApiRequest("/api/v2/Packages/$count?semVerLevel=");
             return (await GetAsync(
                 options,
                 semVerLevel,
@@ -198,6 +200,7 @@ namespace NuGetGallery.Controllers
             string version,
             [FromUri] bool hijack = true)
         {
+            _telemetryService.TrackApiRequest("/api/v2/Packages(Id=,Version=)");
             // We are defaulting to semVerLevel = "2.0.0" by design.
             // The client is requesting a specific package version and should support what it requests.
             // If not, too bad :)
@@ -226,6 +229,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]string id,
             [FromUri]string semVerLevel = null)
         {
+            _telemetryService.TrackApiRequest("/api/v2/FindPackagesById()?id=&semVerLevel=");
             return await FindPackagesByIdAsync(
                 options,
                 id,
@@ -244,6 +248,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri] string id,
             [FromUri] string semVerLevel = null)
         {
+            _telemetryService.TrackApiRequest("/api/v2/FindPackagesById()/$count?semVerLevel=");
             return (await FindPackagesByIdAsync(
                 options,
                 id,
@@ -413,6 +418,7 @@ namespace NuGetGallery.Controllers
         [HttpGet]
         public IHttpActionResult GetPropertyFromPackages(string propertyName, string id, string version)
         {
+            _telemetryService.TrackApiRequest("/api/v2/Packages(Id=,Version=)/propertyName");
             switch (propertyName.ToLowerInvariant())
             {
                 case "id": return Ok(id);
@@ -436,6 +442,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]bool includePrerelease = false,
             [FromUri]string semVerLevel = null)
         {
+            _telemetryService.TrackApiRequest("/api/v2/Search()?searchTerm=&targetFramework=&includePrerelease=");
             return await SearchAsync(
                 options,
                 searchTerm,
@@ -458,6 +465,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri] bool includePrerelease = false,
             [FromUri] string semVerLevel = null)
         {
+            _telemetryService.TrackApiRequest("/api/v2/Search()/$count?searchTerm=&targetFramework=&includePrerelease=&semVerLevel=");
             return (await SearchAsync(
                 options,
                 searchTerm,
@@ -589,6 +597,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]string versionConstraints = "",
             [FromUri]string semVerLevel = null)
         {
+            _telemetryService.TrackApiRequest("/api/v2/GetUpdates()?packageIds=&versions=&includePrerelease=&includeAllVersions=&targetFrameworks=&versionConstraints=&semVerLevel=");
             if (string.IsNullOrEmpty(packageIds) || string.IsNullOrEmpty(versions))
             {
                 return TrackedQueryResult(
@@ -684,6 +693,7 @@ namespace NuGetGallery.Controllers
             [FromODataUri]string versionConstraints = "",
             [FromUri]string semVerLevel = null)
         {
+            _telemetryService.TrackApiRequest("/api/v2/GetUpdates()/$count?packageIds=&versions=&includePrerelease=&includeAllVersions=&targetFrameworks=&versionConstraints=&semVerLevel=");
             return GetUpdates(
                 options, 
                 packageIds, 

--- a/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
@@ -378,6 +378,11 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
+        public void TrackApiRequest(string endpoint)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackVerifyPackageKeyEvent(string packageId, string packageVersion, User user, IIdentity identity, int statusCode)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/4133 (without user agent consideration).

Added support for client-side metric pre-aggregation as I see no reason to have each individual request tracked as an instance of a metric: AI metrics are not subject for sampling, and we are getting millions of API requests per hour. Non-preaggregated metric would waste resources.

There seems to be two options for submitting sample for pre-aggregation:
1. By calling [`Metric.TrackValue`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.applicationinsights.metric.trackvalue?view=azure-dotnet) that has no overload that accepts any kind of list of dimension values.
2. By obtaining a [`MetricSeries`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.applicationinsights.metrics.metricseries?view=azure-dotnet) object by calling [`Metric.TryGetDataSeries`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.applicationinsights.metric.trygetdataseries?view=azure-dotnet) (which does have an overload accepting an *array* of dimension values) and then call its `TrackValue` method.

None of those accepts a dictionary of dimensions names and dimension values (I'd guess, order matters in this case and dictionary enumeration does not produce stable sequence of keys). I chose to go with the first approach to provide dictionary-like interface (and eliminate the possibility of mismatching dimension names with values) to add dimensions and not to waste time/memory converting the list of values to an array. Because of that, I had to write that ugly switch of `TrackValue` calls.

With pre-aggregation, AI SDK sends pre-aggregated metrics once per minute (default aggregation interval).

Added telemetry calls to all public methods of `ODataV1FeedController` and `ODataV2FeedController`.