### PR TITLE
Adjust deprecation API slightly to prepare for public preview

### DIFF
--- a/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
+++ b/src/GitHubVulnerabilities2Db/Gallery/ThrowingTelemetryService.cs
@@ -206,7 +206,7 @@ namespace GitHubVulnerabilities2Db.Gallery
             throw new NotImplementedException();
         }
 
-        public void TrackPackageDeprecate(IReadOnlyList<Package> packages, PackageDeprecationStatus status, PackageRegistration alternateRegistration, Package alternatePackage, bool hasCustomMessage)
+        public void TrackPackageDeprecate(IReadOnlyList<Package> packages, PackageDeprecationStatus status, PackageRegistration alternateRegistration, Package alternatePackage, bool hasCustomMessage, bool hasChanges)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.Infrastructure.Annotations;
+using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Services.Entities;
 
@@ -88,6 +89,8 @@ namespace NuGetGallery
         /// User or organization accounts.
         /// </summary>
         public DbSet<User> Users { get; set; }
+
+        public bool HasChanges => ChangeTracker.HasChanges();
 
         DbSet<T> IReadOnlyEntitiesContext.Set<T>()
         {
@@ -540,6 +543,7 @@ namespace NuGetGallery
                 .HasForeignKey(r => r.ToPackageRegistrationKey)
                 .WillCascadeOnDelete(false);
         }
+
 #pragma warning restore 618
 
         private class QueryHintScope : IDisposable

--- a/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/IEntitiesContext.cs
@@ -25,6 +25,8 @@ namespace NuGetGallery
         DbSet<VulnerablePackageVersionRange> VulnerableRanges { get; set; }
         DbSet<PackageRename> PackageRenames { get; set; }
 
+        bool HasChanges { get; }
+
         Task<int> SaveChangesAsync();
         void DeleteOnCommit<T>(T entity) where T : class;
         IDatabase GetDatabase();

--- a/src/NuGetGallery.Services/Extensions/HttpContextBaseExtensions.cs
+++ b/src/NuGetGallery.Services/Extensions/HttpContextBaseExtensions.cs
@@ -64,7 +64,7 @@ namespace NuGetGallery
         /// </summary>
         public static string GetClientInformation(this HttpContextBase httpContext)
         {
-            string userAgent = httpContext.Request.Headers[ServicesConstants.UserAgentHeaderName];
+            string userAgent = httpContext.GetUserAgent();
             string result = string.Empty;
 
             if (!string.IsNullOrEmpty(userAgent))
@@ -84,6 +84,12 @@ namespace NuGetGallery
             }
 
             return result;
+        }
+
+        public static string GetUserAgent(this HttpContextBase httpContext)
+        {
+            string userAgent = httpContext.Request.Headers[ServicesConstants.UserAgentHeaderName];
+            return userAgent ?? string.Empty;
         }
     }
 

--- a/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/ITelemetryService.cs
@@ -59,7 +59,8 @@ namespace NuGetGallery
             PackageDeprecationStatus status,
             PackageRegistration alternateRegistration,
             Package alternatePackage,
-            bool hasCustomMessage);
+            bool hasCustomMessage,
+            bool hasChanges);
 
         void TrackPackageReadMeChangeEvent(Package package, string readMeSourceType, PackageEditReadMeState readMeState);
 

--- a/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
+++ b/src/NuGetGallery.Services/Telemetry/TelemetryService.cs
@@ -128,6 +128,7 @@ namespace NuGetGallery
         public const string ClientVersion = "ClientVersion";
         public const string ProtocolVersion = "ProtocolVersion";
         public const string ClientInformation = "ClientInformation";
+        public const string UserAgent = "UserAgent";
         public const string IsAuthenticated = "IsAuthenticated";
         public const string IsScoped = "IsScoped";
         public const string KeyCreationDate = "KeyCreationDate";
@@ -143,6 +144,7 @@ namespace NuGetGallery
         public const string DeprecationAlternatePackageId = "PackageDeprecationAlternatePackageId";
         public const string DeprecationAlternatePackageVersion = "PackageDeprecationAlternatePackageVersion";
         public const string DeprecationCustomMessage = "PackageDeprecationCustomMessage";
+        public const string DeprecationHasChanges = "PackageDeprecationHasChanges";
 
         // User properties
         public const string RegistrationMethod = "RegistrationMethod";
@@ -527,7 +529,8 @@ namespace NuGetGallery
             PackageDeprecationStatus status,
             PackageRegistration alternateRegistration,
             Package alternatePackage,
