### PR TITLE
Hide metadata when a package is unlisted and locked

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1289,6 +1289,9 @@ p.frameworktableinfo-text {
 .page-package-details .package-header {
   margin-bottom: 35px;
 }
+.page-package-details .content-hidden-notice {
+  margin-top: 33px;
+}
 .page-package-details .package-title {
   margin-bottom: 16px;
 }

--- a/src/Bootstrap/less/theme/page-display-package.less
+++ b/src/Bootstrap/less/theme/page-display-package.less
@@ -14,6 +14,11 @@
   .package-header {
     margin-bottom: 35px;
   }
+  
+  .content-hidden-notice {
+    // Same margin as h1
+    margin-top: (@line-height-computed * 1.5)
+  }
 
   .package-title {
     margin-bottom: 16px;

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -163,7 +163,7 @@ namespace NuGetGallery
         {
             get
             {
-                return Listed || !Locked; 
+                return (Listed || !Locked) && (!Deleted || !Locked); 
             }
         }
 

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -163,7 +163,7 @@ namespace NuGetGallery
         {
             get
             {
-                return Listed || !Locked || !Owners.Any(x => x.IsLocked); 
+                return Listed || !Locked; 
             }
         }
 

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -3,7 +3,10 @@
 
 @model DisplayPackageViewModel
 @{
-    ViewBag.Title = Model.Id + " " + Model.Version;
+    if (Model.ShowDetailsAndLinks && !Model.Deleted)
+    {
+        ViewBag.Title = Model.Id + " " + Model.Version;
+    }
     ViewBag.Tab = "Packages";
     ViewBag.BlockSearchEngineIndexing = Model.BlockSearchEngineIndexing;
 
@@ -156,28 +159,34 @@
 }
 
 @section Meta {
-    <meta name="description" content="@Model.ShortDescription">
+    @if (Model.ShowDetailsAndLinks && !Model.Deleted)
+    {
+        <meta name="description" content="@Model.ShortDescription">
+    }
 }
 
 @section SocialMeta {
-    @if (!String.IsNullOrWhiteSpace(ViewBag.FacebookAppID))
+    @if (Model.ShowDetailsAndLinks)
     {
-        <meta property="fb:app_id" content="@ViewBag.FacebookAppID" />
-    }
+        if (!String.IsNullOrWhiteSpace(ViewBag.FacebookAppID))
+        {
+            <meta property="fb:app_id" content="@ViewBag.FacebookAppID" />
+        }
 
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:site" content="@("@nuget")">
+        <meta name="twitter:card" content="summary">
+        <meta name="twitter:site" content="@("@nuget")">
 
-    <meta property="og:title" content="@Model.Id @Model.Version" />
-    <meta property="og:type" content="nugetgallery:package" />
-    <meta property="og:url" content="@absolutePackageUrl" />
-    <meta property="og:description" content="@Model.Description" />
-    <meta property="og:determiner" content="a" />
-    <meta property="og:image" content="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png"))" />
+        <meta property="og:title" content="@Model.Id @Model.Version" />
+        <meta property="og:type" content="nugetgallery:package" />
+        <meta property="og:url" content="@absolutePackageUrl" />
+        <meta property="og:description" content="@Model.Description" />
+        <meta property="og:determiner" content="a" />
+        <meta property="og:image" content="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png"))" />
 
-    @if (Model.IsAtomFeedEnabled)
-    {
-        <link rel="alternate" type="application/atom+xml" title="Subscribe to @Model.Id updates" href="@Url.PackageAtomFeed(Model.Id)" />
+        if (Model.IsAtomFeedEnabled)
+        {
+            <link rel="alternate" type="application/atom+xml" title="Subscribe to @Model.Id updates" href="@Url.PackageAtomFeed(Model.Id)" />
+        }
     }
 }
 
@@ -252,36 +261,49 @@
     <div class="row">
         <div class="col-sm-9 package-details-main">
             <div class="package-header">
-                <div class="package-title">
-                    <h1>
-                        <span class="pull-left">
-                            <img class="package-icon img-responsive" aria-hidden="true" alt=""
-                                    src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) && Model.ShowDetailsAndLinks ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
-                                    @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
-                        </span>
-                        <span class="title">
-                            @Html.BreakWord(Model.Id)
-                        </span>
-                        <span class="version-title">
-                            @Model.Version
-                        </span>
-                    </h1>
-                    @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
-                    {
-                        <span class="prefix-reserve-title">
-                            <img class="reserved-indicator"
-                                    src="~/Content/gallery/img/reserved-indicator.svg"
-                                    @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
-                                    data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"
-                                    alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip"/>
-                            <a href="https://docs.microsoft.com/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
-                                Prefix Reserved
-                            </a>
-                        </span>
-                    }
-                </div>
+                @if (Model.ShowDetailsAndLinks)
+                {
+                    <div class="package-title">
+                        <h1>
+                            <span class="pull-left">
+                                <img class="package-icon img-responsive" aria-hidden="true" alt=""
+                                     src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) && Model.ShowDetailsAndLinks ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
+                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
+                            </span>
+                            <span class="title">
+                                @Html.BreakWord(Model.Id)
+                            </span>
+                            <span class="version-title">
+                                @Model.Version
+                            </span>
+                        </h1>
 
