### PR TITLE
Fix user credential result on admin panel

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Controllers/PasswordAuthenticationController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PasswordAuthenticationController.cs
@@ -62,12 +62,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
                         IsAADorMACredential = false
                     };
 
-                    Credential microftAccountOrAADCredentail = null;
-
-                    if (user.Credentials.GetMicrosoftAccountCredential() == null)
-                    {
-                        microftAccountOrAADCredentail = user.Credentials.GetAzureActiveDirectoryCredential();
-                    }
+                    Credential microftAccountOrAADCredentail = user.Credentials.GetMicrosoftAccountCredential() ?? user.Credentials.GetAzureActiveDirectoryCredential();
 
                     if (microftAccountOrAADCredentail != null)
                     {

--- a/src/NuGetGallery/Areas/Admin/Controllers/PasswordAuthenticationController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PasswordAuthenticationController.cs
@@ -59,15 +59,22 @@ namespace NuGetGallery.Areas.Admin.Controllers
                     {
                         Username = user.Username,
                         EmailAddress = user.EmailAddress,
+                        IsAADorMACredential = false
                     };
-                         
-                    result.Credential = new UserCredential()
-                    {
-                        TenantId = user.Credentials.GetAzureActiveDirectoryCredential()?.TenantId,
-                        Value = user.Credentials.GetAzureActiveDirectoryCredential()?.Value,
-                        Type = user.Credentials.GetMicrosoftAccountCredential()?.Type
 
-                    };
+                    Credential microftAccountOrAADCredentail = null;
+
+                    if (user.Credentials.GetMicrosoftAccountCredential() == null)
+                    {
+                        microftAccountOrAADCredentail = user.Credentials.GetAzureActiveDirectoryCredential();
+                    }
+
+                    if (microftAccountOrAADCredentail != null)
+                    {
+                        result.IsAADorMACredential = true;
+                        result.Credential = GetMAorAADCredential(microftAccountOrAADCredentail);
+                    }
+
                     results.Add(result);
                 }
             }
@@ -125,6 +132,18 @@ namespace NuGetGallery.Areas.Admin.Controllers
         private async Task TrySaveEmailAddress(string emailAddress, ContentOperations operation)
         {
            await _storage.AddUserEmailAddressforPasswordAuthenticationAsync(emailAddress, operation);
+        }
+
+        private UserCredential GetMAorAADCredential(Credential microftAccountOrAADCredentail)
+        {
+            var userCredential = new UserCredential()
+            {
+                TenantId = microftAccountOrAADCredentail.TenantId,
+                Value = microftAccountOrAADCredentail.Value,
+                Type = microftAccountOrAADCredentail.Type
+            };
+
+            return userCredential;
         }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/Views/PasswordAuthentication/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/PasswordAuthentication/Index.cshtml
@@ -48,18 +48,20 @@
             <tr>
                 <th>AccountName</th>
                 <th>Email Address</th>
-                <th>Credential</th>
-                <th>TentendID</th>
                 <th>IsAADorMACredential</th>
+                <th>Credential Type</th>
+                <th>TentendID</th>
             </tr>
         </thead>
         <tbody data-bind="foreach: searchResults">
             <tr>
                 <td><a href="#" data-bind="text: Username, attr: { href: $parent.generateProfileUrl($data) }"></a></td>
                 <td><span data-bind="text: EmailAddress"></span></td>
-                <td><span data-bind="text: Credential.Value"></span></td>
-                <td><span data-bind="text: Credential.TenantId"></span></td>
                 <td><span data-bind="text: IsAADorMACredential"></span></td>
+                <!-- ko if: Credential -->
+                <td><span data-bind="text: Credential.Type"></span></td>
+                <td><span data-bind="text: Credential.TenantId"></span></td>
+                <!-- /ko -->
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

problem: `IsAADorMACredential` is not assigned. 

Fix: check if credential is AAD or MA, then assign `IsAADorMACredential = true`, otherwise false

Test: Tested in dev environment

Addresses: https://github.com/NuGet/Engineering/issues/4904