### PR TITLE
Update ServerCommon version to pull in the latest Markdig version (0.26.0)

### DIFF
--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-5066115</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -50,7 +50,7 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -59,13 +59,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -317,10 +317,10 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2248,7 +2248,7 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Configuration">
-      <Version>5.9.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol">
       <Version>5.9.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2254,13 +2254,13 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.91.0</Version>
+      <Version>2.94.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -574,6 +574,14 @@
   </system.diagnostics>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Configuration" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.280" newVersion="6.0.0.280"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Common" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.280" newVersion="6.0.0.280"/>
+			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-5.3.0.0" newVersion="5.3.0.0"/>
@@ -584,7 +592,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.9.0.7134" newVersion="5.9.0.7134"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.280" newVersion="6.0.0.280"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
@@ -604,15 +612,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.9.0.7134" newVersion="5.9.0.7134"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.280" newVersion="6.0.0.280"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.9.0.7134" newVersion="5.9.0.7134"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.280" newVersion="6.0.0.280"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>

--- a/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
+++ b/tests/NuGetGallery.FunctionalTests/NuGetGallery.FunctionalTests.csproj
@@ -91,7 +91,7 @@
       <Version>1.0.0.10</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>5.9.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>


### PR DESCRIPTION
- Update reference to 2.94.0 where built from serverCommon
- Update NuGet.packaging to 6.0.0 align with serverCommon, avoid package downgrading.

ServerCommon: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5560161&view=artifacts&pathAsName=false&type=publishedArtifacts
