### PR TITLE
Modify warning message on display package page when missing readme

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -296,6 +296,11 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
+        public bool IsDisplayPackageReadmeWarningEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsFrameworkFilteringEnabled(User user) {
             throw new NotImplementedException();
         }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1598,6 +1598,9 @@ p.frameworktableinfo-text {
   font-weight: bold;
   margin-bottom: -1px;
 }
+.page-package-details .body-tabs .nav-tabs > li.active > a.body-warning-tab {
+  background-color: #fff4ce;
+}
 .page-package-details .body-tabs .nav-tabs > li > a {
   border-left: 0px;
   border-right: 0px;

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -423,6 +423,10 @@
       margin-bottom: -1px;
     }
 
+    .nav-tabs > li.active > a.body-warning-tab > {
+      background-color: #fff4ce;
+    }
+
     .nav-tabs > li > a {
       border-left: 0px;
       border-right: 0px;

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -135,6 +135,11 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
+        public bool IsDisplayPackageReadmeWarningEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsODataDatabaseReadOnlyEnabled()
         {
             throw new NotImplementedException();

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -48,6 +48,7 @@ namespace NuGetGallery
         private const string MarkdigMdRenderingFlightName = GalleryPrefix + "MarkdigMdRendering";
         private const string MarkdigMdSyntaxHighlightFlightName = GalleryPrefix + "MarkdigMdSyntaxHighlight";
         private const string DisplayUploadWarningV2FlightName = GalleryPrefix + "DisplayUploadWarningV2";
+        private const string DisplayPackageReadmeWarningFlightName = GalleryPrefix + "DisplayPackageReadmeWarning";
         private const string DeletePackageApiFlightName = GalleryPrefix + "DeletePackageApi";
         private const string ImageAllowlistFlightName = GalleryPrefix + "ImageAllowlist";
         private const string DisplayBannerFlightName = GalleryPrefix + "Banner";
@@ -346,6 +347,11 @@ namespace NuGetGallery
         public bool IsDisplayUploadWarningV2Enabled(User user)
         {
             return _client.IsEnabled(DisplayUploadWarningV2FlightName, user, defaultValue: false);
+        }
+
+        public bool IsDisplayPackageReadmeWarningEnabled(User user)
+        {
+            return _client.IsEnabled(DisplayPackageReadmeWarningFlightName, user, defaultValue: false);
         }
 
         public bool IsDeletePackageApiEnabled(User user)

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -274,6 +274,11 @@ namespace NuGetGallery
         bool IsDisplayUploadWarningV2Enabled(User user);
 
         /// <summary>
+        /// Whether the new warning of the missing readme is displayed to package authors
+        /// </summary>
+        bool IsDisplayPackageReadmeWarningEnabled(User user);
+
+        /// <summary>
         /// Whether or not the user can delete a package through the API.
         /// </summary>
         bool IsDeletePackageApiEnabled(User user);

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -120,6 +120,12 @@
       "SiteAdmins": false,
       "Accounts": [],
       "Domains": []
+    },
+    "NuGetGallery.DisplayPackageReadmeWarning": {
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
     }
   }
 }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -941,7 +941,7 @@ namespace NuGetGallery
                 packageRenames,
                 readme);
 
-            var isDisplayPackageReadmeWarningEnabled = _featureFlagService.IsDisplayPackageReadmeWarningEnabled(currentUser) && !model.HasEmbeddedReadmeFile && model.ReadMeHtml == null;
+            var canDisplayReadmeWarning = _featureFlagService.IsDisplayPackageReadmeWarningEnabled(currentUser) && !model.HasEmbeddedReadmeFile && model.ReadMeHtml == null;
 
             model.ValidatingTooLong = _validationService.IsValidatingTooLong(package);
             model.PackageValidationIssues = _validationService.GetLatestPackageValidationIssues(package);
