### PR TITLE
Add revoke button to API keys page

### DIFF
--- a/src/NuGet.Services.Entities/CredentialRevocationSource.cs
+++ b/src/NuGet.Services.Entities/CredentialRevocationSource.cs
@@ -4,7 +4,7 @@
 namespace NuGet.Services.Entities
 {
     /// <summary>
-    /// Specify the source about where the credential is leaked
+    /// Specify the source about where the credential is revoked
     /// </summary>
     public enum CredentialRevocationSource
     {
@@ -12,5 +12,10 @@ namespace NuGet.Services.Entities
         /// Indicate the credential is leaked and revoked by GitHub.
         /// </summary>
         GitHub = 0,
+
+        /// <summary>
+        /// Indicate the credential is revoked by User.
+        /// </summary>
+        User = 1,
     }
 }

--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -178,7 +178,7 @@ namespace NuGetGallery.Authentication
             return FindMatchingApiKey(credential);
         }
 
-        public async Task RevokeApiKeyCredential(Credential apiKeyCredential, CredentialRevocationSource revocationSourceKey, bool commitChanges = true)
+        public virtual async Task RevokeApiKeyCredential(Credential apiKeyCredential, CredentialRevocationSource revocationSourceKey, bool commitChanges = true)
         {
             if (apiKeyCredential == null)
             {

--- a/src/NuGetGallery/Infrastructure/Mail/Messages/ApiKeyRevokedMessage.cs
+++ b/src/NuGetGallery/Infrastructure/Mail/Messages/ApiKeyRevokedMessage.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Net.Mail;
+using NuGet.Services.Entities;
+using NuGet.Services.Messaging.Email;
+using NuGetGallery.Authentication;
+
+namespace NuGetGallery.Infrastructure.Mail.Messages
+{
+    public class ApiKeyRevokedMessage : MarkdownEmailBuilder
+    {
+        private readonly IMessageServiceConfiguration _configuration;
+
+        public ApiKeyRevokedMessage(
+            IMessageServiceConfiguration configuration,
+            User user,
+            CredentialTypeInfo credentialType)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            User = user ?? throw new ArgumentNullException(nameof(user));
+            CredentialType = credentialType ?? throw new ArgumentNullException(nameof(credentialType));
+            if (!credentialType.IsApiKey) throw new ArgumentException("Provided credential is not an api key.");
+        }
+
+        public override MailAddress Sender => _configuration.GalleryOwner;
+
+        public CredentialTypeInfo CredentialType { get; }
+
+        public User User { get; }
+
+        public override IEmailRecipients GetRecipients()
+            => new EmailRecipients(
+                to: new[] { User.ToMailAddress() });
+
+        public override string GetSubject()
+            => string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.Emails_ApiKeyRevoked_Subject,
+                _configuration.GalleryOwner.DisplayName,
+                CredentialType.Description);
+
+        protected override string GetMarkdownBody()
+            => string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.Emails_ApiKeyRevoked_Body,
+                CredentialType.Description);
+    }
+}

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Infrastructure\ABTestEnrollmentFactory.cs" />
     <Compile Include="Infrastructure\CookieBasedABTestService.cs" />
     <Compile Include="Infrastructure\Jobs\PackageVulnerabilitiesCacheRefreshJob.cs" />
+    <Compile Include="Infrastructure\Mail\Messages\ApiKeyRevokedMessage.cs" />
     <Compile Include="Infrastructure\RequestValidationExceptionFilter.cs" />
     <Compile Include="Infrastructure\HttpStatusCodeWithHeadersResult.cs" />
     <Compile Include="Infrastructure\IABTestEnrollmentFactory.cs" />

--- a/src/NuGetGallery/Scripts/gallery/page-api-keys.js
+++ b/src/NuGetGallery/Scripts/gallery/page-api-keys.js
@@ -9,6 +9,8 @@
     var DeleteErrorMessage = "An error occurred while deleting the API key. Please try again.";
     var CreateErrorMessage = "An error occurred while creating a new API key. Please try again.";
     var EditErrorMessage = "An error occurred while editing an API key. Please try again.";
+    var ConfirmRevokeMessage = "Are you sure you want to revoke the API key?";
+    var RevokeErrorMessage = "An error occurred while revoking the API key. Please try again.";
 
     $(function () {
         function addAntiForgeryToken(data) {
@@ -520,6 +522,38 @@
                 });
             };
 
