### PR TITLE
AAD account checks on packages for safety reports

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -276,6 +276,11 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
+        public bool IsBlockAadContentSafetyReportsEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsTyposquattingEnabled()
         {
             throw new NotImplementedException();

--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -276,7 +276,7 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public bool IsBlockAadContentSafetyReportsEnabled()
+        public bool IsAllowAadContentSafetyReportsEnabled()
         {
             throw new NotImplementedException();
         }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -215,6 +215,11 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
+        public bool IsBlockAadContentSafetyReportsEnabled()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsPackageDependentsEnabled(User user)
         {
             throw new NotImplementedException();

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -215,7 +215,7 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
-        public bool IsBlockAadContentSafetyReportsEnabled()
+        public bool IsAllowAadContentSafetyReportsEnabled()
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -115,17 +115,6 @@ namespace NuGetGallery
             return type?.Equals(External.AzureActiveDirectoryAccount, StringComparison.OrdinalIgnoreCase) ?? false;
         }
 
-        public static bool PackageHasNoAadOwners(Package package)
-        {
-            var owners = package?.PackageRegistration?.Owners;
-            if (owners == null || !owners.Any()) 
-            {
-                return true;
-            }
-
-            return !owners.Where(o => o.Credentials.GetAzureActiveDirectoryCredential() != null).Any();
-        }
-
         public static bool IsPackageVerificationApiKey(string type)
         {
             return type?.Equals(ApiKey.VerifyV1, StringComparison.OrdinalIgnoreCase) ?? false;

--- a/src/NuGetGallery.Core/CredentialTypes.cs
+++ b/src/NuGetGallery.Core/CredentialTypes.cs
@@ -104,6 +104,7 @@ namespace NuGetGallery
         {
             return type?.StartsWith(ApiKey.Prefix, StringComparison.OrdinalIgnoreCase) ?? false;
         }
+
         public static bool IsMicrosoftAccount(string type)
         {
             return type?.Equals(External.MicrosoftAccount, StringComparison.OrdinalIgnoreCase) ?? false;
@@ -112,6 +113,17 @@ namespace NuGetGallery
         public static bool IsAzureActiveDirectoryAccount(string type)
         {
             return type?.Equals(External.AzureActiveDirectoryAccount, StringComparison.OrdinalIgnoreCase) ?? false;
+        }
+
+        public static bool PackageHasNoAadOwners(Package package)
+        {
+            var owners = package?.PackageRegistration?.Owners;
+            if (owners == null || !owners.Any()) 
+            {
+                return true;
+            }
+
+            return !owners.Where(o => o.Credentials.GetAzureActiveDirectoryCredential() != null).Any();
         }
 
         public static bool IsPackageVerificationApiKey(string type)

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -52,7 +52,7 @@ namespace NuGetGallery
         private const string ImageAllowlistFlightName = GalleryPrefix + "ImageAllowlist";
         private const string DisplayBannerFlightName = GalleryPrefix + "Banner";
         private const string ShowReportAbuseSafetyChanges = GalleryPrefix + "ShowReportAbuseSafetyChanges";
-        private const string BlockAadContentSafetyReports = GalleryPrefix + "BlockAadContentSafetyReports";
+        private const string AllowAadContentSafetyReports = GalleryPrefix + "AllowAadContentSafetyReports";
         private const string DisplayTargetFrameworkFeatureName = GalleryPrefix + "DisplayTargetFramework";
         private const string ComputeTargetFrameworkFeatureName = GalleryPrefix + "ComputeTargetFramework";
         private const string RecentPackagesNoIndexFeatureName = GalleryPrefix + "RecentPackagesNoIndex";
@@ -334,9 +334,9 @@ namespace NuGetGallery
             return _client.IsEnabled(ShowReportAbuseSafetyChanges, defaultValue: false);
         }
 
-        public bool IsBlockAadContentSafetyReportsEnabled()
+        public bool IsAllowAadContentSafetyReportsEnabled()
         {
-            return _client.IsEnabled(BlockAadContentSafetyReports, defaultValue: false);
+            return _client.IsEnabled(AllowAadContentSafetyReports, defaultValue: false);
         }
 
         public bool IsMarkdigMdRenderingEnabled()

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -52,6 +52,7 @@ namespace NuGetGallery
         private const string ImageAllowlistFlightName = GalleryPrefix + "ImageAllowlist";
         private const string DisplayBannerFlightName = GalleryPrefix + "Banner";
         private const string ShowReportAbuseSafetyChanges = GalleryPrefix + "ShowReportAbuseSafetyChanges";
+        private const string BlockAadContentSafetyReports = GalleryPrefix + "BlockAadContentSafetyReports";
         private const string DisplayTargetFrameworkFeatureName = GalleryPrefix + "DisplayTargetFramework";
         private const string ComputeTargetFrameworkFeatureName = GalleryPrefix + "ComputeTargetFramework";
         private const string RecentPackagesNoIndexFeatureName = GalleryPrefix + "RecentPackagesNoIndex";
@@ -331,6 +332,11 @@ namespace NuGetGallery
         public bool IsShowReportAbuseSafetyChangesEnabled()
         {
             return _client.IsEnabled(ShowReportAbuseSafetyChanges, defaultValue: false);
+        }
+
+        public bool IsBlockAadContentSafetyReportsEnabled()
+        {
+            return _client.IsEnabled(BlockAadContentSafetyReports, defaultValue: false);
         }
 
         public bool IsMarkdigMdRenderingEnabled()

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -259,6 +259,11 @@ namespace NuGetGallery
         bool IsShowReportAbuseSafetyChangesEnabled();
 
         /// <summary>
+        /// Whether the online safety changes to the report abuse form have been enabled
+        /// </summary>
+        bool IsBlockAadContentSafetyReportsEnabled();
+
+        /// <summary>
         /// Whether rendering Markdown content to HTML using Markdig is enabled
         /// </summary>
         bool IsMarkdigMdRenderingEnabled();

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -259,9 +259,9 @@ namespace NuGetGallery
         bool IsShowReportAbuseSafetyChangesEnabled();
 
         /// <summary>
-        /// Whether the online safety changes to the report abuse form have been enabled
+        /// Whether online safety categories are available to content owned by at least one AAD-authenticated account
         /// </summary>
-        bool IsBlockAadContentSafetyReportsEnabled();
+        bool IsAllowAadContentSafetyReportsEnabled();
 
         /// <summary>
         /// Whether rendering Markdown content to HTML using Markdig is enabled

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1385,7 +1385,7 @@ namespace NuGetGallery
             var model = new ReportAbuseViewModel
             {
                 ReasonChoices = _featureFlagService.IsShowReportAbuseSafetyChangesEnabled() 
-                    && CredentialTypes.PackageHasNoAadOwners(package)
+                    && PackageHasNoAadOwners(package)
                     ? ReportAbuseWithSafetyReasons
                     : ReportAbuseReasons,
                 PackageId = id,
@@ -2856,6 +2856,15 @@ namespace NuGetGallery
                 _telemetryService.TrackPackagePushFailureEvent(packageId, packageVersion);
                 throw;
             }
+        }
+
+        private static bool PackageHasNoAadOwners(Package package) {
+            var owners = package?.PackageRegistration?.Owners;
+            if (owners == null || !owners.Any()) {
+                return true;
+            }
+
+            return !owners.Any(o => o.Credentials.GetAzureActiveDirectoryCredential() != null);
         }
 
         private async Task DeleteUploadedFileForUser(User currentUser, Stream uploadedFileStream)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1385,7 +1385,7 @@ namespace NuGetGallery
             var model = new ReportAbuseViewModel
             {
                 ReasonChoices = _featureFlagService.IsShowReportAbuseSafetyChangesEnabled() 
-                    && PackageHasNoAadOwners(package)
+                    && (!_featureFlagService.IsBlockAadContentSafetyReportsEnabled() || PackageHasNoAadOwners(package))
                     ? ReportAbuseWithSafetyReasons
                     : ReportAbuseReasons,
                 PackageId = id,

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1384,8 +1384,8 @@ namespace NuGetGallery
 
             var model = new ReportAbuseViewModel
             {
-                ReasonChoices = _featureFlagService.IsShowReportAbuseSafetyChangesEnabled() 
-                    && (!_featureFlagService.IsBlockAadContentSafetyReportsEnabled() || PackageHasNoAadOwners(package))
+                ReasonChoices = _featureFlagService.IsShowReportAbuseSafetyChangesEnabled()
+                    && (_featureFlagService.IsAllowAadContentSafetyReportsEnabled() || PackageHasNoAadOwners(package))
                     ? ReportAbuseWithSafetyReasons
                     : ReportAbuseReasons,
                 PackageId = id,

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1384,7 +1384,8 @@ namespace NuGetGallery
 
             var model = new ReportAbuseViewModel
             {
-                ReasonChoices = _featureFlagService.IsShowReportAbuseSafetyChangesEnabled()
+                ReasonChoices = _featureFlagService.IsShowReportAbuseSafetyChangesEnabled() 
+                    && CredentialTypes.PackageHasNoAadOwners(package)
                     ? ReportAbuseWithSafetyReasons
                     : ReportAbuseReasons,
                 PackageId = id,

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -103,7 +103,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsShowReportAbuseSafetyChangesEnabled() => throw new NotImplementedException();
 
-        public bool IsBlockAadContentSafetyReportsEnabled() => throw new NotImplementedException();
+        public bool IsAllowAadContentSafetyReportsEnabled() => throw new NotImplementedException();
 
         public bool IsMarkdigMdRenderingEnabled() => throw new NotImplementedException();
 

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -103,6 +103,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsShowReportAbuseSafetyChangesEnabled() => throw new NotImplementedException();
 
+        public bool IsBlockAadContentSafetyReportsEnabled() => throw new NotImplementedException();
+
         public bool IsMarkdigMdRenderingEnabled() => throw new NotImplementedException();
 
         public bool IsMarkdigMdSyntaxHighlightEnabled() => throw new NotImplementedException();

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -5737,8 +5737,12 @@ namespace NuGetGallery
                     Version = PackageVersion
                 };
 
+                var featureFlagService = new Mock<IFeatureFlagService>();
+                featureFlagService.Setup(ff => ff.IsShowReportAbuseSafetyChangesEnabled()).Returns(true);
+                featureFlagService.Setup(ff => ff.IsAllowAadContentSafetyReportsEnabled()).Returns(false);
+
                 // Act
-                var result = GetReportAbuseResult(null, package);
+                var result = GetReportAbuseResult(null, package, featureFlagService);
 
                 // Assert
                 Assert.IsType<ViewResult>(result);
@@ -5766,7 +5770,10 @@ namespace NuGetGallery
                 return GetReportAbuseResult(currentUser, package);
             }
 
-            private ActionResult GetReportAbuseResult(User currentUser, Package package)
+            private ActionResult GetReportAbuseResult(User currentUser, Package package) =>
+                GetReportAbuseResult(currentUser, package, featureFlagService: null);
+
+            private ActionResult GetReportAbuseResult(User currentUser, Package package, Mock<IFeatureFlagService> featureFlagService)
             {
                 var packageService = new Mock<IPackageService>();
                 packageService.Setup(p => p.FindPackageByIdAndVersionStrict(PackageId, PackageVersion)).Returns(package);
@@ -5774,6 +5781,7 @@ namespace NuGetGallery
                 var controller = CreateController(
                     GetConfigurationService(),
                     packageService: packageService,
+                    featureFlagService: featureFlagService,
                     httpContext: httpContext);
                 controller.SetCurrentUser(currentUser);
                 TestUtility.SetupUrlHelper(controller, httpContext);

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -16,6 +16,7 @@ using System.Web;
 using System.Web.Caching;
 using System.Web.Mvc;
 using System.Web.Routing;
+using Autofac.Features.OwnedInstances;
 using Moq;
 using NuGet.Packaging;
 using NuGet.Services.Entities;
@@ -5387,6 +5388,234 @@ namespace NuGetGallery
                 }
             }
 
+            public static IEnumerable<object[]> Credential_Data
+            {
+                get
+                {
+                    // Format:
+                    // 1. bool - true -> expecting to see safety categories
+                    // 2. First array is direct credentials (owners)
+                    // 3. Second array is an array of indirect credentials through owner organization members (first array contains credentials of the org itself)
+
+                    yield return new object[]
+                    {
+                        true, // no owners, we still want to enable safety reporting
+                        null,
+                        null
+                    };
+
+                    yield return new object[]
+                    {
+                        true,
+                        new object[]
+                        { // owners
+                            new object[] { "external.MicrosoftAccount" }
+                        },
+                        null
+                    };
+
+                    yield return new object[]
+                    {
+                        false,
+                        new object[]
+                        { // owners
+                            new object[] { "external.AzureActiveDirectory" }
+                        },
+                        null
+                    };
+
+                    yield return new object[]
+                    {
+                        false,
+                        new object[]
+                        { // owners
+                            new object[] { "external.AzureActiveDirectory" },
+                            new object[] { "external.MicrosoftAccount", "apikey.v1" }
+                        },
+                        null
+                    };
+
+                    yield return new object[]
+                    {
+                        false,
+                        new object[]
+                        { // owners
+                            new object[] { "external.AzureActiveDirectory", "external.MicrosoftAccount" }
+                        },
+                        null
+                    };
+
+                    yield return new object[]
+                    {
+                        false,
+                        new object[]
+                        { // owners
+                            new object[] { "external.MicrosoftAccount" },
+                            new object[] { "external.AzureActiveDirectory", "apikey.v4" },
+                            new object[] { "external.MicrosoftAccount", "apikey.v4" }
+                        },
+                        null
+                    };
+
+                    yield return new object[]
+                    {
+                        true,
+                        new object[]
+                        { // owners
+                            new object [] { "external.MicrosoftAccount" }
+                        },
+                        new object[]
+                        { // owner orgs
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount" }, // org credentials
+                                new object [] { "external.MicrosoftAccount" }
+                            }
+                        },
+                    };
+
+                    yield return new object[]
+                    {
+                        true,
+                        null,
+                        new object[]
+                        { // owner orgs
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" }, // org credentials
+                                new object[] { "external.MicrosoftAccount" },
+                                new object[] { "external.MicrosoftAccount" },
+                                new object[] { "external.MicrosoftAccount" }
+                            },
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount" }, // org credentials
+                                new object[] { "external.MicrosoftAccount", "apikey.v4", "apikey.v4" }
+                            }
+                        },
+                    };
+
+                    yield return new object[]
+                    {
+                        false,
+                        null,
+                        new object[]
+                        { // owner orgs
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" }, // org credentials
+                                new object[] { "external.MicrosoftAccount" }
+                            },
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount" }, // org credentials
+                                new object[] {  "external.MicrosoftAccount", "apikey.v4", "apikey.v4" }
+                            },
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" }, // org credentials
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" },
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" },
+                                new object[] { "external.AzureActiveDirectory" }
+                            }
+                        },
+                    };
+
+                    yield return new object[]
+                    {
+                        true,
+                        new object[]
+                        { // owners
+                            new object[] {"external.MicrosoftAccount", "apikey.v4" }
+                        },
+                        new object[]
+                        { // owner orgs
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount" }, // org credentials
+                                new object[] { "external.MicrosoftAccount" }
+                            },
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" }, // org credentials
+                                new object[] { "external.MicrosoftAccount" },
+                                new object[] { "apikey.v4", "external.MicrosoftAccount", "apikey.v4" }
+                            }
+                        },
+                    };
+
+                    yield return new object[]
+                    {
+                        false,
+                        new object[]
+                        { // owners
+                            new object[] {"external.MicrosoftAccount", "apikey.v4" }
+                        },
+                        new object[]
+                        { // owner orgs
+                            new object[]
+                            { // members
+                                new object[] { "apikey.v1", "external.MicrosoftAccount" }, // org credentials
+                                new object[] { "external.MicrosoftAccount" }
+                            },
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount" }, // org credentials
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" },
+                                new object[] { "external.AzureActiveDirectory", "apikey.v4" }
+                            }
+                        },
+                    };
+
+                    yield return new object[]
+                    {
+                        false,
+                        new object[]
+                        { // owners
+                            new object[] {"external.MicrosoftAccount", "apikey.v4" }
+                        },
+                        new object[]
+                        { // owner orgs
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount" }, // org credentials
+                                new object[] { "external.MicrosoftAccount" }
+                            },
+                            new object[]
+                            { // members
+                                new object[] { "external.AzureActiveDirectory", "apikey.v4" }, // org credentials
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" },
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" }
+                            }
+                        },
+                    };
+
+                    yield return new object[]
+                    {
+                        false,
+                        new object[]
+                        { // owners
+                            new object[] {"external.MicrosoftAccount", "apikey.v4" }
+                        },
+                        new object[]
+                        { // owner orgs
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount" }, // org credentials
+                                new object[] { "external.MicrosoftAccount" }
+                            },
+                            new object[] { }, // allow for corner case where an org has no members
+                            new object[]
+                            { // members
+                                new object[] { "external.MicrosoftAccount" }, // org credentials
+                                new object[] { "external.MicrosoftAccount", "apikey.v4" },
+                                new object[] { "external.AzureActiveDirectory", "apikey.v4" }
+                            }
+                        },
+                    };
+                }
+            }
+
             [Theory]
             [MemberData(nameof(NotOwner_Data))]
             public void ShowsFormWhenNotOwner(User currentUser, User owner)
