### PR TITLE
Keyboard focus is not clearly visible 

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1148,7 +1148,7 @@ p.frameworktableinfo-text {
   border-left: 1px solid #dbdbdb;
 }
 .page-api-keys .api-key-details .package-list li {
-  overflow-y: initial;
+  overflow-y: visible;
 }
 .page-api-keys .api-key-details:not(:first-child) {
   border-top: 1px solid #dbdbdb;
@@ -1466,9 +1466,12 @@ p.frameworktableinfo-text {
 .page-package-details .owner-list li {
   margin-bottom: 14px;
   display: block;
-  overflow: initial;
+  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+.page-package-details .owner-list li a.owner-image-link {
+  overflow-y: visible;
 }
 .page-package-details .owner-list img {
   margin-right: 8px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1470,9 +1470,6 @@ p.frameworktableinfo-text {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
-.page-package-details .owner-list li a.owner-image-link {
-  overflow-y: visible;
-}
 .page-package-details .owner-list img {
   margin-right: 8px;
   border-radius: 5px;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1147,6 +1147,9 @@ p.frameworktableinfo-text {
   padding-left: 10px;
   border-left: 1px solid #dbdbdb;
 }
+.page-api-keys .api-key-details .package-list li {
+  overflow-y: initial;
+}
 .page-api-keys .api-key-details:not(:first-child) {
   border-top: 1px solid #dbdbdb;
 }
@@ -1463,7 +1466,7 @@ p.frameworktableinfo-text {
 .page-package-details .owner-list li {
   margin-bottom: 14px;
   display: block;
-  overflow: hidden;
+  overflow: initial;
   white-space: nowrap;
   text-overflow: ellipsis;
 }

--- a/src/Bootstrap/less/theme/page-api-keys.less
+++ b/src/Bootstrap/less/theme/page-api-keys.less
@@ -132,6 +132,11 @@
         border-left: 1px solid @gray-lighter;
       }
     }
+    .package-list {
+      li {
+        overflow-y: initial;
+      }
+    }
   }
   
   .api-key-details:not(:first-child)

--- a/src/Bootstrap/less/theme/page-api-keys.less
+++ b/src/Bootstrap/less/theme/page-api-keys.less
@@ -134,7 +134,7 @@
     }
     .package-list {
       li {
-        overflow-y: initial;
+        overflow-y: visible;
       }
     }
   }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -248,10 +248,6 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-
-      a.owner-image-link {
-        overflow-y: visible;
-      }
     }
 
     img {

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -245,9 +245,13 @@
     li {
       margin-bottom: 14px;
       display: block;
-      overflow: initial;
+      overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
+
+      a.owner-image-link {
+        overflow-y: visible;
+      }
     }
 
     img {

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -245,7 +245,7 @@
     li {
       margin-bottom: 14px;
       display: block;
-      overflow: hidden;
+      overflow: initial;
       white-space: nowrap;
       text-overflow: ellipsis;
     }


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

Problem:  Keyboard focus is not clearly visible because of overflow was set to hidden. 

Fix: Changed to visible since the button name length is fix, won't be overflow.

For "Eidt, Regenerate, Delete" buttons, it's ok to 

Addresses https://github.com/NuGet/Engineering/issues/4827