### PR TITLE
Fixing popularity transfer download count bug, surfacing additional validation info

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
@@ -98,14 +98,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 }
 
                 // create validated input result
-                var input = new PopularityTransferItem(CreatePackageSearchResult(packageFrom.Packages.First()),
-                                                       CreatePackageSearchResult(packageTo.Packages.First()),
-                                                       packageFrom.DownloadCount,
-                                                       packageTo.DownloadCount,
-                                                       packageFrom.Key,
-                                                       packageTo.Key);
-
-                result.ValidatedInputs.Add(input);
+                result.ValidatedInputs.Add(new PopularityTransferItem(packageFrom, packageTo));
 
                 // check for existing entries in the PackageRename table for the 'From' packages
                 var existingRenamesFrom = _packageRenameService.GetPackageRenames(packageFrom);
@@ -114,25 +107,16 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 {
                     if (existingRenamesFrom.Count == 1)
                     {
-                        var existingRenamesMessage = $"{packageFrom.Id} already has 1 entry in the PackageRenames table. This will be removed with this operation.";
-                        result.ExistingPackageRenamesMessagesFrom.Add(existingRenamesMessage);
+                        result.ExistingPackageRenamesMessagesFrom.Add($"{packageFrom.Id} already has 1 entry in the PackageRenames table. This will be removed with this operation.");
                     }
                     else
                     {
-                        var existingRenamesMessage = $"{packageFrom.Id} already has {existingRenamesFrom.Count} entries in the PackageRenames table. These will be removed with this operation.";
-                        result.ExistingPackageRenamesMessagesFrom.Add(existingRenamesMessage);
+                        result.ExistingPackageRenamesMessagesFrom.Add($"{packageFrom.Id} already has {existingRenamesFrom.Count} entries in the PackageRenames table. These will be removed with this operation.");
                     }
 
                     foreach (var existingRename in existingRenamesFrom)
                     {
-                        var item = new PopularityTransferItem(CreatePackageSearchResult(existingRename.FromPackageRegistration.Packages.First()),
-                                                              CreatePackageSearchResult(existingRename.ToPackageRegistration.Packages.First()),
-                                                              existingRename.FromPackageRegistration.DownloadCount,
-                                                              existingRename.ToPackageRegistration.DownloadCount,
-                                                              existingRename.FromPackageRegistration.Key,
-                                                              existingRename.ToPackageRegistration.Key);
-
-                        result.ExistingPackageRenamesFrom.Add(item);
+                        result.ExistingPackageRenamesFrom.Add(new PopularityTransferItem(existingRename.FromPackageRegistration, existingRename.ToPackageRegistration));
                     }
                 }
 
@@ -146,14 +130,7 @@ namespace NuGetGallery.Areas.Admin.Controllers
 
                     foreach (var existingRename in existingRenamesTo)
                     {
-                        var item = new PopularityTransferItem(CreatePackageSearchResult(existingRename.FromPackageRegistration.Packages.First()),
-                                                              CreatePackageSearchResult(existingRename.ToPackageRegistration.Packages.First()),
-                                                              existingRename.FromPackageRegistration.DownloadCount,
-                                                              existingRename.ToPackageRegistration.DownloadCount,
-                                                              existingRename.FromPackageRegistration.Key,
-                                                              existingRename.ToPackageRegistration.Key);
-
-                        result.ExistingPackageRenamesTo.Add(item);
+                        result.ExistingPackageRenamesTo.Add(new PopularityTransferItem(existingRename.FromPackageRegistration, existingRename.ToPackageRegistration));
                     }
                 }
             }

--- a/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
@@ -100,6 +100,8 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 // create validated input result
                 var input = new PopularityTransferItem(CreatePackageSearchResult(packageFrom.Packages.First()),
                                                        CreatePackageSearchResult(packageTo.Packages.First()),
+                                                       packageFrom.DownloadCount,
+                                                       packageTo.DownloadCount,
                                                        packageFrom.Key,
                                                        packageTo.Key);
 

