### PR TITLE
Show information about parent namespaces on the ID prefix reservation admin panel

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Controllers/ReservedNamespaceController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/ReservedNamespaceController.cs
@@ -39,29 +39,28 @@ namespace NuGetGallery.Areas.Admin.Controllers
             var prefixQueries = GetPrefixesFromQuery(query);
 
             var foundPrefixes = _reservedNamespaceService.FindReservedNamespacesForPrefixList(prefixQueries);
+            var valueToNamespace = foundPrefixes.ToDictionary(x => x.Value, StringComparer.OrdinalIgnoreCase);
 
-            var notFoundPrefixQueries = prefixQueries.Except(foundPrefixes.Select(p => p.Value), StringComparer.OrdinalIgnoreCase);
-            var notFoundPrefixes = notFoundPrefixQueries.Select(q => new ReservedNamespace(value: q, isSharedNamespace: false, isPrefix: true));
-
-            var resultModel = foundPrefixes.Select(fp => new ReservedNamespaceResultModel(fp, isExisting: true)).ToList();
-
-            // Find if there are any shorter, parent reservations that should be inspected by the site admin.
-            // If you are reserving a new namespace that exists under and existing ("parent") namespace, the interests
-            // of the parent namespace should be considered by the site admin.
-            foreach (var model in resultModel)
+            var resultModel = new List<ReservedNamespaceResultModel>();
+            foreach (var value in prefixQueries)
             {
-                var existingPrefixes = _reservedNamespaceService.GetReservedNamespacesForId(model.prefix.Value);
-                model.parents = existingPrefixes
-                    .Where(x => model.prefix.Value.StartsWith(x.Value, StringComparison.OrdinalIgnoreCase)
-                             && model.prefix.Value.Length > x.Value.Length)
+                bool isExisting = valueToNamespace.TryGetValue(value, out var ns);
+                if (!isExisting)
+                {
+                    ns = new ReservedNamespace(value: value, isSharedNamespace: false, isPrefix: true);
+                }
+
+                var existingPrefixes = _reservedNamespaceService.GetReservedNamespacesForId(value);
+
+                var parents = existingPrefixes
+                    .Where(x => value.StartsWith(x.Value, StringComparison.OrdinalIgnoreCase)
+                             && value.Length > x.Value.Length)
                     .Select(x => x.Value + (x.IsPrefix ? "*" : string.Empty))
                     .OrderBy(x => x.Length)
                     .ToArray();
-            }
 
-            resultModel = resultModel
-                .Concat(notFoundPrefixes.Select(nfp => new ReservedNamespaceResultModel(nfp, isExisting: false)).ToList())
-                .ToList();
+                resultModel.Add(new ReservedNamespaceResultModel(ns, isExisting, parents));
+            }
 
             var results = new ReservedNamespaceSearchResult
             {

--- a/src/NuGetGallery/Areas/Admin/ViewModels/ReservedNamespaceResultModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/ReservedNamespaceResultModel.cs
@@ -18,6 +18,8 @@ namespace NuGetGallery.Areas.Admin.ViewModels
 
         public string[] owners { get; }
 
+        public string[] parents { get; set; }
+
         public ReservedNamespaceResultModel() { }
 
         public ReservedNamespaceResultModel(ReservedNamespace reservedNamespace, bool isExisting)
@@ -31,6 +33,7 @@ namespace NuGetGallery.Areas.Admin.ViewModels
             registrations = reservedNamespace.PackageRegistrations?.Select(pr => pr.Id).ToArray();
             owners = reservedNamespace.Owners?.Select(u => u.Username).ToArray();
             this.isExisting = isExisting;
+            parents = Array.Empty<string>();
         }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/ViewModels/ReservedNamespaceResultModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/ReservedNamespaceResultModel.cs
@@ -18,11 +18,11 @@ namespace NuGetGallery.Areas.Admin.ViewModels
 
         public string[] owners { get; }
 
-        public string[] parents { get; set; }
+        public string[] parents { get; }
 
         public ReservedNamespaceResultModel() { }
 
