### PR TITLE
[A11y] Fixes tag link color in search results

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -258,9 +258,6 @@ img.reserved-indicator-icon {
   line-height: 20px;
   color: #666666;
 }
-.package-list a {
-  color: #337ab7;
-}
 .package-list li {
   list-style: none;
   display: list-item;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -258,8 +258,8 @@ img.reserved-indicator-icon {
   line-height: 20px;
   color: #666666;
 }
-.package-list a:not(.more-tags) {
-  color: #666666;
+.package-list a {
+  color: #337ab7;
 }
 .package-list li {
   list-style: none;
@@ -578,12 +578,6 @@ img.reserved-indicator-icon {
     margin-left: 0;
     display: block;
   }
-}
-.list-packages .package .package-list .package-tags {
-  margin-left: 10px;
-}
-.list-packages .package .package-list .package-tags .tag-link {
-  color: #337ab7;
 }
 .list-packages .package .package-title {
   font-size: 16px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -579,6 +579,12 @@ img.reserved-indicator-icon {
     display: block;
   }
 }
+.list-packages .package .package-list .package-tags {
+  margin-left: 10px;
+}
+.list-packages .package .package-list .package-tags .tag-link {
+  color: #337ab7;
+}
 .list-packages .package .package-title {
   font-size: 16px;
   margin-top: 2px;

--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -1,6 +1,6 @@
 /*!
  * Bootstrap v3.4.1 (https://getbootstrap.com/)
- * Copyright 2011-2021 Twitter, Inc.
+ * Copyright 2011-2022 Twitter, Inc.
  * Licensed under the MIT license
  */
 

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -335,10 +335,6 @@ img.reserved-indicator-icon {
   line-height: @package-list-line-height;
   color: @gray-light;
 
-  a {
-    color: @link-color;
-  }
-
   li {
     list-style: none;
     display: list-item;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -335,8 +335,8 @@ img.reserved-indicator-icon {
   line-height: @package-list-line-height;
   color: @gray-light;
 
-  a:not(.more-tags) {
-    color: @gray-light;
+  a {
+    color: @link-color;
   }
 
   li {

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -44,7 +44,6 @@
         }
       }
     }
-    
 
     .package-title {
       font-size: 16px;

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -36,6 +36,16 @@
       }
     }
 
+    .package-list {
+      .package-tags {
+        margin-left: @padding-small-horizontal;
+        .tag-link {
+          color: @link-color;
+        }
+      }
+    }
+    
+
     .package-title {
       font-size: 16px;
       margin-top: 2px;

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -36,15 +36,6 @@
       }
     }
 
-    .package-list {
-      .package-tags {
-        margin-left: @padding-small-horizontal;
-        .tag-link {
-          color: @link-color;
-        }
-      }
-    }
-
     .package-title {
       font-size: 16px;
       margin-top: 2px;

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -108,13 +108,13 @@
                             }
                             @foreach (var tag in tags)
                             {
-                                <a href="@Url.Search("Tags:\"" + tag + "\"")" class="tag-link" title="Search for @tag">@tag</a>
+                                <a href="@Url.Search("Tags:\"" + tag + "\"")" title="Search for @tag">@tag</a>
                             }
                             @if (lastTag != null)
                             {
                                 <span class="text-nowrap">
-                                    <a href="@Url.Search("Tags:\"" + lastTag + "\"")" class="tag-link" title="Search for @lastTag">@lastTag</a>
-                                    <a href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)" title="View more tags" class="more-tags">More tags</a>
+                                    <a href="@Url.Search("Tags:\"" + lastTag + "\"")" title="Search for @lastTag">@lastTag</a>
+                                    <a href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)" title="View more tags">More tags</a>
                                 </span>
                             }
                         </span>

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -108,12 +108,12 @@
                             }
                             @foreach (var tag in tags)
                             {
-                                <a href="@Url.Search("Tags:\"" + tag + "\"")" title="Search for @tag">@tag</a>
+                                <a href="@Url.Search("Tags:\"" + tag + "\"")" class="tag-link" title="Search for @tag">@tag</a>
                             }
                             @if (lastTag != null)
                             {
                                 <span class="text-nowrap">
-                                    <a href="@Url.Search("Tags:\"" + lastTag + "\"")" title="Search for @lastTag">@lastTag</a>
+                                    <a href="@Url.Search("Tags:\"" + lastTag + "\"")" class="tag-link" title="Search for @lastTag">@lastTag</a>
                                     <a href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)" title="View more tags" class="more-tags">More tags</a>
                                 </span>
                             }


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/8921

When viewing package search results on nuget.org, the links for the tags were indistinguishable from non-hyperlink text around it:
 
![image](https://user-images.githubusercontent.com/82980589/148151368-1b4305b8-1d28-43eb-a86f-88b94e38284b.png)

This PR fixes it and changes the tag hyperlink color such that users can differentiate between regular text and the links:

![image](https://user-images.githubusercontent.com/82980589/148151488-1d2f0193-3084-4cca-8613-07d51636f958.png)
