### PR TITLE
[A11y] Added tabindex="-1" to ReCAPTCHA iframes

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -645,7 +645,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
             $submit.before(
                 '<div id="recaptcha" class="g-recaptcha" '
                 + 'data-sitekey="@reCaptchaPublicKey" data-size="invisible" '
-                + 'data-callback="onSubmit" data-tabindex="-1"></div>');
+                + 'data-callback="onSubmit"></div>');
 
             var $form = $submit.parents('form')
             $submit.click(function (e) {

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -660,7 +660,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
             }
 
             window.onload = function () {
-                $("iframe").attr({ tabindex: "-1" });
+                $('div.g-recaptcha iframe').attr({ tabindex: "-1" });
             }
         </script>
     }

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -658,6 +658,10 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
             function onSubmit(token) {
                 $form.submit();
             }
+
+            window.onload = function () {
+                $("iframe").attr({ tabindex: "-1" });
+            }
         </script>
     }
 }

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -645,7 +645,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
             $submit.before(
                 '<div id="recaptcha" class="g-recaptcha" '
                 + 'data-sitekey="@reCaptchaPublicKey" data-size="invisible" '
-                + 'data-callback="onSubmit" data-tabindex="0"></div>');
+                + 'data-callback="onSubmit" data-tabindex="-1"></div>');
 
             var $form = $submit.parents('form')
             $submit.click(function (e) {

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -645,7 +645,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
             $submit.before(
                 '<div id="recaptcha" class="g-recaptcha" '
                 + 'data-sitekey="@reCaptchaPublicKey" data-size="invisible" '
-                + 'data-callback="onSubmit"></div>');
+                + 'data-callback="onSubmit" data-tabindex="0"></div>');
 
             var $form = $submit.parents('form')
             $submit.click(function (e) {


### PR DESCRIPTION
Addresses https://github.com/nuget/nugetgallery/issues/9052

**Problem:**
 
On the Forgot Password page, when tab navigating from the 'Email' input field onwards, you expect the focus to move to the 'Send' button, but the focus shifts to the Privacy and Terms links in the ReCAPTCHA element in the bottom-right of the page, before resuming the regular tab stop order from the 'Send' button onwards.

**Currently:**
![Recaptcha receives focus](https://user-images.githubusercontent.com/82980589/159816300-1c5d5a40-e274-474e-8809-a7a9e76131e6.gif)

The parent div that we were loading the ReCAPTCHA element into had a data-tabindex="-1" attribute, but the iframes within this were still receiving tab focus.

**Fix:**

To fix this, I added the tabindex="-1" attribute to all the ReCAPTCHA iframes after they have been loaded into the page, so that they do not receive tab focus.

![image](https://user-images.githubusercontent.com/82980589/159816635-75a9fe52-8890-40b1-ad51-de691fc13171.png)

**After the changes:**
![Recaptcha doesn't receive focus](https://user-images.githubusercontent.com/82980589/159816681-c68813e1-e5be-4d59-a39b-a7eea4d800e5.gif)

**_NOTE:_** These changes mean that the Privacy and Terms links within the ReCAPTCHA widget do not receive focus at all. Do I need to enable them to receive focus after everything else in the footer, or should they not be receiving focus at all?