### PR TITLE
Add section link support for READMEs

### DIFF
--- a/src/NuGetGallery/Services/MarkdownService.cs
+++ b/src/NuGetGallery/Services/MarkdownService.cs
@@ -203,7 +203,7 @@ namespace NuGetGallery
                 .UseTaskLists()
                 .UseEmojiAndSmiley()
                 .UseAutoLinks()
-                .UseReferralLinks("noopener noreferrer nofollow")
+                .UseAutoIdentifiers()
                 .UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
                 .DisableHtml() //block inline html
                 .UseBootstrap()

--- a/src/NuGetGallery/Services/MarkdownService.cs
+++ b/src/NuGetGallery/Services/MarkdownService.cs
@@ -264,7 +264,10 @@ namespace NuGetGallery
                                 // Allow only http or https links in markdown. Transform link to https for known domains.
                                 if (!PackageHelper.TryPrepareUrlForRendering(linkInline.Url, out string readyUriString))
                                 {
-                                    linkInline.Url = string.Empty;
+                                    if (!linkInline.Url.StartsWith("#")) //allow internal section links
+                                    {
+                                        linkInline.Url = string.Empty;
+                                    }
                                 }
                                 else
                                 {

--- a/src/NuGetGallery/Services/MarkdownService.cs
+++ b/src/NuGetGallery/Services/MarkdownService.cs
@@ -203,6 +203,7 @@ namespace NuGetGallery
                 .UseTaskLists()
                 .UseEmojiAndSmiley()
                 .UseAutoLinks()
+                .UseReferralLinks("noopener noreferrer nofollow")
                 .UseAutoIdentifiers()
                 .UseEmphasisExtras(EmphasisExtraOptions.Strikethrough)
                 .DisableHtml() //block inline html


### PR DESCRIPTION
Fixes the issue where internal section links in a README do not link to the specified section, but instead take a user back to the top.

Addresses https://github.com/NuGet/NuGetGallery/issues/8833 