### PR TITLE
Handle missing X-Forwarded-For header in TableErrorLog

### DIFF
--- a/tests/NuGetGallery.Core.Facts/Infrastructure/TableErrorLogFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Infrastructure/TableErrorLogFacts.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Elmah;
+using Xunit;
+
+namespace NuGetGallery.Infrastructure
+{
+    public class TableErrorLogFacts
+    {
+        public class TheObfuscateMethod
+        {
+            [Fact]
+            public void HandlesMissingForwardedHeader()
+            {
+                // Arrange
+                var error = new Error();
+
+                // Act
+                TableErrorLog.Obfuscate(error);
+
+                // Assert
+                Assert.DoesNotContain("HTTP_X_FORWARDED_FOR", error.ServerVariables.Keys.Cast<string>());
+            }
+
+            [Theory]
+            [InlineData("", "")]
+            [InlineData(",", ",")]
+            [InlineData(" ", " ")]
+            [InlineData("127.0.0.1", "127.0.0.0")]
+            [InlineData("127.1.2.3,127.1.2.4", "127.1.2.0,127.1.2.0")]
+            [InlineData("127.1.2.3   ,  127.1.2.4", "127.1.2.0,127.1.2.0")]
+            public void ObfuscatesForwardedHeader(string input, string expected)
+            {
+                // Arrange
+                var error = new Error();
+                error.ServerVariables["HTTP_X_FORWARDED_FOR"] = input;
+
+                // Act
+                TableErrorLog.Obfuscate(error);
+
+                // Assert
+                Assert.Equal(expected, error.ServerVariables["HTTP_X_FORWARDED_FOR"]);
+            }
+        }
+    }
+}

--- a/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
+++ b/tests/NuGetGallery.Core.Facts/NuGetGallery.Core.Facts.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Infrastructure\Mail\Messages\SymbolPackageValidationFailedMessageFacts.cs" />
     <Compile Include="Infrastructure\Mail\Messages\SymbolPackageValidationTakingTooLongMessageFacts.cs" />
     <Compile Include="Infrastructure\Mail\TestMessageServiceConfiguration.cs" />
+    <Compile Include="Infrastructure\TableErrorLogFacts.cs" />
     <Compile Include="Packaging\ManifestValidatorFacts.cs" />
     <Compile Include="Packaging\PackageIdValidatorTest.cs" />
     <Compile Include="Packaging\PackageMetadataFacts.cs" />


### PR DESCRIPTION
This helps reduce debugging locally when AzureStorage is being used.