### PR TITLE
[2FA] Update link msa/aad account page with legacy password account information.

### DIFF
--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -137,7 +137,7 @@ namespace NuGetGallery
             }
 
             var authenticationResult = await _authService.Authenticate(model.SignIn.UserNameOrEmail, model.SignIn.Password);
-
+            
             if (authenticationResult.Result != PasswordAuthenticationResult.AuthenticationResult.Success)
             {
                 string modelErrorMessage = string.Empty;
@@ -930,7 +930,7 @@ namespace NuGetGallery
             existingModel.SignIn = existingModel.SignIn ?? new SignInViewModel();
             existingModel.Register = existingModel.Register ?? new RegisterViewModel();
             existingModel.IsNuGetAccountPasswordLoginEnabled = _featureFlagService.IsNuGetAccountPasswordLoginEnabled();
-
+            existingModel.IsEmailOnExceptionList = _contentObjectService.LoginDiscontinuationConfiguration.IsEmailOnExceptionsList(existingModel.SignIn.UserNameOrEmail);
             return View(viewName, existingModel);
         }
 

--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -16,6 +16,7 @@ namespace NuGetGallery
         public RegisterViewModel Register { get; set; }
         public IList<AuthenticationProviderViewModel> Providers { get; set; }
         public bool IsNuGetAccountPasswordLoginEnabled { get; set; }
+        public bool IsEmailOnExceptionList { get; set; }
 
         public LogOnViewModel()
             : this(new SignInViewModel())

--- a/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
+++ b/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
@@ -19,16 +19,11 @@
                         </div>
                     </div>
                     <p class="text-center">
-                        We found an account with this email address that uses legacy password login. Unfortunately, <b>password login has been disabled</b>.
+                        We found an account with this email address (@Model.SignIn.UserNameOrEmail) that uses legacy password login. Unfortunately, <b>password login has been disabled</b>.
                     </p>
                     <p class="text-center">
                         Some accounts can be recovered through manual proof of ownership.
                         Please reach out to <a href="mailto:@Config.Current.GalleryOwner.Address">nuget support</a> for assistance.
-                    </p>
-
-                    <p>
-                        @Html.ShowLabelFor(m => m.SignIn.UserNameOrEmail)<br />
-                        @Model.SignIn.UserNameOrEmail
                     </p>
                 }
                 else

