### PR TITLE
Pretty readme table

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -657,6 +657,14 @@ img.reserved-indicator-icon {
   overflow: auto;
   max-height: 450px;
 }
+#readme-container .table {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+#readme-container tr:nth-child(even) {
+  background-color: #f2f2f2;
+}
 #readme-less img {
   max-width: 100%;
 }
@@ -677,6 +685,14 @@ img.reserved-indicator-icon {
 #readme-preview ul.contains-task-list,
 #readme-preview li.task-list-item {
   list-style-type: none;
+}
+#readme-preview .table {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+#readme-preview tr:nth-child(even) {
+  background-color: #f2f2f2;
 }
 #edit-markdown {
   padding-top: 3em;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -670,7 +670,6 @@ img.reserved-indicator-icon {
 .readme-common tr:nth-child(even) {
   background-color: #f2f2f2;
 }
-.readme-common img,
 .readme-common img.img-fluid {
   max-width: 100%;
 }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -690,9 +690,37 @@ img.reserved-indicator-icon {
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
+  border: 1px solid #ddd;
+}
+#readme-preview .table > thead > tr > th,
+#readme-preview .table > tbody > tr > th,
+#readme-preview .table > tfoot > tr > th,
+#readme-preview .table > thead > tr > td,
+#readme-preview .table > tbody > tr > td,
+#readme-preview .table > tfoot > tr > td {
+  border: 1px solid #ddd;
+}
+#readme-preview .table > thead > tr > th,
+#readme-preview .table > thead > tr > td {
+  border-bottom-width: 2px;
 }
 #readme-preview tr:nth-child(even) {
   background-color: #f2f2f2;
+}
+.table-bordered {
+  border: 1px solid #ddd;
+}
+.table-bordered > thead > tr > th,
+.table-bordered > tbody > tr > th,
+.table-bordered > tfoot > tr > th,
+.table-bordered > thead > tr > td,
+.table-bordered > tbody > tr > td,
+.table-bordered > tfoot > tr > td {
+  border: 1px solid #ddd;
+}
+.table-bordered > thead > tr > th,
+.table-bordered > thead > tr > td {
+  border-bottom-width: 2px;
 }
 #edit-markdown {
   padding-top: 3em;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -657,52 +657,29 @@ img.reserved-indicator-icon {
   overflow: auto;
   max-height: 450px;
 }
-#readme-container .table {
+#readme-common .table {
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
   border: 1px solid #ddd;
 }
-#readme-container .table th,
-#readme-container .table td {
+#readme-common .table th,
+#readme-common .table td {
   border: 1px solid #ddd;
 }
-#readme-container tr:nth-child(even) {
+#readme-common tr:nth-child(even) {
   background-color: #f2f2f2;
 }
-#readme-less img {
+#readme-common img,
+#readme-common .img-fluid {
   max-width: 100%;
 }
-#readme-less ul.contains-task-list,
-#readme-less li.task-list-item {
-  list-style-type: none;
-}
-#readme-more img {
-  max-width: 100%;
-}
-#readme-more ul.contains-task-list,
-#readme-more li.task-list-item {
+#readme-common ul.contains-task-list,
+#readme-common li.task-list-item {
   list-style-type: none;
 }
 #readme-preview {
   padding-top: 0.25em;
-}
-#readme-preview ul.contains-task-list,
-#readme-preview li.task-list-item {
-  list-style-type: none;
-}
-#readme-preview .table {
-  width: -webkit-max-content;
-  width: -moz-max-content;
-  width: max-content;
-  border: 1px solid #ddd;
-}
-#readme-preview .table th,
-#readme-preview .table td {
-  border: 1px solid #ddd;
-}
-#readme-preview tr:nth-child(even) {
-  background-color: #f2f2f2;
 }
 #edit-markdown {
   padding-top: 3em;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -671,7 +671,7 @@ img.reserved-indicator-icon {
   background-color: #f2f2f2;
 }
 .readme-common img,
