### PR TITLE
Removing tests that are feature-flag-state-dependent.

### DIFF
--- a/tests/NuGetGallery.FunctionalTests/ErrorHandling/ErrorHandlingTests.cs
+++ b/tests/NuGetGallery.FunctionalTests/ErrorHandling/ErrorHandlingTests.cs
@@ -40,8 +40,6 @@ namespace NuGetGallery.FunctionalTests.ErrorHandling
         [InlineData("/", "__Controller::TempData", "Message=You successfully uploaded z̡̜͍̈̍̐̃̊͋́a̜̣͍̬̞̝͉̽ͧ͗l̸̖͕̤̠̹̘͖̃̌ͤg͓̝͓̰̀ͪo͈͌ 1.0.0.", 400)]
         [InlineData("/", "__Controller::TempData", "Message=<script>alert(1)</script>", 400)]
         [InlineData("/", "__Controller::TempData", "<script>alert(1)</script>", 400)]
-        [InlineData("/packages", "nugetab", "<script>alert(1)</script>", 400)]
-        [InlineData("/packages", "nugetab", "z̡̜͍̈̍̐̃̊͋́a̜̣͍̬̞̝͉̽ͧ͗l̸̖͕̤̠̹̘͖̃̌ͤg͓̝͓̰̀ͪo͈͌", 400)]
         public async Task RejectedCookie(string relativePath, string name, string value, int statusCode)
         {
             // Arrange


### PR DESCRIPTION
`/packages` request produces 400 for the test only if the code path that analyzes the content of `nugetab` cookie is executed (i.e. A/B testing feature flag is enabled). When it is not, the cookie is completely ignored and tests that involve it fail. We don't need that feature flag dependency in tests that are gateway for the deployment, hence the removal.