### PR TITLE
Resolve top 2 HTTP 500 sources on NuGetGallery

### DIFF
--- a/src/AccountDeleter/Configuration/GalleryConfiguration.cs
+++ b/src/AccountDeleter/Configuration/GalleryConfiguration.cs
@@ -116,5 +116,6 @@ namespace NuGetGallery.AccountDeleter
         public string InternalMicrosoftTenantKey { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string AdminSenderUser { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string SupportEmailSiteRoot { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public int MaxJsonLengthOverride { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/AppConfiguration.cs
@@ -424,5 +424,7 @@ namespace NuGetGallery.Configuration
         public int? MaxIoThreads { get; set; }
         public string InternalMicrosoftTenantKey { get; set; }
         public string AdminSenderUser { get; set; }
+        [DefaultValue(16 * 1024 * 1024)]
+        public int MaxJsonLengthOverride { get; set; }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IAppConfiguration.cs
@@ -515,5 +515,11 @@ namespace NuGetGallery.Configuration
         /// account should not have any credentials or be marked as a site admin.
         /// </summary>
         string AdminSenderUser { get; set; }
+
+        /// <summary>
+        /// The maximum size of JSON that can be returned by a JSON endpoint. This overrides the default 4 MB in
+        /// select places where large JSON response bodies are possible.
+        /// </summary>
+        int MaxJsonLengthOverride { get; set; }
     }
 }

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -113,6 +113,7 @@
     <EmbeddedResource Update="ServicesStrings.resx" StronglyTypedNamespace="NuGetGallery" StronglyTypedLanguage="C#">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>ServicesStrings.Designer.cs</LastGenOutput>
+      <CustomToolNamespace>NuGetGallery</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/src/NuGetGallery.Services/ServicesStrings.Designer.cs
+++ b/src/NuGetGallery.Services/ServicesStrings.Designer.cs
@@ -524,6 +524,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The given authentication provider is not supported..
+        /// </summary>
+        public static string AuthenticationProviderNotFound {
+            get {
+                return ResourceManager.GetString("AuthenticationProviderNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to (automated).
         /// </summary>
         public static string AutomatedPackageDeleteSignature {
@@ -1932,7 +1941,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have not published a package with this prefix in the past. This means other users may be able to push packages starting with the same prefix. Contact account@nuget.org to reserve the prefix. Go to https://docs.microsoft.com/en-us/nuget/reference/id-prefix-reservation to learn more about Package ID prefix reservation..
+        ///   Looks up a localized string similar to You have not published a package with this prefix in the past. This means other users may be able to push packages starting with the same prefix. Contact account@nuget.org to reserve the prefix. Go to https://docs.microsoft.com/nuget/reference/id-prefix-reservation to learn more about Package ID prefix reservation..
         /// </summary>
         public static string SecurityPolicy_RequirePackagePrefixReserved {
             get {

--- a/src/NuGetGallery.Services/ServicesStrings.resx
+++ b/src/NuGetGallery.Services/ServicesStrings.resx
@@ -1139,4 +1139,7 @@ The {1} Team</value>
   <data name="TransformAccount_AccountIsLocked" xml:space="preserve">
     <value>Account '{0}' is locked and cannot be transformed to an organization. Please contact support@nuget.org.</value>
   </data>
+  <data name="AuthenticationProviderNotFound" xml:space="preserve">
+    <value>The given authentication provider is not supported.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -422,6 +422,12 @@ namespace NuGetGallery
         [HttpGet]
         public virtual ActionResult AuthenticateGet(string returnUrl, string provider)
         {
+            if (provider == null || !_authService.Authenticators.ContainsKey(provider))
+            {
+                TempData["ErrorMessage"] = ServicesStrings.AuthenticationProviderNotFound;
+                return SafeRedirect(returnUrl);
+            }
+
             return AuthenticateAndLinkExternal(returnUrl, provider);
         }
 

--- a/src/NuGetGallery/Controllers/StatisticsController.cs
+++ b/src/NuGetGallery/Controllers/StatisticsController.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Web.Mvc;
 using System.Web.UI;
 using NuGet.Versioning;
+using NuGetGallery.Configuration;
 
 namespace NuGetGallery
 {
@@ -16,14 +17,17 @@ namespace NuGetGallery
     {
         private readonly IStatisticsService _statisticsService = null;
         private readonly IAggregateStatsService _aggregateStatsService = null;
+        private readonly IAppConfiguration _appConfiguration = null;
 
-        private static readonly string[] PackageDownloadsByVersionDimensions = new[] {
+        private static readonly string[] PackageDownloadsByVersionDimensions = new[]
+        {
             GalleryConstants.StatisticsDimensions.Version,
             GalleryConstants.StatisticsDimensions.ClientName,
             GalleryConstants.StatisticsDimensions.ClientVersion,
         };
 
-        private static readonly string[] PackageDownloadsDetailDimensions = new[] {
+        private static readonly string[] PackageDownloadsDetailDimensions = new[]
+        {
             GalleryConstants.StatisticsDimensions.ClientName,
             GalleryConstants.StatisticsDimensions.ClientVersion,
         };
@@ -40,10 +44,14 @@ namespace NuGetGallery
             _aggregateStatsService = null;
         }
 
-        public StatisticsController(IStatisticsService statisticsService, IAggregateStatsService aggregateStatsService)
+        public StatisticsController(
+            IStatisticsService statisticsService,
+            IAggregateStatsService aggregateStatsService,
+            IAppConfiguration appConfiguration)
         {
             _statisticsService = statisticsService;
             _aggregateStatsService = aggregateStatsService;
+            _appConfiguration = appConfiguration;
         }
 
         [AcceptVerbs(HttpVerbs.Get | HttpVerbs.Head)]
@@ -199,7 +207,9 @@ namespace NuGetGallery
                 return Json(HttpStatusCode.NotFound, new[] { Strings.PackageWithIdDoesNotExist }, JsonRequestBehavior.AllowGet);
             }
 
-            return Json(HttpStatusCode.OK, packageStatisticsReport, JsonRequestBehavior.AllowGet);
+            var response = Json(HttpStatusCode.OK, packageStatisticsReport, JsonRequestBehavior.AllowGet);
+            response.MaxJsonLength = _appConfiguration?.MaxJsonLengthOverride;
+            return response;
         }
 
         //

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -1342,6 +1342,41 @@ namespace NuGetGallery.Controllers
             }
         }
 
+        public class TheAuthenticateGetAction : TestContainer
+        {
+            [Fact]
+            public void ReturnsErrorWhenProviderIsNull()
+            {
+                // Arrange
+                const string returnUrl = "/theReturnUrl";
+                EnableAllAuthenticators(Get<AuthenticationService>());
+                var controller = GetController<AuthenticationController>();
+
+                // Act
+                var result = controller.AuthenticateGet(returnUrl, provider: null);
+
+                // Assert
+                ResultAssert.IsSafeRedirectTo(result, returnUrl);
+                Assert.Equal(ServicesStrings.AuthenticationProviderNotFound, controller.TempData["ErrorMessage"]);
+            }
+
+            [Fact]
+            public void ReturnsErrorWhenProviderIsUnknown()
+            {
+                // Arrange
+                const string returnUrl = "/theReturnUrl";
+                EnableAllAuthenticators(Get<AuthenticationService>());
+                var controller = GetController<AuthenticationController>();
+
+                // Act
+                var result = controller.AuthenticateGet(returnUrl, provider: "a provider that will never exist... hopefully!");
+
+                // Assert
+                ResultAssert.IsSafeRedirectTo(result, returnUrl);
+                Assert.Equal(ServicesStrings.AuthenticationProviderNotFound, controller.TempData["ErrorMessage"]);
+            }
+        }
+
         public class TheLinkOrChangeExternalCredentialAction : TestContainer
         {
             [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -9,10 +9,12 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+using System.Web.Http.Results;
 using System.Web.Mvc;
 using System.Web.Routing;
 using Moq;
 using Newtonsoft.Json.Linq;
+using NuGetGallery.Configuration;
 using NuGetGallery.Cookies;
 using NuGetGallery.Framework;
 using Xunit;
@@ -665,6 +667,32 @@ namespace NuGetGallery
             await controller.PackageDownloadsByVersionReport(PackageId, It.IsAny<string[]>());
 
             Assert.Equal(200, controller.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task StatisticsDownloadByVersionAction_OverridesMaxJsonLength()
+        {
+            const string PackageId = "A";
+
+            var fakeStatisticsService = new Mock<IStatisticsService>();
+            fakeStatisticsService
+                .Setup(service => service.GetPackageDownloadsByVersion(PackageId))
+                .Returns(Task.FromResult(new StatisticsPackagesReport()));
+            var fakeAppConfiguration = new Mock<IAppConfiguration>();
+            fakeAppConfiguration
+                .Setup(service => service.MaxJsonLengthOverride)
+                .Returns(12345);
+
+            var controller = new StatisticsController(
+                fakeStatisticsService.Object,
+                aggregateStatsService: null,
+                appConfiguration: fakeAppConfiguration.Object);
+            TestUtility.SetupUrlHelperForUrlGeneration(controller);
+
+            var result = await controller.PackageDownloadsByVersionReport(PackageId, It.IsAny<string[]>());
+
+            var jsonResult = Assert.IsType<JsonResult>(result);
+            Assert.Equal(12345, jsonResult.MaxJsonLength);
         }
 
         public class TheTotalsAllAction


### PR DESCRIPTION
This fixes the top 2 buckets of HTTP 500s on NuGet.org during the past 30 days. The first issue has user impact. The second one generates alerting noise for us.

Fix https://github.com/NuGet/NuGetGallery/issues/9486 - verified locally with a large stats blob. I believe the only risk here is increasing the load on our front-end nodes. Currently, the data is already being loaded into memory just failing at the time of JSON serialization. Memory utilization on our front-end nodes is very acceptable right now so I don't anticipate any problem. The largest response body I see is 11,339,294 bytes for AWSSDK.Core with all 3 checkboxes. That's why I picked a default of 16 MB.

Fix https://github.com/NuGet/NuGetGallery/issues/9487 - simply handle the null or unknown provider parameter and return an error message.

Consider looking at the commits individually to understand what changes correspond to what bug. I combined these into two PRs since they are small and low risk.