### PR TITLE
Admin Panel for Popularity Transfers

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1060,36 +1060,33 @@ p.frameworktableinfo-text {
 .page-admin-index p {
   margin-bottom: 16px;
 }
-#popularity-transfer-success-message {
+.page-admin-popularity-transfers #popularityTransferSuccessMessage {
   white-space: pre-wrap;
 }
-.col-group-from-header {
-  background-color: #f2f2f2;
-}
-.col-group-to-header {
-  background-color: #ebebeb;
-}
-.col-group-from-data {
-  background-color: #f2f2f2;
-}
-.col-group-to-data {
-  background-color: #ebebeb;
-}
-#validatedInputResult {
+.page-admin-popularity-transfers #validatedInputResult {
   table-layout: fixed;
   width: 100%;
 }
-.col-group-1 {
+.page-admin-popularity-transfers .col-group-1 {
   width: 20%;
 }
-.col-group-2 {
+.page-admin-popularity-transfers .col-group-2 {
   width: 10%;
 }
-.col-group-3 {
+.page-admin-popularity-transfers .col-group-3 {
   width: 20%;
 }
-.display-validated-input {
-  padding-left: 0px;
+.page-admin-popularity-transfers .col-group-from-header {
+  background-color: #f2f2f2;
+}
+.page-admin-popularity-transfers .col-group-to-header {
+  background-color: #ebebeb;
+}
+.page-admin-popularity-transfers .col-group-from-data {
+  background-color: #f2f2f2;
+}
+.page-admin-popularity-transfers .col-group-to-data {
+  background-color: #ebebeb;
 }
 .page-api-keys .example-commands {
   background-color: #002440;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1060,6 +1060,37 @@ p.frameworktableinfo-text {
 .page-admin-index p {
   margin-bottom: 16px;
 }
+#popularity-transfer-success-message {
+  white-space: pre-wrap;
+}
+.col-group-from-header {
+  background-color: #f2f2f2;
+}
+.col-group-to-header {
+  background-color: #ebebeb;
+}
+.col-group-from-data {
+  background-color: #f2f2f2;
+}
+.col-group-to-data {
+  background-color: #ebebeb;
+}
+#validatedInputResult {
+  table-layout: fixed;
+  width: 100%;
+}
+.col-group-1 {
+  width: 20%;
+}
+.col-group-2 {
+  width: 10%;
+}
+.col-group-3 {
+  width: 20%;
+}
+.display-validated-input {
+  padding-left: 0px;
+}
 .page-api-keys .example-commands {
   background-color: #002440;
   font-family: Consolas, Menlo, Monaco, "Courier New", monospace;

--- a/src/Bootstrap/less/theme/all.less
+++ b/src/Bootstrap/less/theme/all.less
@@ -12,6 +12,7 @@
 @import "page-account-settings.less";
 @import "page-add-organization.less";
 @import "page-admin-index.less";
+@import "page-admin-popularity-transfers.less";
 @import "page-api-keys.less";
 @import "page-blog.less";
 @import "page-delete-account.less";

--- a/src/Bootstrap/less/theme/page-admin-popularity-transfers.less
+++ b/src/Bootstrap/less/theme/page-admin-popularity-transfers.less
@@ -1,40 +1,38 @@
-#popularity-transfer-success-message {
-    white-space: pre-wrap;
-}
-
-.col-group-from-header {
-    background-color: #f2f2f2;
-}
-
-.col-group-to-header {
-    background-color: #ebebeb;
-}
-
-.col-group-from-data {
-    background-color: #f2f2f2;
-}
-
-.col-group-to-data {
-    background-color: #ebebeb;
-}
-
-#validatedInputResult {
-    table-layout: fixed;
-    width: 100%;
-}
-
-.col-group-1 {
-    width: 20%;
-}
-
-.col-group-2 {
-    width: 10%;
-}
-
-.col-group-3 {
-    width: 20%;
-}
-
-.display-validated-input {
-    padding-left: 0px;
+.page-admin-popularity-transfers {
+    #popularityTransferSuccessMessage {
+        white-space: pre-wrap;
+    }
+    
+    #validatedInputResult {
+        table-layout: fixed;
+        width: 100%;
+    }
+    
+    .col-group-1 {
+        width: 20%;
+    }
+    
+    .col-group-2 {
+        width: 10%;
+    }
+    
+    .col-group-3 {
+        width: 20%;
+    }
+    
+    .col-group-from-header {
+        background-color: #f2f2f2;
+    }
+    
+    .col-group-to-header {
+        background-color: #ebebeb;
+    }
+    
+    .col-group-from-data {
+        background-color: #f2f2f2;
+    }
+    
+    .col-group-to-data {
+        background-color: #ebebeb;
+    }
 }

--- a/src/Bootstrap/less/theme/page-admin-popularity-transfers.less
+++ b/src/Bootstrap/less/theme/page-admin-popularity-transfers.less
@@ -1,0 +1,40 @@
+#popularity-transfer-success-message {
+    white-space: pre-wrap;
+}
+
+.col-group-from-header {
+    background-color: #f2f2f2;
+}
+
+.col-group-to-header {
+    background-color: #ebebeb;
+}
+
+.col-group-from-data {
+    background-color: #f2f2f2;
+}
+
+.col-group-to-data {
+    background-color: #ebebeb;
+}
+
+#validatedInputResult {
+    table-layout: fixed;
+    width: 100%;
+}
+
+.col-group-1 {
+    width: 20%;
+}
+
+.col-group-2 {
+    width: 10%;
+}
+
+.col-group-3 {
+    width: 20%;
+}
+
+.display-validated-input {
+    padding-left: 0px;
+}

--- a/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
@@ -164,7 +164,6 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
             _packageRenameRepository.DeleteOnCommit(previousPackageRenames);
             _packageRenameRepository.InsertOnCommit(newPackageRenames);
-            await _packageRenameRepository.CommitChangesAsync();
 
             await _entitiesContext.SaveChangesAsync();
 

--- a/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
@@ -70,13 +70,13 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 var packageTo = _packageService.FindPackageRegistrationById(packagesTo[i]);
 
                 // check for invalid package ids
-                if (packageFrom is null)
+                if (packageFrom is null || !packageFrom.Packages.Any())
                 {
                     return Json(HttpStatusCode.BadRequest,
                                 $"Could not find a package with the Package ID: {packagesFrom[i]}",
                                 JsonRequestBehavior.AllowGet);
                 }