--- a/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PopularityTransferController.cs
@@ -115,12 +115,24 @@ namespace NuGetGallery.Areas.Admin.Controllers
                     if (existingRenamesFrom.Count == 1)
                     {
                         var existingRenamesMessage = $"{packageFrom.Id} already has 1 entry in the PackageRenames table. This will be removed with this operation.";
-                        result.ExistingPackageRenames.Add(existingRenamesMessage);
+                        result.ExistingPackageRenamesMessagesFrom.Add(existingRenamesMessage);
                     }
                     else
                     {
                         var existingRenamesMessage = $"{packageFrom.Id} already has {existingRenamesFrom.Count} entries in the PackageRenames table. These will be removed with this operation.";
-                        result.ExistingPackageRenames.Add(existingRenamesMessage);
+                        result.ExistingPackageRenamesMessagesFrom.Add(existingRenamesMessage);
+                    }
+
+                    foreach (var existingRename in existingRenamesFrom)
+                    {
+                        var item = new PopularityTransferItem(CreatePackageSearchResult(existingRename.FromPackageRegistration.Packages.First()),
+                                                              CreatePackageSearchResult(existingRename.ToPackageRegistration.Packages.First()),
+                                                              existingRename.FromPackageRegistration.DownloadCount,
+                                                              existingRename.ToPackageRegistration.DownloadCount,
+                                                              existingRename.FromPackageRegistration.Key,
+                                                              existingRename.ToPackageRegistration.Key);
+
+                        result.ExistingPackageRenamesFrom.Add(item);
                     }
                 }
 
@@ -130,7 +142,19 @@ namespace NuGetGallery.Areas.Admin.Controllers
                 if (existingRenamesTo.Any())
                 {
                     var existingRenamesMessage = $"{packageTo.Id} already has entries in the PackageRenames table. This popularity transfer will result in a new transitive relationship. Please look at the PackageRenames table and verify your input before proceeding.";
-                    result.ExistingPackageRenames.Insert(0, existingRenamesMessage);
+                    result.ExistingPackageRenamesMessagesTo.Add(existingRenamesMessage);
+
+                    foreach (var existingRename in existingRenamesTo)
+                    {
+                        var item = new PopularityTransferItem(CreatePackageSearchResult(existingRename.FromPackageRegistration.Packages.First()),
+                                                              CreatePackageSearchResult(existingRename.ToPackageRegistration.Packages.First()),
+                                                              existingRename.FromPackageRegistration.DownloadCount,
+                                                              existingRename.ToPackageRegistration.DownloadCount,
+                                                              existingRename.FromPackageRegistration.Key,
+                                                              existingRename.ToPackageRegistration.Key);
+
+                        result.ExistingPackageRenamesTo.Add(item);
+                    }
                 }
             }
 

--- a/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
@@ -12,12 +12,18 @@ namespace NuGetGallery.Areas.Admin.ViewModels
         public PopularityTransferViewModel()
         {
             ValidatedInputs = new List<PopularityTransferItem>();
-            ExistingPackageRenames = new List<string>();
+            ExistingPackageRenamesFrom = new List<PopularityTransferItem>();
+            ExistingPackageRenamesTo = new List<PopularityTransferItem>();
+            ExistingPackageRenamesMessagesFrom = new List<string>();
+            ExistingPackageRenamesMessagesTo = new List<string>();
             SuccessMessage = string.Empty;
         }
 
         public List<PopularityTransferItem> ValidatedInputs { get; set; }
-        public List<string> ExistingPackageRenames { get; set; }
+        public List<PopularityTransferItem> ExistingPackageRenamesFrom { get; set; }
+        public List<PopularityTransferItem> ExistingPackageRenamesTo { get; set; }
+        public List<string> ExistingPackageRenamesMessagesFrom { get; set; }
+        public List<string> ExistingPackageRenamesMessagesTo { get; set; }
         public string SuccessMessage { get; set; } = string.Empty;
     }
 

--- a/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
@@ -28,22 +28,24 @@ namespace NuGetGallery.Areas.Admin.ViewModels
             FromOwners = new List<UserViewModel>();
             ToOwners = new List<UserViewModel>();
         }
-        
+
         public PopularityTransferItem(
-            PackageSearchResult packageFrom, 
+            PackageSearchResult packageFrom,
             PackageSearchResult packageTo,
+            long fromDownloads,
+            long toDownloads,
             int fromKey,
             int toKey)
         {
             FromId = packageFrom.PackageId;
             FromUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageFrom.PackageId);
-            FromDownloads = packageFrom.DownloadCount;
+            FromDownloads = fromDownloads;
             FromOwners = packageFrom.Owners;
             FromKey = fromKey;
 
             ToId = packageTo.PackageId;
             ToUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageTo.PackageId);
-            ToDownloads = packageTo.DownloadCount;
+            ToDownloads = toDownloads;
             ToOwners = packageTo.Owners;
             ToKey = toKey;
         }

