### PR TITLE
[2FA] Disable nuget.org password login

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -86,7 +86,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public bool IsEmailLoggingEnabled()
+        public bool IsEmailLoginEnabled()
         {
             throw new NotImplementedException();
         }

--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -86,6 +86,11 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
+        public bool IsEmailLoggingEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsForceFlatContainerIconsEnabled()
         {
             throw new NotImplementedException();

--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -86,7 +86,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public bool IsEmailLoginEnabled()
+        public bool IsNuGetAccountPasswordLoginUnsupportedEnabled()
         {
             throw new NotImplementedException();
         }

--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -86,7 +86,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public bool IsNuGetAccountPasswordLoginUnsupportedEnabled()
+        public bool IsNuGetAccountPasswordLoginEnabled()
         {
             throw new NotImplementedException();
         }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -280,7 +280,7 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
-        public bool IsEmailLoggingEnabled()
+        public bool IsEmailLoginEnabled()
         {
             throw new NotImplementedException();
         }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -279,5 +279,10 @@ namespace GitHubVulnerabilities2Db.Fakes
         {
             throw new NotImplementedException();
         }
+
+        public bool IsEmailLoggingEnabled()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -280,7 +280,7 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
-        public bool IsNuGetAccountPasswordLoginUnsupportedEnabled()
+        public bool IsNuGetAccountPasswordLoginEnabled()
         {
             throw new NotImplementedException();
         }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -280,7 +280,7 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
-        public bool IsEmailLoginEnabled()
+        public bool IsNuGetAccountPasswordLoginUnsupportedEnabled()
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Core/Auditing/AuditedAuthenticatedOperationAction.cs
+++ b/src/NuGetGallery.Core/Auditing/AuditedAuthenticatedOperationAction.cs
@@ -28,6 +28,11 @@ namespace NuGetGallery.Auditing
         /// <summary>
         /// Symbol package push was attempted by a non-owner of the package
         /// </summary>
-        SymbolsPackagePushAttemptByNonOwner
+        SymbolsPackagePushAttemptByNonOwner,
+
+        /// <summary>
+        /// User attempted to login when password login is unsupported
+        /// </summary>
+        PasswordLoginUnsupported
     }
 }

--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -33,6 +33,7 @@ namespace NuGetGallery.Authentication
         private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IContentObjectService _contentObjectService;
         private readonly ITelemetryService _telemetryService;
+        private readonly IFeatureFlagService _featureFlagService;
 
         /// <summary>
         /// This ctor is used for test only.
@@ -48,7 +49,7 @@ namespace NuGetGallery.Authentication
             IEntitiesContext entities, IAppConfiguration config, IDiagnosticsService diagnostics,
             IAuditingService auditing, IEnumerable<Authenticator> providers, ICredentialBuilder credentialBuilder,
             ICredentialValidator credentialValidator, IDateTimeProvider dateTimeProvider, ITelemetryService telemetryService,
-            IContentObjectService contentObjectService)
+            IContentObjectService contentObjectService, IFeatureFlagService featureFlagService)
         {
             InitCredentialFormatters();
 
@@ -62,6 +63,7 @@ namespace NuGetGallery.Authentication
             _dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _contentObjectService = contentObjectService ?? throw new ArgumentNullException(nameof(contentObjectService));
+            _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
         }
 
         public IEntitiesContext Entities { get; private set; }