-.readme-common .img-fluid {
+.readme-common img.img-fluid {
   max-width: 100%;
 }
 .readme-common ul.contains-task-list,

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -663,17 +663,9 @@ img.reserved-indicator-icon {
   width: max-content;
   border: 1px solid #ddd;
 }
-#readme-container .table > thead > tr > th,
-#readme-container .table > tbody > tr > th,
-#readme-container .table > tfoot > tr > th,
-#readme-container .table > thead > tr > td,
-#readme-container .table > tbody > tr > td,
-#readme-container .table > tfoot > tr > td {
+#readme-container .table th,
+#readme-container .table td {
   border: 1px solid #ddd;
-}
-#readme-container .table > thead > tr > th,
-#readme-container .table > thead > tr > td {
-  border-bottom-width: 2px;
 }
 #readme-container tr:nth-child(even) {
   background-color: #f2f2f2;
@@ -705,17 +697,9 @@ img.reserved-indicator-icon {
   width: max-content;
   border: 1px solid #ddd;
 }
-#readme-preview .table > thead > tr > th,
-#readme-preview .table > tbody > tr > th,
-#readme-preview .table > tfoot > tr > th,
-#readme-preview .table > thead > tr > td,
-#readme-preview .table > tbody > tr > td,
-#readme-preview .table > tfoot > tr > td {
+#readme-preview .table th,
+#readme-preview .table td {
   border: 1px solid #ddd;
-}
-#readme-preview .table > thead > tr > th,
-#readme-preview .table > thead > tr > td {
-  border-bottom-width: 2px;
 }
 #readme-preview tr:nth-child(even) {
   background-color: #f2f2f2;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -661,6 +661,19 @@ img.reserved-indicator-icon {
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
+  border: 1px solid #ddd;
+}
+#readme-container .table > thead > tr > th,
+#readme-container .table > tbody > tr > th,
+#readme-container .table > tfoot > tr > th,
+#readme-container .table > thead > tr > td,
+#readme-container .table > tbody > tr > td,
+#readme-container .table > tfoot > tr > td {
+  border: 1px solid #ddd;
+}
+#readme-container .table > thead > tr > th,
+#readme-container .table > thead > tr > td {
+  border-bottom-width: 2px;
 }
 #readme-container tr:nth-child(even) {
   background-color: #f2f2f2;
@@ -706,21 +719,6 @@ img.reserved-indicator-icon {
 }
 #readme-preview tr:nth-child(even) {
   background-color: #f2f2f2;
-}
-.table-bordered {
-  border: 1px solid #ddd;
-}
-.table-bordered > thead > tr > th,
-.table-bordered > tbody > tr > th,
-.table-bordered > tfoot > tr > th,
-.table-bordered > thead > tr > td,
-.table-bordered > tbody > tr > td,
-.table-bordered > tfoot > tr > td {
-  border: 1px solid #ddd;
-}
-.table-bordered > thead > tr > th,
-.table-bordered > thead > tr > td {
-  border-bottom-width: 2px;
 }
 #edit-markdown {
   padding-top: 3em;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -657,25 +657,25 @@ img.reserved-indicator-icon {
   overflow: auto;
   max-height: 450px;
 }
-#readme-common .table {
+.readme-common .table {
   width: -webkit-max-content;
   width: -moz-max-content;
   width: max-content;
   border: 1px solid #ddd;
 }
-#readme-common .table th,
-#readme-common .table td {
+.readme-common .table th,
+.readme-common .table td {
   border: 1px solid #ddd;
 }
-#readme-common tr:nth-child(even) {
+.readme-common tr:nth-child(even) {
   background-color: #f2f2f2;
 }
-#readme-common img,
-#readme-common .img-fluid {
+.readme-common img,
+.readme-common .img-fluid {
   max-width: 100%;
 }
-#readme-common ul.contains-task-list,
-#readme-common li.task-list-item {
+.readme-common ul.contains-task-list,
+.readme-common li.task-list-item {
   list-style-type: none;
 }
 #readme-preview {

