### PR TITLE
Use table-responsive for sample glob descriptions.

### DIFF
--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -457,7 +457,7 @@
                         <div class="panel-body">
                             <p>A glob pattern allows you to replace any sequence of characters with '*'.</p>
                             <p>Example glob patterns:</p>
-                            <table class="table table-condensed borderless">
+                            <table class="table-responsive table-condensed borderless">
                                 <thead>
                                     <tr>
                                         <th>Pattern</th>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8919
This was being caused by a table in the API keys page being wider than the page when zoomed in.
This behaviour could also be replicated by making the window very narrow.
Update this table to use BootStrap's table-responsive, which causes the table content to correctly collapse with page width.