@@ -82,6 +84,18 @@ namespace NuGetGallery.Authentication
             using (_trace.Activity("Authenticate"))
             {
                 var user = FindByUserNameOrEmail(userNameOrEmail);
+
+                if (!_featureFlagService.IsNuGetAccountPasswordLoginEnabled() &&
+                !_contentObjectService.LoginDiscontinuationConfiguration.IsUserOnExceptionsList(user))
+                {
+                    _trace.Information("Password login unsupported.");
+
+                    await Auditing.SaveAuditRecordAsync(
+                        new FailedAuthenticatedOperationAuditRecord(
+                            userNameOrEmail, AuditedAuthenticatedOperationAction.PasswordLoginUnsupported));
+                    
+                    return new PasswordAuthenticationResult(PasswordAuthenticationResult.AuthenticationResult.PasswordLoginUnsupported);
+                }
 
                 // Check if the user exists
                 if (user == null)

--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -86,7 +86,7 @@ namespace NuGetGallery.Authentication
                 var user = FindByUserNameOrEmail(userNameOrEmail);
 
                 if (!_featureFlagService.IsNuGetAccountPasswordLoginEnabled() &&
-                !_contentObjectService.LoginDiscontinuationConfiguration.IsUserOnExceptionsList(user))
+                !_contentObjectService.LoginDiscontinuationConfiguration.IsEmailOnExceptionsList(userNameOrEmail))
                 {
                     _trace.Information("Password login unsupported.");
 

--- a/src/NuGetGallery.Services/Authentication/PasswordAuthenticationResult.cs
+++ b/src/NuGetGallery.Services/Authentication/PasswordAuthenticationResult.cs
@@ -8,6 +8,7 @@ namespace NuGetGallery.Authentication
         public enum AuthenticationResult
         {
             AccountLocked, // The account is locked
+            PasswordLoginUnsupported, // Password login is not supported
             BadCredentials, // Bad user name or password provided
             Success // All good
         }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -372,7 +372,7 @@ namespace NuGetGallery
 
         public bool IsEmailLoginEnabled()
         {
-            return _client.IsEnabled(EmailLoginFeatureName, defaultValue: false);
+            return _client.IsEnabled(EmailLoginFeatureName, defaultValue: true);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -54,7 +54,7 @@ namespace NuGetGallery
         private const string ComputeTargetFrameworkFeatureName = GalleryPrefix + "ComputeTargetFramework";
         private const string RecentPackagesNoIndexFeatureName = GalleryPrefix + "RecentPackagesNoIndex";
         private const string NewAccount2FAEnforcementFeatureName = GalleryPrefix + "NewAccount2FAEnforcement";
-        private const string EmailLoginFeatureName = GalleryPrefix + "EmailLogin";
+        private const string NuGetAccountPasswordLoginUnsupportedFeatureName = GalleryPrefix + "NuGetAccountPasswordLoginUnsupported";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -370,9 +370,9 @@ namespace NuGetGallery
             return _client.IsEnabled(NewAccount2FAEnforcementFeatureName, defaultValue: false);
         }
 
-        public bool IsEmailLoginEnabled()
+        public bool IsNuGetAccountPasswordLoginUnsupportedEnabled()
         {
-            return _client.IsEnabled(EmailLoginFeatureName, defaultValue: true);
+            return _client.IsEnabled(NuGetAccountPasswordLoginUnsupportedFeatureName, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -54,7 +54,7 @@ namespace NuGetGallery
         private const string ComputeTargetFrameworkFeatureName = GalleryPrefix + "ComputeTargetFramework";
         private const string RecentPackagesNoIndexFeatureName = GalleryPrefix + "RecentPackagesNoIndex";
         private const string NewAccount2FAEnforcementFeatureName = GalleryPrefix + "NewAccount2FAEnforcement";
-        private const string NuGetAccountPasswordLoginUnsupportedFeatureName = GalleryPrefix + "NuGetAccountPasswordLoginUnsupported";
+        private const string NuGetAccountPasswordLoginFeatureName = GalleryPrefix + "NuGetAccountPasswordLogin";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -370,9 +370,9 @@ namespace NuGetGallery
             return _client.IsEnabled(NewAccount2FAEnforcementFeatureName, defaultValue: false);
         }
 
-        public bool IsNuGetAccountPasswordLoginUnsupportedEnabled()
+        public bool IsNuGetAccountPasswordLoginEnabled()
         {
-            return _client.IsEnabled(NuGetAccountPasswordLoginUnsupportedFeatureName, defaultValue: false);
+            return _client.IsEnabled(NuGetAccountPasswordLoginFeatureName, defaultValue: true);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -54,7 +54,7 @@ namespace NuGetGallery
         private const string ComputeTargetFrameworkFeatureName = GalleryPrefix + "ComputeTargetFramework";
         private const string RecentPackagesNoIndexFeatureName = GalleryPrefix + "RecentPackagesNoIndex";
         private const string NewAccount2FAEnforcementFeatureName = GalleryPrefix + "NewAccount2FAEnforcement";
-        private const string EmailLoggingFeatureName = GalleryPrefix + "EmailLogging";
+        private const string EmailLoginFeatureName = GalleryPrefix + "EmailLogin";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -370,9 +370,9 @@ namespace NuGetGallery
             return _client.IsEnabled(NewAccount2FAEnforcementFeatureName, defaultValue: false);
         }
 
-        public bool IsEmailLoggingEnabled()
+        public bool IsEmailLoginEnabled()
         {
-            return _client.IsEnabled(EmailLoggingFeatureName, defaultValue: false);
+            return _client.IsEnabled(EmailLoginFeatureName, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -54,6 +54,7 @@ namespace NuGetGallery
         private const string ComputeTargetFrameworkFeatureName = GalleryPrefix + "ComputeTargetFramework";
         private const string RecentPackagesNoIndexFeatureName = GalleryPrefix + "RecentPackagesNoIndex";
         private const string NewAccount2FAEnforcementFeatureName = GalleryPrefix + "NewAccount2FAEnforcement";
+        private const string EmailLoggingFeatureName = GalleryPrefix + "EmailLogging";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -367,6 +368,11 @@ namespace NuGetGallery
         public bool IsNewAccount2FAEnforcementEnabled()
         {
             return _client.IsEnabled(NewAccount2FAEnforcementFeatureName, defaultValue: false);
+        }
+
+        public bool IsEmailLoggingEnabled()
+        {
+            return _client.IsEnabled(EmailLoggingFeatureName, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -296,5 +296,10 @@ namespace NuGetGallery
         /// Whether or not to enforce 2FA for new external account link or replacement.
         /// </summary>
         bool IsNewAccount2FAEnforcementEnabled();
+
+        /// <summary>
+        /// Whether or not email login is accepted. Accounts in the exception list will always be accepted.
+        /// </summary>
+        bool IsEmailLoggingEnabled();
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -300,6 +300,6 @@ namespace NuGetGallery
         /// <summary>
         /// Whether or not email login is accepted. Accounts in the exception list will always be accepted.
         /// </summary>
-        bool IsEmailLoggingEnabled();
+        bool IsEmailLoginEnabled();
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using NuGet.Services.Entities;
+using System.Collections.Generic;
 
 namespace NuGetGallery
 {
@@ -177,7 +177,7 @@ namespace NuGetGallery
         /// Whether the user is able to publish the package with an embedded readme file.
         /// </summary>
         bool AreEmbeddedReadmesEnabled(User user);
-        
+
         /// <summary>
         /// Whether the /Packages() endpoint is enabled for the V1 OData API.
         /// </summary>
@@ -262,7 +262,7 @@ namespace NuGetGallery
         /// Whether rendering Markdown content to HTML using Markdig is enabled
         /// </summary>
         bool IsMarkdigMdRenderingEnabled();
-        
+
         /// Whether or not the user can delete a package through the API.
         /// </summary>
         bool IsDeletePackageApiEnabled(User user);
@@ -276,7 +276,7 @@ namespace NuGetGallery
         /// Whether or not display the banner on nuget.org
         /// </summary>
         bool IsDisplayBannerEnabled();
-        
+
         /// <summary>
         /// Whether or not display target framework badges and table on nuget.org
         /// </summary>
@@ -298,8 +298,8 @@ namespace NuGetGallery
         bool IsNewAccount2FAEnforcementEnabled();
 
         /// <summary>
-        /// Whether or not email login is accepted. Accounts in the exception list will always be accepted.
+        /// Whether or not NuGet.org password login is unsupported. NuGet.org accounts in the <see cref="LoginDiscontinuationConfiguration.ExceptionsForEmailAddresses"/> will always be supported.
         /// </summary>
-        bool IsEmailLoginEnabled();
+        bool IsNuGetAccountPasswordLoginUnsupportedEnabled();
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using NuGet.Services.Entities;
 using System.Collections.Generic;
+using NuGet.Services.Entities;
 
 namespace NuGetGallery
 {
@@ -298,8 +298,8 @@ namespace NuGetGallery
         bool IsNewAccount2FAEnforcementEnabled();
 
         /// <summary>
-        /// Whether or not NuGet.org password login is unsupported. NuGet.org accounts in the <see cref="LoginDiscontinuationConfiguration.ExceptionsForEmailAddresses"/> will always be supported.
+        /// Whether or not NuGet.org password login is supported. NuGet.org accounts in the <see cref="LoginDiscontinuationConfiguration.ExceptionsForEmailAddresses"/> will always be supported.
         /// </summary>
-        bool IsNuGetAccountPasswordLoginUnsupportedEnabled();
+        bool IsNuGetAccountPasswordLoginEnabled();
     }
 }

--- a/src/NuGetGallery.Services/Configuration/ILoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/ILoginDiscontinuationConfiguration.cs
@@ -13,6 +13,6 @@ namespace NuGetGallery
         bool IsUserOnWhitelist(User user);
         bool ShouldUserTransformIntoOrganization(User user);
         bool IsTenantIdPolicySupportedForOrganization(string emailAddress, string tenantId);
-        bool IsUserOnExceptionsForEmailAddress(User user);
+        bool IsUserOnExceptionsList(User user);
     }
 }

--- a/src/NuGetGallery.Services/Configuration/ILoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/ILoginDiscontinuationConfiguration.cs
@@ -13,6 +13,6 @@ namespace NuGetGallery
         bool IsUserOnWhitelist(User user);
         bool ShouldUserTransformIntoOrganization(User user);
         bool IsTenantIdPolicySupportedForOrganization(string emailAddress, string tenantId);
-        bool IsUserOnExceptionsList(User user);
+        bool IsEmailOnExceptionsList(string emailAddress);
     }
 }

--- a/src/NuGetGallery.Services/Configuration/ILoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/ILoginDiscontinuationConfiguration.cs
@@ -13,5 +13,6 @@ namespace NuGetGallery
         bool IsUserOnWhitelist(User user);
         bool ShouldUserTransformIntoOrganization(User user);
         bool IsTenantIdPolicySupportedForOrganization(string emailAddress, string tenantId);
+        bool IsUserEmailOnExceptionsForEmailAddress(User user);
     }
 }

