### PR TITLE
[TFM Tab] Fix border and background color.

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -704,6 +704,7 @@ img.reserved-indicator-icon {
   -ms-flex-pack: center;
   justify-content: center;
   display: inline-block;
+  border: 1px solid #0078d4;
 }
 .framework-badge:not(:last-child) {
   margin-right: 8px;
@@ -716,6 +717,7 @@ img.reserved-indicator-icon {
   -ms-flex-pack: center;
   justify-content: center;
   display: inline-block;
+  border: 1px solid #0078d4;
   background: #0078d4;
   color: white;
 }
@@ -728,7 +730,7 @@ img.reserved-indicator-icon {
   justify-content: center;
   display: inline-block;
   border: 1px solid #0078d4;
-  background: rgba(0, 183, 195, 0.1);
+  background: rgba(0, 120, 212, 0.1);
 }
 .framework-table {
   margin-bottom: 30px;

--- a/src/Bootstrap/less/theme/common-supported-frameworks.less
+++ b/src/Bootstrap/less/theme/common-supported-frameworks.less
@@ -1,5 +1,5 @@
 @badge-dark: #0078d4;
-@badge-dark-opaque: rgba(0, 183, 195, 0.1);
+@badge-dark-opaque: rgba(0, 120, 212, 0.1);
 @table-product-width: 232px;
 
 .framework {
@@ -18,6 +18,7 @@
   border-radius: 2px;
   justify-content: center;
   display: inline-block;
+  border: 1px solid @badge-dark;
 }
 
 .framework-badge:not(:last-child) {
@@ -32,7 +33,6 @@
 
 .framework-badge-computed {
   .framework-badge;
-  border: 1px solid @badge-dark;
   background: @badge-dark-opaque
 }
 

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
@@ -40,7 +40,7 @@
         <span class="frameworktableinfo-text">Compatible target framework(s)</span>
     </div>
     <div>
-        <i class="ms-Icon ms-Icon--SquareShape frameworktableinfo-computed-icon"></i>
+        <i class="ms-Icon ms-Icon--SquareShape frameworktableinfo-computed-icon framework-badge-computed"></i>
         <span class="frameworktableinfo-text">Additional computed target framework(s)</span>
     </div>
     <span class="frameworktableinfo-text"><i>Learn more about <a href='https://docs.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://docs.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></span>


### PR DESCRIPTION
* Asset TFM badge border adjusted to be the same size as computed.
* Background color changed to light blue instead of teal.

Addresses https://github.com/NuGet/Engineering/issues/4229

### Before

![Before](https://user-images.githubusercontent.com/17834924/152865983-a15b098a-17e2-44ef-bad3-ea6a1a7e6ac5.png)

### After

![After 2](https://user-images.githubusercontent.com/17834924/152867491-829b66d8-f15d-4b1e-9310-4ddeb73e05d3.png)
