### PR TITLE
[A11y] Added alt text to reserved namespace icon on package details page

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -751,6 +751,7 @@
                                                             <img class="reserved-indicator"
                                                                  src="~/Content/gallery/img/reserved-indicator.svg"
                                                                  @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-14x14.png"))
+                                                                 alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"
                                                                  title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
                                                         }
                                                         <p class="used-by-desc">@item.Description</p>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9036

**Problem:**

In the Package Details page's 'Used By' tab, the 'reserved namespace' icons next to the Package Dependents did not have alt attributes.

Previous version:
![image](https://user-images.githubusercontent.com/82980589/157561027-35f0bf2b-182b-427f-93c9-893623193477.png)
![image](https://user-images.githubusercontent.com/82980589/157561109-7bc0d30d-a780-45af-83ae-716a33b443cd.png)

**Fix:**

To fix this, I added the alt attribute to the reserved namespace img element.

After the changes:
![image](https://user-images.githubusercontent.com/82980589/157560972-4dc54599-1207-4404-8b12-e3e08d8d8d3e.png)
