### PR TITLE
[A11y] Improved visibility of checkboxes when keyboard navigating a page (especially in high-contrast mode)

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -1861,6 +1861,12 @@ input[type="checkbox"]:focus {
   outline: 4px solid -webkit-focus-ring-color;
   outline-offset: -2px;
 }
+@media (forced-colors: active) {
+  input[type="checkbox"]:focus {
+    outline: 3px solid -webkit-focus-ring-color;
+    outline-offset: 2px;
+  }
+}
 output {
   display: block;
   padding-top: 7px;

--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -303,7 +303,7 @@ a:focus {
   text-decoration: underline;
 }
 a:focus {
-  outline: 5px auto -webkit-focus-ring-color;
+  outline: 4px solid -webkit-focus-ring-color;
   outline-offset: -2px;
 }
 figure {
@@ -1858,7 +1858,7 @@ select[size] {
 input[type="file"]:focus,
 input[type="radio"]:focus,
 input[type="checkbox"]:focus {
-  outline: 5px auto -webkit-focus-ring-color;
+  outline: 4px solid -webkit-focus-ring-color;
   outline-offset: -2px;
 }
 output {
@@ -2340,7 +2340,7 @@ select[multiple].input-lg {
 .btn.focus,
 .btn:active.focus,
 .btn.active.focus {
-  outline: 5px auto -webkit-focus-ring-color;
+  outline: 4px solid -webkit-focus-ring-color;
   outline-offset: -2px;
 }
 .btn:hover,

--- a/src/Bootstrap/less/forms.less
+++ b/src/Bootstrap/less/forms.less
@@ -100,6 +100,13 @@ input[type="checkbox"]:focus {
   .tab-focus();
 }
 
+// Focus for checkboxes in forced-color modes (eg. Windows high-contrast mode)
+@media (forced-colors: active) {
+  input[type="checkbox"]:focus {
+    .forced-colors-tab-focus();
+  }
+}
+
 // Adjust output element
 output {
   display: block;

--- a/src/Bootstrap/less/mixins/tab-focus.less
+++ b/src/Bootstrap/less/mixins/tab-focus.less
@@ -4,6 +4,6 @@
   // WebKit-specific. Other browsers will keep their default outline style.
   // (Initially tried to also force default via `outline: initial`,
   // but that seems to erroneously remove the outline in Firefox altogether.)
-  outline: 5px auto -webkit-focus-ring-color;
+  outline: 4px solid -webkit-focus-ring-color;
   outline-offset: -2px;
 }

--- a/src/Bootstrap/less/mixins/tab-focus.less
+++ b/src/Bootstrap/less/mixins/tab-focus.less
@@ -7,3 +7,10 @@
   outline: 4px solid -webkit-focus-ring-color;
   outline-offset: -2px;
 }
+
+.forced-colors-tab-focus() {
+  // Specific to high-contrast mode, and other forced-color schemes
+  // To override color changes in high-contrast mode, use "forced-color-adjust: none;"
+  outline: 3px solid -webkit-focus-ring-color;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/8924

**Problem:**

On NuGet.org, when navigating a page using the keyboard (tab key), checkboxes were not completely visible, especially in high-contrast mode.

Previous version:
![Old, regular](https://user-images.githubusercontent.com/82980589/148620633-a09160df-098e-44c8-9694-9520182adfcb.gif)

Previous version (high-contrast mode):
![Old, high contrast](https://user-images.githubusercontent.com/82980589/148620774-13cd88b9-7dda-438f-a14f-bcd04a8b0058.gif)

**Fix:**

To fix this, I changed the outline to solid (and reduced the size of the outline so it wasn't too big and overbearing).

After making the changes:

New version:
![New, regular](https://user-images.githubusercontent.com/82980589/148620788-0599f751-d49e-4388-8e24-0a3cf28516f5.gif)

New version (high-contrast mode):
![New, high contrast](https://user-images.githubusercontent.com/82980589/148620798-5f98e793-4579-46ce-8317-4c1634a7eb16.gif)