@@ -958,7 +958,7 @@ namespace NuGetGallery
             model.IsDisplayTargetFrameworkEnabled = _featureFlagService.IsDisplayTargetFrameworkEnabled(currentUser);
             model.IsComputeTargetFrameworkEnabled = _featureFlagService.IsComputeTargetFrameworkEnabled();
             model.IsMarkdigMdSyntaxHighlightEnabled = _featureFlagService.IsMarkdigMdSyntaxHighlightEnabled();
-            model.IsDisplayPackageReadmeWarningEnabled = isDisplayPackageReadmeWarningEnabled;
+            model.CanDisplayReadmeWarning = canDisplayReadmeWarning;
 
             if (model.IsComputeTargetFrameworkEnabled || model.IsDisplayTargetFrameworkEnabled)
             {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -941,6 +941,8 @@ namespace NuGetGallery
                 packageRenames,
                 readme);
 
+            var isDisplayPackageReadmeWarningEnabled = _featureFlagService.IsDisplayPackageReadmeWarningEnabled(currentUser) && !model.HasEmbeddedReadmeFile && model.ReadMeHtml == null;
+
             model.ValidatingTooLong = _validationService.IsValidatingTooLong(package);
             model.PackageValidationIssues = _validationService.GetLatestPackageValidationIssues(package);
             model.SymbolsPackageValidationIssues = _validationService.GetLatestPackageValidationIssues(model.LatestSymbolsPackage);
@@ -956,7 +958,7 @@ namespace NuGetGallery
             model.IsDisplayTargetFrameworkEnabled = _featureFlagService.IsDisplayTargetFrameworkEnabled(currentUser);
             model.IsComputeTargetFrameworkEnabled = _featureFlagService.IsComputeTargetFrameworkEnabled();
             model.IsMarkdigMdSyntaxHighlightEnabled = _featureFlagService.IsMarkdigMdSyntaxHighlightEnabled();
