### PR TITLE
Hotfix: don't use v3-cache for VerifyGitHubVulnerabilities

### DIFF
--- a/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
+++ b/src/VerifyGitHubVulnerabilities/Verify/PackageVulnerabilitiesVerifier.cs
@@ -307,14 +307,18 @@ namespace VerifyGitHubVulnerabilities.Verify
             {
                 if (!_packageMetadata.TryGetValue(packageId, out IEnumerable<IPackageSearchMetadata> metadata))
                 {
-                    metadata = (await (await _packageMetadataResource.Value).GetMetadataAsync(
-                        packageId,
-                        includePrerelease: true,
-                        includeUnlisted: false,
-                        sourceCacheContext: new SourceCacheContext(),
-                        log: NuGet.Common.NullLogger.Instance,
-                        token: CancellationToken.None)).ToList();
-                    _packageMetadata[packageId] = metadata;
+                    using (var cacheContext = new SourceCacheContext())
+                    {
+                        cacheContext.NoCache = true;
+                        metadata = (await (await _packageMetadataResource.Value).GetMetadataAsync(
+                            packageId,
+                            includePrerelease: true,
+                            includeUnlisted: true,
+                            sourceCacheContext: cacheContext,
+                            log: NuGet.Common.NullLogger.Instance,
+                            token: CancellationToken.None)).ToList();
+                        _packageMetadata[packageId] = metadata;
+                    }
                 }
 
                 return metadata;


### PR DESCRIPTION
Resolve https://github.com/NuGet/NuGetGallery/issues/9703. The job is currently failing with a long path problem due to the v3-cache. We don't need the v3-cache for this workflow.

This also sets the `includeUnlisted` to `true` because those should be verified also.