### PR TITLE
Fix the font of the framework badges

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -686,12 +686,12 @@ img.reserved-indicator-icon {
   padding-bottom: 3em;
 }
 .framework {
-  font-family: Segoe UI;
+  font-family: 'Segoe UI', "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 20px;
 }
 .framework-badges {
-  font-family: Segoe UI;
+  font-family: 'Segoe UI', "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 20px;
   margin-bottom: 14px;
@@ -734,7 +734,7 @@ img.reserved-indicator-icon {
 }
 .framework-table {
   margin-bottom: 30px;
-  font-family: Segoe UI;
+  font-family: 'Segoe UI', "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
   line-height: 20px;
   width: 100%;


### PR DESCRIPTION
The recently introduced frameworks tab contrasts with the rest of the web page on systems that don't have the Segoe UI font installed. For example, on macOS, all the framework badges are rendered with a serif font (Times) whereas the rest of the page is rendered with Helvetica Neue. You can even see it in the screenshots on the blog post announcing the new [Compatible Packages][1] feature!

This commit fixes the `font-family` of all .framework* classes to use the same font family as everywhere else in the css file, i.e. `'Segoe UI', "Helvetica Neue", Helvetica, Arial, sans-serif;`

[1]: https://devblogs.microsoft.com/nuget/introducing-compatible-frameworks-on-nuget-org/