--- a/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
@@ -15,18 +15,18 @@ namespace NuGetGallery.Areas.Admin.ViewModels
         public PopularityTransferViewModel()
         {
             ValidatedInputs = new List<PopularityTransferItem>();
-            ExistingPackageRenamesFrom = new List<PopularityTransferItem>();
-            ExistingPackageRenamesTo = new List<PopularityTransferItem>();
-            ExistingPackageRenamesMessagesFrom = new List<string>();
-            ExistingPackageRenamesMessagesTo = new List<string>();
+            ExistingPackageRenamesConflict = new List<PopularityTransferItem>();
+            ExistingPackageRenamesTransitive = new List<PopularityTransferItem>();
+            ExistingPackageRenamesMessagesConflict = new List<string>();
+            ExistingPackageRenamesMessagesTransitive = new List<string>();
             SuccessMessage = string.Empty;
         }
 
         public List<PopularityTransferItem> ValidatedInputs { get; set; }
-        public List<PopularityTransferItem> ExistingPackageRenamesFrom { get; set; }
-        public List<PopularityTransferItem> ExistingPackageRenamesTo { get; set; }
-        public List<string> ExistingPackageRenamesMessagesFrom { get; set; }
-        public List<string> ExistingPackageRenamesMessagesTo { get; set; }
+        public List<PopularityTransferItem> ExistingPackageRenamesConflict { get; set; }
+        public List<PopularityTransferItem> ExistingPackageRenamesTransitive { get; set; }
+        public List<string> ExistingPackageRenamesMessagesConflict { get; set; }
+        public List<string> ExistingPackageRenamesMessagesTransitive { get; set; }
         public string SuccessMessage { get; set; } = string.Empty;
     }
 

--- a/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Web;
 using System.Web.Mvc;
+using NuGet.Services.Entities;
 
 namespace NuGetGallery.Areas.Admin.ViewModels
 {
@@ -35,25 +38,37 @@ namespace NuGetGallery.Areas.Admin.ViewModels
             ToOwners = new List<UserViewModel>();
         }
 
-        public PopularityTransferItem(
-            PackageSearchResult packageFrom,
-            PackageSearchResult packageTo,
-            long fromDownloads,
-            long toDownloads,
-            int fromKey,
-            int toKey)
+        public PopularityTransferItem(PackageRegistration packageFrom, PackageRegistration packageTo)
         {
-            FromId = packageFrom.PackageId;
-            FromUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageFrom.PackageId);
-            FromDownloads = fromDownloads;
-            FromOwners = packageFrom.Owners;
-            FromKey = fromKey;
+            FromId = packageFrom.Id;
+            FromUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageFrom.Id);
+            FromDownloads = packageFrom.DownloadCount;
+            FromOwners = packageFrom
+                            .Owners
+                            .Select(u => u.Username)
+                            .OrderBy(u => u, StringComparer.OrdinalIgnoreCase)
+                            .Select(u => new UserViewModel
+                                            {
+                                                Username = u,
+                                                ProfileUrl = UrlHelperExtensions.User(new UrlHelper(HttpContext.Current.Request.RequestContext), u),
+                                            })
+                            .ToList();
+            FromKey = packageFrom.Key;
 
-            ToId = packageTo.PackageId;
-            ToUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageTo.PackageId);
-            ToDownloads = toDownloads;
-            ToOwners = packageTo.Owners;
-            ToKey = toKey;
+            ToId = packageTo.Id;
+            ToUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageTo.Id);
+            ToDownloads = packageTo.DownloadCount;
+            ToOwners = packageTo
+                            .Owners
+                            .Select(u => u.Username)
+                            .OrderBy(u => u, StringComparer.OrdinalIgnoreCase)
+                            .Select(u => new UserViewModel
+                                            {
+                                                Username = u,
+                                                ProfileUrl = UrlHelperExtensions.User(new UrlHelper(HttpContext.Current.Request.RequestContext), u),
+                                            })
+                            .ToList();
+            ToKey = packageTo.Key;
         }
 
         public string FromId { get; set; }

--- a/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/PopularityTransferViewModel.cs
@@ -42,7 +42,7 @@ namespace NuGetGallery.Areas.Admin.ViewModels
         {
             FromId = packageFrom.Id;
             FromUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageFrom.Id);
-            FromDownloads = packageFrom.DownloadCount;
+            FromDownloads = packageFrom.DownloadCount.ToNuGetNumberString();
             FromOwners = packageFrom
                             .Owners
                             .Select(u => u.Username)
@@ -57,7 +57,7 @@ namespace NuGetGallery.Areas.Admin.ViewModels
 
             ToId = packageTo.Id;
             ToUrl = UrlHelperExtensions.Package(new UrlHelper(HttpContext.Current.Request.RequestContext), packageTo.Id);
