### PR TITLE
Remove the client secret from AAD V2 authenticator

### DIFF
--- a/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
+++ b/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2Authenticator.cs
@@ -101,12 +101,13 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
                 RedirectUri = siteRoot + _callbackPath,
                 PostLogoutRedirectUri = siteRoot,
                 Scope = OpenIdConnectScope.OpenIdProfile + " email",
-                ResponseType = OpenIdConnectResponseType.CodeIdToken,
+                ResponseType = OpenIdConnectResponseType.IdToken,
                 TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters() { ValidateIssuer = false },
                 Notifications = new OpenIdConnectAuthenticationNotifications
                 {
                     AuthenticationFailed = AuthenticationFailed,
-                    RedirectToIdentityProvider = RedirectToIdentityProvider
+                    RedirectToIdentityProvider = RedirectToIdentityProvider,
+                    AuthorizationCodeReceived = AuthorizationCodeReceived,
                 }
             };
 
@@ -257,7 +258,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
             // Set the redirect_uri token for the alternate domains of same gallery instance
             if (_alternateSiteRootList != null && _alternateSiteRootList.Contains(notification.Request.Uri.Host))
             {
-                notification.ProtocolMessage.RedirectUri = "https://" + notification.Request.Uri.Host + "/" + _callbackPath ;
+                notification.ProtocolMessage.RedirectUri = "https://" + notification.Request.Uri.Host + "/" + _callbackPath;
             }
 
             // We always want to show the options to select account when signing in and while changing account.
@@ -270,6 +271,14 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
         {
             var authenticationPropertiesEncodedString = message.State.Split('=');
             return options.StateDataFormat.Unprotect(authenticationPropertiesEncodedString[1]);
+        }
+
+        private Task AuthorizationCodeReceived(AuthorizationCodeReceivedNotification context)
+        {
+            // Explicitly set the access_token to null. The access_token is used for authorized requests to AAD on
+            // behalf of the end user. We do not use this feature. We only use the id_token.
+            context.HandleCodeRedemption(accessToken: null, idToken: context.JwtSecurityToken.RawData);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2AuthenticatorConfiguration.cs
+++ b/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2AuthenticatorConfiguration.cs
@@ -30,7 +30,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
                 // the auth flow.
                 openIdOptions.AuthenticationMode = AuthenticationMode.Passive;
 
-                // Make sure ClientId
+                // Make sure ClientId is configured
                 if (String.IsNullOrEmpty(ClientId))
                 {
                     throw new ConfigurationErrorsException(String.Format(

--- a/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2AuthenticatorConfiguration.cs
+++ b/src/NuGetGallery.Services/Authentication/Providers/AzureActiveDirectoryV2/AzureActiveDirectoryV2AuthenticatorConfiguration.cs
@@ -12,7 +12,6 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
     public class AzureActiveDirectoryV2AuthenticatorConfiguration : AuthenticatorConfiguration
     {
         public string ClientId { get; set; }
-        public string ClientSecret { get; set; }
 
         public AzureActiveDirectoryV2AuthenticatorConfiguration()
         {
@@ -31,7 +30,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
                 // the auth flow.
                 openIdOptions.AuthenticationMode = AuthenticationMode.Passive;
 
-                // Make sure ClientId and ClientSecret is configured
+                // Make sure ClientId
                 if (String.IsNullOrEmpty(ClientId))
                 {
                     throw new ConfigurationErrorsException(String.Format(
@@ -40,16 +39,7 @@ namespace NuGetGallery.Authentication.Providers.AzureActiveDirectoryV2
                         "Auth.CommonAuth.ClientId"));
                 }
 
-                if (String.IsNullOrEmpty(ClientSecret))
-                {
-                    throw new ConfigurationErrorsException(String.Format(
-                        CultureInfo.CurrentCulture,
-                        ServicesStrings.MissingRequiredConfigurationValue,
-                        "Auth.CommonAuth.ClientSecret"));
-                }
-
                 openIdOptions.ClientId = ClientId;
-                openIdOptions.ClientSecret = ClientSecret;
                 openIdOptions.Authority = String.Format(CultureInfo.InvariantCulture, AzureActiveDirectoryV2Authenticator.Authority, AzureActiveDirectoryV2Authenticator.V2CommonTenant);
             }
         }

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -101,7 +101,6 @@
     <add key="Auth.MicrosoftAccount.ClientSecret" value=""/>
     <add key="Auth.AzureActiveDirectoryV2.Enabled" value="false"/>
     <add key="Auth.AzureActiveDirectoryV2.ClientId" value=""/>
-    <add key="Auth.AzureActiveDirectoryV2.ClientSecret" value=""/>
     <add key="Auth.AzureActiveDirectory.Enabled" value="false"/>
     <add key="Auth.AzureActiveDirectory.ClientId" value=""/>
     <add key="Auth.AzureActiveDirectory.Authority" value=""/>


### PR DESCRIPTION
We were only ever using the id_token which contains enough detail for NuGet.org sign in. The code response is not used. Progress on https://github.com/NuGet/Engineering/issues/4099

The benefit here is that we have less secrets to rotate 😄.

I've confirmed the general approach with the team that owns the AAD SDK.