### PR TITLE
Address three CodeQL errors

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,6 @@
+path_classifiers:
+  library:
+    # The default behavior is to tag library code as `library`. Results are hidden 
+    # for library code. You can tag further files as being library code by adding them
+    # to the `library` section.
+    - "src/NuGetGallery/Scripts/gallery/moment-*.js"

--- a/src/NuGetGallery/Scripts/gallery/autocomplete.js
+++ b/src/NuGetGallery/Scripts/gallery/autocomplete.js
@@ -187,7 +187,7 @@
     }
 
     function jquerySafeId(id) {
-        return id.replace(/\./g, "\\.");
+        return jQuery.escapeSelector(id);
     }
 
     function safeId(id) {

--- a/src/NuGetGallery/Services/CertificateService.cs
+++ b/src/NuGetGallery/Services/CertificateService.cs
@@ -60,6 +60,7 @@ namespace NuGetGallery
                     certificate = new Certificate()
                     {
 #pragma warning disable CS0618 // Only set the SHA1 thumbprint, for backwards compatibility. Never read it.
+                        // CodeQL [SM02196] Only set the SHA1 thumbprint, for backwards compatibility. Never read it.
                         Sha1Thumbprint = certificateFile.Sha1Thumbprint,
 #pragma warning restore CS0618
                         Thumbprint = certificateFile.Sha256Thumbprint,


### PR DESCRIPTION
First, ignore moment.js issues by classifying it as a library.
Second, resolve an escaping issue by using a built-in jQuery method.
Third, supress a usage of MD5 for backwards compatibility reasons.
