### PR TITLE
[Hotfix]Disable DownloadCount Mapping temporarily

### DIFF
--- a/src/NuGet.Services.Entities/Package.cs
+++ b/src/NuGet.Services.Entities/Package.cs
@@ -58,6 +58,7 @@ namespace NuGet.Services.Entities
         /// </remarks>
         public string ReleaseNotes { get; set; }
 
+        [NotMapped]
         public long DownloadCount { get; set; }
 
         /// <remarks>

--- a/src/NuGet.Services.Entities/PackageRegistration.cs
+++ b/src/NuGet.Services.Entities/PackageRegistration.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace NuGet.Services.Entities
 {
@@ -23,6 +24,7 @@ namespace NuGet.Services.Entities
         [Required]
         public string Id { get; set; }
 
+        [NotMapped]
         public long DownloadCount { get; set; }
 
         public bool IsVerified { get; set; }

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -209,9 +209,9 @@ namespace NuGetGallery
                                 join p in _entitiesContext.Packages on pd.PackageKey equals p.Key
                                 join pr in _entitiesContext.PackageRegistrations on p.PackageRegistrationKey equals pr.Key
                                 where p.IsLatestSemVer2 && pd.Id == id
-                                group 1 by new { pr.Id, pr.DownloadCount, pr.IsVerified, p.Description } into ng
-                                orderby ng.Key.DownloadCount descending
-                                select new PackageDependent { Id = ng.Key.Id, DownloadCount = ng.Key.DownloadCount, IsVerified = ng.Key.IsVerified, Description = ng.Key.Description }
+                                group 1 by new { pr.Id, /*pr.DownloadCount,*/ pr.IsVerified, p.Description } into ng
+                                //orderby ng.Key.DownloadCount descending
+                                select new PackageDependent { Id = ng.Key.Id, /*DownloadCount = ng.Key.DownloadCount,*/ IsVerified = ng.Key.IsVerified, Description = ng.Key.Description }
                                 ).Take(packagesDisplayed).ToList();
 
             return listPackages;

--- a/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
+++ b/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
@@ -47,7 +47,7 @@ namespace NuGetGallery
 
                         Cache = packageService.GetAllPackageRegistrations()
                             .OrderByDescending(pr => pr.IsVerified)
-                            .ThenByDescending(pr => pr.DownloadCount)
+                            //.ThenByDescending(pr => pr.DownloadCount)
                             .Select(pr => pr.Id)
                             .Take(TyposquattingCheckListConfiguredLength)
                             .ToList();

--- a/tests/NuGet.Services.DatabaseMigration.Facts/PendingMigrationsFacts.cs
+++ b/tests/NuGet.Services.DatabaseMigration.Facts/PendingMigrationsFacts.cs
@@ -94,7 +94,7 @@ namespace NuGet.Services.DatabaseMigration.Facts
             }
         }
 
-        [Theory]
+        [Theory(Skip = "Temporary while transitioning to int64")]
         [MemberData(nameof(TestData))]
         public async Task NoPendingMigrations(string dbName, string argumentName, MigrationContextFactory factory, IServiceProvider serviceProvider)
         {


### PR DESCRIPTION
Temporarily disables mapping of the DownloadCount column to the Package and PackageRegistration entities.

After this has been merged, there will be a second PR reverting this as we only need this changeset to enable readonly scenarios while the DownloadCount column data type is being migrated.