### PR TITLE
Add namespace and package prefix search tools to namespace reservation admin panel

### DIFF
--- a/src/NuGetGallery/Areas/Admin/ViewModels/ReservedNamespaceViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/ReservedNamespaceViewModel.cs
@@ -9,8 +9,8 @@ namespace NuGetGallery.Areas.Admin.ViewModels
     public sealed class ReservedNamespaceViewModel
     {
         public string ReservedNamespacesQuery { get; set; }
-        public IReadOnlyCollection<ReservedNamespace> ReservedNamespaces { get; set; }
+        public IReadOnlyList<ReservedNamespace> ReservedNamespaces { get; set; }
         public string PackageRegistrationsQuery { get; set; }
-        public IReadOnlyCollection<PackageRegistration> PackageRegistrations { get; set; }
+        public IReadOnlyList<PackageRegistration> PackageRegistrations { get; set; }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/ViewModels/ReservedNamespaceViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/ReservedNamespaceViewModel.cs
@@ -1,13 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using NuGet.Services.Entities;
+
 namespace NuGetGallery.Areas.Admin.ViewModels
 {
     public sealed class ReservedNamespaceViewModel
     {
-        /// <summary>
-        /// Prefix search query.
-        /// </summary>
-        public string PrefixSearchQuery { get; set; }
+        public string ReservedNamespacesQuery { get; set; }
+        public IReadOnlyCollection<ReservedNamespace> ReservedNamespaces { get; set; }
+        public string PackageRegistrationsQuery { get; set; }
+        public IReadOnlyCollection<PackageRegistration> PackageRegistrations { get; set; }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
@@ -6,75 +6,196 @@
 @ViewHelpers.AjaxAntiForgeryToken(Html)
 
 <section role="main" class="container main-container">
-    <div class="message-container" data-bind="visible: message">
-        @ViewHelpers.AlertInfo(@<text><span class="message" data-bind="text: message"></span></text>)
-    </div>
-    <h2>Reserve Namespace</h2>
-    <form data-bind="submit: prefixSearch">
-        <div class="form-horizontal">
-            <input type="text" placeholder="Search for a prefix" autocomplete="on" autofocus data-bind="value: prefixSearchQuery" />
-            <input type="submit" value="Search Prefix" title="Search Prefix" />
-        </div>
-    </form><br />
 
-    <div data-bind="visible: allPrefixResults().length > 0">
-        @using (Html.BeginForm())
-        {
-            <div id="prefixResult" data-bind="foreach: allPrefixResults">
-                <table aria-label="Reserved Namespaces Search Results">
-                    <tr>
-                        <td>
-                            <span style="font-weight: bold">Details:</span>
-                            <div style="margin-left: 20px">
-                                <div>
-                                    <span style="font-weight: bold">Namespace: </span>
-                                    <span data-bind="text: $data.prefix.Value" />
-                                </div>
-                                <div>
-                                    <label>
-                                        <input type="checkbox" data-bind="checked: $data.prefix.IsSharedNamespace, disable: $data.isExisting" />IsSharedNamespace
-                                    </label>
-                                </div>
-                                <div>
-                                    <label>
-                                        <input type="checkbox" data-bind="checked: $data.prefix.IsPrefix, disable: $data.isExisting" value="IsPrefix" />IsPrefix
-                                    </label>
-                                </div>
-                                <div>
-                                    <span style="font-weight: bold">Matching Pattern: </span>
-                                    <span data-bind="text: $data.pattern" />
-                                </div>
-                                <!-- ko if: $data.isExisting -->
-                                <input style="margin-top: 5px" type="submit" value="Deallocate Namespace" title="Delete this namespace"
-                                       data-bind="click: $parent.managePrefix.bind(this, $data.prefix, false)" />
-                                <!-- /ko -->
-                                <!-- ko ifnot: $data.isExisting -->
-                                <input style="margin-top: 5px" type="submit" value="Reserve Namespace" title="Add this namespace"
-                                       data-bind="click: $parent.managePrefix.bind(this, $data.prefix, true)" />
-                                <!-- /ko -->
-                            </div>
-                        </td>
-                        <td style="vertical-align: top">
-                            <!-- ko if: $data.isExisting -->
-                            <span style="font-weight: bold">Owners:</span>
-                            <div style="margin-left: 20px">
-                                <div id="prefixOwners" data-bind="foreach: $data.owners">
-                                    <div style="margin: 5px">
-                                        <a href="#" target="_blank" data-bind="text: $data, attr: { href: $root.generateUserUrl($data) }"></a>
-                                        <input style="float: right" type="button" value="Remove" title="Remove this owner" data-bind="click: $root.removeOwner.bind(this, $data, $parent.prefix)" />
-                                    </div>
-                                </div>
-                                <div style="margin: 5px">
-                                    <input type="text" placeholder="Enter username" autocomplete="off" data-bind="value: $parent.newOwner, valueUpdate: 'afterkeydown'" />
-                                    <input type="button" value="Add" title="Add new owner for this prefix" data-bind="click: $parent.addOwner.bind(this, $data.prefix), enable: $parent.newOwner().length > 0" />
-                                </div>
-                            </div>
-                            <!-- /ko -->
-                        </td>
-                    </tr>
-                </table>
+    <div class="row">
+        <div class="col-xs-12">
+            <div class="message-container" data-bind="visible: message">
+                @ViewHelpers.AlertInfo(@<text><span class="message" data-bind="text: message"></span></text>)
             </div>
-        }
+            <h2>Reserve namespace</h2>
+            <form data-bind="submit: prefixSearch">
+                <div class="form-horizontal">
+                    <input type="text" placeholder="Specific namespace" autocomplete="on" autofocus data-bind="value: prefixSearchQuery" />
+                    <input type="submit" value="Search" title="Search" />
+                </div>
+            </form>
+            <br />
+
+            <div data-bind="visible: allPrefixResults().length > 0">
+                @using (Html.BeginForm())
+                {
+                    <div id="prefixResult" data-bind="foreach: allPrefixResults">
+                        <table aria-label="Reserved Namespaces Search Results">
+                            <tr>
+                                <td>
+                                    <span style="font-weight: bold">Details:</span>
+                                    <div style="margin-left: 20px">
+                                        <div>
+                                            <span style="font-weight: bold">Namespace: </span>
+                                            <span data-bind="text: $data.prefix.Value" />
+                                        </div>
+                                        <div>
+                                            <label>
+                                                <input type="checkbox" data-bind="checked: $data.prefix.IsSharedNamespace, disable: $data.isExisting" />IsSharedNamespace
+                                            </label>
+                                        </div>
+                                        <div>
+                                            <label>
+                                                <input type="checkbox" data-bind="checked: $data.prefix.IsPrefix, disable: $data.isExisting" value="IsPrefix" />IsPrefix
+                                            </label>
+                                        </div>
+                                        <div>
+                                            <span style="font-weight: bold">Matching Pattern: </span>
+                                            <span data-bind="text: $data.pattern" />
+                                        </div>
+                                        <!-- ko if: $data.isExisting -->
+                                        <input style="margin-top: 5px" type="submit" value="Deallocate Namespace" title="Delete this namespace"
+                                               data-bind="click: $parent.managePrefix.bind(this, $data.prefix, false)" />
+                                        <!-- /ko -->
+                                        <!-- ko ifnot: $data.isExisting -->
+                                        <input style="margin-top: 5px" type="submit" value="Reserve Namespace" title="Add this namespace"
+                                               data-bind="click: $parent.managePrefix.bind(this, $data.prefix, true)" />
+                                        <!-- /ko -->
+                                    </div>
+                                </td>
+                                <td style="vertical-align: top">
+                                    <!-- ko if: $data.isExisting -->
+                                    <span style="font-weight: bold">Owners:</span>
+                                    <div style="margin-left: 20px">
+                                        <div id="prefixOwners" data-bind="foreach: $data.owners">
+                                            <div style="margin: 5px">
+                                                <a href="#" target="_blank" data-bind="text: $data, attr: { href: $root.generateUserUrl($data) }"></a>
+                                                <input style="float: right" type="button" value="Remove" title="Remove this owner" data-bind="click: $root.removeOwner.bind(this, $data, $parent.prefix)" />
+                                            </div>
+                                        </div>
+                                        <div style="margin: 5px">
+                                            <input type="text" placeholder="Enter username" autocomplete="off" data-bind="value: $parent.newOwner, valueUpdate: 'afterkeydown'" />
+                                            <input type="button" value="Add" title="Add new owner for this prefix" data-bind="click: $parent.addOwner.bind(this, $data.prefix), enable: $parent.newOwner().length > 0" />
+                                        </div>
+                                    </div>
+                                    <!-- /ko -->
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-xs-12">
+            <h2>Find namespaces by prefix</h2>
+            <form method="get" action="@Url.Action("FindNamespacesByPrefix")">
+                <div class="form-horizontal">
+                    <input type="text" placeholder="Namespace prefix" autocomplete="on" name="prefix" value="@Model.ReservedNamespacesQuery" />
+                    <input type="submit" value="Search" />
+                </div>
+            </form>
+            <br />
+            @if (Model.ReservedNamespaces != null)
+            {
+                if (Model.ReservedNamespaces.Count == 0)
+                {
+                    <p>No reserved namespaces found.</p>
+                }
+                else
+                {
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Value</th>
+                                <th>IsSharedNamespace</th>
+                                <th>IsPrefix</th>
+                                <th>Owners</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var rn in Model.ReservedNamespaces)
+                            {
+                                <tr>
+                                    <td>@(rn.Value + (rn.IsPrefix ? "*" : ""))</td>
+                                    <td>@rn.IsSharedNamespace</td>
+                                    <td>@rn.IsPrefix</td>
+                                    <td>
+                                        @foreach (var owner in rn.Owners)
+                                        {
+                                            <a href="@Url.User(owner)">@owner.Username</a>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            }
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-xs-12">
+            <h2>Find package registrations by prefix</h2>
+            <form method="get" action="@Url.Action("FindPackagesByPrefix")">
+                <div class="form-horizontal">
+                    <input type="text" placeholder="Package ID prefix" autocomplete="on" name="prefix" value="@Model.PackageRegistrationsQuery" />
+                    <input type="submit" value="Search" />
+                </div>
+            </form>
+            <br />
+            @if (Model.PackageRegistrations != null)
+            {
+                if (Model.PackageRegistrations.Count == 0)
+                {
+                    <p>No package registrations found.</p>
+                }
+                else
+                {
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Package ID</th>
+                                <th>IsVerified</th>
+                                <th>Download count</th>
+                                <th>Owners</th>
+                                <th>Reserved Namespaces</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var pr in Model.PackageRegistrations)
+                            {
+                            <tr>
+                                <td><a href="@Url.Package(pr.Id)">@pr.Id</a></td>
+                                <td>
+                                    @if (pr.IsVerified)
+                                    {
+                                        <img class="img-responsive"
+                                             src="~/Content/gallery/img/reserved-indicator.svg"
+                                             alt="Reserved namespace icon"
+                                             width="24" height="24"
+                                             @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-256x256.png"))
+                                             title="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                                    }
+                                </td>
+                                <td>@pr.DownloadCount.ToNuGetNumberString()</td>
+                                <td>
+                                    @foreach (var owner in pr.Owners)
+                                    {
+                                        <a href="@Url.User(owner)">@owner.Username</a>
+                                    }
+                                </td>
+                                <td>
+                                    @foreach (var rn in pr.ReservedNamespaces)
+                                    {
+                                        @(rn.Value + (rn.IsPrefix ? "* " : " "))
+                                    }
+                                </td>
+                            </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            }
+        </div>
     </div>
 </section>
 

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -348,7 +348,7 @@ namespace NuGetGallery
         }
 
         [Fact]
-        public async void StatisticsHomePage_Per_Package_ValidateModel()
+        public async Task StatisticsHomePage_Per_Package_ValidateModel()
         {
             string PackageId = "A";
 
@@ -531,7 +531,7 @@ namespace NuGetGallery
         }
 
         [Fact]
-        public async void Statistics_By_Client_Operation_ValidateModel()
+        public async Task Statistics_By_Client_Operation_ValidateModel()
         {
             string PackageId = "A";
             string PackageVersion = "2.0";

--- a/tests/NuGetGallery.Facts/Queries/AutocompleteDatabasePackageIdsQueryFacts.cs
+++ b/tests/NuGetGallery.Facts/Queries/AutocompleteDatabasePackageIdsQueryFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Moq;
 using NuGet.Services.Entities;
 using Xunit;
@@ -24,7 +25,7 @@ namespace NuGetGallery.Queries
         public class Execute : FactBase
         {
             [Fact]
-            public async void ValidPackageIdShouldReturnIdsWhosePackagesAreListed()
+            public async Task ValidPackageIdShouldReturnIdsWhosePackagesAreListed()
             {
                 var queryResult = await _packageIdsQuery.Execute("n", null, null);
 
@@ -38,7 +39,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void ValidPackageIdShouldReturnIdsWhosePackageStatusIsAvailable()
+            public async Task ValidPackageIdShouldReturnIdsWhosePackageStatusIsAvailable()
             {
                 var queryResult = await _packageIdsQuery.Execute("n", null, null);
 
@@ -58,7 +59,7 @@ namespace NuGetGallery.Queries
             [InlineData("2.0.0-rc.1")]
             [InlineData("1.0.0")]
             [InlineData("1.0.0-beta")]
-            public async void WithValidSemVerLevelReturnIdsWhosePackagesSemVerLevelCompliant(string semVerLevel)
+            public async Task WithValidSemVerLevelReturnIdsWhosePackagesSemVerLevelCompliant(string semVerLevel)
             {
                 var queryResult = await _packageIdsQuery.Execute("nuget", null, null, semVerLevel);
 
@@ -74,7 +75,7 @@ namespace NuGetGallery.Queries
             [Theory]
             [InlineData(null)]
             [InlineData(false)]
-            public async void ValidPackageIdWithWithPrereleaseFalseOrNullReturnsIdsWhosePackagePrereleaseIsFalse(bool? includePrerelease)
+            public async Task ValidPackageIdWithWithPrereleaseFalseOrNullReturnsIdsWhosePackagePrereleaseIsFalse(bool? includePrerelease)
             {
                 var queryResult = await _packageIdsQuery.Execute("nuget", includePrerelease, null);
 
@@ -88,7 +89,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void InexistentPartialIdShouldReturnEmptyArray()
+            public async Task InexistentPartialIdShouldReturnEmptyArray()
             {
                 var queryResult = await _packageIdsQuery.Execute("inexistent-partial-package-id", null, null);
 
@@ -96,7 +97,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void WithPrereleaseTrueReturnsIdsWThatStartsWithThatPartialId()
+            public async Task WithPrereleaseTrueReturnsIdsWThatStartsWithThatPartialId()
             {
                 var queryResult = await _packageIdsQuery.Execute("nuget", true, null);
 
@@ -110,7 +111,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void WithValidPartialIdReturnsIdsThatStartsWithThatPartialId()
+            public async Task WithValidPartialIdReturnsIdsThatStartsWithThatPartialId()
             {
                 var queryResult = await _packageIdsQuery.Execute("n", null, null);
 
@@ -124,7 +125,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void WithValidPartialIdReturnsIdsThatAreOrderedById()
+            public async Task WithValidPartialIdReturnsIdsThatAreOrderedById()
             {
                 var queryResult = await _packageIdsQuery.Execute("n", null, null);
 
@@ -143,7 +144,7 @@ namespace NuGetGallery.Queries
             [Theory]
             [InlineData("")]
             [InlineData(null)]
-            public async void WithNoPartialIdReturnsIdsThatAreOrderedDescByMaxDownloadCount(string partialId)
+            public async Task WithNoPartialIdReturnsIdsThatAreOrderedDescByMaxDownloadCount(string partialId)
             {
                 var queryResult = await _packageIdsQuery.Execute(partialId, null, null);
 
@@ -161,7 +162,7 @@ namespace NuGetGallery.Queries
 
             [Theory]
             [MemberData(nameof(ConstructorData))]
-            public async void Returns30IdsAtMost(IList<Package> packages)
+            public async Task Returns30IdsAtMost(IList<Package> packages)
             {
                 _packageRepository
                     .Setup(context => context.GetAll())

--- a/tests/NuGetGallery.Facts/Queries/AutocompleteDatabasePackageVersionsQueryFacts.cs
+++ b/tests/NuGetGallery.Facts/Queries/AutocompleteDatabasePackageVersionsQueryFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Moq;
 using NuGet.Services.Entities;
 using Xunit;
@@ -32,7 +33,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void OnlyReturnsVersionsOfTheSamePackage()
+            public async Task OnlyReturnsVersionsOfTheSamePackage()
             {
                 var queryResult = await _packageVersionsQuery.Execute("nuget", null, null);
 
@@ -46,7 +47,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void InexistentIdShouldReturnEmptyVersionArray()
+            public async Task InexistentIdShouldReturnEmptyVersionArray()
             {
                 var queryResult = await _packageVersionsQuery.Execute("inexistent-package-id", null, null);
 
@@ -54,7 +55,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void ValidPackageIdShouldReturnVersionsWhosePackageStatusIsAvailable()
+            public async Task ValidPackageIdShouldReturnVersionsWhosePackageStatusIsAvailable()
             {
                 var queryResult = await _packageVersionsQuery.Execute("nuget", null, null);
 
@@ -68,7 +69,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void ValidPackageIdShouldReturnVersionsWhosePackagesAreListed()
+            public async Task ValidPackageIdShouldReturnVersionsWhosePackagesAreListed()
             {
                 var queryResult = await _packageVersionsQuery.Execute("nuget", null, null);
 
@@ -88,7 +89,7 @@ namespace NuGetGallery.Queries
             [InlineData("2.0.0-rc.1")]
             [InlineData("1.0.0")]
             [InlineData("1.0.0-beta")]
-            public async void ValidPackageIdWithSemVerLevelReturnVersionsWhosePackagesHaveSemVerLevelCompliant(string semVerLevel)
+            public async Task ValidPackageIdWithSemVerLevelReturnVersionsWhosePackagesHaveSemVerLevelCompliant(string semVerLevel)
             {
                 var queryResult = await _packageVersionsQuery.Execute("nuget", null, null, semVerLevel);
                 
@@ -104,7 +105,7 @@ namespace NuGetGallery.Queries
             [Theory]
             [InlineData(null)]
             [InlineData(false)]
-            public async void ValidPackageIdWithWithPrereleaseFalseOrNullReturnsVersionsWhosePackagePrereleaseIsFalse(bool? includePrerelease)
+            public async Task ValidPackageIdWithWithPrereleaseFalseOrNullReturnsVersionsWhosePackagePrereleaseIsFalse(bool? includePrerelease)
             {
                 var queryResult = await _packageVersionsQuery.Execute("nuget", includePrerelease, null);
 
@@ -118,7 +119,7 @@ namespace NuGetGallery.Queries
             }
 
             [Fact]
-            public async void WithPrereleaseTrueReturnsAllVersionsOfTheSamePackage()
+            public async Task WithPrereleaseTrueReturnsAllVersionsOfTheSamePackage()
             {
                 var queryResult = await _packageVersionsQuery.Execute("nuget", true, null);
 

--- a/tests/NuGetGallery.Facts/TestUtils/ContractAssert.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/ContractAssert.cs
@@ -43,7 +43,7 @@ namespace NuGetGallery
                 argEx.Message);
         }
 
-        public static async void ThrowsArgExceptionAsync(Func<Task> act, string paramName, string message = "")
+        public static async Task ThrowsArgExceptionAsync(Func<Task> act, string paramName, string message = "")
         {
             var argEx = await Assert.ThrowsAsync<ArgumentException>(async () => await act());
             Assert.Equal(paramName, argEx.ParamName);


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4269

This will allow admins to find the root cause of the "more liberal" error message.

## Initial page

![image](https://user-images.githubusercontent.com/94054/158246544-21dc71d3-a24c-40cc-9800-3b62236ae4b9.png)

## Search for namespaces by prefix

![image](https://user-images.githubusercontent.com/94054/158246656-7a639b2d-67ee-44bd-b8be-08de7be84599.png)

## Search for package registrations by prefix

![image](https://user-images.githubusercontent.com/94054/158246729-0dd3902c-6884-456e-ae0d-3c19779405f9.png)
