### PR TITLE
Remove the trailing slash when formatting the tab fragment

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -161,7 +161,7 @@
             storage.setItem(bodyStorageKey, e.target.id);
         }
 
-        window.history.replaceState("", "", window.location.pathname.replace(/\/$/, "") + "#" + e.target.id);
+        window.history.replaceState("", "", "#" + e.target.id);
 
         clampUsedByDescriptions();
 

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -161,7 +161,7 @@
             storage.setItem(bodyStorageKey, e.target.id);
         }
 
-        window.history.replaceState("", "", "#" + e.target.id);
+        window.history.replaceState("", "", window.location.pathname.replace(/\/$/, "") + "#" + e.target.id);
 
         clampUsedByDescriptions();
 

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -37,7 +37,7 @@
         <div class="col-sm-11">
             <div class="package-header">
                 <a class="package-title"
-                   href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null)"
+                   href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null).TrimEnd('/')"
                    @if (itemIndex.HasValue)
                    {
                        @:data-track="@eventName" data-track-value="@itemIndex"


### PR DESCRIPTION
The search result may point to a URL like this:
https://dev.nugettest.org/packages/Newtonsoft.Json/

The existing approach appends the tab fragment like this:
https://dev.nugettest.org/packages/Newtonsoft.Json/#versions-body-tab

This is to remove the trailing slash when formatting the tab fragment:
https://dev.nugettest.org/packages/Newtonsoft.Json#versions-body-tab