### PR TITLE
[a11y] remove span element in version history table

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -955,11 +955,8 @@
                                             }
                                             else
                                             {
-                                                <td class="package-icon-cell">
-                                                    <span class="package-warning-icon" aria-label="@packageVersion.PackageWarningIconTitle"
-                                                          data-content="@packageVersion.PackageWarningIconTitle" tabindex="0">
-                                                        <i class="ms-Icon ms-Icon--Warning package-icon"></i>
-                                                    </span>
+                                                <td tabindex="0" class="package-icon-cell package-warning-icon" aria-label="@packageVersion.PackageWarningIconTitle">
+                                                    <i class="ms-Icon ms-Icon--Warning package-icon" title="@packageVersion.PackageWarningIconTitle"></i>
                                                 </td>
                                             }
                                         </tr>


### PR DESCRIPTION
Fixes an issue where JAWS and NVDA cannot access the package warnings column in Version History table using `ctrl` + `alt` + `right arrow key`. Removing the `span` element and distributing its attributes solves the issue. 

Addresses: https://github.com/NuGet/NuGetGallery/issues/9472