### PR TITLE
Only assert HTTP 400 for bad cookies since behavior is flaky in App Service

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/Helpers/UrlHelper.cs
+++ b/tests/NuGetGallery.FunctionalTests.Core/Helpers/UrlHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net;
 
 namespace NuGetGallery.FunctionalTests
 {
@@ -10,6 +11,12 @@ namespace NuGetGallery.FunctionalTests
     /// </summary>
     public class UrlHelper
     {
+        static UrlHelper()
+        {
+            // This test suite hits the gallery which requires TLS 1.2 (at least in some environments).
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+        }
+
         private const string _logonPageUrlSuffix = "users/account/LogOnNuGetAccount";
         private const string _editUrlSuffix = "packages/{0}/{1}/Edit";
         private const string _cancelUrlSuffix = "packages/manage/cancel-upload";

--- a/tests/NuGetGallery.FunctionalTests/ErrorHandling/ErrorHandlingTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ErrorHandling/ErrorHandlingTests.cs
@@ -37,12 +37,12 @@ namespace NuGetGallery.FunctionalTests.ErrorHandling
         [Theory]
         [Priority(2)]
         [Category("P2Tests")]
-        [InlineData("/", "__Controller::TempData", "Message=You successfully uploaded z̡̜͍̈̍̐̃̊͋́a̜̣͍̬̞̝͉̽ͧ͗l̸̖͕̤̠̹̘͖̃̌ͤg͓̝͓̰̀ͪo͈͌ 1.0.0.", 400, false)]
-        [InlineData("/", "__Controller::TempData", "Message=<script>alert(1)</script>", 400, false)]
-        [InlineData("/", "__Controller::TempData", "<script>alert(1)</script>", 400, false)]
-        [InlineData("/packages", "nugetab", "<script>alert(1)</script>", 400, true)]
-        [InlineData("/packages", "nugetab", "z̡̜͍̈̍̐̃̊͋́a̜̣͍̬̞̝͉̽ͧ͗l̸̖͕̤̠̹̘͖̃̌ͤg͓̝͓̰̀ͪo͈͌", 400, false)]
-        public async Task RejectedCookie(string relativePath, string name, string value, int statusCode, bool pretty)
+        [InlineData("/", "__Controller::TempData", "Message=You successfully uploaded z̡̜͍̈̍̐̃̊͋́a̜̣͍̬̞̝͉̽ͧ͗l̸̖͕̤̠̹̘͖̃̌ͤg͓̝͓̰̀ͪo͈͌ 1.0.0.", 400)]
+        [InlineData("/", "__Controller::TempData", "Message=<script>alert(1)</script>", 400)]
+        [InlineData("/", "__Controller::TempData", "<script>alert(1)</script>", 400)]
+        [InlineData("/packages", "nugetab", "<script>alert(1)</script>", 400)]
+        [InlineData("/packages", "nugetab", "z̡̜͍̈̍̐̃̊͋́a̜̣͍̬̞̝͉̽ͧ͗l̸̖͕̤̠̹̘͖̃̌ͤg͓̝͓̰̀ͪo͈͌", 400)]
+        public async Task RejectedCookie(string relativePath, string name, string value, int statusCode)
         {
             // Arrange
             _httpClientHandler.UseCookies = false;
@@ -55,14 +55,7 @@ namespace NuGetGallery.FunctionalTests.ErrorHandling
                 var response = await GetTestResponseAsync(relativePath, request);
 
                 // Assert
-                if (pretty)
-                {
-                    Validator.PrettyHtml((HttpStatusCode)statusCode)(response);
-                }
-                else
-                {
-                    Validator.SimpleHtml((HttpStatusCode)statusCode)(response);
-                }
+                Assert.Equal((HttpStatusCode)statusCode, response.StatusCode);
             }
         }
 


### PR DESCRIPTION
Some of these bad cookies cause flaky error responses. It's not important enough to chase down why do we'll make the tests less specific.

![image](https://user-images.githubusercontent.com/94054/152621108-8791e3b0-2567-4759-bcc9-6ccbdc3b634f.png)

![image](https://user-images.githubusercontent.com/94054/152621141-db33c5f2-bf1f-4b7e-b790-6e6ef189d0c8.png)

Also enable TLS 1.2 in another static constructor. This makes running some individual tests possible.