### PR TITLE
[A11y] Add screen reader description to More information and Add new links

### DIFF
--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -126,7 +126,7 @@
                 @Model.ShortDescription
                 @if (Model.IsDescriptionTruncated)
                 {
-                    @Html.RouteLink("More information", RouteName.DisplayPackage, new { Model.Id, Model.Version }, new { @title = "More information about " + Model.Id + " package." })
+                    @Html.RouteLink("More information", RouteName.DisplayPackage, new { Model.Id, Model.Version }, new { @title = "More information about " + Model.Id + " package", @aria_label = "More information about " + Model.Id + " package" })
                 }
             </div>
         </div>

--- a/src/NuGetGallery/Views/Users/Organizations.cshtml
+++ b/src/NuGetGallery/Views/Users/Organizations.cshtml
@@ -12,7 +12,7 @@
                         Url, 
                         CurrentUser, 
                         false, 
-                        @<text>Organizations&nbsp;<span aria-hidden="true" class="ms-font-xl organizations-divider">|</span>&nbsp;<a href="@Url.AddOrganization()" title="Add new organization."><span aria-hidden="true" class="ms-font-m ms-Icon ms-Icon--Add"></span>&nbsp;Add new</a></text>)
+                        @<text>Organizations&nbsp;<span aria-hidden="true" class="ms-font-xl organizations-divider">|</span>&nbsp;<a href="@Url.AddOrganization()" title="Add new organization" aria-label="Add new organization"><span aria-hidden="true" class="ms-font-m ms-Icon ms-Icon--Add"></span>&nbsp;Add new</a></text>)
                 </div>
             </div>
             <hr class="breadcrumb-divider"/>


### PR DESCRIPTION
# Changes

* Apparently adding `title` didn't fix entirely this issue so I added `aria-label` to those links.

Addresses https://github.com/NuGet/NuGetGallery/issues/9423