### PR TITLE
Fix minor unlisted + locked metadata issue on package details page

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -640,7 +640,7 @@
                         </a>
                     </li>
 
-                    @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
+                    @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes) && Model.ShowDetailsAndLinks)
                     {
                         activeBodyTab = activeBodyTab ?? "releasenotes";
                         <li role="presentation">


### PR DESCRIPTION
For the locked + unlisted case, the release notes tab is shown when none of the other tabs are. This is something I missed from a previous PR (https://github.com/NuGet/NuGetGallery/pull/9490).