### PR TITLE
Added CSRF token checks to address CodeQL bugs

### DIFF
--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -328,10 +328,10 @@ namespace NuGetGallery
 
         [HttpPost]
         [ApiAuthorize]
-        [ValidateAntiForgeryToken]
         [ApiScopeRequired(NuGetScopes.PackagePush, NuGetScopes.PackagePushVersion)]
         [ActionName("CreatePackageVerificationKey")]
         public virtual async Task<ActionResult> CreatePackageVerificationKeyAsync(string id, string version)
+        // CodeQL [SM00433] This endpoint uses API Key authentication
         {
             // For backwards compatibility, we must preserve existing behavior where the client always pushes
             // symbols and the VerifyPackageKey callback returns the appropriate response. For this reason, we
@@ -425,10 +425,10 @@ namespace NuGetGallery
 
         [HttpPost]
         [ApiAuthorize]
-        [ValidateAntiForgeryToken]
         [ApiScopeRequired(NuGetScopes.PackagePush, NuGetScopes.PackagePushVersion)]
         [ActionName("PushPackageApi")]
         public virtual Task<ActionResult> CreatePackagePost()
+        // CodeQL [SM00433] This endpoint uses API Key authentication
         {
             return CreatePackageInternal();
         }
@@ -947,10 +947,10 @@ namespace NuGetGallery
 
         [HttpPost]
         [ApiAuthorize]
-        [ValidateAntiForgeryToken]
         [ApiScopeRequired(NuGetScopes.PackageUnlist)]
         [ActionName("PublishPackageApi")]
         public virtual async Task<ActionResult> PublishPackage(string id, string version)
+        // CodeQL [SM00433] This endpoint uses API Key authentication
         {
             var package = PackageService.FindPackageByIdAndVersionStrict(id, version);
             if (package == null)

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -328,6 +328,7 @@ namespace NuGetGallery
 
         [HttpPost]
         [ApiAuthorize]
+        [ValidateAntiForgeryToken]
         [ApiScopeRequired(NuGetScopes.PackagePush, NuGetScopes.PackagePushVersion)]
         [ActionName("CreatePackageVerificationKey")]
         public virtual async Task<ActionResult> CreatePackageVerificationKeyAsync(string id, string version)
@@ -424,6 +425,7 @@ namespace NuGetGallery
 
         [HttpPost]
         [ApiAuthorize]
+        [ValidateAntiForgeryToken]
         [ApiScopeRequired(NuGetScopes.PackagePush, NuGetScopes.PackagePushVersion)]
         [ActionName("PushPackageApi")]
         public virtual Task<ActionResult> CreatePackagePost()
@@ -945,6 +947,7 @@ namespace NuGetGallery
 
         [HttpPost]
         [ApiAuthorize]
+        [ValidateAntiForgeryToken]
         [ApiScopeRequired(NuGetScopes.PackageUnlist)]
         [ActionName("PublishPackageApi")]
         public virtual async Task<ActionResult> PublishPackage(string id, string version)


### PR DESCRIPTION
Fixed 3 CodeQL bugs that required us to add checks to validate anti-forgery tokens on HttpPost requests.

Part of https://github.com/NuGet/Engineering/issues/4593

Addresses https://github.com/NuGet/Engineering/issues/4608
(https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1632798, https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1632799, https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1632803)