--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -1,6 +1,6 @@
 /*!
  * Bootstrap v3.4.1 (https://getbootstrap.com/)
- * Copyright 2011-2021 Twitter, Inc.
+ * Copyright 2011-2022 Twitter, Inc.
  * Licensed under the MIT license
  */
 

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -14,6 +14,23 @@
 #readme-container{
   .table {
     width: max-content;
+    border: 1px solid @table-border-color;
+    > thead,
+    > tbody,
+    > tfoot {
+      > tr {
+        > th,
+        > td {
+          border: 1px solid @table-border-color;
+        }
+      }
+    }
+    > thead > tr {
+      > th,
+      > td {
+        border-bottom-width: 2px;
+      }
+    }
   }
 
   tr:nth-child(even) {
@@ -71,26 +88,6 @@
 
   tr:nth-child(even) {
     background-color: @readme-table-bg-color;
-  }
-}
-
-.table-bordered {
-  border: 1px solid @table-border-color;
-  > thead,
-  > tbody,
-  > tfoot {
-    > tr {
-      > th,
-      > td {
-        border: 1px solid @table-border-color;
-      }
-    }
-  }
-  > thead > tr {
-    > th,
-    > td {
-      border-bottom-width: 2px;
-    }
   }
 }
 

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -25,7 +25,9 @@
     background-color: @readme-table-bg-color;
   }
 
-  img, img.img-fluid{
+  // We added boostrap extension in Markdig to render markdown file, it adds .img-fluid class to all images links <img>,
+  // images in Bootstrap are made responsive with .img-fluid, but it was first introduced to Boostrap 4, added style here since we are still in Bootstrap 3.
+  img.img-fluid{
     max-width: 100%;
   }
 

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -47,12 +47,50 @@
   ul.contains-task-list, li.task-list-item {
     list-style-type: none;
   }
+  
   .table {
     width: max-content;
+    border: 1px solid @table-border-color;
+    > thead,
+    > tbody,
+    > tfoot {
+      > tr {
+        > th,
+        > td {
+          border: 1px solid @table-border-color;
+        }
+      }
+    }
+    > thead > tr {
+      > th,
+      > td {
+        border-bottom-width: 2px;
+      }
+    }
   }
 
   tr:nth-child(even) {
     background-color: @readme-table-bg-color;
+  }
+}
+
+.table-bordered {
+  border: 1px solid @table-border-color;
+  > thead,
+  > tbody,
+  > tfoot {
+    > tr {
+      > th,
+      > td {
+        border: 1px solid @table-border-color;
+      }
+    }
+  }
+  > thead > tr {
+    > th,
+    > td {
+      border-bottom-width: 2px;
+    }
   }
 }
 

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -11,7 +11,7 @@
   }
 }
 
-.readme-common{
+.readme-common {
   .table {
     width: max-content;
     border: 1px solid @table-border-color;
@@ -27,7 +27,7 @@
 
   // We added boostrap extension in Markdig to render markdown file, it adds .img-fluid class to all images links <img>,
   // images in Bootstrap are made responsive with .img-fluid, but it was first introduced to Boostrap 4, added style here since we are still in Bootstrap 3.
-  img.img-fluid{
+  img.img-fluid {
     max-width: 100%;
   }
 

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -25,7 +25,7 @@
     background-color: @readme-table-bg-color;
   }
 
-  img, .img-fluid{
+  img, img.img-fluid{
     max-width: 100%;
   }
 

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -32,7 +32,6 @@
   ul.contains-task-list, li.task-list-item {
     list-style-type: none;
   }
-
 } 
 
 #readme-preview {

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -11,6 +11,16 @@
   }
 }
 
+#readme-container{
+  .table {
+    width: max-content;
+  }
+
+  tr:nth-child(even) {
+    background-color: @readme-table-bg-color;
+  }
+} 
+
 #readme-less {
   img {
     max-width: 100%;
@@ -36,6 +46,13 @@
 
   ul.contains-task-list, li.task-list-item {
     list-style-type: none;
+  }
+  .table {
+    width: max-content;
+  }
+
+  tr:nth-child(even) {
+    background-color: @readme-table-bg-color;
   }
 }
 

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -11,7 +11,7 @@
   }
 }
 
