### PR TITLE
Update newtonsoft.json 

### DIFF
--- a/tests/NuGetGallery.LoadTests/NuGetGallery.LoadTests.csproj
+++ b/tests/NuGetGallery.LoadTests/NuGetGallery.LoadTests.csproj
@@ -24,6 +24,7 @@
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
@@ -98,6 +99,9 @@
   <ItemGroup>
     <PackageReference Include="FluentLinkChecker">
       <Version>1.0.0.10</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Choose>


### PR DESCRIPTION
Functional test failed with error message below: 
Run deployment issue: The assembly or module 'Newtonsoft.Json' directly or indirectly referenced by the test container 'd:\a\_work\1\s\tests\nugetgallery.loadtests\bin\release\nugetgallery.loadtests.dll' was not found.

There are several workarounds: 
1. Add package reference with specific version
2. Download assembly to Global Assembly Cache at agent where we run functional tests

Since we don't have control of agent pool, I think workaround 1 will be better.  Please let me know if there is better workaround

Addresses https://github.com/NuGet/Engineering/issues/4452