### PR TITLE
[A11y] Added aria-labels to tabs on Package Details page

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -604,7 +604,7 @@
             <div class="tab-content body-tab-content">
                 @if (!Model.Deleted)
                 {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "readme" ? "active" : "")" id="readme-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "readme" ? "active" : "")" id="readme-tab" aria-label="Readme tab content">
                         @if ((Model.Validating || Model.FailedValidation) && Model.HasEmbeddedReadmeFile)
                         {
                             @ViewHelpers.AlertWarning(
@@ -644,7 +644,7 @@
 
                     if (Model.CanDisplayTargetFrameworks())
                     {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-label="Supported frameworks tab content">
                         @if (Model.PackageFrameworkCompatibility.Table.Count > 0)
                         {
                             @Html.Partial("_SupportedFrameworksTable", Model.PackageFrameworkCompatibility.Table)
@@ -657,7 +657,7 @@
                     </div>
                     }
 
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-label="Dependencies tab content">
                         @if (!Model.Deleted)
                         {
                             if (Model.Dependencies.DependencySets == null)
@@ -715,7 +715,7 @@
                         }
                     </div>
                 }
-                <div role="tabpanel" class="tab-pane @(activeBodyTab == "usedby" ? "active" : "")" id="usedby-tab">
+                <div role="tabpanel" class="tab-pane @(activeBodyTab == "usedby" ? "active" : "")" id="usedby-tab" aria-label="Used by tab content">
                     @if (!Model.IsDotnetToolPackageType && (Model.IsGitHubUsageEnabled || Model.IsPackageDependentsEnabled))
                     {
                         <div class="used-by" id="used-by">
@@ -824,7 +824,7 @@
                         </div>
                     }
                 </div>
-                <div role="tabpanel" class="tab-pane @(activeBodyTab == "versions" ? "active" : "")" id="versions-tab">
+                <div role="tabpanel" class="tab-pane @(activeBodyTab == "versions" ? "active" : "")" id="versions-tab" aria-label="Versions tab content">
                     <div class="version-history" id="version-history">
                         <table aria-label="Version History of @Model.Id" class="table borderless">
                             <thead>
@@ -941,7 +941,7 @@
                 </div>
                 @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
                 {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "releasenotes" ? "active" : "")" id="releasenotes-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "releasenotes" ? "active" : "")" id="releasenotes-tab" aria-label="Release notes tab content">
                         <p>@Html.PreFormattedText(Model.ReleaseNotes, Config)</p>
                     </div>
                 }


### PR DESCRIPTION
Addresses https://github.com/nuget/nugetgallery/issues/9061

**Problem:**

On the Package Details page, individual tabs do not have descriptive aria-labels that can be read by screen readers to inform users. We need to describe the purpose of the tab contents to account for cases where it may not be self-evident, like this isolated link in the Release Notes section here:
![image](https://user-images.githubusercontent.com/82980589/159563014-15389a49-8469-4c09-b133-b7544a2cc896.png)

**Fix:**

To fix this, I added aria-label attributes to each of the tab content divs.
