### PR TITLE
Disable dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,31 +3,31 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
-version: 2
+#version: 2
 
-registries:
-  nuget-azure-devops:
-    type: nuget-feed
-    url: https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json
+#registries:
+#  nuget-azure-devops:
+#    type: nuget-feed
+#    url: https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json
 
-updates:
-  - package-ecosystem: nuget
-    directory: "/"
-    schedule:
-      interval: monthly
-    registries:
-      - nuget-azure-devops
-    open-pull-requests-limit: 10
-    assignees:
-      - nuget/gallery-team
-    target-branch: "dev"
+#updates:
+#  - package-ecosystem: nuget
+#    directory: "/"
+#    schedule:
+#      interval: monthly
+#    registries:
+#      - nuget-azure-devops
+#    open-pull-requests-limit: 10
+#    assignees:
+#      - nuget/gallery-team
+#    target-branch: "dev"
 
-  - package-ecosystem: gitsubmodule
-    directory: "/"
-    schedule:
-      interval: weekly
-      day: monday
-      time: '07:00'
-    open-pull-requests-limit: 10
-    assignees:
-    - nuget/gallery-team
+#  - package-ecosystem: gitsubmodule
+#    directory: "/"
+#    schedule:
+#      interval: weekly
+#      day: monday
+#      time: '07:00'
+#    open-pull-requests-limit: 10
+#    assignees:
+#    - nuget/gallery-team


### PR DESCRIPTION
There are risks that we discovered associated with enabled Dependabot that we don't want to take now: After configuring it on Gallery, we had a lot of build breaks and runtime errors. There are also risks of performance regressions.

1ES is enabling 1ES Dependabot (see thread "1ES Dependabot is coming to your repositories for NuGet Service") which should take care of our CG alerts automatically for us.

Decision:
We are postponing enabling Dependabot for when we have more capacity.  We will do it in priority order, updating some packages first, starting with the ones that are likely to be in security asks (Azure SDKs or anything else that we interact with resources, scary dependencies: SQL, KeyVault, etc.).

Related to https://github.com/NuGet/Engineering/issues/4938