### PR TITLE
MaxSupportedMinClientVersion update.

### DIFF
--- a/src/NuGetGallery/GalleryConstants.cs
+++ b/src/NuGetGallery/GalleryConstants.cs
@@ -24,7 +24,7 @@ namespace NuGetGallery
         public const int GravatarCacheDurationSeconds = 300;
 
         public const int MaxFileLengthBytes = 1024 * 1024; // 1MB for License, Icon, readme file
-        internal static readonly NuGetVersion MaxSupportedMinClientVersion = new NuGetVersion("5.9.0.0");
+        internal static readonly NuGetVersion MaxSupportedMinClientVersion = new NuGetVersion("6.5.0.0");
 
         public const string RecentSortOrder = "package-created";
 

--- a/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ApiControllerFacts.cs
@@ -834,7 +834,7 @@ namespace NuGetGallery
             public async Task CreatePackageReturns400IfMinClientVersionIsTooHigh()
             {
                 // Arrange
-                const string HighClientVersion = "6.0.0.0";
+                const string HighClientVersion = "7.0.0.0";
                 var nuGetPackage = TestPackage.CreateTestPackageStream("theId", "1.0.42", minClientVersion: HighClientVersion);
 
                 var user = new User() { EmailAddress = "confirmed@email.com" };


### PR DESCRIPTION
6.5 version of the client was published. Bumping the constant and updating tests.