### PR TITLE
Tooltip/popover placement update

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -467,7 +467,7 @@
         var popoverHideTimeMS = 2000;
         var popoverFadeTimeMS = 200;
 
-        popoverElement.popover({ trigger: 'hover' });
+        popoverElement.popover({ trigger: 'hover', placement: 'auto right' });
         popoverElement.click(popoverShowAndHide);
         popoverElement.focus(popoverShowAndHide);
         popoverElement.keyup(function (event) {

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -460,8 +460,12 @@
         }
     };
 
-    nuget.setPopovers = function () {
+    nuget.setPopoversAutoRight = function () {
         setPopoversInternal(this, 'auto right');
+    }
+
+    nuget.setPopovers = function () {
+        setPopoversInternal(this);
     }
 
     function setPopoversInternal(element, placement) {

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -460,12 +460,8 @@
         }
     };
 
-    nuget.setPopoversAutoRight = function () {
-        setPopoversInternal(this, 'auto right');
-    }
-
     nuget.setPopovers = function () {
-        setPopoversInternal(this);
+        setPopoversInternal(this, 'auto right');
     }
 
     function setPopoversInternal(element, placement) {

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -460,12 +460,22 @@
         }
     };
 
-    nuget.setPopoversAutoRight = function () {
-        setPopoversInternal(this, 'auto right');
+    nuget.setPopovers = function () {
+        setPopoversInternal(this, rightWithVerticalFallback);
     }
 
-    nuget.setPopovers = function () {
-        setPopoversInternal(this);
+    function rightWithVerticalFallback(popoverElement, ownerElement) {
+        let ownerBoundingBox = ownerElement.getBoundingClientRect();
+        const pixelsOnRight = window.innerWidth - ownerBoundingBox.right;
+        if (pixelsOnRight > 150) {
+            return 'right';
+        }
+        const pixelsOnTop = ownerBoundingBox.top;
+        if (pixelsOnTop > 100) {
+            return 'top';
+        }
+
+        return 'bottom';
     }
 
     function setPopoversInternal(element, placement) {

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -460,14 +460,27 @@
         }
     };
 
+    nuget.setPopoversAutoRight = function () {
+        setPopoversInternal(this, 'auto right');
+    }
+
     nuget.setPopovers = function () {
-        var popoverElement = $(this);
-        var popoverElementDom = this;
+        setPopoversInternal(this);
+    }
+
+    function setPopoversInternal(element, placement) {
+        var popoverElement = $(element);
+        var popoverElementDom = element;
         var originalLabel = popoverElementDom.ariaLabel;
         var popoverHideTimeMS = 2000;
         var popoverFadeTimeMS = 200;
 
-        popoverElement.popover({ trigger: 'hover', placement: 'auto right' });
+        var popoverOptions = { trigger: 'hover' };
+        if (placement) {
+            popoverOptions.placement = placement;
+        }
+
+        popoverElement.popover(popoverOptions);
         popoverElement.click(popoverShowAndHide);
         popoverElement.focus(popoverShowAndHide);
         popoverElement.keyup(function (event) {

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -465,13 +465,17 @@
     }
 
     function rightWithVerticalFallback(popoverElement, ownerElement) {
+        // Both numbers below are in CSS pixels.
+        const MinSpaceOnRight = 150;
+        const MinSpaceOnTop = 100;
+
         let ownerBoundingBox = ownerElement.getBoundingClientRect();
-        const pixelsOnRight = window.innerWidth - ownerBoundingBox.right;
-        if (pixelsOnRight > 150) {
+        const spaceOnRight = window.innerWidth - ownerBoundingBox.right;
+        if (spaceOnRight > MinSpaceOnRight) {
             return 'right';
         }
-        const pixelsOnTop = ownerBoundingBox.top;
-        if (pixelsOnTop > 100) {
+        const spaceOnTop = ownerBoundingBox.top;
+        if (spaceOnTop > MinSpaceOnTop) {
             return 'top';
         }
 

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -475,7 +475,7 @@
         var popoverHideTimeMS = 2000;
         var popoverFadeTimeMS = 200;
 
-        var popoverOptions = { trigger: 'hover' };
+        var popoverOptions = { trigger: 'hover', container: 'body' };
         if (placement) {
             popoverOptions.placement = placement;
         }

--- a/src/NuGetGallery/Scripts/gallery/common.js
+++ b/src/NuGetGallery/Scripts/gallery/common.js
@@ -469,7 +469,7 @@
         const MinSpaceOnRight = 150;
         const MinSpaceOnTop = 100;
 
-        let ownerBoundingBox = ownerElement.getBoundingClientRect();
+        const ownerBoundingBox = ownerElement.getBoundingClientRect();
         const spaceOnRight = window.innerWidth - ownerBoundingBox.right;
         if (spaceOnRight > MinSpaceOnRight) {
             return 'right';

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -196,5 +196,5 @@
 
     $(".reserved-indicator").each(window.nuget.setPopovers);
     $(".framework-badge-asset").each(window.nuget.setPopovers);
-    $(".package-warning-icon").each(window.nuget.setPopovers);
+    $(".package-warning-icon").each(window.nuget.setPopoversAutoRight);
 });

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -196,5 +196,5 @@
 
     $(".reserved-indicator").each(window.nuget.setPopovers);
     $(".framework-badge-asset").each(window.nuget.setPopovers);
-    $(".package-warning-icon").each(window.nuget.setPopoversAutoRight);
+    $(".package-warning-icon").each(window.nuget.setPopovers);
 });


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9424 and maybe some others.

## Old behavior

Tooltip always appears to the right of the "parent" element and is inserted after it into the DOM tree sharing the same parent. This results in two things:
1. tooltips often try to occupy as little horizontal space as possible:
![image](https://user-images.githubusercontent.com/102933/230510833-a297b910-64ee-4825-ace4-b73425a0cf4c.png)
2. When there is not enough space to the right to fit it, it is drawn off screen (and horizontal scrollbar appears for the window):
![image](https://user-images.githubusercontent.com/102933/230510999-1f708443-8143-405c-b698-efabf7916c86.png)

## New behavior

Tooltips are now parented to the `body` element, which results in them using as much horizontal space as possible (up to the limits set in bootstrap CSS for those):
![image](https://user-images.githubusercontent.com/102933/230511191-d7ad8f74-8609-4935-a387-94d132a445c8.png)

When there is little (<150 CSS pixels) space on the right side, the tooltip is shown above the "parent" element and if the page is scrolled down so that there isn't much space on top (<100 CSS pixels, fits 3 lines of text usually), it is drawn to the bottom of the "parent" element.

![image](https://user-images.githubusercontent.com/102933/230511633-c1d837bf-4952-41ce-a9c0-386ac6c5a8ce.png)

![image](https://user-images.githubusercontent.com/102933/230511659-57831017-5090-43cd-9708-3b6e1afb06b4.png)

I had to resort to magic numbers in determining the direction as by the time placement function is called the exact size of the tooltip is undetermined.

The change is applied to all tooltips, so it addresses similar issues in other locations: blue checkmark tooltips on package details page and in search results, framework tooltips on package details page, etc.

`getBoundingClientRect` support matrix:

[![image](https://user-images.githubusercontent.com/102933/230513686-5c6e68fe-0549-492e-ad3a-0edf9f1c772e.png)](https://caniuse.com/getboundingclientrect)