### PR TITLE
Fix url frameworks tab

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -102,6 +102,10 @@
         if (windowHash === '#show-readme-container') {
             windowHash = '#readme-body-tab';
         }
+        //if windowhash doesn't contain body, add it
+        if (!windowHash.includes("body")) {
+            windowHash = windowHash.replace(new RegExp("-tab", "g"), "-body-tab");
+        }
 
         $(windowHash).focus();
         $(windowHash).tab('show');

--- a/src/NuGetGallery/Scripts/gallery/page-display-package.js
+++ b/src/NuGetGallery/Scripts/gallery/page-display-package.js
@@ -102,10 +102,6 @@
         if (windowHash === '#show-readme-container') {
             windowHash = '#readme-body-tab';
         }
-        //if windowhash doesn't contain body, add it
-        if (!windowHash.includes("body")) {
-            windowHash = windowHash.replace(new RegExp("-tab", "g"), "-body-tab");
-        }
 
         $(windowHash).focus();
         $(windowHash).tab('show');

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -573,9 +573,10 @@
                      {
                         activeBodyTab = activeBodyTab ?? "supportedframeworks";
                         <li role="presentation" id="show-supportedframeworks-container">
-                            <a href="#supportedframeworks-tab"
+                            <a href="#supportedframeworks-body-tab"
                                 role="tab"
                                 data-toggle="tab"
+                                data-target="#supportedframeworks-tab"
                                 id="supportedframeworks-body-tab"
                                 class="body-tab"
                                 aria-controls="supportedframeworks-tab"

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -35,6 +35,7 @@
             {
                 Id = "dotnet-cli-global",
                 CommandPrefix = "> ",
+
                 InstallPackageCommands = new [] { string.Format("dotnet tool install --global {0} --version {1}", Model.Id, Model.Version) },
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET tool</a> you can call from the shell/command line.",
@@ -193,8 +194,9 @@
 @helper CommandTab(PackageManagerViewModel packageManager, bool active)
 {
     <li role="presentation" class="@(active ? "active" : string.Empty)">
-        <a href="#@packageManager.Id"
-           id="@packageManager.Id-tab" class="package-manager-tab"
+        <a href="#@packageManager.Id-body-tab"
+           data-target="@packageManager.Id-tab"
+           id="@packageManager.Id-body-tab" class="package-manager-tab"
            aria-selected="@(active ? "true" : "false")" tabindex="@(active ? "0" : "-1")"
            aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
            title="Switch to tab panel which contains package installation command for @packageManager.Name">
@@ -591,9 +593,10 @@
 
                         activeBodyTab = activeBodyTab ?? "dependencies";
                         <li role="presentation">
-                            <a href="#dependencies-tab"
+                            <a href="#dependencies-body-tab"
                                role="tab"
                                data-toggle="tab"
+                               data-target="#dependencies-tab"
                                id="dependencies-body-tab"
                                class="body-tab"
                                aria-controls="dependencies-tab"
@@ -610,9 +613,10 @@
                     {
                         activeBodyTab = activeBodyTab ?? "usedby";
                         <li role="presentation">
-                            <a href="#usedby-tab"
+                            <a href="#usedby-body-tab"
                                role="tab"
                                data-toggle="tab"
+                               data-target="#usedby-tab"
                                id="usedby-body-tab"
                                class="body-tab"
                                aria-controls="usedby-tab"
@@ -627,9 +631,10 @@
 
                     @{ activeBodyTab = activeBodyTab ?? "versions"; }
                     <li role="presentation">
-                        <a href="#versions-tab"
+                        <a href="#versions-body-tab"
                            role="tab"
                            data-toggle="tab"
+                           data-target="#versions-tab"
                            id="versions-body-tab"
                            class="body-tab"
                            aria-controls="versions-tab"

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -193,11 +193,10 @@
 @helper CommandTab(PackageManagerViewModel packageManager, bool active)
 {
     <li role="presentation" class="@(active ? "active" : string.Empty)">
-        <a href="#@packageManager.Id-body-tab"
-           id="@packageManager.Id-body-tab" class="package-manager-tab"
+        <a href="#@packageManager.Id"
+           id="@packageManager.Id-tab" class="package-manager-tab"
            aria-selected="@(active ? "true" : "false")" tabindex="@(active ? "0" : "-1")"
            aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
-           data-target="#@packageManager.Id"
            title="Switch to tab panel which contains package installation command for @packageManager.Name">
             @packageManager.Name
         </a>
@@ -649,10 +648,11 @@
                     {
                         activeBodyTab = activeBodyTab ?? "releasenotes";
                         <li role="presentation">
-                            <a href="#releasenotes-tab"
+                            <a href="#releasenotes-body-tab"
                                role="tab"
                                data-toggle="tab"
-                               id="release-body-tab"
+                               data-target="#releasenotes-tab"
+                               id="releasenotes-body-tab"
                                class="body-tab"
                                aria-controls="releasenotes-tab"
                                aria-expanded="@(activeBodyTab == "releasenotes" ? "true" : "false")"

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1373,8 +1373,6 @@
                 continue;
             }
 
-            packageManagersCss = string.Empty;
-
             packageManagersCss += "#" + packageManager.Id + " .install-command-row::before {";
             packageManagersCss += "    content: \"" + packageManager.CommandPrefix + "\"";
             packageManagersCss += "}";

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -548,9 +548,10 @@
                     {
                         activeBodyTab = activeBodyTab ?? "readme";
                         <li role="presentation" class="active" id="show-readme-container">
-                            <a href="#readme-tab"
+                            <a href="#readme-body-tab"
                                role="tab"
                                data-toggle="tab"
+                               data-target="#readme-tab"
                                id="readme-body-tab"
                                class="body-@(Model.CanDisplayReadmeWarning && Model.CanDisplayPrivateMetadata? "warning-" : "")tab"
                                aria-controls="readme-tab"

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -35,7 +35,6 @@
             {
                 Id = "dotnet-cli-global",
                 CommandPrefix = "> ",
-
                 InstallPackageCommands = new [] { string.Format("dotnet tool install --global {0} --version {1}", Model.Id, Model.Version) },
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET tool</a> you can call from the shell/command line.",
@@ -195,10 +194,10 @@
 {
     <li role="presentation" class="@(active ? "active" : string.Empty)">
         <a href="#@packageManager.Id-body-tab"
-           data-target="@packageManager.Id-tab"
            id="@packageManager.Id-body-tab" class="package-manager-tab"
            aria-selected="@(active ? "true" : "false")" tabindex="@(active ? "0" : "-1")"
            aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
+           data-target="#@packageManager.Id"
            title="Switch to tab panel which contains package installation command for @packageManager.Name">
             @packageManager.Name
         </a>
@@ -1373,6 +1372,8 @@
             {
                 continue;
             }
+
+            packageManagersCss = string.Empty;
 
             packageManagersCss += "#" + packageManager.Id + " .install-command-row::before {";
             packageManagersCss += "    content: \"" + packageManager.CommandPrefix + "\"";


### PR DESCRIPTION
These buttons can now be opened in a new tab:

<img width="616" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/ca2ded9e-3f4b-416e-8821-95829556dad1">

Testing: Enter any package on nuget page. Right-click on a button, click "open in new tab". It should open a new tab with the button contents displayed.

Addresses https://github.com/NuGet/NuGetGallery/issues/9283

After discussing the issue of other buttons with Advay (Package Manager, PackageReference...), we reached the conclusion that these don't need to be opened in a new tab and hence abandoned further work on them. I have removed the changes I made that caused them to be broken.