### PR TITLE
Putting back missing word

### DIFF
--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -27,7 +27,7 @@
             else
             {
                 <div class="text-left">
-                    <p class="message">Your package file will be uploaded and on the @(Config.Current.Brand) server (@(Config.Current.SiteRoot)).</p>
+                    <p class="message">Your package file will be uploaded and hosted on the @(Config.Current.Brand) server (@(Config.Current.SiteRoot)).</p>
                     <p class="message">
                         To learn more about authoring great packages, view our
                         <a href="https://docs.microsoft.com/nuget/create-packages/package-authoring-best-practices" alt="Best Practices" aria-label="Read here about publishing packages">Best Practices</a> page.


### PR DESCRIPTION
A [change](https://github.com/NuGet/NuGetGallery/commit/2e49db62585e14eb2fe65164f88e7f26109077cb) dropped the word "hosted" from the upload package page a while ago. Adding it back.