-                @if (Model.CanDisplayTargetFrameworks())
+                        @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
+                        {
+                            <span class="prefix-reserve-title">
+                                <img class="reserved-indicator"
+                                     src="~/Content/gallery/img/reserved-indicator.svg"
+                                     @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/reserved-indicator-25x25.png"))
+                                     data-content="@Strings.ReservedNamespace_ReservedIndicatorTooltip" tabindex="0"
+                                     alt="@Strings.ReservedNamespace_ReservedIndicatorTooltip" />
+                                <a href="https://docs.microsoft.com/nuget/nuget-org/id-prefix-reservation" class="prefix-reserve-label">
+                                    Prefix Reserved
+                                </a>
+                            </span>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <div class="content-hidden-notice">
+                        @ViewHelpers.AlertDanger(
+                            @<text>
+                                This package's content is hidden as it violates our <a href="https://www.nuget.org/policies/terms" title="Terms of Use">Terms of Use</a>.
+                            </text>)
+                    </div>
+                }
+
+                @if (Model.CanDisplayTargetFrameworks() && Model.ShowDetailsAndLinks)
                 {
                     @Html.Partial("_SupportedFrameworksBadges", Model.PackageFrameworkCompatibility.Badges);
                 }
@@ -416,7 +438,7 @@
                     )
                 }
 
-                @if (Model.HasEmbeddedIcon && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && (Model.Available || Model.Validating))
+                @if (Model.HasEmbeddedIcon && Model.ShowDetailsAndLinks && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && (Model.Available || Model.Validating))
                 {
                     @ViewHelpers.AlertWarning(
                         @<text>
@@ -466,7 +488,7 @@
                     }
                 }
 
-                @if (!Model.Listed && Model.Available)
+                @if (!Model.Listed && Model.Available && Model.ShowDetailsAndLinks)
                 {
                     if (Model.CanDisplayPrivateMetadata)
                     {
@@ -489,12 +511,12 @@
                     }
                 }
 
-                @if (!Model.Deleted && !String.IsNullOrEmpty(Model.MinClientVersion))
+                @if (!Model.Deleted && Model.ShowDetailsAndLinks && !String.IsNullOrEmpty(Model.MinClientVersion))
                 {
                     <p>Requires NuGet @Model.MinClientVersion or higher.</p>
                 }
 
