### PR TITLE
Getting back the error message when uploading large files.

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -194,7 +194,7 @@
                 case "error":
                     // IIS returns 404.13 (NotFound) when maxAllowedContentLength limit is exceeded.
                     if (fullResponse === "Not Found" || fullResponse === "Request Entity Too Large") {
-                        displayErrors(["The package file exceeds the size limit. Please try again."]);
+                        displayErrors(["The package file exceeds the size limit of 250 MB. Please reduce the package size and try again."]);
                     }
                     else {
                         displayErrors(model.responseJSON);

--- a/src/NuGetGallery/Scripts/gallery/async-file-upload.js
+++ b/src/NuGetGallery/Scripts/gallery/async-file-upload.js
@@ -193,7 +193,7 @@
                     break;
                 case "error":
                     // IIS returns 404.13 (NotFound) when maxAllowedContentLength limit is exceeded.
-                    if (fullResponse === "Not Found") {
+                    if (fullResponse === "Not Found" || fullResponse === "Request Entity Too Large") {
                         displayErrors(["The package file exceeds the size limit. Please try again."]);
                     }
                     else {


### PR DESCRIPTION
Addresses #9393.

The error message for large files is now back and with updated error message:
![image](https://user-images.githubusercontent.com/102933/232632282-0c5271f7-539b-4d11-8e5d-5c8a579d44f1.png)

