### PR TITLE
[A11y] Read out "warning" when tabbing to Paket CLI

### DIFF
--- a/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery
         {
             ContactUrl = contactUrl;
             AlertLevel = AlertLevel.Warning;
-            AlertMessage = "The NuGet Team does not provide support for this client. Please contact its "
+            AlertMessage = "<b display=\"none\" aria-label=\"warning\"></b> The NuGet Team does not provide support for this client. Please contact its "
                 + $"<a href=\"{contactUrl}\" aria-label=\"Contact the maintainers of the {name} client\">maintainers</a> for support.";
         }
     }


### PR DESCRIPTION
The original fix for the issue specified below reads out the warning message when tabbing to the Paket CLI tab in the package details page but does not specify that the message is a warning message. This fix adds a hidden element with `aria-label="warning"` before the warning message.

Addresses https://github.com/NuGet/NuGetGallery/issues/9172