### PR TITLE
Support emphasis

### DIFF
--- a/src/NuGetGallery/Services/MarkdownService.cs
+++ b/src/NuGetGallery/Services/MarkdownService.cs
@@ -204,7 +204,7 @@ namespace NuGetGallery
                 .UseEmojiAndSmiley()
                 .UseAutoLinks()
                 .UseReferralLinks("noopener noreferrer nofollow")
-                .UseEmphasisExtras()
+                .UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
                 .DisableHtml() //block inline html
                 .UseBootstrap()
                 .Build();

--- a/src/NuGetGallery/Services/MarkdownService.cs
+++ b/src/NuGetGallery/Services/MarkdownService.cs
@@ -11,6 +11,7 @@ using System.Web;
 using CommonMark;
 using CommonMark.Syntax;
 using Markdig;
+using Markdig.Extensions.EmphasisExtras;
 using Markdig.Parsers;
 using Markdig.Renderers;
 using Markdig.Syntax;
@@ -203,6 +204,7 @@ namespace NuGetGallery
                 .UseEmojiAndSmiley()
                 .UseAutoLinks()
                 .UseReferralLinks("noopener noreferrer nofollow")
+                .UseEmphasisExtras()
                 .DisableHtml() //block inline html
                 .UseBootstrap()
                 .Build();

--- a/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
@@ -234,6 +234,21 @@ Some text
                 Assert.Equal(expectedHtml, readMeResult.Content);
                 Assert.False(readMeResult.ImagesRewritten);
             }
+
+            [Theory]
+            [InlineData("Hello ~~world~~", "<p>Hello <del>world</del></p>")]
+            [InlineData("H~2~O is a liquid. 2^10^ is 1024", "<p>H<sub>2</sub>O is a liquid. 2<sup>10</sup> is 1024</p>")]
+            [InlineData("Daggers^†^ and double-daggers^‡^ can be used to denote notes.", "<p>Daggers<sup>†</sup> and double-daggers<sup>‡</sup> can be used to denote notes.</p>")]
+            [InlineData("++Inserted text++", "<p><ins>Inserted text</ins></p>")]
+            [InlineData("==Marked text==", "<p><mark>Marked text</mark></p>")]
+            [InlineData("This is text MyBrand~&reg;~ and MyCopyright^&copy;^", "<p>This is text MyBrand<sub>®</sub> and MyCopyright<sup>©</sup></p>")]
+            public void TestToHtmlWithStrikethrough(string originalMd, string expectedHtml)
+            {
+                _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(true);
+                var readMeResult = _markdownService.GetHtmlFromMarkdown(originalMd);
+                Assert.Equal(expectedHtml, readMeResult.Content);
+                Assert.False(readMeResult.ImagesRewritten);
+            }
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
@@ -237,11 +237,6 @@ Some text
 
             [Theory]
             [InlineData("Hello ~~world~~", "<p>Hello <del>world</del></p>")]
-            [InlineData("H~2~O is a liquid. 2^10^ is 1024", "<p>H<sub>2</sub>O is a liquid. 2<sup>10</sup> is 1024</p>")]
-            [InlineData("Daggers^†^ and double-daggers^‡^ can be used to denote notes.", "<p>Daggers<sup>†</sup> and double-daggers<sup>‡</sup> can be used to denote notes.</p>")]
-            [InlineData("++Inserted text++", "<p><ins>Inserted text</ins></p>")]
-            [InlineData("==Marked text==", "<p><mark>Marked text</mark></p>")]
-            [InlineData("This is text MyBrand~&reg;~ and MyCopyright^&copy;^", "<p>This is text MyBrand<sub>®</sub> and MyCopyright<sup>©</sup></p>")]
             public void TestToHtmlWithStrikethrough(string originalMd, string expectedHtml)
             {
                 _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(true);


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Support
strike through ~~,


Before change: 
![Before](https://user-images.githubusercontent.com/64443925/172444378-b676f045-f1ad-497f-b9fa-69596c144162.png)



After change: 

![emphasis](https://user-images.githubusercontent.com/64443925/172444388-57fe1f1c-8a86-402e-ba12-8ab11b7d4b7f.png)


Addresses https://github.com/NuGet/NuGetGallery/issues/8726