### PR TITLE
[A11y] Remove aria-hidden attribute for prefix reserved element

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -268,13 +268,13 @@
                     </h1>
                     @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
                     {
-                        <span class="prefix-reserve-title" aria-hidden="true">
-                            <img class="reserved-indicator" aria-hidden="true" tabindex="-1"
+                        <span class="prefix-reserve-title">
+                            <img class="reserved-indicator"
                                     src="~/Content/gallery/img/reserved-indicator.svg"
                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
                                     data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"
                                     alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"/>
-                            <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label" aria-hidden="true" tabindex="-1">
+                            <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
                                 Prefix Reserved
                             </a>
                         </span>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -269,12 +269,12 @@
                     @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
                     {
                         <span class="prefix-reserve-title" aria-hidden="true">
-                            <img class="reserved-indicator" aria-hidden="true"
+                            <img class="reserved-indicator" aria-hidden="true" tabindex="-1"
                                     src="~/Content/gallery/img/reserved-indicator.svg"
                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
                                     data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"
                                     alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"/>
-                            <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label" ari-hidden="true">
+                            <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label" aria-hidden="true" tabindex="-1">
                                 Prefix Reserved
                             </a>
                         </span>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -275,7 +275,6 @@
                                     data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"
                                     alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"/>
                             <a href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
-
                                 Prefix Reserved
                             </a>
                         </span>


### PR DESCRIPTION
Previous PR addressing the below issued introduced a new accessibility issue in which the prefix reserved checkmark was not accessible to screen readers. This PR removes the aria-hidden attribute associated with the prefix reserved icon and link. This solves the issue of the below a11y bug while also maintaining that the prefix reserved icon is not read aloud along with the package title header.

Previous PR: https://github.com/NuGet/NuGetGallery/pull/9314

Addresses https://github.com/NuGet/NuGetGallery/issues/9299