### PR TITLE
Set aspect-ratio for package-icon images

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -241,6 +241,7 @@ h3 a:active {
   img.package-icon {
     max-width: 60px;
     max-height: 60px;
+    aspect-ratio: 1 / 1;
   }
 }
 @media screen and (max-width: 480px) {
@@ -251,6 +252,7 @@ h3 a:active {
 img.package-icon {
   margin-left: auto;
   margin-right: auto;
+  aspect-ratio: 1 / 1;
 }
 img.reserved-indicator-icon {
   margin-left: auto;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -317,6 +317,7 @@ h2, h3 {
   img.package-icon {
     max-width: 60px;
     max-height: 60px;
+    aspect-ratio: 1 / 1;
   }
 }
 
@@ -329,6 +330,7 @@ h2, h3 {
 img.package-icon {
   margin-left: auto;
   margin-right: auto;
+  aspect-ratio: 1 / 1;
 }
 
 img.reserved-indicator-icon {


### PR DESCRIPTION
Keeps `aspect-ratio` as a square, as the recommendation suggests.

Before: 

![Arc -2023-10-06 -11-10-33](https://github.com/NuGet/NuGetGallery/assets/228256/5642c31b-76c9-465b-a768-48e1ed29efba)

After:

![Arc -2023-10-06 -11-10-59](https://github.com/NuGet/NuGetGallery/assets/228256/05674ef6-77bb-4076-8b6d-4a4e34c80f34)

Relates to #9694. A potential UI exploit would allow folks to have very long vertical icons in the search results.