### PR TITLE
[TFM Badges][UI] Add tooltip on badges.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -470,7 +470,7 @@
             setTimeout(function () {
                     popoverElement.popover('destroy');
                 },
-                1000);
+                2000);
         });
     };
 

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -186,5 +186,6 @@
     }
 
     $(".reserved-indicator").each(window.nuget.setPopovers);
+    $(".framework-badge-asset").each(window.nuget.setPopovers);
     $(".package-warning-icon").each(window.nuget.setPopovers);
 });

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2085,6 +2085,24 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This package is compatible with all versions of this framework..
+        /// </summary>
+        public static string SupportedFrameworks_EmptyVersionTooltip {
+            get {
+                return ResourceManager.GetString("SupportedFrameworks_EmptyVersionTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This package is compatible with this framework or higher..
+        /// </summary>
+        public static string SupportedFrameworks_Tooltip {
+            get {
+                return ResourceManager.GetString("SupportedFrameworks_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Your support request has been sent to the gallery operators..
         /// </summary>
         public static string SupportRequestSentTransientMessage {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1224,4 +1224,10 @@ The {1} Team</value>
   <data name="ApiKeyOwnerLocked" xml:space="preserve">
     <value>The specified API key is scoped to an owner that is locked. Please contact support@nuget.org.</value>
   </data>
+  <data name="SupportedFrameworks_EmptyVersionTooltip" xml:space="preserve">
+    <value>This package is compatible with all versions of this framework.</value>
+  </data>
+  <data name="SupportedFrameworks_Tooltip" xml:space="preserve">
+    <value>This package is compatible with this framework or higher.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -1,21 +1,44 @@
-﻿@using NuGetGallery.Frameworks;
+﻿@using String = NuGetGallery.Strings;
+@using NuGetGallery.Frameworks;
 @model PackageFrameworkCompatibilityBadges
 
 <div class="framework framework-badges">
     @if (Model.Net != null)
     {
-        <span class="framework-badge-asset" tabindex="0">.NET @Model.Net.GetBadgeVersion()</span>
+        <!-- .NET cannot be an empty version since the lowest version for this framework is "net5.0", if the package contains just "net" framework it will fall into .NET Framework badge instead.' -->
+        <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.GetBadgeVersion()</span>
     }
     @if (Model.NetCore != null)
     {
-        <span class="framework-badge-asset" tabindex="0">.NET Core @Model.NetCore.GetBadgeVersion()</span>
+        if (Model.NetCore.GetBadgeVersion().IsEmpty())
+        {
+            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
+        }
+        else
+        {
+            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.GetBadgeVersion()</span>
+        }
     }
     @if (Model.NetStandard != null)
     {
-        <span class="framework-badge-asset" tabindex="0">.NET Standard @Model.NetStandard.GetBadgeVersion()</span>
+        if (Model.NetStandard.GetBadgeVersion().IsEmpty())
+        {
+            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
+        }
+        else
+        {
+            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.GetBadgeVersion()</span>
+        }
     }
     @if (Model.NetFramework != null)
     {
-        <span class="framework-badge-asset" tabindex="0">.NET Framework @Model.NetFramework.GetBadgeVersion()</span>
+        if (Model.NetFramework.GetBadgeVersion().IsEmpty())
+        {
+            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
+        }
+        else
+        {
+            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.GetBadgeVersion()</span>
+        }
     }
 </div>


### PR DESCRIPTION
Since we wanted to improve the experience of users on what badges means, we added tooltip for the badges, this will show one of two messages depending if the badge contains a version or if it's an empty version.

* When clicking the badge the tooltip will take 2 seconds to hide, it was one second before and it was just to short for users to read it.
* Added role button for better A11y experience.
* Verified that Narrator/NVDA reads the tooltip when traversing the page.

### Screenshots
#### With version
![Badge with version](https://user-images.githubusercontent.com/17834924/155606204-7ac2ed42-4653-4ed4-a1fa-2bb8e589b3f9.png)

#### Empty version
![Package with empty version](https://user-images.githubusercontent.com/17834924/155606224-2ecba0bf-82cc-4b9f-b045-f4c82a60d0e0.png)

Addresses: https://github.com/NuGet/Engineering/issues/4230.