### PR TITLE
Normalize TFM platform versions when determining computed compatibility

### DIFF
--- a/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
+++ b/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
@@ -33,7 +33,7 @@ namespace NuGetGallery.Frameworks
                 var normalizedPackageFramework = packageFramework;
                 bool hasPlatformVersion = false;
 
-                if ((packageFramework.Platform != string.Empty) && (packageFramework.PlatformVersion != FrameworkConstants.EmptyVersion))
+                if (!string.IsNullOrEmpty(packageFramework.Platform) && (packageFramework.PlatformVersion != FrameworkConstants.EmptyVersion))
                 {
                     normalizedPackageFramework = new NuGetFramework(packageFramework.Framework,
                                                                     packageFramework.Version,

--- a/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
+++ b/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
@@ -47,7 +47,10 @@ namespace NuGetGallery.Frameworks
                 {
                     if (hasPlatformVersion)
                     {
-                        compatibleFrameworks = AddPlatformVersionToComputedTfms(compatibleFrameworks, packageFramework.PlatformVersion);
+                        compatibleFrameworks = compatibleFrameworks.ToHashSet(); // make a copy
+
+                        compatibleFrameworks.Remove(normalizedPackageFramework);
+                        compatibleFrameworks.Add(packageFramework);
                     }
 
                     allCompatibleFrameworks.UnionWith(compatibleFrameworks);
@@ -81,13 +84,6 @@ namespace NuGetGallery.Frameworks
             }
 
             return matrix;
-        }
-
-        private static ISet<NuGetFramework> AddPlatformVersionToComputedTfms(ISet<NuGetFramework> computedTfms, Version platformVersion)
-        {
-            return computedTfms
-                        .Select(tfm => new NuGetFramework(tfm.Framework, tfm.Version, tfm.Platform, platformVersion))
-                        .ToHashSet();
         }
     }
 }

--- a/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
+++ b/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
@@ -72,10 +72,12 @@ namespace NuGetGallery.Frameworks
                 }
             }
 
+            /*
             matrix.Add(SupportedFrameworks.Net60Windows7, 
                 new HashSet<NuGetFramework>() {
                     SupportedFrameworks.Net60Windows, SupportedFrameworks.Net60Windows7,
                     SupportedFrameworks.Net70Windows, SupportedFrameworks.Net70Windows7 });
+            */
 
             return matrix;
         }

--- a/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
+++ b/src/NuGetGallery.Core/Frameworks/FrameworkCompatibilityService.cs
@@ -29,9 +29,20 @@ namespace NuGetGallery.Frameworks
                     continue;
                 }
 
-                if (CompatibilityMatrix.TryGetValue(packageFramework, out var compatibleFrameworks))
+                var normalizedPackageFramework = packageFramework;
+                if ((packageFramework.Platform != string.Empty) && (packageFramework.PlatformVersion != FrameworkConstants.EmptyVersion))
+                {
+                    normalizedPackageFramework = new NuGetFramework(packageFramework.Framework,
+                                                                    packageFramework.Version,
+                                                                    packageFramework.Platform,
+                                                                    FrameworkConstants.EmptyVersion);
+                }
+
+                if (CompatibilityMatrix.TryGetValue(normalizedPackageFramework, out var compatibleFrameworks))
                 {
                     allCompatibleFrameworks.UnionWith(compatibleFrameworks);
+                    allCompatibleFrameworks.Add(packageFramework); // If the TFM has a platform version, then only the normalized TFM gets added with the above step,
+                                                                   // and we need to add the original TFM separately. 
                 }
                 else
                 {

--- a/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
+++ b/src/NuGetGallery.Core/Frameworks/SupportedFrameworks.cs
@@ -57,9 +57,6 @@ namespace NuGetGallery.Frameworks
         public static readonly NuGetFramework XamarinMac = new NuGetFramework(FrameworkIdentifiers.XamarinMac, EmptyVersion);
         public static readonly NuGetFramework XamarinTvOs = new NuGetFramework(FrameworkIdentifiers.XamarinTVOS, EmptyVersion);
         public static readonly NuGetFramework XamarinWatchOs = new NuGetFramework(FrameworkIdentifiers.XamarinWatchOS, EmptyVersion);
-
-        public static readonly NuGetFramework Net60Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version6, "windows", Version7);
-        public static readonly NuGetFramework Net70Windows7 = new NuGetFramework(FrameworkIdentifiers.NetCoreApp, Version7, "windows", Version7);
         
         public static readonly IReadOnlyList<NuGetFramework> AllSupportedNuGetFrameworks;
 

