### PR TITLE
[TFM] net6.0-windows7.0 compatibility added.

### DIFF
--- a/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
+++ b/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
@@ -61,6 +61,11 @@ namespace NuGetGallery.Frameworks
                 }
             }
 
+            matrix.Add(SupportedFrameworks.Net60Windows7, 
+                new HashSet<NuGetFramework>() {
+                    SupportedFrameworks.Net60Windows, SupportedFrameworks.Net60Windows7,
+                    SupportedFrameworks.Net70Windows, SupportedFrameworks.Net70Windows7 });
+
             return matrix;
         }
     }

--- a/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
+++ b/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
@@ -49,6 +49,9 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework XamarinMac = new NuGetFramework(FrameworkIdentifiers.XamarinMac, EmptyVersion);
         public static readonly NuGetFramework XamarinTvOs = new NuGetFramework(FrameworkIdentifiers.XamarinTVOS, EmptyVersion);
         public static readonly NuGetFramework XamarinWatchOs = new NuGetFramework(FrameworkIdentifiers.XamarinWatchOS, EmptyVersion);
+
+        public static readonly NuGetFramework Net60Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "windows", Version7);
+        public static readonly NuGetFramework Net70Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "windows", Version7);
         
         public static readonly IReadOnlyList<NuGetFramework> AllSupportedNuGetFrameworks;
 

--- a/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
@@ -96,5 +96,23 @@ namespace NuGetGallery.Frameworks
                 Assert.True(isCompatible);
             }
         }
+
+        [Theory]
+        [InlineData("net6.0-windows7.0", "net6.0-windows", "net6.0-windows7.0", "net7.0-windows", "net7.0-windows7.0")]
+        public void WindowsPlatformVersionsShouldContainAllSpecifiedFrameworks(string windowsDefaultVersionFramework, params string[]  windowsProjectFrameworks) 
+        {
+            var packageFramework = NuGetFramework.Parse(windowsDefaultVersionFramework);
+            var projectFrameworks = new HashSet<NuGetFramework>();
+
+            foreach (var frameworkName in windowsProjectFrameworks) {
+                projectFrameworks.Add(NuGetFramework.Parse(frameworkName));
+            }
+
+            var compatibleFrameworks = _service.GetCompatibleFrameworks(new HashSet<NuGetFramework>() { packageFramework });
+            Assert.Equal(windowsProjectFrameworks.Length, compatibleFrameworks.Count);
+
+            var containsAllCompatibleFrameworks = compatibleFrameworks.All(cf => projectFrameworks.Contains(cf));
+            Assert.True(containsAllCompatibleFrameworks);
+        }
     }
 }


### PR DESCRIPTION
## Description
We use NuGet client sdk in order to create a compatibility matrix for displaying TFMs on nuget.org. Currently there is no knowledge on nuget client sdk on what net5+ platform version exists (like net6.0-windows7.0) and they are not computed.

## Changes
* net6.0-windows7.0 compatibility has been hardcoded with known values.
* This compatibility will only show if a package contains that specific TFM in their assets.

## Screenshots

![Before](https://user-images.githubusercontent.com/17834924/214958483-83ed5463-ce87-4a93-86e0-de2ceedfe872.png)

![After](https://user-images.githubusercontent.com/17834924/214958491-6f98386b-02b2-4d79-b40c-baa369998355.png)

## Notes
* Why doesn't these PR cover all the other versions?
  * We don't know the exhaustive compatibility on platform versions. 
* For further improvements we will need to collaborate with NuGet client and dotnet sdk: https://github.com/NuGet/Engineering/issues/4730. 

Addresses: https://github.com/NuGet/NuGetGallery/issues/9337