### PR TITLE
Users/lilixie/package tab accessibility

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -658,7 +658,7 @@
             <div class="tab-content body-tab-content">
                 @if (!Model.Deleted && Model.ShowDetailsAndLinks)
                 {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "readme" ? "active" : "")" id="readme-tab"  aria-label="Readme tab content" aria-labelledby="readme-body-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "readme" ? "active" : "")" id="readme-tab"  aria-label="Readme tab content">
                         @if ((Model.Validating || Model.FailedValidation) && Model.HasEmbeddedReadmeFile)
                         {
                             @ViewHelpers.AlertWarning(
@@ -701,7 +701,7 @@
 
                     if (Model.CanDisplayTargetFrameworks())
                     {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-label="Supported frameworks tab content" aria-labelledby="supportedframeworks-body-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-label="Supported frameworks tab content">
                         @if (Model.PackageFrameworkCompatibility.Table.Count > 0)
                         {
                             @Html.Partial("_SupportedFrameworksTable", Model.PackageFrameworkCompatibility.Table)
@@ -714,7 +714,7 @@
                     </div>
                     }
 
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-label="Dependencies tab content" aria-labelledby="dependencies-body-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-label="Dependencies tab content">
                         @if (!Model.Deleted && Model.ShowDetailsAndLinks)
                         {
                             if (Model.Dependencies.DependencySets == null)
@@ -772,7 +772,7 @@
                         }
                     </div>
                 }
-                <div role="tabpanel" class="tab-pane @(activeBodyTab == "usedby" ? "active" : "")" id="usedby-tab" aria-label="Used by tab content" aria-labelledby="usedby-body-tab">
+                <div role="tabpanel" class="tab-pane @(activeBodyTab == "usedby" ? "active" : "")" id="usedby-tab" aria-label="Used by tab content">
                     @if (!Model.IsDotnetToolPackageType && (Model.IsGitHubUsageEnabled || Model.IsPackageDependentsEnabled))
                     {
                         <div class="used-by" id="used-by">
@@ -881,7 +881,7 @@
                         </div>
                     }
                 </div>
-                <div role="tabpanel" class="tab-pane @(activeBodyTab == "versions" ? "active" : "")" id="versions-tab" aria-label="Versions tab content" aria-labelledby="versions-body-tab">
+                <div role="tabpanel" class="tab-pane @(activeBodyTab == "versions" ? "active" : "")" id="versions-tab" aria-label="Versions tab content">
                     <div class="version-history" id="version-history">
                         <table aria-label="Version History of @Model.Id" class="table borderless">
                             <thead>
@@ -995,7 +995,7 @@
                 </div>
                 @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
                 {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "releasenotes" ? "active" : "")" id="releasenotes-tab" aria-label="Release notes tab content" aria-labelledby="release-body-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "releasenotes" ? "active" : "")" id="releasenotes-tab" aria-label="Release notes tab content">
                         <p>@Html.PreFormattedText(Model.ReleaseNotes, Config)</p>
                     </div>
                 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -554,7 +554,6 @@
                                id="readme-body-tab"
                                class="body-@(Model.CanDisplayReadmeWarning && Model.CanDisplayPrivateMetadata? "warning-" : "")tab"
                                aria-controls="readme-tab"
-                               aria-expanded="@(activeBodyTab == "readme" ? "true" : "false")"
                                aria-selected="@(activeBodyTab == "readme" ? "true" : "false")"
                                tabindex="@(activeBodyTab == "readme" ? "0" : "-1")">
                                 @if (Model.CanDisplayReadmeWarning && Model.CanDisplayPrivateMetadata)
@@ -579,7 +578,6 @@
                                 id="supportedframeworks-body-tab"
                                 class="body-tab"
                                 aria-controls="supportedframeworks-tab"
-                                aria-expanded="@(activeBodyTab == "supportedframeworks" ? "true" : "false")"
                                 aria-selected="@(activeBodyTab == "supportedframeworks" ? "true" : "false")"
                                 tabindex="@(activeBodyTab == "supportedframeworks" ? "0" : "-1")">
                                 <i class="ms-Icon ms-Icon--Package" aria-hidden="true"></i>
@@ -596,7 +594,6 @@
                                id="dependencies-body-tab"
                                class="body-tab"
                                aria-controls="dependencies-tab"
-                               aria-expanded="@(activeBodyTab == "dependencies" ? "true" : "false")"
                                aria-selected="@(activeBodyTab == "dependencies" ? "true" : "false")"
                                tabindex="@(activeBodyTab == "dependencies" ? "0" : "-1")">
                                 <i class="ms-Icon ms-Icon--Packages" aria-hidden="true"></i>
@@ -615,7 +612,6 @@
                                id="usedby-body-tab"
                                class="body-tab"
                                aria-controls="usedby-tab"
-                               aria-expanded="@(activeBodyTab == "usedby" ? "true" : "false")"
                                aria-selected="@(activeBodyTab == "usedby" ? "true" : "false")"
                                tabindex="@(activeBodyTab == "usedby" ? "0" : "-1")">
                                 <i class="ms-Icon ms-Icon--BranchFork2" aria-hidden="true"></i>
@@ -632,7 +628,6 @@
                            id="versions-body-tab"
                            class="body-tab"
                            aria-controls="versions-tab"
-                           aria-expanded="@(activeBodyTab == "versions" ? "true" : "false")"
                            aria-selected="@(activeBodyTab == "versions" ? "true" : "false")"
                            tabindex="@(activeBodyTab == "versions" ? "0" : "-1")">
                             <i class="ms-Icon ms-Icon--Stopwatch" aria-hidden="true"></i>
@@ -650,7 +645,6 @@
                                id="release-body-tab"
                                class="body-tab"
                                aria-controls="releasenotes-tab"
-                               aria-expanded="@(activeBodyTab == "releasenotes" ? "true" : "false")"
                                aria-selected="@(activeBodyTab == "releasenotes" ? "true" : "false")"
                                tabindex="@(activeBodyTab == "releasenotes" ? "0" : "-1")">
                                 <i class="ms-Icon ms-Icon--ReadingMode" aria-hidden="true"></i>
@@ -664,7 +658,7 @@
             <div class="tab-content body-tab-content">
                 @if (!Model.Deleted && Model.ShowDetailsAndLinks)
                 {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "readme" ? "active" : "")" id="readme-tab" aria-label="Readme tab content">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "readme" ? "active" : "")" id="readme-tab" aria-labelledby="readme-body-tab">
                         @if ((Model.Validating || Model.FailedValidation) && Model.HasEmbeddedReadmeFile)
                         {
                             @ViewHelpers.AlertWarning(
@@ -707,7 +701,7 @@
 
                     if (Model.CanDisplayTargetFrameworks())
                     {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-label="Supported frameworks tab content">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-labelledby="supportedframeworks-body-tab">
                         @if (Model.PackageFrameworkCompatibility.Table.Count > 0)
                         {
                             @Html.Partial("_SupportedFrameworksTable", Model.PackageFrameworkCompatibility.Table)
@@ -720,7 +714,7 @@
                     </div>
                     }
 
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-label="Dependencies tab content">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-labelledby="dependencies-body-tab">
                         @if (!Model.Deleted && Model.ShowDetailsAndLinks)
                         {
                             if (Model.Dependencies.DependencySets == null)
@@ -778,7 +772,7 @@
                         }
                     </div>
                 }
-                <div role="tabpanel" class="tab-pane @(activeBodyTab == "usedby" ? "active" : "")" id="usedby-tab" aria-label="Used by tab content">
+                <div role="tabpanel" class="tab-pane @(activeBodyTab == "usedby" ? "active" : "")" id="usedby-tab" aria-labelledby="usedby-body-tab">
                     @if (!Model.IsDotnetToolPackageType && (Model.IsGitHubUsageEnabled || Model.IsPackageDependentsEnabled))
                     {
                         <div class="used-by" id="used-by">
@@ -887,7 +881,7 @@
                         </div>
                     }
                 </div>
-                <div role="tabpanel" class="tab-pane @(activeBodyTab == "versions" ? "active" : "")" id="versions-tab" aria-label="Versions tab content">
+                <div role="tabpanel" class="tab-pane @(activeBodyTab == "versions" ? "active" : "")" id="versions-tab" aria-labelledby="versions-body-tab">
                     <div class="version-history" id="version-history">
                         <table aria-label="Version History of @Model.Id" class="table borderless">
                             <thead>
@@ -1001,7 +995,7 @@
                 </div>
                 @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
                 {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "releasenotes" ? "active" : "")" id="releasenotes-tab" aria-label="Release notes tab content">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "releasenotes" ? "active" : "")" id="releasenotes-tab" aria-labelledby="release-body-tab">
                         <p>@Html.PreFormattedText(Model.ReleaseNotes, Config)</p>
                     </div>
                 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -658,7 +658,7 @@
             <div class="tab-content body-tab-content">
                 @if (!Model.Deleted && Model.ShowDetailsAndLinks)
                 {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "readme" ? "active" : "")" id="readme-tab" aria-labelledby="readme-body-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "readme" ? "active" : "")" id="readme-tab"  aria-label="Readme tab content" aria-labelledby="readme-body-tab">
                         @if ((Model.Validating || Model.FailedValidation) && Model.HasEmbeddedReadmeFile)
                         {
                             @ViewHelpers.AlertWarning(
@@ -701,7 +701,7 @@
 
                     if (Model.CanDisplayTargetFrameworks())
                     {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-labelledby="supportedframeworks-body-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "supportedframeworks" ? "active" : "")" id="supportedframeworks-tab" aria-label="Supported frameworks tab content" aria-labelledby="supportedframeworks-body-tab">
                         @if (Model.PackageFrameworkCompatibility.Table.Count > 0)
                         {
                             @Html.Partial("_SupportedFrameworksTable", Model.PackageFrameworkCompatibility.Table)
@@ -714,7 +714,7 @@
                     </div>
                     }
 
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-labelledby="dependencies-body-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "dependencies" ? "active" : "")" id="dependencies-tab" aria-label="Dependencies tab content" aria-labelledby="dependencies-body-tab">
                         @if (!Model.Deleted && Model.ShowDetailsAndLinks)
                         {
                             if (Model.Dependencies.DependencySets == null)
@@ -772,7 +772,7 @@
                         }
                     </div>
                 }
-                <div role="tabpanel" class="tab-pane @(activeBodyTab == "usedby" ? "active" : "")" id="usedby-tab" aria-labelledby="usedby-body-tab">
+                <div role="tabpanel" class="tab-pane @(activeBodyTab == "usedby" ? "active" : "")" id="usedby-tab" aria-label="Used by tab content" aria-labelledby="usedby-body-tab">
                     @if (!Model.IsDotnetToolPackageType && (Model.IsGitHubUsageEnabled || Model.IsPackageDependentsEnabled))
                     {
                         <div class="used-by" id="used-by">
@@ -881,7 +881,7 @@
                         </div>
                     }
                 </div>
-                <div role="tabpanel" class="tab-pane @(activeBodyTab == "versions" ? "active" : "")" id="versions-tab" aria-labelledby="versions-body-tab">
+                <div role="tabpanel" class="tab-pane @(activeBodyTab == "versions" ? "active" : "")" id="versions-tab" aria-label="Versions tab content" aria-labelledby="versions-body-tab">
                     <div class="version-history" id="version-history">
                         <table aria-label="Version History of @Model.Id" class="table borderless">
                             <thead>
@@ -995,7 +995,7 @@
                 </div>
                 @if (!String.IsNullOrWhiteSpace(Model.ReleaseNotes))
                 {
-                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "releasenotes" ? "active" : "")" id="releasenotes-tab" aria-labelledby="release-body-tab">
+                    <div role="tabpanel" class="tab-pane @(activeBodyTab == "releasenotes" ? "active" : "")" id="releasenotes-tab" aria-label="Release notes tab content" aria-labelledby="release-body-tab">
                         <p>@Html.PreFormattedText(Model.ReleaseNotes, Config)</p>
                     </div>
                 }


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Remove aria-expanded attribute
*Add aria-labelledby attribute to tab pane

Addresses https://github.com/NuGet/NuGetGallery/issues/9607
Note: refer to documentation ( https://www.w3.org/WAI/ARIA/apg/patterns/tabs/, https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/), aria-expanded attribute is not required for tabs. This PR remove the unnecessary attribute aria-expanded and add the required attribute aria-labelledby.