### PR TITLE
Update to latest SharpZipLib to resolve CG alert

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2284,7 +2284,7 @@
       <Version>1.1.3</Version>
     </PackageReference>
     <PackageReference Include="SharpZipLib">
-      <Version>1.1.0</Version>
+      <Version>1.3.3</Version>
     </PackageReference>
     <PackageReference Include="Strathweb.CacheOutput.WebApi2.StrongName">
       <Version>0.9.0</Version>


### PR DESCRIPTION
Verified locally. SharpZipLib is a dependency of the local, Lucene-based search indexing.