### PR TITLE
Add api.reuse.software to image allowlist

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
@@ -7,6 +7,7 @@
         "api.dependabot.com",
         "api.travis-ci.com",
         "api.travis-ci.org",
+        "api.reuse.software",
         "app.fossa.io",
         "app.fossa.com",
         "badge.fury.io",


### PR DESCRIPTION
After evaluation of api.resue.software, we decide to include this domain to our allowlist
Addresses https://github.com/NuGet/NuGetGallery/issues/9200