### PR TITLE
Set explicit width and height for package icons

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -267,6 +267,7 @@
                         <h1>
                             <span class="pull-left">
                                 <img class="package-icon img-responsive" aria-hidden="true" alt=""
+                                     width="256" height="256"
                                      src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) && Model.ShowDetailsAndLinks ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
                                      @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
                             </span>

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -35,7 +35,6 @@
             {
                 Id = "dotnet-cli-global",
                 CommandPrefix = "> ",
-
                 InstallPackageCommands = new [] { string.Format("dotnet tool install --global {0} --version {1}", Model.Id, Model.Version) },
                 AlertLevel = AlertLevel.Info,
                 AlertMessage = "This package contains a <a href='https://aka.ms/global-tools'>.NET tool</a> you can call from the shell/command line.",
@@ -194,9 +193,8 @@
 @helper CommandTab(PackageManagerViewModel packageManager, bool active)
 {
     <li role="presentation" class="@(active ? "active" : string.Empty)">
-        <a href="#@packageManager.Id-body-tab"
-           data-target="@packageManager.Id-tab"
-           id="@packageManager.Id-body-tab" class="package-manager-tab"
+        <a href="#@packageManager.Id"
+           id="@packageManager.Id-tab" class="package-manager-tab"
            aria-selected="@(active ? "true" : "false")" tabindex="@(active ? "0" : "-1")"
            aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
            title="Switch to tab panel which contains package installation command for @packageManager.Name">
@@ -575,10 +573,9 @@
                      {
                         activeBodyTab = activeBodyTab ?? "supportedframeworks";
                         <li role="presentation" id="show-supportedframeworks-container">
-                            <a href="#supportedframeworks-body-tab"
+                            <a href="#supportedframeworks-tab"
                                 role="tab"
                                 data-toggle="tab"
-                                data-target="#supportedframeworks-tab"
                                 id="supportedframeworks-body-tab"
                                 class="body-tab"
                                 aria-controls="supportedframeworks-tab"
@@ -592,10 +589,9 @@
 
                         activeBodyTab = activeBodyTab ?? "dependencies";
                         <li role="presentation">
-                            <a href="#dependencies-body-tab"
+                            <a href="#dependencies-tab"
                                role="tab"
                                data-toggle="tab"
-                               data-target="#dependencies-tab"
                                id="dependencies-body-tab"
                                class="body-tab"
                                aria-controls="dependencies-tab"
@@ -611,10 +607,9 @@
                     {
                         activeBodyTab = activeBodyTab ?? "usedby";
                         <li role="presentation">
-                            <a href="#usedby-body-tab"
+                            <a href="#usedby-tab"
                                role="tab"
                                data-toggle="tab"
-                               data-target="#usedby-tab"
                                id="usedby-body-tab"
                                class="body-tab"
                                aria-controls="usedby-tab"
@@ -628,10 +623,9 @@
 
                     @{ activeBodyTab = activeBodyTab ?? "versions"; }
                     <li role="presentation">
-                        <a href="#versions-body-tab"
+                        <a href="#versions-tab"
                            role="tab"
                            data-toggle="tab"
-                           data-target="#versions-tab"
                            id="versions-body-tab"
                            class="body-tab"
                            aria-controls="versions-tab"

--- a/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
+++ b/src/NuGetGallery/Views/Packages/_VerifyMetadata.cshtml
@@ -257,7 +257,7 @@
             <div class="verify-package-field row">
                 <label class="verify-package-field-heading col-sm-12">Icon Preview</label>
                 <div id="icon-preview-container" class="col-sm-1">
-                    <img class="package-icon img-responsive" id="icon-preview" aria-label="The icon of your package" data-bind="attr: { src: $data.IconUrl }" /> <!-- probably need to check this for safety-->
+                    <img class="package-icon img-responsive" width="256" height="256" id="icon-preview" aria-label="The icon of your package" data-bind="attr: { src: $data.IconUrl }" /> <!-- probably need to check this for safety-->
                 </div>
             </div>
             <!-- /ko -->

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -31,6 +31,7 @@
     <div class="row">
         <div class="col-sm-1 hidden-xs hidden-sm col-package-icon">
             <img class="package-icon img-responsive" aria-hidden="true" alt=""
+                 width="256" height="256"
                  src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
                  @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
         </div>

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -149,6 +149,7 @@
         <div class="row">
             <div class="col-sm-1">
                 <img class="package-icon img-responsive" aria-hidden="true" alt=""
+                     width="256" height="256"
                      data-bind="attr: { src: IconUrl, onerror: IconUrlFallback }" />
             </div>
             <div class="col-sm-11">

--- a/src/NuGetGallery/Views/Users/Packages.cshtml
+++ b/src/NuGetGallery/Views/Users/Packages.cshtml
@@ -130,7 +130,7 @@
                 <tbody data-bind="foreach: Packages">
                     <tr class="manage-package-listing" data-bind="visible: Visible">
                         <td class="align-middle hidden-xs">
-                            <img class="package-icon img-responsive" aria-hidden="true"
+                            <img class="package-icon img-responsive" aria-hidden="true" width="256" height="256"
                                  data-bind="attr: { src: PackageIconUrl, onerror: PackageIconUrlFallback, alt: 'Icon for ' + Id }" />
                         </td>
                         <td class="align-middle package-id text-nowrap">
@@ -266,7 +266,7 @@
                 <tbody data-bind="foreach: Requests">
                     <tr class="manage-package-listing" data-bind="visible: Visible">
                         <td class="align-middle hidden-xs">
-                            <img class="package-icon img-responsive" aria-hidden="true"
+                            <img class="package-icon img-responsive" aria-hidden="true" width="256" height="256"
                                  data-bind="attr: { src: PackageIconUrl, onerror: PackageIconUrlFallback, alt: 'Icon for ' + Id }" />
                         </td>
                         <td class="align-middle package-id">

--- a/src/NuGetGallery/Views/Users/_UserPackagesListForDeletedAccount.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesListForDeletedAccount.cshtml
@@ -44,6 +44,7 @@
                             </td>
                             <td class="align-middle hidden-xs">
                                 <img class="package-icon img-responsive" aria-hidden="true" alt="Package Icon"
+                                     width="256" height="256"
                                      src="@(PackageHelper.ShouldRenderUrl(package.IconUrl) ? package.IconUrl : Url.Absolute("~/Content/gallery/img/default-package-icon.svg"))"
                                      @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
                             </td>


### PR DESCRIPTION
The width and height attributes were added to the `img` tags for package icons. This change was implemented to ensure the package icons don't overflow vertically when displayed in the user interface.

This should also make pages load a tiny bit faster since those images in the rendering phase of the page will be accounted for in the layout.

Please take a look at the examples below for the issues.

![image](https://github.com/NuGet/NuGetGallery/assets/228256/5af7d277-40d1-40f2-ba89-3181ddf35776)
![image](https://github.com/NuGet/NuGetGallery/assets/228256/1e404ce9-072a-421b-be58-2daf9145157d)
