### PR TITLE
Fix dispose violation error in tests

### DIFF
--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/DeleteControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/DeleteControllerFacts.cs
@@ -128,6 +128,16 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
                 TestUtility.SetupHttpContextMockForUrlGeneration(_httpContextBase, _target);
             }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _target?.Dispose();
+                    base.Dispose(disposing);
+                }
+            }
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/OrganizationsControllerFacts.cs
@@ -1978,6 +1978,16 @@ namespace NuGetGallery
 
                 _certificateService.VerifyAll();
             }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _controller?.Dispose();
+                    base.Dispose(disposing);
+                }
+            }
         }
 
         public class TheGetCertificatesAction : AccountsControllerTestContainer
@@ -2142,6 +2152,16 @@ namespace NuGetGallery
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
 
                 _certificateService.VerifyAll();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _controller?.Dispose();
+                    base.Dispose(disposing);
+                }
             }
         }
 
@@ -2335,6 +2355,16 @@ namespace NuGetGallery
 
                 return new StubHttpPostedFile((int)stream.Length, "certificate.cer", stream);
             }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _controller?.Dispose();
+                    base.Dispose(disposing);
+                }
+            }
         }
 
         public class TheDeleteCertificateAction : AccountsControllerTestContainer
@@ -2462,6 +2492,16 @@ namespace NuGetGallery
 
                 Assert.NotNull(response);
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _controller?.Dispose();
+                    base.Dispose(disposing);
+                }
             }
         }
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -6492,6 +6492,16 @@ namespace NuGetGallery
                     x => x.SendMessageAsync(It.IsAny<ReportMyPackageMessage>(), false, false),
                     Times.Once);
             }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _controller?.Dispose();
+                    base.Dispose(disposing);
+                }
+            }
         }
 
         public class TheUploadFileActionForGetRequests
@@ -9726,6 +9736,16 @@ namespace NuGetGallery
                 // Assert
                 Assert.IsType<HttpNotFoundResult>(result);
             }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _target?.Dispose();
+                    base.Dispose(disposing);
+                }
+            }
         }
 
         public class TheRevalidateSymbolsMethod : TestContainer
@@ -9869,6 +9889,16 @@ namespace NuGetGallery
                 // Assert
                 Assert.IsType<HttpStatusCodeResult>(result);
                 ResultAssert.IsStatusCode(result, HttpStatusCode.BadRequest);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _target?.Dispose();
+                    base.Dispose(disposing);
+                }
             }
         }
 

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -3633,6 +3633,16 @@ namespace NuGetGallery
 
                 _certificateService.VerifyAll();
             }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _controller?.Dispose();
+                    base.Dispose(disposing);
+                }
+            }
         }
 
         public class TheGetCertificatesAction : TestContainer
@@ -3707,6 +3717,16 @@ namespace NuGetGallery
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
 
                 _certificateService.VerifyAll();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _controller?.Dispose();
+                    base.Dispose(disposing);
+                }
             }
         }
 
@@ -3839,6 +3859,16 @@ namespace NuGetGallery
 
                 return new StubHttpPostedFile((int)stream.Length, "certificate.cer", stream);
             }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _controller?.Dispose();
+                    base.Dispose(disposing);
+                }
+            }
         }
 
         public class TheDeleteCertificateAction : TestContainer
@@ -3911,6 +3941,16 @@ namespace NuGetGallery
 
                 Assert.NotNull(response);
                 Assert.Equal((int)HttpStatusCode.OK, _controller.Response.StatusCode);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _controller?.Dispose();
+                    base.Dispose(disposing);
+                }
             }
         }
 
@@ -4122,6 +4162,16 @@ namespace NuGetGallery
 
                 Assert.False(model.ListedPackages.ToArray()[0].IsVulnerable);  // alpha
                 Assert.True(model.ListedPackages.ToArray()[1].IsVulnerable);   // zebra
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources
+                    _testController?.Dispose();
+                    base.Dispose(disposing);
+                }
             }
         }
 


### PR DESCRIPTION
With latest .net sdk with command line build causing ton of warnings about Disposable is not implemented.

![image](https://github.com/NuGet/NuGetGallery/assets/8766776/c13acd10-afe3-4de0-898a-6e8989191239)
