### PR TITLE
Search-by-TFM Bug Bash feedback

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1773,19 +1773,6 @@ p.frameworktableinfo-text {
 .page-list-packages .no-margin {
   margin: 0 !important;
 }
-.page-list-packages .btn-filter {
-  margin-top: 33px;
-  margin-bottom: 33px;
-  width: 90px;
-  height: 45px;
-  font-weight: 500;
-  font-size: medium;
-  background-color: transparent;
-  border: none;
-}
-.page-list-packages .btn-filter:hover {
-  background-color: #f4f4f4;
-}
 @media (max-width: 992px) {
   .page-list-packages .btn-filter {
     text-align: left;
@@ -1863,6 +1850,7 @@ p.frameworktableinfo-text {
 .page-list-packages .advanced-search-panel .collapsible {
   color: #494949;
   background-color: #f4f4f4;
+  position: relative;
   padding-top: 0px;
   padding-bottom: 0px;
   border: none;
@@ -1875,6 +1863,7 @@ p.frameworktableinfo-text {
 }
 .page-list-packages .advanced-search-panel .collapsible:focus {
   outline: solid;
+  z-index: 1;
 }
 .page-list-packages .advanced-search-panel .tfmTab {
   max-height: 0;

--- a/src/Bootstrap/less/theme/page-list-packages.less
+++ b/src/Bootstrap/less/theme/page-list-packages.less
@@ -11,21 +11,6 @@
     margin: 0 !important;
   }
 
-  .btn-filter {
-    margin-top: 33px;
-    margin-bottom: 33px;
-    width: 90px;
-    height: 45px;
-    font-weight: 500;
-    font-size: medium;
-    background-color: transparent;
-    border: none;
-  }
-
-  .btn-filter:hover {
-    background-color: #f4f4f4;
-  }
-
   @media (max-width: @screen-md) {
     .btn-filter {
       text-align: left;
@@ -118,6 +103,7 @@
     .collapsible {
       color: rgb(73, 73, 73);
       background-color: @alert-info-bg;
+      position: relative;
       padding-top: 0px;
       padding-bottom: 0px;
       border: none;
@@ -131,6 +117,7 @@
 
     .collapsible:focus {
       outline: solid;
+      z-index: 1;
     }
 
     .tfmTab {

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -8,10 +8,6 @@ $(function() {
     const allFrameworks = document.querySelectorAll('.framework');
     const allTfms = document.querySelectorAll('.tfm');
 
-    // Hide the default search bar in the page header
-    const defaultSearchBarHeader = document.getElementById("search-bar-header");
-    defaultSearchBarHeader.parentNode.removeChild(defaultSearchBarHeader);
-
     // Checkbox logic for Framework and Tfm filters
     for (const framework of allFrameworks) {
         framework.addEventListener('click', clickFrameworkCheckbox);

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -23,12 +23,10 @@ $(function() {
 
     function clickFrameworkCheckbox() {
         this.indeterminate = false;
-        updateFrameworkFilters(searchForm.frameworks, this.id, this.checked);
 
         const tfms = document.querySelectorAll('[parent=' + this.id + ']');
         tfms.forEach((tfm) => {
             tfm.checked = false;
-            updateFrameworkFilters(searchForm.tfms, tfm.id, false);
         });
     }
 
@@ -40,25 +38,12 @@ $(function() {
 
         framework.checked = false;
         framework.indeterminate = checkedCount !== 0;
-        updateFrameworkFilters(searchForm.frameworks, framework.id, false);
-
-        updateFrameworkFilters(searchForm.tfms, this.id, this.checked);
-    }
-
-    // Update the query string with the selected Frameworks and Tfms
-    function updateFrameworkFilters(searchField, frameworkName, add) {
-        if (add) {
-            searchField.value += frameworkName + ",";
-        }
-        else {
-            searchField.value = searchField.value.replace(frameworkName + ",", "")
-        }
     }
 
     // Submit the form when a user changes the selected 'sortBy' option
     searchForm.sortby.addEventListener('change', (e) => {
         searchForm.sortby.value = e.target.value;
-        searchForm.submit();
+        submitSearchForm();
     });
 
     // Accordion/collapsible logic
@@ -95,6 +80,28 @@ $(function() {
         }
     }
 
+    searchForm.addEventListener('submit', submitSearchForm);
+
+    function submitSearchForm() {
+        constructFilterParameter(searchForm.frameworks, allFrameworks);
+        constructFilterParameter(searchForm.tfms, allTfms);
+        searchForm.submit();
+    }
+
+    // Update the query string with the selected frameworks and tfms
+    function constructFilterParameter(searchField, checkboxList) {
+        searchField.value = "";
+
+        checkboxList.forEach((framework) => {
+            if (framework.checked) {
+                searchField.value += framework.id + ",";
+            }
+        });
+
+        // trim trailing commas
+        searchField.value = searchField.value.replace(/,+$/, '');
+    }
+
     // Initialize state for Framework and Tfm checkboxes
     // NOTE: We first click on all selected Framework checkboxes and then on the selected Tfm checkboxes, which
     // allows us to correctly handle cases where a Framework AND one of its child Tfms is present in the query
@@ -107,5 +114,12 @@ $(function() {
 
         inputFrameworkFilters.map(id => document.getElementById(id)).forEach(checkbox => checkbox.click());
         inputTfmFilters.map(id => document.getElementById(id)).forEach(checkbox => checkbox.click());
+
+        // expand TFM section if a TFM from that generation has been selected
+        allFrameworks.forEach((checkbox) => {
+            if (checkbox.indeterminate) {
+                document.querySelector('[tab=' + checkbox.id + ']').click();
+            }
+        });
     }
 });

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -76,6 +76,8 @@
                 @if (Model.IsAdvancedSearchFlightEnabled)
                 {
                     <div class="row clearfix advanced-search-panel" id="advancedSearchPanel">
+                        <input type="text" hidden id="frameworks" name="frameworks" value="@Model.Frameworks">
+                        <input type="text" hidden id="tfms" name="tfms" value="@Model.Tfms">
                         @if (Model.IsFrameworkFilteringEnabled)
                         {
                             <div>
@@ -108,7 +110,7 @@
                             <fieldset id="packagetype">
                                 <legend>Package type</legend>
                                 @foreach (var packageType in UiSupportedPackageTypes)
-                                {
+                                    {
                                     @AddPackageFilterOption(packageType.Value, packageType.Key, isDefault: packageType.Key == DefaultPackageType)
                                 }
                             </fieldset>
@@ -133,9 +135,7 @@
                             </div>
 
                         </div>
-                        <input type="text" hidden id="frameworks" name="frameworks" value="@Model.Frameworks">
-                        <input type="text" hidden id="tfms" name="tfms" value="@Model.Tfms">
-                        <input type="hidden" id="prerel" name="prerel" value="@Model.IncludePrerelease.ToString()">
+                        <input type="hidden" id="prerel" name="prerel" value="@Model.IncludePrerelease.ToString().ToLower()">
                     </div>
                 }
             </div>

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -110,7 +110,7 @@
                             <fieldset id="packagetype">
                                 <legend>Package type</legend>
                                 @foreach (var packageType in UiSupportedPackageTypes)
-                                    {
+                                {
                                     @AddPackageFilterOption(packageType.Value, packageType.Key, isDefault: packageType.Key == DefaultPackageType)
                                 }
                             </fieldset>

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -4,6 +4,7 @@
     ViewBag.SortText = String.IsNullOrWhiteSpace(Model.SearchTerm) ? "recent installs" : "relevance";
     ViewBag.Tab = "Packages";
     ViewBag.BlockSearchEngineIndexing = !String.IsNullOrWhiteSpace(Model.SearchTerm) || Model.PageIndex != 0;
+    ViewBag.ShowSearchInNavbar = false;
 }
 
 @helper AddPackageFilterOption(string optionName, string optionValue, bool isDefault = false)


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9367,
https://github.com/NuGet/NuGetGallery/issues/9368,
https://github.com/NuGet/NuGetGallery/issues/9369,
https://github.com/NuGet/NuGetGallery/issues/9370,
https://github.com/NuGet/NuGetGallery/issues/9371,
https://github.com/NuGet/NuGetGallery/issues/9375,
https://github.com/NuGet/NuGetGallery/issues/9377,
https://github.com/NuGet/NuGetGallery/issues/9376

This PR addresses some of the issues flagged by the Search-by-TFM bug bash:

1. The Prerelease url parameter sometimes had an uppercase boolean ('True') and sometimes a lowercase boolean ('true'). It will always show a lowercase boolean now. 
https://github.com/NuGet/NuGetGallery/issues/9367
2. The frameworks and tfms parameters were being added to the query string in the order that the user selected them, rather than the order of the checkboxes in the UI. This has been fixed.
https://github.com/NuGet/NuGetGallery/issues/9368
3. The frameworks and tfms parameters always ended in a comma (`net,` ; `net5.0,net472,`). This has been fixed.
https://github.com/NuGet/NuGetGallery/issues/9369
4. Previously, all TFM sections were always collapsed when the page loaded. Now, if any individual TFMs have been selected, their TFM sections will be expanded when the page loads.
https://github.com/NuGet/NuGetGallery/issues/9370
5. The packageType query parameter was before frameworks and tfms in the url, but appears after them in the UI. This has been fixed so that the frameworks and tfms params appear before packageType in the url.
https://github.com/NuGet/NuGetGallery/issues/9371
6. The box around the framework generation collapsible arrows (when they're selected/in focus) was distorted by the box below it. Some of the bottom part of the box was hidden. This has been fixed.
https://github.com/NuGet/NuGetGallery/issues/9375

**UPDATE:** Added a small fix that addresses 2 other bugs:
1. Search bar disappears on the Profiles page. We needed to remove the default search bar on the Search page, but the search bar was being removed from the Profiles page too with the same javascript code. We now use a ViewBag property, the same way that the [Home page](https://github.com/NuGet/NuGetGallery/blob/60fc5d5b8a5211a47d3722199ff459e660c59823/src/NuGetGallery/Views/Pages/Home.cshtml#L4) does, instead of javascript. With these changes, the search bar removal will only happen on the Search page.
https://github.com/NuGet/NuGetGallery/issues/9377
2. An extra Search bar flickers before disappearing when the search page is rendering. The switch from the javascript code to the ViewBag property fixes this too.
https://github.com/NuGet/NuGetGallery/issues/9376