### PR TITLE
Fully Qualify Install-Package command on website

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -86,7 +86,9 @@
             {
                 Id = "package-manager",
                 CommandPrefix = "PM> ",
-                InstallPackageCommands = new [] { string.Format("Install-Package {0} -Version {1}", Model.Id, Model.Version) },
+                InstallPackageCommands = new [] { string.Format("NuGet\Install-Package {0} -Version {1}", Model.Id, Model.Version) },
+                AlertLevel = AlertLevel.Info,
+                AlertMessage = "This command is intended to be used within the Package Manager Console in Visual Studio, as it uses the NuGet module's version of Install-Package. To use the Install-Package command included in the PackageManagement module, use the code supplied within the PowerShell tab."
             },
 
             new PackageManagerViewModel(".NET CLI")

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -86,7 +86,7 @@
             {
                 Id = "package-manager",
                 CommandPrefix = "PM> ",
-                InstallPackageCommands = new [] { string.Format("NuGet\Install-Package {0} -Version {1}", Model.Id, Model.Version) },
+                InstallPackageCommands = new [] { string.Format("NuGet\\Install-Package {0} -Version {1}", Model.Id, Model.Version) },
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This command is intended to be used within the Package Manager Console in Visual Studio, as it uses the NuGet module's version of <a href='https://docs.microsoft.com/en-us/nuget/reference/ps-reference/ps-ref-install-package'>Install-Package</a>."
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -136,15 +136,6 @@
                 Id = Model.IsCakeExtension() ? "cake-extension" : "cake",
                 InstallPackageCommands = new [] { Model.GetCakeInstallPackageCommand() },
             },
-
-            new PackageManagerViewModel("PowerShell")
-            {
-                Id = "powershell",
-                CommandPrefix = "PS> ",
-                InstallPackageCommands = new [] { string.Format("PackageManagement\Install-Package {0} -RequiredVersion {1}", Model.Id, Model.Version) }
-                AlertLevel = AlertLevel.Info,
-                AlertMessage = "This command calls the version of Install-Package that is found within the PackageManagement module and is intended to be used within the default PowerShell console. Do not use this command within the Package Manager Console in Visual Studio."
-            },
         };
     }
 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -88,7 +88,8 @@
                 CommandPrefix = "PM> ",
                 InstallPackageCommands = new [] { string.Format("NuGet\Install-Package {0} -Version {1}", Model.Id, Model.Version) },
                 AlertLevel = AlertLevel.Info,
-                AlertMessage = "This command is intended to be used within the Package Manager Console in Visual Studio, as it uses the NuGet module's version of Install-Package. To use the Install-Package command included in the PackageManagement module, use the code supplied within the PowerShell tab."
+                AlertMessage = "This command is intended to be used within the Package Manager Console in Visual Studio, as it uses the NuGet module's version of <a href='https://docs.microsoft.com/en-us/nuget/reference/ps-reference/ps-ref-install-package'>Install-Package</a>."
+
             },
 
             new PackageManagerViewModel(".NET CLI")

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -135,6 +135,15 @@
                 Id = Model.IsCakeExtension() ? "cake-extension" : "cake",
                 InstallPackageCommands = new [] { Model.GetCakeInstallPackageCommand() },
             },
+
+            new PackageManagerViewModel("PowerShell")
+            {
+                Id = "powershell",
+                CommandPrefix = "PS> ",
+                InstallPackageCommands = new [] { string.Format("PackageManagement\Install-Package {0} -RequiredVersion {1}", Model.Id, Model.Version) }
+                AlertLevel = AlertLevel.Info,
+                AlertMessage = "This command calls the version of Install-Package that is found within the PackageManagement module and is intended to be used within the default PowerShell console. Do not use this command within the Package Manager Console in Visual Studio."
+            },
         };
     }
 }


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Install-Package exists in both Microsoft's NuGet module and PackageManagement module. This clarifies which Install-Package is expected, which helps PowerShell end-users
* Added a PowerShell tab to further clarify

Addresses https://github.com/NuGet/NuGetGallery/issues/9201