### PR TITLE
Fix url frameworks tab

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -102,6 +102,10 @@
         if (windowHash === '#show-readme-container') {
             windowHash = '#readme-body-tab';
         }
+        //if windowhash doesn't contain body, add it
+        if (!windowHash.includes("body")) {
+            windowHash = windowHash.replace(new RegExp("-tab", "g"), "-body-tab");
+        }
 
         $(windowHash).focus();
         $(windowHash).tab('show');

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -102,10 +102,6 @@
         if (windowHash === '#show-readme-container') {
             windowHash = '#readme-body-tab';
         }
-        //if windowhash doesn't contain body, add it
-        if (!windowHash.includes("body")) {
-            windowHash = windowHash.replace(new RegExp("-tab", "g"), "-body-tab");
-        }
 
         $(windowHash).focus();
         $(windowHash).tab('show');

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -573,9 +573,10 @@
                      {
                         activeBodyTab = activeBodyTab ?? "supportedframeworks";
                         <li role="presentation" id="show-supportedframeworks-container">
-                            <a href="#supportedframeworks-tab"
+                            <a href="#supportedframeworks-body-tab"
                                 role="tab"
                                 data-toggle="tab"
+                                data-target="#supportedframeworks-tab"
                                 id="supportedframeworks-body-tab"
                                 class="body-tab"
                                 aria-controls="supportedframeworks-tab"

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -35,6 +35,7 @@
             {
                 Id = "dotnet-cli-global",
                 CommandPrefix = "> ",
+
                 InstallPackageCommands = new [] { string.Format("dotnet tool install --global {0} --version {1}", Model.Id, Model.Version) },
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET tool</a> you can call from the shell/command line.",
@@ -193,8 +194,9 @@
 @helper CommandTab(PackageManagerViewModel packageManager, bool active)
 {
     <li role="presentation" class="@(active ? "active" : string.Empty)">
-        <a href="#@packageManager.Id"
-           id="@packageManager.Id-tab" class="package-manager-tab"
+        <a href="#@packageManager.Id-body-tab"
+           data-target="@packageManager.Id-tab"
+           id="@packageManager.Id-body-tab" class="package-manager-tab"
            aria-selected="@(active ? "true" : "false")" tabindex="@(active ? "0" : "-1")"
            aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
            title="Switch to tab panel which contains package installation command for @packageManager.Name">
@@ -591,9 +593,10 @@
 
                         activeBodyTab = activeBodyTab ?? "dependencies";
                         <li role="presentation">
-                            <a href="#dependencies-tab"
+                            <a href="#dependencies-body-tab"
                                role="tab"
                                data-toggle="tab"
+                               data-target="#dependencies-tab"
                                id="dependencies-body-tab"
                                class="body-tab"
                                aria-controls="dependencies-tab"
@@ -610,9 +613,10 @@
                     {
                         activeBodyTab = activeBodyTab ?? "usedby";
                         <li role="presentation">
-                            <a href="#usedby-tab"
+                            <a href="#usedby-body-tab"
                                role="tab"
                                data-toggle="tab"
+                               data-target="#usedby-tab"
                                id="usedby-body-tab"
                                class="body-tab"
                                aria-controls="usedby-tab"
@@ -627,9 +631,10 @@
 
                     @{ activeBodyTab = activeBodyTab ?? "versions"; }
                     <li role="presentation">
-                        <a href="#versions-tab"
+                        <a href="#versions-body-tab"
                            role="tab"
                            data-toggle="tab"
+                           data-target="#versions-tab"
                            id="versions-body-tab"
                            class="body-tab"
                            aria-controls="versions-tab"


### PR DESCRIPTION
Opening new tabs by right-clicking on buttons didn't work.

Buttons in question: 
<img width="452" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/2a561aa1-3eed-4582-a4bc-88728f408dad">
<img width="442" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/f3307c8a-153a-4cca-81ca-667c2dc039cb">


It now works.

Addresses https://github.com/NuGet/NuGetGallery/issues/9283