--- a/src/NuGetGallery.Services/Configuration/ILoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/ILoginDiscontinuationConfiguration.cs
@@ -13,6 +13,6 @@ namespace NuGetGallery
         bool IsUserOnWhitelist(User user);
         bool ShouldUserTransformIntoOrganization(User user);
         bool IsTenantIdPolicySupportedForOrganization(string emailAddress, string tenantId);
-        bool IsUserEmailOnExceptionsForEmailAddress(User user);
+        bool IsUserOnExceptionsForEmailAddress(User user);
     }
 }

--- a/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
@@ -104,6 +104,17 @@ namespace NuGetGallery
         {
             return IsPasswordDiscontinuedForAll;
         }
+
+        public bool IsUserEmailOnExceptionsForEmailAddress(User user)
+        {
+            if (user == null)
+            {
+                return false;
+            }
+
+            var email = user.ToMailAddress();
+            return ExceptionsForEmailAddresses.Contains(email.Address);
+        }
     }
 
     public class OrganizationTenantPair : IEquatable<OrganizationTenantPair>

--- a/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
@@ -105,15 +105,14 @@ namespace NuGetGallery
             return IsPasswordDiscontinuedForAll;
         }
 
-        public bool IsUserOnExceptionsList(User user)
+        public bool IsEmailOnExceptionsList(string emailAddress)
         {
-            if (user == null)
+            if (string.IsNullOrEmpty(emailAddress))
             {
                 return false;
             }
 
-            var email = user.ToMailAddress();
-            return ExceptionsForEmailAddresses.Contains(email.Address);
+            return ExceptionsForEmailAddresses.Contains(emailAddress);
         }
     }
 

--- a/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
@@ -105,7 +105,7 @@ namespace NuGetGallery
             return IsPasswordDiscontinuedForAll;
         }
 
