### PR TITLE
[Hotfix] Don't index the license page and hide content when locked

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,3 +33,7 @@ dotnet_diagnostic.CA1065.severity = none
 
 # CA2214: Do not call overridable methods in constructors
 dotnet_diagnostic.CA2214.severity = none
+
+# Suppressions we want to reset
+dotnet_diagnostic.CA2017.severity = warning
+dotnet_diagnostic.IDE0005.severity = default # unnecessary usings

--- a/NuGetGallery.sln
+++ b/NuGetGallery.sln
@@ -55,6 +55,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C643C106-D245-4F00-A486-146357812D8D}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		build.ps1 = build.ps1
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
 		SdkProjects.props = SdkProjects.props

--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,7 @@ param (
     [string]$PackageSuffix,
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranchCommit = '65e723253187442f5b8ea537f672bd9328ade5a7', #DevSkim: ignore DS173237. Not a secret/token. It is a commit hash.
+    [string]$BuildBranchCommit = '5295c6e0d2ae7357fccf01e48c56b768b192f022', #DevSkim: ignore DS173237. Not a secret/token. It is a commit hash.
     [string]$VerifyMicrosoftPackageVersion = $null
 )
 

--- a/build.ps1
+++ b/build.ps1
@@ -5,12 +5,12 @@ param (
     [int]$BuildNumber,
     [switch]$SkipRestore,
     [switch]$CleanCache,
-    [string]$SimpleVersion = '1.0.0',
-    [string]$SemanticVersion = '1.0.0-zlocal',
+    [string]$SimpleVersion = '4.4.5',
+    [string]$SemanticVersion = '4.4.5-zlocal',
     [string]$PackageSuffix,
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranchCommit = '5295c6e0d2ae7357fccf01e48c56b768b192f022', #DevSkim: ignore DS173237. Not a secret/token. It is a commit hash.
+    [string]$BuildBranchCommit = '65e723253187442f5b8ea537f672bd9328ade5a7', #DevSkim: ignore DS173237. Not a secret/token. It is a commit hash.
     [string]$VerifyMicrosoftPackageVersion = $null
 )
 

--- a/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/DisplayPackageViewModel.cs
@@ -159,14 +159,6 @@ namespace NuGetGallery
             }
         }
 
-        public bool ShowDetailsAndLinks
-        {
-            get
-            {
-                return (Listed || !Locked) && (!Deleted || !Locked); 
-            }
-        }
-
         public enum RepositoryKind
         {
             Unknown,

--- a/src/NuGetGallery/ViewModels/PackageViewModel.cs
+++ b/src/NuGetGallery/ViewModels/PackageViewModel.cs
@@ -36,5 +36,13 @@ namespace NuGetGallery
         {
             return current.Version == Version && current.Id == Id;
         }
+
+        public bool ShowDetailsAndLinks
+        {
+            get
+            {
+                return (Listed || !Locked) && (!Deleted || !Locked);
+            }
+        }
     }
 }

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -376,67 +376,73 @@
                     @Html.Partial("_DisplayPackageVulnerabilities")
                 }
 