--- a/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
+++ b/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
@@ -13,18 +13,37 @@
             <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
                 @if (Model.External.ExistingUserCanBeLinked)
                 {
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <h1 class="text-center">Legacy Account</h1>
+                    if (Model.IsEmailOnExceptionList)
+                    {
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <h1 class="text-center">Link @Model.External.ProviderAccountNoun</h1>
+                            </div>
                         </div>
-                    </div>
-                    <p class="text-center">
-                        We found an account with this email address (@Model.SignIn.UserNameOrEmail) that uses legacy password login. Unfortunately, <b>password login has been disabled</b>.
-                    </p>
-                    <p class="text-center">
-                        Some accounts can be recovered through manual proof of ownership.
-                        Please reach out to <a href="mailto:@Config.Current.GalleryOwner.Address">nuget support</a> for assistance.
-                    </p>
+                        <p class="text-center">
+                            Sign in with your NuGet.org password to link with this Microsoft account.
+                        </p>
+                        <p class="text-center">
+                            Please <a href="mailto:@Config.Current.GalleryOwner.Address">contact support</a> if you need more assistance.
+                        </p>
+
+                        @Html.Partial("_SignIn", Model)
+                    }
+                    else
+                    {
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <h1 class="text-center">Legacy Account</h1>
+                            </div>
+                        </div>
+                        <p class="text-center">
+                            We found an account with this email address (@Model.SignIn.UserNameOrEmail) that uses legacy password login. Unfortunately, <b>password login has been disabled</b>.
+                        </p>
+                        <p class="text-center">
+                            Some accounts can be recovered through manual proof of ownership.
+                            Please reach out to <a href="mailto:@Config.Current.GalleryOwner.Address">nuget support</a> for assistance.
+                        </p>
+                    }
                 }
                 else
                 {

--- a/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
+++ b/src/NuGetGallery/Views/Authentication/LinkExternal.cshtml
@@ -10,28 +10,34 @@
     @if (Model.External.FoundExistingUser)
     {
         <div class="row">
-            <div class="col-xs-12">
-                <h1 class="text-center">Link @Model.External.ProviderAccountNoun</h1>
-            </div>
-        </div>
-        <div class="row">
             <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
                 @if (Model.External.ExistingUserCanBeLinked)
                 {
+                    <div class="row">
+                        <div class="col-xs-12">
+                            <h1 class="text-center">Legacy Account</h1>
+                        </div>
+                    </div>
                     <p class="text-center">
-                        We found an account with this email address. Sign in with your NuGet.org password to link with this Microsoft account.
+                        We found an account with this email address that uses legacy password login. Unfortunately, <b>password login has been disabled</b>.
                     </p>
                     <p class="text-center">
-                        Note that <b>your existing password login will be disabled</b> and you will need to use this Microsoft account to sign into NuGet.org
-                    </p>
-                    <p class="text-center">
-                        Please <a href="mailto:@Config.Current.GalleryOwner.Address">contact support</a> if you need more assistance.
+                        Some accounts can be recovered through manual proof of ownership.
+                        Please reach out to <a href="mailto:@Config.Current.GalleryOwner.Address">nuget support</a> for assistance.
                     </p>
 
-                    @Html.Partial("_SignIn", Model)
+                    <p>
+                        @Html.ShowLabelFor(m => m.SignIn.UserNameOrEmail)<br />
+                        @Model.SignIn.UserNameOrEmail
+                    </p>
                 }
                 else
                 {
+                    <div class="row">
+                        <div class="col-xs-12">
+                            <h1 class="text-center">Link @Model.External.ProviderAccountNoun</h1>
+                        </div>
+                    </div>
                     switch (Model.External.ExistingUserLinkingError)
                     {
                         case AssociateExternalAccountViewModel.ExistingUserLinkingErrorType.AccountIsAlreadyLinked:

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -33,6 +33,17 @@ namespace NuGetGallery.Controllers
 
         public class TheLogOnAction : TestContainer
         {
+            public TheLogOnAction()
+            {
+                var isEmailOnExceptionList = new Mock<ILoginDiscontinuationConfiguration>();
+                isEmailOnExceptionList
+                    .Setup(x => x.IsEmailOnExceptionsList(It.IsAny<String>()))
+                    .Returns(false);
+                GetMock<IContentObjectService>()
+                    .Setup(x => x.LoginDiscontinuationConfiguration)
+                    .Returns(isEmailOnExceptionList.Object);
+            }
+
             [Fact]
             public void GivenUserAlreadyAuthenticated_ItRedirectsToReturnUrl()
             {
@@ -215,6 +226,17 @@ namespace NuGetGallery.Controllers
 
         public class TheSignInAction : TestContainer
         {
+            public TheSignInAction()
+            {
+                var isEmailOnExceptionList = new Mock<ILoginDiscontinuationConfiguration>();
+                isEmailOnExceptionList
+                    .Setup(x => x.IsEmailOnExceptionsList(It.IsAny<String>()))
+                    .Returns(false);
+                GetMock<IContentObjectService>()
+                    .Setup(x => x.LoginDiscontinuationConfiguration)
+                    .Returns(isEmailOnExceptionList.Object);
+            }
+
             [Fact]
             public async Task GivenUserAlreadyAuthenticated_ItRedirectsToReturnUrl()
             {
@@ -722,6 +744,17 @@ namespace NuGetGallery.Controllers
 
         public class TheRegisterAction : TestContainer
         {
+            public TheRegisterAction()
+            {
+                var isEmailOnExceptionList = new Mock<ILoginDiscontinuationConfiguration>();
+                isEmailOnExceptionList
+                    .Setup(x => x.IsEmailOnExceptionsList(It.IsAny<String>()))
+                    .Returns(false);
+                GetMock<IContentObjectService>()
+                    .Setup(x => x.LoginDiscontinuationConfiguration)
+                    .Returns(isEmailOnExceptionList.Object);
+            }
+
             [Fact]
             public async Task WillShowTheViewWithErrorsIfTheModelStateIsInvalid()
             {
@@ -1689,6 +1722,17 @@ namespace NuGetGallery.Controllers
 
         public class TheLinkExternalAccountAction : TestContainer
         {
+            public TheLinkExternalAccountAction()
+            {
+                var isEmailOnExceptionList = new Mock<ILoginDiscontinuationConfiguration>();
+                isEmailOnExceptionList
+                    .Setup(x => x.IsEmailOnExceptionsList(It.IsAny<String>()))
+                    .Returns(false);
+                GetMock<IContentObjectService>()
+                    .Setup(x => x.LoginDiscontinuationConfiguration)
+                    .Returns(isEmailOnExceptionList.Object);
+            }
+
             [Theory]
             [InlineData("access_denied")]
             [InlineData("consent_required")]
@@ -2182,7 +2226,7 @@ namespace NuGetGallery.Controllers
                 var msAuther = new MicrosoftAccountAuthenticator();
                 var msaUI = msAuther.GetUI();
 
-                GetMock<AuthenticationService>(); // Force a mock to be created
+                GetMock<AuthenticationService>(); // Force a mock to be created                
 
                 var controller = GetController<AuthenticationController>();
 


### PR DESCRIPTION
### Changes
* Updated wording of the "Link Microsoft Account" page to include Legacy Account information.
* Legacy account page: This page will show when users have password account and are not part of the exception list.
* Link Microsoft account page: After a user with a legacy account issue sends a SR to us, we will verify the request and ownership. Once we approve it using our processes, the user will see this page and will be able to link their MSA if they know their password, otherwise they will be able to use the **Forgot your password?** link.

### Screenshot
#### Legacy account page
![Legacy Account](https://user-images.githubusercontent.com/17834924/223597221-14a360b6-7ddc-48d3-97ac-7b8398fe6788.png)

#### Link MSA account page
![Linking account](https://user-images.githubusercontent.com/17834924/223597400-5abed200-6841-4bfb-9ee2-9c3fa30e1a78.png)

Addresses: https://github.com/NuGet/Engineering/issues/4617