### PR TITLE
Ensure new role exists for anonymous uploaders when migrating db

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -6,6 +6,7 @@ namespace NuGetGallery
     public static class CoreConstants
     {
         public const string AdminRoleName = "Admins";
+        public const string AnonymousUploaderRoleName = "AnonymousUploaders";
 
         public const string PackageFileSavePathTemplate = "{0}.{1}{2}";
         public const string PackageFileBackupSavePathTemplate = "{0}/{1}/{2}.{3}";

--- a/src/NuGetGallery/Migrations/MigrationsConfiguration.cs
+++ b/src/NuGetGallery/Migrations/MigrationsConfiguration.cs
@@ -25,6 +25,12 @@ namespace NuGetGallery.Migrations
                 context.SaveChanges();
             }
 
+            if (!roles.Any(x => x.Name == CoreConstants.AnonymousUploaderRoleName))
+            {
+                roles.Add(new Role { Name = CoreConstants.AnonymousUploaderRoleName });
+                context.SaveChanges();
+            }
+
             var gallerySettings = context.Set<GallerySetting>();
             if (!gallerySettings.Any())
             {


### PR DESCRIPTION
This one is up for discussion--we can do one of:
- Not do this at all and make it a manual process
- Do this as-is
- Ensure not just the existence of an `AnonymousUploaders` Role, but also a User that is joined to it