### PR TITLE
Fix Update-Database.ps1 to work on DevBox

### DIFF
--- a/tools/Update-Databases.ps1
+++ b/tools/Update-Databases.ps1
@@ -20,7 +20,13 @@ function Initialize-EF6Exe() {
             | Where-Object { $_.Node.Attributes["Include"].Value -eq "EntityFramework" }
         $efVersion = $efPackageReference.Node.Version
         Write-Host "Using EntityFramework version $efVersion."
-        $efDirectory = "$env:userprofile\.nuget\packages\EntityFramework\$efVersion"
+
+        if ([Environment]::GetEnvironmentVariable('NUGET_PACKAGES') -ne $null) {
+            $efDirectory = "$env:NUGET_PACKAGES\EntityFramework\$efVersion"
+        }
+        else {
+            $efDirectory = "$env:userprofile\.nuget\packages\EntityFramework\$efVersion"
+        }
     }
 
     Copy-Item `

--- a/tools/Update-Databases.ps1
+++ b/tools/Update-Databases.ps1
@@ -21,11 +21,11 @@ function Initialize-EF6Exe() {
         $efVersion = $efPackageReference.Node.Version
         Write-Host "Using EntityFramework version $efVersion."
 
-        if ([Environment]::GetEnvironmentVariable('NUGET_PACKAGES') -ne $null) {
-            $efDirectory = "$env:NUGET_PACKAGES\EntityFramework\$efVersion"
+        if ($env:NUGET_PACKAGES) {
+            $efDirectory = Join-Path $env:NUGET_PACKAGES "EntityFramework\$efVersion"
         }
         else {
-            $efDirectory = "$env:userprofile\.nuget\packages\EntityFramework\$efVersion"
+            $efDirectory = Join-Path $env:USERPROFILE ".nuget\packages\EntityFramework\$efVersion"
         }
     }
 


### PR DESCRIPTION
On DevBox, global packages folder location is overridden using NUGET_PACKAGES environment variable. This currently breaks the Update-Database.ps1 script, which assumes GPF is at the default location: %userprofile%\.nuget\packages.

NuGet Client docs: https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders