### PR TITLE
Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -18,6 +18,7 @@
       <package pattern="Antlr" />
       <package pattern="Autofac" />
       <package pattern="Autofac.*" />
+      <package pattern="Azure.Identity" />
       <package pattern="Castle.Core" />
       <package pattern="CommonMark.NET" />
       <package pattern="CsvHelper" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -18,8 +18,7 @@
       <package pattern="Antlr" />
       <package pattern="Autofac" />
       <package pattern="Autofac.*" />
-      <package pattern="Azure.Identity" />
-      <package pattern="Azure.Security.KeyVault.Secrets" />
+      <package pattern="Azure.*" />
       <package pattern="Castle.Core" />
       <package pattern="CommonMark.NET" />
       <package pattern="CsvHelper" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -19,6 +19,7 @@
       <package pattern="Autofac" />
       <package pattern="Autofac.*" />
       <package pattern="Azure.Identity" />
+      <package pattern="Azure.Security.KeyVault.Secrets" />
       <package pattern="Castle.Core" />
       <package pattern="CommonMark.NET" />
       <package pattern="CsvHelper" />

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
+++ b/src/DatabaseMigrationTools/DatabaseMigrationTools.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.109.0</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-8079991</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-8079991</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -92,6 +92,7 @@
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
       <Version>2.109.0</Version>
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-8079991</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-8079991</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,7 +91,7 @@
       <Version>4.3.0-dev-8079991</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -91,8 +91,7 @@
       <Version>4.3.0-dev-8079991</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.109.0</Version>
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -51,7 +51,7 @@
       <Version>6.4.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -60,13 +60,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -51,7 +51,7 @@
       <Version>6.4.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -60,13 +60,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -51,7 +51,7 @@
       <Version>6.4.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -60,13 +60,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -52,6 +52,7 @@
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
       <Version>2.109.0</Version>
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -67,6 +68,13 @@
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
       <Version>2.109.0</Version>
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Validation">
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Validation.Issues">
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -51,7 +51,7 @@
       <Version>6.4.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -60,13 +60,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -51,8 +51,7 @@
       <Version>6.4.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.109.0</Version>
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -61,20 +60,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.109.0</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.109.0</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.109.0</Version>
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -51,7 +51,7 @@
       <Version>6.4.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.FeatureFlags">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
@@ -60,13 +60,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.elmah.corelibrary">
       <Version>1.2.2</Version>

--- a/src/NuGetGallery.Services/Configuration/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGetGallery.Services/Configuration/SecretReader/SecretReaderFactory.cs
@@ -13,6 +13,7 @@ namespace NuGetGallery.Configuration.SecretReader
         internal const string KeyVaultConfigurationPrefix = "KeyVault.";
         internal const string UseManagedIdentityConfigurationKey = "UseManagedIdentity";
         internal const string VaultNameConfigurationKey = "VaultName";
+        internal const string TenantIdConfigurationKey = "TenantId";
         internal const string ClientIdConfigurationKey = "ClientId";
         internal const string CertificateThumbprintConfigurationKey = "CertificateThumbprint";
         internal const string CertificateStoreLocation = "StoreLocation";
@@ -58,12 +59,13 @@ namespace NuGetGallery.Configuration.SecretReader
                 }
                 else
                 {
+                    var tenantId = _configurationService.ReadRawSetting(ResolveKeyVaultSettingName(TenantIdConfigurationKey));
                     var clientId = _configurationService.ReadRawSetting(ResolveKeyVaultSettingName(ClientIdConfigurationKey));
                     var certificateThumbprint = _configurationService.ReadRawSetting(ResolveKeyVaultSettingName(CertificateThumbprintConfigurationKey));
                     var storeName = GetOptionalKeyVaultEnumSettingValue(CertificateStoreName, StoreName.My);
                     var storeLocation = GetOptionalKeyVaultEnumSettingValue(CertificateStoreLocation, StoreLocation.LocalMachine);
                     var certificate = CertificateUtility.FindCertificateByThumbprint(storeName, storeLocation, certificateThumbprint, validationRequired: true);
-                    keyVaultConfiguration = new KeyVaultConfiguration(vaultName, clientId, certificate);
+                    keyVaultConfiguration = new KeyVaultConfiguration(vaultName, tenantId, clientId, certificate);
                 }
 
                 secretReader = new KeyVaultReader(keyVaultConfiguration);

--- a/src/NuGetGallery.Services/Configuration/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGetGallery.Services/Configuration/SecretReader/SecretReaderFactory.cs
@@ -56,7 +56,7 @@ namespace NuGetGallery.Configuration.SecretReader
                 KeyVaultConfiguration keyVaultConfiguration;
                 if (useManagedIdentity)
                 {
-                    keyVaultConfiguration = new KeyVaultConfiguration(vaultName);
+                    keyVaultConfiguration = new KeyVaultConfiguration(vaultName, clientId);
                 }
                 else
                 {

--- a/src/NuGetGallery.Services/Configuration/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGetGallery.Services/Configuration/SecretReader/SecretReaderFactory.cs
@@ -56,7 +56,7 @@ namespace NuGetGallery.Configuration.SecretReader
                 KeyVaultConfiguration keyVaultConfiguration;
                 if (useManagedIdentity)
                 {
-                    keyVaultConfiguration = new KeyVaultConfiguration(vaultName, clientId);
+                    keyVaultConfiguration = new KeyVaultConfiguration(vaultName);
                 }
                 else
                 {

--- a/src/NuGetGallery.Services/Configuration/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGetGallery.Services/Configuration/SecretReader/SecretReaderFactory.cs
@@ -51,16 +51,16 @@ namespace NuGetGallery.Configuration.SecretReader
             if (!string.IsNullOrEmpty(vaultName))
             {
                 var useManagedIdentity = GetOptionalKeyVaultBoolSettingValue(UseManagedIdentityConfigurationKey, defaultValue: false);
+                var clientId = _configurationService.ReadRawSetting(ResolveKeyVaultSettingName(ClientIdConfigurationKey));
 
                 KeyVaultConfiguration keyVaultConfiguration;
                 if (useManagedIdentity)
                 {
-                    keyVaultConfiguration = new KeyVaultConfiguration(vaultName);
+                    keyVaultConfiguration = new KeyVaultConfiguration(vaultName, clientId);
                 }
                 else
                 {
                     var tenantId = _configurationService.ReadRawSetting(ResolveKeyVaultSettingName(TenantIdConfigurationKey));
-                    var clientId = _configurationService.ReadRawSetting(ResolveKeyVaultSettingName(ClientIdConfigurationKey));
                     var certificateThumbprint = _configurationService.ReadRawSetting(ResolveKeyVaultSettingName(CertificateThumbprintConfigurationKey));
                     var storeName = GetOptionalKeyVaultEnumSettingValue(CertificateStoreName, StoreName.My);
                     var storeLocation = GetOptionalKeyVaultEnumSettingValue(CertificateStoreLocation, StoreLocation.LocalMachine);

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -88,10 +88,10 @@
       <Version>6.6.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -88,14 +88,10 @@
       <Version>6.6.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.109.0</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.109.0</Version>
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -88,10 +88,10 @@
       <Version>6.6.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -88,10 +88,10 @@
       <Version>6.6.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -92,6 +92,10 @@
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
       <Version>2.109.0</Version>
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Logging">
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -88,10 +88,10 @@
       <Version>6.6.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -88,10 +88,10 @@
       <Version>6.6.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.StrongName.WebBackgrounder">
       <Version>0.2.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2256,20 +2256,13 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.109.0</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.109.0</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.109.0</Version>
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2256,13 +2256,13 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2256,13 +2256,13 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2256,13 +2256,13 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2263,6 +2263,13 @@
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
       <Version>2.109.0</Version>
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Owin">
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Sql">
+      <Version>2.108.0-agr-kv-lib-upgrade-7060168</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2256,13 +2256,13 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.110.0-agr-kv-lib-upgrade-8222688</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade-defaultcred-8223527</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2256,13 +2256,13 @@
       <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Licenses">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Owin">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.110.0-agr-kv-lib-upgrade-8228637</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade2-8229803</Version>
     </PackageReference>
     <PackageReference Include="Owin">
       <Version>1.0.0</Version>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -584,6 +584,34 @@
   </system.diagnostics>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.Json" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.46.0.0" newVersion="4.46.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.25.0.0" newVersion="1.25.0.0"/>
+			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -584,34 +584,6 @@
   </system.diagnostics>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Json" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.46.0.0" newVersion="4.46.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-1.25.0.0" newVersion="1.25.0.0"/>
-			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -585,6 +585,30 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.46.0.0" newVersion="4.46.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.25.0.0" newVersion="1.25.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
       </dependentAssembly>


### PR DESCRIPTION
Related to: https://github.com/NuGet/Engineering/issues/4704

Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault package dependency. Former one is deprecated.
I manually tested this change in [Gallery dev environment](https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1478870)
