### PR TITLE
Make search collapsible

### DIFF
--- a/src/Bootstrap/less/theme/page-list-packages.less
+++ b/src/Bootstrap/less/theme/page-list-packages.less
@@ -153,7 +153,7 @@
     }
   }
 
-  .toggle-button {
+  .toggle-advanced-search-panel {
     display: none;
     margin-top: 30px;
     color: rgb(73, 73, 73);
@@ -161,7 +161,7 @@
     position: relative;
     border: none;
 
-    .coolButton {
+    .advanced-search-toggle-button {
       padding-top: 0px;
       padding-bottom: 0px;
       border: none;
@@ -169,13 +169,13 @@
       float: right;
     }
 
-    .coolButton:hover {
+    .advanced-search-toggle-button:hover {
       color: rgb(90, 135, 220);
     }
   }
 
   @media (max-width: 992px) {
-    .toggle-button{
+    .toggle-advanced-search-panel{
       display: block;
     }
     .advanced-search-panel{

--- a/src/Bootstrap/less/theme/page-list-packages.less
+++ b/src/Bootstrap/less/theme/page-list-packages.less
@@ -160,10 +160,13 @@
     background-color: @alert-info-bg;
     position: relative;
     border: none;
+    padding-left: 19px;
 
     .advanced-search-toggle-button {
       padding-top: 0px;
       padding-bottom: 0px;
+      margin-right: 20px;
+      background-color: transparent;
       border: none;
       outline: none;
       float: right;

--- a/src/Bootstrap/less/theme/page-list-packages.less
+++ b/src/Bootstrap/less/theme/page-list-packages.less
@@ -137,4 +137,30 @@
       text-align: right;
     }
   }
+
+  @media (min-width: @screen-sm) {
+    .advanced-search-panel{
+      position: relative;
+      top: 0;
+    }
+  }
+/*
+  @media (max-width: 992px){
+    .advanced-search-panel{
+      display: none;
+    }
+  }*/
+
+  .toggle-button {
+    display: block; // Initially hidden
+    cursor: pointer;
+    /* Your styles for the toggle button, e.g., background color, padding, etc. */
+    background-color: rgb(90, 135, 220);
+  
+    // Show the toggle button only on small screens
+    @media (max-width: 992px) {
+      display: block;
+    }
+  }
+  
 }

--- a/src/Bootstrap/less/theme/page-list-packages.less
+++ b/src/Bootstrap/less/theme/page-list-packages.less
@@ -142,6 +142,7 @@
     .advanced-search-panel{
       position: relative;
       top: 0;
+      margin-top: 0px;
     }
   }
 /*
@@ -152,14 +153,19 @@
   }*/
 
   .toggle-button {
-    display: block; // Initially hidden
+    display: none; // Initially hidden
     cursor: pointer;
+    margin-top: 30px;
     /* Your styles for the toggle button, e.g., background color, padding, etc. */
-    background-color: rgb(90, 135, 220);
-  
-    // Show the toggle button only on small screens
-    @media (max-width: 992px) {
+    background-color: rgb(90, 135, 220);    
+  }
+
+  @media (max-width: 992px) {
+    .toggle-button{
       display: block;
+    }
+    .advanced-search-panel{
+      display: none;
     }
   }
   

--- a/src/Bootstrap/less/theme/page-list-packages.less
+++ b/src/Bootstrap/less/theme/page-list-packages.less
@@ -143,6 +143,7 @@
       position: relative;
       top: 0;
       margin-top: 0px;
+      display: block;
     }
   }
 /*

--- a/src/Bootstrap/less/theme/page-list-packages.less
+++ b/src/Bootstrap/less/theme/page-list-packages.less
@@ -146,19 +146,32 @@
       display: block;
     }
   }
-/*
-  @media (max-width: 992px){
+
+  @media (max-width: @screen-sm){
     .advanced-search-panel{
-      display: none;
+      margin-top: 0px;
     }
-  }*/
+  }
 
   .toggle-button {
-    display: none; // Initially hidden
-    cursor: pointer;
+    display: none;
     margin-top: 30px;
-    /* Your styles for the toggle button, e.g., background color, padding, etc. */
-    background-color: rgb(90, 135, 220);    
+    color: rgb(73, 73, 73);
+    background-color: @alert-info-bg;
+    position: relative;
+    border: none;
+
+    .coolButton {
+      padding-top: 0px;
+      padding-bottom: 0px;
+      border: none;
+      outline: none;
+      float: right;
+    }
+
+    .coolButton:hover {
+      color: rgb(90, 135, 220);
+    }
   }
 
   @media (max-width: 992px) {

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -52,8 +52,6 @@ $(function() {
         collapsible.addEventListener('click', toggleCollapsible);
     }
 
-
-
     const advancedSearchToggleButton = document.getElementById('advancedSearchToggleButton');
     advancedSearchToggleButton.addEventListener('click', toggleAdvancedSearchPanel);
     var resized = false;
@@ -73,6 +71,9 @@ $(function() {
         }
         else if (window.innerWidth <= 992 && initialScreenSize > 992 && resized) {
             filtersContent.style.display = 'none';
+            chevronIcon.classList.add('ms-Icon--ChevronDown');
+            chevronIcon.classList.remove('ms-Icon--ChevronUp');
+
         }
         else if (window.innerWidth > 992) {
             filtersContent.style.display = 'block';

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -52,6 +52,65 @@ $(function() {
         collapsible.addEventListener('click', toggleCollapsible);
     }
 
+
+
+
+
+
+    // Define the breakpoint for small screens
+    const smallScreenBreakpoint = 992; // You can adjust this value as needed
+
+    // Function to create the toggle button
+    function createToggleButton() {
+        // Check if the screen width is small
+        if (window.innerWidth <= smallScreenBreakpoint && !document.getElementById('advancedSearchToggleButton')) {
+            // Create the toggle button element dynamically
+            const toggleButton = document.createElement('div');
+            toggleButton.className = 'toggle-button';
+            toggleButton.id = 'advancedSearchToggleButton'
+            toggleButton.textContent = 'Toggle Filters';
+            const theButton = document.createElement('button');
+            theButton.innerHTML = 'Click Me';
+            toggleButton.appendChild(theButton);
+
+            // Get the container element that wraps the filters content
+            const filtersContainer = document.getElementById('advancedSearchPanel');
+
+            //filtersContainer.appendChild(toggleButton);
+
+            // Insert the toggle button as the first child of the container
+            filtersContainer.insertBefore(toggleButton, filtersContainer.firstChild);
+
+            // Add the event listener to the toggle button
+            toggleButton.addEventListener('click', toggleFilters);
+        }
+    }
+
+    // Call the function on page load
+    window.addEventListener('load', createToggleButton);
+
+    
+    function toggleFilters() {
+        const filtersContent = document.getElementById('advancedSearchPanel');
+
+        // Check if the screen width is small
+        //if (window.innerWidth <= smallScreenBreakpoint) {
+        //    filtersContent.style.display = (filtersContent.style.display === 'none') ? 'block' : 'none';
+        //}
+    }
+
+    // Call the function on window resize to handle changes in screen size
+    window.addEventListener('resize', createToggleButton);
+
+
+
+
+
+
+
+
+
+
     function toggleCollapsible() {
         var dataTab = document.getElementById(this.getAttribute('tab') + 'tab');
         var expandButton = document.getElementById(this.getAttribute('tab') + 'button');
@@ -96,7 +155,7 @@ $(function() {
         tfms.name = "";
         allTfms.forEach(function (tfm) {
             if (tfm.checked) {
-                tfms.name = "tfms";
+                tfm.name = "tfms";
             }
         });
 

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -54,10 +54,13 @@ $(function() {
 
 
 
-    const advancedSearchToggleButton = document.getElementById('advancedSearchToggleButton');
+    const advancedSearchToggleButton = document.getElementById('chevronButtonAdvancedSearch');
     advancedSearchToggleButton.addEventListener('click', toggleAdvancedSearchPanel);
     var resized = false;
     var initialScreenSize = window.innerWidth;
+    var chevronish = document.getElementById('pleaseWork');
+    const chevronIcon = document.getElementById('pleaseWork');
+
 
     /* For narrow screens only */
     function toggleAdvancedSearchPanel() {
@@ -67,6 +70,8 @@ $(function() {
 
         if (window.innerWidth <= 992 && !resized) {
             filtersContent.style.display = (computedStyle.display === 'none') ? 'block' : 'none';
+            chevronIcon.classList.toggle('ms-Icon--ChevronDown');
+            chevronIcon.classList.toggle('ms-Icon--ChevronUp');
         }
         else if (window.innerWidth <= 992 && initialScreenSize > 992 && resized) {
             filtersContent.style.display = 'none';
@@ -81,7 +86,7 @@ $(function() {
 
     window.addEventListener('resize', () => {
         resized = true;
-        toggleAdvancedSearchPanel();
+        toggleAdvancedSearchPanel(); 
     });
 
 

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -131,7 +131,7 @@ $(function() {
         tfms.name = "";
         allTfms.forEach(function (tfm) {
             if (tfm.checked) {
-                tfm.name = "tfms";
+                tfms.name = "tfms";
             }
         });
 

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -63,7 +63,7 @@ $(function() {
     // Function to create the toggle button
     function createToggleButton() {
         // Check if the screen width is small
-        if (window.innerWidth <= smallScreenBreakpoint && !document.getElementById('advancedSearchToggleButton')) {
+        //if (window.innerWidth <= smallScreenBreakpoint && !document.getElementById('advancedSearchToggleButton')) {
             // Create the toggle button element dynamically
             const toggleButton = document.createElement('div');
             toggleButton.className = 'toggle-button';
@@ -83,12 +83,23 @@ $(function() {
 
             // Add the event listener to the toggle button
             toggleButton.addEventListener('click', toggleFilters);
+        //}
+        if (window.innerWidth > smallScreenBreakpoint) {
+            toggleButton.style.display = 'none';
         }
     }
 
     // Call the function on page load
     window.addEventListener('load', createToggleButton);
 
+    function toggleCollapsibleFiltersButton() {
+        if (window.innerWidth > smallScreenBreakpoint) {
+            toggleButton.style.display = 'none';
+        }
+        else {
+            toggleButton.style.display = 'block';
+        }
+    }
     
     function toggleFilters() {
         const filtersContent = document.getElementById('advancedSearchPanel');
@@ -100,7 +111,7 @@ $(function() {
     }
 
     // Call the function on window resize to handle changes in screen size
-    window.addEventListener('resize', createToggleButton);
+    window.addEventListener('resize', toggleCollapsibleFiltersButton);
 
 
 

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -53,69 +53,39 @@ $(function() {
     }
 
 
+    const advancedSearchToggleButton = document.getElementById('advancedSearchToggleButton');
+    advancedSearchToggleButton.addEventListener('click', toggleAdvancedSearchPanel);
 
 
-
-
-    // Define the breakpoint for small screens
-    const smallScreenBreakpoint = 992; // You can adjust this value as needed
-
-    // Function to create the toggle button
-    function createToggleButton() {
-        // Check if the screen width is small
-        //if (window.innerWidth <= smallScreenBreakpoint && !document.getElementById('advancedSearchToggleButton')) {
-            // Create the toggle button element dynamically
-            const toggleButton = document.createElement('div');
-            toggleButton.className = 'toggle-button';
-            toggleButton.id = 'advancedSearchToggleButton'
-            toggleButton.textContent = 'Toggle Filters';
-            const theButton = document.createElement('button');
-            theButton.innerHTML = 'Click Me';
-            toggleButton.appendChild(theButton);
-
-            // Get the container element that wraps the filters content
-            const filtersContainer = document.getElementById('advancedSearchPanel');
-
-            //filtersContainer.appendChild(toggleButton);
-
-            // Insert the toggle button as the first child of the container
-            filtersContainer.insertBefore(toggleButton, filtersContainer.firstChild);
-
-            // Add the event listener to the toggle button
-            toggleButton.addEventListener('click', toggleFilters);
-        //}
-        if (window.innerWidth > smallScreenBreakpoint) {
-            toggleButton.style.display = 'none';
-        }
-    }
-
-    // Call the function on page load
-    window.addEventListener('load', createToggleButton);
-
-    function toggleCollapsibleFiltersButton() {
-        if (window.innerWidth > smallScreenBreakpoint) {
-            toggleButton.style.display = 'none';
-        }
-        else {
-            toggleButton.style.display = 'block';
-        }
-    }
     
-    function toggleFilters() {
+   /* function toggleFilters() {
         const filtersContent = document.getElementById('advancedSearchPanel');
 
         // Check if the screen width is small
         //if (window.innerWidth <= smallScreenBreakpoint) {
         //    filtersContent.style.display = (filtersContent.style.display === 'none') ? 'block' : 'none';
         //}
+    }*/
+
+
+    /* For narrow screens only */
+    function toggleAdvancedSearchPanel() {
+
+        const filtersContent = document.getElementById('advancedSearchPanel');
+        console.log(filtersContent.style.display);
+        if (window.innerWidth <= 992) {
+            if (filtersContent.style.display == 'none') {
+                filtersContent.style.display = 'block';
+            }
+            else if (filtersContent.style.display == 'block') {
+                filtersContent.style.display = 'block';
+            }
+            else {
+                console.log(filtersContent.style.display);
+            }
+            //filtersContent.style.display = (filtersContent.style.display === 'none') ? 'block' : 'none';
+        }
     }
-
-    // Call the function on window resize to handle changes in screen size
-    window.addEventListener('resize', toggleCollapsibleFiltersButton);
-
-
-
-
 
 
 

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -71,21 +71,27 @@ $(function() {
     /* For narrow screens only */
     function toggleAdvancedSearchPanel() {
 
-        const filtersContent = document.getElementById('advancedSearchPanel');
+        var filtersContent = document.getElementById('advancedSearchPanel');
+        var computedStyle = window.getComputedStyle(filtersContent);
         console.log(filtersContent.style.display);
         if (window.innerWidth <= 992) {
-            if (filtersContent.style.display == 'none') {
-                filtersContent.style.display = 'block';
-            }
-            else if (filtersContent.style.display == 'block') {
-                filtersContent.style.display = 'block';
-            }
-            else {
-                console.log(filtersContent.style.display);
-            }
-            //filtersContent.style.display = (filtersContent.style.display === 'none') ? 'block' : 'none';
+            filtersContent.style.display = (computedStyle.display === 'none') ? 'block' : 'none';
         }
     }
+
+    function enablePanelAfterResize() {
+        var filtersContent = document.getElementById('advancedSearchPanel');
+        if (window.innerWidth > 992) {
+            filtersContent.style.display = 'block';
+        } else {
+            filtersContent.style.display = 'none';
+        }
+    }
+
+    window.addEventListener('resize', () => {
+        toggleAdvancedSearchPanel();
+        enablePanelAfterResize(); // Call the toggleFilters function on window resize
+    });
 
 
 

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -54,18 +54,16 @@ $(function() {
 
 
 
-    const advancedSearchToggleButton = document.getElementById('chevronButtonAdvancedSearch');
+    const advancedSearchToggleButton = document.getElementById('advancedSearchToggleButton');
     advancedSearchToggleButton.addEventListener('click', toggleAdvancedSearchPanel);
     var resized = false;
     var initialScreenSize = window.innerWidth;
-    var chevronish = document.getElementById('pleaseWork');
-    const chevronIcon = document.getElementById('pleaseWork');
-
+    const chevronIcon = document.getElementById('advancedSearchToggleChevron');
 
     /* For narrow screens only */
     function toggleAdvancedSearchPanel() {
 
-        var filtersContent = document.getElementById('advancedSearchPanel');
+        const filtersContent = document.getElementById('advancedSearchPanel');
         var computedStyle = window.getComputedStyle(filtersContent);
 
         if (window.innerWidth <= 992 && !resized) {
@@ -88,11 +86,6 @@ $(function() {
         resized = true;
         toggleAdvancedSearchPanel(); 
     });
-
-
-
-
-
 
     function toggleCollapsible() {
         var dataTab = document.getElementById(this.getAttribute('tab') + 'tab');

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -53,44 +53,35 @@ $(function() {
     }
 
 
+
     const advancedSearchToggleButton = document.getElementById('advancedSearchToggleButton');
     advancedSearchToggleButton.addEventListener('click', toggleAdvancedSearchPanel);
-
-
-    
-   /* function toggleFilters() {
-        const filtersContent = document.getElementById('advancedSearchPanel');
-
-        // Check if the screen width is small
-        //if (window.innerWidth <= smallScreenBreakpoint) {
-        //    filtersContent.style.display = (filtersContent.style.display === 'none') ? 'block' : 'none';
-        //}
-    }*/
-
+    var resized = false;
+    var initialScreenSize = window.innerWidth;
 
     /* For narrow screens only */
     function toggleAdvancedSearchPanel() {
 
         var filtersContent = document.getElementById('advancedSearchPanel');
         var computedStyle = window.getComputedStyle(filtersContent);
-        console.log(filtersContent.style.display);
-        if (window.innerWidth <= 992) {
+
+        if (window.innerWidth <= 992 && !resized) {
             filtersContent.style.display = (computedStyle.display === 'none') ? 'block' : 'none';
         }
-    }
-
-    function enablePanelAfterResize() {
-        var filtersContent = document.getElementById('advancedSearchPanel');
-        if (window.innerWidth > 992) {
-            filtersContent.style.display = 'block';
-        } else {
+        else if (window.innerWidth <= 992 && initialScreenSize > 992 && resized) {
             filtersContent.style.display = 'none';
         }
+        else if (window.innerWidth > 992) {
+            filtersContent.style.display = 'block';
+        }
+
+        initialScreenSize = window.innerWidth;
+        resized = false;
     }
 
     window.addEventListener('resize', () => {
+        resized = true;
         toggleAdvancedSearchPanel();
-        enablePanelAfterResize(); // Call the toggleFilters function on window resize
     });
 
 

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -78,7 +78,6 @@
                         <i class="ms-Icon ms-Icon--ChevronDown" id="advancedSearchToggleChevron" ></i></button>
                     </div>
                     <div class="row clearfix advanced-search-panel" id="advancedSearchPanel">
-
                         <input type="text" hidden id="frameworks" name="frameworks" value="@Model.Frameworks">
                         <input type="text" hidden id="tfms" name="tfms" value="@Model.Tfms">
                         @if (Model.IsFrameworkFilteringEnabled)

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -74,7 +74,7 @@
                 @if (Model.IsAdvancedSearchFlightEnabled)
                 {
                     <div class="toggle-button" id="advancedSearchToggleButton">
-                        <button> Click me </button>
+                        <button type="button"> Click me </button>
                     </div>
                     <div class="row clearfix advanced-search-panel" id="advancedSearchPanel">
 

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -74,7 +74,8 @@
                 @if (Model.IsAdvancedSearchFlightEnabled)
                 {
                     <div class="toggle-button" id="advancedSearchToggleButton">
-                        <button type="button"> Click me </button>
+                        Advanced search filters <button class ="coolButton" id="chevronButtonAdvancedSearch" type="button">
+                        <i class="ms-Icon ms-Icon--ChevronDown" id="pleaseWork" ></i></button>
                     </div>
                     <div class="row clearfix advanced-search-panel" id="advancedSearchPanel">
 

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -73,7 +73,11 @@
             <div class="@(Model.IsAdvancedSearchFlightEnabled ? "col-md-3" : "") no-padding" id="filters-column">
                 @if (Model.IsAdvancedSearchFlightEnabled)
                 {
+                    <div class="toggle-button" id="advancedSearchToggleButton">
+                        <button> Click me </button>
+                    </div>
                     <div class="row clearfix advanced-search-panel" id="advancedSearchPanel">
+
                         <input type="text" hidden id="frameworks" name="frameworks" value="@Model.Frameworks">
                         <input type="text" hidden id="tfms" name="tfms" value="@Model.Tfms">
                         @if (Model.IsFrameworkFilteringEnabled)

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -73,9 +73,9 @@
             <div class="@(Model.IsAdvancedSearchFlightEnabled ? "col-md-3" : "") no-padding" id="filters-column">
                 @if (Model.IsAdvancedSearchFlightEnabled)
                 {
-                    <div class="toggle-button" id="advancedSearchToggleButton">
-                        Advanced search filters <button class ="coolButton" id="chevronButtonAdvancedSearch" type="button">
-                        <i class="ms-Icon ms-Icon--ChevronDown" id="pleaseWork" ></i></button>
+                    <div class="toggle-advanced-search-panel">
+                        Advanced search filters <button class ="advanced-search-toggle-button" id="advancedSearchToggleButton" type="button">
+                        <i class="ms-Icon ms-Icon--ChevronDown" id="advancedSearchToggleChevron" ></i></button>
                     </div>
                     <div class="row clearfix advanced-search-panel" id="advancedSearchPanel">
 


### PR DESCRIPTION
I made the advanced search collapsible on narrow screens.

Before:

![image](https://github.com/NuGet/NuGetGallery/assets/58230697/dfebb221-8f79-45ee-92b3-a60417f9b06b)

After:

![image](https://github.com/NuGet/NuGetGallery/assets/58230697/4482e612-6d3b-4e4b-918d-c521c56c88a8)

![image](https://github.com/NuGet/NuGetGallery/assets/58230697/9007b134-1713-47c1-9585-6737fd8a319e)


There are details in the problem description that I didn't change (removing sort-by and putting filters below packages returned) because I talked with PM and designers and we didn't find these changes useful.

Addresses https://github.com/NuGet/NuGetGallery/issues/9374