### PR TITLE
[TFM Display][Bug] Any framework fix as supported framework.

### DIFF
--- a/src/GalleryTools/Commands/BackfillCommand.cs
+++ b/src/GalleryTools/Commands/BackfillCommand.cs
@@ -466,7 +466,7 @@ namespace GalleryTools.Commands
             var zipDirectory = await zipDirectoryReader.ReadAsync();
             var files = zipDirectory
                 .Entries
-                .Select(x => x.GetName())
+                .Select(x => FileNameHelper.GetZipEntryPath(x.GetName()))
                 .ToList();
 
             return ReadMetadata(files, nuspecReader);

--- a/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
+++ b/src/GalleryTools/Commands/BackfillTfmMetadataCommand.cs
@@ -47,7 +47,7 @@ namespace GalleryTools.Commands
                     // See https://github.com/NuGet/NuGet.Client/blob/ba008e14611f4fa518c2d02ed78dfe5969e4a003/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs#L487                }
                     try
                     {
-                        var tfmToAdd = tfm.ToShortNameOrNull();
+                        var tfmToAdd = tfm.GetShortFolderName();
                         if (!string.IsNullOrEmpty(tfmToAdd))
                         {
                             supportedTFMs.Add(tfmToAdd);

--- a/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityFactory.cs
+++ b/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityFactory.cs
@@ -38,7 +38,7 @@ namespace NuGetGallery.Frameworks
 
             var filteredPackageFrameworks = packageFrameworks
                 .Select(pf => pf.FrameworkName)
-                .Where(f => !f.IsUnsupported && !f.IsPCL)
+                .Where(f => !f.IsUnsupported && !f.IsPCL && !f.IsAny)
                 .ToHashSet();
 
             var table = CreateFrameworkCompatibilityTable(filteredPackageFrameworks);

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -165,7 +165,7 @@ namespace NuGetGallery
             {
                 throw new ArgumentNullException(nameof(id));
             }
-            
+
             PackageDependents result = new PackageDependents();
 
             // We use OPTIMIZE FOR UNKNOWN by default here because there are distinct 2-3 query plans that may be
@@ -321,7 +321,7 @@ namespace NuGetGallery
                 var semvered = localPackages
                     .Select(package => new {package, semVer= NuGetVersion.Parse(package.NormalizedVersion)})
                     .ToList();
-                
+
                 return semvered
                     .Where(d => d.semVer.IsPrerelease == prerelease || !applyPrereleaseFilter)
                     .OrderByDescending(d => d.semVer)
@@ -342,13 +342,13 @@ namespace NuGetGallery
                         .FirstOrDefault();
                 }
             }
-            
+
             Package GetLatestPrerelease()
             {
                 return GetSortedFiltered(packages)
                     .FirstOrDefault();
             }
-            
+
             Package GetLatestStable()
             {
                 return GetSortedFiltered(packages, false)
@@ -663,23 +663,17 @@ namespace NuGetGallery
                 package.Authors.Add(new PackageAuthor { Name = author });
             }
 #pragma warning restore 618
-
-            var supportedFrameworks = GetSupportedFrameworks(packageArchive)
+            
+            var supportedFrameworkNames = GetSupportedFrameworks(packageArchive)
+                .Select(fn => fn.GetShortFolderName())
+                .Where(fn => fn != null)
                 .ToArray();
 
-            if (!supportedFrameworks.Any(fx => fx != null && fx.IsAny))
+            ValidateSupportedFrameworks(supportedFrameworkNames);
+
+            foreach (var supportedFramework in supportedFrameworkNames)
             {
-                var supportedFrameworkNames = supportedFrameworks
-                                .Select(fn => fn.ToShortNameOrNull())
-                                .Where(fn => fn != null)
-                                .ToArray();
-
-                ValidateSupportedFrameworks(supportedFrameworkNames);
-
-                foreach (var supportedFramework in supportedFrameworkNames)
-                {
-                    package.SupportedFrameworks.Add(new PackageFramework { TargetFramework = supportedFramework });
-                }
+                package.SupportedFrameworks.Add(new PackageFramework { TargetFramework = supportedFramework });
             }
 
             package.Dependencies = packageMetadata

--- a/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
@@ -80,6 +80,23 @@ namespace NuGetGallery.Frameworks
             Assert.Null(result.Badges.NetFramework);
         }
 
+        [Fact]
+        public void AnyFrameworksShouldBeIgnored()
+        {
+            var packageFrameworks = new HashSet<PackageFramework>()
+            {
+                new PackageFramework() { TargetFramework = "any" },
+            };
+
+            var result = _factory.Create(packageFrameworks.ToList());
+
+            Assert.Empty(result.Table);
+            Assert.Null(result.Badges.Net);
+            Assert.Null(result.Badges.NetCore);
+            Assert.Null(result.Badges.NetStandard);
+            Assert.Null(result.Badges.NetFramework);
+        }
+
         [Theory]
         [InlineData(FrameworkProductNames.Net, "net5.0", "net6.0", "net6.0-android")]
         [InlineData(FrameworkProductNames.NetCore, "netcoreapp1.0", "netcoreapp3.1")]

--- a/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageServiceFacts.cs
@@ -944,7 +944,8 @@ namespace NuGetGallery
                         new[]
                         {
                                            NuGetFramework.Parse("net40"),
-                                           NuGetFramework.Parse("net35")
+                                           NuGetFramework.Parse("net35"),
+                                           NuGetFramework.Parse("any")
                         });
                 });
                 var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
@@ -954,28 +955,7 @@ namespace NuGetGallery
 
                 Assert.Equal("net40", package.SupportedFrameworks.First().TargetFramework);
                 Assert.Equal("net35", package.SupportedFrameworks.ElementAt(1).TargetFramework);
-            }
-
-            [Fact]
-            public async Task WillNotSaveAnySupportedFrameworksWhenThereIsAnAnyTargetFramework()
-            {
-                var packageRegistrationRepository = new Mock<IEntityRepository<PackageRegistration>>();
-                var service = CreateService(packageRegistrationRepository: packageRegistrationRepository, setup: mockPackageService =>
-                {
-                    mockPackageService.Setup(p => p.FindPackageRegistrationById(It.IsAny<string>())).Returns((PackageRegistration)null);
-                    mockPackageService.Setup(p => p.GetSupportedFrameworks(It.IsAny<PackageArchiveReader>())).Returns(
-                        new[]
-                        {
-                            NuGetFramework.Parse("any"),
-                            NuGetFramework.Parse("net35")
-                        });
-                });
-                var nugetPackage = PackageServiceUtility.CreateNuGetPackage();
-                var currentUser = new User();
-
-                var package = await service.CreatePackageAsync(nugetPackage.Object, new PackageStreamMetadata(), currentUser, currentUser, isVerified: false);
-
-                Assert.Empty(package.SupportedFrameworks);
+                Assert.Equal("any", package.SupportedFrameworks.ElementAt(2).TargetFramework);
             }
 
             [Theory]


### PR DESCRIPTION
* TFM data now allows a package that contains `any` framework to collect all their asset frameworks and store them in DB.
* `PackageFrameworkCompatibilityFactory` filters `any` framework, this won't show on the package details page.
* `BackfillTfmMetadataCommand` now supports adding `any` as a supported framework.

Addresses https://github.com/NuGet/Engineering/issues/4219.