### PR TITLE
[2FA] Avoid new accounts coming to the Register page.

### DIFF
--- a/src/NuGetGallery/Controllers/AuthenticationController.cs
+++ b/src/NuGetGallery/Controllers/AuthenticationController.cs
@@ -115,6 +115,10 @@ namespace NuGetGallery
             {
                 return LoggedInRedirect(returnUrl);
             }
+            else if (_featureFlagService.IsNewAccount2FAEnforcementEnabled())
+            {
+                return LogOn(UrlHelperExtensions.GetSiteRoot(true));
+            }
 
             return RegisterView(new LogOnViewModel());
         }

--- a/src/NuGetGallery/Views/Authentication/Register.cshtml
+++ b/src/NuGetGallery/Views/Authentication/Register.cshtml
@@ -4,6 +4,7 @@
     ViewBag.Tab = "Register";
     ViewBag.SmPageColumns = GalleryConstants.ColumnsAuthenticationSm;
     ViewBag.MdPageColumns = GalleryConstants.ColumnsAuthenticationMd;
+    ViewBag.BlockSearchEngineIndexing = true;
 }
 
 <section role="main" class="container main-container page-sign-in">

--- a/src/NuGetGallery/Views/Authentication/SignInNugetAccount.cshtml
+++ b/src/NuGetGallery/Views/Authentication/SignInNugetAccount.cshtml
@@ -4,6 +4,7 @@
     ViewBag.Tab = "Sign in";
     ViewBag.SmPageColumns = GalleryConstants.ColumnsAuthenticationSm;
     ViewBag.MdPageColumns = GalleryConstants.ColumnsAuthenticationMd;
+    ViewBag.BlockSearchEngineIndexing = true;
 }
 
 <section role="main" class="container main-container page-sign-in">

--- a/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/AuthenticationControllerFacts.cs
@@ -32,6 +32,66 @@ namespace NuGetGallery.Controllers
         private const string SignInViewNuGetName = "SignInNuGetAccount";
         private const string LinkExternalViewName = "LinkExternal";
 
+        public class TheSignUpAction : TestContainer
+        {
+            public TheSignUpAction()
+            {
+                var isEmailOnExceptionList = new Mock<ILoginDiscontinuationConfiguration>();
+                isEmailOnExceptionList
+                    .Setup(x => x.IsEmailInExceptionsList(It.IsAny<String>()))
+                    .Returns(false);
+                GetMock<IContentObjectService>()
+                    .Setup(x => x.LoginDiscontinuationConfiguration)
+                    .Returns(isEmailOnExceptionList.Object);
+                GetMock<IFeatureFlagService>()
+                    .Setup(f => f.IsNewAccount2FAEnforcementEnabled())
+                    .Returns(false);
+            }
+
+            [Fact]
+            public void WhenRequestAuthenticatedRedirectsToReturnUrl()
+            {
+                var controller = GetController<AuthenticationController>();
+                GetMock<HttpRequestBase>()
+                    .SetupGet(x => x.IsAuthenticated)
+                    .Returns(true);
+                var returnUrl = "/foo/bar/baz";
+                var fakes = Get<Fakes>();
+                controller.SetCurrentUser(fakes.User);
+
+                var result = controller.SignUp(returnUrl);
+
+                ResultAssert.IsSafeRedirectTo(result, returnUrl);
+                Assert.Equal(Strings.AlreadyLoggedIn, controller.TempData["Message"]);
+            }
+
+            [Fact]
+            public void When2faEnforcementEnabledReturnSignInView()
+            {
+                var controller = GetController<AuthenticationController>();
+                var featureFlagServiceMock = GetMock<IFeatureFlagService>();
+                featureFlagServiceMock
+                    .Setup(f => f.IsNewAccount2FAEnforcementEnabled())
+                    .Returns(true)
+                    .Verifiable();
+
+                var result = controller.SignUp(string.Empty);
+
+                featureFlagServiceMock.Verify();
+                ResultAssert.IsView<LogOnViewModel>(result, viewName: SignInViewName);
+            }
+
+            [Fact]
+            public void WhenNotAuthenticatedAnd2faEnforcementDisabledReturnsRegisterView()
+            {
+                var controller = GetController<AuthenticationController>();
+
+                var result = controller.SignUp(string.Empty);
+
+                ResultAssert.IsView<LogOnViewModel>(result, viewName: RegisterViewName);
+            }
+        }
+
         public class TheLogOnAction : TestContainer
         {
             public TheLogOnAction()


### PR DESCRIPTION
# Changes
* Add `noindex` for `Register` (signup) and `SignInNugetAccount` (LogOnNuGetAccount) to avoid displaying them on search engines
* `Register` page now redirects to `Sign In`.

Addresses https://github.com/NuGet/NuGetGallery/issues/123