### PR TITLE
Allow case insensitive comparison of X-Frame-Options

### DIFF
--- a/tests/NuGetGallery.WebUITests.P2/BasicPages/SecurityHeaderTest.cs
+++ b/tests/NuGetGallery.WebUITests.P2/BasicPages/SecurityHeaderTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.WebTesting;
 using NuGetGallery.FunctionalTests.Helpers;
@@ -23,7 +24,7 @@ namespace NuGetGallery.FunctionalTests.WebUITests.BasicPages
             // Send a request to home page and check for security headers.
             var homePageRequest = new WebTestRequest(UrlHelper.BaseUrl);
             homePageRequest.ParseDependentRequests = false;
-            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Frame-Options: deny").Validate;
+            homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Frame-Options: DENY", StringComparison.OrdinalIgnoreCase).Validate;
             homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-XSS-Protection: 1; mode=block").Validate;
             homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Content-Type-Options: nosniff").Validate;
             homePageRequest.ValidateResponse += new ValidationRuleFindHeaderText("Strict-Transport-Security: max-age=31536000").Validate;
@@ -32,7 +33,7 @@ namespace NuGetGallery.FunctionalTests.WebUITests.BasicPages
             // Send a request to Packages page and check for security headers.
             var packagesPageRequest = new WebTestRequest(UrlHelper.PackagesPageUrl);
             packagesPageRequest.ParseDependentRequests = false;
-            packagesPageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Frame-Options: deny").Validate;
+            packagesPageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Frame-Options: DENY", StringComparison.OrdinalIgnoreCase).Validate;
             packagesPageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-XSS-Protection: 1; mode=block").Validate;
             packagesPageRequest.ValidateResponse += new ValidationRuleFindHeaderText("X-Content-Type-Options: nosniff").Validate;
             packagesPageRequest.ValidateResponse += new ValidationRuleFindHeaderText("Strict-Transport-Security: max-age=31536000").Validate;

--- a/tests/NuGetGallery.WebUITests.P2/ValidationRuleFindHeaderText.cs
+++ b/tests/NuGetGallery.WebUITests.P2/ValidationRuleFindHeaderText.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.TestTools.WebTesting;
+using System;
 
 namespace NuGetGallery.FunctionalTests.Helpers
 {
@@ -12,15 +13,22 @@ namespace NuGetGallery.FunctionalTests.Helpers
         : ValidationRule
     {
         private readonly string _findText;
+        private readonly StringComparison _stringComparison;
 
-        public ValidationRuleFindHeaderText(string findText)
+        public ValidationRuleFindHeaderText(string findText) : this(findText, StringComparison.Ordinal)
         {
             _findText = findText;
         }
 
+        public ValidationRuleFindHeaderText(string findText, StringComparison stringComparison)
+        {
+            _findText = findText;
+            _stringComparison = stringComparison;
+        }
+
         public override void Validate(object sender, ValidationEventArgs e)
         {
-            e.IsValid = e.Response.Headers.ToString().Contains(_findText);
+            e.IsValid = e.Response.Headers.ToString().IndexOf(_findText, _stringComparison) >= 0;
         }
     }
 }


### PR DESCRIPTION
This unblocks functional tests.