### PR TITLE
[A11y] Fix Framework filter tooltip's confusing double behavior

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -2,7 +2,6 @@ $(function() {
     'use strict';
 
     $(".reserved-indicator").each(window.nuget.setPopovers);
-    $(".framework-filter-info-icon").each(window.nuget.setPopovers);
 
     const searchForm = document.forms.search;
     const allFrameworks = document.querySelectorAll('.framework');

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1103,15 +1103,6 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filters packages based on the target frameworks included in the NuGet Package..
-        /// </summary>
-        public static string FrameworkFilterInformation_Tooltip {
-            get {
-                return ResourceManager.GetString("FrameworkFilterInformation_Tooltip", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The API key &apos;{0}&apos; is invalid..
         /// </summary>
         public static string InvalidApiKey {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1254,7 +1254,4 @@ The {1} Team</value>
   <data name="ForgotPassword_Disabled_Error" xml:space="preserve">
     <value>Forgot password is disabled.</value>
   </data>
-  <data name="FrameworkFilterInformation_Tooltip" xml:space="preserve">
-    <value>Filters packages based on the target frameworks included in the NuGet Package.</value>
-  </data>
 </root>

--- a/src/NuGetGallery/ViewModels/PackageListViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageListViewModel.cs
@@ -84,6 +84,6 @@ namespace NuGetGallery
 
         public Dictionary<string, FrameworkFilterHelper.FrameworkFilterGroup> FrameworkFilters = FrameworkFilterHelper.FrameworkFilters;
 
-        public string TargetFrameworkInformationLink = "https://learn.microsoft.com/en-us/dotnet/standard/frameworks";
+        public string FrameworksFilteringInformationLink = "https://learn.microsoft.com/nuget/consume-packages/finding-and-choosing-packages#advanced-filtering-and-sorting";
     }
 }

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -83,7 +83,7 @@
                                     <legend>
                                         Frameworks
                                         <a href="@(Model.FrameworksFilteringInformationLink)" title="Filters packages based on the target frameworks included in the NuGet Package. Click here to learn more.">
-                                            <i class="framework-filter-info-icon ms-Icon ms-Icon--Info" tabindex="0"></i>
+                                            <i class="framework-filter-info-icon ms-Icon ms-Icon--Info"></i>
                                         </a>
                                     </legend>
                                     @foreach (var framework in Model.FrameworkFilters.Values)

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -82,10 +82,8 @@
                                 <fieldset id="frameworkfilters">
                                     <legend>
                                         Frameworks
-                                        <a href="@(Model.TargetFrameworkInformationLink)" title="Frameworks filter information">
-                                            <i class="framework-filter-info-icon ms-Icon ms-Icon--Info" tabindex="0"
-                                               data-content="@Strings.FrameworkFilterInformation_Tooltip"
-                                               alt="@Strings.FrameworkFilterInformation_Tooltip"></i>
+                                        <a href="@(Model.FrameworksFilteringInformationLink)" title="Filters packages based on the target frameworks included in the NuGet Package. Click here to learn more.">
+                                            <i class="framework-filter-info-icon ms-Icon ms-Icon--Info" tabindex="0"></i>
                                         </a>
                                     </legend>
                                     @foreach (var framework in Model.FrameworkFilters.Values)


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9414

The tooltip next to the Frameworks filters served both as a popover (showed some info when you hovered) and also as a link to our Target Frameworks docs, and the same tooltip icon produced two separate tab stops that told users this icon served different purposes. We needed to either separate these into 2 separate controls, or get rid of one of them. I got rid of the popover, but using the 'title' attribute in the link allows me to serve up the same information when a user hovers or tabs to the link icon. I think this should fix the a11y issue while still providing the users the same level of context.

I also changed the link to point to our [nuget.org filtering and sorting docs](https://learn.microsoft.com/en-us/nuget/consume-packages/finding-and-choosing-packages#advanced-filtering-and-sorting), rather than this page that covers [Target Frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks) in general. The search docs are more relevant in this case, and they contain a link to the Target Frameworks docs anyway.

Earlier, we would see this popover when we hovered on the icon,
![image](https://user-images.githubusercontent.com/82980589/230223782-a5cb20aa-ba99-4907-bfa4-0104732fe02f.png)

Now, when you hover, the same information will pop up, but it will look different to these popovers. I wasn't able to get a screenshot because the info disappeared when I tried, but it looks like what you'll see when you hover over any of the other links on the search page like owners or tags. There is no other UI change.
![image](https://user-images.githubusercontent.com/82980589/230224194-069297d7-473a-4c9b-9260-7493ed4aef12.png)