-                @if (Model.IsPackageDeprecationEnabled && Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                @if (Model.ShowDetailsAndLinks)
                 {
-                    @Html.Partial("_DisplayPackageDeprecation")
-                }
+                    if (Model.IsPackageDeprecationEnabled && Model.DeprecationStatus != PackageDeprecationStatus.NotDeprecated)
+                    {
+                        @Html.Partial("_DisplayPackageDeprecation")
+                    }
 
-                @if (Model.IsPackageRenamesEnabled && Model.PackageRenames != null && Model.PackageRenames.Count != 0)
-                {
-                    @Html.Partial("_DisplayPackageRenames")
-                }
+                    if (Model.IsPackageRenamesEnabled && Model.PackageRenames != null && Model.PackageRenames.Count != 0)
+                    {
+                        @Html.Partial("_DisplayPackageRenames")
+                    }
 
-                @if (Model.Prerelease)
-                {
-                    @ViewHelpers.AlertInfo(
-                        @<text>
-                            This is a prerelease version of @(Model.Id).
-                        </text>
-                    )
-                }
-                @if (Model.NuGetVersion.HasMetadata)
-                {
-                    @ViewHelpers.AlertInfo(
-                        @<text>
-                            This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
-                        </text>
-                    )
-                }
-                @if (Model.VersionRequestedWasNotFound)
-                {
-                    @ViewHelpers.AlertWarning(
-                        @<text>
-                            The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
-                        </text>
-                    )
-                }
-                @if (Model.HasNewerRelease)
-                {
-                    @ViewHelpers.AlertInfo(
-                        @<text>
-                            There is a newer version of this package available.
-                            <br /> See the version list below for details.
-                        </text>
-                    )
-                }
-                else if (Model.HasNewerPrerelease)
-                {
-                    @ViewHelpers.AlertInfo(
-                        @<text>
-                            There is a newer prerelease version of this package available.
-                            <br /> See the version list below for details.
-                        </text>
-                    )
-                }
+                    if (Model.Prerelease)
+                    {
+                        @ViewHelpers.AlertInfo(
+                            @<text>
+                                This is a prerelease version of @(Model.Id).
+                            </text>
+                        )
+                    }
+                    
+                    if (Model.NuGetVersion.HasMetadata)
+                    {
+                        @ViewHelpers.AlertInfo(
+                            @<text>
+                                This package has a SemVer 2.0.0 package version: @(Model.FullVersion).
+                            </text>
+                        )
+                    }
+                    
+                    if (Model.VersionRequestedWasNotFound)
+                    {
+                        @ViewHelpers.AlertWarning(
+                            @<text>
+                                The specified version @Model.VersionRequested was not found. You have been taken to version @(Model.Version).
+                            </text>
+                        )
+                    }
+                    
+                    if (Model.HasNewerRelease)
+                    {
+                        @ViewHelpers.AlertInfo(
+                            @<text>
+                                There is a newer version of this package available.
+                                <br /> See the version list below for details.
+                            </text>
+                        )
+                    }
+                    else if (Model.HasNewerPrerelease)
+                    {
+                        @ViewHelpers.AlertInfo(
+                            @<text>
+                                There is a newer prerelease version of this package available.
+                                <br /> See the version list below for details.
+                            </text>
+                        )
+                    }
 
-                @if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
-                {
-                    @ViewHelpers.AlertWarning(
-                        @<text>
-                            <strong>This package has not been indexed yet.</strong> It will appear in search results
-                            and will be available for install/restore after indexing is complete.
-                        </text>
-                    )
+                    if (Model.Listed && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && Model.Available)
+                    {
+                        @ViewHelpers.AlertWarning(
+                            @<text>
+                                <strong>This package has not been indexed yet.</strong> It will appear in search results
+                                and will be available for install/restore after indexing is complete.
+                            </text>
+                        )
+                    }
                 }
 
                 @if (Model.HasEmbeddedIcon && Model.ShowDetailsAndLinks && Model.IsIndexed.HasValue && !Model.IsIndexed.Value && (Model.Available || Model.Validating))

--- a/src/NuGetGallery/Views/Packages/License.cshtml
+++ b/src/NuGetGallery/Views/Packages/License.cshtml
@@ -111,19 +111,16 @@
                         @ViewHelpers.AlertWarning(
                                     @<text>
                                         This package contains no license information.
-                                    </text>
-)
+                                    </text>)
                     </div>
                 }
             }
             else
             {
-                <div class="content-hidden-notice">
                     @ViewHelpers.AlertDanger(
                             @<text>
                                 This package's content is hidden as it violates our <a href="https://www.nuget.org/policies/terms" title="Terms of Use">Terms of Use</a>.
                             </text>)
-                </div>
             }
         </div>
     </div>

--- a/src/NuGetGallery/Views/Packages/License.cshtml
+++ b/src/NuGetGallery/Views/Packages/License.cshtml
@@ -5,6 +5,7 @@
     ViewBag.Title = "License of " + Model.Id + " " + Model.Version;
     ViewBag.Tab = "Licenses";
     ViewBag.MdPageColumns = GalleryConstants.ColumnsFormMd;
+    ViewBag.BlockSearchEngineIndexing = true;
 }
 
 @* The following two helpers must be on a single line each so no extra whitespace is introduced in the expression when rendered. *@
@@ -17,99 +18,111 @@
 <section role="main" class="container main-container page-licenses">
     <div class="row">
         <div class="@ViewHelpers.GetColumnClasses(ViewBag)">
-            @Html.Partial(
-                "_PackageHeading",
-                new PackageHeadingModel(
-                    Model.Id,
-                    Model.Version,
-                    "License Info"))
 
