### PR TITLE
Make sure account and package links on the support requests page use the same host

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-support-requests.js
+++ b/src/NuGetGallery/Scripts/gallery/page-support-requests.js
@@ -210,13 +210,13 @@ var SupportRequestsViewModel = (function () {
 
         this.generateUserProfileUrl = function (supportRequestViewModel) {
             if (supportRequestViewModel.CreatedBy.toUpperCase !== 'ANONYMOUS') {
-                return supportRequestViewModel.SiteRoot + 'Profiles/' + supportRequestViewModel.CreatedBy;
+                return '/Profiles/' + supportRequestViewModel.CreatedBy;
             }
             return '#';
         };
 
         this.generatePackageDetailsUrl = function (supportRequestViewModel) {
-            return supportRequestViewModel.SiteRoot + 'packages/' + supportRequestViewModel.PackageId + '/' + supportRequestViewModel.PackageVersion;
+            return '/packages/' + supportRequestViewModel.PackageId + '/' + supportRequestViewModel.PackageVersion;
         };
 
         this.generateHistoryUrl = function (supportRequestViewModel) {


### PR DESCRIPTION
Admin-only instance in support requests links accounts and packages to the originating host (www.nuget.org) which creates complications for processing support requests.
This change replaces absolute URLs with relative ones that works around the issue.