-            model.IsDisplayPackageReadmeWarningEnabled = _featureFlagService.IsDisplayPackageReadmeWarningEnabled(currentUser);
+            model.IsDisplayPackageReadmeWarningEnabled = isDisplayPackageReadmeWarningEnabled;
 
             if (model.IsComputeTargetFrameworkEnabled || model.IsDisplayTargetFrameworkEnabled)
             {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -956,6 +956,7 @@ namespace NuGetGallery
             model.IsDisplayTargetFrameworkEnabled = _featureFlagService.IsDisplayTargetFrameworkEnabled(currentUser);
             model.IsComputeTargetFrameworkEnabled = _featureFlagService.IsComputeTargetFrameworkEnabled();
             model.IsMarkdigMdSyntaxHighlightEnabled = _featureFlagService.IsMarkdigMdSyntaxHighlightEnabled();
+            model.IsDisplayPackageReadmeWarningEnabled = _featureFlagService.IsDisplayPackageReadmeWarningEnabled(currentUser);
 
             if (model.IsComputeTargetFrameworkEnabled || model.IsDisplayTargetFrameworkEnabled)
             {

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -44,6 +44,7 @@ namespace NuGetGallery
         public bool IsPackageDependentsEnabled { get; set; }
         public bool IsRecentPackagesNoIndexEnabled { get; set; }
         public bool IsMarkdigMdSyntaxHighlightEnabled { get; set; }
+        public bool IsDisplayPackageReadmeWarningEnabled { get; set; }
         public NuGetPackageGitHubInformation GitHubDependenciesInformation { get; set; }
         public bool HasEmbeddedIcon { get; set; }
         public bool HasEmbeddedReadmeFile { get; set; }
@@ -148,6 +149,11 @@ namespace NuGetGallery
         public bool CanDisplayTargetFrameworks()
         {
             return IsDisplayTargetFrameworkEnabled && !Deleted && !IsDotnetNewTemplatePackageType;
+        }
+
+        public bool CanDisplayNewWarningWithoutReadme()
+        {
+            return !HasEmbeddedReadmeFile && ReadMeHtml == null && IsDisplayPackageReadmeWarningEnabled;
         }
 
         public bool BlockSearchEngineIndexing

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -151,11 +151,6 @@ namespace NuGetGallery
             return IsDisplayTargetFrameworkEnabled && !Deleted && !IsDotnetNewTemplatePackageType;
         }
 
-        public bool CanDisplayNewWarningWithoutReadme()
-        {
-            return !HasEmbeddedReadmeFile && ReadMeHtml == null && IsDisplayPackageReadmeWarningEnabled;
-        }
-
         public bool BlockSearchEngineIndexing
         {
             get

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -44,7 +44,7 @@ namespace NuGetGallery
         public bool IsPackageDependentsEnabled { get; set; }
         public bool IsRecentPackagesNoIndexEnabled { get; set; }
         public bool IsMarkdigMdSyntaxHighlightEnabled { get; set; }
-        public bool IsDisplayPackageReadmeWarningEnabled { get; set; }
+        public bool CanDisplayReadmeWarning { get; set; }
         public NuGetPackageGitHubInformation GitHubDependenciesInformation { get; set; }
         public bool HasEmbeddedIcon { get; set; }
         public bool HasEmbeddedReadmeFile { get; set; }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -530,12 +530,12 @@
                                role="tab"
                                data-toggle="tab"
                                id="readme-body-tab"
-                               class="body-tab"
+                               class="body-@(Model.IsDisplayPackageReadmeWarningEnabled && Model.CanDisplayPrivateMetadata? "warning-" : "")tab"
                                aria-controls="readme-tab"
                                aria-expanded="@(activeBodyTab == "readme" ? "true" : "false")"
                                aria-selected="@(activeBodyTab == "readme" ? "true" : "false")"
                                tabindex="@(activeBodyTab == "readme" ? "0" : "-1")">
-                                @if (Model.CanDisplayNewWarningWithoutReadme())
+                                @if (Model.IsDisplayPackageReadmeWarningEnabled && Model.CanDisplayPrivateMetadata)
                                 {
                                     <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
                                 } 
@@ -677,7 +677,7 @@
                         }
                         else
                         {
-                            if (Model.CanDisplayPrivateMetadata & Model.IsDisplayPackageReadmeWarningEnabled)
+                            if (Model.CanDisplayPrivateMetadata && Model.IsDisplayPackageReadmeWarningEnabled)
                             {
                                 @ViewHelpers.AlertWarning(@<text>Your package is missing a README. Please update your package to <a href='https://aka.ms/nuget-include-readme'>include a README</a> or <a href=@Url.ManagePackage(Model)>add a README here</a>.</text>);
                             }
@@ -1379,13 +1379,6 @@
                 hljs.highlightElement(el);
             });
         });
-        </script>
-    }
-
-    if (Model.CanDisplayNewWarningWithoutReadme())
-    {
-        <script>
-            document.getElementById('readme-body-tab').style = "background-color:#fff4ce"
         </script>
     }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -677,7 +677,7 @@
                         }
                         else
                         {
-                            if (Model.CanDisplayPrivateMetadata && Model.IsDisplayPackageReadmeWarningEnabled)
+                            if (Model.CanDisplayPrivateMetadata && Model.CanDisplayReadmeWarning)
                             {
                                 @ViewHelpers.AlertWarning(@<text>Your package is missing a README. Please update your package to <a href='https://aka.ms/nuget-include-readme'>include a README</a> or <a href=@Url.ManagePackage(Model)>add a README here</a>.</text>);
                             }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -534,7 +534,6 @@
                                aria-controls="readme-tab"
                                aria-expanded="@(activeBodyTab == "readme" ? "true" : "false")"
                                aria-selected="@(activeBodyTab == "readme" ? "true" : "false")"
-                               style="@(Model.CanDisplayNewWarningWithoutReadme()? "background-color: #fff4ce": "background-color: #transparent")"
                                tabindex="@(activeBodyTab == "readme" ? "0" : "-1")">
                                 @if (Model.CanDisplayNewWarningWithoutReadme())
                                 {
@@ -1380,6 +1379,13 @@
                 hljs.highlightElement(el);
             });
         });
