### PR TITLE
Add .NET 8 constants for TFM badges and search filters

### DIFF
--- a/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
+++ b/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
@@ -47,7 +47,6 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework Net80Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "ios", EmptyVersion);
         public static readonly NuGetFramework Net80MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "macos", EmptyVersion);
         public static readonly NuGetFramework Net80MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "maccatalyst", EmptyVersion);
-        public static readonly NuGetFramework Net80Tizen = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "tizen", EmptyVersion);
         public static readonly NuGetFramework Net80TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "tvos", EmptyVersion);
         public static readonly NuGetFramework Net80Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "windows", EmptyVersion);
         public static readonly NuGetFramework NetCore = new NuGetFramework(FrameworkIdentifiers.NetCore, EmptyVersion);

--- a/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
+++ b/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
@@ -34,14 +34,12 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework Net60Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "ios", EmptyVersion);
         public static readonly NuGetFramework Net60MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "macos", EmptyVersion);
         public static readonly NuGetFramework Net60MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "maccatalyst", EmptyVersion);
-        public static readonly NuGetFramework Net60Tizen = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "tizen", EmptyVersion);
         public static readonly NuGetFramework Net60TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "tvos", EmptyVersion);
         public static readonly NuGetFramework Net60Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "windows", EmptyVersion);
         public static readonly NuGetFramework Net70Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "android", EmptyVersion);
         public static readonly NuGetFramework Net70Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "ios", EmptyVersion);
         public static readonly NuGetFramework Net70MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "macos", EmptyVersion);
         public static readonly NuGetFramework Net70MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "maccatalyst", EmptyVersion);
-        public static readonly NuGetFramework Net70Tizen = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "tizen", EmptyVersion);
         public static readonly NuGetFramework Net70TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "tvos", EmptyVersion);
         public static readonly NuGetFramework Net70Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "windows", EmptyVersion);
         public static readonly NuGetFramework Net80 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8); // https://github.com/NuGet/Engineering/issues/5112

--- a/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
+++ b/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
@@ -21,6 +21,8 @@ namespace NuGetGallery.Frameworks
     /// </remarks>
     public static class SupportedFrameworks
     {
+        public static readonly Version Version8 = new Version(8, 0, 0, 0); // https://github.com/NuGet/Engineering/issues/5112
+
         public static readonly NuGetFramework MonoAndroid = new NuGetFramework(FrameworkIdentifiers.MonoAndroid, EmptyVersion);
         public static readonly NuGetFramework MonoTouch = new NuGetFramework(FrameworkIdentifiers.MonoTouch, EmptyVersion);
         public static readonly NuGetFramework MonoMac = new NuGetFramework(FrameworkIdentifiers.MonoMac, EmptyVersion);
@@ -42,6 +44,14 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework Net70Tizen = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "tizen", EmptyVersion);
         public static readonly NuGetFramework Net70TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "tvos", EmptyVersion);
         public static readonly NuGetFramework Net70Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "windows", EmptyVersion);
+        public static readonly NuGetFramework Net80 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8); // https://github.com/NuGet/Engineering/issues/5112
+        public static readonly NuGetFramework Net80Android = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "android", EmptyVersion);
+        public static readonly NuGetFramework Net80Ios = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "ios", EmptyVersion);
+        public static readonly NuGetFramework Net80MacOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "macos", EmptyVersion);
+        public static readonly NuGetFramework Net80MacCatalyst = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "maccatalyst", EmptyVersion);
+        public static readonly NuGetFramework Net80Tizen = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "tizen", EmptyVersion);
+        public static readonly NuGetFramework Net80TvOs = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "tvos", EmptyVersion);
+        public static readonly NuGetFramework Net80Windows = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version8, "windows", EmptyVersion);
         public static readonly NuGetFramework NetCore = new NuGetFramework(FrameworkIdentifiers.NetCore, EmptyVersion);
         public static readonly NuGetFramework NetMf = new NuGetFramework(FrameworkIdentifiers.NetMicro, EmptyVersion);
         public static readonly NuGetFramework UAP = new NuGetFramework(FrameworkIdentifiers.UAP, EmptyVersion);
@@ -66,6 +76,7 @@ namespace NuGetGallery.Frameworks
                 Net50, Net50Windows,
                 Net60, Net60Android, Net60Ios, Net60MacCatalyst, Net60MacOs, Net60TvOs, Net60Windows,
                 Net70, Net70Android, Net70Ios, Net70MacCatalyst, Net70MacOs, Net70TvOs, Net70Windows,
+                Net80, Net80Android, Net80Ios, Net80MacCatalyst, Net80MacOs, Net80TvOs, Net80Windows,
                 NetCore, NetCore45, NetCore451,
                 NetCoreApp10, NetCoreApp11, NetCoreApp20, NetCoreApp21, NetCoreApp22, NetCoreApp30, NetCoreApp31,
                 NetMf,
@@ -84,6 +95,7 @@ namespace NuGetGallery.Frameworks
         public static class TfmFilters {
             public static readonly List<NuGetFramework> NetTfms = new List<NuGetFramework>
             {
+                Net80,
                 Net70,
                 Net60,
                 Net50


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/5111

We want to add .NET 8 search filters and TFM badges in time for the .NET 8 release.

**Search filters:**

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/890c6a01-24ff-424f-b42e-bb267aec7635)

**TFM badges:**

Previously,
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/49acc9ad-bf3f-48f0-8e09-3b9a94604f12)

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/b1d7c22f-90c6-4a6f-a484-40e742eb70c2)

After the changes,
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/352d39eb-6bcd-4751-8d63-05b6b199b9b6)

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/3ec44334-cbd5-4e17-96d3-eb295473b44c)


NOTE: We usually rely on constants from the NuGet.Frameworks package, but those changes have not been published yet. Once those changes are published with v6.9.0 of the Client SDK, we can remove our Gallery-only constants (`Version8` and `Net80`) and replace them with the appropriate constants from the NuGet.Frameworks package (See https://github.com/NuGet/Engineering/issues/5112).