### PR TITLE
Audit the AddCredential action after we commit to the DB

### DIFF
--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Data.Entity;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Web.Mvc;

--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data.Entity;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Web.Mvc;
@@ -473,6 +474,9 @@ namespace NuGetGallery.Authentication
         {
             await ReplaceCredentialInternal(user, credential);
             await Entities.SaveChangesAsync();
+
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(
+                user, AuditedUserAction.AddCredential, credential));
         }
 
         public virtual async Task<Credential> ResetPasswordWithToken(string username, string token, string newPassword)
@@ -501,6 +505,10 @@ namespace NuGetGallery.Authentication
                 user.FailedLoginCount = 0;
                 user.LastFailedLoginUtc = null;
                 await Entities.SaveChangesAsync();
+
+                await Auditing.SaveAuditRecordAsync(new UserAuditRecord(
+                    user, AuditedUserAction.AddCredential, cred));
+
                 return cred;
             }
 
@@ -590,6 +598,10 @@ namespace NuGetGallery.Authentication
 
             // Save changes
             await Entities.SaveChangesAsync();
+
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(
+                user, AuditedUserAction.AddCredential, passwordCredential));
+
             return true;
         }
 
@@ -623,10 +635,10 @@ namespace NuGetGallery.Authentication
                 throw new InvalidOperationException(ServicesStrings.OrganizationsCannotCreateCredentials);
             }
 
-            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.AddCredential, credential));
             user.Credentials.Add(credential);
             await Entities.SaveChangesAsync();
 
+            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.AddCredential, credential));
             _telemetryService.TrackNewCredentialCreated(user, credential);
         }
 
@@ -838,9 +850,6 @@ namespace NuGetGallery.Authentication
             }
 
             user.Credentials.Add(credential);
-
-            await Auditing.SaveAuditRecordAsync(new UserAuditRecord(
-                user, AuditedUserAction.AddCredential, credential));
         }
 
         private static CredentialKind GetCredentialKind(string type)
@@ -1024,15 +1033,20 @@ namespace NuGetGallery.Authentication
             await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.RemoveCredential, toRemove));
 
             // Now add one if there are no credentials left
+            Credential newCred = null;
             if (creds.Count == 0)
             {
-                var newCred = _credentialBuilder.CreatePasswordCredential(password);
-                await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.AddCredential, newCred));
+                newCred = _credentialBuilder.CreatePasswordCredential(password);
                 user.Credentials.Add(newCred);
             }
 
             // Save changes, if any
             await Entities.SaveChangesAsync();
+
+            if (newCred != null)
+            {
+                await Auditing.SaveAuditRecordAsync(new UserAuditRecord(user, AuditedUserAction.AddCredential, newCred));
+            }
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -2072,10 +2072,6 @@ namespace NuGetGallery.Authentication
                     ar.AffectedCredential.Length == 1 &&
                     ar.AffectedCredential[0].Type == cred.Type &&
                     ar.AffectedCredential[0].Identity == cred.Identity));
-
-                Assert.Equal(
-                    new List<string> { nameof(IEntitiesContext.SaveChangesAsync), nameof(IAuditingService.SaveAuditRecordAsync) },
-                    operations);
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -15,6 +15,8 @@ using NuGet.Services.Entities;
 using NuGetGallery.Auditing;
 using NuGetGallery.Authentication.Providers;
 using NuGetGallery.Authentication.Providers.MicrosoftAccount;
+using NuGetGallery.Configuration;
+using NuGetGallery.Diagnostics;
 using NuGetGallery.Framework;
 using NuGetGallery.Infrastructure.Authentication;
 using Xunit;
@@ -2070,6 +2072,55 @@ namespace NuGetGallery.Authentication
                     ar.AffectedCredential.Length == 1 &&
                     ar.AffectedCredential[0].Type == cred.Type &&
                     ar.AffectedCredential[0].Identity == cred.Identity));
+
+                Assert.Equal(
+                    new List<string> { nameof(IEntitiesContext.SaveChangesAsync), nameof(IAuditingService.SaveAuditRecordAsync) },
+                    operations);
+            }
+
+            [Fact]
+            public async Task WritesAuditRecordAfterDbCommit()
+            {
+                // Arrange
+                var entitiesContext = new Mock<IEntitiesContext>();
+                var auditingService = new Mock<IAuditingService>();
+                var credentialBuilder = new CredentialBuilder();
+
+                var authService = new AuthenticationService(
+                    entitiesContext.Object,
+                    Get<IAppConfiguration>(),
+                    Get<IDiagnosticsService>(),
+                    auditingService.Object,
+                    Enumerable.Empty<Authenticator>(),
+                    credentialBuilder,
+                    Get<ICredentialValidator>(),
+                    Get<IDateTimeProvider>(),
+                    Get<ITelemetryService>(),
+                    Get<IContentObjectService>(),
+                    Get<IFeatureFlagService>());
+                var operations = new List<string>();
+
+                var fakes = Get<Fakes>();
+                var user = fakes.CreateUser("test", credentialBuilder.CreatePasswordCredential(Fakes.Password));
+                var cred = credentialBuilder.CreateExternalCredential("flarg", "glarb", "blarb");
+                Mock
+                    .Get(authService.Auditing)
+                    .Setup(x => x.SaveAuditRecordAsync(It.IsAny<AuditRecord>()))
+                    .Returns(Task.CompletedTask)
+                    .Callback(() => operations.Add(nameof(IAuditingService.SaveAuditRecordAsync)));
+                Mock
+                    .Get(authService.Entities)
+                    .Setup(x => x.SaveChangesAsync())
+                    .ReturnsAsync(() => 0)
+                    .Callback(() => operations.Add(nameof(IEntitiesContext.SaveChangesAsync)));
+
+                // Act
+                await authService.AddCredential(user, cred);
+
+                // Assert
+                Assert.Equal(
+                    new List<string> { nameof(IEntitiesContext.SaveChangesAsync), nameof(IAuditingService.SaveAuditRecordAsync) },
+                    operations);
             }
         }
 


### PR DESCRIPTION
This allows the new DB key on the credential to be included in the audit record.

Resolve https://github.com/NuGet/Engineering/issues/4660.