### PR TITLE
[TFM Display] Stop showing badges and tab when package is deleted or a template.

### DIFF
--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -141,6 +141,11 @@ namespace NuGetGallery
             return IsFuGetLinksEnabled && !string.IsNullOrEmpty(FuGetUrl) && Available;
         }
 
+        public bool CanDisplayTargetFrameworks()
+        {
+            return IsDisplayTargetFrameworkEnabled && !Deleted && !IsDotnetNewTemplatePackageType;
+        }
+
         public bool BlockSearchEngineIndexing
         {
             get

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -265,7 +265,7 @@
                     </h1>
                 </div>
 
-                @if (Model.IsDisplayTargetFrameworkEnabled)
+                @if (Model.CanDisplayTargetFrameworks())
                 {
                     @Html.Partial("_SupportedFrameworksBadges", Model.PackageFrameworkCompatibility.Badges);
                 }
@@ -523,7 +523,7 @@
                             </a>
                         </li>
 
-                     if (!Model.Deleted && Model.IsDisplayTargetFrameworkEnabled)
+                     if (Model.CanDisplayTargetFrameworks())
                      {
                         activeBodyTab = activeBodyTab ?? "supportedframeworks";
                         <li role="presentation" id="show-supportedframeworks-container">
@@ -644,8 +644,10 @@
                         }
                     </div>
 
+                    if (Model.CanDisplayTargetFrameworks())
+                    {
                     <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab">
-                        @if (Model.IsDisplayTargetFrameworkEnabled && Model.PackageFrameworkCompatibility.Table.Count > 0)
+                        @if (Model.PackageFrameworkCompatibility.Table.Count > 0)
                         {
                             @Html.Partial("_SupportedFrameworksTable", Model.PackageFrameworkCompatibility.Table)
                         }
@@ -655,6 +657,7 @@
                             <p class="frameworktableinfo-text"><i>Learn more about <a href='https://docs.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://docs.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></p>
                         }
                     </div>
+                    }
 
                     <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab">
                         @if (!Model.Deleted)

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -291,6 +291,61 @@ namespace NuGetGallery.ViewModels
         }
 
         [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(false, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(true, true, false)]
+        [InlineData(false, false, true)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, false)]
+        public void CannotDisplayTargetFrameworksWhenInvalid(bool isEnabled, bool isDeleted, bool isTemplate)
+        {
+            var package = new Package
+            {
+                Version = "1.0.0",
+                NormalizedVersion = "1.0.0",
+                PackageRegistration = new PackageRegistration
+                {
+                    Id = "foo",
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
+            };
+
+            var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
+
+            model.IsDisplayTargetFrameworkEnabled = isEnabled;
+            model.Deleted = isDeleted;
+            model.IsDotnetNewTemplatePackageType = isTemplate;
+
+            Assert.False(model.CanDisplayTargetFrameworks());
+        }
+
+        [Fact]
+        public void CanDisplayTargetFrameworksWhenValid()
+        {
+            var package = new Package
+            {
+                Version = "1.0.0",
+                NormalizedVersion = "1.0.0",
+                PackageRegistration = new PackageRegistration
+                {
+                    Id = "foo",
+                    Owners = Enumerable.Empty<User>().ToList(),
+                    Packages = Enumerable.Empty<Package>().ToList()
+                }
+            };
+
+            var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
+
+            model.IsDisplayTargetFrameworkEnabled = true;
+            model.Deleted = false;
+            model.IsDotnetNewTemplatePackageType = false;
+
+            Assert.True(model.CanDisplayTargetFrameworks());
+        }
+
+        [Theory]
         [InlineData(null, null)]
         [InlineData("not a url", null)]
         [InlineData("git://github.com/notavalidscheme", null)]


### PR DESCRIPTION
* Badges and Frameworks tab doesn't show when a package is deleted, or if the package is a template.

Addresses:  https://github.com/NuGet/Engineering/issues/4231
Addresses:  https://github.com/NuGet/Engineering/issues/4225