### PR TITLE
[A11y Bug] Make TFM badges asset and compatible different for high contrast.

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -806,6 +806,16 @@ p.frameworktableinfo-text {
   line-height: 16px;
   margin-top: 10px;
 }
+@media (-ms-high-contrast: active), (forced-colors: active) {
+  .framework-badge-asset {
+    font-weight: bold;
+    border: 2px solid #0078d4;
+    padding: 0px 8px;
+  }
+  .frameworktableinfo-asset-icon {
+    border: 2px solid #0078d4;
+  }
+}
 .user-package-list .manage-package-listing .package-icon {
   max-height: 2em;
   min-width: 20px;

--- a/src/Bootstrap/less/theme/common-supported-frameworks.less
+++ b/src/Bootstrap/less/theme/common-supported-frameworks.less
@@ -91,3 +91,15 @@ p.frameworktableinfo-text {
   .frameworktableinfo-text;
   margin-top: 10px;
 }
+
+@media (-ms-high-contrast: active), (forced-colors: active) {
+  .framework-badge-asset {
+    font-weight: bold;
+    border: 2px solid @badge-dark;
+    padding: 0px 8px;
+  }
+
+  .frameworktableinfo-asset-icon {
+    border: 2px solid @badge-dark;
+  }
+}


### PR DESCRIPTION
## Changes

* When high contrast, badges on table and on badge component now have border and font bolder.
* Compatible target bottom label now has a square icon with bolder border.

## Screenshots
The following are screenshot from different contrast themes on windows 11.

<details>
<summary>Aquathic theme</summary>

### Before

![Aquatic Before](https://user-images.githubusercontent.com/17834924/163901346-d4798121-bd30-4807-8fdb-f88fb7db9c82.png)

### After

![Aquatic](https://user-images.githubusercontent.com/17834924/163901357-249e714e-98bc-4ba8-8385-de4578c5c0ba.png)

</details>

<details>
<summary>Desert theme</summary>

### Before

![Desert Before](https://user-images.githubusercontent.com/17834924/163901466-e20621b5-8aa2-4799-af73-d5e23ee18512.png)

### After

![Desert](https://user-images.githubusercontent.com/17834924/163901473-32bccf06-4268-48e0-acd0-931f7c88f8b3.png)

</details>

<details>
<summary>Dusk theme</summary>

### Before

![Dusk Before](https://user-images.githubusercontent.com/17834924/163901511-1c18158f-449c-4537-ae8e-b3e4e7c55cf6.png)

### After

![Dusk](https://user-images.githubusercontent.com/17834924/163901535-639fbe29-1016-42fd-a657-b28e56f4d0bf.png)

</details>

<details>
<summary>Night Sky theme</summary>

### Before

![Night Sky Before](https://user-images.githubusercontent.com/17834924/163901568-959bc723-21d5-4678-b5f4-8b8055863f96.png)

### After

![Night Sky](https://user-images.githubusercontent.com/17834924/163901583-9dd0049a-c3bd-4b4b-82d3-99fa322f1097.png)

</details>

## Addresses
https://github.com/nuget/engineering/issues/4347