### PR TITLE
[A11y bug] More Information link on search results page is ambiguous.

### DIFF
--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -126,7 +126,7 @@
                 @Model.ShortDescription
                 @if (Model.IsDescriptionTruncated)
                 {
-                    @Html.RouteLink("More information", RouteName.DisplayPackage, new { Model.Id, Model.Version })
+                    @Html.RouteLink("More information", RouteName.DisplayPackage, new { Model.Id, Model.Version }, new { @title = "More information about " + Model.Id + " package." })
                 }
             </div>
         </div>

--- a/src/NuGetGallery/Views/Users/Organizations.cshtml
+++ b/src/NuGetGallery/Views/Users/Organizations.cshtml
@@ -12,7 +12,7 @@
                         Url, 
                         CurrentUser, 
                         false, 
-                        @<text>Organizations&nbsp;<span aria-hidden="true" class="ms-font-xl organizations-divider">|</span>&nbsp;<a href="@Url.AddOrganization()"><span aria-hidden="true" class="ms-font-m ms-Icon ms-Icon--Add"></span>&nbsp;Add new</a></text>)
+                        @<text>Organizations&nbsp;<span aria-hidden="true" class="ms-font-xl organizations-divider">|</span>&nbsp;<a href="@Url.AddOrganization()" title="Add new organization."><span aria-hidden="true" class="ms-font-m ms-Icon ms-Icon--Add"></span>&nbsp;Add new</a></text>)
                 </div>
             </div>
             <hr class="breadcrumb-divider"/>


### PR DESCRIPTION
# Changes

* Added title for `More information` link on search page.
* Added title for `Add new` link on organization page.

Addresses https://github.com/NuGet/NuGetGallery/issues/9423