### PR TITLE
Framework Generation constants for Search-by-TFM

### DIFF
--- a/src/NuGetGallery.Core/Services/AssetFrameworkHelper.cs
+++ b/src/NuGetGallery.Core/Services/AssetFrameworkHelper.cs
@@ -112,5 +112,19 @@ namespace NuGetGallery
 
             return false;
         }
+
+        /// <summary>
+        /// These are the Framework Generation constant strings used by the Search Service for framework filtering.
+        /// </summary>
+        public static class FrameworkGenerationIdentifiers
+        {
+            public const string Net = "net";
+
+            public const string NetFramework = "netframework";
+
+            public const string NetCore = "netcore";
+
+            public const string NetStandard = "netstandard";
+        }
     }
 }

--- a/src/NuGetGallery.Core/Services/AssetFrameworkHelper.cs
+++ b/src/NuGetGallery.Core/Services/AssetFrameworkHelper.cs
@@ -114,7 +114,7 @@ namespace NuGetGallery
         }
 
         /// <summary>
-        /// These are the Framework Generation constant strings used by the Search Service for framework filtering.
+        /// Framework Generation shortname identifiers used by the Search Service for framework filtering.
         /// </summary>
         public static class FrameworkGenerationIdentifiers
         {
@@ -122,7 +122,7 @@ namespace NuGetGallery
 
             public const string NetFramework = "netframework";
 
-            public const string NetCore = "netcore";
+            public const string NetCoreApp = "netcoreapp";
 
             public const string NetStandard = "netstandard";
         }


### PR DESCRIPTION
This is part of the work in https://github.com/NuGet/NuGet.Jobs/pull/1096.

We will need to use these constants to represent Framework Generations in the search index, and in the URL query parameters, so they will be used by both NuGet.Jobs and NuGetGallery.

These Framework Generation strings are based on the shortname framework identifiers. There isn't currently a shortname identifier for .NET Framework (< 5.0), so we created our own constants, which includes "netframework" for .NET Framework.