### PR TITLE
[A11y]Fix Graph on stats for narrow screen.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
+++ b/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
@@ -113,17 +113,6 @@
             .attr("height", function (d) { return height - yScale(d.downloads); })
             .append("title").text(function (d) { return d.downloads + " Downloads"; });
 
-        //svg.append("foreignObject")
-        //    .attr("x", "1.71em")
-        //    .attr("y", -30)
-        //    .attr("width", width - 20 + "px")
-        //    .attr("height", "2em")
-        //    .attr("font-weight", "bold")
-        //    .append("xhtml:body")
-        //    .append("p")
-        //    .attr("style", "text-align:center")
-        //    .text("Downloads for 15 Latest Package Versions (Last 6 weeks)");
-
         svg.append("g")
             .attr("class", "y axis")
             .call(yAxis)
@@ -223,17 +212,6 @@
             .attr("y", function (d) { return yScale(d.label); })
             .attr("height", yScale.bandwidth())
             .append("title").text(function (d) { return d.downloads.toLocaleString() + " Downloads"; });
-
-        //svg.append("foreignObject")
-        //    .attr("x", 0)
-        //    .attr("y", -10)
-        //    .attr("width", width + "px")
-        //    .attr("height", "2em")
-        //    .attr("font-weight", "bold")
-        //    .append("xhtml:body")
-        //    .append("p")
-        //    .attr("style", "text-align:center")
-        //    .text("Downloads by Client (Last 6 weeks)");
 
         svg.append("g")
             .attr("class", "y axis long")

--- a/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
+++ b/src/NuGetGallery/Scripts/gallery/stats-perpackagestatsgraphs.js
@@ -113,16 +113,16 @@
             .attr("height", function (d) { return height - yScale(d.downloads); })
             .append("title").text(function (d) { return d.downloads + " Downloads"; });
 
-        svg.append("foreignObject")
-            .attr("x", "1.71em")
-            .attr("y", -30)
-            .attr("width", width - 20 + "px")
-            .attr("height", "2em")
-            .attr("font-weight", "bold")
-            .append("xhtml:body")
-            .append("p")
-            .attr("style", "text-align:center")
-            .text("Downloads for 15 Latest Package Versions (Last 6 weeks)");
+        //svg.append("foreignObject")
+        //    .attr("x", "1.71em")
+        //    .attr("y", -30)
+        //    .attr("width", width - 20 + "px")
+        //    .attr("height", "2em")
+        //    .attr("font-weight", "bold")
+        //    .append("xhtml:body")
+        //    .append("p")
+        //    .attr("style", "text-align:center")
+        //    .text("Downloads for 15 Latest Package Versions (Last 6 weeks)");
 
         svg.append("g")
             .attr("class", "y axis")
@@ -133,6 +133,8 @@
             .attr("dy", ".71em")
             .style("text-anchor", "end")
             .text("Downloads");
+
+        $("#statistics-graph-title-id").text("Downloads for 15 Latest Package Versions (Last 6 weeks)");
     }
 
     var drawDownloadsByClientNameBarChart = function (rawData) {
@@ -222,20 +224,23 @@
             .attr("height", yScale.bandwidth())
             .append("title").text(function (d) { return d.downloads.toLocaleString() + " Downloads"; });
 
-        svg.append("foreignObject")
-            .attr("x", 0)
-            .attr("y", -10)
-            .attr("width", width + "px")
-            .attr("height", "2em")
-            .attr("font-weight", "bold")
-            .append("xhtml:body")
-            .append("p")
-            .attr("style", "text-align:center")
-            .text("Downloads by Client (Last 6 weeks)");
+        //svg.append("foreignObject")
+        //    .attr("x", 0)
+        //    .attr("y", -10)
+        //    .attr("width", width + "px")
+        //    .attr("height", "2em")
+        //    .attr("font-weight", "bold")
+        //    .append("xhtml:body")
+        //    .append("p")
+        //    .attr("style", "text-align:center")
+        //    .text("Downloads by Client (Last 6 weeks)");
 
         svg.append("g")
             .attr("class", "y axis long")
             .call(yAxis);
+
+
+        $("#statistics-graph-title-id").text("Downloads by Client (Last 6 weeks)");
     }
 
     var GetChartData = function (rawData, filter) {

--- a/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
+++ b/src/NuGetGallery/Views/Statistics/_PivotTable.cshtml
@@ -48,7 +48,8 @@
                 <div class="loader"></div>
             </div>
             <div class="col-sm-10" id="stats-data-display">
-                <div class="stats-graph col-xs-12 hidden-tiny" id="statistics-graph-id"></div>
+                <div class="stats-graph-title col-xs-12" id="statistics-graph-title-id"></div>
+                <div class="stats-graph col-xs-12" id="statistics-graph-id"></div>
                 <div class="stats-table-data">
                     <table data-bind="if: Table" class="pivot-table table">
                         <thead>


### PR DESCRIPTION
Disables removing the chart when screen in very narrow.
Moves the title out of the chart itself since chart no longer is removed. This also improves readability of the title.

Old:
![image](https://user-images.githubusercontent.com/11051729/156249413-1d900878-47a2-4563-b016-5f58f0084f83.png)

New:
![image](https://user-images.githubusercontent.com/11051729/156249472-eaa234e4-b7c6-4ad2-9ee3-6d218f8f10bc.png)

Note difference in displayed data comes from dev vs public.