### PR TITLE
[Usability] Show a success message when adding members to your org

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -2071,6 +2071,7 @@ p.frameworktableinfo-text {
 }
 .members-list .manage-members-listing #add-member-success-message {
   display: none;
+  margin: 0px;
 }
 .members-list .form-flex {
   display: block;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1931,6 +1931,52 @@ p.frameworktableinfo-text {
     text-align: right;
   }
 }
+@media (min-width: 768px) {
+  .page-list-packages .advanced-search-panel {
+    position: relative;
+    top: 0;
+    margin-top: 0px;
+    display: block;
+  }
+}
+@media (max-width: 768px) {
+  .page-list-packages .advanced-search-panel {
+    margin-top: 0px;
+  }
+}
+.page-list-packages .toggle-advanced-search-panel {
+  display: none;
+  margin-top: 30px;
+  color: #494949;
+  background-color: #f4f4f4;
+  position: relative;
+  border: none;
+  padding-left: 19px;
+}
+.page-list-packages .toggle-advanced-search-panel .advanced-search-toggle-button {
+  padding-top: 0px;
+  padding-bottom: 0px;
+  margin-right: 20px;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  float: right;
+}
+.page-list-packages .toggle-advanced-search-panel .advanced-search-toggle-button:hover {
+  color: #5a87dc;
+}
+.page-list-packages .toggle-advanced-search-panel .advanced-search-toggle-button:focus {
+  outline: solid;
+  z-index: 1;
+}
+@media (max-width: 992px) {
+  .page-list-packages .toggle-advanced-search-panel {
+    display: block;
+  }
+  .page-list-packages .advanced-search-panel {
+    display: none;
+  }
+}
 .page-manage-deprecation .full-line {
   display: block;
   width: 100%;
@@ -2022,6 +2068,9 @@ p.frameworktableinfo-text {
 .members-list .manage-members-listing .member-item .member-column {
   height: 36px;
   display: block;
+}
+.members-list .manage-members-listing #add-member-success-message {
+  display: none;
 }
 .members-list .form-flex {
   display: block;

--- a/src/Bootstrap/less/theme/page-manage-organizations.less
+++ b/src/Bootstrap/less/theme/page-manage-organizations.less
@@ -102,6 +102,7 @@
 
     #add-member-success-message {
       display: none;
+      margin: 0px;
     }
   }
   //form display flex

--- a/src/Bootstrap/less/theme/page-manage-organizations.less
+++ b/src/Bootstrap/less/theme/page-manage-organizations.less
@@ -99,6 +99,10 @@
         display: block;
       }
     }
+
+    #add-member-success-message {
+      display: none;
+    }
   }
   //form display flex
   .form-flex {

--- a/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
@@ -169,6 +169,9 @@
                 return self.AddMemberRole() == self.RoleNames()[0];
             });
             this.AddMember = function () {
+                // Hide any previous form success messages
+                $('#add-member-success-message').hide();
+
                 if (!self.NewMemberUsername()) {
                     self.Error("You must specify a user to add as a member.");
                     return;
@@ -212,6 +215,7 @@
                         });
 
                         self.Members.push(new OrganizationMemberViewModel(self, data));
+                        $('#add-member-success-message').show();
                         self.NewMemberUsername(null);
                     },
                     error: function (jqXHR, textStatus, errorThrown) {

--- a/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
+++ b/src/NuGetGallery/Scripts/gallery/page-manage-organization.js
@@ -215,7 +215,10 @@
                         });
 
                         self.Members.push(new OrganizationMemberViewModel(self, data));
+
+                        document.getElementById('add-member-success-message').innerHTML = "<b>" + data.Username + "</b> was successfully added to your organization (pending approval)";
                         $('#add-member-success-message').show();
+
                         self.NewMemberUsername(null);
                     },
                     error: function (jqXHR, textStatus, errorThrown) {

--- a/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
+++ b/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
@@ -44,13 +44,16 @@
                         </div>
                         <div class="form-group col-sm-3">
                             <label for="addMemberRole">Add member role</label>
-                            <select class="form-control" data-bind="value: AddMemberRole, options: RoleNames" aria-label="Role Filter" id="addMemberRole"></select> 
+                            <select class="form-control" data-bind="value: AddMemberRole, options: RoleNames" aria-label="Role Filter" id="addMemberRole"></select>
                         </div>
                         <div class="col-sm-1 btn-row">
                             <button class="btn btn-primary" type="submit" title="Add new member" aria-label="Add new member" data-bind="click: AddMember">Add</button>
                         </div>
                     </div>
                 </form>
+                <span id="add-member-success-message" class="alert alert-success" role="alert">
+                    New member was added successfully (pending approval)
+                </span>
                 <div data-bind="template: 'error-container'"></div>
             }
             <div class="table-container table-responsive">
@@ -82,7 +85,7 @@
                                         @if (Model.CanManageMemberships)
                                         {
 
-                                            <select id="selectRole" class="form-control"
+                                            <select class="form-control selectRole"
                                                     data-bind="value: SelectedRole, options: OrganizationViewModel.RoleNames, event: { change: ToggleIsAdmin }, attr: { 'aria-label': 'Role for ' + Username }">
                                             </select>
                                         }

--- a/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
+++ b/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
@@ -51,9 +51,7 @@
                         </div>
                     </div>
                 </form>
-                <div id="add-member-success-message" class="alert alert-success" role="alert">
-                    New member was added successfully (pending approval)
-                </div>
+                <div id="add-member-success-message" class="alert alert-success" role="alert"></div>
                 <div data-bind="template: 'error-container'"></div>
             }
             <div class="table-container table-responsive">

--- a/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
+++ b/src/NuGetGallery/Views/Organizations/_OrganizationAccountManageMembers.cshtml
@@ -51,9 +51,9 @@
                         </div>
                     </div>
                 </form>
-                <span id="add-member-success-message" class="alert alert-success" role="alert">
+                <div id="add-member-success-message" class="alert alert-success" role="alert">
                     New member was added successfully (pending approval)
-                </span>
+                </div>
                 <div data-bind="template: 'error-container'"></div>
             }
             <div class="table-container table-responsive">


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9609

**Problem:**

Users want to see a confirmation message when they successfully add a member to their organization. They can currently see the Members list to see the new member with "(pending approval)" next to their name, but they want to see a more explicit success message.

**Solution:**

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/16a1eb13-4bfd-4f8e-813e-77cf5d509925)


**NOTE:** I also fixed an a11y issue that showed up on A11y Fastpass where multiple 'member role' elements (the 'Select role' dropdowns in the screenshot) had the same ids. This id wasn't being used anywhere so I just moved the value to the element's class list instead.