### PR TITLE
Changing a binding redirect to fix Gallery runtime issues

### DIFF
--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -696,7 +696,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.34.0.0" newVersion="1.34.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.35.0.0" newVersion="1.35.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Autofac.Integration.Owin" publicKeyToken="17863AF14B0044DA" culture="neutral"/>


### PR DESCRIPTION
We updated some package versions in dev recently and started seeing runtime issues.

Changing this binding redirect in the Web.config file should fix it.