### PR TITLE
Fix bug causing reduced vulnerabilities version ranges to not flow into V3

### DIFF
--- a/src/GitHubVulnerabilities2Db/Ingest/AdvisoryIngestor.cs
+++ b/src/GitHubVulnerabilities2Db/Ingest/AdvisoryIngestor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GitHubVulnerabilities2Db.GraphQL;
+using Microsoft.Extensions.Logging;
 using NuGet.Services.Entities;
 using NuGetGallery;
 
@@ -15,19 +16,24 @@ namespace GitHubVulnerabilities2Db.Ingest
     {
         private readonly IPackageVulnerabilitiesManagementService _packageVulnerabilityService;
         private readonly IGitHubVersionRangeParser _gitHubVersionRangeParser;
+        private readonly ILogger<AdvisoryIngestor> _logger;
 
         public AdvisoryIngestor(
             IPackageVulnerabilitiesManagementService packageVulnerabilityService,
-            IGitHubVersionRangeParser gitHubVersionRangeParser)
+            IGitHubVersionRangeParser gitHubVersionRangeParser,
+            ILogger<AdvisoryIngestor> logger)
         {
             _packageVulnerabilityService = packageVulnerabilityService ?? throw new ArgumentNullException(nameof(packageVulnerabilityService));
             _gitHubVersionRangeParser = gitHubVersionRangeParser ?? throw new ArgumentNullException(nameof(gitHubVersionRangeParser));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task IngestAsync(IReadOnlyList<SecurityAdvisory> advisories)
         {
-            foreach (var advisory in advisories)
+            for (int i = 0; i < advisories.Count; i++)
             {
+                _logger.LogInformation("Processing advisory {Current} of {Total}...", i + 1, advisories.Count);
+                SecurityAdvisory advisory = advisories[i];
                 var vulnerabilityTuple = FromAdvisory(advisory);
                 var vulnerability = vulnerabilityTuple.Item1;
                 var wasWithdrawn = vulnerabilityTuple.Item2;

--- a/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilitiesManagementService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageVulnerabilitiesManagementService.cs
@@ -212,9 +212,9 @@ namespace NuGetGallery
                         existingRange.PackageVersionRange,
                         vulnerability.GitHubDatabaseKey);
 
+                    packagesToUpdate.UnionWith(existingRange.Packages);
                     _entitiesContext.VulnerableRanges.Remove(existingRange);
                     existingVulnerability.AffectedRanges.Remove(existingRange);
-                    packagesToUpdate.UnionWith(existingRange.Packages);
                 }
                 else
                 {

--- a/src/VerifyGitHubVulnerabilities/README.md
+++ b/src/VerifyGitHubVulnerabilities/README.md
@@ -20,7 +20,9 @@ The easiest way to run the tool if you are on the nuget.org team is to use the D
 1. Install the certificate used to authenticate as our client AAD app registration into your `CurrentUser` certificate store.
 1. Clone our internal [`NuGetDeployment`](https://nuget.visualstudio.com/DefaultCollection/NuGetMicrosoft/_git/NuGetDeploymentp) repository.
 1. Take a copy of the [DEV GitHubVulnerabilities2Db appsettings.json](https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetDeployment?path=%2Fsrc%2FJobs%2FNuGet.Jobs.Cloud%2FJobs%2FGitHubVulnerabilities2Db%2FDEV%2Fnorthcentralus%2Fappsettings.json) file and place it in the same directory as the `verifygithubvulnerabilities.exe`. This will use our secrets to authenticate to the SQL server (this file also contains a reference to the secret used for the access token to GitHub).
-1. Run as per above.
+1. Set the following property, in the `appsettings.json`, under the `"Initialization"` object: `"NuGetV3Index": "https://apidev.nugettest.org/v3/index.json"`.
+1. Overwrite the Gallery DB `"ConnectionString"` property to be the connection string from [DEV USSC (read-only) gallery config](https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetDeployment?path=/src/Gallery/ExpressV2/ServiceSpecs/Parameters.AS/DEV/USSC/NuGet.Gallery.Parameters.json&version=GBmaster). This provides an additional protection to ensure the job runs as read-only.
+2. Run as per above.
 
 ## Algorithm
 

--- a/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
+++ b/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
@@ -258,7 +258,7 @@ namespace VerifyGitHubVulnerabilities.Verify
                     {
                         Console.Error.WriteLine(
                             $@"[Metadata] Vulnerability advisory {advisoryDatabaseKey
-                                }, version {versionMetadata} of package {packageId} is marked vulnerable and is not in a vulnerable range!");
+                                }, version {versionMetadata.Identity.Version} of package {packageId} is marked vulnerable and is not in a vulnerable range!");
                         HasErrors = true;
                     }
                 }

--- a/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
+++ b/tests/GitHubVulnerabilities2Db.Facts/AdvisoryIngestorFacts.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using GitHubVulnerabilities2Db.GraphQL;
 using GitHubVulnerabilities2Db.Ingest;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
@@ -137,7 +138,8 @@ namespace GitHubVulnerabilities2Db.Facts
                 GitHubVersionRangeParserMock = new Mock<IGitHubVersionRangeParser>();
                 Ingestor = new AdvisoryIngestor(
                     PackageVulnerabilityServiceMock.Object,
-                    GitHubVersionRangeParserMock.Object);
+                    GitHubVersionRangeParserMock.Object,
+                    Mock.Of<ILogger<AdvisoryIngestor>>());
             }
 
             public Mock<IPackageVulnerabilitiesManagementService> PackageVulnerabilityServiceMock { get; }

--- a/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesManagementServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageVulnerabilitiesManagementServiceFacts.cs
@@ -481,6 +481,14 @@ namespace NuGetGallery.Services
                     .Verifiable();
 
                 Context.SetupDatabase(_databaseMock.Object);
+
+                // Entity Framework clears the collection. We use the Packages collection to know which packages to
+                // mark as updated so it's important to use the collection prior to removing the range.
+                // Related to: https://github.com/NuGet/Engineering/issues/4566
+                Mock
+                    .Get(Context.VulnerableRanges)
+                    .Setup(x => x.Remove(It.IsAny<VulnerablePackageVersionRange>()))
+                    .Callback<VulnerablePackageVersionRange>(x => x.Packages.Clear());
             }
 
             private Mock<IDbContextTransaction> _transactionMock { get; }


### PR DESCRIPTION
Entity Framework clears dependent collections when the parent entity is removed from the DB context. This means it can't be used to do further cleanup. The database was properly updated (based on cascading deletion logic from EF) but the packages did not get their LastEdited timestamp updated meaning Db2Catalog did not flow the latest (no longer vulnerable) state into V3.

Progress on https://github.com/NuGet/Engineering/issues/4566.

Here's an example of a GitHub advisory that had its version range reduced: https://github.com/github/advisory-database/commit/3fa7f26a3e7d23d5fd4feb255720d53d27f68286#diff-601b57f388e2622aed5945b89aef348e24c299b05d64c1cddf7f0870fee6b05f (package ID: Microsoft.AspNetCore.Authentication.JwtBearer).

After running VerifyGitHubVulnerabilities and reflowing any affected packages, DEV, INT, and PROD environments are now fully consistent with the GitHub advisory database.