### PR TITLE
[TFM Display][Bug] Packages with backslash path didn't show TFM information.

### DIFF
--- a/src/NuGetGallery.Services/Helpers/PackageValidationHelper.cs
+++ b/src/NuGetGallery.Services/Helpers/PackageValidationHelper.cs
@@ -2,19 +2,25 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NuGet.Packaging;
 
 namespace NuGetGallery.Helpers
 {
-    public class ValidationHelper
+    public class PackageValidationHelper
     {
         public static bool HasDuplicatedEntries(PackageArchiveReader nuGetPackage)
         {
             // Normalize paths and ensures case sensitivity is also considered
-            var packageFiles = nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile));
+            var packageFiles = GetNormalizedEntryPaths(nuGetPackage);
 
             return packageFiles.Count() != packageFiles.Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        }
+
+        public static IEnumerable<string> GetNormalizedEntryPaths(PackageArchiveReader nuGetPackage)
+        {
+            return nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile));
         }
     }
 }

--- a/src/NuGetGallery.Services/Helpers/PackageValidationHelper.cs
+++ b/src/NuGetGallery.Services/Helpers/PackageValidationHelper.cs
@@ -20,7 +20,7 @@ namespace NuGetGallery.Helpers
 
         public static IEnumerable<string> GetNormalizedEntryPaths(PackageArchiveReader nuGetPackage)
         {
-            return nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile));
+            return nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile)).ToList();
         }
     }
 }

--- a/src/NuGetGallery.Services/Helpers/PackageValidationHelper.cs
+++ b/src/NuGetGallery.Services/Helpers/PackageValidationHelper.cs
@@ -18,7 +18,7 @@ namespace NuGetGallery.Helpers
             return packageFiles.Count() != packageFiles.Distinct(StringComparer.OrdinalIgnoreCase).Count();
         }
 
-        public static IEnumerable<string> GetNormalizedEntryPaths(PackageArchiveReader nuGetPackage)
+        public static IList<string> GetNormalizedEntryPaths(PackageArchiveReader nuGetPackage)
         {
             return nuGetPackage.GetFiles().Select(packageFile => FileNameHelper.GetZipEntryPath(packageFile)).ToList();
         }

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Helpers\LatestPackageRouteVerifier.cs" />
     <Compile Include="Helpers\MailAddressConverter.cs" />
     <Compile Include="Helpers\UploadHelper.cs" />
+    <Compile Include="Helpers\PackageValidationHelper.cs" />
     <Compile Include="Mail\GalleryEmailRecipientsUtility.cs" />
     <Compile Include="Mail\Messages\PackageOwnerAddedMessage.cs" />
     <Compile Include="Mail\Messages\PackageOwnerRemovedMessage.cs" />

--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -116,7 +116,7 @@ namespace NuGetGallery
 
         IEnumerable<NuGetFramework> GetSupportedFrameworks(PackageArchiveReader package);
 
-        IEnumerable<NuGetFramework> GetSupportedFrameworks(NuspecReader nuspecReader, IEnumerable<string> packageFiles);
+        IEnumerable<NuGetFramework> GetSupportedFrameworks(NuspecReader nuspecReader, IList<string> packageFiles);
 
         Task PublishPackageAsync(string id, string version, bool commitChanges = true);
         Task PublishPackageAsync(Package package, bool commitChanges = true);

--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -116,7 +116,7 @@ namespace NuGetGallery
 
         IEnumerable<NuGetFramework> GetSupportedFrameworks(PackageArchiveReader package);
 
-        IEnumerable<NuGetFramework> GetSupportedFrameworks(NuspecReader nuspecReader, IList<string> packageFiles);
+        IEnumerable<NuGetFramework> GetSupportedFrameworks(NuspecReader nuspecReader, IEnumerable<string> packageFiles);
 
         Task PublishPackageAsync(string id, string version, bool commitChanges = true);
         Task PublishPackageAsync(Package package, bool commitChanges = true);

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -17,6 +17,7 @@ using NuGet.RuntimeModel;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
 using NuGetGallery.Auditing;
+using NuGetGallery.Helpers;
 using NuGetGallery.Packaging;
 using NuGetGallery.Security;
 using PackageType = NuGet.Packaging.Core.PackageType;
