### PR TITLE
[A11y]Enable dismissing Verified tooltip with esc

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -473,8 +473,11 @@
                 2000);
         });
         popoverElement.keyup(function (event) {
+            // normalize keycode for browser compatibility
+            var code = event.which || event.keyCode || event.charCode;
+
             // This is the keycode for the 'Esc' key
-            if (event.which === 27) {
+            if (code === 27) {
                 popoverElement.popover('hide');
             }
         });

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -468,9 +468,15 @@
         popoverElement.click(function () {
             popoverElement.popover('show');
             setTimeout(function () {
-                    popoverElement.popover('destroy');
+                    popoverElement.popover('hide');
                 },
                 2000);
+        });
+        popoverElement.keyup(function (event) {
+            // This is the keycode for the 'Esc' key
+            if (event.which === 27) {
+                popoverElement.popover('hide');
+            }
         });
     };
 


### PR DESCRIPTION
Currently, when navigated to by keyboard, the verified tooltip cannot be dismissed without tabbing away from the icon.
This change enables dismissing this tooltip by usage of the esc key for all locations where this tooltip is used.

As a bonus it also fixes a bug that could cause the tooltip to stop working altogether when clicked on.