### PR TITLE
[A11y] Correct role attribute for package lists

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -4723,6 +4723,10 @@ button.list-group-item-danger.active:focus {
   margin-bottom: 0;
   line-height: 1.3;
 }
+ul.list-packages {
+  list-style-type: none;
+  padding-left: 0;
+}
 .panel {
   margin-bottom: 22px;
   background-color: #fff;

--- a/src/Bootstrap/less/list-group.less
+++ b/src/Bootstrap/less/list-group.less
@@ -128,3 +128,8 @@ button.list-group-item {
   margin-bottom: 0;
   line-height: 1.3;
 }
+
+ul.list-packages {
+  list-style-type: none;
+  padding-left: 0;
+}

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -151,7 +151,7 @@
         </div>
     }
 
-    <div class="list-packages" role="list">
+    <ul class="list-packages">
         @{
             var itemIndex = Model.PageIndex * Model.PageSize;
             var eventName = Model.IsPreviewSearch ? "preview-search-selection" : "search-selection";
@@ -161,7 +161,7 @@
             @Html.Partial("_ListPackage", package, new ViewDataDictionary { { "itemIndex", itemIndex }, { "eventName", eventName } })
             itemIndex++;
         }
-    </div>
+    </ul>
 
     <div class="row">
         <div class="col-xs-12 clearfix">

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -41,7 +41,7 @@
 <section role="main" class="container main-container page-list-packages">
     <div class="row clearfix no-margin">
         <div class="col-md-10 no-padding">
-            <h1 role="heading">
+            <h1 tabindex="0">
                 @if (String.IsNullOrEmpty(Model.SearchTerm))
                 {
                     if (Model.TotalCount == 1)

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -41,7 +41,7 @@
 <section role="main" class="container main-container page-list-packages">
     <div class="row clearfix no-margin">
         <div class="col-md-10 no-padding">
-            <h1 role="alert">
+            <h1 role="heading">
                 @if (String.IsNullOrEmpty(Model.SearchTerm))
                 {
                     if (Model.TotalCount == 1)

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -26,7 +26,7 @@
     }
 }
 
-<article class="package" role="listitem">
+<li class="package">
 
     <div class="row">
         <div class="col-sm-1 hidden-xs hidden-sm col-package-icon">
@@ -131,4 +131,4 @@
             </div>
         </div>
     </div>
-</article>
+</li>

--- a/src/NuGetGallery/Views/Users/Profiles.cshtml
+++ b/src/NuGetGallery/Views/Users/Profiles.cshtml
@@ -97,12 +97,12 @@
 
             <hr class="profile-title-divider" />
 
-            <div class="list-packages" role="list">
+            <ul class="list-packages">
                 @foreach (var package in Model.PagedPackages)
                 {
                     @Html.Partial("_ListPackage", package)
                 }
-            </div>
+            </ul>
 
             @ViewHelpers.PreviousNextPager(Model.Pager)
         </article>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9301

**Problem:**
 
On the Profiles page and the List Packages page, the lists of packages were flagged for not having the appropriate role on the individual list items. These were already marked with role="listitem" and the enclosing div was marked with role="list", so I'm unsure why this was flagged. However, we can bypass the need for these manual role attributes by using `<ul>` and `<li>` tags directly instead.

**Previously,**
![image](https://user-images.githubusercontent.com/82980589/200703988-0ba5e6c3-e113-492c-a6ef-1f0823520af8.png)

**Fix:**

These package lists now use `<ul>` and `<li>` tags, which do not require additional role attributes. I also had to remove the bullet and left padding from these package list `<ul>`s.

**After the changes,**
![image](https://user-images.githubusercontent.com/82980589/200704058-7c7f400a-3ffe-420b-8ddc-94f21097d35b.png)