-            <div class="package-title">
-                <h1>
-                    @Html.BreakWord(Model.Id)
-                    <small class="text-nowrap">@Model.FullVersion</small>
-                </h1>
-            </div>
-
-
-            @if (!string.IsNullOrWhiteSpace(Model.LicenseExpression))
+            @if (Model.ShowDetailsAndLinks)
             {
-                <label>License expression</label>
-                <div>
-                    @if (Model.LicenseExpressionSegments.AnySafe())
-                    {
-                        foreach (var segment in Model.LicenseExpressionSegments)
-                        {
-                            if (@ViewHelpers.IsLicenseOrException(segment))
-                            {
-                                @MakeLicenseLink(segment);
-                            }
-                            else
-                            {
-                                @MakeLicenseSpan(segment);
-                            }
-                        }
-                    }
+                @Html.Partial(
+                    "_PackageHeading",
+                    new PackageHeadingModel(
+                        Model.Id,
+                        Model.Version,
+                        "License Info"))
+
+                <div class="package-title">
+                    <h1>
+                        @Html.BreakWord(Model.Id)
+                        <small class="text-nowrap">@Model.FullVersion</small>
+                    </h1>
                 </div>
-            }
-            else if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
-            {
-                if (Model.Validating)
-                {
-                    @ViewHelpers.AlertWarning(
-                        @<text>
-                            The license file will become available once package validation has completed successfully.
-                        </text>
-                    )
-                }
-                else
-                {
-                    <label>License file</label>
-                    <div class="common-licenses">
-                        @if (Model.LicenseFileContentsHtml != null)
-                        {
-                            if (Model.LicenseFileContentsHtml.ImageSourceDisallowed && Model.CanDisplayPrivateMetadata)
-                            {
-                                @ViewHelpers.AlertImageSourceDisallowed();
-                            }
 
-                            if (Model.LicenseFileContentsHtml.ImagesRewritten && Model.CanDisplayPrivateMetadata)
-                            {
-                                @ViewHelpers.AlertImagesRewritten();
-                            }
-                            @Html.Raw(Model.LicenseFileContentsHtml.Content)
-                        }
-                        else
+                if (!string.IsNullOrWhiteSpace(Model.LicenseExpression))
+                {
+                    <label>License expression</label>
+                    <div>
+                        @if (Model.LicenseExpressionSegments.AnySafe())
                         {
-                            <pre class="license-file-contents custom-license-container">@Model.LicenseFileContents</pre>
+                            foreach (var segment in Model.LicenseExpressionSegments)
+                            {
+                                if (@ViewHelpers.IsLicenseOrException(segment))
+                                {
+                                    @MakeLicenseLink(segment);
+                                }
+                                else
+                                {
+                                    @MakeLicenseSpan(segment);
+                                }
+                            }
                         }
                     </div>
                 }
-            }
-            else if (Model.LicenseUrl != null)
-            {
-                <label>License URL</label>
-                <div>
-                    <a href="@Model.LicenseUrl">
-                        @if (Model.LicenseNames.AnySafe())
-                        {
-                            @(string.Join(", ", Model.LicenseNames.Select(x => x + " License")))
-                        }
-                        else
-                        {
-                            @Model.LicenseUrl
-                        }
-                    </a>
-                </div>
+                else if (Model.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
+                {
+                    if (Model.Validating)
+                    {
+                        @ViewHelpers.AlertWarning(
+                                    @<text>
+                                        The license file will become available once package validation has completed successfully.
+                                    </text>
+)
+                    }
+                    else
+                    {
+                        <label>License file</label>
+                        <div class="common-licenses">
+                            @if (Model.LicenseFileContentsHtml != null)
+                            {
+                                if (Model.LicenseFileContentsHtml.ImageSourceDisallowed && Model.CanDisplayPrivateMetadata)
+                                {
+                                    @ViewHelpers.AlertImageSourceDisallowed();
+                                }
+
+                                if (Model.LicenseFileContentsHtml.ImagesRewritten && Model.CanDisplayPrivateMetadata)
+                                {
+                                    @ViewHelpers.AlertImagesRewritten();
+                                }
+                                @Html.Raw(Model.LicenseFileContentsHtml.Content)
+                            }
+                            else
+                            {
+                                <pre class="license-file-contents custom-license-container">@Model.LicenseFileContents</pre>
+                            }
+                        </div>
+                    }
+                }
+                else if (Model.LicenseUrl != null)
+                {
+                    <label>License URL</label>
+                    <div>
+                        <a href="@Model.LicenseUrl">
+                            @if (Model.LicenseNames.AnySafe())
+                            {
+                                @(string.Join(", ", Model.LicenseNames.Select(x => x + " License")))
+                            }
+                            else
+                            {
+                                @Model.LicenseUrl
+                            }
+                        </a>
+                    </div>
+                }
+                else
+                {
+                    <div>
+                        @ViewHelpers.AlertWarning(
+                                    @<text>
+                                        This package contains no license information.
+                                    </text>
+)
+                    </div>
+                }
             }
             else
             {
-                <div>
-                    @ViewHelpers.AlertWarning(
-                        @<text>
-                            This package contains no license information.
-                        </text>
-                    )
+                <div class="content-hidden-notice">
+                    @ViewHelpers.AlertDanger(
+                            @<text>
+                                This package's content is hidden as it violates our <a href="https://www.nuget.org/policies/terms" title="Terms of Use">Terms of Use</a>.
+                            </text>)
                 </div>
             }
         </div>


### PR DESCRIPTION
Resolve https://github.com/NuGet/NuGetGallery/issues/9670.

The diff is best viewed when [hiding whitespace](https://github.com/NuGet/NuGetGallery/pull/9719/files?diff=unified&w=1).

Summary of changes:
- Add `no-index` to all license pages. I think this is the right approach. We index the "parent" page (per ID - version). 
  - We already don't index the Report abuse page, which is the other child page not requiring sign in
- Hide license content when the package is locked
- Hide other warnings/info messages on the package details
- Unrelated: default generated assembly version to 4.4.5 to make matching release builds easier (strong name is unsolved)
- Unrelated: fix minor devskim warnings 
- Unrelated: two super helpful warnings back to editorconfig

![image](https://github.com/NuGet/NuGetGallery/assets/94054/7fb15cc3-6764-463e-811a-ed44abfb5c9a)
