### PR TITLE
[A11y] Made Package Details page's tabs navigable with left/right arrow keys

### DIFF
--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -2449,7 +2449,10 @@ if (typeof jQuery === 'undefined') {
   var keyUpHandler = function (e) {
     e.preventDefault()
 
-    switch (e.keyCode) {
+    // normalized for broswer compatibility
+    var code = e.keyCode || e.which;
+
+    switch (code) {
       case keys.left:
         Plugin.call($(this), 'navigateTabLeft')
         break;

--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -2439,7 +2439,7 @@ if (typeof jQuery === 'undefined') {
     Plugin.call($(this), 'show')
   }
 
-  var keyUpHandler = function (e) {
+  var keyDownHandler = function (e) {
     e.preventDefault()
 
     switch (e.keyCode) {
@@ -2455,7 +2455,7 @@ if (typeof jQuery === 'undefined') {
   $(document)
     .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
     .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
-    .on('keyup', '[data-toggle="tab"]', keyUpHandler)
+    .on('keydown', '[data-toggle="tab"]', keyDownHandler)
 
 }(jQuery);
 

--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -2434,19 +2434,26 @@ if (typeof jQuery === 'undefined') {
   // TAB DATA-API
   // ============
 
+  var keys = {
+    left: 37,
+    right: 39,
+    up: 38,
+    down: 40
+  }
+
   var clickHandler = function (e) {
     e.preventDefault()
     Plugin.call($(this), 'show')
   }
 
-  var keyDownHandler = function (e) {
+  var keyUpHandler = function (e) {
     e.preventDefault()
 
     switch (e.keyCode) {
-      case 37: // left arrow key
+      case keys.left:
         Plugin.call($(this), 'navigateTabLeft')
         break;
-      case 39: // right arrow key
+      case keys.right:
         Plugin.call($(this), 'navigateTabRight')
         break;
     }
@@ -2455,7 +2462,7 @@ if (typeof jQuery === 'undefined') {
   $(document)
     .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
     .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
-    .on('keydown', '[data-toggle="tab"]', keyDownHandler)
+    .on('keyup', '[data-toggle="tab"]', keyUpHandler)
 
 }(jQuery);
 

--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -2344,12 +2344,14 @@ if (typeof jQuery === 'undefined') {
         .removeClass('active')
         .end()
         .find('[data-toggle="tab"]')
+          .attr('tabindex', "-1")
           .attr('aria-expanded', false)
           .attr('aria-selected', false)
 
       element
         .addClass('active')
         .find('[data-toggle="tab"]')
+          .attr('tabindex', "0")
           .attr('aria-expanded', true)
           .attr('aria-selected', true)
 
@@ -2381,6 +2383,25 @@ if (typeof jQuery === 'undefined') {
     $active.removeClass('in')
   }
 
+  Tab.prototype.navigateTabLeft = function () {
+    var $this = this.element
+
+    if ($this.parent('li').is($this.closest('ul').children().first())) return
+
+    var $target = $this.parent('li').prev().children('a')[0]
+
+    $target.focus()
+  }
+
+  Tab.prototype.navigateTabRight = function () {
+    var $this = this.element
+
+    if ($this.parent('li').is($this.closest('ul').children().last())) return
+
+    var $target = $this.parent('li').next().children('a')[0]
+
+    $target.focus()
+  }
 
   // TAB PLUGIN DEFINITION
   // =====================
@@ -2418,9 +2439,23 @@ if (typeof jQuery === 'undefined') {
     Plugin.call($(this), 'show')
   }
 
+  var keyUpHandler = function (e) {
+    e.preventDefault()
+
+    switch (e.keyCode) {
+      case 37: // left arrow key
+        Plugin.call($(this), 'navigateTabLeft')
+        break;
+      case 39: // right arrow key
+        Plugin.call($(this), 'navigateTabRight')
+        break;
+    }
+  }
+
   $(document)
     .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
     .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
+    .on('keyup', '[data-toggle="tab"]', keyUpHandler)
 
 }(jQuery);
 

--- a/src/Bootstrap/js/tab.js
+++ b/src/Bootstrap/js/tab.js
@@ -181,7 +181,10 @@
   var keyUpHandler = function (e) {
     e.preventDefault()
 
-    switch (e.keyCode) {
+    // normalized for broswer compatibility
+    var code = e.keyCode || e.which;
+
+    switch (code) {
       case keys.left:
         Plugin.call($(this), 'navigateTabLeft')
         break;

--- a/src/Bootstrap/js/tab.js
+++ b/src/Bootstrap/js/tab.js
@@ -166,19 +166,26 @@
   // TAB DATA-API
   // ============
 
+  var keys = {
+    left: 37,
+    right: 39,
+    up: 38,
+    down: 40
+  }
+
   var clickHandler = function (e) {
     e.preventDefault()
     Plugin.call($(this), 'show')
   }
 
-  var keyDownHandler = function (e) {
+  var keyUpHandler = function (e) {
     e.preventDefault()
 
     switch (e.keyCode) {
-      case 37: // left arrow key
+      case keys.left:
         Plugin.call($(this), 'navigateTabLeft')
         break;
-      case 39: // right arrow key
+      case keys.right:
         Plugin.call($(this), 'navigateTabRight')
         break;
     }
@@ -187,6 +194,6 @@
   $(document)
     .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
     .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
-    .on('keydown', '[data-toggle="tab"]', keyDownHandler)
+    .on('keyup', '[data-toggle="tab"]', keyUpHandler)
 
 }(jQuery);

--- a/src/Bootstrap/js/tab.js
+++ b/src/Bootstrap/js/tab.js
@@ -76,12 +76,14 @@
         .removeClass('active')
         .end()
         .find('[data-toggle="tab"]')
+          .attr('tabindex', "-1")
           .attr('aria-expanded', false)
           .attr('aria-selected', false)
 
       element
         .addClass('active')
         .find('[data-toggle="tab"]')
+          .attr('tabindex', "0")
           .attr('aria-expanded', true)
           .attr('aria-selected', true)
 
@@ -113,6 +115,25 @@
     $active.removeClass('in')
   }
 
+  Tab.prototype.navigateTabLeft = function () {
+    var $this = this.element
+
+    if ($this.parent('li').is($this.closest('ul').children().first())) return
+
+    var $target = $this.parent('li').prev().children('a')[0]
+
+    $target.focus()
+  }
+
+  Tab.prototype.navigateTabRight = function () {
+    var $this = this.element
+
+    if ($this.parent('li').is($this.closest('ul').children().last())) return
+
+    var $target = $this.parent('li').next().children('a')[0]
+
+    $target.focus()
+  }
 
   // TAB PLUGIN DEFINITION
   // =====================
@@ -150,8 +171,22 @@
     Plugin.call($(this), 'show')
   }
 
+  var keyUpHandler = function (e) {
+    e.preventDefault()
+
+    switch (e.keyCode) {
+      case 37: // left arrow key
+        Plugin.call($(this), 'navigateTabLeft')
+        break;
+      case 39: // right arrow key
+        Plugin.call($(this), 'navigateTabRight')
+        break;
+    }
+  }
+
   $(document)
     .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
     .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
+    .on('keyup', '[data-toggle="tab"]', keyUpHandler)
 
 }(jQuery);

--- a/src/Bootstrap/js/tab.js
+++ b/src/Bootstrap/js/tab.js
@@ -171,7 +171,7 @@
     Plugin.call($(this), 'show')
   }
 
-  var keyUpHandler = function (e) {
+  var keyDownHandler = function (e) {
     e.preventDefault()
 
     switch (e.keyCode) {
@@ -187,6 +187,6 @@
   $(document)
     .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
     .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
-    .on('keyup', '[data-toggle="tab"]', keyUpHandler)
+    .on('keydown', '[data-toggle="tab"]', keyDownHandler)
 
 }(jQuery);

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -168,7 +168,7 @@
     <li role="presentation" class="@(active ? "active" : string.Empty)">
         <a href="#@packageManager.Id" aria-expanded="@(active ? "true" : "false")"
            id="@packageManager.Id-tab" class="package-manager-tab"
-           aria-selected="@(active ? "true" : "false")"
+           aria-selected="@(active ? "true" : "false")" tabindex="@(active ? "0" : "-1")"
            aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
            title="Switch to tab panel which contains package installation command for @packageManager.Name">
             @packageManager.Name
@@ -515,7 +515,8 @@
                                class="body-tab"
                                aria-controls="readme-tab"
                                aria-expanded="@(activeBodyTab == "readme" ? "true" : "false")"
-                               aria-selected="@(activeBodyTab == "readme" ? "true" : "false")">
+                               aria-selected="@(activeBodyTab == "readme" ? "true" : "false")"
+                               tabindex="@(activeBodyTab == "readme" ? "0" : "-1")">
                                 <i class="ms-Icon ms-Icon--Dictionary" aria-hidden="true"></i>
                                 README
                             </a>
@@ -532,7 +533,8 @@
                                 class="body-tab"
                                 aria-controls="supportedframeworks-tab"
                                 aria-expanded="@(activeBodyTab == "supportedframeworks" ? "true" : "false")"
-                                aria-selected="@(activeBodyTab == "supportedframeworks" ? "true" : "false")">
+                                aria-selected="@(activeBodyTab == "supportedframeworks" ? "true" : "false")"
+                                tabindex="@(activeBodyTab == "supportedframeworks" ? "0" : "-1")">
                                 <i class="ms-Icon ms-Icon--Package" aria-hidden="true"></i>
                                 Frameworks
                             </a>
@@ -548,7 +550,8 @@
                                class="body-tab"
                                aria-controls="dependencies-tab"
                                aria-expanded="@(activeBodyTab == "dependencies" ? "true" : "false")"
-                               aria-selected="@(activeBodyTab == "dependencies" ? "true" : "false")">
+                               aria-selected="@(activeBodyTab == "dependencies" ? "true" : "false")"
+                               tabindex="@(activeBodyTab == "dependencies" ? "0" : "-1")">
                                 <i class="ms-Icon ms-Icon--Packages" aria-hidden="true"></i>
                                 Dependencies
                             </a>
@@ -566,7 +569,8 @@
                                class="body-tab"
                                aria-controls="usedby-tab"
                                aria-expanded="@(activeBodyTab == "usedby" ? "true" : "false")"
-                               aria-selected="@(activeBodyTab == "usedby" ? "true" : "false")">
+                               aria-selected="@(activeBodyTab == "usedby" ? "true" : "false")"
+                               tabindex="@(activeBodyTab == "usedby" ? "0" : "-1")">
                                 <i class="ms-Icon ms-Icon--BranchFork2" aria-hidden="true"></i>
                                 Used By
                             </a>
@@ -582,7 +586,8 @@
                            class="body-tab"
                            aria-controls="versions-tab"
                            aria-expanded="@(activeBodyTab == "versions" ? "true" : "false")"
-                           aria-selected="@(activeBodyTab == "versions" ? "true" : "false")">
+                           aria-selected="@(activeBodyTab == "versions" ? "true" : "false")"
+                           tabindex="@(activeBodyTab == "versions" ? "0" : "-1")">
                             <i class="ms-Icon ms-Icon--Stopwatch" aria-hidden="true"></i>
                             Versions
                         </a>
@@ -592,7 +597,15 @@
                     {
                         activeBodyTab = activeBodyTab ?? "releasenotes";
                         <li role="presentation">
-                            <a href="#releasenotes-tab" aria-controls="releasenotes-tab" role="tab" data-toggle="tab" id="release-body-tab" class="body-tab">
+                            <a href="#releasenotes-tab"
+                               role="tab"
+                               data-toggle="tab"
+                               id="release-body-tab"
+                               class="body-tab"
+                               aria-controls="releasenotes-tab"
+                               aria-expanded="@(activeBodyTab == "releasenotes" ? "true" : "false")"
+                               aria-selected="@(activeBodyTab == "releasenotes" ? "true" : "false")"
+                               tabindex="@(activeBodyTab == "releasenotes" ? "0" : "-1")">
                                 <i class="ms-Icon ms-Icon--ReadingMode" aria-hidden="true"></i>
                                 Release Notes
                             </a>

--- a/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
+++ b/src/NuGetGallery/Views/Packages/_ImportReadMe.cshtml
@@ -3,6 +3,7 @@
     <li role="presentation" class="@(active ? "active" : string.Empty)">
         <a href="#@id" aria-expanded="@(active ? "true" : "false")"
            aria-selected="@(active ? "true" : "false")"
+           tabindex="@(active ? "0" : "-1")"
            aria-controls="@id" role="tab" data-toggle="tab"
            data-source-type="@sourceType"
            data-bind="event: { 'show.bs.tab': OnReadmeTabChange }"


### PR DESCRIPTION
Addresses https://github.com/nuget/nugetgallery/issues/9068

**Problem:**
 
On the Package Details page, tabs are navigated between using the tab key, rather than the left and right arrow keys, as it is supposed to be. This means that once a user has selected a tab, they must still tab navigate through the remaining inactive tabs before they can access the tab content.

**Previously,**
![20220325_182528](https://user-images.githubusercontent.com/82980589/160219270-24b3d6af-42ae-484e-a867-cbae22dbc822.gif)

**Fix:**

I added an event listener for left and right arrow keys, and changed the tab in focus based on the input. I used keyUp as the trigger here rather than keyDown, because adding an event listener for keyDown also messed with other keyboard functionality (eg. 'tab' and 'enter' keys) when focused on the tab element.

To enable this, I also made it such that only the selected/expanded tab has _tabindex="0"_ and receives tab focus sequentially with other elements on the page, while all inactive tabs have _tabindex="-1"_, and can only receive focus when using left/right arrow keys from their active sibling tab. Once a new tab is made active, we set _tabindex="-1"_ on the previous tab, and _tabindex="0"_ on the new active tab.

**After the changes,**
![20220325_181409](https://user-images.githubusercontent.com/82980589/160219028-f8bd7c95-7efc-410a-8d32-3140726d749d.gif)