### PR TITLE
Fixing package upgrade conflicts in NuGet.Services.Entities.csproj

### DIFF
--- a/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
+++ b/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.4.2" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.6.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <!-- This was lifted to a top-level dependency to resolve a Component Governance alert. -->
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />


### PR DESCRIPTION
Dependabot made changes to this project file to upgrade a package version in **main** first, and then made changes to the same file in **dev** for a different package, so the file had conflicts that needed to be resolved. This should fix it.