### PR TITLE
Fix bug around handling security advisories with 100 or more affected packages

### DIFF
--- a/src/GitHubVulnerabilities2Db/Collector/AdvisoryQueryService.cs
+++ b/src/GitHubVulnerabilities2Db/Collector/AdvisoryQueryService.cs
@@ -53,7 +53,7 @@ namespace GitHubVulnerabilities2Db.Collector
             var lastVulnerabilitiesFetchedCount = advisory.Vulnerabilities?.Edges?.Count() ?? 0;
             while (lastVulnerabilitiesFetchedCount == _queryBuilder.GetMaximumResultsPerRequest())
             {
-                _logger.LogInformation("Fetching more vulnerabilities for advisory with database key {GitHubDatabaseKey}", advisory.DatabaseId);
+                _logger.LogInformation("Fetching more vulnerabilities for advisory with database key {GitHubDatabaseKey} / GHSA ID {GhsaId}", advisory.DatabaseId, advisory.GhsaId);
                 var queryForAdditionalVulnerabilities = _queryBuilder.CreateSecurityAdvisoryQuery(advisory);
                 var responseForAdditionalVulnerabilities = await _queryService.QueryAsync(queryForAdditionalVulnerabilities, token);
                 var advisoryWithAdditionalVulnerabilities = responseForAdditionalVulnerabilities.Data.SecurityAdvisory;

--- a/src/GitHubVulnerabilities2Db/GraphQL/QueryResponse.cs
+++ b/src/GitHubVulnerabilities2Db/GraphQL/QueryResponse.cs
@@ -11,6 +11,16 @@ namespace GitHubVulnerabilities2Db.GraphQL
     public class QueryResponse
     {
         public QueryResponseData Data { get; set; }
+        public List<QueryError> Errors { get; set; }
+    }
+
+    /// <summary>
+    /// The optional error details returned by the GraphQL endpoint.
+    /// See: https://www.apollographql.com/docs/react/data/error-handling/#graphql-errors
+    /// </summary>
+    public class QueryError
+    {
+        public string Message { get; set; }
     }
 
     /// <summary>

--- a/src/GitHubVulnerabilities2Db/GraphQL/SecurityAdvisory.cs
+++ b/src/GitHubVulnerabilities2Db/GraphQL/SecurityAdvisory.cs
@@ -11,6 +11,7 @@ namespace GitHubVulnerabilities2Db.GraphQL
     public class SecurityAdvisory : INode
     {
         public int DatabaseId { get; set; }
+        public string GhsaId { get; set; }
         public string Permalink { get; set; }
         public string Severity { get; set; }
         public DateTimeOffset UpdatedAt { get; set; }

--- a/src/GitHubVulnerabilities2Db/Job.cs
+++ b/src/GitHubVulnerabilities2Db/Job.cs
@@ -34,7 +34,8 @@ namespace GitHubVulnerabilities2Db
         public override async Task Run()
         {
             var collector = _serviceProvider.GetRequiredService<IAdvisoryCollector>();
-            while (await collector.ProcessAsync(CancellationToken.None)) ;
+            while (await collector.ProcessAsync(CancellationToken.None));
+            
         }
 
         protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)

--- a/tests/GitHubVulnerabilities2Db.Facts/QueryServiceFacts.cs
+++ b/tests/GitHubVulnerabilities2Db.Facts/QueryServiceFacts.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -54,6 +56,56 @@ namespace GitHubVulnerabilities2Db.Facts
 
             // Assert
             Assert.True(_handler.WasCalled);
+        }
+
+        [Fact]
+        public async Task ErrorStatusCodeIsRejected()
+        {
+            // Arrange
+            var query = "someString";
+            _handler.ExpectedQueryContent = (new JObject { ["query"] = query }).ToString();
+
+            _handler.ExpectedEndpoint = new Uri("https://graphQL.net");
+            _configuration.GitHubGraphQLQueryEndpoint = _handler.ExpectedEndpoint;
+
+            _handler.ExpectedApiKey = "patpatpat";
+            _configuration.GitHubPersonalAccessToken = _handler.ExpectedApiKey;
+
+            var response = new QueryResponse();
+            _handler.ResponseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(response))
+            };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _service.QueryAsync(query, new CancellationToken()));
+            Assert.True(_handler.WasCalled);
+            Assert.Equal("The GitHub GraphQL response returned status code 400 Bad Request. Response body:\r\n{\"Data\":null,\"Errors\":null}", ex.Message);
+        }
+
+        [Fact]
+        public async Task ErrorResponseJsonIsRejected()
+        {
+            // Arrange
+            var query = "someString";
+            _handler.ExpectedQueryContent = (new JObject { ["query"] = query }).ToString();
+
+            _handler.ExpectedEndpoint = new Uri("https://graphQL.net");
+            _configuration.GitHubGraphQLQueryEndpoint = _handler.ExpectedEndpoint;
+
+            _handler.ExpectedApiKey = "patpatpat";
+            _configuration.GitHubPersonalAccessToken = _handler.ExpectedApiKey;
+
+            var response = new QueryResponse { Errors = new List<QueryError> { new QueryError { Message = "Query = not great" } } };
+            _handler.ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(response))
+            };
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _service.QueryAsync(query, new CancellationToken()));
+            Assert.True(_handler.WasCalled);
+            Assert.Equal("The GitHub GraphQL response returned errors in the response JSON. Response body:\r\n{\"Data\":null,\"Errors\":[{\"Message\":\"Query = not great\"}]}", ex.Message);
         }
 
         private class QueryServiceHttpClientHandler : HttpClientHandler


### PR DESCRIPTION
The original implementation used a `securityAdvisory(databaseId)` query which no longer exists. This switches to using GHSA ID as the parameter.

Fixes https://github.com/NuGet/Engineering/issues/4619.