### PR TITLE
[A11y] Adjusted homepage circuit board label sizes to accommodate text spacing

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1627,7 +1627,7 @@ p.frameworktableinfo-text {
   left: 423px;
   top: 10px;
   float: left;
-  width: 230px;
+  width: 235px;
 }
 .page-home .circuit-board .circuit-board-pd.triangle:after {
   left: 20px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1603,7 +1603,7 @@ p.frameworktableinfo-text {
 }
 .page-home .circuit-board {
   margin-top: 20px;
-  width: 768px;
+  width: 860px;
   height: 396px;
   position: relative;
   margin: 0 auto;
@@ -1624,7 +1624,7 @@ p.frameworktableinfo-text {
   margin: 9px 0 0 0;
 }
 .page-home .circuit-board .circuit-board-pd {
-  left: 377px;
+  left: 423px;
   top: 10px;
   float: left;
   width: 230px;
@@ -1636,7 +1636,7 @@ p.frameworktableinfo-text {
   left: 0;
   top: 63px;
   float: left;
-  width: 144px;
+  width: 190px;
 }
 .page-home .circuit-board .circuit-board-pv.triangle:after {
   right: 30px;
@@ -1645,7 +1645,7 @@ p.frameworktableinfo-text {
   right: 0;
   top: 87px;
   float: right;
-  width: 144px;
+  width: 190px;
 }
 .page-home .circuit-board .circuit-board-up.triangle:after {
   left: 30px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1603,7 +1603,7 @@ p.frameworktableinfo-text {
 }
 .page-home .circuit-board {
   margin-top: 20px;
-  width: 860px;
+  width: 830px;
   height: 396px;
   position: relative;
   margin: 0 auto;
@@ -1624,7 +1624,7 @@ p.frameworktableinfo-text {
   margin: 9px 0 0 0;
 }
 .page-home .circuit-board .circuit-board-pd {
-  left: 423px;
+  left: 408px;
   top: 10px;
   float: left;
   width: 235px;
@@ -1636,7 +1636,7 @@ p.frameworktableinfo-text {
   left: 0;
   top: 63px;
   float: left;
-  width: 190px;
+  width: 175px;
 }
 .page-home .circuit-board .circuit-board-pv.triangle:after {
   right: 30px;
@@ -1645,7 +1645,7 @@ p.frameworktableinfo-text {
   right: 0;
   top: 87px;
   float: right;
-  width: 190px;
+  width: 175px;
 }
 .page-home .circuit-board .circuit-board-up.triangle:after {
   left: 30px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1603,7 +1603,7 @@ p.frameworktableinfo-text {
 }
 .page-home .circuit-board {
   margin-top: 20px;
-  width: 830px;
+  width: 900px;
   height: 396px;
   position: relative;
   margin: 0 auto;
@@ -1614,6 +1614,8 @@ p.frameworktableinfo-text {
 .page-home .circuit-board .circuit-board-label {
   position: absolute;
   height: 75px;
+  padding-left: 25px;
+  padding-right: 25px;
   background-color: #fff;
   color: #000;
   -webkit-box-shadow: 0 0 3px black;
@@ -1624,31 +1626,28 @@ p.frameworktableinfo-text {
   margin: 9px 0 0 0;
 }
 .page-home .circuit-board .circuit-board-pd {
-  left: 408px;
+  left: 443px;
   top: 10px;
   float: left;
-  width: 235px;
 }
 .page-home .circuit-board .circuit-board-pd.triangle:after {
   left: 20px;
 }
 .page-home .circuit-board .circuit-board-pv {
-  left: 0;
+  right: 675px;
   top: 63px;
   float: left;
-  width: 175px;
 }
 .page-home .circuit-board .circuit-board-pv.triangle:after {
-  right: 30px;
+  right: 45px;
 }
 .page-home .circuit-board .circuit-board-up {
-  right: 0;
-  top: 87px;
+  left: 675px;
+  top: 105px;
   float: right;
-  width: 175px;
 }
 .page-home .circuit-board .circuit-board-up.triangle:after {
-  left: 30px;
+  left: 45px;
 }
 .page-list-packages h1 {
   margin-bottom: 33px;

--- a/src/Bootstrap/less/theme/page-home.less
+++ b/src/Bootstrap/less/theme/page-home.less
@@ -41,7 +41,7 @@
 
   .circuit-board {
     margin-top: 20px;
-    width: 768px;
+    width: 860px;
     height: 396px;
     position: relative;
     margin: 0 auto;
@@ -62,7 +62,7 @@
     }
 
     .circuit-board-pd {
-      left: 377px;
+      left: 423px;
       top: 10px;
       float: left;
       width: 230px;
@@ -76,7 +76,7 @@
       left: 0;
       top: 63px;
       float: left;
-      width: 144px;
+      width: 190px;
 
       &.triangle:after {
         right: 30px;
@@ -87,7 +87,7 @@
       right: 0;
       top: 87px;
       float: right;
-      width: 144px;
+      width: 190px;
 
       &.triangle:after {
         left: 30px;

--- a/src/Bootstrap/less/theme/page-home.less
+++ b/src/Bootstrap/less/theme/page-home.less
@@ -41,7 +41,7 @@
 
   .circuit-board {
     margin-top: 20px;
-    width: 830px;
+    width: 900px;
     height: 396px;
     position: relative;
     margin: 0 auto;
@@ -52,6 +52,8 @@
     .circuit-board-label {
       position: absolute;
       height: 75px;
+      padding-left: 25px;
+      padding-right: 25px;
       background-color: #fff;
       color: @text-color;
       box-shadow: 0 0 3px black;
@@ -62,10 +64,9 @@
     }
 
     .circuit-board-pd {
-      left: 408px;
+      left: 443px;
       top: 10px;
       float: left;
-      width: 235px;
 
       &.triangle:after {
         left: 20px;
@@ -73,24 +74,22 @@
     }
 
     .circuit-board-pv {
-      left: 0;
+      right: 675px;
       top: 63px;
       float: left;
-      width: 175px;
 
       &.triangle:after {
-        right: 30px;
+        right: 45px;
       }
     }
 
     .circuit-board-up {
-      right: 0;
-      top: 87px;
+      left: 675px;
+      top: 105px;
       float: right;
-      width: 175px;
 
       &.triangle:after {
-        left: 30px;
+        left: 45px;
       }
     }
   }

--- a/src/Bootstrap/less/theme/page-home.less
+++ b/src/Bootstrap/less/theme/page-home.less
@@ -65,7 +65,7 @@
       left: 423px;
       top: 10px;
       float: left;
-      width: 230px;
+      width: 235px;
 
       &.triangle:after {
         left: 20px;

--- a/src/Bootstrap/less/theme/page-home.less
+++ b/src/Bootstrap/less/theme/page-home.less
@@ -41,7 +41,7 @@
 
   .circuit-board {
     margin-top: 20px;
-    width: 860px;
+    width: 830px;
     height: 396px;
     position: relative;
     margin: 0 auto;
@@ -62,7 +62,7 @@
     }
 
     .circuit-board-pd {
-      left: 423px;
+      left: 408px;
       top: 10px;
       float: left;
       width: 235px;
@@ -76,7 +76,7 @@
       left: 0;
       top: 63px;
       float: left;
-      width: 190px;
+      width: 175px;
 
       &.triangle:after {
         right: 30px;
@@ -87,7 +87,7 @@
       right: 0;
       top: 87px;
       float: right;
-      width: 190px;
+      width: 175px;
 
       &.triangle:after {
         left: 30px;

--- a/src/NuGetGallery/Content/gallery/img/circuit-board.svg
+++ b/src/NuGetGallery/Content/gallery/img/circuit-board.svg
@@ -1,1 +1,824 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="574px" height="396px" viewBox="0 0 444.02 288.03"><defs><style>.cls-1,.cls-2,.cls-3,.cls-5{fill:none;stroke-width:3px;}.cls-1,.cls-2{stroke:#9ebbe2;}.cls-1,.cls-2,.cls-3,.cls-4,.cls-5{stroke-linejoin:round;}.cls-2,.cls-5{stroke-linecap:round;}.cls-3,.cls-4,.cls-5{stroke:#fff;}.cls-4{fill:#fff;}@media screen and (-ms-high-contrast:active){.cls-3,.cls-4,.cls-5{stroke:windowText;}.cls-4{fill:windowText;}}</style></defs><title>Hero Image v7</title><g id="Layer_2" data-name="Layer 2"><g id="Hero"><g id="chip"><polygon class="cls-1" points="215.98 176.65 289.6 134.15 289.6 124.15 250.63 101.65 177.01 144.15 177.01 154.15 215.98 176.65"/><polygon class="cls-1" points="177.01 144.15 215.99 166.65 215.98 176.65 177.01 154.15 177.01 144.15"/><polygon class="cls-1" points="215.99 166.65 289.6 124.15 289.6 134.15 215.98 176.65 215.99 166.65"/><g id="clips"><polyline class="cls-2" points="280.94 134.15 289.52 139.1 289.52 144.19"/><polyline id="_7" data-name="7" class="cls-2" points="272.31 139.12 280.94 144.15 281.01 149.1"/><polyline id="_6" data-name="6" class="cls-2" points="263.62 143.65 272.2 149.1 272.31 154.17"/><polyline id="_5" data-name="5" class="cls-2" points="255.03 149.1 263.62 154.15 263.65 159.17"/><polyline id="_4" data-name="4" class="cls-2" points="246.3 154.15 254.85 159.09 255.03 164.19"/><polyline id="_3" data-name="3" class="cls-2" points="237.63 159.15 246.3 164.15 246.3 169.15"/><polyline id="_2" data-name="2" class="cls-2" points="228.97 164.15 237.63 169.15 237.63 174.15"/><polyline id="_1" data-name="1" class="cls-2" points="220.31 169.15 228.97 174.15 228.97 179.15"/></g><g id="clips-2" data-name="clips"><polyline class="cls-2" points="181.34 146.65 172.68 141.65 172.68 146.65"/><polyline class="cls-2" points="185.76 139.18 181.34 136.62 181.34 141.62"/><polyline class="cls-2" points="194.42 134.2 190 131.65 190 136.65"/><polyline class="cls-2" points="203.1 129.2 198.68 126.65 198.68 131.65"/><polyline class="cls-2" points="207.41 126.65 207.32 121.65 211.66 124.15"/><polyline class="cls-2" points="215.98 121.65 215.98 116.65 220.31 119.15"/><polyline class="cls-2" points="224.65 116.65 224.65 111.65 228.97 114.15"/><polyline class="cls-2" points="233.3 111.65 233.31 106.65 237.64 109.15"/><polyline class="cls-2" points="241.97 106.65 241.97 101.65 246.3 104.15"/></g><g id="clips_copy_2" data-name="clips copy 2"><polyline id="_4-2" data-name="4" class="cls-2" points="181.43 151.65 172.88 156.59 172.7 161.69"/><polyline id="_3-2" data-name="3" class="cls-2" points="190.09 156.65 181.43 161.65 181.43 166.65"/><polyline id="_2-2" data-name="2" class="cls-2" points="198.75 161.65 190.09 166.65 190.09 171.65"/><polyline id="_1-2" data-name="1" class="cls-2" points="207.41 166.65 198.75 171.65 198.75 176.65"/></g><g id="clipsBack"><polyline class="cls-2" points="255.03 104.1 259.29 101.65 259.29 106.65"/><polyline class="cls-2" points="263.62 109.15 267.97 106.66 267.97 111.65"/><polyline class="cls-2" points="272.28 114.15 276.66 111.68 276.61 116.65"/><polyline class="cls-2" points="280.94 119.15 285.23 116.67 285.27 121.65"/></g></g><g id="chips"><g id="_2-3" data-name="2"><polygon class="cls-2" points="315.33 118.95 345.56 101.5 345.56 96.5 328.24 86.5 297.97 103.98 297.97 109.02 315.33 118.95"/><polygon class="cls-2" points="315.33 113.95 345.56 96.5 345.56 101.5 315.33 118.95 315.33 113.95"/><polygon class="cls-2" points="297.97 103.98 315.33 113.95 315.33 118.95 297.97 109.02 297.97 103.98"/></g><g id="_1-3" data-name="1"><polygon class="cls-2" points="280.76 98.94 311 81.48 311 76.48 293.68 66.48 263.4 83.96 263.4 89 280.76 98.94"/><polygon class="cls-2" points="280.76 93.94 311 76.48 311 81.48 280.76 98.94 280.76 93.94"/><polygon class="cls-2" points="263.4 83.96 280.76 93.94 280.76 98.94 263.4 89 263.4 83.96"/></g></g><g id="wires"><path class="cls-1" d="M290,189.15c-2.38,1.37-2.38,3.62,0,5a9.61,9.61,0,0,0,8.66,0c2.38-1.38,2.38-3.63,0-5A9.61,9.61,0,0,0,290,189.15Z" transform="translate(-9.54)"/><line class="cls-2" x1="250.94" y1="172.15" x2="280.5" y2="189.15"/><path class="cls-1" d="M189.68,241.53c-2.38,1.37-2.38,3.62,0,5a9.61,9.61,0,0,0,8.66,0c2.38-1.38,2.38-3.63,0-5A9.61,9.61,0,0,0,189.68,241.53Z" transform="translate(-9.54)"/><line class="cls-2" x1="145.58" y1="221.53" x2="180.15" y2="241.53"/><polyline class="cls-2" points="233.7 182.07 258.93 196.53 198.4 231.48 163.67 211.53"/><polyline class="cls-2" points="155.01 216.53 198.4 241.58 276.26 196.53 242.28 177.03"/><polyline class="cls-2" points="259.6 167.03 302.02 191.65 189.65 256.53 137.69 226.53"/><line class="cls-2" x1="194.12" y1="178.95" x2="163.67" y2="196.53"/><path class="cls-2" d="M199.28,176.58" transform="translate(-9.54)"/><line class="cls-2" x1="185.41" y1="174.08" x2="155.69" y2="191.25"/><line class="cls-2" x1="176.71" y1="169.05" x2="155.69" y2="181.26"/><line class="cls-2" x1="168.07" y1="164.08" x2="155.69" y2="171.09"/><polyline class="cls-2" points="59.79 216.55 16.5 241.58 51.37 261.37"/><line class="cls-2" x1="94.43" y1="236.55" x2="51.37" y2="261.37"/><polyline class="cls-2" points="129.03 231.48 189.65 266.53 302 201.66"/><polyline class="cls-2" points="167.94 109.06 180.97 116.48 150.73 134.15 168.14 144.19"/><polyline class="cls-2" points="176.66 104.03 194.13 114.16 163.77 131.37 176.49 139.12"/><polyline class="cls-2" points="185.46 98.95 206.9 111.53 176.47 129.15 185.12 134.15"/><polyline class="cls-2" points="194.12 93.95 219.96 109.06 189.79 126.67"/><line class="cls-2" x1="202.63" y1="89.02" x2="228.59" y2="103.98"/><path class="cls-2" d="M29.77,229c-2.36-1.41-2.38-3.67,0-5a9.52,9.52,0,0,1,8.59,0c2.38,1.38,2.39,3.64,0,5A9.32,9.32,0,0,1,29.77,229Z" transform="translate(-9.54)"/><line class="cls-2" x1="51.08" y1="211.53" x2="29.47" y2="224.05"/><path class="cls-2" d="M51.67,236.38c-2.36-1.41-2.38-3.67,0-5a9.52,9.52,0,0,1,8.59,0c2.38,1.38,2.39,3.64,0,5A9.32,9.32,0,0,1,51.67,236.38Z" transform="translate(-9.54)"/><line class="cls-2" x1="68.45" y1="221.53" x2="51.37" y2="231.42"/><path class="cls-2" d="M103.56,116.75c-2.36-1.41-2.38-3.67,0-5a9.52,9.52,0,0,1,8.59,0c2.38,1.38,2.39,3.64,0,5A9.32,9.32,0,0,1,103.56,116.75Z" transform="translate(-9.54)"/><line class="cls-2" x1="124.88" y1="99.27" x2="103.27" y2="111.79"/><polyline class="cls-2" points="107.52 89.11 33.76 131.53 68.41 151.53"/><polyline class="cls-2" points="115.89 93.95 51.09 131.53 77.06 146.53"/><polyline class="cls-2" points="133.36 104.03 77.1 136.51 85.73 141.53"/><polyline class="cls-2" points="141.96 109.06 111.89 126.23 163.77 156.47 155.11 161.47"/><line class="cls-2" x1="267.51" y1="221.49" x2="293.61" y2="236.55"/><polyline class="cls-2" points="302.23 241.53 293.57 246.53 258.97 226.55"/><polyline class="cls-2" points="310.89 246.53 293.57 256.53 250.36 231.48"/><polyline class="cls-2" points="319.55 251.53 293.61 266.5 233.04 231.48"/><polyline class="cls-2" points="328.21 256.53 293.57 276.53 215.63 231.61"/><polyline class="cls-2" points="336.87 261.53 293.57 286.53 224.18 246.53"/><polyline class="cls-2" points="77.06 226.53 59.79 236.55 77.06 246.53"/><polyline class="cls-2" points="85.77 231.42 77.11 236.5 85.73 241.53"/><line class="cls-2" x1="258.88" y1="96.5" x2="263.4" y2="93.95"/><line class="cls-2" x1="277.05" y1="156.96" x2="310.49" y2="176.58"/><line class="cls-2" x1="285.5" y1="151.98" x2="319.34" y2="171.41"/><line class="cls-2" x1="294.24" y1="147.03" x2="327.98" y2="166.49"/><line class="cls-2" x1="280.38" y1="104.15" x2="271.75" y2="98.93"/><line class="cls-2" x1="297.71" y1="93.92" x2="302.04" y2="96.5"/><line class="cls-2" x1="306.37" y1="88.92" x2="310.7" y2="91.64"/><polyline class="cls-2" points="280.38 114.15 289.24 109.03 319.55 126.53 336.87 116.53"/><polyline class="cls-2" points="293.33 116.67 319.34 131.41 349.95 114.08 341.25 109.24"/><line class="cls-2" x1="268.54" y1="162.09" x2="301.99" y2="181.72"/><line class="cls-2" x1="280.38" y1="104.15" x2="271.75" y2="108.98"/><line class="cls-2" x1="258.88" y1="96.5" x2="267.55" y2="101.5"/><line class="cls-2" x1="263.4" y1="104.11" x2="267.55" y2="101.5"/><line class="cls-2" x1="332.46" y1="113.94" x2="336.87" y2="116.53"/><line class="cls-2" x1="293.33" y1="116.67" x2="289.52" y2="118.87"/><path class="cls-1" d="M159.69,253.78c-2.38,1.37-2.38,3.62,0,5a9.61,9.61,0,0,0,8.66,0c2.38-1.38,2.38-3.63,0-5A9.61,9.61,0,0,0,159.69,253.78Z" transform="translate(-9.54)"/><line class="cls-2" x1="115.59" y1="233.78" x2="150.15" y2="253.78"/><path class="cls-2" d="M70.92,104.73c-2.36-1.41-2.38-3.67,0-5a9.52,9.52,0,0,1,8.59,0c2.38,1.38,2.39,3.64,0,5A9.32,9.32,0,0,1,70.92,104.73Z" transform="translate(-9.54)"/><line class="cls-2" x1="98.31" y1="83.74" x2="70.63" y2="99.78"/></g><g id="box2"><polygon class="cls-3" points="302 226.49 349.63 253.99 397.37 226.49 397.37 181.43 349.68 153.96 302 181.49 302 226.49"/><polygon class="cls-3" points="349.67 208.96 397.37 181.43 397.37 226.49 349.63 253.99 349.67 208.96"/><polygon class="cls-3" points="302 181.49 349.67 208.96 349.63 253.99 302 226.49 302 181.49"/><g id="Layer_6_copy" data-name="Layer 6 copy"><polygon class="cls-4" points="327.98 166.49 375.61 193.99 375.61 228.99 371.28 231.49 371.28 196.49 323.65 168.99 327.98 166.49"/><polygon class="cls-4" points="371.28 166.49 323.65 193.96 323.65 228.99 327.98 231.49 327.98 196.46 375.61 168.99 371.28 166.49"/></g><g id="clips_copy_4" data-name="clips copy 4"><polyline class="cls-5" points="392.93 223.99 401.59 228.99 401.59 233.99"/><polyline class="cls-5" points="384.27 228.99 392.93 233.99 392.93 238.99"/><polyline class="cls-5" points="375.61 233.99 384.27 238.99 384.27 243.99"/><polyline class="cls-5" points="366.95 238.99 375.61 243.99 375.61 248.99"/><polyline class="cls-5" points="358.29 243.99 366.95 248.99 366.95 253.99"/><polyline class="cls-5" points="349.67 248.96 358.29 253.99 358.29 258.99"/></g><g id="clipsFront_copy" data-name="clipsFront copy"><polyline class="cls-5" points="306.37 223.99 297.71 228.99 297.71 233.99"/><polyline class="cls-5" points="315.03 228.99 306.37 233.99 306.37 238.99"/><polyline class="cls-5" points="323.69 233.99 315.03 238.99 315.03 243.99"/><polyline class="cls-5" points="332.35 238.99 323.69 243.99 323.69 248.99"/><polyline class="cls-5" points="341.01 243.99 332.35 248.99 332.35 253.99"/><polyline class="cls-5" points="349.63 248.96 341.01 253.99 341.01 258.99"/></g><polyline id="MrClips" class="cls-5" points="397.37 221.43 401.59 218.99 401.59 223.99"/></g><g id="box3"><g id="box"><polygon class="cls-3" points="59.74 201.53 107.38 229.03 155.11 201.53 155.11 156.47 107.43 129 59.74 156.53 59.74 201.53"/><polygon class="cls-3" points="107.42 184 155.11 156.47 155.11 201.53 107.38 229.03 107.42 184"/><polygon class="cls-3" points="59.74 156.53 107.42 184 107.38 229.03 59.74 201.53 59.74 156.53"/><g id="Layer_6" data-name="Layer 6"><polygon class="cls-4" points="85.73 141.53 133.36 169.03 133.36 204.03 129.03 206.53 129.03 171.53 81.39 144.03 85.73 141.53"/><polygon class="cls-4" points="129.03 141.53 81.39 169.01 81.39 204.03 85.73 206.53 85.73 171.5 133.36 144.03 129.03 141.53"/></g><g id="clips-3" data-name="clips"><polyline class="cls-5" points="150.68 199.03 159.34 204.03 159.34 209.03"/><polyline class="cls-5" points="142.02 204.03 150.68 209.03 150.68 214.03"/><polyline class="cls-5" points="133.36 209.03 142.02 214.03 142.02 219.03"/><polyline class="cls-5" points="124.7 214.03 133.36 219.03 133.36 224.03"/><polyline class="cls-5" points="116.04 219.03 124.7 224.03 124.7 229.03"/><polyline class="cls-5" points="107.42 224 116.04 229.03 116.04 234.03"/></g><g id="clipsFront"><polyline class="cls-5" points="64.12 199.03 55.46 204.03 55.46 209.03"/><polyline class="cls-5" points="72.78 204.03 64.12 209.03 64.12 214.03"/><polyline class="cls-5" points="81.44 209.03 72.78 214.03 72.78 219.03"/><polyline class="cls-5" points="90.1 214.03 81.44 219.03 81.44 224.03"/><polyline class="cls-5" points="98.76 219.03 90.1 224.03 90.1 229.03"/><polyline class="cls-5" points="107.38 224 98.76 229.03 98.76 234.03"/></g><polyline id="MrClips-2" data-name="MrClips" class="cls-5" points="155.11 196.47 159.34 194.03 159.34 199.03"/></g><polygon class="cls-3" points="107.52 74.03 155.15 101.53 202.88 74.03 202.88 28.97 155.2 1.5 107.52 29.03 107.52 74.03"/><polygon class="cls-3" points="155.19 56.51 202.88 28.97 202.88 74.03 155.15 101.53 155.19 56.51"/><polygon class="cls-3" points="107.52 29.03 155.19 56.51 155.15 101.53 107.52 74.03 107.52 29.03"/><g id="Layer_6_copy_2" data-name="Layer 6 copy 2"><polygon class="cls-4" points="133.5 14.03 181.13 41.53 181.13 76.53 176.8 79.03 176.8 44.03 129.17 16.53 133.5 14.03"/><polygon class="cls-4" points="176.8 14.03 129.17 41.51 129.17 76.53 133.5 79.03 133.5 44 181.13 16.53 176.8 14.03"/></g><g id="clips_copy_5" data-name="clips copy 5"><polyline class="cls-5" points="198.45 71.53 207.11 76.53 207.11 81.53"/><polyline class="cls-5" points="189.79 76.53 198.45 81.53 198.45 86.53"/><polyline class="cls-5" points="181.13 81.53 189.79 86.53 189.79 91.53"/><polyline class="cls-5" points="172.47 86.53 181.13 91.53 181.13 96.53"/><polyline class="cls-5" points="163.81 91.53 172.47 96.53 172.47 101.53"/><polyline class="cls-5" points="155.19 96.5 163.81 101.53 163.81 106.53"/></g><g id="clipsFront_copy_2" data-name="clipsFront copy 2"><polyline class="cls-5" points="111.89 71.53 103.23 76.53 103.23 81.53"/><polyline class="cls-5" points="120.55 76.53 111.89 81.53 111.89 86.53"/><polyline class="cls-5" points="129.21 81.53 120.55 86.53 120.55 91.53"/><polyline class="cls-5" points="137.87 86.53 129.21 91.53 129.21 96.53"/><polyline class="cls-5" points="146.53 91.53 137.87 96.53 137.87 101.53"/><polyline class="cls-5" points="155.15 96.5 146.53 101.53 146.53 106.53"/></g></g><g id="callouts"><polyline class="cls-5" points="406.23 221.49 436.41 204 436.39 134.07"/><path class="cls-5" d="M441.61,127.56c-2.38,1.38-2.38,3.63,0,5a9.61,9.61,0,0,0,8.66,0c2.38-1.37,2.38-3.62,0-5A9.61,9.61,0,0,0,441.61,127.56Z" transform="translate(-9.54)"/><polyline class="cls-5" points="7.88 116.47 7.62 161.47 55.2 189.15"/><path class="cls-5" d="M0,111.53" transform="translate(-9.54)"/><path class="cls-5" d="M12.79,109c-2.35,1.38-2.33,3.63.05,5a9.61,9.61,0,0,0,8.66,0c2.38-1.37,2.36-3.62-.05-5A9.61,9.61,0,0,0,12.79,109Z" transform="translate(-9.54)"/><path class="cls-5" d="M242.42,67.56c-2.38,1.37-2.38,3.62,0,5a9.61,9.61,0,0,0,8.66,0c2.38-1.37,2.38-3.62,0-5A9.61,9.61,0,0,0,242.42,67.56Z" transform="translate(-9.54)"/><polyline class="cls-5" points="237.22 73.99 237.22 98.81 211.33 84.21"/></g></g></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="574px"
+   height="396px"
+   viewBox="0 0 444.02 288.03"
+   version="1.1"
+   id="svg321"
+   sodipodi:docname="circuit-board.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview323"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
+     showgrid="false"
+     inkscape:zoom="1.8156566"
+     inkscape:cx="292.73157"
+     inkscape:cy="219.47983"
+     inkscape:window-width="1620"
+     inkscape:window-height="1001"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_2" />
+  <defs
+     id="defs4">
+    <style
+       id="style2">.cls-1,.cls-2,.cls-3,.cls-5{fill:none;stroke-width:3px;}.cls-1,.cls-2{stroke:#9ebbe2;}.cls-1,.cls-2,.cls-3,.cls-4,.cls-5{stroke-linejoin:round;}.cls-2,.cls-5{stroke-linecap:round;}.cls-3,.cls-4,.cls-5{stroke:#fff;}.cls-4{fill:#fff;}@media screen and (-ms-high-contrast:active){.cls-3,.cls-4,.cls-5{stroke:windowText;}.cls-4{fill:windowText;}}</style>
+  </defs>
+  <title
+     id="title6">Hero Image v7</title>
+  <g
+     id="Layer_2"
+     data-name="Layer 2">
+    <g
+       id="chip">
+      <polygon
+         class="cls-1"
+         points="289.6,124.15 250.63,101.65 177.01,144.15 177.01,154.15 215.98,176.65 289.6,134.15 "
+         id="polygon8" />
+      <polygon
+         class="cls-1"
+         points="215.98,176.65 177.01,154.15 177.01,144.15 215.99,166.65 "
+         id="polygon10" />
+      <polygon
+         class="cls-1"
+         points="289.6,134.15 215.98,176.65 215.99,166.65 289.6,124.15 "
+         id="polygon12" />
+      <g
+         id="clips">
+        <polyline
+           class="cls-2"
+           points="280.94 134.15 289.52 139.1 289.52 144.19"
+           id="polyline14" />
+        <polyline
+           id="_7"
+           data-name="7"
+           class="cls-2"
+           points="272.31 139.12 280.94 144.15 281.01 149.1" />
+        <polyline
+           id="_6"
+           data-name="6"
+           class="cls-2"
+           points="263.62 143.65 272.2 149.1 272.31 154.17" />
+        <polyline
+           id="_5"
+           data-name="5"
+           class="cls-2"
+           points="255.03 149.1 263.62 154.15 263.65 159.17" />
+        <polyline
+           id="_4"
+           data-name="4"
+           class="cls-2"
+           points="246.3 154.15 254.85 159.09 255.03 164.19" />
+        <polyline
+           id="_3"
+           data-name="3"
+           class="cls-2"
+           points="237.63 159.15 246.3 164.15 246.3 169.15" />
+        <polyline
+           id="_2"
+           data-name="2"
+           class="cls-2"
+           points="228.97 164.15 237.63 169.15 237.63 174.15" />
+        <polyline
+           id="_1"
+           data-name="1"
+           class="cls-2"
+           points="220.31 169.15 228.97 174.15 228.97 179.15" />
+      </g>
+      <g
+         id="clips-2"
+         data-name="clips">
+        <polyline
+           class="cls-2"
+           points="181.34 146.65 172.68 141.65 172.68 146.65"
+           id="polyline24" />
+        <polyline
+           class="cls-2"
+           points="185.76 139.18 181.34 136.62 181.34 141.62"
+           id="polyline26" />
+        <polyline
+           class="cls-2"
+           points="194.42 134.2 190 131.65 190 136.65"
+           id="polyline28" />
+        <polyline
+           class="cls-2"
+           points="203.1 129.2 198.68 126.65 198.68 131.65"
+           id="polyline30" />
+        <polyline
+           class="cls-2"
+           points="207.41 126.65 207.32 121.65 211.66 124.15"
+           id="polyline32" />
+        <polyline
+           class="cls-2"
+           points="215.98 121.65 215.98 116.65 220.31 119.15"
+           id="polyline34" />
+        <polyline
+           class="cls-2"
+           points="224.65 116.65 224.65 111.65 228.97 114.15"
+           id="polyline36" />
+        <polyline
+           class="cls-2"
+           points="233.3 111.65 233.31 106.65 237.64 109.15"
+           id="polyline38" />
+        <polyline
+           class="cls-2"
+           points="241.97 106.65 241.97 101.65 246.3 104.15"
+           id="polyline40" />
+      </g>
+      <g
+         id="clips_copy_2"
+         data-name="clips copy 2">
+        <polyline
+           id="_4-2"
+           data-name="4"
+           class="cls-2"
+           points="181.43 151.65 172.88 156.59 172.7 161.69" />
+        <polyline
+           id="_3-2"
+           data-name="3"
+           class="cls-2"
+           points="190.09 156.65 181.43 161.65 181.43 166.65" />
+        <polyline
+           id="_2-2"
+           data-name="2"
+           class="cls-2"
+           points="198.75 161.65 190.09 166.65 190.09 171.65" />
+        <polyline
+           id="_1-2"
+           data-name="1"
+           class="cls-2"
+           points="207.41 166.65 198.75 171.65 198.75 176.65" />
+      </g>
+      <g
+         id="clipsBack">
+        <polyline
+           class="cls-2"
+           points="255.03 104.1 259.29 101.65 259.29 106.65"
+           id="polyline48" />
+        <polyline
+           class="cls-2"
+           points="263.62 109.15 267.97 106.66 267.97 111.65"
+           id="polyline50" />
+        <polyline
+           class="cls-2"
+           points="272.28 114.15 276.66 111.68 276.61 116.65"
+           id="polyline52" />
+        <polyline
+           class="cls-2"
+           points="280.94 119.15 285.23 116.67 285.27 121.65"
+           id="polyline54" />
+      </g>
+    </g>
+    <g
+       id="chips">
+      <g
+         id="_2-3"
+         data-name="2">
+        <polygon
+           class="cls-2"
+           points="345.56,96.5 328.24,86.5 297.97,103.98 297.97,109.02 315.33,118.95 345.56,101.5 "
+           id="polygon58" />
+        <polygon
+           class="cls-2"
+           points="345.56,101.5 315.33,118.95 315.33,113.95 345.56,96.5 "
+           id="polygon60" />
+        <polygon
+           class="cls-2"
+           points="315.33,118.95 297.97,109.02 297.97,103.98 315.33,113.95 "
+           id="polygon62" />
+      </g>
+      <g
+         id="_1-3"
+         data-name="1">
+        <polygon
+           class="cls-2"
+           points="311,76.48 293.68,66.48 263.4,83.96 263.4,89 280.76,98.94 311,81.48 "
+           id="polygon65" />
+        <polygon
+           class="cls-2"
+           points="311,81.48 280.76,98.94 280.76,93.94 311,76.48 "
+           id="polygon67" />
+        <polygon
+           class="cls-2"
+           points="280.76,98.94 263.4,89 263.4,83.96 280.76,93.94 "
+           id="polygon69" />
+      </g>
+    </g>
+    <g
+       id="wires">
+      <path
+         class="cls-1"
+         d="m 290,189.15 c -2.38,1.37 -2.38,3.62 0,5 a 9.61,9.61 0 0 0 8.66,0 c 2.38,-1.38 2.38,-3.63 0,-5 a 9.61,9.61 0 0 0 -8.66,0 z"
+         transform="translate(-9.54)"
+         id="path73" />
+      <line
+         class="cls-2"
+         x1="250.94"
+         y1="172.14999"
+         x2="280.5"
+         y2="189.14999"
+         id="line75" />
+      <path
+         class="cls-1"
+         d="m 189.68,241.53 c -2.38,1.37 -2.38,3.62 0,5 a 9.61,9.61 0 0 0 8.66,0 c 2.38,-1.38 2.38,-3.63 0,-5 a 9.61,9.61 0 0 0 -8.66,0 z"
+         transform="translate(-9.54)"
+         id="path77" />
+      <line
+         class="cls-2"
+         x1="145.58"
+         y1="221.53"
+         x2="180.14999"
+         y2="241.53"
+         id="line79" />
+      <polyline
+         class="cls-2"
+         points="233.7 182.07 258.93 196.53 198.4 231.48 163.67 211.53"
+         id="polyline81" />
+      <polyline
+         class="cls-2"
+         points="155.01 216.53 198.4 241.58 276.26 196.53 242.28 177.03"
+         id="polyline83" />
+      <polyline
+         class="cls-2"
+         points="259.6 167.03 302.02 191.65 189.65 256.53 137.69 226.53"
+         id="polyline85" />
+      <line
+         class="cls-2"
+         x1="194.12"
+         y1="178.95"
+         x2="163.67"
+         y2="196.53"
+         id="line87" />
+      <path
+         class="cls-2"
+         d="M 199.28,176.58"
+         transform="translate(-9.54)"
+         id="path89" />
+      <line
+         class="cls-2"
+         x1="185.41"
+         y1="174.08"
+         x2="155.69"
+         y2="191.25"
+         id="line91" />
+      <line
+         class="cls-2"
+         x1="176.71001"
+         y1="169.05"
+         x2="155.69"
+         y2="181.25999"
+         id="line93" />
+      <line
+         class="cls-2"
+         x1="168.07001"
+         y1="164.08"
+         x2="155.69"
+         y2="171.09"
+         id="line95" />
+      <polyline
+         class="cls-2"
+         points="59.79 216.55 16.5 241.58 51.37 261.37"
+         id="polyline97" />
+      <line
+         class="cls-2"
+         x1="94.43"
+         y1="236.55"
+         x2="51.369999"
+         y2="261.37"
+         id="line99" />
+      <polyline
+         class="cls-2"
+         points="129.03 231.48 189.65 266.53 302 201.66"
+         id="polyline101" />
+      <polyline
+         class="cls-2"
+         points="167.94 109.06 180.97 116.48 150.73 134.15 168.14 144.19"
+         id="polyline103" />
+      <polyline
+         class="cls-2"
+         points="176.66 104.03 194.13 114.16 163.77 131.37 176.49 139.12"
+         id="polyline105" />
+      <polyline
+         class="cls-2"
+         points="185.46 98.95 206.9 111.53 176.47 129.15 185.12 134.15"
+         id="polyline107" />
+      <polyline
+         class="cls-2"
+         points="194.12 93.95 219.96 109.06 189.79 126.67"
+         id="polyline109" />
+      <line
+         class="cls-2"
+         x1="202.63"
+         y1="89.019997"
+         x2="228.59"
+         y2="103.98"
+         id="line111" />
+      <path
+         class="cls-2"
+         d="m 29.77,229 c -2.36,-1.41 -2.38,-3.67 0,-5 a 9.52,9.52 0 0 1 8.59,0 c 2.38,1.38 2.39,3.64 0,5 a 9.32,9.32 0 0 1 -8.59,0 z"
+         transform="translate(-9.54)"
+         id="path113" />
+      <line
+         class="cls-2"
+         x1="51.080002"
+         y1="211.53"
+         x2="29.469999"
+         y2="224.05"
+         id="line115" />
+      <path
+         class="cls-2"
+         d="m 51.67,236.38 c -2.36,-1.41 -2.38,-3.67 0,-5 a 9.52,9.52 0 0 1 8.59,0 c 2.38,1.38 2.39,3.64 0,5 a 9.32,9.32 0 0 1 -8.59,0 z"
+         transform="translate(-9.54)"
+         id="path117" />
+      <line
+         class="cls-2"
+         x1="68.449997"
+         y1="221.53"
+         x2="51.369999"
+         y2="231.42"
+         id="line119" />
+      <path
+         class="cls-2"
+         d="m 103.56,116.75 c -2.36,-1.41 -2.38,-3.67 0,-5 a 9.52,9.52 0 0 1 8.59,0 c 2.38,1.38 2.39,3.64 0,5 a 9.32,9.32 0 0 1 -8.59,0 z"
+         transform="translate(-9.54)"
+         id="path121" />
+      <line
+         class="cls-2"
+         x1="124.88"
+         y1="99.269997"
+         x2="103.27"
+         y2="111.79"
+         id="line123" />
+      <polyline
+         class="cls-2"
+         points="107.52 89.11 33.76 131.53 68.41 151.53"
+         id="polyline125" />
+      <polyline
+         class="cls-2"
+         points="115.89 93.95 51.09 131.53 77.06 146.53"
+         id="polyline127" />
+      <polyline
+         class="cls-2"
+         points="133.36 104.03 77.1 136.51 85.73 141.53"
+         id="polyline129" />
+      <polyline
+         class="cls-2"
+         points="141.96 109.06 111.89 126.23 163.77 156.47 155.11 161.47"
+         id="polyline131" />
+      <line
+         class="cls-2"
+         x1="267.51001"
+         y1="221.49001"
+         x2="293.60999"
+         y2="236.55"
+         id="line133" />
+      <polyline
+         class="cls-2"
+         points="302.23 241.53 293.57 246.53 258.97 226.55"
+         id="polyline135" />
+      <polyline
+         class="cls-2"
+         points="310.89 246.53 293.57 256.53 250.36 231.48"
+         id="polyline137" />
+      <polyline
+         class="cls-2"
+         points="319.55 251.53 293.61 266.5 233.04 231.48"
+         id="polyline139" />
+      <polyline
+         class="cls-2"
+         points="328.21 256.53 293.57 276.53 215.63 231.61"
+         id="polyline141" />
+      <polyline
+         class="cls-2"
+         points="336.87 261.53 293.57 286.53 224.18 246.53"
+         id="polyline143" />
+      <polyline
+         class="cls-2"
+         points="77.06 226.53 59.79 236.55 77.06 246.53"
+         id="polyline145" />
+      <polyline
+         class="cls-2"
+         points="85.77 231.42 77.11 236.5 85.73 241.53"
+         id="polyline147" />
+      <line
+         class="cls-2"
+         x1="258.88"
+         y1="96.5"
+         x2="263.39999"
+         y2="93.949997"
+         id="line149" />
+      <line
+         class="cls-2"
+         x1="277.04999"
+         y1="156.96001"
+         x2="310.48999"
+         y2="176.58"
+         id="line151" />
+      <line
+         class="cls-2"
+         x1="285.5"
+         y1="151.98"
+         x2="319.34"
+         y2="171.41"
+         id="line153" />
+      <line
+         class="cls-2"
+         x1="294.23999"
+         y1="147.03"
+         x2="327.98001"
+         y2="166.49001"
+         id="line155" />
+      <line
+         class="cls-2"
+         x1="280.38"
+         y1="104.15"
+         x2="271.75"
+         y2="98.93"
+         id="line157" />
+      <line
+         class="cls-2"
+         x1="297.70999"
+         y1="93.919998"
+         x2="302.04001"
+         y2="96.5"
+         id="line159" />
+      <line
+         class="cls-2"
+         x1="306.37"
+         y1="88.919998"
+         x2="310.70001"
+         y2="91.639999"
+         id="line161" />
+      <polyline
+         class="cls-2"
+         points="280.38 114.15 289.24 109.03 319.55 126.53 336.87 116.53"
+         id="polyline163" />
+      <polyline
+         class="cls-2"
+         points="293.33 116.67 319.34 131.41 349.95 114.08 341.25 109.24"
+         id="polyline165" />
+      <line
+         class="cls-2"
+         x1="268.54001"
+         y1="162.09"
+         x2="301.98999"
+         y2="181.72"
+         id="line167" />
+      <line
+         class="cls-2"
+         x1="280.38"
+         y1="104.15"
+         x2="271.75"
+         y2="108.98"
+         id="line169" />
+      <line
+         class="cls-2"
+         x1="258.88"
+         y1="96.5"
+         x2="267.54999"
+         y2="101.5"
+         id="line171" />
+      <line
+         class="cls-2"
+         x1="263.39999"
+         y1="104.11"
+         x2="267.54999"
+         y2="101.5"
+         id="line173" />
+      <line
+         class="cls-2"
+         x1="332.45999"
+         y1="113.94"
+         x2="336.87"
+         y2="116.53"
+         id="line175" />
+      <line
+         class="cls-2"
+         x1="293.32999"
+         y1="116.67"
+         x2="289.51999"
+         y2="118.87"
+         id="line177" />
+      <path
+         class="cls-1"
+         d="m 159.69,253.78 c -2.38,1.37 -2.38,3.62 0,5 a 9.61,9.61 0 0 0 8.66,0 c 2.38,-1.38 2.38,-3.63 0,-5 a 9.61,9.61 0 0 0 -8.66,0 z"
+         transform="translate(-9.54)"
+         id="path179" />
+      <line
+         class="cls-2"
+         x1="115.59"
+         y1="233.78"
+         x2="150.14999"
+         y2="253.78"
+         id="line181" />
+      <path
+         class="cls-2"
+         d="m 70.92,104.73 c -2.36,-1.41 -2.38,-3.67 0,-5 a 9.52,9.52 0 0 1 8.59,0 c 2.38,1.38 2.39,3.64 0,5 a 9.32,9.32 0 0 1 -8.59,0 z"
+         transform="translate(-9.54)"
+         id="path183" />
+      <line
+         class="cls-2"
+         x1="98.309998"
+         y1="83.739998"
+         x2="70.629997"
+         y2="99.779999"
+         id="line185" />
+    </g>
+    <g
+       id="box2">
+      <polygon
+         class="cls-3"
+         points="397.37,226.49 397.37,181.43 349.68,153.96 302,181.49 302,226.49 349.63,253.99 "
+         id="polygon188" />
+      <polygon
+         class="cls-3"
+         points="397.37,226.49 349.63,253.99 349.67,208.96 397.37,181.43 "
+         id="polygon190" />
+      <polygon
+         class="cls-3"
+         points="349.63,253.99 302,226.49 302,181.49 349.67,208.96 "
+         id="polygon192" />
+      <g
+         id="Layer_6_copy"
+         data-name="Layer 6 copy">
+        <polygon
+           class="cls-4"
+           points="375.61,228.99 371.28,231.49 371.28,196.49 323.65,168.99 327.98,166.49 375.61,193.99 "
+           id="polygon194" />
+        <polygon
+           class="cls-4"
+           points="323.65,228.99 327.98,231.49 327.98,196.46 375.61,168.99 371.28,166.49 323.65,193.96 "
+           id="polygon196" />
+      </g>
+      <g
+         id="clips_copy_4"
+         data-name="clips copy 4">
+        <polyline
+           class="cls-5"
+           points="392.93 223.99 401.59 228.99 401.59 233.99"
+           id="polyline199" />
+        <polyline
+           class="cls-5"
+           points="384.27 228.99 392.93 233.99 392.93 238.99"
+           id="polyline201" />
+        <polyline
+           class="cls-5"
+           points="375.61 233.99 384.27 238.99 384.27 243.99"
+           id="polyline203" />
+        <polyline
+           class="cls-5"
+           points="366.95 238.99 375.61 243.99 375.61 248.99"
+           id="polyline205" />
+        <polyline
+           class="cls-5"
+           points="358.29 243.99 366.95 248.99 366.95 253.99"
+           id="polyline207" />
+        <polyline
+           class="cls-5"
+           points="349.67 248.96 358.29 253.99 358.29 258.99"
+           id="polyline209" />
+      </g>
+      <g
+         id="clipsFront_copy"
+         data-name="clipsFront copy">
+        <polyline
+           class="cls-5"
+           points="306.37 223.99 297.71 228.99 297.71 233.99"
+           id="polyline212" />
+        <polyline
+           class="cls-5"
+           points="315.03 228.99 306.37 233.99 306.37 238.99"
+           id="polyline214" />
+        <polyline
+           class="cls-5"
+           points="323.69 233.99 315.03 238.99 315.03 243.99"
+           id="polyline216" />
+        <polyline
+           class="cls-5"
+           points="332.35 238.99 323.69 243.99 323.69 248.99"
+           id="polyline218" />
+        <polyline
+           class="cls-5"
+           points="341.01 243.99 332.35 248.99 332.35 253.99"
+           id="polyline220" />
+        <polyline
+           class="cls-5"
+           points="349.63 248.96 341.01 253.99 341.01 258.99"
+           id="polyline222" />
+      </g>
+      <polyline
+         id="MrClips"
+         class="cls-5"
+         points="397.37 221.43 401.59 218.99 401.59 223.99" />
+    </g>
+    <g
+       id="box3">
+      <g
+         id="box">
+        <polygon
+           class="cls-3"
+           points="155.11,201.53 155.11,156.47 107.43,129 59.74,156.53 59.74,201.53 107.38,229.03 "
+           id="polygon227" />
+        <polygon
+           class="cls-3"
+           points="155.11,201.53 107.38,229.03 107.42,184 155.11,156.47 "
+           id="polygon229" />
+        <polygon
+           class="cls-3"
+           points="107.38,229.03 59.74,201.53 59.74,156.53 107.42,184 "
+           id="polygon231" />
+        <g
+           id="Layer_6"
+           data-name="Layer 6">
+          <polygon
+             class="cls-4"
+             points="133.36,204.03 129.03,206.53 129.03,171.53 81.39,144.03 85.73,141.53 133.36,169.03 "
+             id="polygon233" />
+          <polygon
+             class="cls-4"
+             points="81.39,204.03 85.73,206.53 85.73,171.5 133.36,144.03 129.03,141.53 81.39,169.01 "
+             id="polygon235" />
+        </g>
+        <g
+           id="clips-3"
+           data-name="clips">
+          <polyline
+             class="cls-5"
+             points="150.68 199.03 159.34 204.03 159.34 209.03"
+             id="polyline238" />
+          <polyline
+             class="cls-5"
+             points="142.02 204.03 150.68 209.03 150.68 214.03"
+             id="polyline240" />
+          <polyline
+             class="cls-5"
+             points="133.36 209.03 142.02 214.03 142.02 219.03"
+             id="polyline242" />
+          <polyline
+             class="cls-5"
+             points="124.7 214.03 133.36 219.03 133.36 224.03"
+             id="polyline244" />
+          <polyline
+             class="cls-5"
+             points="116.04 219.03 124.7 224.03 124.7 229.03"
+             id="polyline246" />
+          <polyline
+             class="cls-5"
+             points="107.42 224 116.04 229.03 116.04 234.03"
+             id="polyline248" />
+        </g>
+        <g
+           id="clipsFront">
+          <polyline
+             class="cls-5"
+             points="64.12 199.03 55.46 204.03 55.46 209.03"
+             id="polyline251" />
+          <polyline
+             class="cls-5"
+             points="72.78 204.03 64.12 209.03 64.12 214.03"
+             id="polyline253" />
+          <polyline
+             class="cls-5"
+             points="81.44 209.03 72.78 214.03 72.78 219.03"
+             id="polyline255" />
+          <polyline
+             class="cls-5"
+             points="90.1 214.03 81.44 219.03 81.44 224.03"
+             id="polyline257" />
+          <polyline
+             class="cls-5"
+             points="98.76 219.03 90.1 224.03 90.1 229.03"
+             id="polyline259" />
+          <polyline
+             class="cls-5"
+             points="107.38 224 98.76 229.03 98.76 234.03"
+             id="polyline261" />
+        </g>
+        <polyline
+           id="MrClips-2"
+           data-name="MrClips"
+           class="cls-5"
+           points="155.11 196.47 159.34 194.03 159.34 199.03" />
+      </g>
+      <polygon
+         class="cls-3"
+         points="202.88,74.03 202.88,28.97 155.2,1.5 107.52,29.03 107.52,74.03 155.15,101.53 "
+         id="polygon266" />
+      <polygon
+         class="cls-3"
+         points="202.88,74.03 155.15,101.53 155.19,56.51 202.88,28.97 "
+         id="polygon268" />
+      <polygon
+         class="cls-3"
+         points="155.15,101.53 107.52,74.03 107.52,29.03 155.19,56.51 "
+         id="polygon270" />
+      <g
+         id="Layer_6_copy_2"
+         data-name="Layer 6 copy 2">
+        <polygon
+           class="cls-4"
+           points="181.13,76.53 176.8,79.03 176.8,44.03 129.17,16.53 133.5,14.03 181.13,41.53 "
+           id="polygon272" />
+        <polygon
+           class="cls-4"
+           points="129.17,76.53 133.5,79.03 133.5,44 181.13,16.53 176.8,14.03 129.17,41.51 "
+           id="polygon274" />
+      </g>
+      <g
+         id="clips_copy_5"
+         data-name="clips copy 5">
+        <polyline
+           class="cls-5"
+           points="198.45 71.53 207.11 76.53 207.11 81.53"
+           id="polyline277" />
+        <polyline
+           class="cls-5"
+           points="189.79 76.53 198.45 81.53 198.45 86.53"
+           id="polyline279" />
+        <polyline
+           class="cls-5"
+           points="181.13 81.53 189.79 86.53 189.79 91.53"
+           id="polyline281" />
+        <polyline
+           class="cls-5"
+           points="172.47 86.53 181.13 91.53 181.13 96.53"
+           id="polyline283" />
+        <polyline
+           class="cls-5"
+           points="163.81 91.53 172.47 96.53 172.47 101.53"
+           id="polyline285" />
+        <polyline
+           class="cls-5"
+           points="155.19 96.5 163.81 101.53 163.81 106.53"
+           id="polyline287" />
+      </g>
+      <g
+         id="clipsFront_copy_2"
+         data-name="clipsFront copy 2">
+        <polyline
+           class="cls-5"
+           points="111.89 71.53 103.23 76.53 103.23 81.53"
+           id="polyline290" />
+        <polyline
+           class="cls-5"
+           points="120.55 76.53 111.89 81.53 111.89 86.53"
+           id="polyline292" />
+        <polyline
+           class="cls-5"
+           points="129.21 81.53 120.55 86.53 120.55 91.53"
+           id="polyline294" />
+        <polyline
+           class="cls-5"
+           points="137.87 86.53 129.21 91.53 129.21 96.53"
+           id="polyline296" />
+        <polyline
+           class="cls-5"
+           points="146.53 91.53 137.87 96.53 137.87 101.53"
+           id="polyline298" />
+        <polyline
+           class="cls-5"
+           points="155.15 96.5 146.53 101.53 146.53 106.53"
+           id="polyline300" />
+      </g>
+    </g>
+    <polyline
+       class="cls-5"
+       points="406.23 221.49 436.41 204 436.39 134.07"
+       id="polyline304"
+       transform="matrix(1.0085906,0,0,0.82751763,-3.6193759,38.332751)" />
+    <path
+       class="cls-5"
+       d="m 432.07,141.19349 c -2.38,1.38 -2.38,3.63 0,5 a 9.61,9.61 0 0 0 8.66,0 c 2.38,-1.37 2.38,-3.62 0,-5 a 9.61,9.61 0 0 0 -8.66,0 z"
+       id="path306" />
+    <polyline
+       class="cls-5"
+       points="7.88 116.47 7.62 161.47 55.2 189.15"
+       id="polyline308" />
+    <path
+       class="cls-5"
+       d="M -9.54,111.53"
+       id="path310" />
+    <path
+       class="cls-5"
+       d="m 3.25,109 c -2.35,1.38 -2.33,3.63 0.05,5 a 9.61,9.61 0 0 0 8.66,0 c 2.38,-1.37 2.36,-3.62 -0.05,-5 a 9.61,9.61 0 0 0 -8.66,0 z"
+       id="path312" />
+    <path
+       class="cls-5"
+       d="m 232.88,67.56 c -2.38,1.37 -2.38,3.62 0,5 a 9.61,9.61 0 0 0 8.66,0 c 2.38,-1.37 2.38,-3.62 0,-5 a 9.61,9.61 0 0 0 -8.66,0 z"
+       id="path314" />
+    <polyline
+       class="cls-5"
+       points="237.22 73.99 237.22 98.81 211.33 84.21"
+       id="polyline316" />
+  </g>
+</svg>


### PR DESCRIPTION
Addresses https://github.com/nuget/nugetgallery/issues/8988

**Problem:**
 
On the Home page, when text spacing is applied, the 'package versions' and 'unique packages' text overflows outside its container.

*NOTE:* I was told to use [codepen.io](https://codepen.io/stevef/pen/YLMqbo/) to apply text spacing, but it can also be achieved by adding this to the stylesheet:

```
* {
 line-height: 1.5 !important;
 letter-spacing: 0.12em !important;
 word-spacing: 0.16em !important;
}

p{
 margin-bottom: 2em !important;
}
```

Regular home page:
![image](https://user-images.githubusercontent.com/82980589/158491365-c429a6fe-c839-4d63-9fa5-68fb3d1d2306.png)

After applying text spacing:
![image](https://user-images.githubusercontent.com/82980589/158492807-f1b9ac54-2ebe-43cb-938f-664063c72e53.png)

**Fix:**

To fix this, I made the label containers wider to accommodate the expanded text. The resulting UI changes seem minor to look at, but I'm happy to get additional feedback on that.

**After the changes,**

Regular home page:
![image](https://user-images.githubusercontent.com/82980589/158492514-77ebd7a9-c9ee-45a8-b6fe-96474326b4b9.png)

After applying text spacing:
![image](https://user-images.githubusercontent.com/82980589/158492829-ee5709a3-ac17-4fbf-8d50-c2d4cf02d241.png)