-            ToDownloads = packageTo.DownloadCount;
+            ToDownloads = packageTo.DownloadCount.ToNuGetNumberString();
             ToOwners = packageTo
                             .Owners
                             .Select(u => u.Username)
@@ -73,13 +73,13 @@ namespace NuGetGallery.Areas.Admin.ViewModels
 
         public string FromId { get; set; }
         public string FromUrl { get; set; }
-        public long FromDownloads { get; set; }
+        public string FromDownloads { get; set; }
         public IReadOnlyList<UserViewModel> FromOwners { get; set; } = new List<UserViewModel>();
         public int FromKey { get; set; }
 
         public string ToId { get; set; }
         public string ToUrl { get; set; }
-        public long ToDownloads { get; set; }
+        public string ToDownloads { get; set; }
         public IReadOnlyList<UserViewModel> ToOwners { get; set; } = new List<UserViewModel>();
         public int ToKey { get; set; }
     }

--- a/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
@@ -3,6 +3,36 @@
 }
 @ViewHelpers.AjaxAntiForgeryToken(Html)
 
+@helper AddPopularityTransferItemTable(string inputName, string tableId, string tableLabel)
+{
+    <table class="table form-group col-md-12" id="@(tableId)" style="display:none" data-bind="visible: @(inputName)().length > 0" aria-label="@(tableLabel)">
+        <thead>
+            <tr>
+                <th class="col-group-from-header col-group-1">Package ID<br />(From)</th>
+                <th class="col-group-from-header col-group-2">Downloads<br />(From)</th>
+                <th class="col-group-from-header col-group-3">Owners<br />(From)</th>
+                <th class="col-group-to-header col-group-1">Package ID<br />(To)</th>
+                <th class="col-group-to-header col-group-2">Downloads<br />(To)</th>
+                <th class="col-group-to-header col-group-3">Owners<br />(To)</th>
+            </tr>
+        </thead>
+        <tbody data-bind="foreach: @(inputName)">
+            <tr>
+                <td class="col-group-from-data col-group-1"><a href="#" data-bind="text: FromId, attr: { href: FromUrl }"></a></td>
+                <td class="col-group-from-data col-group-2"><span data-bind="text: FromDownloads"></span></td>
+                <td class="col-group-from-data col-group-3" data-bind="foreach: FromOwners">
+                    <a data-bind="text: Username, attr: { href: ProfileUrl }" />
+                </td>
+                <td class="col-group-to-data col-group-1"><a href="#" data-bind="text: ToId, attr: { href: ToUrl }"></a></td>
+                <td class="col-group-to-data col-group-2"><span data-bind="text: ToDownloads"></span></td>
+                <td class="col-group-to-data col-group-3" data-bind="foreach: ToOwners">
+                    <a data-bind="text: Username, attr: { href: ProfileUrl }" />
+                </td>
+            </tr>
+        </tbody>
+    </table>
+}
+
 <section role="main" class="container main-container page-admin-popularity-transfers">
     <div class="row col-md-12" style="display:none" data-bind="visible: successMessage">
         <div id="popularityTransferSuccessMessage" class="alert alert-success" role="alert" data-bind="text: successMessage"></div>
@@ -34,106 +64,29 @@
         </div>
     </div>
 
-    <div style="display: none" data-bind="visible: doneValidateInputs() && !errorInputs()">
+    <div class="form-horizontal" style="display: none" data-bind="visible: doneValidateInputs() && !errorInputs()">
         <h3>Preview of changes</h3>
 
-        <div class="form-horizontal">
-            <table class="table form-group col-md-12" id="validatedInputResult" aria-label="preview of popularity transfer changes">
-                <thead>
-                    <tr>
-                        <th class="col-group-from-header col-group-1">Package ID<br />(From)</th>
-                        <th class="col-group-from-header col-group-2">Downloads<br />(From)</th>
-                        <th class="col-group-from-header col-group-3">Owners<br />(From)</th>
-                        <th class="col-group-to-header col-group-1">Package ID<br />(To)</th>
-                        <th class="col-group-to-header col-group-2">Downloads<br />(To)</th>
-                        <th class="col-group-to-header col-group-3">Owners<br />(To)</th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: validatedInputs">
-                    <tr>
-                        <td class="col-group-from-data col-group-1"><a href="#" data-bind="text: FromId, attr: { href: FromUrl }"></a></td>
-                        <td class="col-group-from-data col-group-2"><span data-bind="text: FromDownloads"></span></td>
-                        <td class="col-group-from-data col-group-3" data-bind="foreach: FromOwners">
-                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
-                        </td>
-                        <td class="col-group-to-data col-group-1"><a href="#" data-bind="text: ToId, attr: { href: ToUrl }"></a></td>
-                        <td class="col-group-to-data col-group-2"><span data-bind="text: ToDownloads"></span></td>
-                        <td class="col-group-to-data col-group-3" data-bind="foreach: ToOwners">
-                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+        @AddPopularityTransferItemTable("validatedInputs", "validatedInputResult", "preview of popularity transfer changes")
 
