### PR TITLE
[A11y][Fastpass] Add role attribute where aria-label attribute is used

### DIFF
--- a/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
@@ -19,7 +19,7 @@ namespace NuGetGallery
         {
             ContactUrl = contactUrl;
             AlertLevel = AlertLevel.Warning;
-            AlertMessage = "<b display=\"none\" aria-label=\"warning\"></b> The NuGet Team does not provide support for this client. Please contact its "
+            AlertMessage = "<b display=\"none\" aria-label=\"warning\" role=\"alert\"></b> The NuGet Team does not provide support for this client. Please contact its "
                 + $"<a href=\"{contactUrl}\" aria-label=\"Contact the maintainers of the {name} client\">maintainers</a> for support.";
         }
     }

--- a/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ThirdPartyPackageManagerViewModel.cs
@@ -19,6 +19,7 @@ namespace NuGetGallery
         {
             ContactUrl = contactUrl;
             AlertLevel = AlertLevel.Warning;
+            // the b tag below adds an element that is not displayed, but that allows screen readers to announce "warning" before the following alert message text
             AlertMessage = "<b display=\"none\" aria-label=\"warning\" role=\"alert\"></b> The NuGet Team does not provide support for this client. Please contact its "
                 + $"<a href=\"{contactUrl}\" aria-label=\"Contact the maintainers of the {name} client\">maintainers</a> for support.";
         }


### PR DESCRIPTION
Added the `role="alert"` attribute to the warning message for the third party package managers. 

Addresses https://github.com/NuGet/NuGetGallery/issues/9319