### PR TITLE
[A11y] Improved contrast of focus outline on elements in the header and footer

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -68,6 +68,10 @@ body h3 {
 .footer a {
   color: #e3ebf1;
 }
+.footer a:focus {
+  outline: 3px solid white;
+  outline-offset: 2px;
+}
 .footer .footer-release-info {
   font-size: 0.85em;
   margin-top: 20px;

--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -3452,6 +3452,10 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
     border-radius: 0px;
   }
 }
+.navbar a:focus {
+  outline: 4px solid white;
+  outline-offset: -2px;
+}
 @media (min-width: 768px) {
   .navbar-header {
     float: left;

--- a/src/Bootstrap/less/navbar.less
+++ b/src/Bootstrap/less/navbar.less
@@ -21,6 +21,11 @@
   @media (min-width: @grid-float-breakpoint) {
     border-radius: @navbar-border-radius;
   }
+
+  a:focus {
+    outline: 4px solid white;
+    outline-offset: -2px;
+  }
 }
 
 

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -83,6 +83,11 @@ body {
 
   a {
     color: @panel-footer-color;
+
+    &:focus {
+      outline: 3px solid white;
+      outline-offset: 2px;
+    }
   }
 
   .footer-release-info {


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/8986

**Problem:**

On NuGet.org, when navigating a page using the keyboard (tab key), elements in the navbar and footer were given a black outline, which had a low contrast ratio with the blue background.

**Previous version**

Header:
![Old, navbar](https://user-images.githubusercontent.com/82980589/156483103-fe4370dc-5fe4-4831-98d3-021b07b662c9.gif)

![image](https://user-images.githubusercontent.com/82980589/156484206-fe49f7da-b4fd-4357-80cf-e54c7938a768.png)

Footer:
![Old, footer](https://user-images.githubusercontent.com/82980589/156483117-b58d29a4-3015-41ad-8776-b8653664a170.gif)

![image](https://user-images.githubusercontent.com/82980589/156484502-a82b2f10-314e-44bb-83d8-6a1729bff731.png)


**Fix:**

To fix this, I changed the focus outline to white.

After making the changes:

**New version**

Header:
![New, navbar](https://user-images.githubusercontent.com/82980589/156483142-a30f06a0-3546-46ff-ad99-344078424a75.gif)

![image](https://user-images.githubusercontent.com/82980589/156484341-f4a1c557-20ae-4694-a01f-0fbd15280108.png)

Footer:
![New, footer](https://user-images.githubusercontent.com/82980589/156483149-334513ef-d62b-41e0-9f22-b14705087769.gif)

![image](https://user-images.githubusercontent.com/82980589/156484588-832ae602-3076-453a-ab99-84bdd6395e0d.png)

