### PR TITLE
[TFM Display] Add feature flags for TFM.

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -51,6 +51,11 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
+        public bool IsComputeTargetFrameworkEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsDeletePackageApiEnabled(User user)
         {
             throw new NotImplementedException();
@@ -81,7 +86,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public bool IsDisplayTargetFrameworkEnabled()
+        public bool IsDisplayTargetFrameworkEnabled(User user)
         {
             throw new NotImplementedException();
         }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -270,7 +270,12 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
-        public bool IsDisplayTargetFrameworkEnabled()
+        public bool IsDisplayTargetFrameworkEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsComputeTargetFrameworkEnabled()
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -53,6 +53,7 @@ namespace NuGetGallery
         private const string DisplayPackagePageV2FeatureName = GalleryPrefix + "DisplayPackagePageV2";
         private const string ShowReportAbuseSafetyChanges = GalleryPrefix + "ShowReportAbuseSafetyChanges";
         private const string DisplayTargetFrameworkFeatureName = GalleryPrefix + "DisplayTargetFramework";
+        private const string ComputeTargetFrameworkFeatureName = GalleryPrefix + "ComputeTargetFramework";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -253,11 +254,11 @@ namespace NuGetGallery
             return _client.IsEnabled(DisplayPackagePageV2PreviewFeatureName, user, defaultValue: false);
         }
 
-        public bool IsDisplayPackagePageV2Enabled(User user) 
+        public bool IsDisplayPackagePageV2Enabled(User user)
         {
             return _client.IsEnabled(DisplayPackagePageV2FeatureName, user, defaultValue: false);
         }
-        
+
         public bool IsODataV1GetAllEnabled()
         {
             return _client.IsEnabled(ODataV1GetAllNonHijackedFeatureName, defaultValue: true);
@@ -342,7 +343,7 @@ namespace NuGetGallery
         {
             return _client.IsEnabled(MarkdigMdRenderingFlightName, defaultValue: false);
         }
-        
+
         public bool IsDeletePackageApiEnabled(User user)
         {
             return _client.IsEnabled(DeletePackageApiFlightName, user, defaultValue: false);
@@ -358,9 +359,14 @@ namespace NuGetGallery
             return _client.IsEnabled(DisplayBannerFlightName, defaultValue: false);
         }
 
-        public bool IsDisplayTargetFrameworkEnabled()
+        public bool IsDisplayTargetFrameworkEnabled(User user)
         {
-            return _client.IsEnabled(DisplayTargetFrameworkFeatureName, defaultValue: false);
+            return _client.IsEnabled(DisplayTargetFrameworkFeatureName, user, defaultValue: false);
+        }
+
+        public bool IsComputeTargetFrameworkEnabled()
+        {
+            return _client.IsEnabled(ComputeTargetFrameworkFeatureName, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -290,6 +290,11 @@ namespace NuGetGallery
         /// <summary>
         /// Whether or not display target framework badges and table on nuget.org
         /// </summary>
-        bool IsDisplayTargetFrameworkEnabled();
+        bool IsDisplayTargetFrameworkEnabled(User user);
+
+        /// <summary>
+        /// Whether or not to compute backend operations for target framework. This flag is overridden by <see cref="IsDisplayTargetFrameworkEnabled"/> if that flag is true.
+        /// </summary>
+        bool IsComputeTargetFrameworkEnabled();
     }
 }

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -31,7 +31,7 @@
     "NuGetGallery.MarkdigMdRendering": "Enabled",
     "NuGetGallery.ImageAllowlist": "Enabled",
     "NuGetGallery.ShowReportAbuseSafetyChanges": "Enabled",
-    "NuGetGallery.DisplayTFM": "Enabled"
+    "NuGetGallery.ComputeTargetFramework": "Enabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {
@@ -107,6 +107,12 @@
       "Domains": []
     },
     "NuGetGallery.DisplayPackagePageV2Preview": {
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
+    },
+    "NuGetGallery.DisplayTargetFramework": {
       "All": true,
       "SiteAdmins": false,
       "Accounts": [],

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -120,6 +120,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
-        public bool IsDisplayTargetFrameworkEnabled() => throw new NotImplementedException();
+        public bool IsDisplayTargetFrameworkEnabled(User user) => throw new NotImplementedException();
+
+        public bool IsComputeTargetFrameworkEnabled() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
- `ComputeTargetFramework`: This feature flag will be turned on to perform computations on the backend for TFM work, this will help us to check performance before showing TFM to public.
- `DisplayTargetFramework`: This flight is to help testing the behavior of TFMs on display page showing both badges and tab, if this feature flag is turned on, it will override the `ComputeTargetFramework `behavior.

Address: https://github.com/NuGet/Engineering/issues/4183.