-                if (packageTo is null)
+                if (packageTo is null || !packageTo.Packages.Any())
                 {
                     return Json(HttpStatusCode.BadRequest,
                                 $"Could not find a package with the Package ID: {packagesTo[i]}",
@@ -84,21 +84,18 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 }
 
                 // check for duplicate package ids
-                if (inputKeys.Contains(packageFrom.Key))
+                if (!inputKeys.Add(packageFrom.Key))
                 {
                     return Json(HttpStatusCode.BadRequest,
                                 $"{packageFrom.Id} appears twice. Please remove duplicate Package IDs from the 'From' and 'To' fields.",
                                 JsonRequestBehavior.AllowGet);
                 }
-                if (inputKeys.Contains(packageTo.Key))
+                if (!inputKeys.Add(packageTo.Key))
                 {
                     return Json(HttpStatusCode.BadRequest,
                                 $"{packageTo.Id} appears twice. Please remove duplicate Package IDs from the 'From' and 'To' fields.",
                                 JsonRequestBehavior.AllowGet);
                 }
-
-                inputKeys.Add(packageFrom.Key);
-                inputKeys.Add(packageTo.Key);
 
                 // create validated input result
                 var input = new PopularityTransferItem(CreatePackageSearchResult(packageFrom.Packages.First()),
@@ -160,10 +157,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 var previousRenames = _packageRenameService.GetPackageRenames(_packageService.FindPackageRegistrationById(input.FromId));
                 previousPackageRenames.AddRange(previousRenames);
 
-                if (input.FromId.Length > maxIdLength)
-                {
-                    maxIdLength = input.FromId.Length;
-                }
+                maxIdLength = Math.Max(maxIdLength, input.FromId.Length);
             }
 
             var result = new PopularityTransferViewModel();

--- a/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
@@ -48,12 +48,12 @@ namespace NuGetGallery.Areas.Admin.Controllers
             var packagesFrom = packagesFromInput
                                         .Split(null) // all whitespace
                                         .Where(id => id != string.Empty)
-                                        .Select(id => _packageService.FindPackageRegistrationById(id.Trim()))
+                                        .Select(id => id.Trim())
                                         .ToList();
             var packagesTo = packagesToInput
                                         .Split(null) // all whitespace
                                         .Where(id => id != string.Empty)
-                                        .Select(id => _packageService.FindPackageRegistrationById(id.Trim()))
+                                        .Select(id => id.Trim())
                                         .ToList();
 
             if (packagesFrom.Count != packagesTo.Count)
@@ -65,27 +65,19 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
             for (int i = 0; i < packagesFrom.Count; i++)
             {
-                var packageFrom = packagesFrom[i];
-                var packageTo = packagesTo[i];
+                var packageFrom = _packageService.FindPackageRegistrationById(packagesFrom[i]);
+                var packageTo = _packageService.FindPackageRegistrationById(packagesTo[i]);
 
                 if (packageFrom is null)
                 {
-                    var InvalidId = packagesFromInput
-                                                    .Split(null)
-                                                    .Where(id => id != string.Empty)
-                                                    .ToList()[i].Trim();
                     return Json(HttpStatusCode.BadRequest,
-                                $"Could not find a package with the Package ID: {InvalidId}",
+                                $"Could not find a package with the Package ID: {packagesFrom[i]}",
                                 JsonRequestBehavior.AllowGet);
                 }
                 if (packageTo is null)
                 {
-                    var InvalidId = packagesToInput
-                                                    .Split(null)
-                                                    .Where(id => id != string.Empty)
-                                                    .ToList()[i].Trim();
                     return Json(HttpStatusCode.BadRequest,
-                                $"Could not find a package with the Package ID: {InvalidId}",
+                                $"Could not find a package with the Package ID: {packagesTo[i]}",
                                 JsonRequestBehavior.AllowGet);
                 }
 

--- a/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
@@ -1,0 +1,98 @@
+﻿using Azure.Core;
+using Lucene.Net.Search;
+using NuGetGallery.Areas.Admin.Models;
+using NuGetGallery.Areas.Admin.ViewModels;
+using NuGetGallery.Auditing;
+using NuGet.Services.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Mvc;
+
+namespace NuGetGallery.Areas.Admin.Controllers
+{
+    public class PopularityTransferController : AdminControllerBase
+    {
+        private readonly IPackageService _packageService;
+        private readonly IEntityRepository<PackageRename> _packageRenameRepository;
+        private readonly IEntitiesContext _entitiesContext;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IAuditingService _auditingService;
+        private readonly ITelemetryService _telemetryService;
+
+        public PopularityTransferController(
+            IPackageService packageService,
+            ITelemetryService telemetryService,
+            IEntityRepository<PackageRename> packageRenameRepository,
+            IEntitiesContext entitiesContext,
+            IDateTimeProvider dateTimeProvider,
+            IAuditingService auditingService)
+        {
+            _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
+            _packageRenameRepository = packageRenameRepository ?? throw new ArgumentNullException(nameof(packageRenameRepository));
+            _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
+            _dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));
+            _auditingService = auditingService ?? throw new ArgumentNullException(nameof(auditingService));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+        }
+
+        [HttpGet]
+        public ViewResult Index(PopularityTransferViewModel viewModel)
+        {
+            return View(viewModel ?? new PopularityTransferViewModel());
+        }
+
+        [HttpGet]
+        public ActionResult ValidateInputs(string packagesFromInput, string packagesToInput)
+        {
+            if (string.IsNullOrEmpty(packagesFromInput) || string.IsNullOrEmpty(packagesToInput))
+            {
+                return Json(HttpStatusCode.BadRequest, "Package IDs in the 'From' or 'To' fields cannot be null or empty.", JsonRequestBehavior.AllowGet);
+            }
+
+            var packagesFromListTemp = packagesFromInput
+                                                .Split(null) // all whitespace
+                                                .ToList();
+            var packagesToListTemp = packagesToInput
+                                                .Split(null) // all whitespace
+                                                .ToList();
+
+            var packagesFromList = packagesFromInput
+                                                .Split(null) // all whitespace
+                                                .Select(id => _packageService.FindPackageRegistrationById(id))
+                                                .ToList();
+            var packagesToList = packagesToInput
+                                                .Split(null) // all whitespace
+                                                .Select(id => _packageService.FindPackageRegistrationById(id))
+                                                .ToList();
+
+            if (packagesFromList.Count != packagesToList.Count)
+            {
+                return Json(HttpStatusCode.BadRequest, "There must be an equal number of Package IDs in the 'From' and 'To' fields.", JsonRequestBehavior.AllowGet);
+            }
+
+            var resultTemp = new ValidatedInputsResult();
+
+            for (int i = 0; i < packagesFromList.Count; i++)
+            {
+                var input = new ValidatedInput(packagesFromListTemp[i], packagesToListTemp[i]);
+                resultTemp.ValidatedInputs.Add(input);
+            }
+
+            var result = new ValidatedInputsResult();
+
+            for (int i = 0; i < packagesFromList.Count; i++)
+            {
+                var input = new ValidatedInput(CreatePackageSearchResult(packagesFromList[i].Packages.First()),
+                                               CreatePackageSearchResult(packagesToList[i].Packages.First()));
+
+                result.ValidatedInputs.Add(input);
+            }
+
+            return Json(result, JsonRequestBehavior.AllowGet);
+        }
+    }
+}

