### PR TITLE
[Bug Fix] Packages with empty descriptions cause HTTP 500 on reflows

### DIFF
--- a/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
@@ -92,7 +92,7 @@ namespace NuGetGallery.Packaging
             ProjectUrl = GetValue(PackageMetadataStrings.ProjectUrl, (Uri)null);
             LicenseUrl = GetValue(PackageMetadataStrings.LicenseUrl, (Uri)null);
             Copyright = GetValue(PackageMetadataStrings.Copyright, (string)null);
-            Description = GetValue(PackageMetadataStrings.Description, (string)null);
+            Description = GetValue(PackageMetadataStrings.Description, String.Empty);
             ReleaseNotes = GetValue(PackageMetadataStrings.ReleaseNotes, (string)null);
             RequireLicenseAcceptance = GetValue(PackageMetadataStrings.RequireLicenseAcceptance, false);
             DevelopmentDependency = GetValue(PackageMetadataStrings.DevelopmentDependency, false);

--- a/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
+++ b/src/NuGetGallery.Core/Packaging/PackageMetadata.cs
@@ -92,7 +92,7 @@ namespace NuGetGallery.Packaging
             ProjectUrl = GetValue(PackageMetadataStrings.ProjectUrl, (Uri)null);
             LicenseUrl = GetValue(PackageMetadataStrings.LicenseUrl, (Uri)null);
             Copyright = GetValue(PackageMetadataStrings.Copyright, (string)null);
-            Description = GetValue(PackageMetadataStrings.Description, String.Empty);
+            Description = GetValue(PackageMetadataStrings.Description, (string)null);
             ReleaseNotes = GetValue(PackageMetadataStrings.ReleaseNotes, (string)null);
             RequireLicenseAcceptance = GetValue(PackageMetadataStrings.RequireLicenseAcceptance, false);
             DevelopmentDependency = GetValue(PackageMetadataStrings.DevelopmentDependency, false);
@@ -273,7 +273,7 @@ namespace NuGetGallery.Packaging
                 }
             }
 
-            return new PackageMetadata(
+            var packageMetadata = new PackageMetadata(
                 nuspecReader.GetMetadata().ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
                 nuspecReader.GetDependencyGroups(useStrictVersionCheck: strict),
                 nuspecReader.GetFrameworkAssemblyGroups(),
@@ -281,6 +281,14 @@ namespace NuGetGallery.Packaging
                 nuspecReader.GetMinClientVersion(),
                 nuspecReader.GetRepositoryMetadata(),
                 nuspecReader.GetLicenseMetadata());
+
+            // Fix null or empty description values for reflowed packages
+            if (!strict)
+            {
+                packageMetadata.Description = packageMetadata.Description ?? string.Empty;
+            }
+
+            return packageMetadata;
         }
 
         private class StrictNuspecReader : NuspecReader

--- a/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
@@ -205,6 +205,23 @@ namespace NuGetGallery.Packaging
             Assert.Equal("git", packageMetadata.RepositoryType);
         }
 
+        [Fact]
+        public void CanProcessEmptyNuspecDescriptionValue()
+        {
+            // Arrange
+            var packageStream = CreateTestPackageStreamWithEmptyDescription();
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act
+            var packageMetadata = PackageMetadata.FromNuspecReader(
+                nuspec,
+                strict: true);
+
+            // Assert
+            Assert.NotNull(packageMetadata.Description);
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -356,6 +373,22 @@ namespace NuGetGallery.Packaging
                         <licenseUrl>http://www.nuget.org/</licenseUrl>
                         <dependencies />
                         <repository type=""git"" url=""https://github.com/NuGet/NuGetGallery"" commit=""33a34174353a8bf64ab0ee0373936010e948d59d"" branch=""dev"" />
+                      </metadata>
+                    </package>");
+        }
+
+        private static Stream CreateTestPackageStreamWithEmptyDescription()
+        {
+            return CreateTestPackageStream(@"<?xml version=""1.0""?>
+                    <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                      <metadata>
+                        <id>TestPackage</id>
+                        <version>0.0.0.1</version>
+                        <title>Package A</title>
+                        <authors>authora, authorb</authors>
+                        <owners>ownera, ownerb</owners>
+                        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+                        <description></description>
                       </metadata>
                     </package>");
         }

--- a/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Packaging/PackageMetadataFacts.cs
@@ -206,7 +206,24 @@ namespace NuGetGallery.Packaging
         }
 
         [Fact]
-        public void CanProcessEmptyNuspecDescriptionValue()
+        public void CanProcessEmptyNuspecDescriptionValueOnReflow()
+        {
+            // Arrange
+            var packageStream = CreateTestPackageStreamWithEmptyDescription();
+            var nupkg = new PackageArchiveReader(packageStream, leaveStreamOpen: false);
+            var nuspec = nupkg.GetNuspecReader();
+
+            // Act
+            var packageMetadata = PackageMetadata.FromNuspecReader(
+                nuspec,
+                strict: false);
+
+            // Assert
+            Assert.NotNull(packageMetadata.Description);
+        }
+
+        [Fact]
+        public void DoesNotFixEmptyNuspecDescriptionValueOnUpload()
         {
             // Arrange
             var packageStream = CreateTestPackageStreamWithEmptyDescription();
@@ -219,7 +236,7 @@ namespace NuGetGallery.Packaging
                 strict: true);
 
             // Assert
-            Assert.NotNull(packageMetadata.Description);
+            Assert.Null(packageMetadata.Description);
         }
 
         [Theory]


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/4218

Packages with empty descriptions (empty string), when reflowed, see their description parsed as `null`, which triggers an HTTP 500 on the Package Details page.

_NOTE:_ New packages cannot be uploaded with empty descriptions, these packages were already in the system, probably from before these validation checks were enabled.