### PR TITLE
Alter landing displaypackage URL to use a temporary ID for anon uploads

### DIFF
--- a/src/NuGetGallery.Core/Services/CorePackageService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageService.cs
@@ -343,9 +343,16 @@ namespace NuGetGallery
             bool includeDeprecation,
             bool includeDeprecationRelationships)
         {
-            var packages = _packageRepository
-                .GetAll()
-                .Where(p => p.PackageRegistration.Id == id);
+            // We test temporaryId first because if there is a match, this is the only result set we want
+            // --it's a package created by an anonymous upload.
+            var allPackages = _packageRepository.GetAll();
+            var packages = allPackages
+                .Where(p => p.PackageRegistration.TemporaryId == id);
+            if (!packages.Any())
+            {
+                packages = allPackages
+                    .Where(p => p.PackageRegistration.Id == id);
+            }
 
             if (includeLicenseReports)
             {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -2843,9 +2843,17 @@ namespace NuGetGallery
 
                 await DeleteUploadedFileForUser(currentUser, uploadFile);
 
+                var workingId = string.IsNullOrWhiteSpace(package.PackageRegistration.TemporaryId)
+                    ? package.PackageRegistration.Id
+                    : package.PackageRegistration.TemporaryId;
+                if (!string.IsNullOrWhiteSpace(package.ClaimKey))
+                {
+                    TempData["ClaimKey"] = package.ClaimKey;
+                }
+
                 return Json(new
                 {
-                    location = Url.Package(package.PackageRegistration.Id, package.NormalizedVersion)
+                    location = Url.Package(workingId, package.NormalizedVersion)
                 });
             }
             catch (Exception)

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -219,7 +219,7 @@ namespace NuGetGallery
             viewModel.PackageWarningIconTitle =
                 GetWarningIconTitle(viewModel.Version, deprecation, maxVulnerabilitySeverity);
 
-            viewModel.ClaimKey = package.ClaimKey;
+            viewModel.TemporaryId = package.PackageRegistration.TemporaryId;
 
             return viewModel;
         }

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -106,7 +106,7 @@ namespace NuGetGallery
         public bool IsComputeTargetFrameworkEnabled { get; set; }
         public PackageFrameworkCompatibility PackageFrameworkCompatibility { get; set; }
 
-        public string ClaimKey { get; set; }
+        public string TemporaryId { get; set; }
 
         public void InitializeRepositoryMetadata(string repositoryUrl, string repositoryType)
         {

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -479,9 +479,14 @@
                     <p>Requires NuGet @Model.MinClientVersion or higher.</p>
                 }
 
-                @if (!String.IsNullOrEmpty(Model.ClaimKey))
+                @if (!String.IsNullOrEmpty(Model.TemporaryId))
                 {
-                    <p>Claim key: @Model.ClaimKey</p>
+                    <p>Temporary Package ID: @Model.TemporaryId</p>
+                }
+
+                @if (TempData["ClaimKey"] != null)
+                {
+                    <p>Claim key: @TempData["ClaimKey"]</p>
                 }
 
                 @if (Model.Available)


### PR DESCRIPTION
- changes the post-publish URL to use the temporary ID
- changes package lookup to use temporary ID first
- displays temporary ID on Display Package page, while leaving persistent metadata (actual ID, version) in page titles and publish message

![image](https://user-images.githubusercontent.com/14225979/191873924-49218f24-4045-4cfc-94db-52206da465ce.png)


