### PR TITLE
[README] Hotfix for section links 500 error

### DIFF
--- a/src/NuGetGallery/Services/MarkdownService.cs
+++ b/src/NuGetGallery/Services/MarkdownService.cs
@@ -268,7 +268,7 @@ namespace NuGetGallery
                                 // Allow only http or https links in markdown. Transform link to https for known domains.
                                 if (!PackageHelper.TryPrepareUrlForRendering(linkInline.Url, out string readyUriString))
                                 {
-                                    if (!(linkInline.Url is null) && !linkInline.Url.StartsWith("#")) //allow internal section links
+                                    if (linkInline.Url != null && !linkInline.Url.StartsWith("#")) //allow internal section links
                                     {
                                         linkInline.Url = string.Empty;
                                     }

--- a/src/NuGetGallery/Services/MarkdownService.cs
+++ b/src/NuGetGallery/Services/MarkdownService.cs
@@ -268,7 +268,7 @@ namespace NuGetGallery
                                 // Allow only http or https links in markdown. Transform link to https for known domains.
                                 if (!PackageHelper.TryPrepareUrlForRendering(linkInline.Url, out string readyUriString))
                                 {
-                                    if (!linkInline.Url.StartsWith("#")) //allow internal section links
+                                    if (!(linkInline.Url is null) && !linkInline.Url.StartsWith("#")) //allow internal section links
                                     {
                                         linkInline.Url = string.Empty;
                                     }

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -323,7 +323,7 @@
   -->
   <system.web>
     <httpCookies requireSSL="true" httpOnlyCookies="true"/>
-    <compilation debug="false" targetFramework="4.7.2">
+    <compilation debug="true" targetFramework="4.7.2">
       <assemblies>
         <add assembly="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"/>
       </assemblies>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -673,4 +673,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  </configuration>
+</configuration>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -323,7 +323,7 @@
   -->
   <system.web>
     <httpCookies requireSSL="true" httpOnlyCookies="true"/>
-    <compilation debug="true" targetFramework="4.7.2">
+    <compilation debug="false" targetFramework="4.7.2">
       <assemblies>
         <add assembly="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"/>
       </assemblies>
@@ -673,4 +673,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+  </configuration>

--- a/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
@@ -226,7 +226,6 @@ Some text
             [Theory]
             [InlineData("This is a http://www.google.com URL and https://www.google.com", "<p>This is a <a href=\"http://www.google.com/\" rel=\"noopener noreferrer nofollow\">http://www.google.com</a> URL and <a href=\"https://www.google.com/\" rel=\"noopener noreferrer nofollow\">https://www.google.com</a></p>")]
             [InlineData("# This is a heading\n[Link](#this-is-a-heading)", "<h2 id=\"this-is-a-heading\">This is a heading</h2>\n<p><a href=\"#this-is-a-heading\" rel=\"noopener noreferrer nofollow\">Link</a></p>")]
-            [InlineData("# testing\n[test [testing]](https://www.nuget.org)","<h2>testing</h2>\n<p><a href=\"https://www.nuget.org/\" rel=\"noopener noreferrer nofollow\">test [testing]</a></p>")]
             public void TestToHtmlWithAutoLinks(string originalMd, string expectedHtml)
             {
                 _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(true);

--- a/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
@@ -226,6 +226,7 @@ Some text
             [Theory]
             [InlineData("This is a http://www.google.com URL and https://www.google.com", "<p>This is a <a href=\"http://www.google.com/\" rel=\"noopener noreferrer nofollow\">http://www.google.com</a> URL and <a href=\"https://www.google.com/\" rel=\"noopener noreferrer nofollow\">https://www.google.com</a></p>")]
             [InlineData("# This is a heading\n[Link](#this-is-a-heading)", "<h2 id=\"this-is-a-heading\">This is a heading</h2>\n<p><a href=\"#this-is-a-heading\" rel=\"noopener noreferrer nofollow\">Link</a></p>")]
+            [InlineData("# Heading\n[Heading]", "<h2 id=\"heading\">Heading</h2>\n<p><a href=\"#heading\" rel=\"noopener noreferrer nofollow\">Heading</a></p>")]
             public void TestToHtmlWithAutoLinks(string originalMd, string expectedHtml)
             {
                 _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(true);

--- a/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/MarkdownServiceFacts.cs
@@ -226,6 +226,7 @@ Some text
             [Theory]
             [InlineData("This is a http://www.google.com URL and https://www.google.com", "<p>This is a <a href=\"http://www.google.com/\" rel=\"noopener noreferrer nofollow\">http://www.google.com</a> URL and <a href=\"https://www.google.com/\" rel=\"noopener noreferrer nofollow\">https://www.google.com</a></p>")]
             [InlineData("# This is a heading\n[Link](#this-is-a-heading)", "<h2 id=\"this-is-a-heading\">This is a heading</h2>\n<p><a href=\"#this-is-a-heading\" rel=\"noopener noreferrer nofollow\">Link</a></p>")]
+            [InlineData("# testing\n[test [testing]](https://www.nuget.org)","<h2>testing</h2>\n<p><a href=\"https://www.nuget.org/\" rel=\"noopener noreferrer nofollow\">test [testing]</a></p>")]
             public void TestToHtmlWithAutoLinks(string originalMd, string expectedHtml)
             {
                 _featureFlagService.Setup(x => x.IsMarkdigMdRenderingEnabled()).Returns(true);


### PR DESCRIPTION
Added a hotfix for the 500 internal server error resulting from the added support for section links.

Addresses https://github.com/NuGet/NuGetGallery/issues/9226