### PR TITLE
[A11y][Fastpass] Remove aria-expanded attribute where not allowed

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -251,7 +251,6 @@
                 var reportContainerElement = document.createElement("div");
                 $(reportContainerElement).attr("id", "verify-package-block");
                 $(reportContainerElement).attr("class", "collapse in");
-                $(reportContainerElement).attr("aria-expanded", "true");
                 $(reportContainerElement).attr("data-bind", "template: { name: 'verify-metadata-template', data: data }");
                 $("#verify-package-container").append(reportContainerElement);
                 ko.applyBindings({ data: model }, reportContainerElement);
@@ -267,7 +266,6 @@
                 var submitContainerElement = document.createElement("div");
                 $(submitContainerElement).attr("id", "submit-block");
                 $(submitContainerElement).attr("class", "collapse in");
-                $(submitContainerElement).attr("aria-expanded", "true");
                 $(submitContainerElement).attr("data-bind", "template: { name: 'submit-package-template', data: data }");
                 $("#submit-package-container").append(submitContainerElement);
                 ko.applyBindings({ data: model }, submitContainerElement);

--- a/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
+++ b/src/NuGetGallery/Scripts/gallery/page-edit-readme.js
@@ -237,7 +237,6 @@ var BindReadMeDataManager = (function () {
             var readMeContainerElement = document.createElement("div");
             $(readMeContainerElement).attr("id", "import-readme-block");
             $(readMeContainerElement).attr("class", "collapse in");
-            $(readMeContainerElement).attr("aria-expanded", "true");
             $(readMeContainerElement).attr("data-bind", "template: { name: 'import-readme-template', data: data }");
             $("#import-readme-container").append(readMeContainerElement);
             ko.applyBindings({ data: model }, readMeContainerElement);


### PR DESCRIPTION
Removed the `aria-expanded` attribute from the following `div` elements:

URL: https://www.nuget.org/packages/manage/upload
- #verify-package-block
- #import-readme-block
- #submit-block

Addresses https://github.com/NuGet/NuGetGallery/issues/9320