### PR TITLE
Fix accessibility issue - add missing header tag

### DIFF
--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -336,8 +336,7 @@
 
         <div class="row">
             <div class="col-sm-12 form-group">
-                <b id="select-scopes" class="ms-fontSize-xl">Select Scopes</b>
-                <br />
+                <h4 id="select-scopes" class="ms-fontSize-xl"><b>Select Scopes</b></h4>
                 <span class="has-error">
                     <span class="help-block" data-bind="text: ScopesError" aria-live="polite" role="alert"></span>
                 </span>
@@ -394,7 +393,7 @@
         <!-- /ko -->
         <div class="row">
             <div class="col-sm-12">
-                <b class="ms-fontSize-xl">Select Packages</b>
+                <h4 class="ms-fontSize-xl"><b>Select Packages</b></h4>
                 <p>
                     To select which packages to associate with a key, use a glob pattern, select
                     individual packages, or both.


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9417

"Select Scopes" and "Select Packages" headings on the API Keys page were missing header tags. Added `h4` tag to both. 