### PR TITLE
Removed EF dependency from NuGet.Services.Entities project

### DIFF
--- a/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
+++ b/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
@@ -3,15 +3,15 @@
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Description>Entities used for NuGet services</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Frameworks" Version="6.4.0" />
-	<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-	  <!-- This was lifted to a top-level dependency to resolve a Component Governance alert. -->
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <!-- This was lifted to a top-level dependency to resolve a Component Governance alert. -->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 

--- a/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
+++ b/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
@@ -3,15 +3,15 @@
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Entities used for NuGet services</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.4.0-preview3-19553-01" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.Frameworks" Version="6.4.0" />
-	<!-- This was lifted to a top-level dependency to resolve a Component Governance alert. -->
+	<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+	  <!-- This was lifted to a top-level dependency to resolve a Component Governance alert. -->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 

--- a/src/NuGet.Services.Entities/PackageDeprecation.cs
+++ b/src/NuGet.Services.Entities/PackageDeprecation.cs
@@ -30,7 +30,6 @@ namespace NuGet.Services.Entities
         /// <summary>
         /// Gets or sets the key of the package affected by this deprecation.
         /// </summary>
-        [Index(IsUnique = true)]
         public int PackageKey { get; set; }
 
         /// <summary>
@@ -82,7 +81,6 @@ namespace NuGet.Services.Entities
         /// <summary>
         /// The date when the package was deprecated.
         /// </summary>
-        [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
         public DateTime DeprecatedOn { get; set; }
 
         /// <summary>

--- a/src/NuGet.Services.Entities/UserCertificate.cs
+++ b/src/NuGet.Services.Entities/UserCertificate.cs
@@ -18,7 +18,6 @@ namespace NuGet.Services.Entities
         /// <summary>
         /// Gets or sets the foreign key of the certificate entity.
         /// </summary>
-        [Index("IX_UserCertificates_CertificateKeyUserKey", IsUnique = true, Order = 0)]
         public int CertificateKey { get; set; }
 
         /// <summary>
@@ -29,7 +28,6 @@ namespace NuGet.Services.Entities
         /// <summary>
         /// Gets or sets the foreign key of the user entity.
         /// </summary>
-        [Index("IX_UserCertificates_CertificateKeyUserKey", IsUnique = true, Order = 1)]
         public int UserKey { get; set; }
 
         /// <summary>

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -410,6 +410,24 @@ namespace NuGetGallery
             modelBuilder.Entity<UserCertificate>()
                 .HasKey(uc => uc.Key);
 
+            modelBuilder.Entity<UserCertificate>()
+                .Property(uc => uc.CertificateKey)
+                .HasColumnAnnotation(
+                    IndexAnnotation.AnnotationName,
+                    new IndexAnnotation(new IndexAttribute("IX_UserCertificates_CertificateKeyUserKey", order: 0)
+                    {
+                        IsUnique = true,
+                    }));
+
+            modelBuilder.Entity<UserCertificate>()
+                .Property(uc => uc.UserKey)
+                .HasColumnAnnotation(
+                    IndexAnnotation.AnnotationName,
+                    new IndexAnnotation(new IndexAttribute("IX_UserCertificates_CertificateKeyUserKey", order: 1)
+                    {
+                        IsUnique = true,
+                    }));
+
             modelBuilder.Entity<User>()
                 .HasMany(u => u.UserCertificates)
                 .WithRequired(uc => uc.User)
@@ -465,6 +483,14 @@ namespace NuGetGallery
                 .WithMany()
                 .HasForeignKey(d => d.DeprecatedByUserKey)
                 .WillCascadeOnDelete(false);
+
+            modelBuilder.Entity<PackageDeprecation>()
+                .Property(pd => pd.PackageKey)
+                .HasColumnAnnotation(IndexAnnotation.AnnotationName, new IndexAnnotation(new IndexAttribute() { IsUnique = true }));
+
+            modelBuilder.Entity<PackageDeprecation>()
+                .Property(pd => pd.DeprecatedOn)
+                .HasDatabaseGeneratedOption(DatabaseGeneratedOption.Computed);
 
             modelBuilder.Entity<PackageVulnerability>()
                 .HasKey(v => v.Key)

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -43,6 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.4.0-preview3-19553-01" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
       <Version>5.2.6</Version>
     </PackageReference>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -576,8 +576,8 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-	    <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-	    <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
+        <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -576,6 +576,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+	    <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+	    <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-6.4.0.123" newVersion="6.4.0.123"/>
       </dependentAssembly>


### PR DESCRIPTION
Removed EF-specific data annotations from NuGet.Services.Entities and replaced them with fluent API equivalents in `EntitiesContext` (which lives in a different assembly).

This should allow us to reuse entity models in EF core when we decide to switch.

Checked that the change has no effect on migrations: running `Add-Migration` produces empty migration.