### PR TITLE
[A11y][ScreenReader] Prevent Screen Reader from reading non-header elements

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1180,7 +1180,6 @@ p.frameworktableinfo-text {
   margin-top: 40px;
   font-weight: 400;
   margin-right: 18px;
-  display: inline;
 }
 .page-package-details .package-title h1 .version-title {
   font-size: 16px;
@@ -1188,7 +1187,6 @@ p.frameworktableinfo-text {
   color: #666666;
   margin-right: 14px;
   vertical-align: middle;
-  display: inline;
 }
 .page-package-details .package-title h1 .package-icon {
   height: 32px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1174,6 +1174,7 @@ p.frameworktableinfo-text {
   margin-top: 40px;
   font-weight: 400;
   margin-right: 18px;
+  display: inline;
 }
 .page-package-details .package-title h1 .version-title {
   font-size: 16px;
@@ -1181,6 +1182,7 @@ p.frameworktableinfo-text {
   color: #666666;
   margin-right: 14px;
   vertical-align: middle;
+  display: inline;
 }
 .page-package-details .package-title h1 .package-icon {
   height: 32px;
@@ -1188,7 +1190,7 @@ p.frameworktableinfo-text {
   margin-top: 8px;
   margin-right: 12px;
 }
-.page-package-details .package-title h1 .prefix-reserve-title {
+.page-package-details .package-title .prefix-reserve-title {
   background-color: #F3F2F1;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1201,12 +1203,12 @@ p.frameworktableinfo-text {
   border-radius: 100px;
   vertical-align: middle;
 }
-.page-package-details .package-title h1 .prefix-reserve-title .reserved-indicator {
+.page-package-details .package-title .prefix-reserve-title .reserved-indicator {
   width: 18px;
   margin-right: 5px;
   margin-left: 2px;
 }
-.page-package-details .package-title h1 .prefix-reserve-title .prefix-reserve-label {
+.page-package-details .package-title .prefix-reserve-title .prefix-reserve-label {
   font-size: 14px;
   font-weight: 400;
   color: #2F6FA7;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -675,6 +675,9 @@ img.reserved-indicator-icon {
 .readme-common tr:nth-child(even) {
   background-color: #f2f2f2;
 }
+.readme-common tr:nth-child(even) a {
+  color: #2d6da4;
+}
 .readme-common img.img-fluid {
   max-width: 100%;
 }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -25,6 +25,7 @@
         margin-top: 40px;
         font-weight: 400;
         margin-right: 18px;
+        display: inline;
       }
 
       .version-title {
@@ -33,6 +34,7 @@
         color: @gray-light;
         margin-right: 14px;
         vertical-align: middle;
+        display: inline;
       }
 
       .package-icon {
@@ -42,27 +44,28 @@
         margin-right: 12px;
       }
 
-      .prefix-reserve-title {
-        background-color: #F3F2F1;
-        display: inline-flex;
-        align-items: center;
-        border-radius: 100px;
-        vertical-align: middle;
+    }
 
-        .reserved-indicator {
-          width: 18px;
-          margin-right: 5px;
-          margin-left: 2px;
-        }
+    .prefix-reserve-title {
+      background-color: #F3F2F1;
+      display: inline-flex;
+      align-items: center;
+      border-radius: 100px;
+      vertical-align: middle;
 
-        .prefix-reserve-label {
-          font-size: 14px;
-          font-weight: 400;
-          color: #2F6FA7;
-          margin-top: 2px;
-          margin-bottom: 2px;
-          margin-right: 10px;
-        }
+      .reserved-indicator {
+        width: 18px;
+        margin-right: 5px;
+        margin-left: 2px;
+      }
+
+      .prefix-reserve-label {
+        font-size: 14px;
+        font-weight: 400;
+        color: #2F6FA7;
+        margin-top: 2px;
+        margin-bottom: 2px;
+        margin-right: 10px;
       }
     }
 

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -25,7 +25,6 @@
         margin-top: 40px;
         font-weight: 400;
         margin-right: 18px;
-        display: inline;
       }
 
       .version-title {
@@ -34,7 +33,6 @@
         color: @gray-light;
         margin-right: 14px;
         vertical-align: middle;
-        display: inline;
       }
 
       .package-icon {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -247,20 +247,20 @@
                         <span class="version-title">
                             @Model.Version
                         </span>
-                        @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
-                        {
-                            <span class="prefix-reserve-title" aria-hidden="true">
-                                <img class="reserved-indicator" aria-hidden="true"
-                                        src="~/Content/gallery/img/reserved-indicator.svg"
-                                        @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
-                                        data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"
-                                        alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"/>
-                                <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label" ari-hidden="true">
-                                    Prefix Reserved
-                                </a>
-                            </span>
-                        }
                     </h1>
+                    @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
+                    {
+                        <span class="prefix-reserve-title" aria-hidden="true">
+                            <img class="reserved-indicator" aria-hidden="true"
+                                    src="~/Content/gallery/img/reserved-indicator.svg"
+                                    @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
+                                    data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"
+                                    alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"/>
+                            <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label" ari-hidden="true">
+                                Prefix Reserved
+                            </a>
+                        </span>
+                    }
                 </div>
 
                 @if (Model.CanDisplayTargetFrameworks())

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -249,13 +249,13 @@
                         </span>
                         @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
                         {
-                            <span class="prefix-reserve-title">
-                                <img class="reserved-indicator"
+                            <span class="prefix-reserve-title" aria-hidden="true">
+                                <img class="reserved-indicator" aria-hidden="true"
                                         src="~/Content/gallery/img/reserved-indicator.svg"
                                         @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
                                         data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"
                                         alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"/>
-                                <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
+                                <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label" ari-hidden="true">
                                     Prefix Reserved
                                 </a>
                             </span>


### PR DESCRIPTION
Prevent the 'Prefix Reserved' element on a package page from being read when using the 'H' option in the screen reader by setting the element's `aria-hidden` attribute to `true`.

Current Behavior:
![nvda text original](https://user-images.githubusercontent.com/25823466/181644313-8fffa215-639e-4259-a230-88d89bc0686f.jpg)

New Behavior:
![nvda text edited](https://user-images.githubusercontent.com/25823466/181644345-d90c0f02-1423-47ca-b6c7-b358c192b887.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/9173