### PR TITLE
[Upload UI]: Improve experience when package has no license

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -325,6 +325,7 @@
     <Compile Include="Modules\CookieComplianceHttpModule.cs" />
     <Compile Include="RequestModels\DeletePackagesApiRequest.cs" />
     <Compile Include="RequestModels\UpdateListedRequest.cs" />
+    <Compile Include="Services\MissingLicenseValidationMessage.cs" />
     <Compile Include="Services\UploadPackageIdNamespaceConflict.cs" />
     <Compile Include="Services\ImageDomainValidator.cs" />
     <Compile Include="Services\IMarkdownService.cs" />

--- a/src/NuGetGallery/Services/InvalidLicenseUrlValidationMessage.cs
+++ b/src/NuGetGallery/Services/InvalidLicenseUrlValidationMessage.cs
@@ -11,7 +11,7 @@ namespace NuGetGallery
     /// </summary>
     public class InvalidLicenseUrlValidationMessage : IValidationMessage
     {
-        private string DetailsLink => $"<a href=\"https://aka.ms/invalidNuGetLicenseUrl\" aria-label= \"{Strings.UploadPackage_LearMore_PackagingLicense}\">{Strings.UploadPackage_LearnMore}</a>.";
+        private string DetailsLink => $"<a href=\"https://aka.ms/invalidNuGetLicenseUrl\" aria-label= \"{Strings.UploadPackage_LearnMore_PackagingLicense}\">{Strings.UploadPackage_LearnMore}</a>.";
         private string DetailsPlainText => "https://aka.ms/invalidNuGetLicenseUrl";
 
         private readonly string _baseMessage;

--- a/src/NuGetGallery/Services/LicenseUrlDeprecationValidationMessage.cs
+++ b/src/NuGetGallery/Services/LicenseUrlDeprecationValidationMessage.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
     /// </summary>
     public class LicenseUrlDeprecationValidationMessage : IValidationMessage
     {
-        private string DeprecationLink => $"<a href=\"{GalleryConstants.LicenseDeprecationUrl}\" aria-label= \"{Strings.UploadPackage_LearnMore_LicenseUrlDreprecation}\">{Strings.UploadPackage_LearnMore}</a>.";
+        private string DeprecationLink => $"<a href=\"{GalleryConstants.LicenseDeprecationUrl}\" aria-label=\"{Strings.UploadPackage_LearnMore_LicenseUrlDreprecation}\">{Strings.UploadPackage_LearnMore}</a>.";
 
         private readonly string _baseMessage;
         

--- a/src/NuGetGallery/Services/MissingLicenseValidationMessage.cs
+++ b/src/NuGetGallery/Services/MissingLicenseValidationMessage.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Web;
+
+namespace NuGetGallery
+{
+    /// <summary>
+    /// A warning for packages that are missing licensing metadata.
+    /// </summary>
+    public class MissingLicenseValidationMessage : IValidationMessage
+    {
+        private string DeprecationLink => $"<a href=\"https://aka.ms/nuget/authoring-best-practices#licensing\" aria-label= \"{Strings.UploadPackage_LearnMore_PackagingLicense}\">{Strings.UploadPackage_LearnMore}</a>.";
+
+        private readonly string _baseMessage;
+
+        public MissingLicenseValidationMessage(string basePlainTextMessage)
+        {
+            if (string.IsNullOrWhiteSpace(basePlainTextMessage))
+            {
+                throw new ArgumentException(
+                    string.Format(CultureInfo.CurrentCulture, Strings.ParameterCannotBeNullOrEmpty, nameof(basePlainTextMessage)), nameof(basePlainTextMessage));
+            }
+
+            _baseMessage = basePlainTextMessage;
+            PlainTextMessage = $"{_baseMessage} {Strings.UploadPackage_LearnMore}: https://aka.ms/nuget/authoring-best-practices#licensing.";
+        }
+
+        public string PlainTextMessage { get; }
+
+        public bool HasRawHtmlRepresentation => true;
+
+        public string RawHtmlMessage
+            => HttpUtility.HtmlEncode(_baseMessage) + " " + DeprecationLink;
+    }
+}

--- a/src/NuGetGallery/Services/MissingLicenseValidationMessage.cs
+++ b/src/NuGetGallery/Services/MissingLicenseValidationMessage.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
     /// </summary>
     public class MissingLicenseValidationMessage : IValidationMessage
     {
-        private string DeprecationLink => $"<a href=\"https://aka.ms/nuget/authoring-best-practices#licensing\" aria-label= \"{Strings.UploadPackage_LearnMore_PackagingLicense}\">{Strings.UploadPackage_LearnMore}</a>.";
+        private string DocumentationLink => $"<a href=\"https://aka.ms/nuget/authoring-best-practices#licensing\" aria-label= \"{Strings.UploadPackage_LearnMore_PackagingLicense}\">{Strings.UploadPackage_LearnMore}</a>.";
 
         private readonly string _baseMessage;
 
@@ -33,6 +33,6 @@ namespace NuGetGallery
         public bool HasRawHtmlRepresentation => true;
 
         public string RawHtmlMessage
-            => HttpUtility.HtmlEncode(_baseMessage) + " " + DeprecationLink;
+            => HttpUtility.HtmlEncode(_baseMessage) + " " + DocumentationLink;
     }
 }

--- a/src/NuGetGallery/Services/MissingLicenseValidationMessage.cs
+++ b/src/NuGetGallery/Services/MissingLicenseValidationMessage.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
     /// </summary>
     public class MissingLicenseValidationMessage : IValidationMessage
     {
-        private string DocumentationLink => $"<a href=\"https://aka.ms/nuget/authoring-best-practices#licensing\" aria-label= \"{Strings.UploadPackage_LearnMore_PackagingLicense}\">{Strings.UploadPackage_LearnMore}</a>.";
+        private string DocumentationLink => $"<a href=\"https://aka.ms/nuget/authoring-best-practices#licensing\" aria-label=\"{Strings.UploadPackage_LearnMore_PackagingLicense}\">{Strings.UploadPackage_LearnMore}</a>.";
 
         private readonly string _baseMessage;
 

--- a/src/NuGetGallery/Services/PackageMetadataValidationService.cs
+++ b/src/NuGetGallery/Services/PackageMetadataValidationService.cs
@@ -211,7 +211,7 @@ namespace NuGetGallery
                     }
                     else
                     {
-                        warnings.Add(new LicenseUrlDeprecationValidationMessage(Strings.UploadPackage_LicenseShouldBeSpecified));
+                        warnings.Add(new MissingLicenseValidationMessage(Strings.UploadPackage_LicenseShouldBeSpecified));
                     }
                 }
 

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2661,15 +2661,6 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Learn more about including a license within the package.
-        /// </summary>
-        public static string UploadPackage_LearMore_PackagingLicense {
-            get {
-                return ResourceManager.GetString("UploadPackage_LearMore_PackagingLicense", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Learn more.
         /// </summary>
         public static string UploadPackage_LearnMore {
@@ -2702,6 +2693,15 @@ namespace NuGetGallery {
         public static string UploadPackage_LearnMore_LicenseUrlDreprecation {
             get {
                 return ResourceManager.GetString("UploadPackage_LearnMore_LicenseUrlDreprecation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Learn more about including a license within the package.
+        /// </summary>
+        public static string UploadPackage_LearnMore_PackagingLicense {
+            get {
+                return ResourceManager.GetString("UploadPackage_LearnMore_PackagingLicense", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1190,7 +1190,7 @@ The {1} Team</value>
   <data name="ReadmeNotEditableWithEmbeddedReadme" xml:space="preserve">
     <value>The readme is not editable with the package has the embedded readme</value>
   </data>
-  <data name="UploadPackage_LearMore_PackagingLicense" xml:space="preserve">
+  <data name="UploadPackage_LearnMore_PackagingLicense" xml:space="preserve">
     <value>Learn more about including a license within the package</value>
   </data>
   <data name="UploadPackage_LearnMore_IconUrlDeprecation" xml:space="preserve">

--- a/tests/NuGetGallery.Facts/Services/PackageMetadataValidationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageMetadataValidationServiceFacts.cs
@@ -437,7 +437,7 @@ namespace NuGetGallery
                     Assert.Equal(PackageValidationResultType.Accepted, result.Type);
                     Assert.Null(result.Message);
                     Assert.Single(result.Warnings);
-                    Assert.IsType<LicenseUrlDeprecationValidationMessage>(result.Warnings[0]);
+                    Assert.IsType<MissingLicenseValidationMessage>(result.Warnings[0]);
                     Assert.StartsWith("All published packages should have license information specified.", result.Warnings[0].PlainTextMessage);
                 }
             }


### PR DESCRIPTION
The web UI shows a warning if you upload a package without a license:

![image](https://user-images.githubusercontent.com/737941/157503952-c57bf021-8f57-44c0-ab07-68c1d5ddd7f6.png)

This switches the `Learn more` URL from https://aka.ms/deprecateLicenseUrl to https://aka.ms/nuget/authoring-best-practices#licensing as that's a more helpful guide in this scenario.

Addresses https://github.com/NuGet/NuGetGallery/issues/9037

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5859049&view=results
Release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1282731

/cc @agr @chgill-MSFT 