### PR TITLE
Fix unit test that fails locally

### DIFF
--- a/tests/NuGetGallery.Facts/Services/SearchAdaptorFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SearchAdaptorFacts.cs
@@ -486,7 +486,7 @@ namespace NuGetGallery
             public void GeneratesNextLinkForComplexUrl()
             {
                 // Arrange
-                var requestUri = new Uri("https://localhost:8081/api/v2/Search()?searchTerm='foo'&$orderby=Id&$skip=100&$top=1000");
+                var requestUri = new Uri("https://localhost:8081/api/v2/Search()?searchTerm=%27foo%27&$orderby=Id&$skip=100&$top=1000");
                 var resultCount = 2000; // our result set contains 2000 elements
 
                 // Act
@@ -495,14 +495,14 @@ namespace NuGetGallery
                     GetODataQuerySettingsForTest());
 
                 // Assert
-                Assert.Equal(new Uri("https://localhost:8081/api/v2/Search()?searchTerm='foo'&$orderby=Id&$skip=200&$top=1000"), nextLink);
+                Assert.Equal("https://localhost:8081/api/v2/Search()?searchTerm=%27foo%27&$orderby=Id&$skip=200&$top=1000", nextLink.AbsoluteUri);
             }
 
             [Fact]
             public void GeneratesNextLinkForComplexUrlWithSemVerLevel2()
             {
                 // Arrange
-                var requestUri = new Uri("https://localhost:8081/api/v2/Search()?searchTerm='foo'&$orderby=Id&$skip=100&$top=1000&semVerLevel=2.0.0");
+                var requestUri = new Uri("https://localhost:8081/api/v2/Search()?searchTerm=%27foo%27&$orderby=Id&$skip=100&$top=1000&semVerLevel=2.0.0");
                 var resultCount = 2000; // our result set contains 2000 elements
 
                 // Act
@@ -512,7 +512,7 @@ namespace NuGetGallery
                     SemVerLevelKey.SemVer2);
 
                 // Assert
-                Assert.Equal(new Uri("https://localhost:8081/api/v2/Search()?searchTerm='foo'&$orderby=Id&$skip=200&$top=1000&semVerLevel=2.0.0"), nextLink);
+                Assert.Equal("https://localhost:8081/api/v2/Search()?searchTerm=%27foo%27&$orderby=Id&$skip=200&$top=1000&semVerLevel=2.0.0", nextLink.AbsoluteUri);
             }
         }
     }


### PR DESCRIPTION
This UT fails locally, I believe due to a newer version of .NET Framework. Generally apostrophes should be URL encoded so I modified the test to avoid this behavior change.