-        public bool IsUserEmailOnExceptionsForEmailAddress(User user)
+        public bool IsUserOnExceptionsForEmailAddress(User user)
         {
             if (user == null)
             {

--- a/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
@@ -105,7 +105,7 @@ namespace NuGetGallery
             return IsPasswordDiscontinuedForAll;
         }
 
-        public bool IsUserOnExceptionsForEmailAddress(User user)
+        public bool IsUserOnExceptionsList(User user)
         {
             if (user == null)
             {

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -33,7 +33,7 @@
     "NuGetGallery.ShowReportAbuseSafetyChanges": "Enabled",
     "NuGetGallery.ComputeTargetFramework": "Enabled",
     "NuGetGallery.NewAccount2FAEnforcement": "Disabled",
-    "NuGetGallery.EmailLogin": "Enabled"
+    "NuGetGallery.NuGetAccountPasswordLoginUnsupported": "Disabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -33,7 +33,7 @@
     "NuGetGallery.ShowReportAbuseSafetyChanges": "Enabled",
     "NuGetGallery.ComputeTargetFramework": "Enabled",
     "NuGetGallery.NewAccount2FAEnforcement": "Disabled",
-    "NuGetGallery.NuGetAccountPasswordLoginUnsupported": "Disabled"
+    "NuGetGallery.NuGetAccountPasswordLogin": "Enabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -32,7 +32,8 @@
     "NuGetGallery.ImageAllowlist": "Enabled",
     "NuGetGallery.ShowReportAbuseSafetyChanges": "Enabled",
     "NuGetGallery.ComputeTargetFramework": "Enabled",
-    "NuGetGallery.NewAccount2FAEnforcement": "Disabled"
+    "NuGetGallery.NewAccount2FAEnforcement": "Disabled",
+    "NuGetGallery.EmailLogging": "Disabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -33,7 +33,7 @@
     "NuGetGallery.ShowReportAbuseSafetyChanges": "Enabled",
     "NuGetGallery.ComputeTargetFramework": "Enabled",
     "NuGetGallery.NewAccount2FAEnforcement": "Disabled",
-    "NuGetGallery.EmailLogging": "Disabled"
+    "NuGetGallery.EmailLogin": "Disabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -33,7 +33,7 @@
     "NuGetGallery.ShowReportAbuseSafetyChanges": "Enabled",
     "NuGetGallery.ComputeTargetFramework": "Enabled",
     "NuGetGallery.NewAccount2FAEnforcement": "Disabled",
-    "NuGetGallery.EmailLogin": "Disabled"
+    "NuGetGallery.EmailLogin": "Enabled"
   },
   "Flights": {
     "NuGetGallery.TyposquattingFlight": {

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -161,11 +161,10 @@ namespace NuGetGallery
             }
 
             var authenticatedUser = authenticationResult.AuthenticatedUser;
-            await _contentObjectService.Refresh();
 
-            if (_featureFlagService.IsNuGetAccountPasswordLoginUnsupportedEnabled() &&
+            if (!_featureFlagService.IsNuGetAccountPasswordLoginEnabled() &&
                 authenticatedUser.CredentialUsed.IsPassword() &&
-                !_contentObjectService.LoginDiscontinuationConfiguration.IsUserEmailOnExceptionsForEmailAddress(authenticatedUser.User))
+                !_contentObjectService.LoginDiscontinuationConfiguration.IsUserOnExceptionsForEmailAddress(authenticatedUser.User))
             {
                 var message = string.Format(CultureInfo.CurrentCulture, Strings.NuGetAccountPasswordLoginUnsupported);
                 return SignInFailure(model, linkingAccount, message);
@@ -934,7 +933,7 @@ namespace NuGetGallery
             existingModel.Providers = GetProviders();
             existingModel.SignIn = existingModel.SignIn ?? new SignInViewModel();
             existingModel.Register = existingModel.Register ?? new RegisterViewModel();
-            existingModel.IsNuGetAccountPasswordLoginUnsupported = _featureFlagService.IsNuGetAccountPasswordLoginUnsupportedEnabled();
+            existingModel.IsNuGetAccountPasswordLogin = _featureFlagService.IsNuGetAccountPasswordLoginEnabled();
 
             return View(viewName, existingModel);
         }

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -924,6 +924,7 @@ namespace NuGetGallery
             existingModel.Providers = GetProviders();
             existingModel.SignIn = existingModel.SignIn ?? new SignInViewModel();
             existingModel.Register = existingModel.Register ?? new RegisterViewModel();
+            existingModel.IsEmailLoginEnabled = _featureFlagService.IsEmailLoginEnabled();
 
             return View(viewName, existingModel);
         }

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -161,6 +161,15 @@ namespace NuGetGallery
             }
 
             var authenticatedUser = authenticationResult.AuthenticatedUser;
+
+            if (authenticatedUser.CredentialUsed.IsPassword() &&
+                !_featureFlagService.IsNuGetAccountPasswordLoginUnsupportedEnabled() &&
+                !_contentObjectService.LoginDiscontinuationConfiguration.IsUserEmailOnExceptionsForEmailAddress(authenticatedUser.User))
+            {
+                var message = string.Format(CultureInfo.CurrentCulture, Strings.NuGetAccountPasswordLoginUnsupported);
+                return SignInFailure(model, linkingAccount, message);
+            }
+
             bool usedMultiFactorAuthentication = false;
             if (linkingAccount)
             {
@@ -924,7 +933,7 @@ namespace NuGetGallery
             existingModel.Providers = GetProviders();
             existingModel.SignIn = existingModel.SignIn ?? new SignInViewModel();
             existingModel.Register = existingModel.Register ?? new RegisterViewModel();
-            existingModel.IsEmailLoginEnabled = _featureFlagService.IsEmailLoginEnabled();
+            existingModel.IsNuGetAccountPasswordLoginUnsupported = _featureFlagService.IsNuGetAccountPasswordLoginUnsupportedEnabled();
 
             return View(viewName, existingModel);
         }

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -163,8 +163,8 @@ namespace NuGetGallery
             var authenticatedUser = authenticationResult.AuthenticatedUser;
             await _contentObjectService.Refresh();
 
-            if (authenticatedUser.CredentialUsed.IsPassword() &&
-                _featureFlagService.IsNuGetAccountPasswordLoginUnsupportedEnabled() &&
+            if (_featureFlagService.IsNuGetAccountPasswordLoginUnsupportedEnabled() &&
+                authenticatedUser.CredentialUsed.IsPassword() &&
                 !_contentObjectService.LoginDiscontinuationConfiguration.IsUserEmailOnExceptionsForEmailAddress(authenticatedUser.User))
             {
                 var message = string.Format(CultureInfo.CurrentCulture, Strings.NuGetAccountPasswordLoginUnsupported);

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -933,7 +933,7 @@ namespace NuGetGallery
             existingModel.Providers = GetProviders();
             existingModel.SignIn = existingModel.SignIn ?? new SignInViewModel();
             existingModel.Register = existingModel.Register ?? new RegisterViewModel();
-            existingModel.IsNuGetAccountPasswordLogin = _featureFlagService.IsNuGetAccountPasswordLoginEnabled();
+            existingModel.IsNuGetAccountPasswordLoginEnabled = _featureFlagService.IsNuGetAccountPasswordLoginEnabled();
 
             return View(viewName, existingModel);
         }

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -161,9 +161,10 @@ namespace NuGetGallery
             }
 
             var authenticatedUser = authenticationResult.AuthenticatedUser;
+            await _contentObjectService.Refresh();
 
             if (authenticatedUser.CredentialUsed.IsPassword() &&
-                !_featureFlagService.IsNuGetAccountPasswordLoginUnsupportedEnabled() &&
+                _featureFlagService.IsNuGetAccountPasswordLoginUnsupportedEnabled() &&
                 !_contentObjectService.LoginDiscontinuationConfiguration.IsUserEmailOnExceptionsForEmailAddress(authenticatedUser.User))
             {
                 var message = string.Format(CultureInfo.CurrentCulture, Strings.NuGetAccountPasswordLoginUnsupported);

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -142,7 +142,11 @@ namespace NuGetGallery
             {
                 string modelErrorMessage = string.Empty;
 
-                if (authenticationResult.Result == PasswordAuthenticationResult.AuthenticationResult.BadCredentials)
+                if (authenticationResult.Result == PasswordAuthenticationResult.AuthenticationResult.PasswordLoginUnsupported)
+                {
+                    modelErrorMessage = Strings.NuGetAccountPasswordLoginUnsupported;
+                }
+                else if (authenticationResult.Result == PasswordAuthenticationResult.AuthenticationResult.BadCredentials)
                 {
                     modelErrorMessage = Strings.UsernameAndPasswordNotFound;
                 }
@@ -161,15 +165,6 @@ namespace NuGetGallery
             }
 
             var authenticatedUser = authenticationResult.AuthenticatedUser;
-
-            if (!_featureFlagService.IsNuGetAccountPasswordLoginEnabled() &&
-                authenticatedUser.CredentialUsed.IsPassword() &&
-                !_contentObjectService.LoginDiscontinuationConfiguration.IsUserOnExceptionsList(authenticatedUser.User))
-            {
-                var message = string.Format(CultureInfo.CurrentCulture, Strings.NuGetAccountPasswordLoginUnsupported);
-                return SignInFailure(model, linkingAccount, message);
-            }
-
             bool usedMultiFactorAuthentication = false;
             if (linkingAccount)
             {

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -164,7 +164,7 @@ namespace NuGetGallery
 
             if (!_featureFlagService.IsNuGetAccountPasswordLoginEnabled() &&
                 authenticatedUser.CredentialUsed.IsPassword() &&
-                !_contentObjectService.LoginDiscontinuationConfiguration.IsUserOnExceptionsForEmailAddress(authenticatedUser.User))
+                !_contentObjectService.LoginDiscontinuationConfiguration.IsUserOnExceptionsList(authenticatedUser.User))
             {
                 var message = string.Format(CultureInfo.CurrentCulture, Strings.NuGetAccountPasswordLoginUnsupported);
                 return SignInFailure(model, linkingAccount, message);

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -619,6 +619,7 @@ namespace NuGetGallery
             // We don't want Login to have us as a return URL
             // By having this value present in the dictionary BUT null, we don't put "returnUrl" on the Login link at all
             ViewData[GalleryConstants.ReturnUrlViewDataKey] = null;
+
             var model = new ForgotPasswordViewModel();
             model.IsPasswordLoginEnabled = _featureFlagService.IsNuGetAccountPasswordLoginEnabled();
 

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -260,7 +260,7 @@ namespace NuGetGallery
             {
                 return TransformToOrganizationFailed(errorReason);
             }
-            
+
             if (accountToTransform.OrganizationMigrationRequest != null
                 && accountToTransform.OrganizationMigrationRequest.ConfirmationToken == token
                 && !accountToTransform.OrganizationMigrationRequest.AdminUser.MatchesUser(adminUser))
@@ -531,7 +531,7 @@ namespace NuGetGallery
 
             var listedPackages = GetPackages(packages, currentUser, wasAADLoginOrMultiFactorAuthenticated,
                 p => p.Listed && p.PackageStatusKey == PackageStatus.Available);
-            
+
             var unlistedPackages = GetPackages(packages, currentUser, wasAADLoginOrMultiFactorAuthenticated,
                 p => !p.Listed || p.PackageStatusKey != PackageStatus.Available);
 
@@ -620,6 +620,11 @@ namespace NuGetGallery
             // By having this value present in the dictionary BUT null, we don't put "returnUrl" on the Login link at all
             ViewData[GalleryConstants.ReturnUrlViewDataKey] = null;
 
+            if (!_featureFlagService.IsNuGetAccountPasswordLoginEnabled())
+            {
+                TempData["WarningMessage"] = Strings.ForgotPassword_Disabled;
+            }
+
             return View();
         }
 
@@ -628,6 +633,12 @@ namespace NuGetGallery
         [ValidateRecaptchaResponse]
         public virtual async Task<ActionResult> ForgotPassword(ForgotPasswordViewModel model)
         {
+            if(!_featureFlagService.IsNuGetAccountPasswordLoginEnabled())
+            {
+                TempData["ErrorMessage"] = Strings.ForgotPassword_Disabled;
+                return View();
+            }
+
             // We don't want Login to have us as a return URL
             // By having this value present in the dictionary BUT null, we don't put "returnUrl" on the Login link at all
             ViewData[GalleryConstants.ReturnUrlViewDataKey] = null;

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1085,7 +1085,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Forgot password has been disabled. Please reach out to your Microsoft account support to sign into NuGet gallery..
+        ///   Looks up a localized string similar to Forgot password flow has been disabled. Please reach out to your Microsoft account support to sign into NuGet gallery..
         /// </summary>
         public static string ForgotPassword_Disabled {
             get {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1310,6 +1310,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to NuGet.org password login is no longer supported..
+        /// </summary>
+        public static string NuGetAccountPasswordLoginUnsupported {
+            get {
+                return ResourceManager.GetString("NuGetAccountPasswordLoginUnsupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A nuget package&apos;s {0} property is required..
         /// </summary>
         public static string NuGetPackagePropertyMissing {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1094,6 +1094,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Forgot password is disabled..
+        /// </summary>
+        public static string ForgotPassword_Disabled_Error {
+            get {
+                return ResourceManager.GetString("ForgotPassword_Disabled_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The API key &apos;{0}&apos; is invalid..
         /// </summary>
         public static string InvalidApiKey {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1085,6 +1085,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Forgot password has been disabled. Please reach out to your Microsoft account support to sign into NuGet gallery..
+        /// </summary>
+        public static string ForgotPassword_Disabled {
+            get {
+                return ResourceManager.GetString("ForgotPassword_Disabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The API key &apos;{0}&apos; is invalid..
         /// </summary>
         public static string InvalidApiKey {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1233,4 +1233,7 @@ The {1} Team</value>
   <data name="NuGetAccountPasswordLoginUnsupported" xml:space="preserve">
     <value>NuGet.org password login is no longer supported.</value>
   </data>
+  <data name="ForgotPassword_Disabled" xml:space="preserve">
+    <value>Forgot password has been disabled. Please reach out to your Microsoft account support to sign into NuGet gallery.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1234,6 +1234,6 @@ The {1} Team</value>
     <value>NuGet.org password login is no longer supported.</value>
   </data>
   <data name="ForgotPassword_Disabled" xml:space="preserve">
-    <value>Forgot password has been disabled. Please reach out to your Microsoft account support to sign into NuGet gallery.</value>
+    <value>Forgot password flow has been disabled. Please reach out to your Microsoft account support to sign into NuGet gallery.</value>
   </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1230,4 +1230,7 @@ The {1} Team</value>
   <data name="SupportedFrameworks_Tooltip" xml:space="preserve">
     <value>This package is compatible with this framework or higher.</value>
   </data>
+  <data name="NuGetAccountPasswordLoginUnsupported" xml:space="preserve">
+    <value>NuGet.org password login is no longer supported.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1236,4 +1236,7 @@ The {1} Team</value>
   <data name="ForgotPassword_Disabled" xml:space="preserve">
     <value>Forgot password flow has been disabled. Please reach out to your Microsoft account support to sign into NuGet gallery.</value>
   </data>
+  <data name="ForgotPassword_Disabled_Error" xml:space="preserve">
+    <value>Forgot password is disabled.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -15,6 +15,7 @@ namespace NuGetGallery
         public SignInViewModel SignIn { get; set; }
         public RegisterViewModel Register { get; set; }
         public IList<AuthenticationProviderViewModel> Providers { get; set; }
+        public bool IsEmailLoginEnabled { get; set; }
 
         public LogOnViewModel()
             : this(new SignInViewModel())

--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
         public SignInViewModel SignIn { get; set; }
         public RegisterViewModel Register { get; set; }
         public IList<AuthenticationProviderViewModel> Providers { get; set; }
-        public bool IsNuGetAccountPasswordLoginUnsupported { get; set; }
+        public bool IsNuGetAccountPasswordLogin { get; set; }
 
         public LogOnViewModel()
             : this(new SignInViewModel())

--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
         public SignInViewModel SignIn { get; set; }
         public RegisterViewModel Register { get; set; }
         public IList<AuthenticationProviderViewModel> Providers { get; set; }
-        public bool IsNuGetAccountPasswordLogin { get; set; }
+        public bool IsNuGetAccountPasswordLoginEnabled { get; set; }
 
         public LogOnViewModel()
             : this(new SignInViewModel())

--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery
         public SignInViewModel SignIn { get; set; }
         public RegisterViewModel Register { get; set; }
         public IList<AuthenticationProviderViewModel> Providers { get; set; }
-        public bool IsEmailLoginEnabled { get; set; }
+        public bool IsNuGetAccountPasswordLoginUnsupported { get; set; }
 
         public LogOnViewModel()
             : this(new SignInViewModel())

--- a/src/NuGetGallery/ViewModels/PasswordResetRequestViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PasswordResetRequestViewModel.cs
@@ -10,5 +10,7 @@ namespace NuGetGallery
         [StringLength(255)]
         [Display(Name = "Email")]
         public string Email { get; set; }
+
+        public bool IsPasswordLoginEnabled { get; set; }
     }
 }

--- a/src/NuGetGallery/Views/Authentication/SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/SignIn.cshtml
@@ -51,7 +51,7 @@
             </span>
         </div>
 
-        if (Model.IsNuGetAccountPasswordLogin)
+        if (Model.IsNuGetAccountPasswordLoginEnabled)
         {
             <div class="row nuget-signin">
                 <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">

--- a/src/NuGetGallery/Views/Authentication/SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/SignIn.cshtml
@@ -51,7 +51,7 @@
             </span>
         </div>
 
-        if (!Model.IsNuGetAccountPasswordLoginUnsupported)
+        if (Model.IsNuGetAccountPasswordLogin)
         {
             <div class="row nuget-signin">
                 <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">

--- a/src/NuGetGallery/Views/Authentication/SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/SignIn.cshtml
@@ -51,13 +51,16 @@
             </span>
         </div>
 
-        <div class="row nuget-signin">
-            <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
-                <p class="text-center">
-                    <a href="@Url.LogOnNuGetAccount(returnUrl)">Sign in using NuGet.org account</a>
-                </p>
+        if (Model.IsEmailLoginEnabled)
+        {
+            <div class="row nuget-signin">
+                <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">
+                    <p class="text-center">
+                        <a href="@Url.LogOnNuGetAccount(returnUrl)">Sign in using NuGet.org account</a>
+                    </p>
+                </div>
             </div>
-        </div>
+        }
     }
     else
     {

--- a/src/NuGetGallery/Views/Authentication/SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/SignIn.cshtml
@@ -51,7 +51,7 @@
             </span>
         </div>
 
-        if (Model.IsEmailLoginEnabled)
+        if (!Model.IsNuGetAccountPasswordLoginUnsupported)
         {
             <div class="row nuget-signin">
                 <div class="@ViewHelpers.GetColumnClasses(ViewBag) text-center">

--- a/src/NuGetGallery/Views/Authentication/_SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/_SignIn.cshtml
@@ -37,9 +37,14 @@
         @Html.ShowPasswordFor(m => m.SignIn.Password)
         @Html.ShowValidationMessagesFor(m => m.SignIn.Password)
     </div>
-    <p>
-        @Html.ActionLink("Forgot your Password?", "ForgotPassword", "Users")
-    </p>
+
+    if (Model.IsNuGetAccountPasswordLoginEnabled)
+    {
+        <p>
+            @Html.ActionLink("Forgot your Password?", "ForgotPassword", "Users")
+        </p>
+    }
+
     if (Model.External != null && !Model.External.FoundExistingUser)
     {
         <div class="form-group row">

--- a/src/NuGetGallery/Views/Authentication/_SignIn.cshtml
+++ b/src/NuGetGallery/Views/Authentication/_SignIn.cshtml
@@ -38,12 +38,9 @@
         @Html.ShowValidationMessagesFor(m => m.SignIn.Password)
     </div>
 
-    if (Model.IsNuGetAccountPasswordLoginEnabled)
-    {
-        <p>
-            @Html.ActionLink("Forgot your Password?", "ForgotPassword", "Users")
-        </p>
-    }
+    <p>
+        @Html.ActionLink("Forgot your Password?", "ForgotPassword", "Users")
+    </p>
 
     if (Model.External != null && !Model.External.FoundExistingUser)
     {

--- a/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
+++ b/src/NuGetGallery/Views/Users/ForgotPassword.cshtml
@@ -6,7 +6,13 @@
 }
 
 <section role="main" class="container main-container page-forgot-password">
-    @if (this.Config.Current.DeprecateNuGetPasswordLogins)
+    @if (!Model.IsPasswordLoginEnabled)
+    {
+        <div class="deprecate-alert text-center">
+            @ViewHelpers.AlertWarning(@<text>@Strings.ForgotPassword_Disabled</text>)
+        </div>
+    }
+    else if (this.Config.Current.DeprecateNuGetPasswordLogins)
     {
         <div class="deprecate-alert text-center">
             @ViewHelpers.AlertPasswordDeprecation()

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -120,5 +120,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public bool IsRecentPackagesNoIndexEnabled() => throw new NotImplementedException();
 
         public bool IsNewAccount2FAEnforcementEnabled() => throw new NotImplementedException();
+
+        public bool IsEmailLoggingEnabled() => throw new NotImplementedException();
     }
 }

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -121,6 +121,6 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsNewAccount2FAEnforcementEnabled() => throw new NotImplementedException();
 
-        public bool IsEmailLoginEnabled() => throw new NotImplementedException();
+        public bool IsNuGetAccountPasswordLoginUnsupportedEnabled() => throw new NotImplementedException();
     }
 }

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -121,6 +121,6 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsNewAccount2FAEnforcementEnabled() => throw new NotImplementedException();
 
-        public bool IsEmailLoggingEnabled() => throw new NotImplementedException();
+        public bool IsEmailLoginEnabled() => throw new NotImplementedException();
     }
 }

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -121,6 +121,6 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsNewAccount2FAEnforcementEnabled() => throw new NotImplementedException();
 
-        public bool IsNuGetAccountPasswordLoginUnsupportedEnabled() => throw new NotImplementedException();
+        public bool IsNuGetAccountPasswordLoginEnabled() => throw new NotImplementedException();
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Auditing/AuditedAuthenticatedOperationActionTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/AuditedAuthenticatedOperationActionTests.cs
@@ -16,7 +16,8 @@ namespace NuGetGallery.Auditing
                 "FailedLoginNoSuchUser",
                 "FailedLoginUserIsOrganization",
                 "PackagePushAttemptByNonOwner",
-                "SymbolsPackagePushAttemptByNonOwner"
+                "SymbolsPackagePushAttemptByNonOwner",
+                "PasswordLoginUnsupported"
             };
 
             Verify(typeof(AuditedAuthenticatedOperationAction), expectedNames);

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -49,7 +49,7 @@ namespace NuGetGallery.Authentication
 
                 var configMock = new Mock<ILoginDiscontinuationConfiguration>();
                 configMock
-                    .Setup(x => x.IsUserOnExceptionsList(_fakes.User))
+                    .Setup(x => x.IsEmailOnExceptionsList(_fakes.User.EmailAddress))
                     .Returns(false);
                 GetMock<IContentObjectService>()
                     .Setup(x => x.LoginDiscontinuationConfiguration)
@@ -72,7 +72,7 @@ namespace NuGetGallery.Authentication
 
                 var configMock = new Mock<ILoginDiscontinuationConfiguration>();
                 configMock
-                    .Setup(x => x.IsUserOnExceptionsList(null))
+                    .Setup(x => x.IsEmailOnExceptionsList(null))
                     .Returns(false);
                 GetMock<IContentObjectService>()
                     .Setup(x => x.LoginDiscontinuationConfiguration)
@@ -95,7 +95,7 @@ namespace NuGetGallery.Authentication
                     .Returns(false);
                 var configMock = new Mock<ILoginDiscontinuationConfiguration>();
                 configMock
-                    .Setup(x => x.IsUserOnExceptionsList(It.IsAny<User>()))
+                    .Setup(x => x.IsEmailOnExceptionsList(It.IsAny<string>()))
                     .Returns(false);
                 GetMock<IContentObjectService>()
                     .Setup(x => x.LoginDiscontinuationConfiguration)
@@ -124,7 +124,7 @@ namespace NuGetGallery.Authentication
                 var user = _fakes.User;
                 var configMock = new Mock<ILoginDiscontinuationConfiguration>();
                 configMock
-                    .Setup(x => x.IsUserOnExceptionsList(It.IsAny<User>()))
+                    .Setup(x => x.IsEmailOnExceptionsList(It.IsAny<string>()))
                     .Returns(isOnExceptionList);
                 GetMock<IContentObjectService>()
                     .Setup(x => x.LoginDiscontinuationConfiguration)

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -40,7 +40,7 @@ namespace NuGetGallery.Authentication
             }
 
             [Fact]
-            public async Task GivenValidUser_WhenPasswordLoginDisabledAndUserNotOnExceptionList_ItReturnsFailure()
+            public async Task GivenValidUser_WhenPasswordLoginDisabledAndUserEmailNotOnExceptionList_ItReturnsFailure()
             {
                 // Arrange
                 GetMock<IFeatureFlagService>()
@@ -63,7 +63,7 @@ namespace NuGetGallery.Authentication
             }
 
             [Fact]
-            public async Task GivenInvalidUser_WhenPasswordLoginDisabledAndUserNotOnExceptionList_ItReturnsFailure()
+            public async Task GivenInvalidUser_WhenPasswordLoginDisabledAndUserEmailNotOnExceptionList_ItReturnsFailure()
             {
                 // Arrange
                 GetMock<IFeatureFlagService>()
@@ -87,7 +87,7 @@ namespace NuGetGallery.Authentication
             }
 
             [Fact]
-            public async Task WritesAuditRecordWhenGivenPasswordLoginIsDisabledAnd()
+            public async Task WritesAuditRecordWhenGivenPasswordLoginIsDisabledAndUserEmailNotOnExceptionList()
             {
                 // Arrange
                 GetMock<IFeatureFlagService>()

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -359,7 +359,7 @@ namespace NuGetGallery.Controllers
             }
 
             [Fact]
-            public async Task WillInvalidateModelStateAndShowTheViewWithErrorsWhenPasswordLoginIsDisabledAndUserNotOnExceptionList()
+            public async Task WillInvalidateModelStateAndShowTheViewWithErrorsWhenPasswordLoginIsDisabledAndUserEmailNotOnExceptionList()
             {
                 GetMock<AuthenticationService>()
                     .Setup(x => x.Authenticate(It.IsAny<string>(), It.IsAny<string>()))

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -382,7 +382,7 @@ namespace NuGetGallery.Controllers
                     .Verifiable();
                 var loginDiscontinuationConfigMock = new Mock<ILoginDiscontinuationConfiguration>();
                 loginDiscontinuationConfigMock
-                    .Setup(x => x.IsUserOnExceptionsForEmailAddress(user))
+                    .Setup(x => x.IsUserOnExceptionsList(user))
                     .Returns(false)
                     .Verifiable();
                 GetMock<IContentObjectService>()

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -377,12 +377,12 @@ namespace NuGetGallery.Controllers
                     .Setup(x => x.Authenticate(emailAddress, password))
                     .CompletesWith(authResult);
                 GetMock<IFeatureFlagService>()
-                    .Setup(f => f.IsNuGetAccountPasswordLoginUnsupportedEnabled())
-                    .Returns(true)
+                    .Setup(f => f.IsNuGetAccountPasswordLoginEnabled())
+                    .Returns(false)
                     .Verifiable();
                 var loginDiscontinuationConfigMock = new Mock<ILoginDiscontinuationConfiguration>();
                 loginDiscontinuationConfigMock
-                    .Setup(x => x.IsUserEmailOnExceptionsForEmailAddress(user))
+                    .Setup(x => x.IsUserOnExceptionsForEmailAddress(user))
                     .Returns(false)
                     .Verifiable();
                 GetMock<IContentObjectService>()

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -255,6 +255,13 @@ namespace NuGetGallery
 
         public class TheForgotPasswordAction : TestContainer
         {
+            public TheForgotPasswordAction()
+            {
+                GetMock<IFeatureFlagService>()
+                    .Setup(s => s.IsNuGetAccountPasswordLoginEnabled())
+                    .Returns(true);
+            }
+
             [Fact]
             public async Task SendsEmailWithPasswordResetUrl()
             {
@@ -392,6 +399,9 @@ namespace NuGetGallery
             [Fact]
             public void WhenNuGetAccountPasswordLoginEnabledShowsWarningOnGet()
             {
+                GetMock<IFeatureFlagService>()
+                    .Setup(s => s.IsNuGetAccountPasswordLoginEnabled())
+                    .Returns(false);
                 var controller = GetController<UsersController>();
 
                 var result = controller.ForgotPassword() as ViewResult;
@@ -404,6 +414,9 @@ namespace NuGetGallery
             [Fact]
             public async Task WhenNuGetAccountPasswordLoginEnabledShowsErrorOnPost()
             {
+                GetMock<IFeatureFlagService>()
+                    .Setup(s => s.IsNuGetAccountPasswordLoginEnabled())
+                    .Returns(false);
                 var controller = GetController<UsersController>();
 
                 var model = new ForgotPasswordViewModel { Email = "user" };

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -389,6 +389,32 @@ namespace NuGetGallery
                 }
             }
 
+            [Fact]
+            public void WhenNuGetAccountPasswordLoginEnabledShowsWarningOnGet()
+            {
+                var controller = GetController<UsersController>();
+
+                var result = controller.ForgotPassword() as ViewResult;
+
+                Assert.NotNull(result);
+                Assert.IsNotType<RedirectResult>(result);
+                Assert.Equal(Strings.ForgotPassword_Disabled, controller.TempData["WarningMessage"]);
+            }
+
+            [Fact]
+            public async Task WhenNuGetAccountPasswordLoginEnabledShowsErrorOnPost()
+            {
+                var controller = GetController<UsersController>();
+
+                var model = new ForgotPasswordViewModel { Email = "user" };
+
+                var result = await controller.ForgotPassword(model) as ViewResult;
+
+                Assert.NotNull(result);
+                Assert.IsNotType<RedirectResult>(result);
+                Assert.Equal(Strings.ForgotPassword_Disabled, controller.TempData["ErrorMessage"]);
+            }
+
             public static IEnumerable<object[]> ResultTypes
             {
                 get

--- a/tests/NuGetGallery.Facts/Services/LoginDiscontinuationConfigurationFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/LoginDiscontinuationConfigurationFacts.cs
@@ -363,7 +363,7 @@ namespace NuGetGallery.Services
             }
         }
 
-        public class TheIsUserEmailOnExceptionsForEmailAddressMethod
+        public class TheIsEmailOnExceptionsForEmailAddressMethod
         {
             [Theory]
             [InlineData(true)]
@@ -379,7 +379,7 @@ namespace NuGetGallery.Services
                     isWrongCase: false,
                     isPasswordDiscontinuedForAll: false);
 
-                var result = config.IsUserOnExceptionsList(null);
+                var result = config.IsEmailOnExceptionsList(null);
 
                 Assert.False(result);
             }
@@ -398,9 +398,7 @@ namespace NuGetGallery.Services
                     isWrongCase: false,
                     isPasswordDiscontinuedForAll: false);
 
-                var user = new User("test") { EmailAddress = _email };
-
-                var result = config.IsUserOnExceptionsList(user);
+                var result = config.IsEmailOnExceptionsList(_email);
 
                 Assert.Equal(isOnExceptionList, result);
             }

--- a/tests/NuGetGallery.Facts/Services/LoginDiscontinuationConfigurationFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/LoginDiscontinuationConfigurationFacts.cs
@@ -379,7 +379,7 @@ namespace NuGetGallery.Services
                     isWrongCase: false,
                     isPasswordDiscontinuedForAll: false);
 
-                var result = config.IsUserEmailOnExceptionsForEmailAddress(null);
+                var result = config.IsUserOnExceptionsForEmailAddress(null);
 
                 Assert.False(result);
             }
@@ -400,7 +400,7 @@ namespace NuGetGallery.Services
 
                 var user = new User("test") { EmailAddress = _email };
 
-                var result = config.IsUserEmailOnExceptionsForEmailAddress(user);
+                var result = config.IsUserOnExceptionsForEmailAddress(user);
 
                 Assert.Equal(isOnExceptionList, result);
             }

--- a/tests/NuGetGallery.Facts/Services/LoginDiscontinuationConfigurationFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/LoginDiscontinuationConfigurationFacts.cs
@@ -362,5 +362,48 @@ namespace NuGetGallery.Services
                 }
             }
         }
+
+        public class TheIsUserEmailOnExceptionsForEmailAddressMethod
+        {
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void NullUserReturnsFalse(bool isOnExceptionList)
+            {
+                var config = CreateConfiguration(
+                    isOnWhiteList: false,
+                    isOnDomainList: false,
+                    isOnExceptionList: isOnExceptionList,
+                    isOnTransformList: false,
+                    isOnTenantPairList: false,
+                    isWrongCase: false,
+                    isPasswordDiscontinuedForAll: false);
+
+                var result = config.IsUserEmailOnExceptionsForEmailAddress(null);
+
+                Assert.False(result);
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void ValidUserReturnsIfEmailIsOnExceptionList(bool isOnExceptionList)
+            {
+                var config = CreateConfiguration(
+                    isOnWhiteList: false,
+                    isOnDomainList: false,
+                    isOnExceptionList: isOnExceptionList,
+                    isOnTransformList: false,
+                    isOnTenantPairList: false,
+                    isWrongCase: false,
+                    isPasswordDiscontinuedForAll: false);
+
+                var user = new User("test") { EmailAddress = _email };
+
+                var result = config.IsUserEmailOnExceptionsForEmailAddress(user);
+
+                Assert.Equal(isOnExceptionList, result);
+            }
+        }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/LoginDiscontinuationConfigurationFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/LoginDiscontinuationConfigurationFacts.cs
@@ -379,7 +379,7 @@ namespace NuGetGallery.Services
                     isWrongCase: false,
                     isPasswordDiscontinuedForAll: false);
 
-                var result = config.IsUserOnExceptionsForEmailAddress(null);
+                var result = config.IsUserOnExceptionsList(null);
 
                 Assert.False(result);
             }
@@ -400,7 +400,7 @@ namespace NuGetGallery.Services
 
                 var user = new User("test") { EmailAddress = _email };
 
-                var result = config.IsUserOnExceptionsForEmailAddress(user);
+                var result = config.IsUserOnExceptionsList(user);
 
                 Assert.Equal(isOnExceptionList, result);
             }


### PR DESCRIPTION
### Changes
- `NuGetAccountPasswordLoginSupported` feature flag added.
- When feature flag is enabled, the site behaves the following way:
  - `Sign in using NuGet.org account` is removed.
  - NuGet Password login shows an error if email is not in exception list.
  - `ForgotPassword` page shows a warning.
  - On `ForgotPassword` page, if you submit an email, an error will show since the endpoint will be blocked on the backend.

### Screenshot

#### Error when trying to sign in
![NuGet password unsupported](https://user-images.githubusercontent.com/17834924/174191218-1fdc7f64-e8d4-485b-9af9-780a6fcc081c.png)

#### Sign in using NuGet.org account removed
![Sign in with nuget removed](https://user-images.githubusercontent.com/17834924/174191488-9ff7c219-88fb-4dbf-b876-db96cf326634.png)

#### Forgot password warning

![Forgot Password warning](https://user-images.githubusercontent.com/17834924/181123189-181fef57-701c-4791-ab0f-40b9a3c8f7da.png)

#### Forgot password error

![Forgot Password error](https://user-images.githubusercontent.com/17834924/181123205-b80598cf-40df-493b-b7e6-30535866457a.png)

### Addresses

- https://github.com/NuGet/Engineering/issues/4234
- https://github.com/NuGet/Engineering/issues/4314