### PR TITLE
[A11y]Update statistics chart to resize correctly.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
+++ b/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
@@ -283,7 +283,7 @@
     }
 
     $(window).resize(function () {
-        packageDisplayGraphs(graphData);
+        packageDisplayGraphs(window.graphData);
     });
 
     return packageDisplayGraphs;


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8920
Turns out this was actually caused by a bug where the data being sent in on resize was actually a null object, which broke the graph for the rest of the session.
This update passes in the object that is attached to the window on page load instead and should prevent the graph data being lost.