@@ -711,7 +712,7 @@ namespace NuGetGallery
         {
             if (_featureFlagService.ArePatternSetTfmHeuristicsEnabled())
             {
-                return GetSupportedFrameworks(package.NuspecReader, package.GetFiles().ToList());
+                return GetSupportedFrameworks(package.NuspecReader, PackageValidationHelper.GetNormalizedEntryPaths(package));
             }
 
             return package.GetSupportedFrameworks();
@@ -729,7 +730,7 @@ namespace NuGetGallery
         /// - If this isn't a tools package, we look for build-time, runtime, content and resource file patterns
         /// For added details on the various cases, see unit tests targeting this method.
         /// </summary>
-        public virtual IEnumerable<NuGetFramework> GetSupportedFrameworks(NuspecReader nuspecReader, IList<string> packageFiles)
+        public virtual IEnumerable<NuGetFramework> GetSupportedFrameworks(NuspecReader nuspecReader, IEnumerable<string> packageFiles)
         {
             var supportedTFMs = Enumerable.Empty<NuGetFramework>();
             if (packageFiles != null && packageFiles.Any() && nuspecReader != null)

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -730,7 +730,7 @@ namespace NuGetGallery
         /// - If this isn't a tools package, we look for build-time, runtime, content and resource file patterns
         /// For added details on the various cases, see unit tests targeting this method.
         /// </summary>
-        public virtual IEnumerable<NuGetFramework> GetSupportedFrameworks(NuspecReader nuspecReader, IEnumerable<string> packageFiles)
+        public virtual IEnumerable<NuGetFramework> GetSupportedFrameworks(NuspecReader nuspecReader, IList<string> packageFiles)
         {
             var supportedTFMs = Enumerable.Empty<NuGetFramework>();
             if (packageFiles != null && packageFiles.Any() && nuspecReader != null)

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -221,7 +221,6 @@
     <Compile Include="Extensions\ImageExtensions.cs" />
     <Compile Include="Filters\AdminActionAttribute.cs" />
     <Compile Include="Helpers\AdminHelper.cs" />
-    <Compile Include="Helpers\ValidationHelper.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeleteAccountListPackageItemViewModelFactory.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeletePackageViewModelFactory.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DisplayLicenseViewModelFactory.cs" />

--- a/src/NuGetGallery/Services/PackageMetadataValidationService.cs
+++ b/src/NuGetGallery/Services/PackageMetadataValidationService.cs
@@ -683,7 +683,7 @@ namespace NuGetGallery
 
         private PackageValidationResult CheckPackageDuplicatedEntries(PackageArchiveReader nuGetPackage)
         {
-            if (ValidationHelper.HasDuplicatedEntries(nuGetPackage))
+            if (PackageValidationHelper.HasDuplicatedEntries(nuGetPackage))
             {
                 return PackageValidationResult.Invalid(Strings.UploadPackage_PackageContainsDuplicatedEntries);
             }

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -90,7 +90,7 @@ namespace NuGetGallery
                     }
 
                     // Check for duplicated entries in symbols package
-                    if (ValidationHelper.HasDuplicatedEntries(packageToPush))
+                    if (PackageValidationHelper.HasDuplicatedEntries(packageToPush))
                     {
                         return SymbolPackageValidationResult.Invalid(Strings.UploadPackage_PackageContainsDuplicatedEntries);
                     }

--- a/tests/NuGetGallery.Facts/Helpers/PackageValidationHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/PackageValidationHelperFacts.cs
@@ -66,10 +66,10 @@ namespace NuGetGallery.Helpers
                 var package = PackageValidationHelperFacts.GeneratePackage(entryNames: paths);
 
                 // Act
-                var normalizedPaths = PackageValidationHelper.GetNormalizedEntryPaths(package.Object).Skip(1);
+                var normalizedPaths = PackageValidationHelper.GetNormalizedEntryPaths(package.Object);
 
                 // Assert
-                Assert.Equal(normalizedPaths.First(), correctPath);
+                Assert.Equal(normalizedPaths.ElementAt(1), correctPath);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Helpers/PackageValidationHelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Helpers/PackageValidationHelperFacts.cs
@@ -56,7 +56,7 @@ namespace NuGetGallery.Helpers
         public class GetNormalizedEntryPathsMethod
         {
             [Theory]
-            [InlineData("./net50\\file.txt", "net50/file.dll")]
+            [InlineData("./net50\\file.dll", "net50/file.dll")]
             [InlineData("\\netstandard10\\file.dll", "netstandard10/file.dll")]
             [InlineData("\\\\net472", "net472")]
             public void AlwaysReturnsCorrectPath(string path, string correctPath)

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -83,7 +83,7 @@
     <Compile Include="Authentication\Providers\CommonAuth\AzureActiveDirectoryV2AuthenticatorFacts.cs" />
     <Compile Include="Authentication\TestCredentialHelper.cs" />
     <Compile Include="Extensions\CakeBuildManagerExtensionsFacts.cs" />
-    <Compile Include="Helpers\ValidationHelperFacts.cs" />
+    <Compile Include="Helpers\PackageValidationHelperFacts.cs" />
     <Compile Include="Infrastructure\ODataCacheOutputAttributeFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageIdsQueryFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageVersionsQueryFacts.cs" />


### PR DESCRIPTION
* Added normalization of package entry paths using `FileNameHelper.GetZipEntryPath`.

Addresses https://github.com/NuGet/Engineering/issues/4220.