### PR TITLE
Add Models classes to netstandard2.1

### DIFF
--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -27,7 +27,6 @@
     <Compile Remove="Extensions\*.cs" />
     <Compile Remove="Helpers\*.cs" />
     <Compile Remove="Mail\**\*.cs" />
-    <Compile Remove="Models\*.cs" />
     <Compile Remove="PackageManagement\*.cs" />
     <Compile Remove="Permissions\*.cs" />
     <Compile Remove="Properties\*.cs" />


### PR DESCRIPTION
This adds the Models classes to the netstandard2.1 target for consumption in this work: https://github.com/NuGet/Engineering/issues/4376.