-                @if (Model.Available)
+                @if (Model.Available && Model.ShowDetailsAndLinks)
                 {
                     <div class="install-tabs">
                         <ul class="nav nav-tabs" role="tablist">
@@ -522,7 +544,7 @@
             <div class="body-tabs">
                 <ul class="nav nav-tabs" role="tablist">
                     @{ string activeBodyTab = null; }
-                    @if (!Model.Deleted)
+                    @if (!Model.Deleted && Model.ShowDetailsAndLinks)
                     {
                         activeBodyTab = activeBodyTab ?? "readme";
                         <li role="presentation" class="active" id="show-readme-container">
@@ -583,7 +605,7 @@
                         </li>
                     }
 
-                    @if (!Model.IsDotnetToolPackageType && (Model.IsGitHubUsageEnabled || Model.IsPackageDependentsEnabled))
+                    @if (!Model.IsDotnetToolPackageType && Model.ShowDetailsAndLinks && !Model.Deleted && (Model.IsGitHubUsageEnabled || Model.IsPackageDependentsEnabled))
                     {
                         activeBodyTab = activeBodyTab ?? "usedby";
                         <li role="presentation">
@@ -640,17 +662,10 @@
             </div>
 
             <div class="tab-content body-tab-content">
-                @if (!Model.Deleted)
+                @if (!Model.Deleted && Model.ShowDetailsAndLinks)
                 {
                     <div role="tabpanel" class="tab-pane @(activeBodyTab == "readme" ? "active" : "")" id="readme-tab" aria-label="Readme tab content">
-                        @if (!Model.ShowDetailsAndLinks)
-                        {
-                            @ViewHelpers.AlertWarning(
-                                @<text>
-                                    This package's content is hidden as it violates our <a href="https://www.nuget.org/policies/terms" title="Terms of use">Terms of use</a>.
-                                </text>)
-                        }
-                        else if ((Model.Validating || Model.FailedValidation) && Model.HasEmbeddedReadmeFile)
+                        @if ((Model.Validating || Model.FailedValidation) && Model.HasEmbeddedReadmeFile)
                         {
                             @ViewHelpers.AlertWarning(
                                 @<text>
@@ -706,7 +721,7 @@
                     }
 
                     <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-label="Dependencies tab content">
-                        @if (!Model.Deleted)
+                        @if (!Model.Deleted && Model.ShowDetailsAndLinks)
                         {
                             if (Model.Dependencies.DependencySets == null)
                             {
@@ -897,7 +912,7 @@
                             <tbody class="no-border">
                                 @foreach (var packageVersion in Model.PackageVersions)
                                 {
-                                    if ((packageVersion.Available && packageVersion.Listed)
+                                    if ((packageVersion.Available && packageVersion.Listed && Model.ShowDetailsAndLinks)
                                         || (!packageVersion.Deleted && Model.CanDisplayPrivateMetadata))
                                     {
                                         <tr class="@(packageVersion.IsCurrent(Model) ? "bg-info" : null)">
@@ -994,33 +1009,36 @@
         </div>
 
         <aside aria-label="Package details info" class="col-sm-3 package-details-info">
-            <div class="sidebar-section">
-                <div class="row sidebar-headers">
-                    <div class="col-md-6">
-                        Downloads
+            @if (Model.ShowDetailsAndLinks && !Model.Deleted)
+            {
+                <div class="sidebar-section">
+                    <div class="row sidebar-headers">
+                        <div class="col-md-6">
+                            Downloads
+                        </div>
+                        <div class="col-md-6 title-links">
+                            @if (StatisticsHelper.IsStatisticsPageAvailable)
+                            {
+                                <a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics">Full stats →</a>
+                            }
+                        </div>
                     </div>
-                    <div class="col-md-6 title-links">
-                        @if (StatisticsHelper.IsStatisticsPageAvailable)
-                        {
-                            <a href="@Url.StatisticsPackageDownloadByVersion(Model.Id)" title="Package Statistics">Full stats →</a>
-                        }
+                    <div class="download-info">
+                        <div class="download-info-row">
+                            <span class="download-info-header">Total</span>
+                            <span class="download-info-content">@Model.TotalDownloadCount.ToKiloFormat()</span>
+                        </div>
+                        <div class="download-info-row">
+                            <span class="download-info-header">Current version</span>
+                            <span class="download-info-content">@Model.DownloadCount.ToKiloFormat()</span>
+                        </div>
+                        <div class="download-info-row">
+                            <span class="download-info-header">Per day average</span>
+                            <span class="download-info-content">@Model.DownloadsPerDay.ToKiloFormat()</span>
+                        </div>
                     </div>
                 </div>
-                <div class="download-info">
-                    <div class="download-info-row">
-                        <span class="download-info-header">Total</span>
-                        <span class="download-info-content">@Model.TotalDownloadCount.ToKiloFormat()</span>
-                    </div>
-                    <div class="download-info-row">
-                        <span class="download-info-header">Current version</span>
-                        <span class="download-info-content">@Model.DownloadCount.ToKiloFormat()</span>
-                    </div>
-                    <div class="download-info-row">
-                        <span class="download-info-header">Per day average</span>
-                        <span class="download-info-content">@Model.DownloadsPerDay.ToKiloFormat()</span>
-                    </div>
-                </div>
-            </div>
+            }
 
             <div class="sidebar-section">
                 <div class="sidebar-headers">About</div>
@@ -1093,7 +1111,7 @@
                         }
                     }
 
-                    @if (Model.Available)
+                    @if (Model.Available && Model.ShowDetailsAndLinks)
                     {
                         <li>
                             <i class="ms-Icon ms-Icon--CloudDownload" aria-hidden="true"></i>
@@ -1110,7 +1128,7 @@
                         }
                     }
 
-                    @if (Model.CanDisplayNuGetPackageExplorerLink())
+                    @if (Model.CanDisplayNuGetPackageExplorerLink() && Model.ShowDetailsAndLinks)
                     {
                         var disclaimer = "nuget.info is a 3rd party website, not controlled by Microsoft. This link is made available to you per the NuGet Terms of Use.";
 
@@ -1124,7 +1142,7 @@
                         </li>
                     }
 
-                    @if (Model.CanDisplayFuGetLink())
+                    @if (Model.CanDisplayFuGetLink() && Model.ShowDetailsAndLinks)
                     {
                         var disclaimer = "fuget.org is a 3rd party website, not controlled by Microsoft. This link is made available to you per the NuGet Terms of Use.";
 
@@ -1141,7 +1159,7 @@
                         </li>
                     }
 
-                    @if (!Model.CanReportAsOwner && Model.Available)
+                    @if (!Model.CanReportAsOwner && Model.Available && Model.ShowDetailsAndLinks)
                     {
                         <li class="report-link">
                             <i class="ms-Icon ms-Icon--Flag" aria-hidden="true"></i>
@@ -1292,7 +1310,7 @@
 
             </div>
                 
-            @if (!Model.Deleted)
+            @if (!Model.Deleted && Model.ShowDetailsAndLinks)
             {
 
                 if (Model.Tags.AnySafe())
@@ -1311,7 +1329,7 @@
                 }
             }
 
-            @if (Model.Available)
+            @if (Model.Available && Model.ShowDetailsAndLinks)
             {
                 var encodedText = Url.Encode(string.Format("Check out {0} on #NuGet.", Model.Id));
                 <p class="share-buttons">

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -351,47 +351,33 @@ namespace NuGetGallery.ViewModels
         }
 
         [Theory]
-        [MemberData(nameof(ShowPackageDetailsData))]
-        public void HidesDetailsAndLinksForCertainPackages(bool listed, bool locked, bool lockedUser, bool shouldHide)
+        [InlineData(false, false, false, true)]
+        [InlineData(false, false, true, true)]
+        [InlineData(false, true, false, true)]
+        [InlineData(false, true, true, true)]
+        [InlineData(true, false, false, false)]
+        [InlineData(true, false, true, false)]
+        [InlineData(true, true, false, true)]
+        [InlineData(true, true, true, false)]
+        public void HidesDetailsAndLinksForCertainPackages(bool locked, bool listed, bool deleted, bool expected)
         {
-            var ownersList = new List<User>() 
-            { 
-                    new User() { 
-                        UserStatusKey = lockedUser ? UserStatus.Locked : UserStatus.Unlocked 
-                    }
-            };
             var package = new Package
             {
                 Version = "1.0.0",
                 NormalizedVersion = "1.0.0",
                 Listed = listed,
+                PackageStatusKey = deleted ? PackageStatus.Deleted : PackageStatus.Available,
                 PackageRegistration = new PackageRegistration
                 {
                     Id = "foo",
-                    Owners = ownersList,
                     Packages = Enumerable.Empty<Package>().ToList(),
                     IsLocked = locked
                 }
             };
 
             var model = CreateDisplayPackageViewModel(package, currentUser: null, packageKeyToDeprecation: null, readmeHtml: null);
-            Assert.Equal(shouldHide, model.ShowDetailsAndLinks);
+            Assert.Equal(expected, model.ShowDetailsAndLinks);
         }
-
-        public static IEnumerable<object[]> ShowPackageDetailsData
-        {
-            get
-            {
-                var operations = new bool[] { true, false };
-                foreach (var listed in operations)
-                    foreach (var locked in operations)
-                        foreach (var userLocked in operations)
-                        {
-                            yield return new object[] { listed, locked, userLocked, listed || !locked || !userLocked };
-                        }
-            }
-        }
-
 
         [Theory]
         [InlineData(null, null)]


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/9466

- Hide package metadata even when the user is not locked, but the package is still locked. This allows more precise metadata hiding and administrative actions. We need not lock the entire user to hide some of the user's package metadata.
- Consider deleted the same as unlisted for this locking + hiding purpose.
- Hide more metadata when a package is locked and unlisted/deleted.

All in all, this makes package locking more powerful for hiding package content that breaks our terms of use.

## Unlisted + Locked - Before

(this example shows vulnerability even when unlisted/locked/deleted)

![image](https://user-images.githubusercontent.com/94054/235214720-7188bdf0-3d80-47eb-b115-2ce68f2e706d.png)

## Unlisted + Locked - After

![image](https://user-images.githubusercontent.com/94054/235212743-ce4731d3-0216-4de4-88c7-89d76f83b1e4.png)

## Deleted - Before 

![image](https://user-images.githubusercontent.com/94054/235213793-3a6dad19-cd71-489a-8add-1791a8f16dc1.png)

## Deleted - After

![image](https://user-images.githubusercontent.com/94054/235213456-4edce56a-066e-49e3-aebf-da5786966712.png)

## Deleted + Locked - Before 

![image](https://user-images.githubusercontent.com/94054/235213903-d99f749c-fc29-4e35-8255-0441bf9a09fb.png)

## Deleted + Locked - After

![image](https://user-images.githubusercontent.com/94054/235213329-cc229dfa-50ce-45a7-a821-2f7301990ff4.png)

