### PR TITLE
[A11y] Change role attribute of Recaptcha iframe

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -661,7 +661,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
 
             window.onload = function () {
                 $('div.g-recaptcha iframe').attr({ tabindex: "1" });
-                $('div.g-recaptcha iframe').attr({ role: "contentinfo" });
+                $('div.g-recaptcha iframe').attr({ role: "document" });
             }
         </script>
     }

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -661,6 +661,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
 
             window.onload = function () {
                 $('div.g-recaptcha iframe').attr({ tabindex: "1" });
+                $('div.g-recaptcha iframe').attr({ role: "contentinfo" });
             }
         </script>
     }


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9300

**Problem:**
 
Th Recaptcha iframes on pages like the Forgot Password page and the Report Abuse page were marked with the role `presentation` by default, but this role (as well as the `none` role) disables some accessibility properties, which is why FastPass was flagging it.

**Previously,**
![iframe before](https://user-images.githubusercontent.com/82980589/201232922-9f0d581a-d2bb-400a-9ebb-be28953b73fa.png)

**Fix:**

Iframes are only allowed to be marked with the roles `document`, `application` or `img` (also `presentation` or `none`, but that causes other a11y problems). I changed the role of this iframe to `document`, and it clears FastPass checks now (on both the pages flagged in the bug, the Forgot Password page and the Report Abuse page).

**After the changes,**
![iframe after](https://user-images.githubusercontent.com/82980589/201232966-a09a6b89-88b7-4a41-b343-d8d0a7f223e1.png)