### PR TITLE
Support more languages for syntax highlighting

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -735,6 +735,9 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
 @helper  IncludeSyntaxHighlightScript()
 {
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/github.min.css" integrity="sha512-0aPQyyeZrWj9sCA46UlmWgKOP0mUipLQ6OZXu8l4IcAmD2u31EPEy9VcIMvl7SoAaKe8bLXZhYoMaE/in+gcgA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    @* highlight.js build includes support for:: bash, c, cpp, csharp, css, diff, go, ini, java, json, javascript, kotlin, less, lua, makefile, xml, markdown, perl, php, objectivec, plaintext, python, r, ruby,rust, scss, shell, sql, swift, vbnet, yaml*@
+    @* highlight.js build includes support for:: bash, c, cpp, csharp, css, diff, go, ini, java, json, javascript, typescript, kotlin, less, lua, makefile, xml, markdown, perl, php, objectivec, plaintext, python, r, ruby,rust, scss, shell, sql, swift, vbnet, yaml, html, fsharp, powershell, dos*@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js" integrity="sha512-gU7kztaQEl7SHJyraPfZLQCNnrKdaQi5ndOyt4L4UPL/FHDd/uB9Je6KDARIqwnNNE27hnqoWLBq+Kpe4iHfeQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/languages/fsharp.min.js" integrity="sha512-DXYctkkhmMYJ4vYp4Dm6jprD4ZareZ7ud/d9mGCKif/Dt3FnN95SjogHvwKvxXHoMAAkZX6EO6ePwpDIR1Y8jw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/languages/dos.min.js" integrity="sha512-mz4SrGyk+dtPY9MNYOMkD81gp8ajViZ4S0VDuM/Zqg40cg9xgIBYSiL5fN79Htbz4f2+uR9lrDO6mgcjM+NAXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/languages/powershell.min.js" integrity="sha512-pnt8OPBTOklRd4/iSW7msOiCVO4uvffF17Egr3c7AaN0h3qFnSu7L6UmdZJUCednMhhruTLRq7X9WbyAWNBegw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 }


### PR DESCRIPTION
Add syntax highlighting for supporting fsharp, dos, powershell. 

before: 
![before](https://user-images.githubusercontent.com/64443925/189755649-5fcbbee7-662b-47f6-b756-a0e35e82ce69.png)

after: 
![after](https://user-images.githubusercontent.com/64443925/189757365-b95c359f-bf86-43bc-ace9-25083355e580.png)

Addresses https://github.com/NuGet/NuGetGallery/issues/9125

Additional:
1.  This is blocked by issue https://github.com/NuGet/NuGetGallery/issues/9226, need merge after. 
2.  We also want to support cshtml, razor, it is in separate library, we will support them later.  Track issue here: https://github.com/NuGet/NuGetGallery/issues/9231