### PR TITLE
[Hotfix] Set download count to Int32.MaxValue for V2 feed packages exceeding this threshold

### DIFF
--- a/src/NuGetGallery/OData/PackageExtensions.cs
+++ b/src/NuGetGallery/OData/PackageExtensions.cs
@@ -88,7 +88,7 @@ namespace NuGetGallery.OData
                     Created = p.Created,
                     Dependencies = p.FlattenedDependencies,
                     Description = p.Description,
-                    DownloadCount = p.PackageRegistration.DownloadCount > Int32.MaxValue ? (long)Int32.MaxValue : p.PackageRegistration.DownloadCount,
+                    DownloadCount = p.PackageRegistration.DownloadCount > 10000 ? (long)Int32.MaxValue : p.PackageRegistration.DownloadCount,
                     GalleryDetailsUrl = siteRoot + "packages/" + p.PackageRegistration.Id + "/" + p.NormalizedVersion,
                     IconUrl = p.IconUrl,
                     // We do not expose the internal IsLatestSemVer2 and IsLatestStableSemVer2 properties; 

--- a/src/NuGetGallery/OData/PackageExtensions.cs
+++ b/src/NuGetGallery/OData/PackageExtensions.cs
@@ -88,7 +88,7 @@ namespace NuGetGallery.OData
                     Created = p.Created,
                     Dependencies = p.FlattenedDependencies,
                     Description = p.Description,
-                    DownloadCount = p.PackageRegistration.DownloadCount,
+                    DownloadCount = p.PackageRegistration.DownloadCount > Int32.MaxValue ? (long)Int32.MaxValue : p.PackageRegistration.DownloadCount,
                     GalleryDetailsUrl = siteRoot + "packages/" + p.PackageRegistration.Id + "/" + p.NormalizedVersion,
                     IconUrl = p.IconUrl,
                     // We do not expose the internal IsLatestSemVer2 and IsLatestStableSemVer2 properties; 

--- a/src/NuGetGallery/OData/PackageExtensions.cs
+++ b/src/NuGetGallery/OData/PackageExtensions.cs
@@ -88,7 +88,10 @@ namespace NuGetGallery.OData
                     Created = p.Created,
                     Dependencies = p.FlattenedDependencies,
                     Description = p.Description,
-                    DownloadCount = p.PackageRegistration.DownloadCount > 1000000 ? (long)Int32.MaxValue : p.PackageRegistration.DownloadCount,
+                    // Some of the older clients and packages (eg: NuGet.Core) suffer from integer overflow when the download count
+                    // exceeds the MaxValue due to usage of Int32 for "DownloadCount" field. As such, for the V2 Feed restrict the download
+                    // count to Int32.MaxValue in order to allow older clients to successfully fetch these values.
+                    DownloadCount = p.PackageRegistration.DownloadCount > Int32.MaxValue ? (long)Int32.MaxValue : p.PackageRegistration.DownloadCount,
                     GalleryDetailsUrl = siteRoot + "packages/" + p.PackageRegistration.Id + "/" + p.NormalizedVersion,
                     IconUrl = p.IconUrl,
                     // We do not expose the internal IsLatestSemVer2 and IsLatestStableSemVer2 properties; 

--- a/src/NuGetGallery/OData/PackageExtensions.cs
+++ b/src/NuGetGallery/OData/PackageExtensions.cs
@@ -88,7 +88,7 @@ namespace NuGetGallery.OData
                     Created = p.Created,
                     Dependencies = p.FlattenedDependencies,
                     Description = p.Description,
-                    DownloadCount = p.PackageRegistration.DownloadCount > 10000 ? (long)Int32.MaxValue : p.PackageRegistration.DownloadCount,
+                    DownloadCount = p.PackageRegistration.DownloadCount > 1000000 ? (long)Int32.MaxValue : p.PackageRegistration.DownloadCount,
                     GalleryDetailsUrl = siteRoot + "packages/" + p.PackageRegistration.Id + "/" + p.NormalizedVersion,
                     IconUrl = p.IconUrl,
                     // We do not expose the internal IsLatestSemVer2 and IsLatestStableSemVer2 properties; 

--- a/tests/NuGetGallery.Facts/OData/Interceptors/PackageExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/OData/Interceptors/PackageExtensionsFacts.cs
@@ -132,6 +132,29 @@ namespace NuGetGallery.OData.Interceptors
                 Assert.Null(actual.LicenseNames);
                 Assert.Null(actual.LicenseReportUrl);
             }
+
+            [Fact]
+            public void RestrictsExceedingDownloadCountsToInt32MaxValue()
+            {
+                // Arrange
+                var package = CreateFakeBasePackage();
+                package.PackageRegistration.DownloadCount = long.MaxValue;
+                var packages = new List<Package>
+                {
+                    package
+                }.AsQueryable();
+
+                // Act
+                var projected = PackageExtensions.ProjectV2FeedPackage(
+                    packages,
+                    siteRoot: "http://nuget.org",
+                    includeLicenseReport: false,
+                    semVerLevelKey: SemVerLevelKey.Unknown).ToList();
+
+                // Assert
+                var actual = projected.Single();
+                Assert.Equal(Int32.MaxValue, actual.DownloadCount);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The Hijacked v2 endpoints return the download counts as is, however, few old package download clients suffer from Integer overflow during the deserialization of the package metadata due to the use of `Int32` for the `DownloadCount` field.

This is now a noticeable issue due to multiple packages exceeding this threshold (`Newtonsoft.Json`, `Microsoft.Extensions.DependencyInjection.Abstractions` etc.)

As a workaround, we can set this field to the max allowed value on the v2 returned response.