-            <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesFrom().length > 0, foreach: existingPackageRenamesMessagesFrom">
-                @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
-            </div>
+        <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesFrom().length > 0, foreach: existingPackageRenamesMessagesFrom">
+            @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
+        </div>
 
-            <h3 style="display:none" data-bind="visible: existingPackageRenamesFrom().length > 0">Entries that will be removed from the PackageRenames table with this operation</h3>
+        <h3 style="display:none" data-bind="visible: existingPackageRenamesFrom().length > 0">Entries that will be removed from the PackageRenames table with this operation</h3>
 
-            <table class="table form-group col-md-12" id="existingRenamesResult" style="display:none" data-bind="visible: existingPackageRenamesFrom().length > 0" aria-label="existing popularity transfers for the selected packages">
-                <thead>
-                    <tr>
-                        <th class="col-group-from-header col-group-1">Package ID<br />(From)</th>
-                        <th class="col-group-from-header col-group-2">Downloads<br />(From)</th>
-                        <th class="col-group-from-header col-group-3">Owners<br />(From)</th>
-                        <th class="col-group-to-header col-group-1">Package ID<br />(To)</th>
-                        <th class="col-group-to-header col-group-2">Downloads<br />(To)</th>
-                        <th class="col-group-to-header col-group-3">Owners<br />(To)</th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: existingPackageRenamesFrom">
-                    <tr>
-                        <td class="col-group-from-data col-group-1"><a href="#" data-bind="text: FromId, attr: { href: FromUrl }"></a></td>
-                        <td class="col-group-from-data col-group-2"><span data-bind="text: FromDownloads"></span></td>
-                        <td class="col-group-from-data col-group-3" data-bind="foreach: FromOwners">
-                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
-                        </td>
-                        <td class="col-group-to-data col-group-1"><a href="#" data-bind="text: ToId, attr: { href: ToUrl }"></a></td>
-                        <td class="col-group-to-data col-group-2"><span data-bind="text: ToDownloads"></span></td>
-                        <td class="col-group-to-data col-group-3" data-bind="foreach: ToOwners">
-                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+        @AddPopularityTransferItemTable("existingPackageRenamesFrom", "existingRenamesFromResult", "existing popularity transfers for the selected packages")
 
-            <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesTo().length > 0, foreach: existingPackageRenamesMessagesTo">
-                @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
-            </div>
+        <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesTo().length > 0, foreach: existingPackageRenamesMessagesTo">
+            @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
+        </div>
 
-            <h3 style="display:none" data-bind="visible: existingPackageRenamesTo().length > 0">Existing entries in the PackageRenames table that will result in a new transitive relationship</h3>
+        <h3 style="display:none" data-bind="visible: existingPackageRenamesTo().length > 0">Existing entries in the PackageRenames table that will result in a new transitive relationship</h3>
 
-            <table class="table form-group col-md-12" id="existingRenamesResult" style="display:none" data-bind="visible: existingPackageRenamesTo().length > 0" aria-label="existing popularity transfers for the selected packages">
-                <thead>
-                    <tr>
-                        <th class="col-group-from-header col-group-1">Package ID<br />(From)</th>
-                        <th class="col-group-from-header col-group-2">Downloads<br />(From)</th>
-                        <th class="col-group-from-header col-group-3">Owners<br />(From)</th>
-                        <th class="col-group-to-header col-group-1">Package ID<br />(To)</th>
-                        <th class="col-group-to-header col-group-2">Downloads<br />(To)</th>
-                        <th class="col-group-to-header col-group-3">Owners<br />(To)</th>
-                    </tr>
-                </thead>
-                <tbody data-bind="foreach: existingPackageRenamesTo">
-                    <tr>
-                        <td class="col-group-from-data col-group-1"><a href="#" data-bind="text: FromId, attr: { href: FromUrl }"></a></td>
-                        <td class="col-group-from-data col-group-2"><span data-bind="text: FromDownloads"></span></td>
-                        <td class="col-group-from-data col-group-3" data-bind="foreach: FromOwners">
-                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
-                        </td>
-                        <td class="col-group-to-data col-group-1"><a href="#" data-bind="text: ToId, attr: { href: ToUrl }"></a></td>
-                        <td class="col-group-to-data col-group-2"><span data-bind="text: ToDownloads"></span></td>
-                        <td class="col-group-to-data col-group-3" data-bind="foreach: ToOwners">
-                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+        @AddPopularityTransferItemTable("existingPackageRenamesTo", "existingRenamesToResult", "existing popularity transfers for the selected packages")
 
