### PR TITLE
Fix accessibility issue - role required when aria-expanded attribute is used

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -577,7 +577,7 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
     </div>
     if (!disabled)
     {
-        <div class="panel panel-default panel-collapse collapse @(expanded ? "in" : string.Empty)"
+        <div role="form" class="panel panel-default panel-collapse collapse @(expanded ? "in" : string.Empty)"
                 aria-expanded="@(expanded ? "true" : "false")" id="@id-container">
             <div class="panel-body">
                 @content(MvcHtmlString.Empty)

--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -577,8 +577,8 @@ var hlp = new AccordionHelper(name, formModelStatePrefix, expanded, page);
     </div>
     if (!disabled)
     {
-        <div role="form" class="panel panel-default panel-collapse collapse @(expanded ? "in" : string.Empty)"
-                aria-expanded="@(expanded ? "true" : "false")" id="@id-container">
+        <div aria-controls="panel-body" class="panel panel-default panel-collapse collapse @(expanded ? "in" : string.Empty)"
+                id="@id-container">
             <div class="panel-body">
                 @content(MvcHtmlString.Empty)
             </div>

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -258,7 +258,7 @@
         </div>
 
         <div class="upsert-api-key">
-            <div class="panel panel-default panel-collapse collapse"
+            <div role="button" class="panel panel-default panel-collapse collapse"
                  data-bind="attr: { id: EditContainerId() },
                             event: { 'show.bs.collapse': StopPropagation,
                                      'hide.bs.collapse': StopPropagation }">

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -258,7 +258,7 @@
         </div>
 
         <div class="upsert-api-key">
-            <div role="button" class="panel panel-default panel-collapse collapse"
+            <div class="panel panel-default panel-collapse collapse"
                  data-bind="attr: { id: EditContainerId() },
                             event: { 'show.bs.collapse': StopPropagation,
                                      'hide.bs.collapse': StopPropagation }">


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9415

Add a role to the `div` elements with the `aria-expanded` attribute. The role `form` is likely the best option in these scenarios.