### PR TITLE
[Ally Bug] Installation command copy button reads as table.

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1445,22 +1445,21 @@ p.frameworktableinfo-text {
   font-weight: 600;
   text-decoration: underline;
 }
-.page-package-details .install-tabs .tab-content .tab-pane > div {
-  display: table;
-  height: 1px;
-}
 .page-package-details .install-tabs .tab-content .tab-pane .install-script-row {
-  display: table-row;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   height: 100%;
+  width: 100%;
 }
 .page-package-details .install-tabs .tab-content .tab-pane .install-script-row .install-script {
-  display: table-cell;
   background-color: #002440;
   font-family: Consolas, Menlo, Monaco, "Courier New", monospace;
   font-size: 1em;
   color: #fff;
-  width: 100%;
-  max-width: 1px;
+  width: -webkit-calc(100% - 40px);
+  width: calc(100% - 40px);
   line-height: 1.5;
   white-space: pre-wrap;
   border-color: #002440;
@@ -1468,9 +1467,7 @@ p.frameworktableinfo-text {
   border-width: 1px 0 1px 1px;
   vertical-align: middle;
   word-break: break-word;
-}
-.page-package-details .install-tabs .tab-content .tab-pane .install-script-row .copy-button {
-  height: 100%;
+  margin: 0px;
 }
 .page-package-details .install-tabs .tab-content .tab-pane .install-script-row .copy-button button {
   height: 100%;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -370,23 +370,18 @@
 
     .tab-content {
       .tab-pane {
-        > div {
-          display: table;
-          height: 1px;
-        }
-
+        
         .install-script-row {
-          display: table-row;
+          display: flex;
           height: 100%;
+          width: 100%;
 
           .install-script {
-            display: table-cell;
             background-color: @panel-footer-bg;
             font-family: @font-family-monospace;
             font-size: 1em;
             color: #fff;
-            width: 100%;
-            max-width: 1px;
+            width: calc(100% - 40px);
             line-height: 1.5;
             white-space: pre-wrap;
             // Add a border with the same color as the background to support visual callout
@@ -396,16 +391,13 @@
             border-width: 1px 0 1px 1px;
             vertical-align: middle;
             word-break: break-word;
+            margin: 0px;
           }
 
-          .copy-button {
-            height: 100%;
-
-            button {
+          .copy-button button {
               height: 100%;
               min-height: 42px;
               line-height: 1.5;
-            }
           }
         }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -180,21 +180,19 @@
 {
     var thirdPartyPackageManager = packageManager as ThirdPartyPackageManagerViewModel;
     <div role="tabpanel" class="tab-pane @(active ? "active" : string.Empty)" id="@packageManager.Id">
-        <div>
-            <div class="install-script-row">
-                @{
-                    var lastIndex = packageManager.InstallPackageCommands.Length - 1;
-                    var cs = packageManager.InstallPackageCommands.Select((c, i) => i < lastIndex ? c + Environment.NewLine : c);
-                }
-                @* Writing out the install command must be on a single line to avoid undesired whitespace in the <pre> tag. *@
-                <pre class="install-script" id="@packageManager.Id-text">@foreach (var c in cs) {<span class="install-command-row">@c</span>}</pre>
-                <div class="copy-button">
-                    <button id="@packageManager.Id-button" class="btn btn-default btn-warning" type="button"
-                            data-toggle="popover" data-placement="bottom" data-content="Copied."
-                            aria-label="@packageManager.CopyLabel" role="button">
-                        <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
-                    </button>
-                </div>
+        <div class="install-script-row">
+            @{
+                var lastIndex = packageManager.InstallPackageCommands.Length - 1;
+                var cs = packageManager.InstallPackageCommands.Select((c, i) => i < lastIndex ? c + Environment.NewLine : c);
+            }
+            @* Writing out the install command must be on a single line to avoid undesired whitespace in the <pre> tag. *@
+            <pre class="install-script" id="@packageManager.Id-text">@foreach (var c in cs) {<span class="install-command-row">@c</span>}</pre>
+            <div class="copy-button">
+                <button id="@packageManager.Id-button" class="btn btn-default btn-warning" type="button"
+                        data-toggle="popover" data-placement="bottom" data-content="Copied."
+                        aria-label="@packageManager.CopyLabel" role="button">
+                    <span class="ms-Icon ms-Icon--Copy" aria-hidden="true"></span>
+                </button>
             </div>
         </div>
 


### PR DESCRIPTION
### Changes
- Removed `display: table, table-row, table-cell` from css for installation command styles.
  - Since the installation commands had table layouts, NVDA was announcing this button as part of a table, which was not correct.
- Removed unecessary `div` element from `DisplayPackage.cshtml`

### Addresses
https://github.com/nuget/engineering/issues/4315