### PR TITLE
Add new domain for image allowlist 

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
@@ -15,6 +15,7 @@
         "badges.gitter.im",
         "bettercodehub.com",
         "buildstats.info",
+        "caniuse.bitsofco.de",
         "cdn.jsdelivr.net",
         "cdn.syncfusion.com",
         "ci.appveyor.com",


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Add domain "caniuse.bitsofco.de" for image allowlist

Addresses https://github.com/NuGet/NuGetGallery/issues/9252