### PR TITLE
If a claim key is present for an anonymously uploaded package, show it

### DIFF
--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -219,6 +219,8 @@ namespace NuGetGallery
             viewModel.PackageWarningIconTitle =
                 GetWarningIconTitle(viewModel.Version, deprecation, maxVulnerabilitySeverity);
 
+            viewModel.ClaimKey = package.ClaimKey;
+
             return viewModel;
         }
 

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -106,6 +106,8 @@ namespace NuGetGallery
         public bool IsComputeTargetFrameworkEnabled { get; set; }
         public PackageFrameworkCompatibility PackageFrameworkCompatibility { get; set; }
 
+        public string ClaimKey { get; set; }
+
         public void InitializeRepositoryMetadata(string repositoryUrl, string repositoryType)
         {
             RepositoryType = RepositoryKind.Unknown;

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -479,6 +479,11 @@
                     <p>Requires NuGet @Model.MinClientVersion or higher.</p>
                 }
 
+                @if (!String.IsNullOrEmpty(Model.ClaimKey))
+                {
+                    <p>Claim key: @Model.ClaimKey</p>
+                }
+
                 @if (Model.Available)
                 {
                     <div class="install-tabs">


### PR DESCRIPTION
It could be formatted up a little more nicely, but it follows the convention of other informational lines like min client version.