### PR TITLE
Don't use the default error page on API responses since this can hide essential error details

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -529,6 +529,15 @@
       <add initializationPage="/api/health-probe"/>
     </applicationInitialization>
   </system.webServer>
+  <!-- Don't use the default error pages for API endpoints. -->
+  <location path="api">
+    <system.webServer>
+      <httpErrors errorMode="DetailedLocalOnly">
+        <remove statusCode="404"/>
+        <remove statusCode="500"/>
+      </httpErrors>
+    </system.webServer>
+  </location>
   <system.serviceModel>
     <serviceHostingEnvironment aspNetCompatibilityEnabled="true" multipleSiteBindingsEnabled="true"/>
     <extensions>


### PR DESCRIPTION
For HTTP 404 and HTTP 500 errors, we have a default response page, which is a pretty HTML thing. It looks like this:
404: https://dev.nugettest.org/dsfsdfseg
500: https://dev.nugettest.org/pages/simulate-error?type=Exception

Unfortunately, this is returned for API response pages. The effect of this is that if we try to return an HTTP 404 from an API response (such as the unlist API or the deprecate API), we get the HTML page for that 404 instead of a response message that has the reason phrase containing the error details. In other words, the pretty HTML page clobbers code that we put in there intentionally.

Example for unlist before the change (note the HTML response body and no helpful reason phrase)
![image](https://github.com/NuGet/NuGetGallery/assets/94054/099aaba8-9953-4ee7-92ba-86f25ca69b18)

After my change:
![image](https://github.com/NuGet/NuGetGallery/assets/94054/0bc82aca-d944-4b86-ab66-f748b3ac0c30)

Essentially the reason phrase (nice error message) provided here became useless long ago when we added pretty default error pages:
https://github.com/NuGet/NuGetGallery/blob/912cd3bd73432f6edf8a9e20106d3cc635ca99df/src/NuGetGallery/Controllers/ApiController.cs#L876-L877

I made the change for HTTP 500 as well since I don't believe a full rich HTML page should be returned for exceptions on API endpoints. The alternative (a simple, small text response without full exception details) is better, and tested in the functional test suite also included in this PR.

This can be shown in the client's support for reason phrase error messages:
![image](https://github.com/NuGet/NuGetGallery/assets/94054/7e92aad3-0c29-45c4-8bb9-d2528e3ed947)

Resolves https://github.com/NuGet/NuGetGallery/issues/9504