### PR TITLE
[A11y Bug] TFM remove role button from badges.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -484,14 +484,13 @@
             popoverElement.popover('show');
 
             // Windows Narrator does not announce popovers' content. See: https://github.com/twbs/bootstrap/issues/18618
-            // We can force Narrator to announce the popover's content by "flashing"
-            // the copy button's ARIA label.
+            // We can force Narrator to announce the popover's content by "flashing" the element's ARIA label.
             popoverElementDom.ariaLabel = "";
 
             setTimeout(function () {
                 popoverElement.popover('hide');
 
-                // We need to restore the copy button's original ARIA label.
+                // We need to restore the element's original ARIA label.
                 // Wait 0.15 seconds for the popover to fade away first.
                 // Otherwise, the screen reader will re-announce the popover's content.
                 setTimeout(function () {

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -305,7 +305,7 @@
             if (e) {
                 e.stopPropagation();
                 e.preventDefault();
-            }            
+            }
             return false;
         }
 
@@ -377,12 +377,10 @@
     nuget.addAjaxAntiForgeryToken = function (data) {
         var $tokenKey = "__RequestVerificationToken";
         var $field = $("#AntiForgeryForm input[name=__RequestVerificationToken]");
-        if (data instanceof FormData)
-        {
+        if (data instanceof FormData) {
             data.append($tokenKey, $field.val());
         }
-        else
-        {
+        else {
             data["__RequestVerificationToken"] = $field.val();
         }
         return data;
@@ -464,14 +462,14 @@
 
     nuget.setPopovers = function () {
         var popoverElement = $(this);
-        popoverElement.popover({ trigger: 'hover focus' });
-        popoverElement.click(function () {
-            popoverElement.popover('show');
-            setTimeout(function () {
-                    popoverElement.popover('hide');
-                },
-                2000);
-        });
+        var popoverElementDom = popoverElement.get(0);
+        var originalLabel = popoverElementDom.ariaLabel;
+        var popoverHideTimeMS = 2000;
+        var popoverFadeTimeMS = 200;
+
+        popoverElement.popover({ trigger: 'hover' });
+        popoverElement.click(popoverShowAndHide);
+        popoverElement.focus(popoverShowAndHide);
         popoverElement.keyup(function (event) {
             // normalize keycode for browser compatibility
             var code = event.which || event.keyCode || event.charCode;
@@ -481,6 +479,26 @@
                 popoverElement.popover('hide');
             }
         });
+
+        function popoverShowAndHide() {
+            popoverElement.popover('show');
+
+            // Windows Narrator does not announce popovers' content. See: https://github.com/twbs/bootstrap/issues/18618
+            // We can force Narrator to announce the popover's content by "flashing"
+            // the copy button's ARIA label.
+            popoverElementDom.ariaLabel = "";
+
+            setTimeout(function () {
+                popoverElement.popover('hide');
+
+                // We need to restore the copy button's original ARIA label.
+                // Wait 0.15 seconds for the popover to fade away first.
+                // Otherwise, the screen reader will re-announce the popover's content.
+                setTimeout(function () {
+                    popoverElementDom.ariaLabel = originalLabel;
+                }, popoverFadeTimeMS);
+            }, popoverHideTimeMS);
+        }
     };
 
     window.nuget = nuget;

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -6,39 +6,39 @@
     @if (Model.Net != null)
     {
         <!-- .NET cannot be an empty version since the lowest version for this framework is "net5.0", if the package contains just "net" framework it will fall into .NET Framework badge instead.' -->
-        <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.GetBadgeVersion()</span>
+        <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.GetBadgeVersion()</span>
     }
     @if (Model.NetCore != null)
     {
         if (Model.NetCore.GetBadgeVersion().IsEmpty())
         {
-            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
+            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
         }
         else
         {
-            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.GetBadgeVersion()</span>
+            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.GetBadgeVersion()</span>
         }
     }
     @if (Model.NetStandard != null)
     {
         if (Model.NetStandard.GetBadgeVersion().IsEmpty())
         {
-            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
+            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
         }
         else
         {
-            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.GetBadgeVersion()</span>
+            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.GetBadgeVersion()</span>
         }
     }
     @if (Model.NetFramework != null)
     {
         if (Model.NetFramework.GetBadgeVersion().IsEmpty())
         {
-            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
+            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
         }
         else
         {
-            <span class="framework-badge-asset" role="button" tabindex="0" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.GetBadgeVersion()</span>
+            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.GetBadgeVersion()</span>
         }
     }
 </div>


### PR DESCRIPTION
## Changes
* `role="button"` removed from badges.
* Added aria-label to badges for screen reader.
* Fixed screen reader not announcing popover content on focus/click.

## Addresses
https://github.com/nuget/engineering/issues/4352