### PR TITLE
Revert "[Hotfix]Disable DownloadCount Mapping temporarily (#9150)"

### DIFF
--- a/src/NuGet.Services.Entities/Package.cs
+++ b/src/NuGet.Services.Entities/Package.cs
@@ -58,7 +58,6 @@ namespace NuGet.Services.Entities
         /// </remarks>
         public string ReleaseNotes { get; set; }
 
-        [NotMapped]
         public long DownloadCount { get; set; }
 
         /// <remarks>

--- a/src/NuGet.Services.Entities/PackageRegistration.cs
+++ b/src/NuGet.Services.Entities/PackageRegistration.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace NuGet.Services.Entities
 {
@@ -24,7 +23,6 @@ namespace NuGet.Services.Entities
         [Required]
         public string Id { get; set; }
 
-        [NotMapped]
         public long DownloadCount { get; set; }
 
         public bool IsVerified { get; set; }

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -209,9 +209,9 @@ namespace NuGetGallery
                                 join p in _entitiesContext.Packages on pd.PackageKey equals p.Key
                                 join pr in _entitiesContext.PackageRegistrations on p.PackageRegistrationKey equals pr.Key
                                 where p.IsLatestSemVer2 && pd.Id == id
-                                group 1 by new { pr.Id, /*pr.DownloadCount,*/ pr.IsVerified, p.Description } into ng
-                                //orderby ng.Key.DownloadCount descending
-                                select new PackageDependent { Id = ng.Key.Id, /*DownloadCount = ng.Key.DownloadCount,*/ IsVerified = ng.Key.IsVerified, Description = ng.Key.Description }
+                                group 1 by new { pr.Id, pr.DownloadCount, pr.IsVerified, p.Description } into ng
+                                orderby ng.Key.DownloadCount descending
+                                select new PackageDependent { Id = ng.Key.Id, DownloadCount = ng.Key.DownloadCount, IsVerified = ng.Key.IsVerified, Description = ng.Key.Description }
                                 ).Take(packagesDisplayed).ToList();
 
             return listPackages;

--- a/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
+++ b/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
@@ -47,7 +47,7 @@ namespace NuGetGallery
 
                         Cache = packageService.GetAllPackageRegistrations()
                             .OrderByDescending(pr => pr.IsVerified)
-                            //.ThenByDescending(pr => pr.DownloadCount)
+                            .ThenByDescending(pr => pr.DownloadCount)
                             .Select(pr => pr.Id)
                             .Take(TyposquattingCheckListConfiguredLength)
                             .ToList();

--- a/tests/NuGet.Services.DatabaseMigration.Facts/PendingMigrationsFacts.cs
+++ b/tests/NuGet.Services.DatabaseMigration.Facts/PendingMigrationsFacts.cs
@@ -94,7 +94,7 @@ namespace NuGet.Services.DatabaseMigration.Facts
             }
         }
 
-        [Theory(Skip = "Temporary while transitioning to int64")]
+        [Theory]
         [MemberData(nameof(TestData))]
         public async Task NoPendingMigrations(string dbName, string argumentName, MigrationContextFactory factory, IServiceProvider serviceProvider)
         {


### PR DESCRIPTION
This reverts commit 1dc90c2f0bf8fafc4d0b38f48acf4aa8d5dfbee6.

This explicitly should not be deployed until AFTER DB migration has completed.