### PR TITLE
[A11y] Search page a11y fixes for tags and framework filter buttons

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -274,6 +274,9 @@ img.reserved-indicator-icon {
   outline: solid 0.25px;
   outline-offset: 0;
 }
+.package-list li .package-tags {
+  display: block;
+}
 @media (min-width: 768px) {
   .package-list li {
     display: inline-block;
@@ -283,6 +286,7 @@ img.reserved-indicator-icon {
     padding-right: 10px;
   }
   .package-list li.package-tags {
+    display: block;
     overflow-y: visible;
   }
 }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -274,9 +274,6 @@ img.reserved-indicator-icon {
   outline: solid 0.25px;
   outline-offset: 0;
 }
-.package-list li .package-tags {
-  display: block;
-}
 @media (min-width: 768px) {
   .package-list li {
     display: inline-block;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -357,6 +357,10 @@ img.reserved-indicator-icon {
         outline-offset: 0;
       }
     }
+
+    .package-tags {
+      display: block;
+    }
   }
 
   @media (min-width: @screen-sm-min) {
@@ -369,6 +373,7 @@ img.reserved-indicator-icon {
     }
 
     li.package-tags {
+      display: block;
       overflow-y: visible;
     }
   }

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -357,10 +357,6 @@ img.reserved-indicator-icon {
         outline-offset: 0;
       }
     }
