### PR TITLE
[A11y] Improved contrast of buttons when in tab focus mode

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -2383,7 +2383,6 @@ fieldset[disabled] a.btn {
 .btn-default:focus,
 .btn-default.focus {
   color: #333;
-  background-color: #e6e6e6;
   border-color: #3f3f3f;
 }
 .btn-default:hover {
@@ -2436,7 +2435,6 @@ fieldset[disabled] .btn-default.focus {
 .btn-primary:focus,
 .btn-primary.focus {
   color: #fff;
-  background-color: #286090;
   border-color: #122b40;
 }
 .btn-primary:hover {
@@ -2489,7 +2487,6 @@ fieldset[disabled] .btn-primary.focus {
 .btn-success:focus,
 .btn-success.focus {
   color: #fff;
-  background-color: #449d44;
   border-color: #255625;
 }
 .btn-success:hover {
@@ -2542,7 +2539,6 @@ fieldset[disabled] .btn-success.focus {
 .btn-info:focus,
 .btn-info.focus {
   color: #fff;
-  background-color: #31b0d5;
   border-color: #1b6d85;
 }
 .btn-info:hover {
@@ -2595,7 +2591,6 @@ fieldset[disabled] .btn-info.focus {
 .btn-warning:focus,
 .btn-warning.focus {
   color: #fff;
-  background-color: #a56000;
   border-color: #3f2500;
 }
 .btn-warning:hover {
@@ -2648,7 +2643,6 @@ fieldset[disabled] .btn-warning.focus {
 .btn-danger:focus,
 .btn-danger.focus {
   color: #fff;
-  background-color: #ac0017;
   border-color: #460009;
 }
 .btn-danger:hover {

--- a/src/Bootstrap/less/mixins/buttons.less
+++ b/src/Bootstrap/less/mixins/buttons.less
@@ -11,7 +11,6 @@
   &:focus,
   &.focus {
     color: @color;
-    background-color: darken(@background, 10%);
     border-color: darken(@border, 25%);
   }
   &:hover {


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8987

_Note:_ One of the original problems called out in the [a11y bug](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1468969) was related to the contrast between the search sign and the white background (the search bar), but it looks like the wrong background color was selected in their tests, and I could not reproduce it while using Accessibility Insights myself.

Their screenshot:
![image](https://user-images.githubusercontent.com/82980589/156466090-cabbae21-3474-4382-9b91-70ce1e361529.png)

When I looked into it:
![image](https://user-images.githubusercontent.com/82980589/156466171-7a646b39-2aaa-4df6-858b-51dfdd718cff.png)
![image](https://user-images.githubusercontent.com/82980589/156466221-101580df-46a3-48dd-97c0-9094232b070e.png)

However, there were other accessibility concerns because of contrast ratios here, which I've tried to fix.

**Problem:**

On NuGet.org, when navigating a page using the keyboard (tab key), buttons would get a black outline and would darken their original color. This reduced the contrast on certain buttons like the Search button in the navbar and the Send button on the Forgot Password page (with respect to the tab focus outline, and in some cases other surrounding colors in the backdrop)

Previous version (Search):
![image](https://user-images.githubusercontent.com/82980589/156465861-8d6a6f5b-8c57-4e9b-a04f-a5e70423711e.png)  ![image](https://user-images.githubusercontent.com/82980589/156465819-ba78de01-95db-45b2-ad33-3695d7d4ec73.png)
![image](https://user-images.githubusercontent.com/82980589/156466569-eaa0edd7-b433-46ee-a4c4-87caebb4e750.png)
![image](https://user-images.githubusercontent.com/82980589/156466794-53da64c6-2e60-4606-9185-9ea618f481fd.png)
![image](https://user-images.githubusercontent.com/82980589/156466843-1b0c24c6-3c01-4830-9822-cc4fcd4062a6.png)

Previous version (Send button on Forgot Password page):
![image](https://user-images.githubusercontent.com/82980589/156466878-e3117931-bbdc-4b48-aaab-4c07a48c8d5c.png)  ![image](https://user-images.githubusercontent.com/82980589/156466899-2153e3df-db8d-4ca3-8d4e-2180da88f0ca.png)
![image](https://user-images.githubusercontent.com/82980589/156467095-ba51a40e-43d0-41a3-b432-cbd10a1c4a2f.png)


**Fix:**

To fix this, I removed the darkening effect when in tab focus. The outline still highlights the element distinctly, and has higher contrast ratios with the original button colors.

After making the changes:

New version (Search):
![image](https://user-images.githubusercontent.com/82980589/156467350-cc85c145-b985-4ea8-acd1-d4d39a3847f2.png)  ![image](https://user-images.githubusercontent.com/82980589/156467326-941db588-4a2c-48d6-b921-dcd144bcebdb.png)
![image](https://user-images.githubusercontent.com/82980589/156467504-192a9457-91fd-4793-8567-2c3a5ac11ed8.png)
![image](https://user-images.githubusercontent.com/82980589/156467415-553609ce-c31e-4539-a39e-f6a332eb99fc.png)
![image](https://user-images.githubusercontent.com/82980589/156467585-2883143f-3042-41b4-ad09-6a73d111906e.png)

New version (Send button on Forgot Password page):
![image](https://user-images.githubusercontent.com/82980589/156467839-bd4da740-22a2-4877-801a-82ff3b031fd5.png)  ![image](https://user-images.githubusercontent.com/82980589/156467862-9c7b2088-8d7f-47f0-9a41-fb5d5184537a.png)
![image](https://user-images.githubusercontent.com/82980589/156467986-bd161f70-f13e-4afe-8cf8-25b483dcb74b.png)