### PR TITLE
[A11y bug] Package Manager tab on Package details reads as both selected and expanded

### DIFF
--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -2345,14 +2345,12 @@ if (typeof jQuery === 'undefined') {
         .end()
         .find('[data-toggle="tab"]')
           .attr('tabindex', "-1")
-          .attr('aria-expanded', false)
           .attr('aria-selected', false)
 
       element
         .addClass('active')
         .find('[data-toggle="tab"]')
           .attr('tabindex', "0")
-          .attr('aria-expanded', true)
           .attr('aria-selected', true)
 
       if (transition) {

--- a/src/Bootstrap/js/tab.js
+++ b/src/Bootstrap/js/tab.js
@@ -77,14 +77,12 @@
         .end()
         .find('[data-toggle="tab"]')
           .attr('tabindex', "-1")
-          .attr('aria-expanded', false)
           .attr('aria-selected', false)
 
       element
         .addClass('active')
         .find('[data-toggle="tab"]')
           .attr('tabindex', "0")
-          .attr('aria-expanded', true)
           .attr('aria-selected', true)
 
       if (transition) {

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -143,8 +143,14 @@
 
     clampUsedByDescriptions();
 
+    // data-toggle="tab" adds aria-expanded when a tab is selected/active. 
+    // This property is removed since tabs should only have aria-selected attribute
+    $(".package-manager-tab").removeAttr("aria-expanded");
+
     // Make sure we save the user's preferred body tab to localStorage.
     $('.package-manager-tab').on('shown.bs.tab', function (e) {
+        $(".package-manager-tab").removeAttr("aria-expanded");
+
         if (storage) {
             storage.setItem(packageManagerStorageKey, e.target.id);
         }

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -143,14 +143,8 @@
 
     clampUsedByDescriptions();
 
-    // data-toggle="tab" adds aria-expanded when a tab is selected/active. 
-    // This property is removed since tabs should only have aria-selected attribute
-    $(".package-manager-tab").removeAttr("aria-expanded");
-
     // Make sure we save the user's preferred body tab to localStorage.
     $('.package-manager-tab').on('shown.bs.tab', function (e) {
-        $(".package-manager-tab").removeAttr("aria-expanded");
-
         if (storage) {
             storage.setItem(packageManagerStorageKey, e.target.id);
         }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -184,7 +184,7 @@
 @helper CommandTab(PackageManagerViewModel packageManager, bool active)
 {
     <li role="presentation" class="@(active ? "active" : string.Empty)">
-        <a href="#@packageManager.Id" aria-expanded="@(active ? "true" : "false")"
+        <a href="#@packageManager.Id"
            id="@packageManager.Id-tab" class="package-manager-tab"
            aria-selected="@(active ? "true" : "false")" tabindex="@(active ? "0" : "-1")"
            aria-controls="@packageManager.Id" role="tab" data-toggle="tab"


### PR DESCRIPTION
# Changes

* Removed `aria-expanded` from DisplayPackage for element that should only have `aria-selected`.
* Added comment stating that `data-toggle="tab"` adds `aria-expanded` every time it's selected/active. So, it needed to be removed when the script is loaded and after the `shown.bs.tab` event.

Addresses https://github.com/NuGet/NuGetGallery/issues/9418