-            <div class="form-group col-md-12">
-                <button type="submit" class="btn btn-block btn-primary" data-bind="click: submitInputs">Submit changes</button>
-            </div>
+        <div class="form-group col-md-12">
+            <button type="submit" class="btn btn-block btn-primary" data-bind="click: submitInputs">Submit changes</button>
         </div>
     </div>
 </section>

--- a/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
@@ -65,9 +65,71 @@
                 </tbody>
             </table>
 
-            <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenames().length > 0, foreach: existingPackageRenames">
+            <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesFrom().length > 0, foreach: existingPackageRenamesMessagesFrom">
                 @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
             </div>
+
+            <h3 style="display:none" data-bind="visible: existingPackageRenamesFrom().length > 0">Entries that will be removed from the PackageRenames table with this operation</h3>
+
+            <table class="table form-group col-md-12" id="existingRenamesResult" style="display:none" data-bind="visible: existingPackageRenamesFrom().length > 0" aria-label="existing popularity transfers for the selected packages">
+                <thead>
+                    <tr>
+                        <th class="col-group-from-header col-group-1">Package ID<br />(From)</th>
+                        <th class="col-group-from-header col-group-2">Downloads<br />(From)</th>
+                        <th class="col-group-from-header col-group-3">Owners<br />(From)</th>
+                        <th class="col-group-to-header col-group-1">Package ID<br />(To)</th>
+                        <th class="col-group-to-header col-group-2">Downloads<br />(To)</th>
+                        <th class="col-group-to-header col-group-3">Owners<br />(To)</th>
+                    </tr>
+                </thead>
+                <tbody data-bind="foreach: existingPackageRenamesFrom">
+                    <tr>
+                        <td class="col-group-from-data col-group-1"><a href="#" data-bind="text: FromId, attr: { href: FromUrl }"></a></td>
+                        <td class="col-group-from-data col-group-2"><span data-bind="text: FromDownloads"></span></td>
+                        <td class="col-group-from-data col-group-3" data-bind="foreach: FromOwners">
+                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
+                        </td>
+                        <td class="col-group-to-data col-group-1"><a href="#" data-bind="text: ToId, attr: { href: ToUrl }"></a></td>
+                        <td class="col-group-to-data col-group-2"><span data-bind="text: ToDownloads"></span></td>
+                        <td class="col-group-to-data col-group-3" data-bind="foreach: ToOwners">
+                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesTo().length > 0, foreach: existingPackageRenamesMessagesTo">
+                @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
+            </div>
+
+            <h3 style="display:none" data-bind="visible: existingPackageRenamesTo().length > 0">Existing entries in the PackageRenames table that will result in a new transitive relationship</h3>
+
+            <table class="table form-group col-md-12" id="existingRenamesResult" style="display:none" data-bind="visible: existingPackageRenamesTo().length > 0" aria-label="existing popularity transfers for the selected packages">
+                <thead>
+                    <tr>
+                        <th class="col-group-from-header col-group-1">Package ID<br />(From)</th>
+                        <th class="col-group-from-header col-group-2">Downloads<br />(From)</th>
+                        <th class="col-group-from-header col-group-3">Owners<br />(From)</th>
+                        <th class="col-group-to-header col-group-1">Package ID<br />(To)</th>
+                        <th class="col-group-to-header col-group-2">Downloads<br />(To)</th>
+                        <th class="col-group-to-header col-group-3">Owners<br />(To)</th>
+                    </tr>
+                </thead>
+                <tbody data-bind="foreach: existingPackageRenamesTo">
+                    <tr>
+                        <td class="col-group-from-data col-group-1"><a href="#" data-bind="text: FromId, attr: { href: FromUrl }"></a></td>
+                        <td class="col-group-from-data col-group-2"><span data-bind="text: FromDownloads"></span></td>
+                        <td class="col-group-from-data col-group-3" data-bind="foreach: FromOwners">
+                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
+                        </td>
+                        <td class="col-group-to-data col-group-1"><a href="#" data-bind="text: ToId, attr: { href: ToUrl }"></a></td>
+                        <td class="col-group-to-data col-group-2"><span data-bind="text: ToDownloads"></span></td>
+                        <td class="col-group-to-data col-group-3" data-bind="foreach: ToOwners">
+                            <a data-bind="text: Username, attr: { href: ProfileUrl }" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
 
             <div class="form-group col-md-12">
                 <button type="submit" class="btn btn-block btn-primary" data-bind="click: submitInputs">Submit changes</button>
