### PR TITLE
Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault

### DIFF
--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -109,7 +109,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.3.0-dev-5066115</Version>
+      <Version>2.110.0-agr-kv-lib-upgrade3-8363300</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -109,7 +109,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8363300</Version>
+      <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -88,7 +88,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-8079991</Version>
+      <Version>4.3.0-dev-eryondon-keyvault2-8369940</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
       <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -88,10 +88,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-eryondon-keyvault2-8369940</Version>
+      <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.110.0-agr-kv-lib-upgrade3-8361872</Version>
+      <Version>2.111.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -79,7 +79,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-eryondon-keyvault2-8369940</Version>
+      <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -79,7 +79,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-8079991</Version>
+      <Version>4.3.0-dev-eryondon-keyvault2-8369940</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
+++ b/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-eryondon-keyvault2-8369940</Version>
+      <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
+++ b/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-8079991</Version>
+      <Version>4.3.0-dev-eryondon-keyvault2-8369940</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Related to: https://github.com/NuGet/Engineering/issues/4704

Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault package dependency. Former one is deprecated.
This one is separate from previously merged https://github.com/NuGet/NuGetGallery/pull/9654, we have to another round of update due to circular dependency in NuGet.Jobs (NuGetGallery -> NuGet.Jobs -> NuGetGallery).