--- a/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
@@ -93,11 +93,13 @@ namespace NuGetGallery.Frameworks
 
         [Theory]
         [InlineData("net6.0-windows", "net6.0-windows", "net7.0-windows", "net8.0-windows")]
-        [InlineData("net6.0-windows7.0", "net6.0-windows7.0", "net6.0-windows", "net7.0-windows", "net8.0-windows")]
+        [InlineData("net6.0-windows7.0", "net6.0-windows7.0", "net7.0-windows7.0", "net8.0-windows7.0")]
         [InlineData("net7.0-windows", "net7.0-windows", "net8.0-windows")]
-        [InlineData("net7.0-windows7.0", "net7.0-windows7.0", "net7.0-windows", "net8.0-windows")]
+        [InlineData("net7.0-windows7.0", "net7.0-windows7.0", "net8.0-windows7.0")]
         [InlineData("net6.0-ios", "net6.0-ios", "net7.0-ios", "net8.0-ios")]
-        [InlineData("net6.0-android31.0", "net6.0-android31.0", "net6.0-android", "net7.0-android", "net8.0-android")]
+        [InlineData("net6.0-ios15.0", "net6.0-ios15.0", "net7.0-ios15.0", "net8.0-ios15.0")]
+        [InlineData("net6.0-android31.0", "net6.0-android31.0", "net7.0-android31.0", "net8.0-android31.0")]
+        [InlineData("net6.0-windows10.0", "net6.0-windows10.0", "net7.0-windows10.0", "net8.0-windows10.0")]
         public void WindowsPlatformVersionsShouldContainAllSpecifiedFrameworks(string windowsDefaultVersionFramework, params string[]  windowsProjectFrameworks) 
         {
             var packageFramework = NuGetFramework.Parse(windowsDefaultVersionFramework);

--- a/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
@@ -92,7 +92,12 @@ namespace NuGetGallery.Frameworks
         }
 
         [Theory]
-        [InlineData("net6.0-windows7.0", "net6.0-windows", "net6.0-windows7.0", "net7.0-windows", "net7.0-windows7.0")]
+        [InlineData("net6.0-windows", "net6.0-windows", "net7.0-windows", "net8.0-windows")]
+        [InlineData("net6.0-windows7.0", "net6.0-windows7.0", "net6.0-windows", "net7.0-windows", "net8.0-windows")]
+        [InlineData("net7.0-windows", "net7.0-windows", "net8.0-windows")]
+        [InlineData("net7.0-windows7.0", "net7.0-windows7.0", "net7.0-windows", "net8.0-windows")]
+        [InlineData("net6.0-ios", "net6.0-ios", "net7.0-ios", "net8.0-ios")]
+        [InlineData("net6.0-android31.0", "net6.0-android31.0", "net6.0-android", "net7.0-android", "net8.0-android")]
         public void WindowsPlatformVersionsShouldContainAllSpecifiedFrameworks(string windowsDefaultVersionFramework, params string[]  windowsProjectFrameworks) 
         {
             var packageFramework = NuGetFramework.Parse(windowsDefaultVersionFramework);

--- a/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
@@ -92,26 +92,69 @@ namespace NuGetGallery.Frameworks
         }
 
         [Theory]