--- a/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
@@ -185,7 +185,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
             foreach (var input in confirmedInputs)
             {
-                message += $"\t{input.FromId.PadRight(maxIdLength)}  --->  {input.ToId}\n";
+                message += $"\t{input.FromId.PadRight(maxIdLength)}  ➡️  {input.ToId}\n";
             }
 
             message += "\nIt can take up to 30 minutes for the popularity transfer(s) to be applied.";

--- a/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
@@ -2,13 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Security.Policy;
 using System.Web;
 using System.Web.Mvc;
-using NuGet.Services.Entities;
-using NuGetGallery;
 
 namespace NuGetGallery.Areas.Admin.ViewModels
 {
@@ -16,74 +11,53 @@ namespace NuGetGallery.Areas.Admin.ViewModels
     {
         public PopularityTransferViewModel()
         {
-            PackagesFromResult = new List<Package>();
-            PackagesToResult = new List<Package>();
-
-            TempPackagesFromResult = new List<string>();
-            TempPackagesToResult = new List<string>();
-
-            Input = new PopularityTransferInput();
+            ValidatedInputs = new List<PopularityTransferItem>();
+            ExistingPackageRenames = new List<string>();
+            SuccessMessage = string.Empty;
         }
 
-        [Required(ErrorMessage = "You must provide at least one package ID.")]
-        public string PackagesFromInput { get; set; }
-        [Required(ErrorMessage = "You must provide at least one package ID.")]
-        public string PackagesToInput { get; set; }
-
-        public List<Package> PackagesFromResult { get; set; }
-        public List<Package> PackagesToResult { get; set; }
-
-        public List<string> TempPackagesFromResult { get; set; }
-        public List<string> TempPackagesToResult { get; set; }
-
-        public PopularityTransferInput Input { get; set; }
+        public List<PopularityTransferItem> ValidatedInputs { get; set; }
+        public List<string> ExistingPackageRenames { get; set; }
+        public string SuccessMessage { get; set; } = string.Empty;
     }
 
-    public class ValidatedInputsResult
+    public class PopularityTransferItem
     {
-        public ValidatedInputsResult()
+        public PopularityTransferItem()
         {
-            ValidatedInputs = new List<ValidatedInput>();
+            FromOwners = new List<UserViewModel>();
+            ToOwners = new List<UserViewModel>();
         }
-
-        public List<ValidatedInput> ValidatedInputs { get; set; }
-        public string Warnings { get; set; }
-    }
-
-    public class ValidatedInput
-    {
-        public ValidatedInput(string packageFrom, string packageTo)
-        {
-            FromId = packageFrom;
-            FromUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageFrom);
-            FromDownloads = 0;
-
-            ToId = packageTo;
-            ToUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageTo);
-            ToDownloads = 0;
-        }
-
-        public ValidatedInput(PackageSearchResult packageFrom, PackageSearchResult packageTo)
+        
+        public PopularityTransferItem(
+            PackageSearchResult packageFrom, 
+            PackageSearchResult packageTo,
+            int fromKey,
+            int toKey)
         {
             FromId = packageFrom.PackageId;
             FromUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageFrom.PackageId);
             FromDownloads = packageFrom.DownloadCount;
             FromOwners = packageFrom.Owners;
+            FromKey = fromKey;
 
             ToId = packageTo.PackageId;
             ToUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageTo.PackageId);
             ToDownloads = packageTo.DownloadCount;
             ToOwners = packageTo.Owners;
+            ToKey = toKey;
         }
 
         public string FromId { get; set; }
         public string FromUrl { get; set; }
         public long FromDownloads { get; set; }
         public IReadOnlyList<UserViewModel> FromOwners { get; set; } = new List<UserViewModel>();
+        public int FromKey { get; set; }
 
         public string ToId { get; set; }
         public string ToUrl { get; set; }
         public long ToDownloads { get; set; }
         public IReadOnlyList<UserViewModel> ToOwners { get; set; } = new List<UserViewModel>();
+        public int ToKey { get; set; }
     }
 }

--- a/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Security.Policy;
+using System.Web;
+using System.Web.Mvc;
+using NuGet.Services.Entities;
+using NuGetGallery;
+
+namespace NuGetGallery.Areas.Admin.ViewModels
+{
+    public class PopularityTransferViewModel
+    {
+        public PopularityTransferViewModel()
+        {
+            PackagesFromResult = new List<Package>();
+            PackagesToResult = new List<Package>();
+
+            TempPackagesFromResult = new List<string>();
+            TempPackagesToResult = new List<string>();
+
+            Input = new PopularityTransferInput();
+        }
+
+        [Required(ErrorMessage = "You must provide at least one package ID.")]
+        public string PackagesFromInput { get; set; }
+        [Required(ErrorMessage = "You must provide at least one package ID.")]
+        public string PackagesToInput { get; set; }
+
+        public List<Package> PackagesFromResult { get; set; }
+        public List<Package> PackagesToResult { get; set; }
+
+        public List<string> TempPackagesFromResult { get; set; }
+        public List<string> TempPackagesToResult { get; set; }
+
+        public PopularityTransferInput Input { get; set; }
+    }
+
+    public class ValidatedInputsResult
+    {
+        public ValidatedInputsResult()
+        {
+            ValidatedInputs = new List<ValidatedInput>();
+        }
+
+        public List<ValidatedInput> ValidatedInputs { get; set; }
+        public string Warnings { get; set; }
+    }
+
+    public class ValidatedInput
+    {
+        public ValidatedInput(string packageFrom, string packageTo)
+        {
+            FromId = packageFrom;
+            FromUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageFrom);
+            FromDownloads = 0;
+
+            ToId = packageTo;
+            ToUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageTo);
+            ToDownloads = 0;
+        }
+
+        public ValidatedInput(PackageSearchResult packageFrom, PackageSearchResult packageTo)
+        {
+            FromId = packageFrom.PackageId;
+            FromUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageFrom.PackageId);
+            FromDownloads = packageFrom.DownloadCount;
+            FromOwners = packageFrom.Owners;
+
+            ToId = packageTo.PackageId;
+            ToUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageTo.PackageId);
+            ToDownloads = packageTo.DownloadCount;
+            ToOwners = packageTo.Owners;
+        }
+
+        public string FromId { get; set; }
+        public string FromUrl { get; set; }
+        public long FromDownloads { get; set; }
+        public IReadOnlyList<UserViewModel> FromOwners { get; set; } = new List<UserViewModel>();
+
+        public string ToId { get; set; }
+        public string ToUrl { get; set; }
+        public long ToDownloads { get; set; }
+        public IReadOnlyList<UserViewModel> ToOwners { get; set; } = new List<UserViewModel>();
+    }
+}

