### PR TITLE
Added null checks to mitigate exceptions on the '/profiles' pages

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -36,15 +36,6 @@ $(function() {
         framework.indeterminate = checkedCount !== 0;
     }
 
-    // Submit the form when a user changes the selected 'sortBy' option
-    if (typeof searchForm != "undefined" &&
-        typeof searchForm.sortby != "undefined") { // /profiles pages use this js file too, but do not have a searchForm element
-        searchForm.sortby.addEventListener('change', (e) => {
-            searchForm.sortby.value = e.target.value;
-            submitSearchForm();
-        });
-    }
-
     // Accordion/collapsible logic
     const collapsibles = document.querySelectorAll('.collapsible');
 
@@ -79,10 +70,7 @@ $(function() {
         }
     }
 
-    if (typeof searchForm != "undefined") { // /profiles pages use this js file too, but do not have a searchForm element
-        searchForm.addEventListener('submit', submitSearchForm);
-    }
-
+    // Update query params before submitting the form
     function submitSearchForm() {
         constructFilterParameter(searchForm.frameworks, allFrameworks);
         constructFilterParameter(searchForm.tfms, allTfms);
@@ -103,12 +91,6 @@ $(function() {
         searchField.value = searchField.value.replace(/,+$/, '');
     }
 
-    if (typeof searchForm != "undefined" &&
-        typeof searchForm.frameworks != "undefined" &&
-        typeof searchForm.tfms != "undefined") { // /profiles pages use this js file too, but do not have a searchForm element
-        initializeFrameworkAndTfmCheckboxes();
-    }
-
     // Initialize state for Framework and Tfm checkboxes
     // NOTE: We first click on all selected Framework checkboxes and then on the selected Tfm checkboxes, which
     // allows us to correctly handle cases where a Framework AND one of its child Tfms is present in the query
@@ -127,5 +109,15 @@ $(function() {
                 document.querySelector('[tab=' + checkbox.id + ']').click();
             }
         });
+    }
+
+    // The /profiles pages use this js file too, but some code needs to be applied only to the search page
+    if (searchForm) {
+        searchForm.sortby.addEventListener('change', (e) => {
+            searchForm.sortby.value = e.target.value;
+            submitSearchForm();
+        });
+        searchForm.addEventListener('submit', submitSearchForm);
+        initializeFrameworkAndTfmCheckboxes();
     }
 });

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -37,10 +37,13 @@ $(function() {
     }
 
     // Submit the form when a user changes the selected 'sortBy' option
-    searchForm.sortby.addEventListener('change', (e) => {
-        searchForm.sortby.value = e.target.value;
-        submitSearchForm();
-    });
+    if (typeof searchForm != "undefined" &&
+        typeof searchForm.sortby != "undefined") { // /profiles pages use this js file too, but do not have a searchForm element
+        searchForm.sortby.addEventListener('change', (e) => {
+            searchForm.sortby.value = e.target.value;
+            submitSearchForm();
+        });
+    }
 
     // Accordion/collapsible logic
     const collapsibles = document.querySelectorAll('.collapsible');
@@ -76,7 +79,9 @@ $(function() {
         }
     }
 
-    searchForm.addEventListener('submit', submitSearchForm);
+    if (typeof searchForm != "undefined") { // /profiles pages use this js file too, but do not have a searchForm element
+        searchForm.addEventListener('submit', submitSearchForm);
+    }
 
     function submitSearchForm() {
         constructFilterParameter(searchForm.frameworks, allFrameworks);
@@ -98,10 +103,15 @@ $(function() {
         searchField.value = searchField.value.replace(/,+$/, '');
     }
 
+    if (typeof searchForm != "undefined" &&
+        typeof searchForm.frameworks != "undefined" &&
+        typeof searchForm.tfms != "undefined") { // /profiles pages use this js file too, but do not have a searchForm element
+        initializeFrameworkAndTfmCheckboxes();
+    }
+
     // Initialize state for Framework and Tfm checkboxes
     // NOTE: We first click on all selected Framework checkboxes and then on the selected Tfm checkboxes, which
     // allows us to correctly handle cases where a Framework AND one of its child Tfms is present in the query
-    initializeFrameworkAndTfmCheckboxes();
     function initializeFrameworkAndTfmCheckboxes() {
         var inputFrameworkFilters = searchForm.frameworks.value.split(',').map(f => f.trim()).filter(f => f);
         var inputTfmFilters = searchForm.tfms.value.split(',').map(f => f.trim()).filter(f => f);

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -12,11 +12,6 @@
     @AddRadioGroupOption("Package Type", "packagetype", optionName, optionValue, Model.PackageType, isDefault);
 }
 
-@helper AddSortByOption(string optionName, string optionValue, bool isDefault = false)
-{
-    @AddRadioGroupOption("Sort By", "sortby", optionName, optionValue, Model.SortBy, isDefault);
-}
-
 @helper AddRadioGroupOption(string ariaSectionLabel, string radioGroupName, string optionName, string optionValue, string optionCompareValue, bool isDefault = false)
 {
     <div style="display: flex;">


### PR DESCRIPTION
The `/profiles` pages use the same js script as the search page, but do not have a `searchForm` element on the page, so we were getting exceptions from the javascript on the `/profiles` pages when we tried to reference the form elements.

I've now added checks in the script so that we do not reference anything that doesn't exist on the page.

I also removed a helper method that was not being used by the search page anymore (`AddSortByOption()`).