+        [InlineData("net5.0", "net5.0", "net6.0", "net7.0", "net5.0-windows")]
+        [InlineData("net6.0", "net6.0", "net7.0", "net6.0-android")]
+        [InlineData("net6.0-windows", "net7.0-windows")]
+        [InlineData("net462", "net472", "net481")]
+        [InlineData("netstandard2.1", "net6.0", "net6.0-windows", "netcoreapp3.1", "tizen60")]
+        [InlineData("netcoreapp3.0", "netcoreapp3.1", "net5.0", "net7.0-windows")]
+        public void ContainsExpectedComputedFrameworks(string assetFramework, params string[] computedFrameworks)
+        {
+            // Arrange
+            var packageFramework = NuGetFramework.Parse(assetFramework);
+
+            var expectedFrameworks = new List<NuGetFramework>();
+
+            foreach (var frameworkName in computedFrameworks)
+            {
+                expectedFrameworks.Add(NuGetFramework.Parse(frameworkName));
+            }
+
+            // Act
+            var compatibleFrameworks = FrameworkCompatibilityService.GetCompatibleFrameworks(new List<NuGetFramework>() { packageFramework });
+
+            // Assert
+            Assert.True(compatibleFrameworks.Count > 0);
+
+            // check that the list of computed TFMs contains all the specified TFMs
+            var containsAllCompatibleFrameworks = expectedFrameworks.All(f => compatibleFrameworks.Contains(f));
+            Assert.True(containsAllCompatibleFrameworks);
+
+            // check that every computed TFM included is compatible with the asset TFM
+            foreach (var compatibleFramework in compatibleFrameworks)
+            {
+                var isCompatible = CompatibilityProvider.IsCompatible(compatibleFramework, packageFramework);
+                Assert.True(isCompatible);
+            }
+        }
+
+        [Theory]
         [InlineData("net6.0-windows", "net6.0-windows", "net7.0-windows", "net8.0-windows")]
         [InlineData("net6.0-windows7.0", "net6.0-windows7.0", "net7.0-windows7.0", "net8.0-windows7.0")]
         [InlineData("net7.0-windows", "net7.0-windows", "net8.0-windows")]
         [InlineData("net7.0-windows7.0", "net7.0-windows7.0", "net8.0-windows7.0")]
+        [InlineData("net5.0-windows", "net5.0-windows", "net6.0-windows", "net7.0-windows", "net8.0-windows")]
+        [InlineData("net5.0-windows7.0", "net5.0-windows7.0", "net6.0-windows7.0", "net7.0-windows7.0", "net8.0-windows7.0")]
         [InlineData("net6.0-ios", "net6.0-ios", "net7.0-ios", "net8.0-ios")]
         [InlineData("net6.0-ios15.0", "net6.0-ios15.0", "net7.0-ios15.0", "net8.0-ios15.0")]
         [InlineData("net6.0-android", "net6.0-android", "net7.0-android", "net8.0-android")]
         [InlineData("net6.0-android31.0", "net6.0-android31.0", "net7.0-android31.0", "net8.0-android31.0")]
         [InlineData("net6.0-windows26.0", "net6.0-windows26.0", "net7.0-windows26.0", "net8.0-windows26.0")]