--- a/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
@@ -241,7 +241,18 @@
                     </a>
                 </h2>
                 <p class="text-muted">
-                    Add or remove a user for Password Authentications
+                    Add or remove a user for Password Authentications.
+                </p>
+            </li>
+            <li class="col-sm-6 col-xs-12">
+                <h2>
+                    <a href="@Url.Action(actionName: "Index", controllerName: "PopularityTransfer")">
+                        <i class="ms-Icon ms-Icon--Flow"></i>
+                        <span>Popularity Transfers</span>
+                    </a>
+                </h2>
+                <p class="text-muted">
+                    Transfer popularity from one package to another.
                 </p>
             </li>
         </ul>

--- a/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
@@ -1,0 +1,295 @@
+﻿@model PopularityTransferViewModel
+@{
+    ViewBag.Title = "Popularity Transfers";
+}
+@ViewHelpers.AjaxAntiForgeryToken(Html)
+
+<section role="main" class="container main-container">
+
+    <div>
+        <h2>Popularity Transfers</h2>
+        <p>Transfer popularity from one package to another.</p>
+
+        <form class="form-horizontal" name="inputValidationForm" method="get">
+            <div class="form-group has-error"><div class="col-xs-12">@Html.ShowValidationMessagesForEmpty()</div></div>
+            <i>List the Package IDs you want to transfer popularity <b>from</b> and <b>to</b>.</i>
+            <div class="form-group @Html.HasErrorFor(m => m.Input.PackagesFromInput)">
+                <div class="col-xs-12">@Html.ShowValidationMessagesFor(m => m.Input.PackagesFromInput)</div>
+                <div class="col-xs-12">
+                    <label for="packagesFromInput" class="control-label">From</label>
+                    <textarea class="form-control" rows="5" id="packagesFromInput" name="packagesFromInput" placeholder="Package IDs to transfer popularity FROM, one per line" data-bind="value: packagesFromInput"></textarea>
+                </div>
+            </div>
+            <div class="form-group @Html.HasErrorFor(m => m.Input.PackagesToInput)">
+                <div class="col-xs-12">@Html.ShowValidationMessagesFor(m => m.Input.PackagesToInput)</div>
+                <div class="col-xs-12">
+                    <label for="packagesToInput" class="control-label">To</label>
+                    <textarea class="form-control" rows="5" id="packagesToInput" name="packagesToInput" placeholder="Package IDs to transfer popularity TO, one per line" data-bind="value: packagesToInput"></textarea>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-xs-12">
+                    <button type="submit" class="btn btn-block btn-primary" data-bind="click: validateInputs">Validate input</button>
+                </div>
+            </div>
+        </form>
+
+        <div style="display:none" data-bind="visible: errorInputs">
+            @ViewHelpers.AlertDanger(@<text><span data-bind="text: errorInputs"></span></text>)
+        </div>
+
+        <div style="display: none" data-bind="visible: doneValidateInputs() && !errorInputs()">
+            <h3>Input</h3>
+            <table class="table" id="validatedInputResult" aria-label="popularity transfer packages selected">
+                <thead>
+                    <tr>
+                        <th>Package ID (From)</th>
+                        <th>Downloads (From)</th>
+                        <th>Owners (From)</th>
+                        <th>Package ID (To)</th>
+                        <th>Downloads (To)</th>
+                        <th>Owners (To)</th>
+                    </tr>
+                </thead>
+                <tbody data-bind="foreach: validatedInputs">
+                    <tr>
+                        <td><a href="#" data-bind="text: FromId, attr: { href: FromUrl }"></a></td>
+                        <td><span data-bind="text: FromDownloads"></span></td>
+                        <td data-bind="foreach: FromOwners">
+                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
+                        </td>
+                        <td><a href="#" data-bind="text: ToId, attr: { href: ToUrl }"></a></td>
+                        <td><span data-bind="text: ToDownloads"></span></td>
+                        <td data-bind="foreach: ToOwners">
+                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <h2>Validate new username</h2>
+
+        <i>Validate if the new username is available and has a valid format.</i><br />
+
+        <input type="text" placeholder="New username" autocomplete="off" autofocus style="width: 200px;" rows="1" data-bind="value: newUsername" />
+        <button type="submit" data-bind="click: validateNewUsername">Validate</button>
+        <div style="display:none" data-bind="visible: errorNewUsername">
+            @ViewHelpers.AlertDanger(@<text><span data-bind="text: errorNewUsername"></span></text>)
+        </div>
+
+        <div style="display: none" data-bind="visible: doneValidatingNewUsername() && !errorNewUsername()">
+            <div style="display:none;" data-bind="visible: validatationUsernameResult.IsFormatValid()"><i class="ms-Icon ms-Icon--CompletedSolid" style="color: green"></i> Username has a valid format.</div>
+            <div style="display:none;" data-bind="visible: !validatationUsernameResult.IsFormatValid()"><i class="ms-Icon ms-Icon--StatusErrorFull" style="color: red"></i> Username has invalid format.</div>
+            <div style="display:none;" data-bind="visible: validatationUsernameResult.IsAvailable()"><i class="ms-Icon ms-Icon--CompletedSolid" style="color: green"></i> Username is available.</div>
+            <div style="display:none;" data-bind="visible: !validatationUsernameResult.IsAvailable()"><i class="ms-Icon ms-Icon--StatusErrorFull" style="color: red"></i> Username is already taken.</div>
+        </div>
+    </div>
+
+    <div>
+        <h2>Change username</h2>
+        @using (Html.BeginForm())
+        {
+            @Html.AntiForgeryToken()
+            <i>Update current account username.</i><br />
+            <input type="text" placeholder="Old username" autocomplete="off" autofocus style="width: 200px;" rows="1" data-bind="value: changeOldUsername" />
+            <input type="text" placeholder="New username" autocomplete="off" autofocus style="width: 200px;" rows="1" data-bind="value: changeNewUsername" />
+            <button type="submit" data-bind="click: changeUsername">Change</button>
+        }
+        <div style="display:none" data-bind="visible: changeUsernameSuccessful">
+            @ViewHelpers.Alert(@<text><span data-bind="text: changeUsernameSuccessful"></span></text>, "success", "Info")
+        </div>
+        <div style="display:none" data-bind="visible: errorChangeUsername">
+            @ViewHelpers.AlertDanger(@<text><span data-bind="text: errorChangeUsername"></span></text>)
+        </div>
+    </div>
+</section>
+
+@section BottomScripts {
+    <script>
+        $(document).ready(function () {
+            var viewModel = function () {
+                var $self = this;
+
+                this.packagesFromInput = ko.observable('');
+                this.packagesToInput = ko.observable('');
+
+                this.doneValidateInputs = ko.observable(false);
+                this.errorInputs = ko.observable('');
+
+                var actionUrlValidateInputs = '@Url.Action("ValidateInputs", "PopularityTransfer", new {area = "Admin"})';
+
+                this.packagesFrom = ko.observableArray([]);
+                this.packagesTo = ko.observableArray([]);
+
+
+                this.validatedInputs = ko.observableArray([]);
+                this.warnings = ko.observable('');
+
+
+
+                this.packagesFromTemp = ko.observableArray([]);
+                this.packagesToTemp = ko.observableArray([]);
+
+
+
+
+                this.account = {
+                    Username: ko.observable(''),
+                    EmailAddress: ko.observable('')
+                }
+
+
+
+                this.validateInputs = function () {
+                    $self.doneValidateInputs(false);
+                    $self.packagesFrom([]);
+                    $self.packagesTo([]);
+                    $self.validatedInputs([]);
+                    $self.errorInputs('');
+
+                    if (!$self.packagesFromInput() || !$self.packagesToInput()) {
+                        $self.errorInputs('Package IDs in the \'From\' or \'To\' fields cannot be null or empty.');
+                        return;
+                    }
+
+                    var queryParams = '?packagesFromInput=' + encodeURIComponent($self.packagesFromInput().trim())
+                        + '&packagesToInput=' + encodeURIComponent($self.packagesToInput().trim());
+
+                    $.ajax({
+                        url: actionUrlValidateInputs + queryParams,
+                        cache: false,
+                        dataType: 'json',
+                        success: function (result) {
+                            //$self.packagesFrom(result.PackagesFrom);
+                            //$self.packagesTo(result.PackagesTo);
+                            //$self.packagesFromTemp(result.PackagesFromTemp);
+                            //$self.packagesToTemp(result.PackagesToTemp);
+                            $self.validatedInputs(result.ValidatedInputs);
+                            //$self.warnings(result.Warnings);
+                        }
+                    })
+                        .fail(function (xhr, textStatus, errorMessage) {
+                            if (jqXhr) {
+                                $self.errorInputs(xhr.responseJSON);
+                            }
+                            else {
+                                alert('Error: ' + errorMessage);
+                            }
+                        })
+                        .always(function () {
+                            $self.doneValidateInputs(true);
+                        });
+                };
+
+                this.individualAccountMessage = 'This is an individual account.';
+                this.organizationAccountMessage = 'This is an organization account.';
+
+                this.accountEmailOrUsername = ko.observable('');
+                this.account = {
+                    Username: ko.observable(''),
+                    EmailAddress: ko.observable('')
+                }
+                this.accountAdministrators = ko.observableArray([]);
+                this.newUsername = ko.observable('');
+                this.validatationUsernameResult = {
+                    IsFormatValid: ko.observable(false),
+                    IsAvailable: ko.observable(false)
+                }
+                this.changeOldUsername = ko.observable('');
+                this.changeNewUsername = ko.observable('');
+
+                this.doneVerifyAccount = ko.observable(false);
+                this.doneValidatingNewUsername = ko.observable(false);
+
+                this.errorAccount = ko.observable('');
+                this.errorNewUsername = ko.observable('');
+                this.errorChangeUsername = ko.observable('');
+                this.changeUsernameSuccessful = ko.observable('');
+
+                var actionUrlVerifyAccount = '@Url.Action("VerifyAccount", "ChangeUsername", new {area = "Admin"})';
+                var actionUrlValidateNewUsername = '@Url.Action("ValidateNewUsername", "ChangeUsername", new {area = "Admin"})';
+                var actionUrlChangeUsername = '@Url.Action("ChangeUsername", "ChangeUsername", new {area = "Admin"})';
+
+                this.validateNewUsername = function () {
+                    $self.doneValidatingNewUsername(false);
+                    $self.errorNewUsername('');
+
+                    if (!$self.newUsername()) {
+                        $self.errorNewUsername('Username cannot be null or empty.');
+                        return;
+                    }
+
+                    var queryParams = '?newUsername=' + encodeURIComponent($self.newUsername().trim());
+
+                    $.ajax({
+                        url: actionUrlValidateNewUsername + queryParams,
+                        cache: false,
+                        dataType: 'json',
+                        success: function (data) {
+                            $self.validatationUsernameResult.IsFormatValid(data.IsFormatValid);
+                            $self.validatationUsernameResult.IsAvailable(data.IsAvailable);
+                        }
+                    })
+                    .fail(function (jqXhr, textStatus, errorThrown) {
+                        if (jqXhr) {
+                            $self.errorNewUsername(jqXhr.responseJSON);
+                        }
+                        else {
+                            alert('Error: ' + errorThrown);
+                        }
+                    })
+                    .always(function () {
+                        $self.doneValidatingNewUsername(true);
+                    });
+                };
+
+                this.changeUsername = function (model, event) {
+                    $self.errorChangeUsername('');
+                    $self.changeUsernameSuccessful('');
+
+                    var data = {
+                        oldUsername: $self.changeOldUsername().trim(),
+                        newUsername: $self.changeNewUsername().trim(),
+                    };
+
+                    if (!data.oldUsername || !data.newUsername) {
+                        $self.errorChangeUsername('Usernames should not be empty.');
+                        event.preventDefault();
+                        return;
+                    }
+
+                    if (data.oldUsername && data.newUsername && !confirm("Are you sure you want to change account username from " + data.oldUsername + " to " + data.newUsername + "?")) {
+                        event.preventDefault();
+                        return;
+                    }
+
+                    $.ajax({
+                        url: actionUrlChangeUsername,
+                        cache: false,
+                        dataType: 'json',
+                        type: 'POST',
+                        data: window.nuget.addAjaxAntiForgeryToken(data),
+                        success: function (data) {
+                            $self.changeUsernameSuccessful(data)
+                        }
+                    })
+                    .fail(function (jqXhr, textStatus, errorThrown) {
+                        if (jqXhr) {
+                            $self.errorChangeUsername(jqXhr.responseJSON);
+                        }
+                        else {
+                            alert('Error: ' + errorThrown);
+                        }
+                    });
+                };
+
+                this.generateProfileUrl = function (username) {
+                    return '/profiles/' + username;
+                };
+            }
+
+            ko.applyBindings(new viewModel(), $('.main-container').get(0));
+        });
+    </script>
+}

