### PR TITLE
[A11y Bug] Narrator not announcing error messages for ReadMe.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
+++ b/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
@@ -369,6 +369,9 @@ var BindReadMeDataManager = (function () {
         }
 
         function displayReadMeError(errorMsg) {
+            // In order for Narrator to read the alert, this should be on an aria-label attribute.
+            $("#readme-error-content").attr("aria-label", errorMsg);
+
             $("#readme-errors").removeClass("hidden");
             $("#preview-readme-button").attr("disabled", "disabled");
 
@@ -388,6 +391,7 @@ var BindReadMeDataManager = (function () {
             if (!$("#readme-errors").hasClass("hidden")) {
                 $("#readme-errors").addClass("hidden");
                 $("#readme-error-content").text("");
+                $("#readme-error-content").removeAttr("aria-label");
             }
             $("#preview-readme-button").prop("disabled", false);
         }


### PR DESCRIPTION
NVDA was working fine, but Windows Narrator was not reading readme error alerts. A workaround for this was to add the same error content as aria-label.

Addresses: https://github.com/NuGet/NuGetGallery/issues/8923