-            bool hasCustomMessage)
+            bool hasCustomMessage,
+            bool hasChanges)
         {
             TrackMetricForPackageVersions(
                 Events.PackageDeprecate,
@@ -538,6 +541,7 @@ namespace NuGetGallery
                     properties.Add(DeprecationAlternatePackageId, alternateRegistration?.Id ?? alternatePackage?.Id);
                     properties.Add(DeprecationAlternatePackageVersion, alternatePackage?.NormalizedVersion);
                     properties.Add(DeprecationCustomMessage, hasCustomMessage.ToString());
+                    properties.Add(DeprecationHasChanges, hasChanges.ToString());
                 });
         }
 

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -68,8 +68,8 @@
       "Domains": []
     },
     "NuGetGallery.ManageDeprecationApi": {
-      "All": false,
-      "SiteAdmins": true,
+      "All": true,
+      "SiteAdmins": false,
       "Accounts": [],
       "Domains": []
     },

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -978,6 +978,7 @@ namespace NuGetGallery
 
         [HttpPut]
         [ApiAuthorize]
+        [RequiresUserAgent]
         [ApiScopeRequired(NuGetScopes.PackageUnlist)]
         [ActionName(RouteName.DeprecatePackageApi)]
         public virtual async Task<ActionResult> DeprecatePackage(

--- a/src/NuGetGallery/Filters/RequiresUserAgentAttribute.cs
+++ b/src/NuGetGallery/Filters/RequiresUserAgentAttribute.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Web.Mvc;
+
+namespace NuGetGallery.Filters
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true, AllowMultiple = true)]
+    public sealed class RequiresUserAgentAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext filterContext)
+        {
+            if (filterContext == null)
+            {
+                throw new ArgumentNullException(nameof(filterContext));
+            }
+
+            if (string.IsNullOrWhiteSpace(filterContext.HttpContext.GetUserAgent()))
+            {
+                filterContext.Result = new HttpStatusCodeWithBodyResult(
+                    HttpStatusCode.BadRequest,
+                    statusDescription: "User-Agent header is required",
+                    body: "A User-Agent header is required for this endpoint.");
+            }
+        }
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Extensions\CakeBuildManagerExtensions.cs" />
     <Compile Include="Extensions\ImageExtensions.cs" />
     <Compile Include="Filters\AdminActionAttribute.cs" />
+    <Compile Include="Filters\RequiresUserAgentAttribute.cs" />
     <Compile Include="Helpers\AdminHelper.cs" />
     <Compile Include="Helpers\SearchResponseHelper.cs" />
     <Compile Include="Helpers\ViewModelExtensions\DeleteAccountListPackageItemViewModelFactory.cs" />

--- a/src/NuGetGallery/Services/PackageDeprecationManagementService.cs
+++ b/src/NuGetGallery/Services/PackageDeprecationManagementService.cs
@@ -94,7 +94,6 @@ namespace NuGetGallery
             var registration = packages.FirstOrDefault()?.PackageRegistration;
             if (registration == null)
             {
-                // This should only happen if someone hacks the form or if the package is deleted while the user is filling out the form.
                 return new UpdateDeprecationError(
                     HttpStatusCode.NotFound,
                     string.Format(Strings.DeprecatePackage_MissingRegistration, id));
@@ -127,7 +126,7 @@ namespace NuGetGallery
                     if (alternatePackage == null)
                     {
                         return new UpdateDeprecationError(
-                            HttpStatusCode.NotFound,
+                            HttpStatusCode.BadRequest,
                             string.Format(Strings.DeprecatePackage_NoAlternatePackage, alternatePackageId, alternatePackageVersion));
                     }
                 }
@@ -137,7 +136,7 @@ namespace NuGetGallery
                     if (alternatePackageRegistration == null)
                     {
                         return new UpdateDeprecationError(
-                            HttpStatusCode.NotFound,
+                            HttpStatusCode.BadRequest,
                             string.Format(Strings.DeprecatePackage_NoAlternatePackageRegistration, alternatePackageId));
                     }
                 }
