### PR TITLE
[A11y] Added tabindex to table headers on Package Details page so that screen readers can read them

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -734,8 +734,8 @@
                                     <table class="table borderless" aria-label="Packages that depend on @Model.Id">
                                         <thead>
                                             <tr>
-                                                <th class="used-by-adjust-table-head">Package</th>
-                                                <th class="used-by-adjust-table-head">Downloads</th>
+                                                <th class="used-by-adjust-table-head" tabindex="0">Package</th>
+                                                <th class="used-by-adjust-table-head" tabindex="0">Downloads</th>
                                             </tr>
                                         </thead>
                                         <tbody class="no-border">
@@ -788,8 +788,8 @@
                                     <table class="table borderless" aria-label="GitHub repositories that depend on @Model.Id">
                                         <thead>
                                             <tr>
-                                                <th class="used-by-adjust-table-head">Repository</th>
-                                                <th class="used-by-adjust-table-head">Stars</th>
+                                                <th class="used-by-adjust-table-head" tabindex="0">Repository</th>
+                                                <th class="used-by-adjust-table-head" tabindex="0">Stars</th>
                                             </tr>
                                         </thead>
                                         <tbody class="no-border">
@@ -831,9 +831,9 @@
                         <table aria-label="Version History of @Model.Id" class="table borderless">
                             <thead>
                                 <tr>
-                                    <th scope="col">Version</th>
-                                    <th scope="col">Downloads</th>
-                                    <th scope="col">Last updated</th>
+                                    <th scope="col" tabindex="0">Version</th>
+                                    <th scope="col" tabindex="0">Downloads</th>
+                                    <th scope="col" tabindex="0">Last updated</th>
                                     @if (Model.CanDisplayPrivateMetadata)
                                     {
                                         <th scope="col">Status</th>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -836,7 +836,7 @@
                                     <th scope="col" tabindex="0">Last updated</th>
                                     @if (Model.CanDisplayPrivateMetadata)
                                     {
-                                        <th scope="col">Status</th>
+                                        <th scope="col" tabindex="0">Status</th>
                                     }
                                     @if (Model.IsCertificatesUIEnabled)
                                     {


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9048

**Problem:**

In the Package Details page's 'Used By' tab, screen readers weren't reading the table header names when using tab navigation.

**Fix:**

To fix this, I added tabindex to the table headers in the two tables in the 'Used By' tab (Dependent packages and dependent GitHub repos) and in the Version History table in the 'Versions' tab.