### PR TITLE
[HOTFIX] Improve .NET banner accessibility

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1896,6 +1896,12 @@ p.frameworktableinfo-text {
   color: white;
   font-weight: 600;
 }
+.page-home .dotnet-20-banner .container .row .banner-text a:focus {
+  outline-color: #fff;
+  outline-style: dashed;
+  outline-width: 2px;
+  outline-offset: 3px;
+}
 .page-home .what-is-nuget {
   font-size: 1.15em;
   padding-bottom: 75px;

--- a/src/Bootstrap/less/theme/page-home.less
+++ b/src/Bootstrap/less/theme/page-home.less
@@ -63,6 +63,13 @@
             color: white;
             font-weight: 600;
           }
+
+          a:focus {
+            outline-color: #fff;
+            outline-style: dashed;
+            outline-width: 2px;
+            outline-offset: 3px;
+          }
         }
       }
     }


### PR DESCRIPTION
Our black focus outline does not work well on the .NET banner:

![image](https://user-images.githubusercontent.com/737941/152023159-68c823f3-9e1b-4c5e-af1c-750b4097fef6.png)

This moves to a white dashed outline to align with develper.microsoft.com:

![image](https://user-images.githubusercontent.com/737941/152023272-9b48d90f-7fc6-4110-94bc-835c9fc84044.png)

This passes Accessibility Insights FastPass (the previous focus outline also passed 🙁)

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5697521&view=results
Release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1255175

Part of https://github.com/NuGet/Engineering/issues/4226