### PR TITLE
Removed the duplicate package

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-downloads.js
+++ b/src/NuGetGallery/Scripts/gallery/page-downloads.js
@@ -13,7 +13,10 @@
         const listContainerParent = document.getElementById('win-x86-versions');
         olderVersionsElement = document.createElement('div');
 
-        // We want to display 2 versions to the users.
+        // We want to display 2 versions to the users. Others should be collapsed.
+        const allVersions = listContainer.querySelectorAll('li');
+        var collapsedVersions = Array.from(allVersions).slice(2);
+
         // If the first two versions in json file are the same, we only want to show the first.
         // The following code checks if they're the same, and if so, removes the second.
         // It checks if they're the same based on the last word, which is a version identifier.
@@ -27,15 +30,8 @@
         var firstVersionLastWord = firstText.split(' ').pop();
         var secondVersionLastWord = secondText.split(' ').pop();
 
-        const hiddenVersions = listContainer.querySelectorAll('li');
-        var displayedVersions;
-
         if (firstVersionLastWord === secondVersionLastWord) {
             listContainer.removeChild(secondElement);
-            displayedVersions = Array.from(hiddenVersions).slice(1);    // we want to display only 1 version outside of the dropdown
-        }
-        else {
-            displayedVersions = Array.from(hiddenVersions).slice(2);
         }
 
         olderVersionsElement.setAttribute('class', 'older-versions-dropdown');
@@ -54,7 +50,7 @@
 
         const versionsList = document.createElement('ul');
 
-        displayedVersions.forEach(li => {
+        collapsedVersions.forEach(li => {
             versionsList.appendChild(li);
         });
 


### PR DESCRIPTION
I removed the duplicate package and refactored the code a bit.

Before:
<img width="274" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/ab1b9f6e-12ef-48d5-9d26-4ccb61d7a2ea">

After:
![image](https://github.com/NuGet/NuGetGallery/assets/58230697/e1ee37e7-24b0-4a87-80f8-5e955bbc16d0)


How to test:
Go to [this file](https://github.com/NuGet/NuGet.Services.Index/blob/main/PROD/dist.nuget.org-index/index.json). Click on "raw" (see image)
<img width="163" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/4f3c52ad-41e7-48c1-a11d-f32b4abd2516">


Copy the URL of the raw file. Now, go to Downloads.cshtml line 86 and instead of //dist.nuget.org/index.json, paste the URL you previously copied. Run the code. Go to Downloads. Older versions of win-x86 should be collapsible. There should also be a red message indicating that these versions are unsupported.