### PR TITLE
Add instructions to install MSBuildSdk packages

### DIFF
--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -104,6 +104,7 @@ namespace NuGetGallery
                 // Lazily load the package types from the database.
                 viewModel.IsDotnetToolPackageType = package.PackageTypes.Any(e => e.Name.Equals("DotnetTool", StringComparison.OrdinalIgnoreCase));
                 viewModel.IsDotnetNewTemplatePackageType = package.PackageTypes.Any(e => e.Name.Equals("Template", StringComparison.OrdinalIgnoreCase));
+                viewModel.IsMSBuildSdkPackageType = package.PackageTypes.Any(e => e.Name.Equals("MSBuildSdk", StringComparison.OrdinalIgnoreCase));
             }
 
             if (packageKeyToDeprecation != null && packageKeyToDeprecation.TryGetValue(package.Key, out var deprecation))

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -33,6 +33,7 @@ namespace NuGetGallery
 
         public bool IsDotnetToolPackageType { get; set; }
         public bool IsDotnetNewTemplatePackageType { get; set; }
+        public bool IsMSBuildSdkPackageType { get; set; }
         public bool IsAtomFeedEnabled { get; set; }
         public bool IsPackageDeprecationEnabled { get; set; }
         public bool IsPackageVulnerabilitiesEnabled { get; set; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -78,6 +78,21 @@
             }
         };
     }
+    else if (Model.IsMSBuildSdkPackageType)
+    {
+        packageManagers = new PackageManagerViewModel[]
+        {
+            new PackageManagerViewModel("SDK")
+            {
+                Id = "sdk",
+                InstallPackageCommands = new [] { string.Format("<Sdk Include=\"{0}\" Version=\"{1}\" />", 
+                Model.Id, Model.Version) },
+                AlertLevel = AlertLevel.Info,
+                AlertMessage = string.Format("For projects that support Sdk, copy this XML node into the project file to reference the package."),
+                CopyLabel = "Copy the SDK XML node",
+            }
+        };
+    }
     else
     {
         packageManagers = new PackageManagerViewModel[]

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -85,7 +85,7 @@
             new PackageManagerViewModel("SDK")
             {
                 Id = "sdk",
-                InstallPackageCommands = new [] { string.Format("<Sdk Include=\"{0}\" Version=\"{1}\" />", 
+                InstallPackageCommands = new [] { string.Format("<Sdk Name=\"{0}\" Version=\"{1}\" />", 
                 Model.Id, Model.Version) },
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = string.Format("For projects that support Sdk, copy this XML node into the project file to reference the package."),


### PR DESCRIPTION
- Added "IsMSBuildSdkPackageType" to determine whether a package is of type MSBuildSdk.
- DisplayPackage view modified to show specific instructions for SDK types in project files as per #8800 

Let me know what you think, I've tested this on a few different packages of different types 