### PR TITLE
Update dependabot config to target dev branch and remove unnecessary …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ registries:
   nuget-azure-devops:
     type: nuget-feed
     url: https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json
-    token: ${{secrets.ADO_FEEDPAT}}
 
 updates:
   - package-ecosystem: nuget
@@ -21,6 +20,7 @@ updates:
     open-pull-requests-limit: 10
     assignees:
       - nuget/gallery-team
+    target-branch: "dev"
 
   - package-ecosystem: gitsubmodule
     directory: "/"


### PR DESCRIPTION
Update dependabot config so that Dependabot targets the dev branch and remove unnecessary token (the feed doesn't require auth)

https://github.com/NuGet/Engineering/issues/4938