### PR TITLE
[A11y] Added column header roles to tables, made each cell accessible with keyboard navigation

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -732,15 +732,15 @@
                                     <table class="table borderless" aria-label="Packages that depend on @Model.Id">
                                         <thead>
                                             <tr>
-                                                <th class="used-by-adjust-table-head" tabindex="0">Package</th>
-                                                <th class="used-by-adjust-table-head" tabindex="0">Downloads</th>
+                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader" tabindex="0">Package</th>
+                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader" tabindex="0">Downloads</th>
                                             </tr>
                                         </thead>
                                         <tbody class="no-border">
                                             @foreach (var item in Model.PackageDependents.TopPackages)
                                             {
                                                 <tr>
-                                                    <td class="used-by-desc-column">
+                                                    <td class="used-by-desc-column" tabindex="0">
                                                         <a class="text-left ngp-link" href="@Url.Package(item.Id)">
                                                             @(item.Id)
                                                         </a>
@@ -754,7 +754,7 @@
                                                         }
                                                         <p class="used-by-desc">@item.Description</p>
                                                     </td>
-                                                    <td>
+                                                    <td tabindex="0">
                                                         <i class="ms-Icon ms-Icon--Download used-by-download-icon" aria-hidden="true"></i> <label class="used-by-count">@(item.DownloadCount.ToKiloFormat())</label>
                                                     </td>
                                                 </tr>
@@ -786,15 +786,15 @@
                                     <table class="table borderless" aria-label="GitHub repositories that depend on @Model.Id">
                                         <thead>
                                             <tr>
-                                                <th class="used-by-adjust-table-head" tabindex="0">Repository</th>
-                                                <th class="used-by-adjust-table-head" tabindex="0">Stars</th>
+                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader" tabindex="0">Repository</th>
+                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader" tabindex="0">Stars</th>
                                             </tr>
                                         </thead>
                                         <tbody class="no-border">
                                             @foreach (var item in Model.GitHubDependenciesInformation.Repos.Select((elem, i) => new { Value = elem, Idx = i }))
                                             {
                                                 <tr>
-                                                    <td class="used-by-desc-column">
+                                                    <td class="used-by-desc-column" tabindex="0">
                                                         <a data-index-number="@item.Idx" class="text-left gh-link" href="@item.Value.Url" target="_blank">
                                                             @(item.Value.Id)
                                                         </a>
@@ -802,7 +802,7 @@
                                                             <span>@(item.Value.Description)</span>
                                                         </div>
                                                     </td>
-                                                    <td>
+                                                    <td tabindex="0">
                                                         <i class="ms-Icon ms-Icon--FavoriteStarFill gh-star" aria-hidden="true"></i> <label class="used-by-count">@(item.Value.Stars.ToKiloFormat())</label>
                                                     </td>
                                                 </tr>
@@ -829,20 +829,20 @@
                         <table aria-label="Version History of @Model.Id" class="table borderless">
                             <thead>
                                 <tr>
-                                    <th scope="col" tabindex="0">Version</th>
-                                    <th scope="col" tabindex="0">Downloads</th>
-                                    <th scope="col" tabindex="0">Last updated</th>
+                                    <th scope="col" role="columnheader" tabindex="0">Version</th>
+                                    <th scope="col" role="columnheader" tabindex="0">Downloads</th>
+                                    <th scope="col" role="columnheader" tabindex="0">Last updated</th>
                                     @if (Model.CanDisplayPrivateMetadata)
                                     {
-                                        <th scope="col" tabindex="0">Status</th>
+                                        <th scope="col" role="columnheader" tabindex="0">Status</th>
                                     }
                                     @if (Model.IsCertificatesUIEnabled)
                                     {
-                                        <th scope="col" aria-hidden="true" abbr="Signature Information"></th>
+                                        <th scope="col" role="columnheader" aria-hidden="true" abbr="Signature Information"></th>
                                     }
                                     @if (Model.IsPackageDeprecationEnabled || Model.IsPackageVulnerabilitiesEnabled)
                                     {
-                                        <th scope="col" aria-hidden="true" abbr="Package Warnings"></th>
+                                        <th scope="col" role="columnheader" aria-hidden="true" abbr="Package Warnings"></th>
                                     }
                                 </tr>
                             </thead>
@@ -853,7 +853,7 @@
                                         || (!packageVersion.Deleted && Model.CanDisplayPrivateMetadata))
                                     {
                                         <tr class="@(packageVersion.IsCurrent(Model) ? "bg-info" : null)">
-                                            <td>
+                                            <td tabindex="0">
                                                 <a href="@Url.Package(packageVersion)" title="@packageVersion.Version">
                                                     @packageVersion.Version.Abbreviate(30)
                                                 </a>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9048

**Problem:**

Reopened a previous a11y bug that I hadn't fixed all the way through.

In the Package Details page's 'Used By' tab, screen readers weren't reading the table header names when using tab navigation. To fix this, I had added tabindex to the table headers so that screen readers would access them and read out the contents ('Package', Downloads', etc.), but I needed to make those cells identifiable as column headers, so that each data cell below it would also be identified with that column header. I have made that fix here.

**Fix:**

To fix this, I added scope and role attributes to identify these header cells as column headers and allow accessibility aids to pick up on that detail.

I also added tabindex to table data cells that were missing it to make each cell accessible with keyboard navigation.

**_NOTE:_** Now, cells with links in them, such as the Package or Repository cells in the 'Used By' tab's tables, receive focus first to the cell itself (allowing it to read the descriptive text surrounding the link), and then to the link, as opposed to just the link.

![image](https://user-images.githubusercontent.com/82980589/160014537-e0867d6c-ceef-4ad4-8c39-e3cdebbf4ceb.png)
