### PR TITLE
Mark backup folders as private

### DIFF
--- a/src/NuGetGallery.Core/Services/GalleryCloudBlobContainerInformationProvider.cs
+++ b/src/NuGetGallery.Core/Services/GalleryCloudBlobContainerInformationProvider.cs
@@ -11,10 +11,8 @@ namespace NuGetGallery
     {
         private static readonly HashSet<string> KnownPublicFolders = new HashSet<string> {
             CoreConstants.Folders.PackagesFolderName,
-            CoreConstants.Folders.PackageBackupsFolderName,
             CoreConstants.Folders.DownloadsFolderName,
             CoreConstants.Folders.SymbolPackagesFolderName,
-            CoreConstants.Folders.SymbolPackageBackupsFolderName,
             CoreConstants.Folders.FlatContainerFolderName,
         };
 
@@ -27,6 +25,8 @@ namespace NuGetGallery
             CoreConstants.Folders.RevalidationFolderName,
             CoreConstants.Folders.StatusFolderName,
             CoreConstants.Folders.PackagesContentFolderName,
+            CoreConstants.Folders.PackageBackupsFolderName,
+            CoreConstants.Folders.SymbolPackageBackupsFolderName,
         };
 
         public string GetCacheControl(string folderName)


### PR DESCRIPTION
They are already set as private in Blob Storage. There is no known scenario that needs public (unauthenticated) access to these blobs.