### PR TITLE
Tags sometimes spill over into the next line when there are multiple of them

### DIFF
--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -93,6 +93,7 @@
                 </li>
                 @if (Model.Tags.AnySafe())
                 {
+                    <br/>
                     <li class="package-tags">
                         <span class="icon-text">
                             <i class="ms-Icon ms-Icon--Tag" aria-hidden="true"></i>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9389

In the search results, tags sometimes spill over into the next line when there are multiple of them, but appear on the same line as downloads, version, etc. when there are very few of them.

Previously:
![a51fdb2a-1c2c-45aa-b1c4-32db778b645d](https://user-images.githubusercontent.com/82980589/218596546-bf541bb9-fd3b-4836-bac2-5d34f710fc97.jpg)

This is a consequence of the search results column now being narrower since the filter panel is on the left of the results rather than being above it.

Now, we will always show tags on the next line so that it is consistent.

After the change:
![5942d32f-fa23-42d5-9042-f543b052b527](https://user-images.githubusercontent.com/82980589/218596542-0d91449b-c104-4cf8-9d98-d4226f7a2272.jpg)