@@ -150,7 +149,6 @@ namespace NuGetGallery
                 var package = packages.SingleOrDefault(v => v.NormalizedVersion == normalizedVersion);
                 if (package == null)
                 {
-                    // This should only happen if someone hacks the form or if a version of the package is deleted while the user is filling out the form.
                     return new UpdateDeprecationError(
                         HttpStatusCode.NotFound,
                         string.Format(Strings.DeprecatePackage_MissingVersion, id));

--- a/src/NuGetGallery/Telemetry/ClientInformationTelemetryEnricher.cs
+++ b/src/NuGetGallery/Telemetry/ClientInformationTelemetryEnricher.cs
@@ -39,6 +39,9 @@ namespace NuGetGallery
                     itemTelemetry.Properties[TelemetryService.ClientInformation]
                         = httpContext.GetClientInformation();
 
+                    itemTelemetry.Properties[TelemetryService.UserAgent]
+                        = httpContext.GetUserAgent();
+
                     // Is the user authenticated or this is an anonymous request?
                     itemTelemetry.Properties[TelemetryService.IsAuthenticated]
                         = httpContext.Request.IsAuthenticated.ToString();

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -529,6 +529,15 @@
       <add initializationPage="/api/health-probe"/>
     </applicationInitialization>
   </system.webServer>
+  <!-- Don't use the default error pages for API endpoints. -->
+  <location path="api">
+    <system.webServer>
+      <httpErrors errorMode="DetailedLocalOnly">
+        <remove statusCode="404"/>
+        <remove statusCode="500"/>
+      </httpErrors>
+    </system.webServer>
+  </location>
   <system.serviceModel>
     <serviceHostingEnvironment aspNetCompatibilityEnabled="true" multipleSiteBindingsEnabled="true"/>
     <extensions>

--- a/src/VerifyMicrosoftPackage/Fakes/FakeEntitiesContext.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeEntitiesContext.cs
@@ -30,6 +30,8 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
 
         public string QueryHint => throw new NotImplementedException();
 
+        public bool HasChanges => throw new NotImplementedException();
+
         public void DeleteOnCommit<T>(T entity) where T : class
         {
             throw new NotImplementedException();

--- a/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeTelemetryService.cs
@@ -203,7 +203,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
             throw new NotImplementedException();
         }
 
-        public void TrackPackageDeprecate(IReadOnlyList<Package> packages, PackageDeprecationStatus status, PackageRegistration alternateRegistration, Package alternatePackage, bool hasCustomMessage)
+        public void TrackPackageDeprecate(IReadOnlyList<Package> packages, PackageDeprecationStatus status, PackageRegistration alternateRegistration, Package alternatePackage, bool hasCustomMessage, bool hasChanges)
         {
             throw new NotImplementedException();
         }

--- a/tests/NuGetGallery.Facts/Filters/RequiresUserAgentAttributeFacts.cs
+++ b/tests/NuGetGallery.Facts/Filters/RequiresUserAgentAttributeFacts.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Specialized;
+using System.Web;
+using System.Web.Mvc;
+using Moq;
+using NuGetGallery.Framework;
+using Xunit;
+
+namespace NuGetGallery.Filters
+{
+    public class RequiresUserAgentAttributeFacts : TestContainer
+    {
+        [Fact]
+        public void RequiresUserAgentHeader()
+        {
+            // Arrange
+            var headers = new NameValueCollection();
+
+            // Act
+            Mock<ActionExecutingContext> mockActionContext = ExecuteWithHeaders(headers);
+
+            // Assert
+            var result = Assert.IsType<HttpStatusCodeWithBodyResult>(mockActionContext.Object.Result);
+            Assert.Equal(400, result.StatusCode);
+            Assert.Equal("User-Agent header is required", result.StatusDescription);
+            Assert.Equal("A User-Agent header is required for this endpoint.", result.Body);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("   ")]
+        public void RejectsEmptyUserAgentHeader(string value)
+        {
+            // Arrange
+            var headers = new NameValueCollection
+            {
+                { "User-Agent", value }
+            };
+
+            // Act
+            Mock<ActionExecutingContext> mockActionContext = ExecuteWithHeaders(headers);
+
+            // Assert
+            var result = Assert.IsType<HttpStatusCodeWithBodyResult>(mockActionContext.Object.Result);
+            Assert.Equal(400, result.StatusCode);
+            Assert.Equal("User-Agent header is required", result.StatusDescription);
+            Assert.Equal("A User-Agent header is required for this endpoint.", result.Body);
+        }
+
+        [Fact]
+        public void AllowsRequestsWithUserAgent()
+        {
+            // Arrange
+            var headers = new NameValueCollection
+            {
+                { "User-Agent", "Mozilla/5.0" }
+            };
+
+            // Act
+            Mock<ActionExecutingContext> mockActionContext = ExecuteWithHeaders(headers);
+
+            // Assert
+            Assert.Null(mockActionContext.Object.Result);
+        }
+
+        private static Mock<ActionExecutingContext> ExecuteWithHeaders(NameValueCollection headers)
+        {
+            var httpRequest = new Mock<HttpRequestBase>(MockBehavior.Strict);
+            httpRequest.SetupGet(r => r.Headers).Returns(headers);
+
+            var httpContext = new Mock<HttpContextBase>(MockBehavior.Strict);
+            httpContext.SetupGet(c => c.Request).Returns(httpRequest.Object);
+
+            var mockActionContext = new Mock<ActionExecutingContext>(MockBehavior.Strict);
+            mockActionContext.SetupGet(x => x.HttpContext).Returns(httpContext.Object);
+
+            // Act
+            new RequiresUserAgentAttribute().OnActionExecuting(mockActionContext.Object);
+            return mockActionContext;
+        }
+    }
+}

--- a/tests/NuGetGallery.Facts/Framework/TestAuditingService.cs
+++ b/tests/NuGetGallery.Facts/Framework/TestAuditingService.cs
@@ -24,6 +24,16 @@ namespace NuGetGallery.Framework
 
     public static class AuditingServiceTestExtensions
     {
+        public static bool WroteNoRecords(this IAuditingService self)
+        {
+            TestAuditingService testService = self as TestAuditingService;
+            if (testService != null)
+            {
+                return !testService.Records.Any();
+            }
+            return false;
+        }
+
         public static bool WroteRecord<T>(this IAuditingService self) where T : AuditRecord
         {
             return self.WroteRecord<T>(ar => true);

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Authentication\Providers\CommonAuth\AzureActiveDirectoryV2AuthenticatorFacts.cs" />
     <Compile Include="Authentication\TestCredentialHelper.cs" />
     <Compile Include="Extensions\CakeBuildManagerExtensionsFacts.cs" />
+    <Compile Include="Filters\RequiresUserAgentAttributeFacts.cs" />
     <Compile Include="Helpers\PackageValidationHelperFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageIdsQueryFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageVersionsQueryFacts.cs" />

--- a/tests/NuGetGallery.Facts/Services/PackageDeprecationManagementServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeprecationManagementServiceFacts.cs
@@ -413,7 +413,7 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(Owner_Data))]
-            public async Task ReturnsNotFoundIfAlternatePackageRegistrationMissing(User currentUser, User owner)
+            public async Task ReturnsBadRequestIfAlternatePackageRegistrationMissing(User currentUser, User owner)
             {
                 // Arrange
                 var id = "id";
@@ -459,7 +459,7 @@ namespace NuGetGallery
                     alternatePackageId: alternatePackageId);
 
                 // Assert
-                Assert.Equal(HttpStatusCode.NotFound, result.Status);
+                Assert.Equal(HttpStatusCode.BadRequest, result.Status);
                 Assert.Equal(string.Format(Strings.DeprecatePackage_NoAlternatePackageRegistration, alternatePackageId), result.Message);
 
                 featureFlagService.Verify();
@@ -468,7 +468,7 @@ namespace NuGetGallery
 
             [Theory]
             [MemberData(nameof(Owner_Data))]
-            public async Task ReturnsNotFoundIfAlternatePackageVersionMissing(User currentUser, User owner)
+            public async Task ReturnsBadRequestIfAlternatePackageVersionMissing(User currentUser, User owner)
             {
                 // Arrange
                 var id = "id";
@@ -516,7 +516,7 @@ namespace NuGetGallery
                     alternatePackageVersion: alternatePackageVersion);
 
                 // Assert
-                Assert.Equal(HttpStatusCode.NotFound, result.Status);
+                Assert.Equal(HttpStatusCode.BadRequest, result.Status);
                 Assert.Equal(string.Format(Strings.DeprecatePackage_NoAlternatePackage, alternatePackageId, alternatePackageVersion), result.Message);
 
                 featureFlagService.Verify();

--- a/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TelemetryServiceFacts.cs
@@ -137,7 +137,7 @@ namespace NuGetGallery
                             packages,
                             PackageDeprecationStatus.Legacy,
                             new PackageRegistration { Id = "alt" },
-                            new Package { PackageRegistration = new PackageRegistration { Id = "alt-2" }, NormalizedVersion = "1.2.3" }, true))
+                            new Package { PackageRegistration = new PackageRegistration { Id = "alt-2" }, NormalizedVersion = "1.2.3" }, true, false))
                     };
 
                     yield return new object[] { "CreatePackageVerificationKey",
@@ -835,7 +835,7 @@ namespace NuGetGallery
             public void TrackPackageDeprecateThrowsIfPackageListInvalid(IReadOnlyList<Package> packages)
             {
                 var service = CreateService();
-                Assert.Throws<ArgumentException>(() => service.TrackPackageDeprecate(packages, PackageDeprecationStatus.CriticalBugs, null, null, false));
+                Assert.Throws<ArgumentException>(() => service.TrackPackageDeprecate(packages, PackageDeprecationStatus.CriticalBugs, null, null, false, false));
             }
 
             public static IEnumerable<object[]> TrackPackageDeprecateSucceedsWithoutAlternate_Data =>
@@ -854,7 +854,7 @@ namespace NuGetGallery
                     .Setup(x => x.TrackMetric(It.IsAny<string>(), It.IsAny<double>(), It.IsAny<IDictionary<string, string>>()))
                     .Callback<string, double, IDictionary<string, string>>((_, __, p) => allProperties.Add(p));
 
-                service.TrackPackageDeprecate(packages, status, null, null, hasCustomMessage);
+                service.TrackPackageDeprecate(packages, status, null, null, hasCustomMessage, true);
 
                 service.TelemetryClient.Verify(
                     x => x.TrackMetric("PackageDeprecate", packages.Count(), It.IsAny<IDictionary<string, string>>()),
@@ -898,7 +898,7 @@ namespace NuGetGallery
                 var alternatePackage = hasPackage ? new Package { PackageRegistration = new PackageRegistration { Id = "alt-P" }, NormalizedVersion = "4.3.2" } : null;
 
                 var status = PackageDeprecationStatus.NotDeprecated;
-                service.TrackPackageDeprecate(packages, status, alternateRegistration, alternatePackage, false);
+                service.TrackPackageDeprecate(packages, status, alternateRegistration, alternatePackage, false, true);
 
                 service.TelemetryClient.Verify(
                     x => x.TrackMetric("PackageDeprecate", packages.Count(), It.IsAny<IDictionary<string, string>>()),

--- a/tests/NuGetGallery.Facts/Telemetry/ClientInformationTelemetryEnricherTests.cs
+++ b/tests/NuGetGallery.Facts/Telemetry/ClientInformationTelemetryEnricherTests.cs
@@ -56,7 +56,7 @@ namespace NuGetGallery.Telemetry
             // Assert
             if (telemetry is RequestTelemetry)
             {
-                Assert.Equal(5, itemTelemetry.Properties.Count);
+                Assert.Equal(6, itemTelemetry.Properties.Count);
             }
             else
             {
@@ -112,7 +112,7 @@ namespace NuGetGallery.Telemetry
 
             var headers = new NameValueCollection
             {
-                { ServicesConstants.UserAgentHeaderName, "user agent" }
+                { ServicesConstants.UserAgentHeaderName, "user agent/1.0.0 (foo bar)" }
             };
 
             var enricher = CreateTestEnricher(headers);
@@ -122,6 +122,28 @@ namespace NuGetGallery.Telemetry
 
             // Assert
             Assert.NotEmpty(telemetry.Properties[TelemetryService.ClientInformation]);
+            Assert.Equal("user agent/1.0.0", telemetry.Properties[TelemetryService.ClientInformation]);
+        }
+
+        [Fact]
+        public void EnrichesTelemetryWithUserAgent()
+        {
+            // Arrange
+            var telemetry = new RequestTelemetry();
+
+            var headers = new NameValueCollection
+            {
+                { ServicesConstants.UserAgentHeaderName, "user agent/1.0.0 (foo bar)" }
+            };
+
+            var enricher = CreateTestEnricher(headers);
+
+            // Act
+            enricher.Initialize(telemetry);
+
+            // Assert
+            Assert.NotEmpty(telemetry.Properties[TelemetryService.UserAgent]);
+            Assert.Equal("user agent/1.0.0 (foo bar)", telemetry.Properties[TelemetryService.UserAgent]);
         }
 
         [Theory]

--- a/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
+++ b/tests/NuGetGallery.Facts/TestUtils/FakeEntitiesContext.cs
@@ -122,6 +122,8 @@ namespace NuGetGallery
 
         public virtual string QueryHint => throw new NotImplementedException();
 
+        public bool HasChanges { get; set; } = true;
+
         public Task<int> SaveChangesAsync()
         {
             _areChangesSaved = true;


### PR DESCRIPTION
- No-op the last edit update if there are no changes (reduces V3 load)
- Require user agent and include the full UA as a custom dimension in App Insights
- Return 400 not 404 when the alternate package is missing 
- Require user agent for the deprecation endpoint
- These changes are backwards compatible with the known integrations with the Deprecation API

Depends on https://github.com/NuGet/NuGetGallery/pull/9505.

Align the API with the design changes described here: https://github.com/NuGet/Engineering/pull/4709 (internal PR now, will be public after public preview begins).