+            this.Revoke = function () {
+                if (!window.nuget.confirmEvent(ConfirmRevokeMessage)) {
+                    return;
+                }
+
+                // Build the request.
+                var data = {
+                    credentialType: this.Type(),
+                    credentialKey: this.Key(),
+                };
+                addAntiForgeryToken(data);
+
+                // Send the request.
+                $.ajax({
+                    url: initialData.RevokeUrl,
+                    type: 'POST',
+                    dataType: 'json',
+                    data: data,
+                    success: function (data) {
+                        parent.Error(null);
+                        self._UpdateData(data);
+                        self.JustCreated(false);
+                        self.JustRegenerated(false);
+                        parent.ApiKeys.remove(self);
+                        parent.ApiKeys.unshift(self);
+                    },
+                    error: function (jqXHR, textStatus, errorThrown) {
+                        parent.Error(RevokeErrorMessage);
+                    }
+                });
+            };
+
             this.CreateOrEdit = function () {
                 if (!this.Valid()) {
                     return;
@@ -657,7 +691,10 @@
                 for (var i in apiKeys) {
                     if (apiKeys[i].HasExpired()) {
                         if (apiKeys[i].RevocationSource()) {
-                            descriptions.push(apiKeys[i].Description());
+                            descriptions.push({
+                                description: apiKeys[i].Description(),
+                                revocationSource: apiKeys[i].RevocationSource()
+                            });
                         }
                     }
                 }

--- a/src/NuGetGallery/Scripts/gallery/page-api-keys.js
+++ b/src/NuGetGallery/Scripts/gallery/page-api-keys.js
@@ -691,10 +691,7 @@
                 for (var i in apiKeys) {
                     if (apiKeys[i].HasExpired()) {
                         if (apiKeys[i].RevocationSource()) {
-                            descriptions.push({
-                                description: apiKeys[i].Description(),
-                                revocationSource: apiKeys[i].RevocationSource()
-                            });
+                            descriptions.push(apiKeys[i].Description());
                         }
                     }
                 }

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -957,6 +957,24 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your API Key &apos;{0}&apos; revoked. If you did not request this change, please reply to this email to contact support..
+        /// </summary>
+        public static string Emails_ApiKeyRevoked_Body {
+            get {
+                return ResourceManager.GetString("Emails_ApiKeyRevoked_Body", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [{0}] API Key &apos;{1}&apos; Revoked.
+        /// </summary>
+        public static string Emails_ApiKeyRevoked_Subject {
+            get {
+                return ResourceManager.GetString("Emails_ApiKeyRevoked_Subject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A {0} was added to your account and can now be used to sign in. If you did not request this change, please reply to this email to contact support..
         /// </summary>
         public static string Emails_CredentialAdded_Body {

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -957,7 +957,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your API Key &apos;{0}&apos; revoked. If you did not request this change, please reply to this email to contact support..
+        ///   Looks up a localized string similar to Your API Key &apos;{0}&apos; has been revoked. If you did not request this change, please reply to this email to contact support..
         /// </summary>
         public static string Emails_ApiKeyRevoked_Body {
             get {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1254,4 +1254,10 @@ The {1} Team</value>
   <data name="ForgotPassword_Disabled_Error" xml:space="preserve">
     <value>Forgot password is disabled.</value>
   </data>
+  <data name="Emails_ApiKeyRevoked_Body" xml:space="preserve">
+    <value>Your API Key '{0}' revoked. If you did not request this change, please reply to this email to contact support.</value>
+  </data>
+  <data name="Emails_ApiKeyRevoked_Subject" xml:space="preserve">
+    <value>[{0}] API Key '{1}' Revoked</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1255,7 +1255,7 @@ The {1} Team</value>
     <value>Forgot password is disabled.</value>
   </data>
   <data name="Emails_ApiKeyRevoked_Body" xml:space="preserve">
-    <value>Your API Key '{0}' revoked. If you did not request this change, please reply to this email to contact support.</value>
+    <value>Your API Key '{0}' has been revoked. If you did not request this change, please reply to this email to contact support.</value>
   </data>
   <data name="Emails_ApiKeyRevoked_Subject" xml:space="preserve">
     <value>[{0}] API Key '{1}' Revoked</value>

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -1460,9 +1460,9 @@ namespace NuGetGallery
             return GetActionLink(url, "RemoveCredential", "Users", relativeUrl);
         }
 
-        public static string RevokeCredential(this UrlHelper url, bool relativeUrl = true)
+        public static string RevokeApiKeyCredential(this UrlHelper url, bool relativeUrl = true)
         {
-            return GetActionLink(url, "RevokeCredential", "Users", relativeUrl);
+            return GetActionLink(url, "RevokeApiKeyCredential", "Users", relativeUrl);
         }
 
         public static string RegenerateCredential(this UrlHelper url, bool relativeUrl = true)

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -1460,6 +1460,11 @@ namespace NuGetGallery
             return GetActionLink(url, "RemoveCredential", "Users", relativeUrl);
         }
 
+        public static string RevokeCredential(this UrlHelper url, bool relativeUrl = true)
+        {
+            return GetActionLink(url, "RevokeCredential", "Users", relativeUrl);
+        }
+
         public static string RegenerateCredential(this UrlHelper url, bool relativeUrl = true)
         {
             return GetActionLink(url, "RegenerateCredential", "Users", relativeUrl);

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -258,7 +258,7 @@
                     <!-- ko ifnot: HasExpired -->
                     <li>
                         <a class="icon-link" href="#" role="button" data-bind="click: Revoke">
-                            <i class="ms-Icon ms-Icon--Clear" aria-hidden="true"></i>
+                            <i class="ms-Icon ms-Icon--Blocked2" aria-hidden="true"></i>
                             <span>Revoke</span>
                         </a>
                     </li>

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -78,7 +78,7 @@
         <!-- ko ifnot: RevocationDescriptions().length === 1 -->
         keys
         <!-- /ko -->
-        <!-- ko text: window.nuget.commaJoin(RevocationDescriptions().map(function(d) { return "'" + d.description + "'"; } )) --><!-- /ko -->
+        <!-- ko text: window.nuget.commaJoin(RevocationDescriptions().map(function(d) { return "'" + d + "'"; } )) --><!-- /ko -->
         <!-- ko if: RevocationDescriptions().length === 1 -->
         has
         <!-- /ko -->
@@ -86,16 +86,14 @@
         have
         <!-- /ko -->
         been revoked.<br />
-        <!-- ko ifnot: RevocationDescriptions().every(function(revocationDescription) { return revocationDescription.revocationSource === "@CredentialRevocationSource.User.ToString()"; }) -->
-            Please check the email from @Config.Current.GalleryOwner.Address for details, and regenerate or create
-            <!-- ko if: RevocationDescriptions().length === 1 -->
-            a new API key
-            <!-- /ko -->
-            <!-- ko ifnot: RevocationDescriptions().length === 1 -->
-            new API keys
-            <!-- /ko -->
-            to use.
+        Please check the email from @Config.Current.GalleryOwner.Address for details, and regenerate or create
+        <!-- ko if: RevocationDescriptions().length === 1 -->
+        a new API key
         <!-- /ko -->
+        <!-- ko ifnot: RevocationDescriptions().length === 1 -->
+        new API keys
+        <!-- /ko -->
+        to use.
         </text>,
         isAlertRole: true)
     <!-- /ko -->
@@ -528,7 +526,7 @@
                          PackagePushVersionScope = NuGetScopes.PackagePushVersion,
                          PackageUnlistScope = NuGetScopes.PackageUnlist,
                          RemoveUrl = Url.RemoveCredential(),
-                         RevokeUrl = Url.RevokeCredential(),
+                         RevokeUrl = Url.RevokeApiKeyCredential(),
                          RegenerateUrl = Url.RegenerateCredential(),
                          EditUrl = Url.EditCredential(),
                          GenerateUrl = Url.GenerateApiKey(),

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -78,7 +78,7 @@
         <!-- ko ifnot: RevocationDescriptions().length === 1 -->
         keys
         <!-- /ko -->
-        <!-- ko text: window.nuget.commaJoin(RevocationDescriptions().map(function(d) { return "'" + d + "'"; } )) --><!-- /ko -->
+        <!-- ko text: window.nuget.commaJoin(RevocationDescriptions().map(function(d) { return "'" + d.description + "'"; } )) --><!-- /ko -->
         <!-- ko if: RevocationDescriptions().length === 1 -->
         has
         <!-- /ko -->
@@ -86,14 +86,16 @@
         have
         <!-- /ko -->
         been revoked.<br />
-        Please check the email from @Config.Current.GalleryOwner.Address for details, and regenerate or create
-        <!-- ko if: RevocationDescriptions().length === 1 -->
-        a new API key
+        <!-- ko ifnot: RevocationDescriptions().every(function(revocationDescription) { return revocationDescription.revocationSource === "@CredentialRevocationSource.User.ToString()"; }) -->
+            Please check the email from @Config.Current.GalleryOwner.Address for details, and regenerate or create
+            <!-- ko if: RevocationDescriptions().length === 1 -->
+            a new API key
+            <!-- /ko -->
+            <!-- ko ifnot: RevocationDescriptions().length === 1 -->
+            new API keys
+            <!-- /ko -->
+            to use.
         <!-- /ko -->
-        <!-- ko ifnot: RevocationDescriptions().length === 1 -->
-        new API keys
-        <!-- /ko -->
-        to use.
         </text>,
         isAlertRole: true)
     <!-- /ko -->
@@ -253,6 +255,14 @@
                             <span>Delete</span>
                         </a>
                     </li>
+                    <!-- ko ifnot: HasExpired -->
+                    <li>
+                        <a class="icon-link" href="#" role="button" data-bind="click: Revoke">
+                            <i class="ms-Icon ms-Icon--Clear" aria-hidden="true"></i>
+                            <span>Revoke</span>
+                        </a>
+                    </li>
+                    <!-- /ko -->
                 </ul>
             </div>
         </div>
@@ -518,6 +528,7 @@
                          PackagePushVersionScope = NuGetScopes.PackagePushVersion,
                          PackageUnlistScope = NuGetScopes.PackageUnlist,
                          RemoveUrl = Url.RemoveCredential(),
+                         RevokeUrl = Url.RevokeCredential(),
                          RegenerateUrl = Url.RegenerateCredential(),
                          EditUrl = Url.EditCredential(),
                          GenerateUrl = Url.GenerateApiKey(),

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -2221,7 +2221,7 @@ namespace NuGetGallery
             }
         }
 
-        public class TheRevokeCredentialAction : TestContainer
+        public class TheRevokeApiKeyCredentialAction : TestContainer
         {
             [Fact]
             public async Task GivenNoCredential_ErrorIsReturnedWithNoChangesMade()
@@ -2237,14 +2237,14 @@ namespace NuGetGallery
                 controller.SetCurrentUser(user);
 
                 // Act
-                var result = await controller.RevokeCredential(
+                var result = await controller.RevokeApiKeyCredential(
                     credentialType: cred.Type,
                     credentialKey: CredentialKey);
 
                 // Assert
                 Assert.Equal((int)HttpStatusCode.NotFound, controller.Response.StatusCode);
                 Assert.Equal(Strings.CredentialNotFound, (string)result.Data);
-                Assert.Equal(1, user.Credentials.Count);
+                Assert.Single(user.Credentials);
                 Assert.Equal(cred.Expires, user.Credentials.First().Expires);
             }
 
@@ -2270,7 +2270,7 @@ namespace NuGetGallery
                 controller.SetCurrentUser(user);
 
                 // Act
-                var result = await controller.RevokeCredential(cred.Type, cred.Key);
+                var result = await controller.RevokeApiKeyCredential(cred.Type, cred.Key);
 
                 // Assert
                 Assert.IsType<JsonResult>(result);
@@ -2281,7 +2281,7 @@ namespace NuGetGallery
                 authenticationService.Verify(x => x.DescribeCredential(It.IsAny<Credential>()), Times.Once);
             }
 
-            private CredentialViewModel GetRevokedApiKeyCredentialViewModel(string apiKeyType)
+            private static CredentialViewModel GetRevokedApiKeyCredentialViewModel(string apiKeyType)
             {
                 return new CredentialViewModel
                 {

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -2221,6 +2221,78 @@ namespace NuGetGallery
             }
         }
 
+        public class TheRevokeCredentialAction : TestContainer
+        {
+            [Fact]
+            public async Task GivenNoCredential_ErrorIsReturnedWithNoChangesMade()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+
+                var user = fakes.CreateUser("test",
+                    new CredentialBuilder().CreateApiKey(TimeSpan.FromHours(1), out string plaintextApiKey));
+                var cred = user.Credentials.First();
+
+                var controller = GetController<UsersController>();
+                controller.SetCurrentUser(user);
+
+                // Act
+                var result = await controller.RevokeCredential(
+                    credentialType: cred.Type,
+                    credentialKey: CredentialKey);
+
+                // Assert
+                Assert.Equal((int)HttpStatusCode.NotFound, controller.Response.StatusCode);
+                Assert.Equal(Strings.CredentialNotFound, (string)result.Data);
+                Assert.Equal(1, user.Credentials.Count);
+                Assert.Equal(cred.Expires, user.Credentials.First().Expires);
+            }
+
+            [Fact]
+            public async Task GivenValidRequest_ItRevokesCredential()
+            {
+                // Arrange
+                var fakes = Get<Fakes>();
+
+                var user = fakes.CreateUser("test",
+                    new CredentialBuilder().CreateApiKey(TimeSpan.FromHours(1), out string plaintextApiKey));
+                var cred = user.Credentials.First();
+
+                var authenticationService = GetMock<AuthenticationService>();
+
+                authenticationService.Setup(x => x.RevokeApiKeyCredential(It.IsAny<Credential>(), It.IsAny<CredentialRevocationSource>(), It.IsAny<bool>()))
+                    .Returns(Task.FromResult(0));
+
+                authenticationService.Setup(x => x.DescribeCredential(It.IsAny<Credential>()))
+                    .Returns(GetRevokedApiKeyCredentialViewModel(cred.Type));
+
+                var controller = GetController<UsersController>();
+                controller.SetCurrentUser(user);
+
+                // Act
+                var result = await controller.RevokeCredential(cred.Type, cred.Key);
+
+                // Assert
+                Assert.IsType<JsonResult>(result);
+                var credentialViewModel = Assert.IsType<ApiKeyViewModel>(result.Data);
+                Assert.True(credentialViewModel.HasExpired);
+
+                authenticationService.Verify(x => x.RevokeApiKeyCredential(It.IsAny<Credential>(), It.IsAny<CredentialRevocationSource>(), It.IsAny<bool>()), Times.Once);
+                authenticationService.Verify(x => x.DescribeCredential(It.IsAny<Credential>()), Times.Once);
+            }
+
+            private CredentialViewModel GetRevokedApiKeyCredentialViewModel(string apiKeyType)
+            {
+                return new CredentialViewModel
+                {
+                    Type = apiKeyType,
+                    RevocationSource = CredentialRevocationSource.User.ToString(),
+                    HasExpired = true,
+                    Scopes = new List<ScopeViewModel>(),
+                };
+            }
+        }
+
         public class TheEditCredentialAction : TestContainer
         {
             public static IEnumerable<object[]> GivenANonApiKeyV2Credential_ReturnsUnsupported_Input

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ApiKeyRevokedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ApiKeyRevokedMessageFacts.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Services.Entities;
+using NuGet.Services.Messaging.Email;
+using NuGetGallery.Authentication;
+using Xunit;
+
+namespace NuGetGallery.Infrastructure.Mail.Messages
+{
+    public class ApiKeyRevokedMessageFacts : MarkdownMessageBuilderFacts
+    {
+        public class TheConstructor
+        {
+            public static IEnumerable<object[]> ConstructorArguments
+            {
+                get
+                {
+                    yield return new object[] { null, Fakes.RequestingUser, Fakes.ApiKeyCredentialTypeInfo };
+                    yield return new object[] { Configuration, null, Fakes.ApiKeyCredentialTypeInfo };
+                    yield return new object[] { Configuration, Fakes.RequestingUser, null };
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(ConstructorArguments))]
+            public void GivenANullArgument_ItShouldThrow(
+                IMessageServiceConfiguration configuration,
+                User user,
+                CredentialTypeInfo credentialTypeInfo)
+            {
+                Assert.Throws<ArgumentNullException>(() => new ApiKeyRevokedMessage(
+                    configuration,
+                    user,
+                    credentialTypeInfo));
+            }
+        }
+
+        public class TheGetRecipientsMethod
+        {
+            [Fact]
+            public void AddsUserEmailAddressToToList()
+            {
+                var message = CreateMessage(Fakes.ApiKeyCredentialTypeInfo);
+                var recipients = message.GetRecipients();
+
+                Assert.Equal(1, recipients.To.Count);
+                Assert.Contains(Fakes.RequestingUser.ToMailAddress(), recipients.To);
+            }
+
+            [Fact]
+            public void HasEmptyReplyToList()
+            {
+                var message = CreateMessage(Fakes.ApiKeyCredentialTypeInfo);
+                var recipients = message.GetRecipients();
+
+                Assert.Empty(recipients.ReplyTo);
+            }
+
+            [Fact]
+            public void HasEmptyCCList()
+            {
+                var message = CreateMessage(Fakes.ApiKeyCredentialTypeInfo);
+                var recipients = message.GetRecipients();
+
+                Assert.Empty(recipients.CC);
+            }
+
+            [Fact]
+            public void HasEmptyBccList()
+            {
+                var message = CreateMessage(Fakes.ApiKeyCredentialTypeInfo);
+                var recipients = message.GetRecipients();
+
+                Assert.Empty(recipients.Bcc);
+            }
+        }
+
+        public class TheGetBodyMethod
+        {
+            [Theory]
+            [InlineData(EmailFormat.Markdown, _expectedMessageBody)]
+            [InlineData(EmailFormat.PlainText, _expectedMessageBody)]
+            [InlineData(EmailFormat.Html, "<p>" + _expectedMessageBody + "</p>\n")]
+            public void ReturnsExpectedBody(EmailFormat format, string expectedString)
+            {
+                var message = CreateMessage(Fakes.ApiKeyCredentialTypeInfo);
+
+                var body = message.GetBody(format);
+                Assert.Equal(expectedString, body);
+            }
+        }
+
+        public class TheGetSubjectMethod
+        {
+            [Fact]
+            public void ReturnsExpectedSubject()
+            {
+                var message = CreateMessage(Fakes.ApiKeyCredentialTypeInfo);
+
+                var body = message.GetSubject();
+                Assert.Equal(_expectedMessageSubject, body);
+            }
+        }
+
+        [Fact]
+        public void SetsGalleryOwnerAsSender()
+        {
+            var message = CreateMessage(Fakes.ApiKeyCredentialTypeInfo);
+
+            Assert.Equal(Configuration.GalleryOwner, message.Sender);
+        }
+
+        private static ApiKeyRevokedMessage CreateMessage(CredentialTypeInfo credentialTypeInfo)
+        {
+            return new ApiKeyRevokedMessage(
+                Configuration,
+                Fakes.RequestingUser,
+                credentialTypeInfo);
+        }
+
+        private const string _expectedMessageBody =
+            @"Your API Key 'Api Key description' revoked. If you did not request this change, please reply to this email to contact support.";
+
+        private const string _expectedMessageSubject =
+            @"[NuGetGallery] API Key 'Api Key description' Revoked";
+    }
+}

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ApiKeyRevokedMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ApiKeyRevokedMessageFacts.cs
@@ -122,7 +122,7 @@ namespace NuGetGallery.Infrastructure.Mail.Messages
         }
 
         private const string _expectedMessageBody =
-            @"Your API Key 'Api Key description' revoked. If you did not request this change, please reply to this email to contact support.";
+            @"Your API Key 'Api Key description' has been revoked. If you did not request this change, please reply to this email to contact support.";
 
         private const string _expectedMessageSubject =
             @"[NuGetGallery] API Key 'Api Key description' Revoked";

--- a/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
+++ b/tests/NuGetGallery.Facts/NuGetGallery.Facts.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Authentication\TestCredentialHelper.cs" />
     <Compile Include="Extensions\CakeBuildManagerExtensionsFacts.cs" />
     <Compile Include="Helpers\PackageValidationHelperFacts.cs" />
+    <Compile Include="Infrastructure\Mail\Messages\ApiKeyRevokedMessageFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageIdsQueryFacts.cs" />
     <Compile Include="Queries\AutocompleteDatabasePackageVersionsQueryFacts.cs" />
     <Compile Include="Queries\AutocompleteServiceQueryFacts.cs" />


### PR DESCRIPTION
* Revoke button added for api keys.
* Existing revocation mechanism used.

Addresses https://github.com/NuGet/NuGetGallery/issues/9426

edit by @joelverhagen -- added screenshot
![image](https://github.com/NuGet/NuGetGallery/assets/94054/7f310b08-f091-4dba-908e-9d614a4bea86)
![image](https://github.com/NuGet/NuGetGallery/assets/102933/12e07f2f-60fa-480c-81af-0257d5537b59)
