### PR TITLE
[TFM Display] Display empty version with only the framework name as badge.

### DIFF
--- a/src/NuGetGallery.Core/Frameworks/NuGetFrameworkExtensions.cs
+++ b/src/NuGetGallery.Core/Frameworks/NuGetFrameworkExtensions.cs
@@ -11,6 +11,11 @@ namespace NuGetGallery.Frameworks
     {
         public static string GetBadgeVersion(this NuGetFramework framework)
         {
+            if (framework.Version == FrameworkConstants.EmptyVersion)
+            {
+                return string.Empty;
+            }
+
             var builder = new StringBuilder();
             builder.Append(framework.Version.Major);
             builder.Append(".");

--- a/tests/NuGetGallery.Core.Facts/Frameworks/NuGetFrameworkExtensionsFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/NuGetFrameworkExtensionsFacts.cs
@@ -9,8 +9,10 @@ namespace NuGetGallery.Frameworks
     public class NuGetFrameworkExtensionsFacts
     {
         [Theory]
-        [InlineData("", "0.0")]
-        [InlineData("0", "0.0")]
+        [InlineData("", "")]
+        [InlineData("0", "")]
+        [InlineData("00", "")]
+        [InlineData("0.0.0.0", "")]
         [InlineData("1", "1.0")]
         [InlineData("01", "0.1")]
         [InlineData("12", "1.2")]


### PR DESCRIPTION
* If a package asset contains an empty version, it won't show 0.0 on the badge component, just the framework name.

### Screenshots

#### Before
![Before](https://user-images.githubusercontent.com/17834924/155406512-750e7968-4d91-4bb1-9191-4ba3d88f7036.png)

#### After
![After](https://user-images.githubusercontent.com/17834924/155406537-e88ed067-a35d-4d4e-914a-6ce6d9ade3af.png)

Addresses https://github.com/NuGet/Engineering/issues/4259