--- a/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
@@ -3,9 +3,9 @@
 }
 @ViewHelpers.AjaxAntiForgeryToken(Html)
 
-<section role="main" class="container main-container">
+<section role="main" class="container main-container page-admin-popularity-transfers">
     <div class="row col-md-12" style="display:none" data-bind="visible: successMessage">
-        <div id="popularity-transfer-success-message" class="alert alert-success" role="alert" data-bind="text: successMessage"></div>
+        <div id="popularityTransferSuccessMessage" class="alert alert-success" role="alert" data-bind="text: successMessage"></div>
     </div>
 
     <div>

--- a/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
@@ -1,106 +1,77 @@
-﻿@model PopularityTransferViewModel
-@{
+﻿@{
     ViewBag.Title = "Popularity Transfers";
 }
 @ViewHelpers.AjaxAntiForgeryToken(Html)
 
 <section role="main" class="container main-container">
+    <div class="row col-md-12" style="display:none" data-bind="visible: successMessage">
+        <div id="popularity-transfer-success-message" class="alert alert-success" role="alert" data-bind="text: successMessage"></div>
+    </div>
 
     <div>
         <h2>Popularity Transfers</h2>
         <p>Transfer popularity from one package to another.</p>
 
-        <form class="form-horizontal" name="inputValidationForm" method="get">
-            <div class="form-group has-error"><div class="col-xs-12">@Html.ShowValidationMessagesForEmpty()</div></div>
-            <i>List the Package IDs you want to transfer popularity <b>from</b> and <b>to</b>.</i>
-            <div class="form-group @Html.HasErrorFor(m => m.Input.PackagesFromInput)">
-                <div class="col-xs-12">@Html.ShowValidationMessagesFor(m => m.Input.PackagesFromInput)</div>
-                <div class="col-xs-12">
+        <div>
+            <form class="form-horizontal" name="inputValidationForm" method="get">
+                <i>List the Package IDs you want to transfer popularity <b>from</b> and <b>to</b>.</i>
+                <div class="form-group col-md-12">
                     <label for="packagesFromInput" class="control-label">From</label>
                     <textarea class="form-control" rows="5" id="packagesFromInput" name="packagesFromInput" placeholder="Package IDs to transfer popularity FROM, one per line" data-bind="value: packagesFromInput"></textarea>
                 </div>
-            </div>
-            <div class="form-group @Html.HasErrorFor(m => m.Input.PackagesToInput)">
-                <div class="col-xs-12">@Html.ShowValidationMessagesFor(m => m.Input.PackagesToInput)</div>
-                <div class="col-xs-12">
+                <div class="form-group col-md-12">
                     <label for="packagesToInput" class="control-label">To</label>
                     <textarea class="form-control" rows="5" id="packagesToInput" name="packagesToInput" placeholder="Package IDs to transfer popularity TO, one per line" data-bind="value: packagesToInput"></textarea>
                 </div>
-            </div>
-            <div class="form-group">
-                <div class="col-xs-12">
+                <div class="form-group col-md-12">
                     <button type="submit" class="btn btn-block btn-primary" data-bind="click: validateInputs">Validate input</button>
                 </div>
-            </div>
-        </form>
-
-        <div style="display:none" data-bind="visible: errorInputs">
-            @ViewHelpers.AlertDanger(@<text><span data-bind="text: errorInputs"></span></text>)
+            </form>
         </div>
 
-        <div style="display: none" data-bind="visible: doneValidateInputs() && !errorInputs()">
-            <h3>Input</h3>
-            <table class="table" id="validatedInputResult" aria-label="popularity transfer packages selected">
+        <div class="row col-md-12" style="display:none" data-bind="visible: errorInputs">
+            @ViewHelpers.AlertDanger(@<text><span data-bind="text: errorInputs"></span></text>)
+        </div>
+    </div>
+
+    <div style="display: none" data-bind="visible: doneValidateInputs() && !errorInputs()">
+        <h3>Preview of changes</h3>
+
+        <div class="form-horizontal">
+            <table class="table form-group col-md-12" id="validatedInputResult" aria-label="preview of popularity transfer changes">
                 <thead>
                     <tr>
-                        <th>Package ID (From)</th>
-                        <th>Downloads (From)</th>
-                        <th>Owners (From)</th>
-                        <th>Package ID (To)</th>
-                        <th>Downloads (To)</th>
-                        <th>Owners (To)</th>
+                        <th class="col-group-from-header col-group-1">Package ID<br />(From)</th>
+                        <th class="col-group-from-header col-group-2">Downloads<br />(From)</th>
+                        <th class="col-group-from-header col-group-3">Owners<br />(From)</th>
+                        <th class="col-group-to-header col-group-1">Package ID<br />(To)</th>
+                        <th class="col-group-to-header col-group-2">Downloads<br />(To)</th>
+                        <th class="col-group-to-header col-group-3">Owners<br />(To)</th>
                     </tr>
                 </thead>
                 <tbody data-bind="foreach: validatedInputs">
                     <tr>
-                        <td><a href="#" data-bind="text: FromId, attr: { href: FromUrl }"></a></td>
-                        <td><span data-bind="text: FromDownloads"></span></td>
-                        <td data-bind="foreach: FromOwners">
+                        <td class="col-group-from-data col-group-1"><a href="#" data-bind="text: FromId, attr: { href: FromUrl }"></a></td>
+                        <td class="col-group-from-data col-group-2"><span data-bind="text: FromDownloads"></span></td>
+                        <td class="col-group-from-data col-group-3" data-bind="foreach: FromOwners">
                             <a data-bind="text: Username, attr: { href: ProfileUrl }" />
                         </td>
-                        <td><a href="#" data-bind="text: ToId, attr: { href: ToUrl }"></a></td>
-                        <td><span data-bind="text: ToDownloads"></span></td>
-                        <td data-bind="foreach: ToOwners">
+                        <td class="col-group-to-data col-group-1"><a href="#" data-bind="text: ToId, attr: { href: ToUrl }"></a></td>
+                        <td class="col-group-to-data col-group-2"><span data-bind="text: ToDownloads"></span></td>
+                        <td class="col-group-to-data col-group-3" data-bind="foreach: ToOwners">
                             <a data-bind="text: Username, attr: { href: ProfileUrl }" />
                         </td>
                     </tr>
                 </tbody>
             </table>
-        </div>
 
-        <h2>Validate new username</h2>
+            <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenames().length > 0, foreach: existingPackageRenames">
+                @ViewHelpers.AlertInfo(@<text><span data-bind="text: $data"></span></text>)
+            </div>
 
-        <i>Validate if the new username is available and has a valid format.</i><br />
-
-        <input type="text" placeholder="New username" autocomplete="off" autofocus style="width: 200px;" rows="1" data-bind="value: newUsername" />
-        <button type="submit" data-bind="click: validateNewUsername">Validate</button>
-        <div style="display:none" data-bind="visible: errorNewUsername">
-            @ViewHelpers.AlertDanger(@<text><span data-bind="text: errorNewUsername"></span></text>)
-        </div>
-
-        <div style="display: none" data-bind="visible: doneValidatingNewUsername() && !errorNewUsername()">
-            <div style="display:none;" data-bind="visible: validatationUsernameResult.IsFormatValid()"><i class="ms-Icon ms-Icon--CompletedSolid" style="color: green"></i> Username has a valid format.</div>
-            <div style="display:none;" data-bind="visible: !validatationUsernameResult.IsFormatValid()"><i class="ms-Icon ms-Icon--StatusErrorFull" style="color: red"></i> Username has invalid format.</div>
-            <div style="display:none;" data-bind="visible: validatationUsernameResult.IsAvailable()"><i class="ms-Icon ms-Icon--CompletedSolid" style="color: green"></i> Username is available.</div>
-            <div style="display:none;" data-bind="visible: !validatationUsernameResult.IsAvailable()"><i class="ms-Icon ms-Icon--StatusErrorFull" style="color: red"></i> Username is already taken.</div>
-        </div>
-    </div>
-
-    <div>
-        <h2>Change username</h2>
-        @using (Html.BeginForm())
-        {
-            @Html.AntiForgeryToken()
-            <i>Update current account username.</i><br />
-            <input type="text" placeholder="Old username" autocomplete="off" autofocus style="width: 200px;" rows="1" data-bind="value: changeOldUsername" />
-            <input type="text" placeholder="New username" autocomplete="off" autofocus style="width: 200px;" rows="1" data-bind="value: changeNewUsername" />
-            <button type="submit" data-bind="click: changeUsername">Change</button>
-        }
-        <div style="display:none" data-bind="visible: changeUsernameSuccessful">
-            @ViewHelpers.Alert(@<text><span data-bind="text: changeUsernameSuccessful"></span></text>, "success", "Info")
-        </div>
-        <div style="display:none" data-bind="visible: errorChangeUsername">
-            @ViewHelpers.AlertDanger(@<text><span data-bind="text: errorChangeUsername"></span></text>)
+            <div class="form-group col-md-12">
+                <button type="submit" class="btn btn-block btn-primary" data-bind="click: submitInputs">Submit changes</button>
+            </div>
         </div>
     </div>
 </section>
@@ -111,42 +82,27 @@
             var viewModel = function () {
                 var $self = this;
 
+                var actionUrlValidateInputs = '@Url.Action("ValidateInputs", "PopularityTransfer", new {area = "Admin"})';
+                var actionUrlSubmitInputs = '@Url.Action("ExecutePopularityTransfer", "PopularityTransfer", new {area = "Admin"})';
+
                 this.packagesFromInput = ko.observable('');
                 this.packagesToInput = ko.observable('');
-
                 this.doneValidateInputs = ko.observable(false);
                 this.errorInputs = ko.observable('');
 
-                var actionUrlValidateInputs = '@Url.Action("ValidateInputs", "PopularityTransfer", new {area = "Admin"})';
-
-                this.packagesFrom = ko.observableArray([]);
-                this.packagesTo = ko.observableArray([]);
-
-
                 this.validatedInputs = ko.observableArray([]);
-                this.warnings = ko.observable('');
+                this.existingPackageRenames = ko.observableArray([]);
 
-
-
-                this.packagesFromTemp = ko.observableArray([]);
-                this.packagesToTemp = ko.observableArray([]);
-
-
-
-
-                this.account = {
-                    Username: ko.observable(''),
-                    EmailAddress: ko.observable('')
-                }
-
-
+                this.successMessage = ko.observable('');
+                this.errorSubmitChanges = ko.observable('');
 
                 this.validateInputs = function () {
                     $self.doneValidateInputs(false);
-                    $self.packagesFrom([]);
-                    $self.packagesTo([]);
-                    $self.validatedInputs([]);
                     $self.errorInputs('');
+                    $self.validatedInputs([]);
+                    $self.existingPackageRenames([]);
+                    $self.successMessage('');
+                    $self.errorSubmitChanges('');
 
                     if (!$self.packagesFromInput() || !$self.packagesToInput()) {
                         $self.errorInputs('Package IDs in the \'From\' or \'To\' fields cannot be null or empty.');
@@ -158,19 +114,14 @@
 
                     $.ajax({
                         url: actionUrlValidateInputs + queryParams,
-                        cache: false,
                         dataType: 'json',
                         success: function (result) {
-                            //$self.packagesFrom(result.PackagesFrom);
-                            //$self.packagesTo(result.PackagesTo);
-                            //$self.packagesFromTemp(result.PackagesFromTemp);
-                            //$self.packagesToTemp(result.PackagesToTemp);
                             $self.validatedInputs(result.ValidatedInputs);
-                            //$self.warnings(result.Warnings);
+                            $self.existingPackageRenames(result.ExistingPackageRenames);
                         }
                     })
                         .fail(function (xhr, textStatus, errorMessage) {
-                            if (jqXhr) {
+                            if (xhr) {
                                 $self.errorInputs(xhr.responseJSON);
                             }
                             else {
@@ -182,110 +133,31 @@
                         });
                 };
 
-                this.individualAccountMessage = 'This is an individual account.';
-                this.organizationAccountMessage = 'This is an organization account.';
-
-                this.accountEmailOrUsername = ko.observable('');
-                this.account = {
-                    Username: ko.observable(''),
-                    EmailAddress: ko.observable('')
-                }
-                this.accountAdministrators = ko.observableArray([]);
-                this.newUsername = ko.observable('');
-                this.validatationUsernameResult = {
-                    IsFormatValid: ko.observable(false),
-                    IsAvailable: ko.observable(false)
-                }
-                this.changeOldUsername = ko.observable('');
-                this.changeNewUsername = ko.observable('');
-
-                this.doneVerifyAccount = ko.observable(false);
-                this.doneValidatingNewUsername = ko.observable(false);
-
-                this.errorAccount = ko.observable('');
-                this.errorNewUsername = ko.observable('');
-                this.errorChangeUsername = ko.observable('');
-                this.changeUsernameSuccessful = ko.observable('');
-
-                var actionUrlVerifyAccount = '@Url.Action("VerifyAccount", "ChangeUsername", new {area = "Admin"})';
-                var actionUrlValidateNewUsername = '@Url.Action("ValidateNewUsername", "ChangeUsername", new {area = "Admin"})';
-                var actionUrlChangeUsername = '@Url.Action("ChangeUsername", "ChangeUsername", new {area = "Admin"})';
-
-                this.validateNewUsername = function () {
-                    $self.doneValidatingNewUsername(false);
-                    $self.errorNewUsername('');
-
-                    if (!$self.newUsername()) {
-                        $self.errorNewUsername('Username cannot be null or empty.');
-                        return;
-                    }
-
-                    var queryParams = '?newUsername=' + encodeURIComponent($self.newUsername().trim());
+                this.submitInputs = function (model, event) {
+                    $self.successMessage('');
+                    $self.errorSubmitChanges('');
 
                     $.ajax({
-                        url: actionUrlValidateNewUsername + queryParams,
-                        cache: false,
-                        dataType: 'json',
-                        success: function (data) {
-                            $self.validatationUsernameResult.IsFormatValid(data.IsFormatValid);
-                            $self.validatationUsernameResult.IsAvailable(data.IsAvailable);
-                        }
-                    })
-                    .fail(function (jqXhr, textStatus, errorThrown) {
-                        if (jqXhr) {
-                            $self.errorNewUsername(jqXhr.responseJSON);
-                        }
-                        else {
-                            alert('Error: ' + errorThrown);
-                        }
-                    })
-                    .always(function () {
-                        $self.doneValidatingNewUsername(true);
-                    });
-                };
-
-                this.changeUsername = function (model, event) {
-                    $self.errorChangeUsername('');
-                    $self.changeUsernameSuccessful('');
-
-                    var data = {
-                        oldUsername: $self.changeOldUsername().trim(),
-                        newUsername: $self.changeNewUsername().trim(),
-                    };
-
-                    if (!data.oldUsername || !data.newUsername) {
-                        $self.errorChangeUsername('Usernames should not be empty.');
-                        event.preventDefault();
-                        return;
-                    }
-
-                    if (data.oldUsername && data.newUsername && !confirm("Are you sure you want to change account username from " + data.oldUsername + " to " + data.newUsername + "?")) {
-                        event.preventDefault();
-                        return;
-                    }
-
-                    $.ajax({
-                        url: actionUrlChangeUsername,
-                        cache: false,
+                        url: actionUrlSubmitInputs,
                         dataType: 'json',
                         type: 'POST',
-                        data: window.nuget.addAjaxAntiForgeryToken(data),
-                        success: function (data) {
-                            $self.changeUsernameSuccessful(data)
+                        data: window.nuget.addAjaxAntiForgeryToken({ confirmedInputs: $self.validatedInputs() }),
+                        success: function (result) {
+                            $self.successMessage(result.SuccessMessage);
+                            $self.doneValidateInputs(false);
+                            $self.validatedInputs([]);
+                            $self.packagesFromInput('');
+                            $self.packagesToInput('');
                         }
                     })
-                    .fail(function (jqXhr, textStatus, errorThrown) {
-                        if (jqXhr) {
-                            $self.errorChangeUsername(jqXhr.responseJSON);
-                        }
-                        else {
-                            alert('Error: ' + errorThrown);
-                        }
-                    });
-                };
-
-                this.generateProfileUrl = function (username) {
-                    return '/profiles/' + username;
+                        .fail(function (xhr, textStatus, errorMessage) {
+                            if (xhr) {
+                                $self.errorSubmitChanges(xhr.responseJSON);
+                            }
+                            else {
+                                alert('Error: ' + errorMessage);
+                            }
+                        });
                 };
             }
 

--- a/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
@@ -66,7 +66,7 @@
             </table>
 
             <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenames().length > 0, foreach: existingPackageRenames">
-                @ViewHelpers.AlertInfo(@<text><span data-bind="text: $data"></span></text>)
+                @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
             </div>
 
             <div class="form-group col-md-12">

--- a/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
@@ -1,6 +1,6 @@
 ﻿@model ReservedNamespaceViewModel
 @{
-    ViewBag.Title = "Index";
+    ViewBag.Title = "Reserve Namespaces";
 }
 
 @ViewHelpers.AjaxAntiForgeryToken(Html)

--- a/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/ReservedNamespace/Index.cshtml
@@ -1,6 +1,6 @@
 ﻿@model ReservedNamespaceViewModel
 @{
-    ViewBag.Title = "Reserve Namespaces";
+    ViewBag.Title = "Reserved Namespaces";
 }
 
 @ViewHelpers.AjaxAntiForgeryToken(Html)

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\sign.thirdparty.props" />
@@ -140,6 +140,7 @@
     <Compile Include="Areas\Admin\Controllers\LockUserController.cs" />
     <Compile Include="Areas\Admin\Controllers\LockPackageController.cs" />
     <Compile Include="Areas\Admin\Controllers\PasswordAuthenticationController.cs" />
+    <Compile Include="Areas\Admin\Controllers\PopularityTransferController.cs" />
     <Compile Include="Areas\Admin\Controllers\ReservedNamespaceController.cs" />
     <Compile Include="Areas\Admin\Controllers\RevalidationController.cs" />
     <Compile Include="Areas\Admin\Controllers\SecurityPolicyController.cs" />
@@ -184,6 +185,7 @@
     <Compile Include="Areas\Admin\Services\RevalidationAdminService.cs" />
     <Compile Include="Areas\Admin\Services\ValidationAdminService.cs" />
     <Compile Include="Areas\Admin\ViewModels\ExceptionEmailListViewModel.cs" />
+    <Compile Include="Areas\Admin\ViewModels\PopularityTransferViewModel.cs" />
     <Compile Include="Areas\Admin\ViewModels\UserCredential.cs" />
     <Compile Include="Areas\Admin\ViewModels\UserCredentialSearchResult.cs" />
     <Compile Include="Areas\Admin\ViewModels\DeleteAccountAsAdminViewModel.cs" />
@@ -2327,6 +2329,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Areas\Admin\Views\ChangeUsername\Index.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Areas\Admin\Views\PopularityTransfer\Index.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>


### PR DESCRIPTION
## Admin Panel for Popularity Transfers

Addresses https://github.com/NuGet/Engineering/issues/4746

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/3a6ef4ec-da95-483c-bad5-89c51673afd1)

<details><summary>You can now enter a list of packages you want to transfer popularity from, and a list of packages you want to transfer to. </summary>

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/4c162811-b05c-4460-9517-9351f5f52ae8)
</details> 

<details><summary>It then validates your input. </summary>

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/265a5abb-3199-4e48-9005-ea26e7e660df)
</details> 

<details><summary>Submitting your changes updates the DB with new entries in the PackageRenames table.</summary>

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/adcaf6c3-35ff-4788-95a3-75e84a443df2)

You can see the new Serilog (Key = 11) --> Moq (Key = 9) entry
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/6a315e46-0686-4776-be62-56fefa752dee)
</details> 

<details><summary>Error Handling</summary>

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/5d5dc90a-b10f-4884-80f0-a51795ef7a83)

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/dea204c9-20bc-44c1-8691-7438c1c4418a)
</details> 

<details><summary>Checking for existing popularity transfers</summary>

**NOTE:** Our current playbook asks us to delete any existing popularity transfers for the 'From' packages, so the popularity transfer operation deletes previous entries from the DB. Let me know if this doesn't sound right, or we want to give the DRIs more information/options on what to do with existing popularity transfers. Currently, we just show a warning when we validate the input, and then if a user submits the changes, then we remove all previous entries.
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/c9130282-d647-40e1-93fd-20139771e7c7)

We also show a warning if one of the 'To' packages has existing renames, as this would result in a transitive popularity transfer relationship (a -> b -> c). The DRI can then look at the table in the DB to see if they still want to proceed.
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/a126aa44-0d18-46dc-bfea-70de63af78fb)

</details> 

<details><summary>Multiple packages at once</summary>

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/fd73204e-b628-4dc3-a0c0-59a8cfc0f51b)

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/48ceb4d5-6c8a-4965-b010-aa0b95111466)
</details> 





