### PR TITLE
Fix two small UI issues (README bg color, Script & Interactive info)

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -666,8 +666,7 @@ img.reserved-indicator-icon {
 .readme .readme-container {
   display: block;
   padding: 10.5px;
-  background-color: #f5f5f5;
-  border: 1px solid #ccc;
+  border: 2px solid #ccc;
   word-break: normal;
   margin-bottom: 24px;
   overflow: auto;
@@ -700,7 +699,7 @@ img.reserved-indicator-icon {
   font-size: 16px;
 }
 .readme-common pre code.hljs {
-  background-color: #f6f8fa;
+  background-color: #f5f5f5;
   color: #24292e;
 }
 .readme-common pre code.hljs .hljs-doctag,
@@ -742,7 +741,7 @@ img.reserved-indicator-icon {
 .readme-common pre code.hljs .hljs-comment,
 .readme-common pre code.hljs .hljs-code,
 .readme-common pre code.hljs .hljs-formula {
-  color: #6a737d;
+  color: #646d76;
 }
 .readme-common pre code.hljs .hljs-name,
 .readme-common pre code.hljs .hljs-quote,

--- a/src/Bootstrap/less/theme/common-readme.less
+++ b/src/Bootstrap/less/theme/common-readme.less
@@ -2,8 +2,7 @@
   .readme-container {
     display: block;
     padding: 10.5px;
-    background-color: @pre-bg;
-    border: 1px solid #ccc;
+    border: 2px solid #ccc;
     word-break: normal;
     margin-bottom: @default-margin-bottom;
     overflow: auto;
@@ -44,7 +43,7 @@
 
   pre {
     code.hljs {
-      background-color: #f6f8fa;
+      background-color: @pre-bg;
       color: #24292e; 
       
       .hljs-doctag,
@@ -92,7 +91,7 @@
       .hljs-comment,
       .hljs-code,
       .hljs-formula {
-        color: #6a737d;
+        color: #646d76;
       }
       
       .hljs-name,

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -143,7 +143,7 @@
                 CommandPrefix = "> ",
                 InstallPackageCommands = new [] { string.Format("#r \"nuget: {0}, {1}\"", Model.Id, Model.Version) },
                 AlertLevel = AlertLevel.Info,
-                AlertMessage = "#r directive can be used in F# Interactive, C# scripting and .NET Interactive. Copy this into the interactive tool or source code of the script to reference the package."
+                AlertMessage = "#r directive can be used in F# Interactive and Polyglot Notebooks. Copy this into the interactive tool or source code of the script to reference the package."
             },
 
             new ThirdPartyPackageManagerViewModel("Cake", "https://cakebuild.net/support/nuget")


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/9354 and https://github.com/NuGet/NuGetGallery/issues/9355.

1. Use a new, prescribed info text for the `Script & Interactive` tab: https://github.com/NuGet/NuGetGallery/issues/9354#issuecomment-1405363060.
2. Make the code block bg color match the rest. I had to darken the comment color to avoid contrast issues.
3. Change the bg color of the README section on the upload page to be white. This fixes link contrast issues (newly discovered problem).