### PR TITLE
Allow admins to select a specific number of package versions

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Views/UpdateListed/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/UpdateListed/Index.cshtml
@@ -106,22 +106,33 @@
                 return true;
             };
 
-            this.selectListed = function (e) {
-                ko.utils.arrayForEach($self.searchResults(), function (result) {
-                    if (result.Listed) {
+            let selectFilteredResults = function (isListedFilter) {
+                var selection = parseInt(window.prompt("How many? (Default: All)", ""));
+                selection = isNaN(selection) ? $self.searchResults().length : selection;
+
+                if (selection === 0) {
+                    return true;
+                }
+
+                let i = 0;
+                ko.utils.arrayFirst($self.searchResults(), function (result) {
+                    if (result.Listed == isListedFilter) {
                         result.Selected(true);
+                        i++;
                     }
+
+                    // Stop looping when we selected enough items
+                    return i >= selection;
                 });
                 return true;
+            }
+
+            this.selectListed = function (e) {
+                selectFilteredResults(true);
             };
 
             this.selectUnlisted = function (e) {
-                ko.utils.arrayForEach($self.searchResults(), function (result) {
-                    if (!result.Listed) {
-                        result.Selected(true);
-                    }
-                });
-                return true;
+                selectFilteredResults(false);                
             };
 
             this.generateValue = function (package) {

--- a/src/NuGetGallery/Areas/Admin/Views/UpdateListed/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/UpdateListed/Index.cshtml
@@ -107,10 +107,14 @@
             };
 
             let selectFilteredResults = function (isListedFilter) {
+                ko.utils.arrayForEach($self.searchResults(), function (result) {
+                    result.Selected(false);
+                });
+
                 var selection = parseInt(window.prompt("How many? (Default: All)", ""));
                 selection = isNaN(selection) ? $self.searchResults().length : selection;
-
-                if (selection === 0) {
+                
+                if (selection <= 0) {
                     return true;
                 }
 


### PR DESCRIPTION
This PR adds a little prompt when you click in the `Select listed` or `Select unlisted` asking you how many packages you want to select. If you type anything but a number, it selects all (default behavior, just press enter) 
![image](https://github.com/NuGet/NuGetGallery/assets/1711217/ee4750ef-e46c-4421-8ae8-2e68483e1087)

After Clicking: 
![image](https://github.com/NuGet/NuGetGallery/assets/1711217/16eeca91-ce67-4bfc-9efb-f6d5e24b581b)


Addresses https://github.com/NuGet/NuGetGallery/issues/9517