### PR TITLE
Add option to backfill tools for specific IDs list

### DIFF
--- a/src/GalleryTools/App.config
+++ b/src/GalleryTools/App.config
@@ -28,8 +28,6 @@
     <add key="Gallery.FileStorageDirectory" value="..\..\..\NuGetGallery\App_Data\Files"/>
     <add key="Gallery.LuceneIndexLocation" value="Temp"/>
     <add key="Gallery.IsHosted" value="false"/>
-
-    <add key="Gallery.ServiceDiscoveryUri" value="https://api.nuget.org/v3/index.json" />
   </appSettings>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">

--- a/src/GalleryTools/Commands/BackfillCommand.cs
+++ b/src/GalleryTools/Commands/BackfillCommand.cs
@@ -197,9 +197,9 @@ namespace GalleryTools.Commands
             }
         }
 
-        private static HashSet<PackageIdentity> ReadPackageIdentityList(string completedPath)
+        private static HashSet<PackageIdentity> ReadPackageIdentityList(string path)
         {
-            var completedLines = File.Exists(completedPath) ? File.ReadAllLines(completedPath) : Array.Empty<string>();
+            var completedLines = File.Exists(path) ? File.ReadAllLines(path) : Array.Empty<string>();
             return completedLines
                 .Where(x => !string.IsNullOrWhiteSpace(x))
                 .Select(x => x.Split(','))

--- a/src/GalleryTools/GalleryTools.csproj
+++ b/src/GalleryTools/GalleryTools.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="Readme.md" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GitHubVulnerabilities2Db\GitHubVulnerabilities2Db.csproj">

--- a/src/GalleryTools/Readme.md
+++ b/src/GalleryTools/Readme.md
@@ -4,38 +4,66 @@ This project contains tools for performing manual one-time/maintenance operation
 
 ---
 
-## Backfill repository metadata
+## Backfill tools
 
-This tool collects repository metadata for all packages in the database using nuspec files in the V3 flat container and updates the database with this data.
+There are several variants of the backfill tool, for different data properties. All of the tools have a similar pattern and set of capabilities. These tools collect repository metadata for packages in the database using .nuspec or .nupkg files in the V3 flat container and update the database with this data.
 
-### Collecting metadata
+There are two ways to use the backfill tools:
 
-1. Configure app.config with database information and service index url
-1. Run this tool with: `GalleryTools.exe fillrepodata -c`
+- Collect metadata and the update metadata for all packages (two different executions of the tool, `-c` then `-u`)
+- Collect and update metadata for specific packages (single execution of the tool, `-i`)
 
-This will create a file `repositoryMetadata.txt` with all collected data. You can stop the job anytime and restart. `cursor.txt` contains current position.    
+The commands that are backfill tools are:
 
-### Updating the database with collected data
+- `fillrepodata` - updates repository URL metadata
+  - The `-f` option defaults to `repositoryMetadata.txt`
+- `filldevdeps` - sets the dev dependency bool
+  - The `-f` option defaults to `developmentDependencyMetadata.txt`
+- `filltfms` - updates framework compatibility
+  - The `-f` option defaults to `tfmMetadata.txt`
 
-1. Run `GalleryTools.exe fillrepodata -u`
-
-This will update the database from file `repositoryMetadata.txt`. You can stop the job anytime and restart.  `cursor.txt` contains current position. 
+All errors are written to the `errors.txt` file, placed in the current working directory.
 
 ---
 
-## Backfill development dependency metadata
-
-This tool collects development dependency metadata for all packages in the database using nuspec files in the V3 flat container and updates the database with this data.
-
 ### Collecting metadata
 
-1. Configure app.config with database information and service index url
-1. Run this tool with: `GalleryTools.exe filldevdeps -c`
+1. Configure app.config with database information
+1. Run this tool with: `GalleryTools.exe {tool} -c -s {v3-url}`
 
-This will create a file `developmentDependencyMetadata.txt` with all collected data. You can stop the job anytime and restart. `cursor.txt` contains current position.    
+`{tool}` is one of the backfill tool names above, e.g. `fillrepodata`.
+
+`{v3-url}` is the V3 service index URL, e.g. `https://api.nuget.org/v3/index.json`.
+
+This will create a file at the default data file location (or whatever is specified by the `-f | --file` option) with all collected data. You can stop the job anytime and restart. `cursor.txt` contains current position.    
+
+---
 
 ### Updating the database with collected data
 
-1. Run `GalleryTools.exe filldevdeps -u`
+This is run after collecting metadata (the previous section).
 
-This will update the database from file `developmentDependencyMetadata.txt`. You can stop the job anytime and restart.  `cursor.txt` contains current position.
+1. Configure app.config with database information (should be already done for the `-c` invocation mentioned above)
+1. Run `GalleryTools.exe {tool} -u`
+
+`{tool}` is one of the backfill tool names above, e.g. `fillrepodata`.
+
+This will update the database from the default data file (or whatever is specified by the `-f | --file` option). You can stop the job anytime and restart. `cursor.txt` contains current position. 
+
+---
+
+### Update specific packages
+
+1. Configure app.config with database information
+1. Create a data file with one package identity per line. The format is `{id},{version}`, e.g. `Newtonsoft.Json,9.0.1`.
+1. Run `GalleryTools.exe {tool} -i -f {path-to-file} -s {v3-url}`
+
+Instead of performing a time consuming collect and update flow for the entire data, you can perform the backfill on a specific set of package IDs and versions.
+
+`{tool}` is one of the backfill tool names above, e.g. `fillrepodata`.
+
+`{path-to-file}` is the path to the file with package identities, `{id},{version}` per line.
+
+`{v3-url}` is the V3 service index URL, e.g. `https://api.nuget.org/v3/index.json`.
+
+A file will be created at `{path-to-file}.completed` containing the list of all package identities that have been completed. This can be deleted to redo the update.

--- a/src/GalleryTools/Readme.md
+++ b/src/GalleryTools/Readme.md
@@ -11,6 +11,8 @@ There are several variants of the backfill tool, for different data properties. 
 There are two ways to use the backfill tools:
 
 - Collect metadata and the update metadata for all packages (two different executions of the tool, `-c` then `-u`)
+  - Note that for test runs `-c` and `-u` can be used at the same time, but we have observed in PROD that the job hangs
+    from time to time causing us to restart the job. Therefore doing `-c` and `-u` all at once is not practical.
 - Collect and update metadata for specific packages (single execution of the tool, `-i`)
 
 The commands that are backfill tools are:


### PR DESCRIPTION
We have found some cases in the TFM data where we may need to reprocess several thousand packages to fix their data. 

This update to the backfill tool allows a list of package IDs to be provided instead of backfilling everything in the DB.

See the README changes for more information.

Fix https://github.com/NuGet/NuGetGallery/issues/8961

/cc @dannyjdev 