### PR TITLE
Redo .NET banner

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1863,25 +1863,32 @@ p.frameworktableinfo-text {
   object-fit: cover;
   background-color: #000;
 }
-.page-home .dotnet-20-banner .container {
-  position: relative;
-  top: 20px;
-  padding-top: 20px;
+.page-home .dotnet-20-banner .container .row {
   color: white;
 }
-.page-home .dotnet-20-banner .container .row {
-  margin-bottom: 80px;
+@media (max-width: 1199px) {
+  .page-home .dotnet-20-banner .container .row {
+    margin-top: 48px;
+    margin-bottom: 48px;
+  }
+}
+@media (min-width: 1199px) {
+  .page-home .dotnet-20-banner .container .row {
+    margin-top: 144px;
+    margin-bottom: 144px;
+  }
 }
 .page-home .dotnet-20-banner .container .row .banner-text {
   -webkit-backdrop-filter: blur(2px);
   backdrop-filter: blur(2px);
 }
 .page-home .dotnet-20-banner .container .row .banner-text h2 {
+  margin-top: 0px;
   font-weight: 600;
 }
 .page-home .dotnet-20-banner .container .row .banner-text h3 {
   margin-top: 0px;
-  font-weight: 600;
+  font-weight: 400;
 }
 .page-home .dotnet-20-banner .container .row .banner-text a {
   padding: 5px 12px 5px 12px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1846,7 +1846,7 @@ p.frameworktableinfo-text {
   margin: 32px;
 }
 .page-home div.dotnet-20-banner {
-  background: black url(../img/dotnet-20-banner.svg);
+  background: url(../img/dotnet-20-banner.svg);
   background-repeat: no-repeat;
   background-position: 0 -150px;
   -webkit-background-size: cover;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1846,20 +1846,31 @@ p.frameworktableinfo-text {
   margin: 32px;
 }
 .page-home div.dotnet-20-banner {
-  background: url(../img/dotnet-20-banner.svg);
-  background-repeat: no-repeat;
-  background-position: 0 -150px;
-  -webkit-background-size: cover;
-  background-size: cover;
+  position: relative;
   margin-top: 32px;
 }
+.page-home .dotnet-20-banner .dotnet-20-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+.page-home .dotnet-20-banner .dotnet-20-image img {
+  height: 100%;
+  width: 100%;
+  -o-object-fit: cover;
+  object-fit: cover;
+  background-color: #000;
+}
 .page-home .dotnet-20-banner .container {
+  position: relative;
+  top: 20px;
   padding-top: 20px;
-  padding-bottom: 140px;
   color: white;
 }
 .page-home .dotnet-20-banner .container .row {
-  margin-bottom: 40px;
+  margin-bottom: 80px;
 }
 .page-home .dotnet-20-banner .container .row .banner-text {
   -webkit-backdrop-filter: blur(2px);
@@ -1877,11 +1888,6 @@ p.frameworktableinfo-text {
   border: 1px solid white;
   color: white;
   font-weight: 600;
-}
-@media (max-width: 991px) {
-  .page-home .what-is-nuget-with-banner {
-    margin-top: -120px;
-  }
 }
 .page-home .what-is-nuget {
   font-size: 1.15em;

--- a/src/Bootstrap/less/theme/page-home.less
+++ b/src/Bootstrap/less/theme/page-home.less
@@ -31,24 +31,30 @@
     }
 
     .container {
-      position: relative;
-      top: 20px;
-      padding-top: 20px;
-      color: white;
-
       .row {
-        margin-bottom: 80px;
+        color: white;
+
+        @media (max-width: @screen-md-max) {
+          margin-top: 48px;
+          margin-bottom: 48px;
+        }
+
+        @media (min-width: @screen-md-max) {
+          margin-top: 144px;
+          margin-bottom: 144px;
+        }
 
         .banner-text {
           backdrop-filter: blur(2px);
 
           h2 {
+            margin-top: 0px;
             font-weight: 600;
           }
 
           h3 {
             margin-top: 0px;
-            font-weight: 600;
+            font-weight: 400;
           }
 
           a {

--- a/src/Bootstrap/less/theme/page-home.less
+++ b/src/Bootstrap/less/theme/page-home.less
@@ -10,24 +10,34 @@
   }
 
   div.dotnet-20-banner {
-    background: url(../img/dotnet-20-banner.svg);
-    background-repeat: no-repeat;
-    background-position: 0 -150px;
-    background-size: cover;
+    position: relative;
     margin-top: 32px;
   }
 
   .dotnet-20-banner {
+    .dotnet-20-image {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+
+      img {
+        height: 100%;
+        width: 100%;
+        object-fit: cover;
+        background-color: #000;
+      }
+    }
+
     .container {
-      // The padding bottom is a hack to force the container's height to
-      // be at least as big as its content. This ensures the background
-      // image covers the entire container on narrow screens.
+      position: relative;
+      top: 20px;
       padding-top: 20px;
-      padding-bottom: 140px;
       color: white;
 
       .row {
-        margin-bottom: 40px;
+        margin-bottom: 80px;
 
         .banner-text {
           backdrop-filter: blur(2px);
@@ -49,14 +59,6 @@
           }
         }
       }
-    }
-  }
-
-  // The banner uses a hack to ensure its container is tall enough
-  // on narrow screens. This offsets that hack.
-  .what-is-nuget-with-banner {
-    @media (max-width: @screen-sm-max) {
-      margin-top: -120px;
     }
   }
 

--- a/src/Bootstrap/less/theme/page-home.less
+++ b/src/Bootstrap/less/theme/page-home.less
@@ -10,7 +10,7 @@
   }
 
   div.dotnet-20-banner {
-    background: black url(../img/dotnet-20-banner.svg);
+    background: url(../img/dotnet-20-banner.svg);
     background-repeat: no-repeat;
     background-position: 0 -150px;
     background-size: cover;

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1348,6 +1348,7 @@
     <Content Include="Content\gallery\img\circuit-board.svg" />
     <Content Include="Content\gallery\img\default-package-icon-256x256.png" />
     <Content Include="Content\gallery\img\default-package-icon.svg" />
+    <Content Include="Content\gallery\img\dotnet-20-banner.svg" />
     <Content Include="Content\gallery\img\dotnet-foundation-42x42.png" />
     <Content Include="Content\gallery\img\dotnet-foundation.svg" />
     <Content Include="Content\gallery\img\facebook-24x24.png" />

--- a/src/NuGetGallery/Views/Pages/Home.cshtml
+++ b/src/NuGetGallery/Views/Pages/Home.cshtml
@@ -77,6 +77,9 @@ else if (AskUserToEnable2FA)
     @if (Model.ShowDotnet20Banner)
     {
         <div class="dotnet-20-banner">
+            <div class="dotnet-20-image">
+                <img src="~/Content/gallery/img/dotnet-20-banner.svg" aria-hidden="true" />
+            </div>
             <div class="container">
                 <div class="row">
                     <div class="banner-text col-md-8">
@@ -96,7 +99,7 @@ else if (AskUserToEnable2FA)
         </div>
     }
 
-    <div class="container text-center what-is-nuget @(Model.ShowDotnet20Banner ? "what-is-nuget-with-banner" : "") ">
+    <div class="container text-center what-is-nuget">
         <div class="row">
             <h2>What is NuGet?</h2>
             <p>


### PR DESCRIPTION
The banner is broken on INT as the image wasn't included in the release artifacts. See:

* https://int.nugettest.org/
* https://int.nugettest.org/Content/gallery/img/dotnet-20-banner.svg

Also the previous implementation used a padding hack to force a container to have a minimal height. This solution did not work well on very wide screens as it caused the background image to be noticeably clipped. This new solution looks much better on very wide screens and removes the padding hack.

I will test this on DEV before merging:

* [x] Accessibility Insights FastPass
* [x] Verified on DEV
    * Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5689834&view=results
    * Release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1253840

Here's what it looks like:

![my-lifes-work](https://user-images.githubusercontent.com/737941/151682696-1b1953f8-605d-476a-91ba-7fdcf6b4e246.gif)

Follow up to https://github.com/NuGet/NuGetGallery/pull/8966
Part of: https://github.com/NuGet/Engineering/issues/4226