### PR TITLE
Search page A11y fixes

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1865,6 +1865,7 @@ p.frameworktableinfo-text {
   z-index: 1;
 }
 .page-list-packages .advanced-search-panel .tfmTab {
+  display: none;
   max-height: 0;
   overflow: hidden;
   -webkit-transition: max-height 0.1s ease-out;

--- a/src/Bootstrap/less/theme/page-list-packages.less
+++ b/src/Bootstrap/less/theme/page-list-packages.less
@@ -121,6 +121,7 @@
     }
 
     .tfmTab {
+      display: none;
       max-height: 0;
       overflow: hidden;
       transition: max-height 0.1s ease-out;

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1363,8 +1363,6 @@ namespace NuGetGallery
 
             // If the experience hasn't been cached, it means it's not the default experienced, therefore, show the panel
             viewModel.IsAdvancedSearchFlightEnabled = searchService.SupportsAdvancedSearch && isAdvancedSearchFlightEnabled;
-            viewModel.ShouldDisplayAdvancedSearchPanel = !shouldCacheAdvancedSearch || !includePrerelease;
-
             viewModel.IsFrameworkFilteringEnabled = isFrameworkFilteringEnabled;
 
             ViewBag.SearchTerm = q;

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -59,20 +59,12 @@ $(function() {
         expandButton.classList.toggle('ms-Icon--ChevronUp');
 
         if (this.classList.contains('active')) {
+            dataTab.style.display = 'block';
             dataTab.style.maxHeight = dataTab.scrollHeight + "px";
-
-            for (const tfm of tfmCheckboxes) {
-                tfm.setAttribute('tabindex', '0');
-                tfm.tabindex = "0";
-            }
         }
         else {
+            dataTab.style.display = 'none';
             dataTab.style.maxHeight = 0;
-
-            for (const tfm of tfmCheckboxes) {
-                tfm.setAttribute('tabindex', '-1');
-                tfm.tabindex = "-1";
-            }
         }
     }
 

--- a/src/NuGetGallery/ViewModels/PackageListViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageListViewModel.cs
@@ -78,8 +78,6 @@ namespace NuGetGallery
 
         public string SortBy { get; set; }
 
-        public bool ShouldDisplayAdvancedSearchPanel { get; set; }
-
         public bool IsAdvancedSearchFlightEnabled { get; set; }
 
         public bool IsFrameworkFilteringEnabled {  get; set; }

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -196,7 +196,7 @@
                 {
                     <div class="row">
                         <div class="col-xs-12 clearfix">
-                            <div class="panel panel-default" aria-expanded="true">
+                            <div class="panel panel-default">
                                 <div class="panel-body">
                                     NuGet package search works the same on nuget.org, from the NuGet CLI, and within the NuGet Package Manager extension in Visual Studio. <br />
                                     Check out our <strong><a href="https://docs.microsoft.com/nuget/consume-packages/finding-and-choosing-packages#search-syntax">Search Syntax</a></strong>.

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -37,9 +37,10 @@
         </button>
         <div class="tfmTab" id="@(frameworkShortName)tab">
             <ul>
-                @foreach (var tfm in tfms) {
+                @foreach (var tfm in tfms)
+                {
                     <li>
-                        <input type="checkbox" id="@(tfm)" class="tfm" tabindex="-1" parent="@(frameworkShortName)">
+                        <input type="checkbox" id="@(tfm)" class="tfm" parent="@(frameworkShortName)">
                         <label for="@(tfm)">@(tfm)</label>
                     </li>
                 }


### PR DESCRIPTION
1. This PR fixes an accessibility issue where, when the TFM section was collapsed and there were very few search results on the page, the black text of some of the TFM checkbox labels could overlap with the dark blue footer background (even though the checkboxes were not visible), causing a contrast issue on A11y FastPass. 
![image](https://user-images.githubusercontent.com/82980589/218198449-23ec3954-7e64-46d7-8347-5df58ac1b18e.png)
We now flip the TFM tab's `display` property between `'none'` and `'block'` when it is collapsed or expanded. This also means we don't need to manually toggle `tabindex` for the checkboxes when the section is collapsed or expanded.

2. The text we show when there's 0 package results also has an a11y issue, where it shouldn't have the `aria-expanded` property. I've removed that now.
![image](https://user-images.githubusercontent.com/82980589/218199365-a21f5d7f-675f-4bd4-8879-6cbbb23fa11a.png)

3. I've also removed an unused ViewModel property (`ShouldDisplayAdvancedSearchPanel`). 