### PR TITLE
[A11y] Make screen readers start with packages list on Search Page.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -4,7 +4,7 @@ $(function() {
     $(".reserved-indicator").each(window.nuget.setPopovers);
 
     const storage = window['localStorage'];
-    const focusResultsColumnKey = 'focus_results-column';
+    const focusResultsColumnKey = 'focus_results_column';
 
     if (storage && storage.getItem(focusResultsColumnKey)) {
         storage.removeItem(focusResultsColumnKey);

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -3,6 +3,14 @@ $(function() {
 
     $(".reserved-indicator").each(window.nuget.setPopovers);
 
+    const storage = window['localStorage'];
+    const focusResultsColumnKey = 'focus_results-column';
+
+    if (storage && storage.getItem(focusResultsColumnKey)) {
+        storage.removeItem(focusResultsColumnKey);
+        document.getElementById('results-column').focus({ preventScroll: true });
+    }
+
     const searchForm = document.forms.search;
     const allFrameworks = document.querySelectorAll('.framework');
     const allTfms = document.querySelectorAll('.tfm');
@@ -69,6 +77,11 @@ $(function() {
     function submitSearchForm() {
         constructFilterParameter(searchForm.frameworks, allFrameworks);
         constructFilterParameter(searchForm.tfms, allTfms);
+
+        if (storage) {
+            storage.setItem(focusResultsColumnKey, true);
+        }
+
         searchForm.submit();
     }
 

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -135,7 +135,7 @@
                     </div>
                 }
             </div>
-            <div class="@(Model.IsAdvancedSearchFlightEnabled ? "col-md-9" : "col-md-12")" id="results-column">
+            <div class="@(Model.IsAdvancedSearchFlightEnabled ? "col-md-9" : "col-md-12")" id="results-column" tabindex="0">
                 <div class="row">
                     <div class="col-md-9">
                         <h1 tabindex="0">


### PR DESCRIPTION
# Changes

* Gives focus to `results-column` element to tell screen readers were to start if the `Apply` button or the `Search` button were clicked.
* uses `localStorage` to track if those buttons were clicked before the page refresh.

Addresses: https://github.com/NuGet/NuGetGallery/issues/9422