### PR TITLE
Fixing package upgrade conflicts in NuGet.Services.Entities.csproj

### DIFF
--- a/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
+++ b/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NuGet.Frameworks" Version="6.6.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <!-- This was lifted to a top-level dependency to resolve a Component Governance alert. -->


### PR DESCRIPTION
Dependabot made changes to this project file to upgrade a package version in **main** first, and then made changes to the same file in **dev** for a different package, so the file had conflicts that needed to be resolved. This was blocking the FI of main -> dev PR.

I made changes to the NuGet.Services.Entities.csproj file and pushed to dev, but those changes weren't enough to resolve the conflict. I need to push some changes to the file in main, and then the files in dev and main will be the same.