### PR TITLE
Not using metric identifier to get metric object.

### DIFF
--- a/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryClientWrapper.cs
@@ -63,14 +63,7 @@ namespace NuGetGallery
         {
             try
             {
-                var metricIdentifier = new MetricIdentifier(
-                    metricNamespace: "Gallery",
-                    metricId: metricName,
-                    dimensionNames: new List<string>
-                    {
-                        dimension0Name
-                    });
-                var metric = UnderlyingClient.GetMetric(metricIdentifier);
+                var metric = UnderlyingClient.GetMetric(metricName, dimension0Name);
                 metric.TrackValue(value, dimension0Value);
             }
             catch


### PR DESCRIPTION
Fixes an issue introduced by #8906 

The `metricNamespace` specified in the code overridden the one specified in the configuration and we ended up with metrics reported to the wrong location. This change fixes it.