-#readme-container{
+#readme-common{
   .table {
     width: max-content;
     border: 1px solid @table-border-color;
@@ -24,47 +24,19 @@
   tr:nth-child(even) {
     background-color: @readme-table-bg-color;
   }
+
+  img, .img-fluid{
+    max-width: 100%;
+  }
+
+  ul.contains-task-list, li.task-list-item {
+    list-style-type: none;
+  }
+
 } 
-
-#readme-less {
-  img {
-    max-width: 100%;
-  }
-
-  ul.contains-task-list, li.task-list-item {
-    list-style-type: none;
-  }
-}
-
-#readme-more {
-  img {
-    max-width: 100%;
-  }
-
-  ul.contains-task-list, li.task-list-item {
-    list-style-type: none;
-  }
-}
 
 #readme-preview {
   padding-top: 0.25em;
-
-  ul.contains-task-list, li.task-list-item {
-    list-style-type: none;
-  }
-  
-  .table {
-    width: max-content;
-    border: 1px solid @table-border-color;
-    
-    th, td {
-      border: 1px solid @table-border-color;
-    }
-  }
-
-  tr:nth-child(even) {
-    background-color: @readme-table-bg-color;
-  }
 }
 
 #edit-markdown {

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -11,7 +11,7 @@
   }
 }
 
