### PR TITLE
Address accessibility for syntax highlighting

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -705,7 +705,6 @@ img.reserved-indicator-icon {
 .readme-common pre code.hljs .hljs-title.class_,
 .readme-common pre code.hljs .hljs-title.class_.inherited__,
 .readme-common pre code.hljs .hljs-title.function_ {
-  /* prettylights-syntax-entity */
   color: #6f42c1;
 }
 .readme-common pre code.hljs .hljs-attr,
@@ -718,65 +717,51 @@ img.reserved-indicator-icon {
 .readme-common pre code.hljs .hljs-selector-attr,
 .readme-common pre code.hljs .hljs-selector-class,
 .readme-common pre code.hljs .hljs-selector-id {
-  /* prettylights-syntax-constant */
   color: #005cc5;
 }
 .readme-common pre code.hljs .hljs-regexp,
 .readme-common pre code.hljs .hljs-string,
 .readme-common pre code.hljs .hljs-meta .hljs-string {
-  /* prettylights-syntax-string */
   color: #032f62;
 }
 .readme-common pre code.hljs .hljs-built_in,
 .readme-common pre code.hljs .hljs-symbol {
-  /* prettylights-syntax-variable */
   color: #b74e05;
 }
 .readme-common pre code.hljs .hljs-comment,
 .readme-common pre code.hljs .hljs-code,
 .readme-common pre code.hljs .hljs-formula {
-  /* prettylights-syntax-comment */
   color: #6a737d;
 }
 .readme-common pre code.hljs .hljs-name,
 .readme-common pre code.hljs .hljs-quote,
 .readme-common pre code.hljs .hljs-selector-tag,
 .readme-common pre code.hljs .hljs-selector-pseudo {
-  /* prettylights-syntax-entity-tag */
-  color: #22863a;
+  color: #207f37;
 }
 .readme-common pre code.hljs .hljs-subst {
-  /* prettylights-syntax-storage-modifier-import */
   color: #24292e;
 }
 .readme-common pre code.hljs .hljs-section {
-  /* prettylights-syntax-markup-heading */
   color: #005cc5;
   font-weight: bold;
 }
 .readme-common pre code.hljs .hljs-bullet {
-  /* prettylights-syntax-markup-list */
   color: #735c0f;
 }
 .readme-common pre code.hljs .hljs-emphasis {
-  /* prettylights-syntax-markup-italic */
   color: #24292e;
   font-style: italic;
 }
 .readme-common pre code.hljs .hljs-strong {
-  /* prettylights-syntax-markup-bold */
   color: #24292e;
   font-weight: bold;
 }
 .readme-common pre code.hljs .hljs-addition {
-  /* prettylights-syntax-markup-inserted */
-  color: #22863a;
-  background-color: #f0fff4;
+  color: #207f37;
 }
 .readme-common pre code.hljs .hljs-deletion {
-  /* prettylights-syntax-markup-deleted */
   color: #b31d28;
-  background-color: #ffeef0;
 }
 #readme-preview {
   padding-top: 0.25em;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -690,6 +690,93 @@ img.reserved-indicator-icon {
 }
 .readme-common pre code.hljs {
   background-color: #f6f8fa;
+  color: #24292e;
+}
+.readme-common pre code.hljs .hljs-doctag,
+.readme-common pre code.hljs .hljs-keyword,
+.readme-common pre code.hljs .hljs-meta .hljs-keyword,
+.readme-common pre code.hljs .hljs-template-tag,
+.readme-common pre code.hljs .hljs-template-variable,
+.readme-common pre code.hljs .hljs-type,
+.readme-common pre code.hljs .hljs-variable.language_ .hljs-built_in {
+  color: #cc3745;
+}
+.readme-common pre code.hljs .hljs-title,
+.readme-common pre code.hljs .hljs-title.class_,
+.readme-common pre code.hljs .hljs-title.class_.inherited__,
+.readme-common pre code.hljs .hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #6f42c1;
+}
+.readme-common pre code.hljs .hljs-attr,
+.readme-common pre code.hljs .hljs-attribute,
+.readme-common pre code.hljs .hljs-literal,
+.readme-common pre code.hljs .hljs-meta,
+.readme-common pre code.hljs .hljs-number,
+.readme-common pre code.hljs .hljs-operator,
+.readme-common pre code.hljs .hljs-variable,
+.readme-common pre code.hljs .hljs-selector-attr,
+.readme-common pre code.hljs .hljs-selector-class,
+.readme-common pre code.hljs .hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #005cc5;
+}
+.readme-common pre code.hljs .hljs-regexp,
+.readme-common pre code.hljs .hljs-string,
+.readme-common pre code.hljs .hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #032f62;
+}
+.readme-common pre code.hljs .hljs-built_in,
+.readme-common pre code.hljs .hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #b74e05;
+}
+.readme-common pre code.hljs .hljs-comment,
+.readme-common pre code.hljs .hljs-code,
+.readme-common pre code.hljs .hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #6a737d;
+}
+.readme-common pre code.hljs .hljs-name,
+.readme-common pre code.hljs .hljs-quote,
+.readme-common pre code.hljs .hljs-selector-tag,
+.readme-common pre code.hljs .hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #22863a;
+}
+.readme-common pre code.hljs .hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #24292e;
+}
+.readme-common pre code.hljs .hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #005cc5;
+  font-weight: bold;
+}
+.readme-common pre code.hljs .hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #735c0f;
+}
+.readme-common pre code.hljs .hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #24292e;
+  font-style: italic;
+}
+.readme-common pre code.hljs .hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #24292e;
+  font-weight: bold;
+}
+.readme-common pre code.hljs .hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #22863a;
+  background-color: #f0fff4;
+}
+.readme-common pre code.hljs .hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #b31d28;
+  background-color: #ffeef0;
 }
 #readme-preview {
   padding-top: 0.25em;

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -99,7 +99,7 @@
       .hljs-quote,
       .hljs-selector-tag,
       .hljs-selector-pseudo {
-        color: #22863a;
+        color: #207f37;
       }
       
       .hljs-subst {
@@ -126,13 +126,11 @@
       }
       
       .hljs-addition {
-        color: #22863a;
-        background-color: #f0fff4;
+        color: #207f37;
       }
       
       .hljs-deletion {
         color: #b31d28;
-        background-color: #ffeef0;
       }
     }
   }

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -42,8 +42,99 @@
     font-size: @font-size-base;
   }
 
