### PR TITLE
[HotFix]Add copy right string

### DIFF
--- a/src/NuGetGallery.Services/Security/MicrosoftTeamSubscription.cs
+++ b/src/NuGetGallery.Services/Security/MicrosoftTeamSubscription.cs
@@ -27,6 +27,7 @@ namespace NuGetGallery.Security
             "© Microsoft Corporation. Wszelkie prawa zastrzeżone.",
             "© Microsoft Corporation. Tous droits réservés.",
             "© Microsoft Corporation。 保留所有权利。",
+            "© Microsoft Corporation. 保留所有权利.",
             "© Microsoft Corporation. Tutti i diritti riservati.",
             "© корпорация Майкрософт. Все права защищены.",
             "© Microsoft Corporation。 著作權所有，並保留一切權利。"

--- a/src/VerifyMicrosoftPackage/README.md
+++ b/src/VerifyMicrosoftPackage/README.md
@@ -86,6 +86,7 @@ If question marks ('?') or weird characters appear below, consider using --write
     "© Microsoft Corporation. Wszelkie prawa zastrzeżone.",
     "© Microsoft Corporation. Tous droits réservés.",
     "© Microsoft Corporation。 保留所有权利。",
+    "© Microsoft Corporation. 保留所有权利.",
     "© Microsoft Corporation. Tutti i diritti riservati.",
     "© корпорация Майкрософт. Все права защищены.",
     "© Microsoft Corporation。 著作權所有，並保留一切權利。"

--- a/tests/NuGetGallery.Facts/Security/MicrosoftTeamSubscriptionFacts.cs
+++ b/tests/NuGetGallery.Facts/Security/MicrosoftTeamSubscriptionFacts.cs
@@ -36,6 +36,7 @@ namespace NuGetGallery.Security
                 "\"© Microsoft Corporation. Wszelkie prawa zastrzeżone.\"," +
                 "\"© Microsoft Corporation. Tous droits réservés.\"," +
                 "\"© Microsoft Corporation。 保留所有权利。\"," +
+                "\"© Microsoft Corporation. 保留所有权利.\"," +
                 "\"© Microsoft Corporation. Tutti i diritti riservati.\"," +
                 "\"© корпорация Майкрософт. Все права защищены.\"," +
                 "\"© Microsoft Corporation。 著作權所有，並保留一切權利。\"" +


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Add localized copyright string:
© Microsoft Corporation. 保留所有权利.

Before change:  example package contains copyright string above
Executing the verify tool...
================================================================================
Using the following package path argument:
*.nupkg

INVALID.
.\Microsoft.AspNet.SignalR.nupkg
The package Microsoft.AspNet.SignalR 2.2.1 is not compliant.
There is 1 problem.
  - The package metadata contains a non-compliant copyright element.

After change:
Executing the verify tool...
================================================================================
Using the following package path argument:
*.nupkg

VALID.
.\Microsoft.AspNet.SignalR.nupkg
The package Microsoft.AspNet.SignalR 2.2.1 is compliant.




Addresses https://github.com/NuGet/Engineering/issues/4308