### PR TITLE
Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault, next iteration

### DIFF
--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -109,7 +109,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
-      <Version>4.3.0-dev-5066115</Version>
       <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
   </ItemGroup>

--- a/src/AccountDeleter/AccountDeleter.csproj
+++ b/src/AccountDeleter/AccountDeleter.csproj
@@ -110,6 +110,7 @@
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Common.Job">
       <Version>4.3.0-dev-5066115</Version>
+      <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -89,6 +89,7 @@
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
       <Version>4.3.0-dev-8079991</Version>
+      <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
       <Version>2.111.0</Version>

--- a/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
+++ b/src/GitHubVulnerabilities2Db/GitHubVulnerabilities2Db.csproj
@@ -88,7 +88,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-8079991</Version>
       <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -80,6 +80,7 @@
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
       <Version>4.3.0-dev-8079991</Version>
+      <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -79,7 +79,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-8079991</Version>
       <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
   </ItemGroup>

--- a/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
+++ b/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
@@ -62,7 +62,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Jobs.Common">
-      <Version>4.3.0-dev-8079991</Version>
       <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
   </ItemGroup>

--- a/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
+++ b/src/VerifyGitHubVulnerabilities/VerifyGitHubVulnerabilities.csproj
@@ -63,6 +63,7 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Jobs.Common">
       <Version>4.3.0-dev-8079991</Version>
+      <Version>4.3.0-dev-8382474</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Related to: https://github.com/NuGet/Engineering/issues/4704

Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault package dependency. Former one is deprecated.

This one is separate from previously merged https://github.com/NuGet/NuGetGallery/pull/9654, we have to another round of update due to circular dependency in NuGet.Jobs (`NuGetGallery -> NuGet.Jobs -> NuGetGallery`).

Previous `NuGetGallery -> NuGet.Jobs` iteration PR:  https://github.com/NuGet/NuGet.Jobs/pull/1148/files
This PR is for `NuGet.Jobs -> NuGetGallery` iteration and it's necessary for `Account Deleter job`.
