### PR TITLE
[A11y bug] Package title on stats is overflowing the content.

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -2229,6 +2229,9 @@ p.frameworktableinfo-text {
 .page-stats-per-package #stats-graph-svg p {
   margin-bottom: none;
 }
+.page-stats-per-package .statistics-report-title {
+  word-wrap: break-word;
+}
 .page-status .status-general {
   padding: 13px;
   margin-bottom: 24px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -2230,7 +2230,7 @@ p.frameworktableinfo-text {
   margin-bottom: none;
 }
 .page-stats-per-package .statistics-report-title {
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 .page-status .status-general {
   padding: 13px;

--- a/src/Bootstrap/less/theme/page-statistics-per-package.less
+++ b/src/Bootstrap/less/theme/page-statistics-per-package.less
@@ -74,6 +74,6 @@
     }
 
     .statistics-report-title {
-        word-wrap: break-word;
+        overflow-wrap: break-word;
     }
 }

--- a/src/Bootstrap/less/theme/page-statistics-per-package.less
+++ b/src/Bootstrap/less/theme/page-statistics-per-package.less
@@ -72,4 +72,8 @@
             margin-bottom: none;
         }
     }
+
+    .statistics-report-title {
+        word-wrap: break-word;
+    }
 }


### PR DESCRIPTION
### Changes
* `overflow-wrap: break-word` added so avoid title overflowing the content.

### Screenshots

#### Before

![Before](https://user-images.githubusercontent.com/17834924/159379669-52602116-2ac3-4e06-93cc-1d5b6b5a1c9a.png)

#### After

![After](https://user-images.githubusercontent.com/17834924/159379766-3ca71cee-a484-4db5-a36e-c6de12940b26.png)

Addresses https://github.com/nuget/engineering/issues/4322