### PR TITLE
[A11y bug] Add visual representation for required field on forgot password page.

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -338,6 +338,10 @@ img.reserved-indicator-icon {
 .sortable {
   cursor: pointer;
 }
+.form-group label.required::after {
+  color: red;
+  content: " *";
+}
 @media (max-width: 767.9px) {
   .hidden-xs {
     display: none !important;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -426,6 +426,11 @@ img.reserved-indicator-icon {
 	cursor: pointer;
 }
 
+.form-group label.required::after {
+  color: red;
+  content: " *";
+}
+
 // Workaround. See https://github.com/NuGet/NuGetGallery/issues/8264
 @media (max-width: 767.9px) {
     .hidden-xs {

--- a/src/NuGetGallery/ExtensionMethods.cs
+++ b/src/NuGetGallery/ExtensionMethods.cs
@@ -124,7 +124,7 @@ namespace NuGetGallery
                 return html.LabelFor(expression, labelText, new
                 {
                     id = $"{propertyName}-label",
-                    @class = "required"
+                    @class = "control-label required"
                 });
             }
             else

--- a/src/NuGetGallery/ExtensionMethods.cs
+++ b/src/NuGetGallery/ExtensionMethods.cs
@@ -124,7 +124,7 @@ namespace NuGetGallery
                 return html.LabelFor(expression, labelText, new
                 {
                     id = $"{propertyName}-label",
-                    @class = "control-label required"
+                    @class = "required"
                 });
             }
             else

--- a/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
+++ b/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
@@ -25,7 +25,7 @@
                     @Html.AntiForgeryToken()
 
                     <div class="form-group @Html.HasErrorFor(m => m.Email)">
-                        @Html.ShowLabelFor(m => m.Email)
+                        @Html.ShowLabelFor(m => m.Email, isrequired: true)
                         @Html.ShowTextBoxFor(m => m.Email)
                         @Html.ShowValidationMessagesFor(m => m.Email)
                     </div>


### PR DESCRIPTION
### Changes
- Every `label` element with class `required` inside another element with `form-group` class will have the red `*` as a representation of a required field.
 
Example:
``` html
<div class="form-group">
    <label class="required">Email: </label>
</div>
```

### Screenshots
#### Before
![before - email required](https://user-images.githubusercontent.com/17834924/157987614-8739b61a-e37d-496a-bb17-328395ef13aa.png)

#### After
![email required](https://user-images.githubusercontent.com/17834924/157987642-850bd98a-9771-4fa9-a085-0bdca7858d68.png)

![email required 2](https://user-images.githubusercontent.com/17834924/157987647-35e8b62c-6d11-4247-89d6-0361ff432670.png)

#### Current API Key page for required input
![apikey required](https://user-images.githubusercontent.com/17834924/157987677-5fa3829b-3002-4fd1-ada3-ec3816ced89b.png)


Addresses https://github.com/nuget/engineering/issues/4309