### PR TITLE
[A11y] Removed incorrect role attribute from breadcrumb headings

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -588,10 +588,10 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
 
 @helper Breadcrumb(bool showDivider, params Func<MvcHtmlString, HelperResult>[] segments)
 {
-    <h1 role="list" class="ms-font-xl breadcrumb-title">
+    <h1 class="ms-font-xl breadcrumb-title">
         @for (int i = 0; i < segments.Length; i++)
         {
-            <span role="listitem" class="ms-noWrap">@segments[i](MvcHtmlString.Empty)</span>
+            <span class="ms-noWrap">@segments[i](MvcHtmlString.Empty)</span>
 
             if (i < segments.Length - 1)
             {


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9310

The breadcrumb headings on pages like the 'Report Package' page were flagged for having the "list" role on an `<h1>` tag. Since these serve more as headings anyway, I simply removed the role attributes from these elements without adding anything (`<h1>` tags are announced as headers anyway), and FastPass doesn't flag it anymore.

Previously,
![image](https://user-images.githubusercontent.com/82980589/201792124-4fa89c38-ecde-4560-8d80-65d1b6705d11.png)

After the change,
![image](https://user-images.githubusercontent.com/82980589/201792482-b9b16dc8-b379-4f29-9ea0-915277aac2e9.png)
