### PR TITLE
Fixed url bug final

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -194,9 +194,8 @@
 @helper CommandTab(PackageManagerViewModel packageManager, bool active)
 {
     <li role="presentation" class="@(active ? "active" : string.Empty)">
-        <a href="#@packageManager.Id-body-tab"
-           data-target="@packageManager.Id-tab"
-           id="@packageManager.Id-body-tab" class="package-manager-tab"
+        <a href="#@packageManager.Id"
+           id="@packageManager.Id-tab" class="package-manager-tab"
            aria-selected="@(active ? "true" : "false")" tabindex="@(active ? "0" : "-1")"
            aria-controls="@packageManager.Id" role="tab" data-toggle="tab"
            title="Switch to tab panel which contains package installation command for @packageManager.Name">


### PR DESCRIPTION
Fixed broken buttons.

Test: open a package and check that buttons for Package Manager, Paket CLI, Script & Interactive, Cake, and .NET CLI work.

Proof:
<img width="464" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/81104633-0c8e-4576-be3e-65b46d7da22e">
<img width="447" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/1a4c57ca-1640-4776-b7aa-353dc0c30884">
<img width="479" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/c1f8ef66-9077-4546-a032-28bf37a48412">
<img width="650" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/90274e31-b46e-408e-820f-fb9b07efbb54">
<img width="647" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/631f423d-e192-4611-8e62-0c26809edb46">
<img width="465" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/10553a16-8696-4d09-bbe8-44b276f2f4ac">
