### PR TITLE
[A11y] Added aria-label attributes to table elements

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Views/ApiKeys/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/ApiKeys/Index.cshtml
@@ -21,7 +21,7 @@
     @using (Html.BeginForm("Revoke", "ApiKeys", new { area = "Admin" }, FormMethod.Post))
     {
         @Html.AntiForgeryToken()
-        <table class="table break-word" style="display: none" data-bind="visible: verifiedResults().length > 0">
+        <table class="table break-word" style="display: none" data-bind="visible: verifiedResults().length > 0" aria-label="API Keys">
             <thead>
                 <tr>
                     <th class="col-sm-1">

--- a/src/NuGetGallery/Areas/Admin/Views/Delete/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Delete/Index.cshtml
@@ -18,7 +18,7 @@
 
     @using (Html.BeginForm("Delete", "Packages", new { area = "" }, FormMethod.Post, new { id = "delete-form" }))
     {
-        <table class="table" id="searchResults" style="display: none" data-bind="visible: searchResults().length > 0">
+        <table class="table" id="searchResults" style="display: none" data-bind="visible: searchResults().length > 0" aria-label="Search results">
             <thead>
                 <tr>
                     <th><input type="checkbox" data-bind="click: toggleSelectAll, checked: selectAllState" /></th>

--- a/src/NuGetGallery/Areas/Admin/Views/Features/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Features/Index.cshtml
@@ -36,7 +36,7 @@
             @<text>Features</text>,
             @<text><p>View and edit features.</p></text>,
             @<text>
-                <table class="table">
+                <table class="table" aria-label="Features">
                     <tr>
                         <th>Name</th>
                         <th>Current Status</th>
@@ -61,7 +61,7 @@
             @<text>Flights</text>,
             @<text><p>View and edit flights.</p></text>,
             @<text>
-                <table class="table">
+                <table class="table" aria-label="Flights">
                     <tr>
                         <th>Name</th>
                         <th>All</th>

--- a/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
@@ -21,7 +21,7 @@
         @using (Html.BeginForm())
         {
             <div id="prefixResult" data-bind="foreach: allPrefixResults">
-                <table>
+                <table aria-label="Reserved Namespaces Search Results">
                     <tr>
                         <td>
                             <span style="font-weight: bold">Details:</span>

--- a/src/NuGetGallery/Areas/Admin/Views/SiteAdmins/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SiteAdmins/Index.cshtml
@@ -5,7 +5,7 @@
 
 <section role="main" class="container main-container">
     <h2>Current Admins</h2>
-    <table class="table">
+    <table class="table" aria-label="Current Admins">
         @foreach (var adminUsername in Model.AdminUsernames)
         {
             <tr>

--- a/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Admins.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Admins.cshtml
@@ -49,7 +49,7 @@
     <div id="sr-admins-container">
         <h2>Support Request Administrators</h2>
 
-        <table id="sr-admins-table" class="sexy-table">
+        <table id="sr-admins-table" class="sexy-table" aria-label="Support Request Administrators">
             <thead>
                 <tr>
                     <th>Admin Key</th>

--- a/src/NuGetGallery/Areas/Admin/Views/UpdateListed/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/UpdateListed/Index.cshtml
@@ -15,7 +15,7 @@
     @using (Html.BeginForm("UpdateListed", "UpdateListed", new { area = "Admin" }, FormMethod.Post, new { id = "update-listed-form" }))
     {
         @Html.AntiForgeryToken()
-        <table class="table" id="searchResults" style="display: none" data-bind="visible: searchResults().length > 0">
+        <table class="table" id="searchResults" style="display: none" data-bind="visible: searchResults().length > 0" aria-label="Search results">
             <thead>
                 <tr>
                     <th><input type="checkbox" data-bind="click: toggleSelectAll, checked: selectAllState" /></th>

--- a/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Validation/Index.cshtml
@@ -181,7 +181,7 @@
                     }
                     else
                     {
-                        <table class="table" style="width: 100%">
+                        <table class="table" style="width: 100%" aria-label="Package Validations">
                             <thead>
                                 <tr>
                                     <th>Key</th>

--- a/src/NuGetGallery/Views/Organizations/_OrganizationMembersListForDeletedAccount.cshtml
+++ b/src/NuGetGallery/Views/Organizations/_OrganizationMembersListForDeletedAccount.cshtml
@@ -4,7 +4,7 @@
     <div class="col-md-12 align-left ">
         <div class="panel-collapse collapse in" id="packages-Packages" aria-expanded="true">
             <div class="list-packages" role="list">
-                <table class="table align-left">
+                <table class="table align-left" aria-label="Organization Members">
                     <thead>
                         <tr class="manage-package-headings">
                             <th class="hidden-xs"></th>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -731,7 +731,7 @@
                                     <p>
                                         Showing the top @(Model.PackageDependents.TopPackages.Count) NuGet packages that depend on @(Model.Id):
                                     </p>
-                                    <table class="table borderless">
+                                    <table class="table borderless" aria-label="Packages that depend on @Model.Id">
                                         <thead>
                                             <tr>
                                                 <th class="used-by-adjust-table-head">Package</th>
@@ -784,7 +784,7 @@
                                     <p>
                                         Showing the top @(Model.GitHubDependenciesInformation.Repos.Count) popular GitHub repositories that depend on @(Model.Id):
                                     </p>
-                                    <table class="table borderless">
+                                    <table class="table borderless" aria-label="GitHub repositories that depend on @Model.Id">
                                         <thead>
                                             <tr>
                                                 <th class="used-by-adjust-table-head">Repository</th>

--- a/src/NuGetGallery/Views/Packages/_DisplayPackageVulnerabilities.cshtml
+++ b/src/NuGetGallery/Views/Packages/_DisplayPackageVulnerabilities.cshtml
@@ -30,7 +30,7 @@
 
         <div class="vulnerabilities-content-container collapse" id="vulnerabilities-content-container">
             <b>Details</b>
-            <table width="100%" class="vulnerabilities-list">
+            <table width="100%" class="vulnerabilities-list" aria-label="Details on Vulnerabilities">
                 @{
                     if (Model.Vulnerabilities != null)
                     {

--- a/src/NuGetGallery/Views/Statistics/Index.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Index.cshtml
@@ -26,7 +26,7 @@
             <div class="col-md-6 col-xs-12">
                 <h2 class="stats-title-text">Package Downloads</h2>
 
-                <table class="table col-xs-12 borderless">
+                <table class="table col-xs-12 borderless" aria-label="Package Downloads">
                     <thead>
                         <tr>
                             <th class="text-left">Name</th>
@@ -62,7 +62,7 @@
             <div class="col-md-6 col-xs-12">
                 <h2 class="stats-title-text">Version Downloads</h2>
 
-                <table class="table col-xs-12 borderless">
+                <table class="table col-xs-12 borderless" aria-label="Version Downloads">
                     <thead>
                         <tr>
                             <th class="text-left">Name</th>
@@ -148,7 +148,7 @@
                         </svg>
                     }
                 </div>
-                <table class="table col-xs-12 borderless">
+                <table class="table col-xs-12 borderless" aria-label="NuGet Client Downloads">
                     <thead>
                         <tr>
                             <th class="text-left">NuGet Client Version</th>
@@ -229,7 +229,7 @@
                         </svg>
                       }
                 </div>
-                <table class="table col-xs-12 borderless">
+                <table class="table col-xs-12 borderless" aria-label="Weekly Downloads">
                     <thead>
                         <tr>
                             <th class="text-left">Week</th>

--- a/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
+++ b/src/NuGetGallery/Views/Statistics/PackageVersions.cshtml
@@ -30,7 +30,7 @@
         </div>
         <div class="row">
             <div class="col-xs-12">
-                <table @ShowIfAllPackageSet() class="table borderless">
+                <table @ShowIfAllPackageSet() class="table borderless" aria-label="Packages with the most downloads">
                     <caption class="sr-only">The packages with the most downloads.</caption>
 
                     <thead>
@@ -60,7 +60,7 @@
                     </tbody>
                 </table>
 
-                <table @ShowIfCommunityPackageSet() class="table borderless">
+                <table @ShowIfCommunityPackageSet() class="table borderless" aria-label="Community packages with the most downloads">
                     <caption class="sr-only">The community packages with the most downloads.</caption>
 
                     <thead>

--- a/src/NuGetGallery/Views/Statistics/Packages.cshtml
+++ b/src/NuGetGallery/Views/Statistics/Packages.cshtml
@@ -30,7 +30,7 @@
     </div>
     <div class="row">
         <div class="col-xs-12">
-            <table @ShowIfAllPackageSet() class="table borderless">
+            <table @ShowIfAllPackageSet() class="table borderless" aria-label="Packages with the most downloads">
                 <caption class="sr-only">The packages with the most downloads.</caption>
 
                 <thead>
@@ -58,7 +58,7 @@
                 </tbody>
             </table>
 
-            <table @ShowIfCommunityPackageSet() class="table borderless">
+            <table @ShowIfCommunityPackageSet() class="table borderless" aria-label="Community packages with the most downloads">
                 <caption class="sr-only">The community packages with the most downloads.</caption>
 
                 <thead>

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -457,7 +457,7 @@
                         <div class="panel-body">
                             <p>A glob pattern allows you to replace any sequence of characters with '*'.</p>
                             <p>Example glob patterns:</p>
-                            <table class="table-responsive table-condensed borderless">
+                            <table class="table-responsive table-condensed borderless" aria-label="Example glob patterns">
                                 <thead>
                                     <tr>
                                         <th>Pattern</th>

--- a/src/NuGetGallery/Views/Users/Organizations.cshtml
+++ b/src/NuGetGallery/Views/Users/Organizations.cshtml
@@ -26,7 +26,7 @@
                     <p>You have @(orgCountString).</p>
                 </div>
                 <div class="table-container">
-                    <table class="table user-package-list">
+                    <table class="table user-package-list" aria-label="Organizations">
                         <thead>
                             <tr class="manage-package-headings">
                                 <th class="hidden-xs"></th>

--- a/src/NuGetGallery/Views/Users/_UserOrganizationsListForDeletedAccount.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserOrganizationsListForDeletedAccount.cshtml
@@ -11,7 +11,7 @@
     <div class="col-md-12 align-left ">
         <div class="panel-collapse collapse in" id="organizations-list" aria-expanded="true">
             <div class="list-packages" role="list">
-                <table class="table align-left">
+                <table class="table align-left" aria-label="Organizations">
                     <thead>
                         <tr class="manage-package-headings">
                             <th class="hidden-xs"></th>

--- a/src/NuGetGallery/Views/Users/_UserPackagesListForDeletedAccount.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesListForDeletedAccount.cshtml
@@ -16,7 +16,7 @@
     <div class="col-md-12 align-left ">
         <div class="panel-collapse collapse in" id="packages-Packages" aria-expanded="true">
             <div class="list-packages" role="list">
-                <table class="table align-left">
+                <table class="table align-left" aria-label="Packages">
                     <thead>
                         <tr class="manage-package-headings">
                             <th class="hidden-xs"></th>


### PR DESCRIPTION
Addresses https://github.com/nuget/nugetgallery/issues/9042

**Problem:**

In the Package Details page's 'Used By' tab, the Dependent Packages table did not have an aria-label attribute that would allow screen readers to read its name.

Previous version: (See the "Name" attribute on the right side of the image)
![image](https://user-images.githubusercontent.com/82980589/157749939-45d7e9b7-836f-47f1-9992-8a136e6adb6c.png)

**Fix:**

To fix this, I added the aria-label attribute to the table element here, as well as other table elements where I noticed the issue.

After the changes:
![image](https://user-images.githubusercontent.com/82980589/157749199-49385c76-caf2-477a-9460-398c4d971534.png)
