### PR TITLE
[A11y] Read warning when tabbing to Paket CLI tab

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -208,7 +208,7 @@
                 @ViewHelpers.AlertWarning(
                     @<text>
                         @Html.Raw(packageManager.AlertMessage)
-                    </text>);
+                    </text>, true);
                 break;
             default:
                 break;


### PR DESCRIPTION
Added `role = alert` to the warning below the Paket CLI command so that the screen reader will read the warning out to the user without having to tab to the warning element itself. 

Addresses https://github.com/NuGet/NuGetGallery/issues/9172