### PR TITLE
[A11y Bug] Remove focus from non-interactive elements on TFM badge and table.

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -241,10 +241,10 @@
                                     src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) && Model.ShowDetailsAndLinks ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
                         </span>
-                        <span class="title" tabindex="0">
+                        <span class="title">
                             @Html.BreakWord(Model.Id)
                         </span>
-                        <span class="version-title" tabindex="0">
+                        <span class="version-title">
                             @Model.Version
                         </span>
                         @if (Model.IsVerified.HasValue && Model.IsVerified.Value)

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -6,39 +6,39 @@
     @if (Model.Net != null)
     {
         <!-- .NET cannot be an empty version since the lowest version for this framework is "net5.0", if the package contains just "net" framework it will fall into .NET Framework badge instead.' -->
-        <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.GetBadgeVersion()</span>
+        <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.GetBadgeVersion()</span>
     }
     @if (Model.NetCore != null)
     {
         if (Model.NetCore.GetBadgeVersion().IsEmpty())
         {
-            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
+            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
         }
         else
         {
-            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.GetBadgeVersion()</span>
+            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.GetBadgeVersion()</span>
         }
     }
     @if (Model.NetStandard != null)
     {
         if (Model.NetStandard.GetBadgeVersion().IsEmpty())
         {
-            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
+            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
         }
         else
         {
-            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.GetBadgeVersion()</span>
+            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.GetBadgeVersion()</span>
         }
     }
     @if (Model.NetFramework != null)
     {
         if (Model.NetFramework.GetBadgeVersion().IsEmpty())
         {
-            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
+            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
         }
         else
         {
-            <span class="framework-badge-asset" tabindex="0" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.GetBadgeVersion()</span>
+            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.GetBadgeVersion()</span>
         }
     }
 </div>

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
@@ -12,7 +12,7 @@
             if (compatibilityFramework.Value.Count > 0)
             {
                 <tr>
-                    <td class="framework-table-product" tabindex="0">
+                    <td class="framework-table-product">
                         @compatibilityFramework.Key
                     </td>
 
@@ -21,11 +21,11 @@
                         {
                             if (frameworkVersion.IsComputed)
                             {
-                                <span class="framework-badge-computed framework-table-margin" tabindex="0">@frameworkVersion.Framework.GetShortFolderName()</span>
+                                <span class="framework-badge-computed framework-table-margin">@frameworkVersion.Framework.GetShortFolderName()</span>
                             }
                             else
                             {
-                                <span class="framework-badge-asset framework-table-margin" tabindex="0">@frameworkVersion.Framework.GetShortFolderName()</span>
+                                <span class="framework-badge-asset framework-table-margin">@frameworkVersion.Framework.GetShortFolderName()</span>
                             }
                         }
                     </td>


### PR DESCRIPTION
### Changes
* `tabindex="0"` removed from package title, version, tfm badges, and tfm table.

### Addresses 
https://github.com/nuget/engineering/issues/4351