-        public void WindowsPlatformVersionsShouldContainAllSpecifiedFrameworks(string windowsDefaultVersionFramework, params string[]  windowsProjectFrameworks) 
+        public void PlatformVersionsShouldContainAllSpecifiedFrameworks(string platformVersionFramework, params string[] expectedFrameworks) 
         {
-            var packageFramework = NuGetFramework.Parse(windowsDefaultVersionFramework);
+            // Arrange
+            var packageFramework = NuGetFramework.Parse(platformVersionFramework);
             var projectFrameworks = new HashSet<NuGetFramework>();
 
-            foreach (var frameworkName in windowsProjectFrameworks) {
+            foreach (var frameworkName in expectedFrameworks) {
                 projectFrameworks.Add(NuGetFramework.Parse(frameworkName));
             }
 
+            // Act
             var compatibleFrameworks = FrameworkCompatibilityService.GetCompatibleFrameworks(new HashSet<NuGetFramework>() { packageFramework });
-            Assert.Equal(windowsProjectFrameworks.Length, compatibleFrameworks.Count);
+
+            // Assert
+            Assert.Equal(expectedFrameworks.Length, compatibleFrameworks.Count);
 
             var containsAllCompatibleFrameworks = compatibleFrameworks.All(cf => projectFrameworks.Contains(cf));
             Assert.True(containsAllCompatibleFrameworks);

--- a/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
@@ -130,23 +130,24 @@ namespace NuGetGallery.Frameworks
 
         [Theory]
         [InlineData("net6.0-windows", "net6.0-windows", "net7.0-windows", "net8.0-windows")]
-        [InlineData("net6.0-windows7.0", "net6.0-windows7.0", "net7.0-windows7.0", "net8.0-windows7.0")]
+        [InlineData("net6.0-windows7.0", "net6.0-windows7.0", "net7.0-windows", "net8.0-windows")]
         [InlineData("net7.0-windows", "net7.0-windows", "net8.0-windows")]
-        [InlineData("net7.0-windows7.0", "net7.0-windows7.0", "net8.0-windows7.0")]
+        [InlineData("net7.0-windows7.0", "net7.0-windows7.0", "net8.0-windows")]
         [InlineData("net5.0-windows", "net5.0-windows", "net6.0-windows", "net7.0-windows", "net8.0-windows")]
-        [InlineData("net5.0-windows7.0", "net5.0-windows7.0", "net6.0-windows7.0", "net7.0-windows7.0", "net8.0-windows7.0")]
+        [InlineData("net5.0-windows7.0", "net5.0-windows7.0", "net6.0-windows", "net7.0-windows", "net8.0-windows")]
         [InlineData("net6.0-ios", "net6.0-ios", "net7.0-ios", "net8.0-ios")]
-        [InlineData("net6.0-ios15.0", "net6.0-ios15.0", "net7.0-ios15.0", "net8.0-ios15.0")]
+        [InlineData("net6.0-ios15.0", "net6.0-ios15.0", "net7.0-ios", "net8.0-ios")]
         [InlineData("net6.0-android", "net6.0-android", "net7.0-android", "net8.0-android")]
-        [InlineData("net6.0-android31.0", "net6.0-android31.0", "net7.0-android31.0", "net8.0-android31.0")]
-        [InlineData("net6.0-windows26.0", "net6.0-windows26.0", "net7.0-windows26.0", "net8.0-windows26.0")]
-        public void PlatformVersionsShouldContainAllSpecifiedFrameworks(string platformVersionFramework, params string[] expectedFrameworks) 
+        [InlineData("net6.0-android31.0", "net6.0-android31.0", "net7.0-android", "net8.0-android")]
+        [InlineData("net6.0-windows99.0", "net6.0-windows99.0", "net7.0-windows", "net8.0-windows")]
+        public void PlatformVersionsShouldContainAllSpecifiedFrameworks(string platformVersionFramework, params string[] expectedFrameworks)
         {
             // Arrange
             var packageFramework = NuGetFramework.Parse(platformVersionFramework);
             var projectFrameworks = new HashSet<NuGetFramework>();
 
-            foreach (var frameworkName in expectedFrameworks) {
+            foreach (var frameworkName in expectedFrameworks)
+            {
                 projectFrameworks.Add(NuGetFramework.Parse(frameworkName));
             }
 
@@ -157,6 +158,40 @@ namespace NuGetGallery.Frameworks
             Assert.Equal(expectedFrameworks.Length, compatibleFrameworks.Count);
 
             var containsAllCompatibleFrameworks = compatibleFrameworks.All(cf => projectFrameworks.Contains(cf));
+            Assert.True(containsAllCompatibleFrameworks);
+        }
+
+        [Theory]
+        [InlineData(new string[] { "net5.0-windows7.0", "net6.0-windows" },
+                    new string[] { "net5.0-windows7.0", "net6.0-windows", "net7.0-windows", "net8.0-windows" })]
+        [InlineData(new string[] { "net5.0-windows", "net6.0-windows7.0" },
+                    new string[] { "net5.0-windows", "net6.0-windows", "net7.0-windows", "net8.0-windows", "net6.0-windows7.0" })]
+        [InlineData(new string[] { "net5.0-windows7.0", "net6.0-windows7.0" },
+                    new string[] { "net5.0-windows7.0", "net6.0-windows", "net7.0-windows", "net8.0-windows", "net6.0-windows7.0" })]
+        [InlineData(new string[] { "net5.0-windows99.0", "net6.0-windows99.0" },
+                    new string[] { "net5.0-windows99.0", "net6.0-windows", "net7.0-windows", "net8.0-windows", "net6.0-windows99.0" })]
+        public void MultiplePlatformVersionCasesShouldContainAllSpecifiedFrameworks(string[] platformVersionFrameworks, string[] expectedFrameworks)
+        {
+            // Arrange
+            var packageFrameworks = new HashSet<NuGetFramework>();
+            foreach (var frameworkName in platformVersionFrameworks)
+            {
+                packageFrameworks.Add(NuGetFramework.Parse(frameworkName));
+            }
+
+            var expectedComputedFrameworks = new HashSet<NuGetFramework>();
+            foreach (var frameworkName in expectedFrameworks)
+            {
+                expectedComputedFrameworks.Add(NuGetFramework.Parse(frameworkName));
+            }
+
+            // Act
+            var compatibleFrameworks = FrameworkCompatibilityService.GetCompatibleFrameworks(packageFrameworks);
+
+            // Assert
+            Assert.Equal(expectedFrameworks.Length, compatibleFrameworks.Count);
+
+            var containsAllCompatibleFrameworks = compatibleFrameworks.All(cf => expectedComputedFrameworks.Contains(cf));
             Assert.True(containsAllCompatibleFrameworks);
         }
     }

--- a/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/FrameworkCompatibilityServiceFacts.cs
@@ -98,8 +98,9 @@ namespace NuGetGallery.Frameworks
         [InlineData("net7.0-windows7.0", "net7.0-windows7.0", "net8.0-windows7.0")]
         [InlineData("net6.0-ios", "net6.0-ios", "net7.0-ios", "net8.0-ios")]
         [InlineData("net6.0-ios15.0", "net6.0-ios15.0", "net7.0-ios15.0", "net8.0-ios15.0")]
+        [InlineData("net6.0-android", "net6.0-android", "net7.0-android", "net8.0-android")]
         [InlineData("net6.0-android31.0", "net6.0-android31.0", "net7.0-android31.0", "net8.0-android31.0")]
-        [InlineData("net6.0-windows10.0", "net6.0-windows10.0", "net7.0-windows10.0", "net8.0-windows10.0")]
+        [InlineData("net6.0-windows26.0", "net6.0-windows26.0", "net7.0-windows26.0", "net8.0-windows26.0")]
         public void WindowsPlatformVersionsShouldContainAllSpecifiedFrameworks(string windowsDefaultVersionFramework, params string[]  windowsProjectFrameworks) 
         {
             var packageFramework = NuGetFramework.Parse(windowsDefaultVersionFramework);


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9711

### Problem:

TFMs that contain platform monikers and versions, like `net6.0-android31.0`, were not showing the `net7.0-android` and `net8.0-android` TFMs as users expected. 
https://www.nuget.org/packages/Xamarin.AndroidX.Lifecycle.Common/2.6.2.2#supportedframeworks-body-tab
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/b71383bc-28e4-4e54-8f39-d2097211f149)

If the TFM didn't have a platform version, say just `net6.0-android`, then the corresponding `net7.0` and `net8.0` TFMs show up as expected.
https://www.nuget.org/packages/Microsoft.CognitiveServices.Speech.Extension.ONNX.Runtime/1.33.0#supportedframeworks-body-tab
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/a021533b-f73e-4c94-aae0-3b7f4909526c)

### Solution:

Currently, if a TFM (.NET 5+) has a platform version, it does not show any computed compatible TFMs. Our compatibility matrix only includes TFMs without platform versions.

To fix this, if we see a TFM with a platform version:
1. Create a normalized copy of the TFM, using an empty platform version 
    `net6.0-windows7.0` -> `net6.0-windows`
2. Use this normalized TFM to find computed compatible TFMs
    `net6.0-windows` -> `net6.0-windows`, `net7.0-windows`, `net8.0-windows`
3. Add the original TFM with its platform version (`net6.0-windows7.0`), and remove the normalized TFM (`net6.0-windows`) from the set
    `net6.0-windows7.0`, `net7.0-windows`, `net8.0-windows`

i.e. `net6.0-windows7.0` -> `net6.0-windows7.0`, `net7.0-windows`, `net8.0-windows`

Similarly,

| Asset TFM | Computed TFMs |
|-----------|---------------|
| `net6.0-windowsY.Z` | `net6.0-windowsY.Z`, `net7.0-windows`, `net8.0-windows` |
| `net6.0-windows` | `net6.0-windows`, `net7.0-windows`, `net8.0-windows` |
| `net6.0-windows7.0` | `net6.0-windows7.0`, `net7.0-windows`, `net8.0-windows` |
| `net6.0-windows99.0` | `net6.0-windows99.0`, `net7.0-windows`, `net8.0-windows` |
| `net7.0-windows7.0` | `net7.0-windows7.0`, `net8.0-windows` |
| `net6.0-ios` | `net6.0-ios`, `net7.0-ios`, `net8.0-ios` |
| `net6.0-ios15.0` | `net6.0-ios15.0`, `net7.0-ios`, `net8.0-ios` |

![image](https://github.com/NuGet/NuGetGallery/assets/82980589/45cc6b3e-7e33-4498-ab23-ec36cde0a233)
