### PR TITLE
Add additional warning about blocked usernames

### DIFF
--- a/src/NuGetGallery/Views/Organizations/DeleteAccount.cshtml
+++ b/src/NuGetGallery/Views/Organizations/DeleteAccount.cshtml
@@ -15,7 +15,7 @@
                 @<text>Delete</text>)
 
             @ViewHelpers.AlertWarning(@<text><strong class="keywords">Important</strong>
-                Once your organization is deleted you cannot undo it. <a href="https://go.microsoft.com/fwlink/?linkid=862770">Read more.</a>
+                Once your organization is deleted you cannot undo it. <b>The organization name will be reserved and it will not be able to be reused.</b> <a href="https://go.microsoft.com/fwlink/?linkid=862770">Read more.</a>
                 </text>)
             <p>
                 When your organization is deleted we will:<br />

--- a/src/NuGetGallery/Views/Users/DeleteAccount.cshtml
+++ b/src/NuGetGallery/Views/Users/DeleteAccount.cshtml
@@ -26,12 +26,12 @@
                 else
                 {
                     @ViewHelpers.AlertWarning(@<text><strong class="keywords">Important</strong>
-                        Once your account is deleted you cannot undo it. <a href="https://go.microsoft.com/fwlink/?linkid=862770">Read more.</a>
+                        Once your account is deleted you cannot undo it. <b>The account name will be reserved and it will not be able to be reused.</b> <a href="https://go.microsoft.com/fwlink/?linkid=862770">Read more.</a>
                     </text>)
                     <p>
                         When you account is deleted we will:<br />
                         <ul>
-                            <li>Revoke your api key(s).</li>
+                            <li>Revoke your API key(s).</li>
                             <li>Remove you as the owner for any packages you own.</li>
                             <li>Remove your ownership from any ID prefix reservations and delete any ID prefix reservations that you were the only owner of.</li>
                             <li>Remove you from any organizations that you are a member of.</li>


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/7447

We have a standing policy of blocking user account and organization account usernames after deletion. The `Users` table record essentially remains in a soft deleted state preventing future registrations. This is to avoid impersonation attacks.

![image](https://user-images.githubusercontent.com/94054/186953759-b283aa52-8940-486d-a0c6-53944b4a89e8.png)

![image](https://user-images.githubusercontent.com/94054/186954338-fe03ddf9-864c-4d5f-a986-de2431e22e87.png)


Over support requests, it's clear that this surprises some users. Let's make it more clear in the deletion pages that this is the case.