@@ -5443,23 +5672,75 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(true, "external.MicrosoftAccount")]
-            [InlineData(false, "external.AzureActiveDirectory")]
-            [InlineData(false, "external.AzureActiveDirectory", "apikey.v1")]
-            [InlineData(false, "external.AzureActiveDirectory", "external.MicrosoftAccount")]
-            [InlineData(false, "external.AzureActiveDirectory", "external.MicrosoftAccount", "external.MicrosoftAccount")]
-            [InlineData(false, "external.AzureActiveDirectory", "external.MicrosoftAccount", "external.MicrosoftAccount", "apikey.v4", "apikey.v4")]
-            [InlineData(true, "external.MicrosoftAccount", "external.MicrosoftAccount", "external.MicrosoftAccount")]
-            [InlineData(true, "external.MicrosoftAccount", "external.MicrosoftAccount", "external.MicrosoftAccount", "apikey.v4", "apikey.v4")]
-            public void IncludesSafetyCategoriesWhenNotAadPresent(bool expectingSafetyCategories, params string[] credentialTypes) 
+            [MemberData(nameof(Credential_Data))]
+            public void IncludesSafetyCategoriesWhenNotAadPresent(bool expectingSafetyCategories, object[] directOwnerCredentials, object[] indirectOwnerCredentials) 
             {
-                var owner = new User 
+                // Arrange
+                List<User> owners = new List<User>();
+
+                // -- Direct owners
+                if (directOwnerCredentials != null)
                 {
-                    Credentials = credentialTypes.Select(ct => new Credential { Type = ct }).ToList()
+                    foreach(var ownerCredentialTypes in directOwnerCredentials)
+                    {
+                        owners.Add(new User
+                        {
+                            Credentials = ((object[])ownerCredentialTypes).Select(ct => new Credential { Type = (string)ct }).ToList()
+                        });
+                    }
+                }
+
+                // -- Organization owners
+                if (indirectOwnerCredentials != null)
+                {
+                    foreach (var ownerMembers in indirectOwnerCredentials)
+                    {
+                        var organization = new Organization
+                        {
+                            Members = new List<Membership>()
+                        };
+
+                        var orgCredentialsDone = false;
+                        foreach(var memberCredentialTypes in (object[])ownerMembers)
+                        {
+                            // the first array in an organization object contains the credentials of the org itself
+                            if (!orgCredentialsDone)
+                            {
+                                organization.Credentials = ((object[])memberCredentialTypes).Select(ct => new Credential { Type = (string)ct }).ToList();
+                                orgCredentialsDone = true;
+                            }
+                            else
+                            {
+                                var membership = new Membership
+                                {
+                                    Organization = organization
+                                };
+
+                                var member = new User
+                                {
+                                    Credentials = ((object[])memberCredentialTypes).Select(ct => new Credential { Type = (string)ct }).ToList(),
+                                    Organizations = new List<Membership> { membership }
+                                };
+
+                                membership.Member = member;
+                                organization.Members.Add(membership);
+                            }
+                        }
+
+                        owners.Add(organization);
+                    }
+                }
+
+                var package = new Package
+                {
+                    PackageRegistration = new PackageRegistration { Id = PackageId, Owners = owners },
+                    Version = PackageVersion
                 };
 
-                var result = GetReportAbuseResult(null, owner);
+                // Act
+                var result = GetReportAbuseResult(null, package);
 
+                // Assert
                 Assert.IsType<ViewResult>(result);
                 var viewResult = result as ViewResult;
 


### PR DESCRIPTION
We'll allow safety report categories only on MSA-only account-owned packages as a first step.