### PR TITLE
[2FA] Enable 2FA by default for new accounts

### DIFF
--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -392,7 +392,8 @@ namespace NuGetGallery.Authentication
                 UnconfirmedEmailAddress = emailAddress,
                 EmailConfirmationToken = CryptographyService.GenerateToken(),
                 NotifyPackagePushed = true,
-                CreatedUtc = _dateTimeProvider.UtcNow
+                CreatedUtc = _dateTimeProvider.UtcNow,
+                EnableMultiFactorAuthentication = true
             };
 
             // Add a credential for the password

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -507,6 +507,13 @@ namespace NuGetGallery
                 return SafeRedirect(returnUrl);
             }
 
+            // All new linking or replacing accounts should have 2FA enabled.
+            if (!result.UserInfo.UsedMultiFactorAuthentication)
+            {
+                TempData["ErrorMessage"] = Strings.ExternalAccountShouldHave2FAEnabled;
+                return SafeRedirect(returnUrl);
+            }
+
             var newCredential = result.Credential;
             if (await _authService.TryReplaceCredential(user, newCredential))
             {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1067,6 +1067,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your account must have two-factor authentication enabled. Please enable it or reach out to your account admin..
+        /// </summary>
+        public static string ExternalAccountShouldHave2FAEnabled {
+            get {
+                return ResourceManager.GetString("ExternalAccountShouldHave2FAEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to read the package file. Ensure it is a valid NuGet package with a valid manifest..
         /// </summary>
         public static string FailedToReadUploadFile {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1230,4 +1230,7 @@ The {1} Team</value>
   <data name="SupportedFrameworks_Tooltip" xml:space="preserve">
     <value>This package is compatible with this framework or higher.</value>
   </data>
+  <data name="ExternalAccountShouldHave2FAEnabled" xml:space="preserve">
+    <value>Your account must have two-factor authentication enabled. Please enable it or reach out to your account admin.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -35,6 +35,7 @@ namespace NuGetGallery
         public bool FoundExistingUser { get; set; }
         public bool ExistingUserCanBeLinked => ExistingUserLinkingError == ExistingUserLinkingErrorType.None;
         public ExistingUserLinkingErrorType ExistingUserLinkingError { get; set; }
+        public bool UsedMultiFactorAuthentication { get; set; }
 
         public enum ExistingUserLinkingErrorType
         {

--- a/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
+++ b/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
@@ -7,7 +7,31 @@
 }
 
 <section role="main" class="container main-container page-sign-in">
-    @if (Model.External.FoundExistingUser)
+    @if (!Model.External.UsedMultiFactorAuthentication)
+    {
+        <div class="row">
+            <div class="col-xs-12">
+                <h1 class="text-center">Your @Model.External.ProviderAccountNoun cannot be linked at this time.</h1>
+            </div>
+        </div>
+        <div class="row">
+            <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
+                <p class="text-center">
+                    All new accounts requires to use two-factor authentication (2FA).
+                    <a href='https://devblogs.microsoft.com/nuget/requiring-two-factor-authentication-on-nuget-org/' aria-label="Learn more.">Learn more.</a>
+                </p>
+                <p class="text-center">
+                    <a href='https://support.microsoft.com/en-us/account-billing/turning-two-step-verification-on-or-off-for-your-microsoft-account-b1a56fc2-caf3-a5a1-f7e3-4309e99987ca'
+                       aria-label="How to enable 2FA for your Microsoft account.">How to enable 2FA for your Microsoft account.</a>
+                </p>
+                <p class="text-center">
+                    <a href='https://support.microsoft.com/en-us/account-billing/set-up-security-info-from-a-sign-in-page-28180870-c256-4ebf-8bd7-5335571bf9a8'
+                       aria-label="How to enable 2FA for your work or school account.">How to enable 2FA for your work or school account.</a>
+                </p>
+            </div>
+        </div>
+    }
+    else if (Model.External.FoundExistingUser)
     {
         <div class="row">
             <div class="col-xs-12">

--- a/src/NuGetGallery/Views/Users/_UserAccountChangeExternalCredential.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserAccountChangeExternalCredential.cshtml
@@ -59,37 +59,5 @@
                     }
                 </div>
             }
-            else
-            {
-                using (Html.BeginForm("ChangeMultiFactorAuthentication", "Users", FormMethod.Post, new { aria_label = "Change multi-factor authentication setting" }))
-                {
-                    @Html.AntiForgeryToken()
-
-                    @Html.Hidden("enableMultiFactor", !Model.User.EnableMultiFactorAuthentication);
-                    <div class="login-account-row">
-                        @if (Model.User.EnableMultiFactorAuthentication)
-                        {
-                            <span class="col-sm-9"  style="padding: 0;">
-                                Two-factor authentication is currently enabled <i class="ms-Icon ms-Icon--CheckMark checkmark-icon" aria-hidden="true"></i>
-                            </span>
-                            <span class="col-sm-3" style="padding: 0;">
-                                <button class="btn btn-danger btn-block" type="submit"
-                                        data-confirm="This action will disable 2FA, making your account less secure. Are you sure you want to disable this setting?">
-                                    Disable
-                                </button>
-                            </span>
-                        }
-                        else
-                        {
-                            <span class="col-sm-9"  style="padding: 0;">
-                                Two-factor authentication is currently disabled <i class="ms-Icon ms-Icon--Warning warning-icon" aria-hidden="true"></i>
-                            </span>
-                            <span class="col-sm-3" style="padding: 0;">
-                                <button class="btn btn-default btn-block" type="submit">Enable</button>
-                            </span>
-                        }
-                    </div>
-                }
-            }
         </text>)
 }

--- a/src/NuGetGallery/Views/Users/_UserAccountChangeExternalCredential.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserAccountChangeExternalCredential.cshtml
@@ -59,5 +59,22 @@
                     }
                 </div>
             }
+            else if (!Model.User.EnableMultiFactorAuthentication)
+            {
+                using (Html.BeginForm("ChangeMultiFactorAuthentication", "Users", FormMethod.Post, new { aria_label = "Change multi-factor authentication setting" }))
+                {
+                    @Html.AntiForgeryToken()
+
+                    @Html.Hidden("enableMultiFactor", !Model.User.EnableMultiFactorAuthentication);
+                    <div class="login-account-row">
+                        <span class="col-sm-9"  style="padding: 0;">
+                            Two-factor authentication is currently disabled <i class="ms-Icon ms-Icon--Warning warning-icon" aria-hidden="true"></i>
+                        </span>
+                        <span class="col-sm-3" style="padding: 0;">
+                            <button class="btn btn-default btn-block" type="submit">Enable</button>
+                        </span>
+                    </div>
+                }
+            }
         </text>)
 }


### PR DESCRIPTION
- All new accounts won't be able to link their account (and unable to register) if the account doesn't have 2FA enabled.
- Current users won't be able to enable to link new accounts if that account doesn't have 2FA enabled.
- Enable/Disable button for changing 2FA status on Account Settings page will only show Enable so users can still follow that flow if they want to enable it before enforcement.


Addresses:
- https://github.com/NuGet/Engineering/issues/4235
- https://github.com/NuGet/Engineering/issues/4236