### PR TITLE
Remove cybertip link from report package page

### DIFF
--- a/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
+++ b/src/NuGetGallery/Views/Packages/ReportAbuse.cshtml
@@ -106,11 +106,6 @@
                                 If you are reporting copyright infringement, please describe the copyrighted material with particularity and provide us with information about your copyright (i.e. title of copyrighted work, URL where to view your copyrighted work, description of your copyrighted work, and any copyright registrations you may have, etc.). For trademark infringement, include the name of your trademark, registration number, and country where registered.
                             </p>
                         </div>
-                        <div class="child-sexual-exploitation" tabindex="0">
-                            <p>
-                                Note: Please complete this form and submit it so we can proceed with an appropriate response regarding the NuGet package (e.g. removing it). In addition, please proceed to <a href="https://report.cybertip.org">https://report.cybertip.org</a> to report the matter in more detail.
-                            </p>
-                        </div>
                         <div class="imminent-harm" tabindex="0">
                             <p>
                                 Note: please ensure when reporting this type of abuse that you've considered whether the following are present:
@@ -206,12 +201,6 @@
             } else {
                 $form.find('.already-contacted-owner').show();
                 $form.find('.online-safety-extras').hide();
-            }
-
-            if (val === 'ChildSexualExploitationOrAbuse') {
-                $form.find('.child-sexual-exploitation').show();
-            } else {
-                $form.find('.child-sexual-exploitation').hide();
             }
 
             if (val === 'ImminentHarm') {


### PR DESCRIPTION
Addresses: https://github.com/NuGet/Engineering/issues/4172

Removes an unnecessary link from the Report Package page (see issue for details).