### PR TITLE
[Db Migration] Fix the tool

### DIFF
--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -70,6 +70,10 @@
       <Project>{f4c8c34f-72a9-4773-a315-8fa3f2d5ce4e}</Project>
       <Name>NuGet.Services.DatabaseMigration</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.Entities\NuGet.Services.Entities.csproj">
+      <Project>{6262f4fc-29be-4226-b676-db391c89d396}</Project>
+      <Name>NuGet.Services.Entities</Name>
+    </ProjectReference>
     <ProjectReference Include="..\NuGetGallery.Core\NuGetGallery.Core.csproj">
       <Project>{097b2cdd-9623-4c34-93c2-d373d51f5b4e}</Project>
       <Name>NuGetGallery.Core</Name>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -64,6 +64,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Services.Validation">
+      <Version>2.97.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Services.DatabaseMigration\NuGet.Services.DatabaseMigration.csproj">


### PR DESCRIPTION
Following the similar solution as https://github.com/NuGet/NuGetGallery/pull/8930, we need to add the project dependency of "NuGet.Services.Entities" as the direct dependency of "DatabaseMigrationTools". Without this direct dependency, DLL doesn't seem being generated or placed after the build on CI.

The issue should be related to the mixed dependences of projects and packages and some client's edge cases.

Main dependency chains:
**Project Reference**: 1. DatabaseMigrationTools -> NuGetGallery -> NuGetGallery.Core -> NuGet.Services.Entities
                              2. DatabaseMigrationTools -> NuGetGallery -> NuGet.Services.Entities
**Package Reference**: 3. DatabaseMigrationTools -> NuGet.Services.DatabaseMigration -> NuGet.Jobs.Common -> 
                                NuGetGallery.Core -> NuGet.Services.Entities

"NuGet.Services.Validation" is added to support the migration of Validation DB as before.

cc @shishirx34 

