### PR TITLE
[Usability] Users can now jump quickly between individual search results

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -575,6 +575,19 @@ img.reserved-indicator-icon {
   font-size: 24px;
   font-weight: 300;
   line-height: 0.9;
+  display: inline-block;
+  color: #337ab7;
+  width: auto;
+  margin: 0px;
+}
+.list-packages .package .package-header .package-title:hover,
+.list-packages .package .package-header .package-title:focus {
+  color: #23527c;
+  text-decoration: underline;
+}
+.list-packages .package .package-header .package-title:focus {
+  outline: 2px solid;
+  outline-offset: 4px;
 }
 .list-packages .package .package-header .reserved-indicator {
   margin-top: 3px;

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -11,6 +11,22 @@
         font-size: 24px;
         font-weight: 300;
         line-height: 0.9;
+
+        display: inline-block;
+        color: @link-color;
+        width: auto;
+        margin: 0px;
+
+        &:hover,
+        &:focus {
+          color: @link-hover-color;
+          text-decoration: @link-hover-decoration;
+        }
+      
+        &:focus {
+          outline: 2px solid;
+          outline-offset: 4px;
+        }
       }
 
       .reserved-indicator {

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -115,6 +115,12 @@
       "Accounts": [],
       "Domains": []
     },
+    "NuGetGallery.AdvancedSearch": {
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
+    },
     "NuGetGallery.FrameworkFiltering": {
       "All": true,
       "SiteAdmins": false,

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -36,14 +36,17 @@
         </div>
         <div class="col-sm-11">
             <div class="package-header">
-                <a class="package-title"
-                   href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null).TrimEnd('/')"
-                   @if (itemIndex.HasValue)
-                   {
-                        @:data-track="@eventName" data-track-value="@itemIndex"
-                        @:data-package-id="@Model.Id" data-package-version="@Model.Version" data-use-version="@Model.UseVersion"
-                   }
-                   >@Html.BreakWord(Model.Id)</a>
+                <h2 class="package-title">
+                    <a class="package-title"
+                        href="@Url.Package(Model.Id, Model.UseVersion ? Model.Version : null).TrimEnd('/')"
+                        @if (itemIndex.HasValue)
+                        {
+                            @:data-track="@eventName" data-track-value="@itemIndex"
+                            @:data-package-id="@Model.Id" data-package-version="@Model.Version" data-use-version="@Model.UseVersion"
+                        }>
+                            @Html.BreakWord(Model.Id)
+                    </a>
+                </h2>
 
                 @if (Model.IsVerified.HasValue && Model.IsVerified.Value)
                 {
@@ -73,20 +76,20 @@
             </div>
 
 
-            @if(Model.IsVulnerable || Model.IsDeprecated)
+            @if (Model.IsVulnerable || Model.IsDeprecated)
             {
                 <ul class="package-list">
                     <li>
-                        @if(Model.IsVulnerable)
+                        @if (Model.IsVulnerable)
                         {
                             <span class="icon-text package-warning--vulnerable" aria-label="@Model.VulnerabilityTitle" data-content="@Model.VulnerabilityTitle">
                                 <i class="ms-Icon ms-Icon--BlockedSiteSolid12" aria-hidden="true"></i>
                                 Vulnerable
                             </span>
                         }
-                        @if(Model.IsDeprecated)
+                        @if (Model.IsDeprecated)
                         {
-                            <span class="icon-text package-warning--deprecated"  aria-label="@Model.DeprecationTitle" data-content="@Model.DeprecationTitle">
+                            <span class="icon-text package-warning--deprecated" aria-label="@Model.DeprecationTitle" data-content="@Model.DeprecationTitle">
                                 <i class="ms-Icon ms-Icon--ShieldAlert" aria-hidden="true"></i>
                                 Deprecated
                             </span>


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9608

**Problem:**

Users don't like the fact that they have to tab through everything in each search result to move down the list of search results. They want to be able to navigate between search results more easily.

**Solution:**

I placed the package IDs for each search result inside `<h2>` heading tags. With screen readers, you can navigate between headings using `H/shift+H`, and then continue sequential navigation through each search result using `tab/shift+tab`. Users will now be able to move between individual search results quicker.

There is no visible UI change here. The css changes are there to just keep the package headers looking the same as they did previously.

**NOTE:** There was an old feature flight that was missing from the `flags.json` file (pointed out by @dannyjdev here: https://github.com/NuGet/NuGetGallery/pull/9537#discussion_r1270107406), so I've added that in with this change too.