### PR TITLE
[A11y] Added alt text to reserved namespace icon element

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -68,6 +68,10 @@ body h3 {
 .footer a {
   color: #e3ebf1;
 }
+.footer a:focus {
+  outline: 3px solid white;
+  outline-offset: 2px;
+}
 .footer .footer-release-info {
   font-size: 0.85em;
   margin-top: 20px;

--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -3446,6 +3446,10 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
     border-radius: 0px;
   }
 }
+.navbar a:focus {
+  outline: 4px solid white;
+  outline-offset: -2px;
+}
 @media (min-width: 768px) {
   .navbar-header {
     float: left;

--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -2383,7 +2383,6 @@ fieldset[disabled] a.btn {
 .btn-default:focus,
 .btn-default.focus {
   color: #333;
-  background-color: #e6e6e6;
   border-color: #3f3f3f;
 }
 .btn-default:hover {
@@ -2436,7 +2435,6 @@ fieldset[disabled] .btn-default.focus {
 .btn-primary:focus,
 .btn-primary.focus {
   color: #fff;
-  background-color: #286090;
   border-color: #122b40;
 }
 .btn-primary:hover {
@@ -2489,7 +2487,6 @@ fieldset[disabled] .btn-primary.focus {
 .btn-success:focus,
 .btn-success.focus {
   color: #fff;
-  background-color: #449d44;
   border-color: #255625;
 }
 .btn-success:hover {
@@ -2542,7 +2539,6 @@ fieldset[disabled] .btn-success.focus {
 .btn-info:focus,
 .btn-info.focus {
   color: #fff;
-  background-color: #31b0d5;
   border-color: #1b6d85;
 }
 .btn-info:hover {
@@ -2595,7 +2591,6 @@ fieldset[disabled] .btn-info.focus {
 .btn-warning:focus,
 .btn-warning.focus {
   color: #fff;
-  background-color: #a56000;
   border-color: #3f2500;
 }
 .btn-warning:hover {
@@ -2648,7 +2643,6 @@ fieldset[disabled] .btn-warning.focus {
 .btn-danger:focus,
 .btn-danger.focus {
   color: #fff;
-  background-color: #ac0017;
   border-color: #460009;
 }
 .btn-danger:hover {

--- a/src/Bootstrap/less/mixins/buttons.less
+++ b/src/Bootstrap/less/mixins/buttons.less
@@ -11,7 +11,6 @@
   &:focus,
   &.focus {
     color: @color;
-    background-color: darken(@background, 10%);
     border-color: darken(@border, 25%);
   }
   &:hover {

--- a/src/Bootstrap/less/navbar.less
+++ b/src/Bootstrap/less/navbar.less
@@ -21,6 +21,11 @@
   @media (min-width: @grid-float-breakpoint) {
     border-radius: @navbar-border-radius;
   }
+
+  a:focus {
+    outline: 4px solid white;
+    outline-offset: -2px;
+  }
 }
 
 

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -83,6 +83,11 @@ body {
 
   a {
     color: @panel-footer-color;
+
+    &:focus {
+      outline: 3px solid white;
+      outline-offset: 2px;
+    }
   }
 
   .footer-release-info {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -751,6 +751,7 @@
                                                             <img class="reserved-indicator"
                                                                  src="~/Content/gallery/img/reserved-indicator.svg"
                                                                  @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-14x14.png"))
+                                                                 alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"
                                                                  title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
                                                         }
                                                         <p class="used-by-desc">@item.Description</p>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9036

**Problem:**

In the Package Details page's 'Used By' tab, the 'reserved namespace' icons next to the Package Dependents did not have alt attributes.

Previous version:
![image](https://user-images.githubusercontent.com/82980589/157561027-35f0bf2b-182b-427f-93c9-893623193477.png)
![image](https://user-images.githubusercontent.com/82980589/157561109-7bc0d30d-a780-45af-83ae-716a33b443cd.png)

**Fix:**

To fix this, I added the alt attribute to the reserved namespace img element.

After the changes:
![image](https://user-images.githubusercontent.com/82980589/157560972-4dc54599-1207-4404-8b12-e3e08d8d8d3e.png)
