### PR TITLE
Add FlatContainer empty config to web.config

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -36,6 +36,7 @@
     <add key="Gallery.AzureStorage.Content.ConnectionString" value=""/>
     <add key="Gallery.AzureStorage.Errors.ConnectionString" value=""/>
     <add key="Gallery.AzureStorage.Packages.ConnectionString" value=""/>
+    <add key="Gallery.AzureStorage.FlatContainer.ConnectionString" value=""/>
     <add key="Gallery.AzureStorage.Statistics.ConnectionString" value=""/>
     <add key="Gallery.AzureStorage.Statistics.ConnectionString.Alternate" value=""/>
     <add key="Gallery.AzureStorage.Uploads.ConnectionString" value=""/>


### PR DESCRIPTION
This makes it easier to remember to set this value when you set the storage type to `AzureStorage`. This is needed when uploading embedded licenses.