-  pre code.hljs{
-    background-color: #f6f8fa;
+  pre {
+    code.hljs {
+      background-color: #f6f8fa;
+      color: #24292e; 
+      
+      .hljs-doctag,
+      .hljs-keyword,
+      .hljs-meta .hljs-keyword,
+      .hljs-template-tag,
+      .hljs-template-variable,
+      .hljs-type,
+      .hljs-variable.language_ 
+      .hljs-built_in {
+        color: #cc3745;
+      }
+
+      .hljs-title,
+      .hljs-title.class_,
+      .hljs-title.class_.inherited__,
+      .hljs-title.function_ {
+        color: #6f42c1;
+      }
+
+      .hljs-attr,
+      .hljs-attribute,
+      .hljs-literal,
+      .hljs-meta,
+      .hljs-number,
+      .hljs-operator,
+      .hljs-variable,
+      .hljs-selector-attr,
+      .hljs-selector-class,
+      .hljs-selector-id {
+        color: #005cc5;
+      }
+
+      .hljs-regexp,
+      .hljs-string,
+      .hljs-meta .hljs-string {
+        color: #032f62;
+      }
+      
+      .hljs-built_in,
+      .hljs-symbol {
+        color: #b74e05;
+      }
+      
+      .hljs-comment,
+      .hljs-code,
+      .hljs-formula {
+        color: #6a737d;
+      }
+      
+      .hljs-name,
+      .hljs-quote,
+      .hljs-selector-tag,
+      .hljs-selector-pseudo {
+        color: #22863a;
+      }
+      
+      .hljs-subst {
+        color: #24292e;
+      }
+      
+      .hljs-section {
+        color: #005cc5;
+        font-weight: bold;
+      }
+      
+      .hljs-bullet {
+        color: #735c0f;
+      }
+      
+      .hljs-emphasis {
+        color: #24292e;
+        font-style: italic;
+      }
+      
+      .hljs-strong {
+        color: #24292e;
+        font-weight: bold;
+      }
+      
+      .hljs-addition {
+        color: #22863a;
+        background-color: #f0fff4;
+      }
+      
+      .hljs-deletion {
+        color: #b31d28;
+        background-color: #ffeef0;
+      }
+    }
   }
 } 
 

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -734,7 +734,6 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
 
 @helper  IncludeSyntaxHighlightScript()
 {
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/github.min.css" integrity="sha512-0aPQyyeZrWj9sCA46UlmWgKOP0mUipLQ6OZXu8l4IcAmD2u31EPEy9VcIMvl7SoAaKe8bLXZhYoMaE/in+gcgA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     @* highlight.js build includes support for:: bash, c, cpp, csharp, css, diff, go, ini, java, json, javascript, typescript, kotlin, less, lua, makefile, xml, markdown, perl, php, objectivec, plaintext, python, r, ruby,rust, scss, shell, sql, swift, vbnet, yaml, html, fsharp, powershell, dos*@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js" integrity="sha512-gU7kztaQEl7SHJyraPfZLQCNnrKdaQi5ndOyt4L4UPL/FHDd/uB9Je6KDARIqwnNNE27hnqoWLBq+Kpe4iHfeQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/languages/fsharp.min.js" integrity="sha512-DXYctkkhmMYJ4vYp4Dm6jprD4ZareZ7ud/d9mGCKif/Dt3FnN95SjogHvwKvxXHoMAAkZX6EO6ePwpDIR1Y8jw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
Approach: use our own syntax highlighting css style to have more control over

contrast issue:  

- Change color from #d73a49 to #cc3745
- Change from #e36209 to #b74e05
Test: Ran few packages with code fence readme with FastPass

Addresses https://github.com/NuGet/NuGetGallery/issues/9269