-        public ReservedNamespaceResultModel(ReservedNamespace reservedNamespace, bool isExisting)
+        public ReservedNamespaceResultModel(ReservedNamespace reservedNamespace, bool isExisting, string[] parents)
         {
             if (reservedNamespace == null)
             {
@@ -33,7 +33,7 @@ namespace NuGetGallery.Areas.Admin.ViewModels
             registrations = reservedNamespace.PackageRegistrations?.Select(pr => pr.Id).ToArray();
             owners = reservedNamespace.Owners?.Select(u => u.Username).ToArray();
             this.isExisting = isExisting;
-            parents = Array.Empty<string>();
+            this.parents = parents;
         }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
@@ -50,11 +50,11 @@
                                         </div>
                                         <!-- ko if: $data.isExisting -->
                                         <input style="margin-top: 5px" type="submit" value="Deallocate Namespace" title="Delete this namespace"
-                                               data-bind="click: $parent.managePrefix.bind(this, $data.prefix, false)" />
+                                               data-bind="click: $parent.managePrefix.bind(this, $data.prefix, false, $data.parents)" />
                                         <!-- /ko -->
                                         <!-- ko ifnot: $data.isExisting -->
                                         <input style="margin-top: 5px" type="submit" value="Reserve Namespace" title="Add this namespace"
-                                               data-bind="click: $parent.managePrefix.bind(this, $data.prefix, true)" />
+                                               data-bind="click: $parent.managePrefix.bind(this, $data.prefix, true, $data.parents)" />
                                         <!-- /ko -->
                                     </div>
                                 </td>
@@ -243,8 +243,14 @@
                     });
                 };
 
-                this.managePrefix = function (data, addPrefix) {
+                this.managePrefix = function (data, addPrefix, parents) {
                     if (!addPrefix && !confirm('Are you sure you want to delete this namespace?')) {
+                        e.preventDefault();
+                    }
+
+                    if (addPrefix
+                        && parents.length > 0
+                        && !confirm("At least one parent namespace exists. Check the owners of these namespaces. Press 'OK' to continue. Existing parent(s):\n" + parents.join("\n"))) {
                         e.preventDefault();
                     }
 

--- a/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
@@ -48,6 +48,16 @@
                                             <span style="font-weight: bold">Matching Pattern: </span>
                                             <span data-bind="text: $data.pattern" />
                                         </div>
+                                        <!-- ko if: $data.parents.length > 0 -->
+                                        <div>
+                                            <span style="font-weight: bold">⚠ Parent namespaces:</span>
+                                            <ul>
+                                                <!-- ko foreach: $data.parents -->
+                                                <li data-bind="text: $data"></li>
+                                                <!-- /ko -->
+                                            </ul>
+                                        </div>
+                                        <!-- /ko -->
                                         <!-- ko if: $data.isExisting -->
                                         <input style="margin-top: 5px" type="submit" value="Deallocate Namespace" title="Delete this namespace"
                                                data-bind="click: $parent.managePrefix.bind(this, $data.prefix, false, $data.parents)" />
@@ -243,18 +253,19 @@
                     });
                 };
 
-                this.managePrefix = function (data, addPrefix, parents) {
+                this.managePrefix = function (prefixToModify, addPrefix, parents, model, e) {
                     if (!addPrefix && !confirm('Are you sure you want to delete this namespace?')) {
                         e.preventDefault();
+                        return;
                     }
 
                     if (addPrefix
                         && parents.length > 0
-                        && !confirm("At least one parent namespace exists. Check the owners of these namespaces. Press 'OK' to continue. Existing parent(s):\n" + parents.join("\n"))) {
+                        && !confirm("At least one parent namespace exists. Ensure the owners of the parent namespaces have approved of the new child namespace. Press 'OK' to continue. Existing parent(s):\n" + parents.join("\n"))) {
                         e.preventDefault();
+                        return;
                     }
 
-                    var prefixToModify = data;
                     var url = addPrefix
                         ? '@Url.Action("AddNamespace", "ReservedNamespace", new { area = "Admin" })'
                         : '@Url.Action("RemoveNamespace", "ReservedNamespace", new { area = "Admin" })';


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4523

This PR adds:
- The "Parent namespaces:" section when reserving a new namespace
- A prompt to remind the site admin to check the owners of the parent namespaces. This will likely be a case we escalate to PM.

Screenshot:
![image](https://user-images.githubusercontent.com/94054/186964346-8f4f6f60-9441-4de5-bd1b-26ae67aa9314.png)

This is the prompt:
![image](https://user-images.githubusercontent.com/94054/186964418-fec8fc24-d8f5-44d3-bbcd-ee88c26fcdae.png)
