### PR TITLE
Manage disposal of httpclient directly - autofac disposing early

### DIFF
--- a/src/GitHubVulnerabilities2Db/Job.cs
+++ b/src/GitHubVulnerabilities2Db/Job.cs
@@ -134,7 +134,8 @@ namespace GitHubVulnerabilities2Db
         {
             containerBuilder
                 .RegisterInstance(_client)
-                .As<HttpClient>();
+                .As<HttpClient>()
+                .ExternallyOwned(); // We don't want autofac disposing this--see https://github.com/NuGet/NuGetGallery/issues/9194
 
             containerBuilder
                 .RegisterType<QueryService>()


### PR DESCRIPTION
Addresses: https://github.com/NuGet/NuGetGallery/issues/9194

If we set a registration to `ExternallyOwned` we control its life cycle--an early disposal was breaking this service: https://autofac.readthedocs.io/en/latest/lifetime/disposal.html