### PR TITLE
Move from ADAL to MSAL

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <NuGetClientPackageVersion>6.6.1</NuGetClientPackageVersion>
-    <ServerCommonPackageVersion>2.113.0-jver-msal-8428984</ServerCommonPackageVersion>
-    <NuGetJobsPackageVersion>4.3.0-jver-msal-8429689</NuGetJobsPackageVersion>
+    <ServerCommonPackageVersion>2.113.0</ServerCommonPackageVersion>
+    <NuGetJobsPackageVersion>4.3.0-dev-8436434</NuGetJobsPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <NuGetClientPackageVersion>6.6.1</NuGetClientPackageVersion>
-    <ServerCommonPackageVersion>2.112.0</ServerCommonPackageVersion>
-    <NuGetJobsPackageVersion>4.3.0-dev-8382474</NuGetJobsPackageVersion>
+    <ServerCommonPackageVersion>2.113.0-jver-msal-8428984</ServerCommonPackageVersion>
+    <NuGetJobsPackageVersion>4.3.0-jver-sb-8422727</NuGetJobsPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <NuGetClientPackageVersion>6.6.1</NuGetClientPackageVersion>
     <ServerCommonPackageVersion>2.113.0-jver-msal-8428984</ServerCommonPackageVersion>
-    <NuGetJobsPackageVersion>4.3.0-jver-sb-8422727</NuGetJobsPackageVersion>
+    <NuGetJobsPackageVersion>4.3.0-jver-msal-8429689</NuGetJobsPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">

--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,7 @@ param (
     [string]$PackageSuffix,
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranchCommit = '344f549684897666a619724271c36002405908bd', #DevSkim: ignore DS173237. Not a secret/token. It is a commit hash.
+    [string]$BuildBranchCommit = '5295c6e0d2ae7357fccf01e48c56b768b192f022', #DevSkim: ignore DS173237. Not a secret/token. It is a commit hash.
     [string]$VerifyMicrosoftPackageVersion = $null
 )
 

--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,7 @@ param (
     [string]$PackageSuffix,
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranchCommit = '65e723253187442f5b8ea537f672bd9328ade5a7',
+    [string]$BuildBranchCommit = '344f549684897666a619724271c36002405908bd', #DevSkim: ignore DS173237. Not a secret/token. It is a commit hash.
     [string]$VerifyMicrosoftPackageVersion = $null
 )
 
@@ -29,10 +29,7 @@ if (-not (Test-Path "$PSScriptRoot/build")) {
     New-Item -Path "$PSScriptRoot/build" -ItemType "directory"
 }
 
-# Enable TLS 1.2 since GitHub requires it.
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-
-wget -UseBasicParsing -Uri "https://raw.githubusercontent.com/NuGet/ServerCommon/$BuildBranchCommit/build/init.ps1" -OutFile "$PSScriptRoot/build/init.ps1"
+Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/NuGet/ServerCommon/$BuildBranchCommit/build/init.ps1" -OutFile "$PSScriptRoot/build/init.ps1"
 . "$PSScriptRoot/build/init.ps1" -BuildBranchCommit $BuildBranchCommit
 
 Function Clean-Tests {

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -44,9 +44,6 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <Version>5.2.6</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.Packaging">
       <Version>$(NuGetClientPackageVersion)</Version>
     </PackageReference>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -647,6 +647,10 @@
         <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0A613F4DD989E8AE" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.56.0.0" newVersion="4.56.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
       </dependentAssembly>


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4992

Summary of the changes:
- Drop `Microsoft.IdentityModel.Clients.ActiveDirectory` (ADAL), pick up `Microsoft.Identity.Client` (MSAL)
- Move to latest ServerCommon to pull in MSAL move
- Drop unnecessary ADAL reference
- Update build tools to latest to drop ADAL reference in a tool
- The NuGet.Jobs update is for the Service Bus update, I'll come back later with another NuGet.Jobs update once ServerCommon has gotten there
- Resolve minor DevSkim warnings