@@ -91,7 +153,10 @@
                 this.errorInputs = ko.observable('');
 
                 this.validatedInputs = ko.observableArray([]);
-                this.existingPackageRenames = ko.observableArray([]);
+                this.existingPackageRenamesFrom = ko.observableArray([]);
+                this.existingPackageRenamesMessagesFrom = ko.observableArray([]);
+                this.existingPackageRenamesTo = ko.observableArray([]);
+                this.existingPackageRenamesMessagesTo = ko.observableArray([]);
 
                 this.successMessage = ko.observable('');
                 this.errorSubmitChanges = ko.observable('');
@@ -100,7 +165,10 @@
                     $self.doneValidateInputs(false);
                     $self.errorInputs('');
                     $self.validatedInputs([]);
-                    $self.existingPackageRenames([]);
+                    $self.existingPackageRenamesFrom([]);
+                    $self.existingPackageRenamesMessagesFrom([]);
+                    $self.existingPackageRenamesTo([]);
+                    $self.existingPackageRenamesMessagesTo([]);
                     $self.successMessage('');
                     $self.errorSubmitChanges('');
 
@@ -117,7 +185,10 @@
                         dataType: 'json',
                         success: function (result) {
                             $self.validatedInputs(result.ValidatedInputs);
-                            $self.existingPackageRenames(result.ExistingPackageRenames);
+                            $self.existingPackageRenamesFrom(result.ExistingPackageRenamesFrom);
+                            $self.existingPackageRenamesMessagesFrom(result.ExistingPackageRenamesMessagesFrom);
+                            $self.existingPackageRenamesTo(result.ExistingPackageRenamesTo);
+                            $self.existingPackageRenamesMessagesTo(result.ExistingPackageRenamesMessagesTo);
                         }
                     })
                         .fail(function (xhr, textStatus, errorMessage) {

--- a/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/PopularityTransfer/Index.cshtml
@@ -69,21 +69,21 @@
 
         @AddPopularityTransferItemTable("validatedInputs", "validatedInputResult", "preview of popularity transfer changes")
 
-        <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesFrom().length > 0, foreach: existingPackageRenamesMessagesFrom">
+        <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesConflict().length > 0, foreach: existingPackageRenamesMessagesConflict">
             @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
         </div>
 
-        <h3 style="display:none" data-bind="visible: existingPackageRenamesFrom().length > 0">Entries that will be removed from the PackageRenames table with this operation</h3>
+        <h3 style="display:none" data-bind="visible: existingPackageRenamesConflict().length > 0">Entries that will be removed from the PackageRenames table with this operation</h3>
 
-        @AddPopularityTransferItemTable("existingPackageRenamesFrom", "existingRenamesFromResult", "existing popularity transfers for the selected packages")
+        @AddPopularityTransferItemTable("existingPackageRenamesConflict", "existingRenamesConflictResult", "existing popularity transfers for the selected packages")
 
-        <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesTo().length > 0, foreach: existingPackageRenamesMessagesTo">
+        <div class="form-group col-md-12" style="display:none" data-bind="visible: existingPackageRenamesMessagesTransitive().length > 0, foreach: existingPackageRenamesMessagesTransitive">
             @ViewHelpers.AlertWarning(@<text><span data-bind="text: $data"></span></text>)
         </div>
 
-        <h3 style="display:none" data-bind="visible: existingPackageRenamesTo().length > 0">Existing entries in the PackageRenames table that will result in a new transitive relationship</h3>
+        <h3 style="display:none" data-bind="visible: existingPackageRenamesTransitive().length > 0">Existing entries in the PackageRenames table that will result in a new transitive relationship</h3>
 
-        @AddPopularityTransferItemTable("existingPackageRenamesTo", "existingRenamesToResult", "existing popularity transfers for the selected packages")
+        @AddPopularityTransferItemTable("existingPackageRenamesTransitive", "existingRenamesTransitiveResult", "existing popularity transfers for the selected packages")
 
         <div class="form-group col-md-12">
             <button type="submit" class="btn btn-block btn-primary" data-bind="click: submitInputs">Submit changes</button>
@@ -106,10 +106,10 @@
                 this.errorInputs = ko.observable('');
 
                 this.validatedInputs = ko.observableArray([]);
-                this.existingPackageRenamesFrom = ko.observableArray([]);
-                this.existingPackageRenamesMessagesFrom = ko.observableArray([]);
-                this.existingPackageRenamesTo = ko.observableArray([]);
-                this.existingPackageRenamesMessagesTo = ko.observableArray([]);
+                this.existingPackageRenamesConflict = ko.observableArray([]);
+                this.existingPackageRenamesMessagesConflict = ko.observableArray([]);
+                this.existingPackageRenamesTransitive = ko.observableArray([]);
+                this.existingPackageRenamesMessagesTransitive = ko.observableArray([]);
 
                 this.successMessage = ko.observable('');
                 this.errorSubmitChanges = ko.observable('');
@@ -118,10 +118,10 @@
                     $self.doneValidateInputs(false);
                     $self.errorInputs('');
                     $self.validatedInputs([]);
-                    $self.existingPackageRenamesFrom([]);
-                    $self.existingPackageRenamesMessagesFrom([]);
-                    $self.existingPackageRenamesTo([]);
-                    $self.existingPackageRenamesMessagesTo([]);
+                    $self.existingPackageRenamesConflict([]);
+                    $self.existingPackageRenamesMessagesConflict([]);
+                    $self.existingPackageRenamesTransitive([]);
+                    $self.existingPackageRenamesMessagesTransitive([]);
                     $self.successMessage('');
                     $self.errorSubmitChanges('');
 
@@ -138,10 +138,10 @@
                         dataType: 'json',
                         success: function (result) {
                             $self.validatedInputs(result.ValidatedInputs);
-                            $self.existingPackageRenamesFrom(result.ExistingPackageRenamesFrom);
-                            $self.existingPackageRenamesMessagesFrom(result.ExistingPackageRenamesMessagesFrom);
-                            $self.existingPackageRenamesTo(result.ExistingPackageRenamesTo);
-                            $self.existingPackageRenamesMessagesTo(result.ExistingPackageRenamesMessagesTo);
+                            $self.existingPackageRenamesConflict(result.ExistingPackageRenamesConflict);
+                            $self.existingPackageRenamesMessagesConflict(result.ExistingPackageRenamesMessagesConflict);
+                            $self.existingPackageRenamesTransitive(result.ExistingPackageRenamesTransitive);
+                            $self.existingPackageRenamesMessagesTransitive(result.ExistingPackageRenamesMessagesTransitive);
                         }
                     })
                         .fail(function (xhr, textStatus, errorMessage) {

--- a/src/NuGetGallery/Services/IPackageRenameService.cs
+++ b/src/NuGetGallery/Services/IPackageRenameService.cs
@@ -9,5 +9,6 @@ namespace NuGetGallery
     public interface IPackageRenameService
     {
         IReadOnlyList<PackageRename> GetPackageRenames(PackageRegistration package);
+        IReadOnlyList<PackageRename> GetPackageRenamesTo(PackageRegistration package);
     }
 }

--- a/src/NuGetGallery/Services/PackageRenameService.cs
+++ b/src/NuGetGallery/Services/PackageRenameService.cs
@@ -23,6 +23,17 @@ namespace NuGetGallery
         {
             return _packageRenameRepository.GetAll()
                 .Where(pr => pr.FromPackageRegistrationKey == packageRegistration.Key)
+                .Include(pr => pr.FromPackageRegistration)
+                .Include(pr => pr.ToPackageRegistration)
+                .ToList();
+        }
+
+
+        public IReadOnlyList<PackageRename> GetPackageRenamesTo(PackageRegistration packageRegistration)
+        {
+            return _packageRenameRepository.GetAll()
+                .Where(pr => pr.ToPackageRegistrationKey == packageRegistration.Key)
+                .Include(pr => pr.FromPackageRegistration)
                 .Include(pr => pr.ToPackageRegistration)
                 .ToList();
         }


### PR DESCRIPTION
1. The Popularity Transfer Admin Panel has a bug where it shows version-specific download counts for packages, rather than the package registration's download count, which is what we want (we transfer popularity from one package registration to another). I had to refactor some code to get that data correctly. This now works:
(DEV packages: https://dev.nugettest.org/packages/Newtonsoft.Json/)
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/cfb0981a-0010-420b-95e6-4a25811e3eef)


2. I also added some more validation info to the Admin Panel page, which should save us from having to go look in the SQL DB manually every time every time: 
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/2650b9a4-7113-429b-8f71-1dcf02f1f2a6)