-
-    .package-tags {
-      display: block;
-    }
   }
 
   @media (min-width: @screen-sm-min) {

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1264,7 +1264,7 @@ namespace NuGetGallery
             var isFrameworkFilteringEnabled = _featureFlagService.IsFrameworkFilteringEnabled(GetCurrentUser());
 
             // If advanced search is disabled, use the default experience
-            if (!isAdvancedSearchFlightEnabled || !searchService.SupportsAdvancedSearch)
+            if ((!isAdvancedSearchFlightEnabled || !searchService.SupportsAdvancedSearch) && false)
             {
                 searchAndListModel.SortBy = GalleryConstants.SearchSortNames.Relevance;
                 searchAndListModel.Frameworks = string.Empty;
@@ -1367,6 +1367,9 @@ namespace NuGetGallery
             // If the experience hasn't been cached, it means it's not the default experienced, therefore, show the panel
             viewModel.IsAdvancedSearchFlightEnabled = searchService.SupportsAdvancedSearch && isAdvancedSearchFlightEnabled;
             viewModel.IsFrameworkFilteringEnabled = isFrameworkFilteringEnabled;
+
+            viewModel.IsAdvancedSearchFlightEnabled = true;
+            viewModel.IsFrameworkFilteringEnabled = true;
 
             ViewBag.SearchTerm = q;
 

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1264,7 +1264,7 @@ namespace NuGetGallery
             var isFrameworkFilteringEnabled = _featureFlagService.IsFrameworkFilteringEnabled(GetCurrentUser());
 
             // If advanced search is disabled, use the default experience
-            if ((!isAdvancedSearchFlightEnabled || !searchService.SupportsAdvancedSearch) && false)
+            if (!isAdvancedSearchFlightEnabled || !searchService.SupportsAdvancedSearch)
             {
                 searchAndListModel.SortBy = GalleryConstants.SearchSortNames.Relevance;
                 searchAndListModel.Frameworks = string.Empty;
@@ -1367,9 +1367,6 @@ namespace NuGetGallery
             // If the experience hasn't been cached, it means it's not the default experienced, therefore, show the panel
             viewModel.IsAdvancedSearchFlightEnabled = searchService.SupportsAdvancedSearch && isAdvancedSearchFlightEnabled;
             viewModel.IsFrameworkFilteringEnabled = isFrameworkFilteringEnabled;
-
-            viewModel.IsAdvancedSearchFlightEnabled = true;
-            viewModel.IsFrameworkFilteringEnabled = true;
 
             ViewBag.SearchTerm = q;
 

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -53,10 +53,14 @@ $(function() {
         expandButton.classList.toggle('ms-Icon--ChevronUp');
 
         if (this.classList.contains('active')) {
+            this.setAttribute("aria-expanded", "true");
+
             dataTab.style.display = 'block';
             dataTab.style.maxHeight = dataTab.scrollHeight + "px";
         }
         else {
+            this.setAttribute("aria-expanded", "false");
+
             dataTab.style.display = 'none';
             dataTab.style.maxHeight = 0;
         }

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -27,7 +27,8 @@
     <div class="frameworkgoup">
         <input type="checkbox" id="@(frameworkShortName)" class="framework">
         <label for="@(frameworkShortName)">@(frameworkDisplayName)</label>
-        <button type="button" class="collapsible" tab="@(frameworkShortName)" tabindex="0" aria-label="shows and hides TFM filters">
+        <button type="button" class="collapsible" tab="@(frameworkShortName)" tabindex="0"
+                aria-label="shows and hides TFM filters for @(frameworkDisplayName)" aria-expanded="false" aria-controls="@(frameworkShortName)tab">
             <i class="ms-Icon ms-Icon--ChevronDown" id="@(frameworkShortName)button"></i>
         </button>
         <div class="tfmTab" id="@(frameworkShortName)tab">

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -40,8 +40,8 @@
                    href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null).TrimEnd('/')"
                    @if (itemIndex.HasValue)
                    {
-                       @:data-track="@eventName" data-track-value="@itemIndex"
-                       @:data-package-id="@Model.Id" data-package-version="@Model.Version" data-use-version="@Model.UseVersion"
+                        @:data-track="@eventName" data-track-value="@itemIndex"
+                        @:data-package-id="@Model.Id" data-package-version="@Model.Version" data-use-version="@Model.UseVersion"
                    }
                    >@Html.BreakWord(Model.Id)</a>
 
@@ -91,9 +91,10 @@
                         Latest version: <span class="text-nowrap">@Model.Version @(Model.Prerelease ? "(prerelease)" : "")</span>
                     </span>
                 </li>
-                @if (Model.Tags.AnySafe())
-                {
-                    <br/>
+            </ul>
+            @if (Model.Tags.AnySafe())
+            {
+                <ul class="package-list">
                     <li class="package-tags">
                         <span class="icon-text">
                             <i class="ms-Icon ms-Icon--Tag" aria-hidden="true"></i>
@@ -120,8 +121,9 @@
                             }
                         </span>
                     </li>
-                }
-            </ul>
+                </ul>
+            }
+
 
             <div class="package-details">
                 @Model.ShortDescription

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -91,10 +91,8 @@
                         Latest version: <span class="text-nowrap">@Model.Version @(Model.Prerelease ? "(prerelease)" : "")</span>
                     </span>
                 </li>
-            </ul>
-            @if (Model.Tags.AnySafe())
-            {
-                <ul class="package-list">
+                @if (Model.Tags.AnySafe())
+                {
                     <li class="package-tags">
                         <span class="icon-text">
                             <i class="ms-Icon ms-Icon--Tag" aria-hidden="true"></i>
@@ -121,9 +119,8 @@
                             }
                         </span>
                     </li>
-                </ul>
-            }
-
+                }
+            </ul>
 
             <div class="package-details">
                 @Model.ShortDescription


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9402, https://github.com/NuGet/NuGetGallery/issues/9412 and https://github.com/NuGet/NuGetGallery/issues/9413

This PR fixes 3 a11y issues:

1. The tags in search results sometimes appeared on the same line as the other package metadata (version, last created, etc.) and sometimes appeared on the next line. We wanted to make this consistent and always have the 'tags' on the next line, but adding a `<br>` element in the middle of a list led to this a11y issue:
    ![image](https://user-images.githubusercontent.com/82980589/225134180-860cebea-4b3e-46a4-bb2d-9eece8107921.png)

    I've now removed the `<br>` element and fixed this with some css:
    ![image](https://user-images.githubusercontent.com/82980589/225132168-62bffd76-acd6-4460-8b58-a549e1a4ee0f.png)
2. The chevrons that expanded/collapsed the TFM sections in the Filters panel did not indicate their expanded/collapsed state. The screen reader should be able to read their state. The 'aria-expanded' can be used to fix this.
3. These chevrons also all had the same 'aria-label': "shows and hides TFM filters". I've now made each button's label relevant to its specific frameworks: eg. "shows and hides TFM filters for .NET Standard".