+        </script>
+    }
+
+    if (Model.CanDisplayNewWarningWithoutReadme())
+    {
+        <script>
+            document.getElementById('readme-body-tab').style = "background-color:#fff4ce"
         </script>
     }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -530,12 +530,12 @@
                                role="tab"
                                data-toggle="tab"
                                id="readme-body-tab"
-                               class="body-@(Model.IsDisplayPackageReadmeWarningEnabled && Model.CanDisplayPrivateMetadata? "warning-" : "")tab"
+                               class="body-@(Model.CanDisplayReadmeWarning && Model.CanDisplayPrivateMetadata? "warning-" : "")tab"
                                aria-controls="readme-tab"
                                aria-expanded="@(activeBodyTab == "readme" ? "true" : "false")"
                                aria-selected="@(activeBodyTab == "readme" ? "true" : "false")"
                                tabindex="@(activeBodyTab == "readme" ? "0" : "-1")">
-                                @if (Model.IsDisplayPackageReadmeWarningEnabled && Model.CanDisplayPrivateMetadata)
+                                @if (Model.CanDisplayReadmeWarning && Model.CanDisplayPrivateMetadata)
                                 {
                                     <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
                                 } 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -534,8 +534,16 @@
                                aria-controls="readme-tab"
                                aria-expanded="@(activeBodyTab == "readme" ? "true" : "false")"
                                aria-selected="@(activeBodyTab == "readme" ? "true" : "false")"
+                               style="@(Model.CanDisplayNewWarningWithoutReadme()? "background-color: #fff4ce": "background-color: #transparent")"
                                tabindex="@(activeBodyTab == "readme" ? "0" : "-1")">
-                                <i class="ms-Icon ms-Icon--Dictionary" aria-hidden="true"></i>
+                                @if (Model.CanDisplayNewWarningWithoutReadme())
+                                {
+                                    <i class="ms-Icon ms-Icon--Warning" aria-hidden="true"></i>
+                                } 
+                                else
+                                {
+                                    <i class="ms-Icon ms-Icon--Dictionary" aria-hidden="true"></i>
+                                }
                                 README
                             </a>
                         </li>
@@ -670,7 +678,11 @@
                         }
                         else
                         {
-                            if (Model.CanDisplayPrivateMetadata)
+                            if (Model.CanDisplayPrivateMetadata & Model.IsDisplayPackageReadmeWarningEnabled)
+                            {
+                                @ViewHelpers.AlertWarning(@<text>Your package is missing a README. Please update your package to <a href='https://aka.ms/nuget-include-readme'>include a README</a> or <a href=@Url.ManagePackage(Model)>add a README here</a>.</text>);
+                            }
+                            else if (Model.CanDisplayPrivateMetadata)
                             {
                                 @ViewHelpers.AlertWarning(@<text>The package description is shown below. Please update your package to <a href='https://docs.microsoft.com/nuget/nuget-org/package-readme-on-nuget-org'>include a README</a>.</text>);
                             }

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -127,6 +127,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public bool IsDisplayUploadWarningV2Enabled(User user) => throw new NotImplementedException();
 
+        public bool IsDisplayPackageReadmeWarningEnabled(User user) => throw new NotImplementedException();
+
         public bool IsFrameworkFilteringEnabled(User user) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Introduced new warning message on package display page when package is missing readme
* only display warning message to package authors
* added feature flag to this new warning

Before: 
![Screenshot 2023-01-31 140711](https://user-images.githubusercontent.com/64443925/215915916-076f6854-e2da-48fb-8a73-6a8f8ddf11ed.png)
After: 
![Screenshot 2023-01-31 140647](https://user-images.githubusercontent.com/64443925/215915939-7573b301-73ad-4108-98c8-5b3a164070df.png)


Addresses https://github.com/NuGet/Engineering/issues/4695