-#readme-common{
+.readme-common{
   .table {
     width: max-content;
     border: 1px solid @table-border-color;

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -15,21 +15,9 @@
   .table {
     width: max-content;
     border: 1px solid @table-border-color;
-    > thead,
-    > tbody,
-    > tfoot {
-      > tr {
-        > th,
-        > td {
-          border: 1px solid @table-border-color;
-        }
-      }
-    }
-    > thead > tr {
-      > th,
-      > td {
-        border-bottom-width: 2px;
-      }
+
+    th, td {
+      border: 1px solid @table-border-color;
     }
   }
 
@@ -68,21 +56,9 @@
   .table {
     width: max-content;
     border: 1px solid @table-border-color;
-    > thead,
-    > tbody,
-    > tfoot {
-      > tr {
-        > th,
-        > td {
-          border: 1px solid @table-border-color;
-        }
-      }
-    }
-    > thead > tr {
-      > th,
-      > td {
-        border-bottom-width: 2px;
-      }
+    
+    th, td {
+      border: 1px solid @table-border-color;
     }
   }
 

--- a/src/Bootstrap/less/variables.less
+++ b/src/Bootstrap/less/variables.less
@@ -142,6 +142,7 @@
 //** Border color for table and cell borders.
 @table-border-color:            #ddd;
 
+@readme-table-bg-color:         #f2f2f2;
 
 //== Buttons
 //

--- a/src/NuGetGallery/Services/MarkdownService.cs
+++ b/src/NuGetGallery/Services/MarkdownService.cs
@@ -204,6 +204,7 @@ namespace NuGetGallery
                 .UseAutoLinks()
                 .UseReferralLinks("noopener noreferrer nofollow")
                 .DisableHtml() //block inline html
+                .UseBootstrap()
                 .Build();
 
             using (var htmlWriter = new StringWriter())

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -519,29 +519,31 @@
                             </a>
                         </h2>
                     </div>
-                    <div id="readme-container" class="collapse in">
-                        @if (Model.ReadMeImagesRewritten && Model.CanDisplayPrivateMetadata)
-                        {
-                            @ViewHelpers.AlertImagesRewritten();
-                        }
+                    <div id= "readme-common">
+                        <div id="readme-container" class="collapse in">
+                            @if (Model.ReadMeImagesRewritten && Model.CanDisplayPrivateMetadata)
+                            {
+                                @ViewHelpers.AlertImagesRewritten();
+                            }
 
-                        @if (Model.ReadmeImageSourceDisallowed && Model.CanDisplayPrivateMetadata)
-                        {
-                            @ViewHelpers.AlertImageSourceDisallowed();
-                        }
-                        <div id="readme-less" class="collapse in">
-                            @Html.Raw(Model.ReadMeHtml)
-                        </div>
-                        <div id="readme-more" class="collapse">
-                            @Html.Raw(Model.ReadMeHtml)
-                        </div>
+                            @if (Model.ReadmeImageSourceDisallowed && Model.CanDisplayPrivateMetadata)
+                            {
+                                @ViewHelpers.AlertImageSourceDisallowed();
+                            }
+                            <div id="readme-less" class="collapse in">
+                                @Html.Raw(Model.ReadMeHtml)
+                            </div>
+                            <div id="readme-more" class="collapse">
+                                @Html.Raw(Model.ReadMeHtml)
+                            </div>
 
-                        <a href="#" role="button" data-toggle="collapse" class="icon-link" data-target="#readme-more"
-                           aria-expanded="false" aria-controls="#readme-more, #readme-less"
-                           id="show-readme-more" data-track="show-package-documentation">
-                            <i class="ms-Icon ms-Icon--CalculatorAddition" aria-hidden="true"></i>
-                            <span>Show more</span>
-                        </a>
+                            <a href="#" role="button" data-toggle="collapse" class="icon-link" data-target="#readme-more"
+                            aria-expanded="false" aria-controls="#readme-more, #readme-less"
+                            id="show-readme-more" data-track="show-package-documentation">
+                                <i class="ms-Icon ms-Icon--CalculatorAddition" aria-hidden="true"></i>
+                                <span>Show more</span>
+                            </a>
+                        </div>
                     </div>
                 }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -519,7 +519,7 @@
                             </a>
                         </h2>
                     </div>
-                    <div id= "readme-common">
+                    <div class="readme-common">
                         <div id="readme-container" class="collapse in">
                             @if (Model.ReadMeImagesRewritten && Model.CanDisplayPrivateMetadata)
                             {

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -594,7 +594,7 @@
                         }
                         else if (Model.ReadMeHtml != null)
                         {
-                            <div id= "readme-common">
+                            <div class="readme-common">
                                 <div id="readme-container">
                                     @if (Model.ReadMeImagesRewritten && Model.CanDisplayPrivateMetadata)
                                     {

--- a/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackageV2.cshtml
@@ -594,18 +594,20 @@
                         }
                         else if (Model.ReadMeHtml != null)
                         {
-                            <div id="readme-container">
-                                @if (Model.ReadMeImagesRewritten && Model.CanDisplayPrivateMetadata)
-                                {
-                                    @ViewHelpers.AlertImagesRewritten();
-                                }
+                            <div id= "readme-common">
+                                <div id="readme-container">
+                                    @if (Model.ReadMeImagesRewritten && Model.CanDisplayPrivateMetadata)
+                                    {
+                                        @ViewHelpers.AlertImagesRewritten();
+                                    }
 
-                                @if (Model.ReadmeImageSourceDisallowed && Model.CanDisplayPrivateMetadata)
-                                {
-                                    @ViewHelpers.AlertImageSourceDisallowed();
-                                }
+                                    @if (Model.ReadmeImageSourceDisallowed && Model.CanDisplayPrivateMetadata)
+                                    {
+                                        @ViewHelpers.AlertImageSourceDisallowed();
+                                    }
 
-                                @Html.Raw(Model.ReadMeHtml)
+                                    @Html.Raw(Model.ReadMeHtml)
+                                </div>
                             </div>
                         }
                         else

--- a/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
@@ -87,9 +87,11 @@
             </div>
         </div>
 
-        <div class="hidden" id="readme-preview">
-            <div class="row">
-                <div class="col-xs-12" id="readme-preview-contents"></div>
+        <div id = "readme-common">
+            <div class="hidden" id="readme-preview">
+                <div class="row">
+                    <div class="col-xs-12" id="readme-preview-contents"></div>
+                </div>
             </div>
         </div>
 

--- a/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
@@ -87,7 +87,7 @@
             </div>
         </div>
 
-        <div id = "readme-common">
+        <div class="readme-common">
             <div class="hidden" id="readme-preview">
                 <div class="row">
                     <div class="col-xs-12" id="readme-preview-contents"></div>

--- a/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
@@ -89,19 +89,19 @@ namespace NuGetGallery
             [InlineData("[text](http://www.test.com)", "<p><a href=\"http://www.test.com/\" rel=\"noopener noreferrer nofollow\">text</a></p>", false, false)]
             [InlineData("[text](javascript:alert('hi'))", "<p><a href=\"\" rel=\"noopener noreferrer nofollow\">text</a></p>", false, true)]
             [InlineData("[text](javascript:alert('hi'))", "<p><a href=\"\" rel=\"noopener noreferrer nofollow\">text</a></p>", false, false)]
-            [InlineData("> <text>Blockquote</text>", "<blockquote>\n<p>&lt;text&gt;Blockquote&lt;/text&gt;</p>\n</blockquote>", false, true)]
+            [InlineData("> <text>Blockquote</text>", "<blockquote class=\"blockquote\">\n<p>&lt;text&gt;Blockquote&lt;/text&gt;</p>\n</blockquote>", false, true)]
             [InlineData("> <text>Blockquote</text>", "<blockquote>\r\n<p>&lt;text&gt;Blockquote&lt;/text&gt;</p>\r\n</blockquote>", false, false)]
-            [InlineData("> > <text>Blockquote</text>", "<blockquote>\n<blockquote>\n<p>&lt;text&gt;Blockquote&lt;/text&gt;</p>\n</blockquote>\n</blockquote>", false, true)]
+            [InlineData("> > <text>Blockquote</text>", "<blockquote class=\"blockquote\">\n<blockquote class=\"blockquote\">\n<p>&lt;text&gt;Blockquote&lt;/text&gt;</p>\n</blockquote>\n</blockquote>", false, true)]
             [InlineData("> > <text>Blockquote</text>", "<blockquote>\r\n<p>&gt; &lt;text&gt;Blockquote&lt;/text&gt;</p>\r\n</blockquote>", false, false)]
             [InlineData("[text](http://www.asp.net)", "<p><a href=\"https://www.asp.net/\" rel=\"noopener noreferrer nofollow\">text</a></p>", false, true)]
             [InlineData("[text](http://www.asp.net)", "<p><a href=\"https://www.asp.net/\" rel=\"noopener noreferrer nofollow\">text</a></p>", false, false)]
             [InlineData("[text](badurl://www.asp.net)", "<p><a href=\"\" rel=\"noopener noreferrer nofollow\">text</a></p>", false, true)]
             [InlineData("[text](badurl://www.asp.net)", "<p><a href=\"\" rel=\"noopener noreferrer nofollow\">text</a></p>", false, false)]
-            [InlineData("![image](http://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" alt=\"image\" /></p>", true, true)]
+            [InlineData("![image](http://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" class=\"img-fluid\" alt=\"image\" /></p>", true, true)]
             [InlineData("![image](http://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" alt=\"image\" /></p>", true, false)]
-            [InlineData("![image](https://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" alt=\"image\" /></p>", false, true)]
+            [InlineData("![image](https://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" class=\"img-fluid\" alt=\"image\" /></p>", false, true)]
             [InlineData("![image](https://www.asp.net/fake.jpg)", "<p><img src=\"https://www.asp.net/fake.jpg\" alt=\"image\" /></p>", false, false)]
-            [InlineData("![image](http://www.otherurl.net/fake.jpg)", "<p><img src=\"https://www.otherurl.net/fake.jpg\" alt=\"image\" /></p>", true, true)]
+            [InlineData("![image](http://www.otherurl.net/fake.jpg)", "<p><img src=\"https://www.otherurl.net/fake.jpg\" class=\"img-fluid\" alt=\"image\" /></p>", true, true)]
             [InlineData("![image](http://www.otherurl.net/fake.jpg)", "<p><img src=\"https://www.otherurl.net/fake.jpg\" alt=\"image\" /></p>", true, false)]
             [InlineData("## License\n\tLicensed under the Apache License, Version 2.0 (the \"License\");", "<h3>License</h3>\n<pre><code>Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);\n</code></pre>", false, true)]
             [InlineData("## License\n\tLicensed under the Apache License, Version 2.0 (the \"License\");", "<h3>License</h3>\n<pre><code>Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);\n</code></pre>", false, true)]
@@ -115,13 +115,12 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(true)]
-            [InlineData(false)]
-            public void ConvertsMarkdownToHtmlWithImageDisaplyed(bool isMarkdigMdRenderingEnabled)
+            [InlineData(true, "<p><img src=\"https://api.bintray.com/example/image.svg\" class=\"img-fluid\" alt=\"image\" /></p>")]
+            [InlineData(false, "<p><img src=\"https://api.bintray.com/example/image.svg\" alt=\"image\" /></p>")]
+            public void ConvertsMarkdownToHtmlWithImageDisaplyed(bool isMarkdigMdRenderingEnabled, string expectedHtml)
             {
                 string imageUrl = "https://api.bintray.com/example/image.svg";
                 string originalMd = "![image](https://api.bintray.com/example/image.svg)";
-                string expectedHtml = "<p><img src=\"https://api.bintray.com/example/image.svg\" alt=\"image\" /></p>";
 
                 _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(isMarkdigMdRenderingEnabled);
                 _featureFlagService.Setup(x => x.IsImageAllowlistEnabled()).Returns(true);
@@ -132,13 +131,12 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(true)]
-            [InlineData(false)]
-            public void ConvertsMarkdownToHtmlWithoutImageDisaplyed(bool isMarkdigMdRenderingEnabled)
+            [InlineData(true, "<p><img src=\"\" class=\"img-fluid\" alt=\"image\" /></p>")]
+            [InlineData(false, "<p><img src=\"\" alt=\"image\" /></p>")]
+            public void ConvertsMarkdownToHtmlWithoutImageDisaplyed(bool isMarkdigMdRenderingEnabled, string expectedHtml)
             {
                 string imageUrl = "https://nuget.org/example/image.svg";
                 string originalMd = "![image](https://nuget.org/example/image.svg)";
-                string expectedHtml = "<p><img src=\"\" alt=\"image\" /></p>";
                 string outUrl = null;
 
                 _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(isMarkdigMdRenderingEnabled);
@@ -156,7 +154,7 @@ namespace NuGetGallery
 -- | -
 0 | 1";
 
-                var expectedHtml = "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>";
+                var expectedHtml = "<table class=\"table\">\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>0</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>";
                 _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(true);
                 var readMeResult = _markdownService.GetHtmlFromMarkdown(originalMd);
                 Assert.Equal(expectedHtml, readMeResult.Content);
@@ -173,7 +171,7 @@ namespace NuGetGallery
 +---+---+
 ";
 
-                var expectedHtml = "<table>\n<col style=\"width:50%\" />\n<col style=\"width:50%\" />\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>2</td>\n</tr>\n</tbody>\n</table>";
+                var expectedHtml = "<table class=\"table\">\n<col style=\"width:50%\" />\n<col style=\"width:50%\" />\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>1</td>\n<td>2</td>\n</tr>\n</tbody>\n</table>";
                 _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(true);
                 var readMeResult = _markdownService.GetHtmlFromMarkdown(originalMd);
                 Assert.Equal(expectedHtml, readMeResult.Content);


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Make table pretty similar to Github table style but without border:

upload preview page: 
![readmeupload](https://user-images.githubusercontent.com/64443925/147602779-005668bc-edcf-4ed1-b51d-ea31fdce85e9.png)
manage page: 
![readmeManage](https://user-images.githubusercontent.com/64443925/147602790-9a04ce0b-b5ce-4d31-af8d-100776cc68dd.png)
package detail page: 
![readmeShow](https://user-images.githubusercontent.com/64443925/147602794-0ca753be-0426-4201-900e-6a9cac136161.png)


[example table](https://github.com/microsoft/PowerToys/blob/main/README.md)
 
github vs before change vs after change 

github:

![github](https://user-images.githubusercontent.com/64443925/147620442-b499d29a-3513-4ae9-8499-ac97445faa2c.png)

before change: 
![beforereadme](https://user-images.githubusercontent.com/64443925/147620459-6fc378d8-b4a9-47ac-9e54-6fb0fa3a54e1.png)

after change: 
![afterreadmedev](https://user-images.githubusercontent.com/64443925/147620483-130c9af2-dbb8-4477-bf33-2a76f6e87afc.png)


Addresses: https://github.com/NuGet/NuGetGallery/issues/8503