### PR TITLE
Show TFM badges in package search results

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -306,7 +306,13 @@ namespace NuGetGallery.AccountDeleter
             throw new NotImplementedException();
         }
 
-        public bool IsFrameworkFilteringEnabled(User user) {
+        public bool IsFrameworkFilteringEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDisplayTfmBadgesEnabled(User user)
+        {
             throw new NotImplementedException();
         }
     }

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -284,7 +284,9 @@ img.reserved-indicator-icon {
   }
   .package-list li.package-warning-indicators {
     display: block;
+    overflow-y: visible;
     margin-bottom: 5px;
+    font-size: 14px;
   }
   .package-list li.package-tfm-badges {
     display: block;
@@ -293,8 +295,12 @@ img.reserved-indicator-icon {
   .package-list li.package-tfm-badges .framework-badges {
     margin-bottom: 2px;
   }
+  .package-list li.package-tfm-badges .framework-badges span {
+    margin-right: 1px;
+  }
   .package-list li.package-tfm-badges .framework-badges .framework-badge-computed {
     color: #000;
+    border: 1px solid rgba(0, 0, 0, 0.15);
   }
   .package-list li.package-tags {
     display: block;
@@ -641,30 +647,29 @@ img.reserved-indicator-icon {
   margin-bottom: 0px;
 }
 .package-warning {
-  padding-right: 8px;
-  padding-left: 8px;
+  padding: 1px 8px;
   border-radius: 2px;
   margin-right: 5px;
   color: #323130;
 }
 .package-warning--vulnerable {
-  padding-right: 8px;
-  padding-left: 8px;
+  padding: 1px 8px;
   border-radius: 2px;
   margin-right: 5px;
   color: #323130;
   background-color: #fed9cc;
+  border: 1px solid #fda181;
 }
 .package-warning--vulnerable i {
   color: #d83b01;
 }
 .package-warning--deprecated {
-  padding-right: 8px;
-  padding-left: 8px;
+  padding: 1px 8px;
   border-radius: 2px;
   margin-right: 5px;
   color: #323130;
   background-color: #fff4ce;
+  border: 1px solid #ffcc1c;
 }
 .multi-select-dropdown {
   position: relative;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -274,6 +274,31 @@ img.reserved-indicator-icon {
   outline: solid 0.25px;
   outline-offset: 0;
 }
+.package-list li.package-warning-indicators {
+  display: block;
+  overflow-y: visible;
+  margin-bottom: 5px;
+  font-size: 14px;
+}
+.package-list li.package-tfm-badges {
+  display: block;
+  overflow-y: visible;
+}
+.package-list li.package-tfm-badges .framework-badges {
+  margin-bottom: 2px;
+}
+.package-list li.package-tfm-badges .framework-badges span {
+  margin-right: 1px;
+}
+.package-list li.package-tfm-badges .framework-badges .framework-badge-computed {
+  color: #000;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+}
+@media (max-width: 768px) {
+  .package-list li.package-tfm-badges .framework-badges a + a span {
+    margin-bottom: 4px;
+  }
+}
 @media (min-width: 768px) {
   .package-list li {
     display: inline-block;
@@ -281,26 +306,6 @@ img.reserved-indicator-icon {
     max-height: 101px;
     overflow-y: hidden;
     padding-right: 10px;
-  }
-  .package-list li.package-warning-indicators {
-    display: block;
-    overflow-y: visible;
-    margin-bottom: 5px;
-    font-size: 14px;
-  }
-  .package-list li.package-tfm-badges {
-    display: block;
-    overflow-y: visible;
-  }
-  .package-list li.package-tfm-badges .framework-badges {
-    margin-bottom: 2px;
-  }
-  .package-list li.package-tfm-badges .framework-badges span {
-    margin-right: 1px;
-  }
-  .package-list li.package-tfm-badges .framework-badges .framework-badge-computed {
-    color: #000;
-    border: 1px solid rgba(0, 0, 0, 0.15);
   }
   .package-list li.package-tags {
     display: block;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -282,6 +282,10 @@ img.reserved-indicator-icon {
     overflow-y: hidden;
     padding-right: 10px;
   }
+  .package-list li.package-warning-indicators {
+    display: block;
+    margin-bottom: 5px;
+  }
   .package-list li.package-tfm-badges {
     display: block;
     overflow-y: visible;

--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -282,6 +282,16 @@ img.reserved-indicator-icon {
     overflow-y: hidden;
     padding-right: 10px;
   }
+  .package-list li.package-tfm-badges {
+    display: block;
+    overflow-y: visible;
+  }
+  .package-list li.package-tfm-badges .framework-badges {
+    margin-bottom: 2px;
+  }
+  .package-list li.package-tfm-badges .framework-badges .framework-badge-computed {
+    color: #000;
+  }
   .package-list li.package-tags {
     display: block;
     overflow-y: visible;

--- a/src/Bootstrap/dist/css/bootstrap.css
+++ b/src/Bootstrap/dist/css/bootstrap.css
@@ -53,7 +53,6 @@ abbr[title] {
   border-bottom: none;
   text-decoration: underline;
   -webkit-text-decoration: underline dotted;
-  -moz-text-decoration: underline dotted;
   text-decoration: underline dotted;
 }
 b,

--- a/src/Bootstrap/dist/js/bootstrap.js
+++ b/src/Bootstrap/dist/js/bootstrap.js
@@ -1,6 +1,6 @@
 /*!
  * Bootstrap v3.4.1 (https://getbootstrap.com/)
- * Copyright 2011-2023 Twitter, Inc.
+ * Copyright 2011-2024 Twitter, Inc.
  * Licensed under the MIT license
  */
 

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -368,6 +368,19 @@ img.reserved-indicator-icon {
       padding-right: @padding-small-horizontal;
     }
 
+    li.package-tfm-badges {
+      display: block;
+      overflow-y: visible;
+
+      .framework-badges {
+        margin-bottom: 2px;
+
+        .framework-badge-computed {
+          color: #000;
+        }
+      }
+    }
+
     li.package-tags {
       display: block;
       overflow-y: visible;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -368,6 +368,11 @@ img.reserved-indicator-icon {
       padding-right: @padding-small-horizontal;
     }
 
+    li.package-warning-indicators {
+      display: block;
+      margin-bottom: 5px;
+    }
+
     li.package-tfm-badges {
       display: block;
       overflow-y: visible;

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -359,6 +359,39 @@ img.reserved-indicator-icon {
     }
   }
 
+  li.package-warning-indicators {
+    display: block;
+    overflow-y: visible;
+    margin-bottom: 5px;
+    font-size: 14px;
+  }
+
+  li.package-tfm-badges {
+    display: block;
+    overflow-y: visible;
+
+    .framework-badges {
+      margin-bottom: 2px;
+
+      span {
+        margin-right: 1px;
+      }
+
+      .framework-badge-computed {
+        color: #000;
+        border: 1px solid rgba(0,0,0,.15);
+      }
+
+      @media (max-width: @screen-sm-min) {
+        a + a {
+          span {
+            margin-bottom: 4px;
+          }
+        }
+      }
+    }
+  }
+
   @media (min-width: @screen-sm-min) {
     li {
       display: inline-block;
@@ -366,31 +399,6 @@ img.reserved-indicator-icon {
       max-height: (@package-list-line-height * 5 + 1px);
       overflow-y: hidden;
       padding-right: @padding-small-horizontal;
-    }
-
-    li.package-warning-indicators {
-      display: block;
-      overflow-y: visible;
-      margin-bottom: 5px;
-      font-size: 14px;
-    }
-
-    li.package-tfm-badges {
-      display: block;
-      overflow-y: visible;
-
-      .framework-badges {
-        margin-bottom: 2px;
-
-        span {
-          margin-right: 1px;
-        }
-
-        .framework-badge-computed {
-          color: #000;
-          border: 1px solid rgba(0,0,0,.15);
-        }
-      }
     }
 
     li.package-tags {

--- a/src/Bootstrap/less/theme/base.less
+++ b/src/Bootstrap/less/theme/base.less
@@ -370,7 +370,9 @@ img.reserved-indicator-icon {
 
     li.package-warning-indicators {
       display: block;
+      overflow-y: visible;
       margin-bottom: 5px;
+      font-size: 14px;
     }
 
     li.package-tfm-badges {
@@ -380,8 +382,13 @@ img.reserved-indicator-icon {
       .framework-badges {
         margin-bottom: 2px;
 
+        span {
+          margin-right: 1px;
+        }
+
         .framework-badge-computed {
           color: #000;
+          border: 1px solid rgba(0,0,0,.15);
         }
       }
     }

--- a/src/Bootstrap/less/theme/common-list-packages.less
+++ b/src/Bootstrap/less/theme/common-list-packages.less
@@ -82,16 +82,16 @@
 @badge-border-radius: 2px;
 
 .package-warning {
-  padding-right: 8px;
-  padding-left: 8px;
+  padding: 1px 8px;
   border-radius: @badge-border-radius;
   margin-right: 5px;
-  color: @package-warning-color
+  color: @package-warning-color;
 }
 
 .package-warning--vulnerable {
   .package-warning;
   background-color: @severe-warning-background-color;
+  border: 1px solid darken(@severe-warning-background-color, 15%);
   i {
     color: @severe-warning-icon-color;
   }
@@ -100,4 +100,5 @@
 .package-warning--deprecated {
   .package-warning;
   background-color: @warning-background-color;
+  border: 1px solid darken(@warning-background-color, 35%);
 }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -305,7 +305,13 @@ namespace GitHubVulnerabilities2Db.Fakes
             throw new NotImplementedException();
         }
 
-        public bool IsFrameworkFilteringEnabled(User user) {
+        public bool IsFrameworkFilteringEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsDisplayTfmBadgesEnabled(User user)
+        {
             throw new NotImplementedException();
         }
     }

--- a/src/NuGetGallery.Core/Frameworks/IPackageFrameworkCompatibilityFactory.cs
+++ b/src/NuGetGallery.Core/Frameworks/IPackageFrameworkCompatibilityFactory.cs
@@ -8,6 +8,6 @@ namespace NuGetGallery.Frameworks
 {
     public interface IPackageFrameworkCompatibilityFactory
     {
-        PackageFrameworkCompatibility Create(ICollection<PackageFramework> packageFrameworks, bool includeComputedBadges = false);
+        PackageFrameworkCompatibility Create(ICollection<PackageFramework> packageFrameworks, string packageId, bool includeComputedBadges = false);
     }
 }

--- a/src/NuGetGallery.Core/Frameworks/IPackageFrameworkCompatibilityFactory.cs
+++ b/src/NuGetGallery.Core/Frameworks/IPackageFrameworkCompatibilityFactory.cs
@@ -8,6 +8,6 @@ namespace NuGetGallery.Frameworks
 {
     public interface IPackageFrameworkCompatibilityFactory
     {
-        PackageFrameworkCompatibility Create(ICollection<PackageFramework> packageFrameworks);
+        PackageFrameworkCompatibility Create(ICollection<PackageFramework> packageFrameworks, bool includeComputedBadges = false);
     }
 }

--- a/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibility.cs
+++ b/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibility.cs
@@ -20,6 +20,6 @@ namespace NuGetGallery.Frameworks
         /// Key: Is the <see cref="FrameworkProductNames"/> if resolved on (<seealso cref="PackageFrameworkCompatibilityFactory.ResolveFrameworkProductName(NuGetFramework)"/>) or the <see cref="NuGetFramework.Framework"/>.<br></br>
         /// Value: Is an ordered collection containing all the compatible frameworks.
         /// </remarks>
-        public IReadOnlyDictionary<string, IReadOnlyCollection<PackageFrameworkCompatibilityTableData>> Table { get; set; }
+        public IReadOnlyDictionary<string, IReadOnlyCollection<PackageFrameworkCompatibilityData>> Table { get; set; }
     }
 }

--- a/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityBadges.cs
+++ b/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityBadges.cs
@@ -10,14 +10,14 @@ namespace NuGetGallery.Frameworks
     /// </summary>
     /// <remarks>
     /// All these properties are retrieved from the <see cref="PackageFrameworkCompatibility.Table"/>, one for each .NET product.<br></br>
-    /// Only package asset frameworks are considered. i.e. <see cref="PackageFrameworkCompatibilityTableData.IsComputed"/> <c>= false</c>.<br></br>
+    /// Only package asset frameworks are considered. i.e. <see cref="PackageFrameworkCompatibilityData.IsComputed"/> <c>= false</c>.<br></br>
     /// If there are no package asset frameworks for a particular .NET product, then the value will be <c>null</c>.
     /// </remarks>
     public class PackageFrameworkCompatibilityBadges
     {
-        public NuGetFramework Net { get; set; }
-        public NuGetFramework NetCore { get; set; }
-        public NuGetFramework NetStandard { get; set; }
-        public NuGetFramework NetFramework { get; set; }
+        public PackageFrameworkCompatibilityData Net { get; set; }
+        public PackageFrameworkCompatibilityData NetCore { get; set; }
+        public PackageFrameworkCompatibilityData NetStandard { get; set; }
+        public PackageFrameworkCompatibilityData NetFramework { get; set; }
     }
 }

--- a/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityBadges.cs
+++ b/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityBadges.cs
@@ -15,7 +15,7 @@ namespace NuGetGallery.Frameworks
     /// </remarks>
     public class PackageFrameworkCompatibilityBadges
     {
-        public string FrameworksTabUrl { get; set; }
+        public string PackageId { get; set; }
         public PackageFrameworkCompatibilityData Net { get; set; }
         public PackageFrameworkCompatibilityData NetCore { get; set; }
         public PackageFrameworkCompatibilityData NetStandard { get; set; }

--- a/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityBadges.cs
+++ b/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityBadges.cs
@@ -15,6 +15,7 @@ namespace NuGetGallery.Frameworks
     /// </remarks>
     public class PackageFrameworkCompatibilityBadges
     {
+        public string FrameworksTabUrl { get; set; }
         public PackageFrameworkCompatibilityData Net { get; set; }
         public PackageFrameworkCompatibilityData NetCore { get; set; }
         public PackageFrameworkCompatibilityData NetStandard { get; set; }

--- a/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityData.cs
+++ b/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityData.cs
@@ -5,7 +5,7 @@ using NuGet.Frameworks;
 
 namespace NuGetGallery.Frameworks
 {
-    public class PackageFrameworkCompatibilityTableData
+    public class PackageFrameworkCompatibilityData
     {
         /// <summary>
         /// Compatible framework.

--- a/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityFactory.cs
+++ b/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityFactory.cs
@@ -156,7 +156,7 @@ namespace NuGetGallery.Frameworks
 
             return new PackageFrameworkCompatibilityBadges
             {
-                FrameworksTabUrl = "/packages/" + packageId + "#supportedframeworks-body-tab",
+                PackageId = packageId,
                 Net = net,
                 NetCore = netCore,
                 NetStandard = netStandard,

--- a/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityFactory.cs
+++ b/src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityFactory.cs
@@ -22,7 +22,7 @@ namespace NuGetGallery.Frameworks
         private readonly NuGetFrameworkSorter Sorter = new NuGetFrameworkSorter();
         private readonly int NetStartingMajorVersion = 5;
 
-        public PackageFrameworkCompatibility Create(ICollection<PackageFramework> packageFrameworks, bool includeComputedBadges = false)
+        public PackageFrameworkCompatibility Create(ICollection<PackageFramework> packageFrameworks, string packageId, bool includeComputedBadges = false)
         {
             if (packageFrameworks == null)
             {
@@ -35,7 +35,7 @@ namespace NuGetGallery.Frameworks
                 .ToHashSet();
 
             var table = CreateFrameworkCompatibilityTable(filteredPackageFrameworks);
-            var badges = CreateFrameworkCompatibilityBadges(table, includeComputedBadges);
+            var badges = CreateFrameworkCompatibilityBadges(table, packageId, includeComputedBadges);
 
             return new PackageFrameworkCompatibility
             {
@@ -147,7 +147,7 @@ namespace NuGetGallery.Frameworks
             }
         }
 
-        private PackageFrameworkCompatibilityBadges CreateFrameworkCompatibilityBadges(IReadOnlyDictionary<string, IReadOnlyCollection<PackageFrameworkCompatibilityData>> table, bool includeComputed = false)
+        private PackageFrameworkCompatibilityBadges CreateFrameworkCompatibilityBadges(IReadOnlyDictionary<string, IReadOnlyCollection<PackageFrameworkCompatibilityData>> table, string packageId, bool includeComputed = false)
         {
             var net = GetBadgeFramework(table, FrameworkProductNames.Net, includeComputed);
             var netCore = GetBadgeFramework(table, FrameworkProductNames.NetCore, includeComputed);
@@ -156,6 +156,7 @@ namespace NuGetGallery.Frameworks
 
             return new PackageFrameworkCompatibilityBadges
             {
+                FrameworksTabUrl = "/packages/" + packageId + "#supportedframeworks-body-tab",
                 Net = net,
                 NetCore = netCore,
                 NetStandard = netStandard,

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -60,6 +60,7 @@ namespace NuGetGallery
         private const string NewAccount2FAEnforcementFeatureName = GalleryPrefix + "NewAccount2FAEnforcement";
         private const string NuGetAccountPasswordLoginFeatureName = GalleryPrefix + "NuGetAccountPasswordLogin";
         private const string FrameworkFilteringFeatureName = GalleryPrefix + "FrameworkFiltering";
+        private const string DisplayTfmBadgesFeatureName = GalleryPrefix + "DisplayTfmBadges";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -402,6 +403,11 @@ namespace NuGetGallery
 
         public bool IsFrameworkFilteringEnabled(User user) {
             return _client.IsEnabled(FrameworkFilteringFeatureName, user, defaultValue: false);
+        }
+
+        public bool IsDisplayTfmBadgesEnabled(User user)
+        {
+            return _client.IsEnabled(DisplayTfmBadgesFeatureName, user, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -327,5 +327,10 @@ namespace NuGetGallery
         /// Whether or not to allow filtering by frameworks on NuGet.org search
         /// </summary>
         bool IsFrameworkFilteringEnabled(User user);
+
+        /// <summary>
+        /// Whether or not to display TFM badges in search results
+        /// </summary>
+        bool IsDisplayTfmBadgesEnabled(User user);
     }
 }

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -132,6 +132,12 @@
       "SiteAdmins": false,
       "Accounts": [],
       "Domains": []
+    },
+    "NuGetGallery.DisplayTfmBadges": {
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
     }
   }
 }

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -1206,7 +1206,8 @@ namespace NuGetGallery
                     c.Resolve<IMessageService>(),
                     c.Resolve<IMessageServiceConfiguration>(),
                     c.Resolve<IIconUrlProvider>(),
-                    c.Resolve<IPackageFrameworkCompatibilityFactory>()))
+                    c.Resolve<IPackageFrameworkCompatibilityFactory>(),
+                    c.Resolve<IFeatureFlagService>()))
                 .As<ISearchSideBySideService>()
                 .InstancePerLifetimeScope();
 

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -1205,7 +1205,8 @@ namespace NuGetGallery
                     c.Resolve<ITelemetryService>(),
                     c.Resolve<IMessageService>(),
                     c.Resolve<IMessageServiceConfiguration>(),
-                    c.Resolve<IIconUrlProvider>()))
+                    c.Resolve<IIconUrlProvider>(),
+                    c.Resolve<IPackageFrameworkCompatibilityFactory>()))
                 .As<ISearchSideBySideService>()
                 .InstancePerLifetimeScope();
 

--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -91,7 +91,7 @@ namespace NuGetGallery
             GravatarProxy = gravatarProxy ?? throw new ArgumentNullException(nameof(gravatarProxy));
             FeatureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
 
-            _deleteAccountListPackageItemViewModelFactory = new DeleteAccountListPackageItemViewModelFactory(PackageService, IconUrlProvider, frameworkCompatibilityFactory);
+            _deleteAccountListPackageItemViewModelFactory = new DeleteAccountListPackageItemViewModelFactory(PackageService, IconUrlProvider, frameworkCompatibilityFactory, featureFlagService);
         }
 
         public abstract string AccountAction { get; }

--- a/src/NuGetGallery/Controllers/AccountsController.cs
+++ b/src/NuGetGallery/Controllers/AccountsController.cs
@@ -13,6 +13,7 @@ using NuGet.Services.Messaging.Email;
 using NuGetGallery.Areas.Admin.ViewModels;
 using NuGetGallery.Authentication;
 using NuGetGallery.Filters;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Helpers;
 using NuGetGallery.Infrastructure.Mail.Messages;
 using NuGetGallery.Security;
@@ -73,7 +74,8 @@ namespace NuGetGallery
             IDeleteAccountService deleteAccountService,
             IIconUrlProvider iconUrlProvider,
             IGravatarProxyService gravatarProxy,
-            IFeatureFlagService featureFlagService)
+            IFeatureFlagService featureFlagService,
+            IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
         {
             AuthenticationService = authenticationService ?? throw new ArgumentNullException(nameof(authenticationService));
             PackageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
@@ -89,7 +91,7 @@ namespace NuGetGallery
             GravatarProxy = gravatarProxy ?? throw new ArgumentNullException(nameof(gravatarProxy));
             FeatureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
 
-            _deleteAccountListPackageItemViewModelFactory = new DeleteAccountListPackageItemViewModelFactory(PackageService, IconUrlProvider);
+            _deleteAccountListPackageItemViewModelFactory = new DeleteAccountListPackageItemViewModelFactory(PackageService, IconUrlProvider, frameworkCompatibilityFactory);
         }
 
         public abstract string AccountAction { get; }

--- a/src/NuGetGallery/Controllers/OrganizationsController.cs
+++ b/src/NuGetGallery/Controllers/OrganizationsController.cs
@@ -11,6 +11,7 @@ using NuGet.Services.Entities;
 using NuGet.Services.Messaging.Email;
 using NuGetGallery.Authentication;
 using NuGetGallery.Filters;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Helpers;
 using NuGetGallery.Infrastructure.Mail.Messages;
 using NuGetGallery.Security;
@@ -35,7 +36,8 @@ namespace NuGetGallery
             IMessageServiceConfiguration messageServiceConfiguration,
             IIconUrlProvider iconUrlProvider,
             IFeatureFlagService features,
-            IGravatarProxyService gravatarProxy)
+            IGravatarProxyService gravatarProxy,
+            IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
             : base(
                   authService,
                   packageService,
@@ -49,7 +51,8 @@ namespace NuGetGallery
                   deleteAccountService,
                   iconUrlProvider,
                   gravatarProxy,
-                  features)
+                  features,
+                  frameworkCompatibilityFactory)
         {
             _features = features ?? throw new ArgumentNullException(nameof(features));
         }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -962,7 +962,7 @@ namespace NuGetGallery
 
             if (model.IsComputeTargetFrameworkEnabled || model.IsDisplayTargetFrameworkEnabled)
             {
-                model.PackageFrameworkCompatibility = _compatibilityFactory.Create(package.SupportedFrameworks);
+                model.PackageFrameworkCompatibility = _compatibilityFactory.Create(package.SupportedFrameworks, id);
             }
 
             if (model.IsPackageDependentsEnabled)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -224,11 +224,11 @@ namespace NuGetGallery
             _abTestService = abTestService ?? throw new ArgumentNullException(nameof(abTestService));
             _iconUrlProvider = iconUrlProvider ?? throw new ArgumentNullException(nameof(iconUrlProvider));
 
-            _displayPackageViewModelFactory = new DisplayPackageViewModelFactory(_iconUrlProvider, _compatibilityFactory);
+            _displayPackageViewModelFactory = new DisplayPackageViewModelFactory(_iconUrlProvider, _compatibilityFactory, featureFlagService);
             _displayLicenseViewModelFactory = new DisplayLicenseViewModelFactory(_iconUrlProvider, _markdownService, _featureFlagService);
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(_iconUrlProvider, _compatibilityFactory);
-            _managePackageViewModelFactory = new ManagePackageViewModelFactory(_iconUrlProvider, _compatibilityFactory);
-            _deletePackageViewModelFactory = new DeletePackageViewModelFactory(_iconUrlProvider, _compatibilityFactory);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(_iconUrlProvider, _compatibilityFactory, _featureFlagService);
+            _managePackageViewModelFactory = new ManagePackageViewModelFactory(_iconUrlProvider, _compatibilityFactory, featureFlagService);
+            _deletePackageViewModelFactory = new DeletePackageViewModelFactory(_iconUrlProvider, _compatibilityFactory, featureFlagService);
         }
 
         [HttpGet]

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -224,11 +224,11 @@ namespace NuGetGallery
             _abTestService = abTestService ?? throw new ArgumentNullException(nameof(abTestService));
             _iconUrlProvider = iconUrlProvider ?? throw new ArgumentNullException(nameof(iconUrlProvider));
 
-            _displayPackageViewModelFactory = new DisplayPackageViewModelFactory(_iconUrlProvider);
+            _displayPackageViewModelFactory = new DisplayPackageViewModelFactory(_iconUrlProvider, _compatibilityFactory);
             _displayLicenseViewModelFactory = new DisplayLicenseViewModelFactory(_iconUrlProvider, _markdownService, _featureFlagService);
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(_iconUrlProvider);
-            _managePackageViewModelFactory = new ManagePackageViewModelFactory(_iconUrlProvider);
-            _deletePackageViewModelFactory = new DeletePackageViewModelFactory(_iconUrlProvider);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(_iconUrlProvider, _compatibilityFactory);
+            _managePackageViewModelFactory = new ManagePackageViewModelFactory(_iconUrlProvider, _compatibilityFactory);
+            _deletePackageViewModelFactory = new DeletePackageViewModelFactory(_iconUrlProvider, _compatibilityFactory);
         }
 
         [HttpGet]
@@ -1346,7 +1346,7 @@ namespace NuGetGallery
 
             var currentUser = GetCurrentUser();
             var items = results.Data
-                .Select(pv => _listPackageItemViewModelFactory.Create(pv, currentUser))
+                .Select(pv => _listPackageItemViewModelFactory.Create(pv, currentUser, false)) // the boolean here will eventually depend on the 'IncludeComputed' search parameter
                 .ToList();
 
             var viewModel = new PackageListViewModel(

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -82,8 +82,8 @@ namespace NuGetGallery
             _packageVulnerabilitiesService = packageVulnerabilitiesService ?? throw new ArgumentNullException(nameof(packageVulnerabilitiesService));
 
             _listPackageItemRequiredSignerViewModelFactory = new ListPackageItemRequiredSignerViewModelFactory(
-                securityPolicyService, iconUrlProvider, packageVulnerabilitiesService, frameworkCompatibilityFactory);
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
+                securityPolicyService, iconUrlProvider, packageVulnerabilitiesService, frameworkCompatibilityFactory, featureFlagService);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory, _featureFlagService);
         }
 
         public override string AccountAction => nameof(Account);

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -18,6 +18,7 @@ using NuGetGallery.Areas.Admin.ViewModels;
 using NuGetGallery.Authentication;
 using NuGetGallery.Configuration;
 using NuGetGallery.Filters;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Helpers;
 using NuGetGallery.Infrastructure.Authentication;
 using NuGetGallery.Infrastructure.Mail.Messages;
@@ -55,7 +56,8 @@ namespace NuGetGallery
             IPackageVulnerabilitiesService packageVulnerabilitiesService,
             IMessageServiceConfiguration messageServiceConfiguration,
             IIconUrlProvider iconUrlProvider,
-            IGravatarProxyService gravatarProxy)
+            IGravatarProxyService gravatarProxy,
+            IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
             : base(
                   authService,
                   packageService,
@@ -69,7 +71,8 @@ namespace NuGetGallery
                   deleteAccountService,
                   iconUrlProvider,
                   gravatarProxy,
-                  featureFlagService)
+                  featureFlagService,
+                  frameworkCompatibilityFactory)
         {
             _packageOwnerRequestService = packageOwnerRequestService ?? throw new ArgumentNullException(nameof(packageOwnerRequestService));
             _config = config ?? throw new ArgumentNullException(nameof(config));
@@ -79,8 +82,8 @@ namespace NuGetGallery
             _packageVulnerabilitiesService = packageVulnerabilitiesService ?? throw new ArgumentNullException(nameof(packageVulnerabilitiesService));
 
             _listPackageItemRequiredSignerViewModelFactory = new ListPackageItemRequiredSignerViewModelFactory(
-                securityPolicyService, iconUrlProvider, packageVulnerabilitiesService);
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider);
+                securityPolicyService, iconUrlProvider, packageVulnerabilitiesService, frameworkCompatibilityFactory);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
         }
 
         public override string AccountAction => nameof(Account);
@@ -748,7 +751,7 @@ namespace NuGetGallery
                 .OrderByDescending(p => p.PackageRegistration.DownloadCount)
                 .Select(p =>
                 {
-                    var viewModel = _listPackageItemViewModelFactory.Create(p, currentUser);
+                    var viewModel = _listPackageItemViewModelFactory.Create(p, currentUser, false);
                     viewModel.DownloadCount = p.PackageRegistration.DownloadCount;
                     return viewModel;
                 }).ToList();

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeleteAccountListPackageItemViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeleteAccountListPackageItemViewModelFactory.cs
@@ -12,9 +12,9 @@ namespace NuGetGallery
         private readonly ListPackageItemViewModelFactory _listPackageItemViewModelFactory;
         private readonly IPackageService _packageService;
 
-        public DeleteAccountListPackageItemViewModelFactory(IPackageService packageService, IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
+        public DeleteAccountListPackageItemViewModelFactory(IPackageService packageService, IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory, IFeatureFlagService featureFlagService)
         {
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory, featureFlagService);
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
         }
 

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeleteAccountListPackageItemViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeleteAccountListPackageItemViewModelFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using NuGet.Services.Entities;
+using NuGetGallery.Frameworks;
 
 namespace NuGetGallery
 {
@@ -11,9 +12,9 @@ namespace NuGetGallery
         private readonly ListPackageItemViewModelFactory _listPackageItemViewModelFactory;
         private readonly IPackageService _packageService;
 
-        public DeleteAccountListPackageItemViewModelFactory(IPackageService packageService, IIconUrlProvider iconUrlProvider)
+        public DeleteAccountListPackageItemViewModelFactory(IPackageService packageService, IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
         {
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
         }
 

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using NuGet.Services.Entities;
+using NuGetGallery.Frameworks;
 
 namespace NuGetGallery
 {
@@ -11,9 +12,9 @@ namespace NuGetGallery
     {
         private readonly DisplayPackageViewModelFactory _displayPackageViewModelFactory;
 
-        public DeletePackageViewModelFactory(IIconUrlProvider iconUrlProvider)
+        public DeletePackageViewModelFactory(IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
         {
-            _displayPackageViewModelFactory = new DisplayPackageViewModelFactory(iconUrlProvider);
+            _displayPackageViewModelFactory = new DisplayPackageViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
         }
 
         public DeletePackageViewModel Create(

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DeletePackageViewModelFactory.cs
@@ -12,9 +12,9 @@ namespace NuGetGallery
     {
         private readonly DisplayPackageViewModelFactory _displayPackageViewModelFactory;
 
-        public DeletePackageViewModelFactory(IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
+        public DeletePackageViewModelFactory(IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory, IFeatureFlagService featureFlagService)
         {
-            _displayPackageViewModelFactory = new DisplayPackageViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
+            _displayPackageViewModelFactory = new DisplayPackageViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory, featureFlagService);
         }
 
         public DeletePackageViewModel Create(

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Helpers;
 
 namespace NuGetGallery
@@ -14,9 +15,9 @@ namespace NuGetGallery
     {
         private readonly ListPackageItemViewModelFactory _listPackageItemViewModelFactory;
 
-        public DisplayPackageViewModelFactory(IIconUrlProvider iconUrlProvider)
+        public DisplayPackageViewModelFactory(IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
         {
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
         }
 
         public DisplayPackageViewModel Create(

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -15,9 +15,9 @@ namespace NuGetGallery
     {
         private readonly ListPackageItemViewModelFactory _listPackageItemViewModelFactory;
 
-        public DisplayPackageViewModelFactory(IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
+        public DisplayPackageViewModelFactory(IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory, IFeatureFlagService featureFlagService)
         {
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory, featureFlagService);
         }
 
         public DisplayPackageViewModel Create(

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemRequiredSignerViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemRequiredSignerViewModelFactory.cs
@@ -20,9 +20,10 @@ namespace NuGetGallery
             ISecurityPolicyService securityPolicyService, 
             IIconUrlProvider iconUrlProvider,
             IPackageVulnerabilitiesService packageVulnerabilitiesService,
-            IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
+            IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory,
+            IFeatureFlagService featureFlagService)
         {
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory, featureFlagService);
             _securityPolicyService = securityPolicyService ?? throw new ArgumentNullException(nameof(securityPolicyService));
             _packageVulnerabilitiesService = packageVulnerabilitiesService ?? throw new ArgumentNullException(nameof(packageVulnerabilitiesService));
         }

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemRequiredSignerViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemRequiredSignerViewModelFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Services.Entities;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Security;
 
 namespace NuGetGallery
@@ -18,9 +19,10 @@ namespace NuGetGallery
         public ListPackageItemRequiredSignerViewModelFactory(
             ISecurityPolicyService securityPolicyService, 
             IIconUrlProvider iconUrlProvider,
-            IPackageVulnerabilitiesService packageVulnerabilitiesService)
+            IPackageVulnerabilitiesService packageVulnerabilitiesService,
+            IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
         {
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
             _securityPolicyService = securityPolicyService ?? throw new ArgumentNullException(nameof(securityPolicyService));
             _packageVulnerabilitiesService = packageVulnerabilitiesService ?? throw new ArgumentNullException(nameof(packageVulnerabilitiesService));
         }

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemViewModelFactory.cs
@@ -71,7 +71,7 @@ namespace NuGetGallery
             viewModel.CanDeprecate = CanPerformAction(currentUser, package, ActionsRequiringPermissions.DeprecatePackage);
             viewModel.CanDisplayTfmBadges = _featureFlagService.IsDisplayTfmBadgesEnabled(currentUser);
 
-            PackageFrameworkCompatibility packageFrameworkCompatibility = _frameworkCompatibilityFactory.Create(package.SupportedFrameworks, includeComputedBadges);
+            PackageFrameworkCompatibility packageFrameworkCompatibility = _frameworkCompatibilityFactory.Create(package.SupportedFrameworks, package.Id, includeComputedBadges);
             viewModel.FrameworkBadges = viewModel.CanDisplayTfmBadges ? packageFrameworkCompatibility?.Badges : new PackageFrameworkCompatibilityBadges();
 
             viewModel.SetShortDescriptionFrom(viewModel.Description);

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/ManagePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/ManagePackageViewModelFactory.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Web.Mvc;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
+using NuGetGallery.Frameworks;
 
 namespace NuGetGallery
 {
@@ -14,9 +15,9 @@ namespace NuGetGallery
     {
         private readonly ListPackageItemViewModelFactory _listPackageItemViewModelFactory;
 
-        public ManagePackageViewModelFactory(IIconUrlProvider iconUrlProvider)
+        public ManagePackageViewModelFactory(IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
         {
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
         }
 
         public ManagePackageViewModel Create(

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/ManagePackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/ManagePackageViewModelFactory.cs
@@ -15,9 +15,9 @@ namespace NuGetGallery
     {
         private readonly ListPackageItemViewModelFactory _listPackageItemViewModelFactory;
 
-        public ManagePackageViewModelFactory(IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
+        public ManagePackageViewModelFactory(IIconUrlProvider iconUrlProvider, IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory, IFeatureFlagService featureFlagService)
         {
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(iconUrlProvider, frameworkCompatibilityFactory, featureFlagService);
         }
 
         public ManagePackageViewModel Create(

--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -184,7 +184,7 @@ namespace NuGetGallery.Infrastructure.Search
                    .ToArray();
 
             var frameworks =
-                doc.Value<JArray>("SupportedFrameworks")
+                doc.Value<JArray>("Tfms")
                    .Select(v => new PackageFramework() { TargetFramework = v.Value<string>() })
                    .ToArray();
 

--- a/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs
@@ -183,10 +183,13 @@ namespace NuGetGallery.Infrastructure.Search
                    })
                    .ToArray();
 
-            var frameworks =
-                doc.Value<JArray>("Tfms")
-                   .Select(v => new PackageFramework() { TargetFramework = v.Value<string>() })
-                   .ToArray();
+            var frameworks = Array.Empty<PackageFramework>();
+            if (doc.Value<JArray>("Tfms") != null)
+            {
+                frameworks = doc.Value<JArray>("Tfms")
+                                   .Select(v => new PackageFramework() { TargetFramework = v.Value<string>() })
+                                   .ToArray();
+            }
 
             var reg = doc["PackageRegistration"];
             PackageRegistration registration = null;

--- a/src/NuGetGallery/Services/SearchSideBySideService.cs
+++ b/src/NuGetGallery/Services/SearchSideBySideService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Services.Entities;
 using NuGet.Services.Messaging.Email;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Infrastructure.Mail.Messages;
 using NuGetGallery.OData;
 
@@ -27,7 +28,8 @@ namespace NuGetGallery
             ITelemetryService telemetryService,
             IMessageService messageService,
             IMessageServiceConfiguration messageServiceConfiguration,
-            IIconUrlProvider iconUrlProvider)
+            IIconUrlProvider iconUrlProvider,
+            IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
         {
             _oldSearchService = oldSearchService ?? throw new ArgumentNullException(nameof(oldSearchService));
             _newSearchService = newSearchService ?? throw new ArgumentNullException(nameof(newSearchService));
@@ -36,7 +38,7 @@ namespace NuGetGallery
             _messageServiceConfiguration = messageServiceConfiguration ?? throw new ArgumentNullException(nameof(messageServiceConfiguration));
             _iconUrlProvider = iconUrlProvider ?? throw new ArgumentNullException(nameof(iconUrlProvider));
 
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(_iconUrlProvider);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(_iconUrlProvider, frameworkCompatibilityFactory);
         }
 
         public async Task<SearchSideBySideViewModel> SearchAsync(string searchTerm, User currentUser)
@@ -59,10 +61,10 @@ namespace NuGetGallery
                     SearchTerm = searchTerm,
                     OldSuccess = SearchResults.IsSuccessful(oldResults),
                     OldHits = oldResults.Hits,
-                    OldItems = oldResults.Data.Select(x => _listPackageItemViewModelFactory.Create(x, currentUser)).ToList(),
+                    OldItems = oldResults.Data.Select(x => _listPackageItemViewModelFactory.Create(x, currentUser, false)).ToList(),
                     NewSuccess = SearchResults.IsSuccessful(newResults),
                     NewHits = newResults.Hits,
-                    NewItems = newResults.Data.Select(x => _listPackageItemViewModelFactory.Create(x, currentUser)).ToList(),
+                    NewItems = newResults.Data.Select(x => _listPackageItemViewModelFactory.Create(x, currentUser, false)).ToList(),
                 };
 
                 _telemetryService.TrackSearchSideBySide(

--- a/src/NuGetGallery/Services/SearchSideBySideService.cs
+++ b/src/NuGetGallery/Services/SearchSideBySideService.cs
@@ -29,7 +29,8 @@ namespace NuGetGallery
             IMessageService messageService,
             IMessageServiceConfiguration messageServiceConfiguration,
             IIconUrlProvider iconUrlProvider,
-            IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory)
+            IPackageFrameworkCompatibilityFactory frameworkCompatibilityFactory,
+            IFeatureFlagService featureFlagService)
         {
             _oldSearchService = oldSearchService ?? throw new ArgumentNullException(nameof(oldSearchService));
             _newSearchService = newSearchService ?? throw new ArgumentNullException(nameof(newSearchService));
@@ -38,7 +39,7 @@ namespace NuGetGallery
             _messageServiceConfiguration = messageServiceConfiguration ?? throw new ArgumentNullException(nameof(messageServiceConfiguration));
             _iconUrlProvider = iconUrlProvider ?? throw new ArgumentNullException(nameof(iconUrlProvider));
 
-            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(_iconUrlProvider, frameworkCompatibilityFactory);
+            _listPackageItemViewModelFactory = new ListPackageItemViewModelFactory(_iconUrlProvider, frameworkCompatibilityFactory, featureFlagService);
         }
 
         public async Task<SearchSideBySideViewModel> SearchAsync(string searchTerm, User currentUser)

--- a/src/NuGetGallery/UrlHelperExtensions.cs
+++ b/src/NuGetGallery/UrlHelperExtensions.cs
@@ -1390,6 +1390,11 @@ namespace NuGetGallery
             return url.PackageVersionAction(nameof(PackagesController.License), package, relativeUrl);
         }
 
+        public static string FrameworksTab(this UrlHelper url, string packageId, bool relativeUrl = true)
+        {
+            return url.Package(packageId, relativeUrl) + "#supportedframeworks-body-tab";
+        }
+
         public static string Terms(this UrlHelper url, bool relativeUrl = true)
         {
             if (!String.IsNullOrEmpty(_configuration.Current.ExternalTermsOfUseUrl))

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Helpers;
 
 namespace NuGetGallery
@@ -21,6 +22,7 @@ namespace NuGetGallery
         public string Authors { get; set; }
         public IReadOnlyCollection<BasicUserViewModel> Owners { get; set; }
         public IReadOnlyCollection<string> Tags { get; set; }
+        public PackageFrameworkCompatibilityBadges FrameworkBadges { get; set; }
         public string MinClientVersion { get; set; }
         public string ShortDescription { get; private set; }
         public bool IsDescriptionTruncated { get; set; }

--- a/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs
@@ -58,6 +58,7 @@ namespace NuGetGallery
         public bool CanReportAsOwner { get; set; }
         public bool CanSeeBreadcrumbWithProfile { get; set; }
         public bool CanDeleteSymbolsPackage { get; set; }
+        public bool CanDisplayTfmBadges { get; set; }
         public bool CanDeprecate { get; set; }
 
         public string VulnerabilityTitle { get; set; }

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -6,39 +6,39 @@
     @if (Model.Net != null)
     {
         <!-- .NET cannot be an empty version since the lowest version for this framework is "net5.0", if the package contains just "net" framework it will fall into .NET Framework badge instead.' -->
-        <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.GetBadgeVersion()</span>
+        <span class=@(Model.Net.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.Framework.GetBadgeVersion()</span>
     }
     @if (Model.NetCore != null)
     {
-        if (Model.NetCore.GetBadgeVersion().IsEmpty())
+        if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
         {
-            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
+            <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
         }
         else
         {
-            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.GetBadgeVersion()</span>
+            <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.Framework.GetBadgeVersion()</span>
         }
     }
     @if (Model.NetStandard != null)
     {
-        if (Model.NetStandard.GetBadgeVersion().IsEmpty())
+        if (Model.NetStandard.Framework.GetBadgeVersion().IsEmpty())
         {
-            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
+            <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
         }
         else
         {
-            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.GetBadgeVersion()</span>
+            <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.Framework.GetBadgeVersion()</span>
         }
     }
     @if (Model.NetFramework != null)
     {
-        if (Model.NetFramework.GetBadgeVersion().IsEmpty())
+        if (Model.NetFramework.Framework.GetBadgeVersion().IsEmpty())
         {
-            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
+            <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
         }
         else
         {
-            <span class="framework-badge-asset" aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.GetBadgeVersion()</span>
+            <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.Framework.GetBadgeVersion()</span>
         }
     }
 </div>

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -6,7 +6,7 @@
     @if (Model.Net != null)
     {
         <!-- .NET cannot be an empty version since the lowest version for this framework is "net5.0", if the package contains just "net" framework it will fall into .NET Framework badge instead.' -->
-        <a href=@Model.FrameworksTabUrl>
+        <a href=@Url.FrameworksTab(Model.PackageId)>
             <span class=@(Model.Net.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.Framework.GetBadgeVersion()</span>
         </a>
     }
@@ -14,13 +14,13 @@
     {
         if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
         {
-            <a href=@Model.FrameworksTabUrl>
+            <a href=@Url.FrameworksTab(Model.PackageId)>
                 <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
             </a>
         }
         else
         {
-            <a href=@Model.FrameworksTabUrl>
+            <a href=@Url.FrameworksTab(Model.PackageId)>
                 <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.Framework.GetBadgeVersion()</span>
             </a>
         }
@@ -29,13 +29,13 @@
     {
         if (Model.NetStandard.Framework.GetBadgeVersion().IsEmpty())
         {
-            <a href=@Model.FrameworksTabUrl>
+            <a href=@Url.FrameworksTab(Model.PackageId)>
                 <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
             </a>
         }
         else
         {
-            <a href=@Model.FrameworksTabUrl>
+            <a href=@Url.FrameworksTab(Model.PackageId)>
                 <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.Framework.GetBadgeVersion()</span>
             </a>
         }
@@ -44,13 +44,13 @@
     {
         if (Model.NetFramework.Framework.GetBadgeVersion().IsEmpty())
         {
-            <a href=@Model.FrameworksTabUrl>
+            <a href=@Url.FrameworksTab(Model.PackageId)>
                 <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
             </a>
         }
         else
         {
-            <a href=@Model.FrameworksTabUrl>
+            <a href=@Url.FrameworksTab(Model.PackageId)>
                 <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.Framework.GetBadgeVersion()</span>
             </a>
         }

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -6,39 +6,53 @@
     @if (Model.Net != null)
     {
         <!-- .NET cannot be an empty version since the lowest version for this framework is "net5.0", if the package contains just "net" framework it will fall into .NET Framework badge instead.' -->
-        <span class=@(Model.Net.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.Framework.GetBadgeVersion()</span>
+        <a href=@Model.FrameworksTabUrl>
+            <span class=@(Model.Net.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET @Model.Net.Framework.GetBadgeVersion()</span>
+        </a>
     }
     @if (Model.NetCore != null)
     {
         if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
         {
-            <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
+            <a href=@Model.FrameworksTabUrl>
+                <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Core</span>
+            </a>
         }
         else
         {
-            <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.Framework.GetBadgeVersion()</span>
+            <a href=@Model.FrameworksTabUrl>
+                <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Core @Model.NetCore.Framework.GetBadgeVersion()</span>
+            </a>
         }
     }
     @if (Model.NetStandard != null)
     {
         if (Model.NetStandard.Framework.GetBadgeVersion().IsEmpty())
         {
-            <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
+            <a href=@Model.FrameworksTabUrl>
+                <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Standard</span>
+            </a>
         }
         else
         {
-            <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.Framework.GetBadgeVersion()</span>
+            <a href=@Model.FrameworksTabUrl>
+                <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Standard @Model.NetStandard.Framework.GetBadgeVersion()</span>
+            </a>
         }
     }
     @if (Model.NetFramework != null)
     {
         if (Model.NetFramework.Framework.GetBadgeVersion().IsEmpty())
         {
-            <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
+            <a href=@Model.FrameworksTabUrl>
+                <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">.NET Framework</span>
+            </a>
         }
         else
         {
-            <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.Framework.GetBadgeVersion()</span>
+            <a href=@Model.FrameworksTabUrl>
+                <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">.NET Framework @Model.NetFramework.Framework.GetBadgeVersion()</span>
+            </a>
         }
     }
 </div>

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
@@ -1,4 +1,4 @@
-﻿@model IReadOnlyDictionary<string, IReadOnlyCollection<NuGetGallery.Frameworks.PackageFrameworkCompatibilityTableData>>
+﻿@model IReadOnlyDictionary<string, IReadOnlyCollection<NuGetGallery.Frameworks.PackageFrameworkCompatibilityData>>
 <table class="framework framework-table" aria-label="Supported frameworks">
     <thead>
         <tr>

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -75,11 +75,10 @@
                 }
             </div>
 
-
-            @if (Model.IsVulnerable || Model.IsDeprecated)
-            {
-                <ul class="package-list">
-                    <li>
+            <ul class="package-list">
+                @if (Model.IsVulnerable || Model.IsDeprecated)
+                {
+                    <li class="package-warning-indicators">
                         @if (Model.IsVulnerable)
                         {
                             <span class="icon-text package-warning--vulnerable" aria-label="@Model.VulnerabilityTitle" data-content="@Model.VulnerabilityTitle">
@@ -95,10 +94,7 @@
                             </span>
                         }
                     </li>
-                </ul>
-            }
-
-            <ul class="package-list">
+                }
                 <li class="package-tfm-badges">
                     @Html.Partial("../Packages/_SupportedFrameworksBadges", Model.FrameworkBadges)
                 </li>

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -99,6 +99,9 @@
             }
 
             <ul class="package-list">
+                <li class="package-tfm-badges">
+                    @Html.Partial("../Packages/_SupportedFrameworksBadges", Model.FrameworkBadges)
+                </li>
                 <li>
                     <span class="icon-text">
                         <i class="ms-Icon ms-Icon--Download" aria-hidden="true"></i>

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -129,5 +129,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public bool IsDisplayPackageReadmeWarningEnabled(User user) => throw new NotImplementedException();
 
         public bool IsFrameworkFilteringEnabled(User user) => throw new NotImplementedException();
+
+        public bool IsDisplayTfmBadgesEnabled(User user) => throw new NotImplementedException();
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
@@ -347,12 +347,10 @@ namespace NuGetGallery.Frameworks
         }
 
         [Fact]
-        public void BadgesIncludeFrameworksTabUrl()
+        public void BadgesIncludePackageIdForFrameworksTabUrl()
         {
             // Arrange
             var packageId = "Foo";
-            var expectedFrameworksTabUrl = "/packages/Foo#supportedframeworks-body-tab";
-
             var packageFrameworks = new HashSet<PackageFramework>();
             var packageAssetFramework = new PackageFramework() { TargetFramework = "net6" };
             packageFrameworks.Add(packageAssetFramework);
@@ -361,7 +359,7 @@ namespace NuGetGallery.Frameworks
             var result = _factory.Create(packageFrameworks.ToList(), packageId);
 
             // Assert
-            Assert.Equal(expectedFrameworksTabUrl, result.Badges.FrameworksTabUrl);
+            Assert.Equal(packageId, result.Badges.PackageId);
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
@@ -22,13 +22,13 @@ namespace NuGetGallery.Frameworks
         [Fact]
         public void NullPackageFrameworksThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => _factory.Create(null, string.Empty));
+            Assert.Throws<ArgumentNullException>(() => _factory.Create(null, packageId: string.Empty));
         }
 
         [Fact]
         public void EmptyPackageFrameworksReturnsEmptyTable()
         {
-            var result = _factory.Create(new List<PackageFramework>(), string.Empty);
+            var result = _factory.Create(new List<PackageFramework>(), packageId: string.Empty);
 
             Assert.Empty(result.Table);
         }
@@ -44,7 +44,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "x64" }
             };
 
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             Assert.Empty(result.Table);
             Assert.Null(result.Badges.Net);
@@ -63,7 +63,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "portable-net45+sl5+win8+wpa81+wp8" }
             };
 
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             Assert.Empty(result.Table);
             Assert.Null(result.Badges.Net);
@@ -80,7 +80,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "any" },
             };
 
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             Assert.Empty(result.Table);
             Assert.Null(result.Badges.Net);
@@ -132,7 +132,7 @@ namespace NuGetGallery.Frameworks
                 packageFrameworks.Add(packageFramework);
             }
 
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             Assert.True(result.Table.TryGetValue(productName, out var compatibleFrameworks));
             Assert.NotEmpty(compatibleFrameworks);
@@ -166,7 +166,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "monoandroid" }
             };
 
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             var productNames = result.Table.Keys.ToArray();
 
@@ -193,7 +193,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "wpa81" }
             };
 
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             var productNames = result.Table.Keys.Skip(4);
             var orderedProductNames = productNames.OrderBy(x => x);
@@ -211,7 +211,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "netstandard10" },
                 new PackageFramework() { TargetFramework = "net45" }
             };
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             Assert.NotEmpty(result.Table);
             foreach (var row in result.Table)
@@ -233,7 +233,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "netstandard10" },
                 new PackageFramework() { TargetFramework = "net45" }
             };
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             Assert.NotEmpty(result.Table);
             foreach (var row in result.Table)
@@ -245,7 +245,7 @@ namespace NuGetGallery.Frameworks
         [Fact]
         public void EmptyPackageFrameworksReturnsNullBadges()
         {
-            var result = _factory.Create(new List<PackageFramework>(), string.Empty);
+            var result = _factory.Create(new List<PackageFramework>(), packageId: string.Empty);
 
             Assert.Null(result.Badges.Net);
             Assert.Null(result.Badges.NetCore);
@@ -273,7 +273,7 @@ namespace NuGetGallery.Frameworks
             var lowestPackageFramework = new PackageFramework() { TargetFramework = lowestFramework };
             packageFrameworks.Add(lowestPackageFramework);
 
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             NuGetFramework badgeFramework = null;
             switch (productFramework)
@@ -306,7 +306,7 @@ namespace NuGetGallery.Frameworks
             }
             var lowestPackageFramework = new PackageFramework() { TargetFramework = expectedFramework };
 
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty, includeComputed);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty, includeComputed);
 
             NuGetFramework badgeFramework = null;
             switch (productFramework)
@@ -332,7 +332,7 @@ namespace NuGetGallery.Frameworks
             var packageAssetFramework = new PackageFramework() { TargetFramework = framework };
             packageFrameworks.Add(packageAssetFramework);
 
-            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
+            var result = _factory.Create(packageFrameworks.ToList(), packageId: string.Empty);
 
             var badges = new List<NuGetFramework>() {
                 result.Badges.Net?.Framework,

--- a/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
@@ -259,7 +259,7 @@ namespace NuGetGallery.Frameworks
         [InlineData(FrameworkProductNames.NetCore, "netcoreapp10", "netcoreapp21", "netcoreapp31")]
         [InlineData(FrameworkProductNames.NetStandard, "netstandard10", "netstandard10", "netstandard21")]
         [InlineData(FrameworkProductNames.NetFramework, "net11", "net45", "net472")]
-        public void BadgeShouldBeTheLowestNonComputedFramework(string productFramework, string lowestFramework, params string[] frameworks)
+        public void BadgeShouldBeTheLowestNonComputedFrameworkByDefault(string productFramework, string lowestFramework, params string[] frameworks)
         {
             var packageFrameworks = new HashSet<PackageFramework>();
             foreach (var framework in frameworks)
@@ -278,10 +278,43 @@ namespace NuGetGallery.Frameworks
             NuGetFramework badgeFramework = null;
             switch (productFramework)
             {
-                case FrameworkProductNames.Net: badgeFramework = result.Badges.Net; break;
-                case FrameworkProductNames.NetCore: badgeFramework = result.Badges.NetCore; break;
-                case FrameworkProductNames.NetStandard: badgeFramework = result.Badges.NetStandard; break;
-                case FrameworkProductNames.NetFramework: badgeFramework = result.Badges.NetFramework; break;
+                case FrameworkProductNames.Net: badgeFramework = result.Badges.Net.Framework; break;
+                case FrameworkProductNames.NetCore: badgeFramework = result.Badges.NetCore.Framework; break;
+                case FrameworkProductNames.NetStandard: badgeFramework = result.Badges.NetStandard.Framework; break;
+                case FrameworkProductNames.NetFramework: badgeFramework = result.Badges.NetFramework.Framework; break;
+            }
+
+            Assert.NotNull(badgeFramework);
+            Assert.Equal(lowestPackageFramework.FrameworkName, badgeFramework);
+        }
+
+        [Theory]
+        [InlineData(FrameworkProductNames.Net, false, "net6.0", "netstandard1.0", "net6.0")]
+        [InlineData(FrameworkProductNames.Net, true, "net5.0", "netstandard1.0", "net6.0")]
+        [InlineData(FrameworkProductNames.NetCore, false, "netcoreapp3.1", "netstandard1.0", "netcoreapp3.1")]
+        [InlineData(FrameworkProductNames.NetCore, true, "netcoreapp1.0", "netstandard1.0", "netcoreapp3.1")]
+        public void BadgeShouldBeTheLowestFramework(string productFramework, bool includeComputed, string expectedFramework, params string[] frameworks)
+        {
+            var packageFrameworks = new HashSet<PackageFramework>();
+            foreach (var framework in frameworks)
+            {
+                var packageFramework = new PackageFramework()
+                {
+                    TargetFramework = framework
+                };
+                packageFrameworks.Add(packageFramework);
+            }
+            var lowestPackageFramework = new PackageFramework() { TargetFramework = expectedFramework };
+
+            var result = _factory.Create(packageFrameworks.ToList(), includeComputed);
+
+            NuGetFramework badgeFramework = null;
+            switch (productFramework)
+            {
+                case FrameworkProductNames.Net: badgeFramework = result.Badges.Net.Framework; break;
+                case FrameworkProductNames.NetCore: badgeFramework = result.Badges.NetCore.Framework; break;
+                case FrameworkProductNames.NetStandard: badgeFramework = result.Badges.NetStandard.Framework; break;
+                case FrameworkProductNames.NetFramework: badgeFramework = result.Badges.NetFramework.Framework; break;
             }
 
             Assert.NotNull(badgeFramework);
@@ -293,7 +326,7 @@ namespace NuGetGallery.Frameworks
         [InlineData("netcoreapp31")]
         [InlineData("netstandard21")]
         [InlineData("net48")]
-        public void BadgesIgnoreComputedFrameworks(string framework)
+        public void BadgesIgnoreComputedFrameworksByDefault(string framework)
         {
             var packageFrameworks = new HashSet<PackageFramework>();
             var packageAssetFramework = new PackageFramework() { TargetFramework = framework };
@@ -302,10 +335,10 @@ namespace NuGetGallery.Frameworks
             var result = _factory.Create(packageFrameworks.ToList());
 
             var badges = new List<NuGetFramework>() {
-                result.Badges.Net,
-                result.Badges.NetCore,
-                result.Badges.NetStandard,
-                result.Badges.NetFramework
+                result.Badges.Net?.Framework,
+                result.Badges.NetCore?.Framework,
+                result.Badges.NetStandard?.Framework,
+                result.Badges.NetFramework?.Framework
             };
 
             var badgeFramework = badges.Single(f => f != null);

--- a/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
@@ -22,13 +22,13 @@ namespace NuGetGallery.Frameworks
         [Fact]
         public void NullPackageFrameworksThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => _factory.Create(null));
+            Assert.Throws<ArgumentNullException>(() => _factory.Create(null, string.Empty));
         }
 
         [Fact]
         public void EmptyPackageFrameworksReturnsEmptyTable()
         {
-            var result = _factory.Create(new List<PackageFramework>());
+            var result = _factory.Create(new List<PackageFramework>(), string.Empty);
 
             Assert.Empty(result.Table);
         }
@@ -44,7 +44,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "x64" }
             };
 
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             Assert.Empty(result.Table);
             Assert.Null(result.Badges.Net);
@@ -63,7 +63,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "portable-net45+sl5+win8+wpa81+wp8" }
             };
 
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             Assert.Empty(result.Table);
             Assert.Null(result.Badges.Net);
@@ -80,7 +80,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "any" },
             };
 
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             Assert.Empty(result.Table);
             Assert.Null(result.Badges.Net);
@@ -132,7 +132,7 @@ namespace NuGetGallery.Frameworks
                 packageFrameworks.Add(packageFramework);
             }
 
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             Assert.True(result.Table.TryGetValue(productName, out var compatibleFrameworks));
             Assert.NotEmpty(compatibleFrameworks);
@@ -166,7 +166,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "monoandroid" }
             };
 
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             var productNames = result.Table.Keys.ToArray();
 
@@ -193,7 +193,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "wpa81" }
             };
 
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             var productNames = result.Table.Keys.Skip(4);
             var orderedProductNames = productNames.OrderBy(x => x);
@@ -211,7 +211,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "netstandard10" },
                 new PackageFramework() { TargetFramework = "net45" }
             };
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             Assert.NotEmpty(result.Table);
             foreach (var row in result.Table)
@@ -233,7 +233,7 @@ namespace NuGetGallery.Frameworks
                 new PackageFramework() { TargetFramework = "netstandard10" },
                 new PackageFramework() { TargetFramework = "net45" }
             };
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             Assert.NotEmpty(result.Table);
             foreach (var row in result.Table)
@@ -245,7 +245,7 @@ namespace NuGetGallery.Frameworks
         [Fact]
         public void EmptyPackageFrameworksReturnsNullBadges()
         {
-            var result = _factory.Create(new List<PackageFramework>());
+            var result = _factory.Create(new List<PackageFramework>(), string.Empty);
 
             Assert.Null(result.Badges.Net);
             Assert.Null(result.Badges.NetCore);
@@ -273,7 +273,7 @@ namespace NuGetGallery.Frameworks
             var lowestPackageFramework = new PackageFramework() { TargetFramework = lowestFramework };
             packageFrameworks.Add(lowestPackageFramework);
 
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             NuGetFramework badgeFramework = null;
             switch (productFramework)
@@ -306,7 +306,7 @@ namespace NuGetGallery.Frameworks
             }
             var lowestPackageFramework = new PackageFramework() { TargetFramework = expectedFramework };
 
-            var result = _factory.Create(packageFrameworks.ToList(), includeComputed);
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty, includeComputed);
 
             NuGetFramework badgeFramework = null;
             switch (productFramework)
@@ -332,7 +332,7 @@ namespace NuGetGallery.Frameworks
             var packageAssetFramework = new PackageFramework() { TargetFramework = framework };
             packageFrameworks.Add(packageAssetFramework);
 
-            var result = _factory.Create(packageFrameworks.ToList());
+            var result = _factory.Create(packageFrameworks.ToList(), string.Empty);
 
             var badges = new List<NuGetFramework>() {
                 result.Badges.Net?.Framework,
@@ -344,7 +344,24 @@ namespace NuGetGallery.Frameworks
             var badgeFramework = badges.Single(f => f != null);
             Assert.Equal(packageAssetFramework.FrameworkName, badgeFramework);
             Assert.Equal(expected: 3, badges.Where(f => f == null).Count());
+        }
 
+        [Fact]
+        public void BadgesIncludeFrameworksTabUrl()
+        {
+            // Arrange
+            var packageId = "Foo";
+            var expectedFrameworksTabUrl = "/packages/Foo#supportedframeworks-body-tab";
+
+            var packageFrameworks = new HashSet<PackageFramework>();
+            var packageAssetFramework = new PackageFramework() { TargetFramework = "net6" };
+            packageFrameworks.Add(packageAssetFramework);
+
+            // Act
+            var result = _factory.Create(packageFrameworks.ToList(), packageId);
+
+            // Assert
+            Assert.Equal(expectedFrameworksTabUrl, result.Badges.FrameworksTabUrl);
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -261,7 +261,7 @@ namespace NuGetGallery
             {
                 compatibilityFactory = new Mock<IPackageFrameworkCompatibilityFactory>();
                 compatibilityFactory
-                    .Setup(x => x.Create(It.IsAny<ICollection<PackageFramework>>(), false))
+                    .Setup(x => x.Create(It.IsAny<ICollection<PackageFramework>>(), string.Empty, false))
                     .Returns(new PackageFrameworkCompatibility());
             }
 
@@ -2202,7 +2202,7 @@ namespace NuGetGallery
                     .Returns(false);
 
                 compatibilityFactory
-                    .Setup(x => x.Create(supportedFrameworks, false))
+                    .Setup(x => x.Create(supportedFrameworks, id, false))
                     .Returns(new PackageFrameworkCompatibility());
 
                 // Arrange and Act
@@ -2263,7 +2263,7 @@ namespace NuGetGallery
                     .Returns(displayFlag);
 
                 compatibilityFactory
-                    .Setup(x => x.Create(supportedFrameworks, false))
+                    .Setup(x => x.Create(supportedFrameworks, id, false))
                     .Returns(new PackageFrameworkCompatibility());
 
                 // Arrange and Act

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -261,7 +261,7 @@ namespace NuGetGallery
             {
                 compatibilityFactory = new Mock<IPackageFrameworkCompatibilityFactory>();
                 compatibilityFactory
-                    .Setup(x => x.Create(It.IsAny<ICollection<PackageFramework>>()))
+                    .Setup(x => x.Create(It.IsAny<ICollection<PackageFramework>>(), false))
                     .Returns(new PackageFrameworkCompatibility());
             }
 
@@ -2202,7 +2202,7 @@ namespace NuGetGallery
                     .Returns(false);
 
                 compatibilityFactory
-                    .Setup(x => x.Create(supportedFrameworks))
+                    .Setup(x => x.Create(supportedFrameworks, false))
                     .Returns(new PackageFrameworkCompatibility());
 
                 // Arrange and Act
@@ -2210,7 +2210,6 @@ namespace NuGetGallery
 
                 // Assert
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
-                compatibilityFactory.Verify(x => x.Create(It.IsAny<ICollection<PackageFramework>>()), Times.Never());
                 Assert.Null(model.PackageFrameworkCompatibility);
             }
 
@@ -2264,7 +2263,7 @@ namespace NuGetGallery
                     .Returns(displayFlag);
 
                 compatibilityFactory
-                    .Setup(x => x.Create(supportedFrameworks))
+                    .Setup(x => x.Create(supportedFrameworks, false))
                     .Returns(new PackageFrameworkCompatibility());
 
                 // Arrange and Act
@@ -2272,7 +2271,6 @@ namespace NuGetGallery
 
                 // Assert
                 var model = ResultAssert.IsView<DisplayPackageViewModel>(result);
-                compatibilityFactory.Verify(x => x.Create(supportedFrameworks), Times.Once());
                 Assert.NotNull(model.PackageFrameworkCompatibility);
             }
 

--- a/tests/NuGetGallery.Facts/Services/SearchSideBySideServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SearchSideBySideServiceFacts.cs
@@ -136,6 +136,7 @@ namespace NuGetGallery
                 MessageServiceConfiguration = new Mock<IMessageServiceConfiguration>();
                 IconUrlProvider = new Mock<IIconUrlProvider>();
                 var compatibilityFactory = new Mock<IPackageFrameworkCompatibilityFactory>();
+                var featureFlagService = new Mock<IFeatureFlagService>();
 
                 CurrentUser = new User
                 {
@@ -187,7 +188,8 @@ namespace NuGetGallery
                     MessageService.Object,
                     MessageServiceConfiguration.Object,
                     IconUrlProvider.Object,
-                    compatibilityFactory.Object);
+                    compatibilityFactory.Object,
+                    featureFlagService.Object);
             }
 
             public Mock<ISearchService> OldSearchService { get; }

--- a/tests/NuGetGallery.Facts/Services/SearchSideBySideServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/SearchSideBySideServiceFacts.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Moq;
 using NuGet.Services.Entities;
 using NuGet.Services.Messaging.Email;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Infrastructure.Mail.Messages;
 using NuGetGallery.Infrastructure.Search.Models;
 using Xunit;
@@ -134,6 +135,7 @@ namespace NuGetGallery
                 MessageService = new Mock<IMessageService>();
                 MessageServiceConfiguration = new Mock<IMessageServiceConfiguration>();
                 IconUrlProvider = new Mock<IIconUrlProvider>();
+                var compatibilityFactory = new Mock<IPackageFrameworkCompatibilityFactory>();
 
                 CurrentUser = new User
                 {
@@ -184,7 +186,8 @@ namespace NuGetGallery
                     TelemetryService.Object,
                     MessageService.Object,
                     MessageServiceConfiguration.Object,
-                    IconUrlProvider.Object);
+                    IconUrlProvider.Object,
+                    compatibilityFactory.Object);
             }
 
             public Mock<ISearchService> OldSearchService { get; }

--- a/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
@@ -147,7 +147,7 @@ namespace NuGetGallery
                 // Act
                 var result = urlHelper
                                     .PackageRegistrationTemplate()
-                                    .Resolve(new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>())
+                                    .Resolve(new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>())
                                     .Create(package, currentUser: null));
 
                 // Assert
@@ -217,7 +217,7 @@ namespace NuGetGallery
                 var urlHelper = TestUtility.MockUrlHelper();
                 
                 var idModel = new TrivialPackageVersionModel(packageId, version: null);
-                var versionModel = new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>())
+                var versionModel = new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>())
                                             .Create(package, currentUser: null);
 
                 // Act

--- a/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
+++ b/tests/NuGetGallery.Facts/UrlHelperExtensionsFacts.cs
@@ -8,6 +8,7 @@ using System.Web.Routing;
 using Moq;
 using NuGet.Services.Entities;
 using NuGetGallery.Framework;
+using NuGetGallery.Frameworks;
 using Xunit;
 
 namespace NuGetGallery
@@ -144,8 +145,10 @@ namespace NuGetGallery
                 var urlHelper = TestUtility.MockUrlHelper();
 
                 // Act
-                var result = urlHelper.PackageRegistrationTemplate()
-                    .Resolve(new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>()).Create(package, currentUser: null));
+                var result = urlHelper
+                                    .PackageRegistrationTemplate()
+                                    .Resolve(new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>())
+                                    .Create(package, currentUser: null));
 
                 // Assert
                 Assert.Equal(urlHelper.Package(package.PackageRegistration), result);
@@ -214,7 +217,8 @@ namespace NuGetGallery
                 var urlHelper = TestUtility.MockUrlHelper();
                 
                 var idModel = new TrivialPackageVersionModel(packageId, version: null);
-                var versionModel = new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>()).Create(package, currentUser: null);
+                var versionModel = new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>())
+                                            .Create(package, currentUser: null);
 
                 // Act
                 var idResult = urlHelper.PackageVersionAction(action, idModel);

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -1186,7 +1186,7 @@ namespace NuGetGallery.ViewModels
         {
             var allVersions = (IReadOnlyCollection<Package>)package.PackageRegistration.Packages;
 
-            return new DisplayPackageViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>()).Create(
+            return new DisplayPackageViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>()).Create(
                 package,
                 allVersions,
                 currentUser: currentUser,

--- a/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/DisplayPackageViewModelFacts.cs
@@ -8,6 +8,7 @@ using Moq;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
 using NuGetGallery.Framework;
+using NuGetGallery.Frameworks;
 using Xunit;
 using static NuGetGallery.DisplayPackageViewModel;
 
@@ -1185,7 +1186,7 @@ namespace NuGetGallery.ViewModels
         {
             var allVersions = (IReadOnlyCollection<Package>)package.PackageRegistration.Packages;
 
-            return new DisplayPackageViewModelFactory(Mock.Of<IIconUrlProvider>()).Create(
+            return new DisplayPackageViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>()).Create(
                 package,
                 allVersions,
                 currentUser: currentUser,

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemRequiredSignerViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemRequiredSignerViewModelFacts.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using NuGet.Services.Entities;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Security;
 using Xunit;
 
@@ -38,7 +39,7 @@ namespace NuGetGallery.ViewModels
         public void WhenPackageIsNull_Throws()
         {
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
             var exception = Assert.Throws<ArgumentNullException>(() => target.Create(
                 package: null,
                 currentUser: _currentUser,
@@ -56,7 +57,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             var exception = Assert.Throws<ArgumentNullException>(
                 () => target.Create(
@@ -77,7 +78,7 @@ namespace NuGetGallery.ViewModels
             };
 
             var exception = Assert.Throws<ArgumentNullException>(() => new ListPackageItemRequiredSignerViewModelFactory(
-                null, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>()));
+                null, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>()));
 
             Assert.Equal("securityPolicyService", exception.ParamName);
         }
@@ -99,7 +100,7 @@ namespace NuGetGallery.ViewModels
                     It.Is<string>(policyName => policyName == ControlRequiredSignerPolicy.PolicyName)))
                 .Returns(false);
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             var viewModel = target.Create(
                 package,
@@ -130,7 +131,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(x => x.IsSubscribed(
                     It.Is<User>(user => user == _currentUser),
@@ -166,7 +167,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(x => x.IsSubscribed(
                     It.Is<User>(user => user == _currentUser),
@@ -201,7 +202,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -237,7 +238,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -288,7 +289,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -325,7 +326,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -362,7 +363,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -426,7 +427,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -463,7 +464,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -500,7 +501,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -548,7 +549,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -607,7 +608,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemRequiredSignerViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemRequiredSignerViewModelFacts.cs
@@ -39,7 +39,7 @@ namespace NuGetGallery.ViewModels
         public void WhenPackageIsNull_Throws()
         {
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
             var exception = Assert.Throws<ArgumentNullException>(() => target.Create(
                 package: null,
                 currentUser: _currentUser,
@@ -57,7 +57,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             var exception = Assert.Throws<ArgumentNullException>(
                 () => target.Create(
@@ -78,7 +78,7 @@ namespace NuGetGallery.ViewModels
             };
 
             var exception = Assert.Throws<ArgumentNullException>(() => new ListPackageItemRequiredSignerViewModelFactory(
-                null, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>()));
+                null, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>()));
 
             Assert.Equal("securityPolicyService", exception.ParamName);
         }
@@ -100,7 +100,7 @@ namespace NuGetGallery.ViewModels
                     It.Is<string>(policyName => policyName == ControlRequiredSignerPolicy.PolicyName)))
                 .Returns(false);
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             var viewModel = target.Create(
                 package,
@@ -131,7 +131,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(x => x.IsSubscribed(
                     It.Is<User>(user => user == _currentUser),
@@ -167,7 +167,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(x => x.IsSubscribed(
                     It.Is<User>(user => user == _currentUser),
@@ -202,7 +202,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -238,7 +238,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -289,7 +289,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -326,7 +326,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -363,7 +363,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -427,7 +427,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -464,7 +464,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -501,7 +501,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -549,7 +549,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(
@@ -608,7 +608,7 @@ namespace NuGetGallery.ViewModels
                 Version = "1.0.0"
             };
             var target = new ListPackageItemRequiredSignerViewModelFactory(
-                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>());
+                _securityPolicyService.Object, Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageVulnerabilitiesService>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>());
 
             _securityPolicyService.Setup(
                 x => x.IsSubscribed(

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
@@ -504,7 +504,7 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
 
         private static ListPackageItemViewModel CreateListPackageItemViewModel(Package package, User user = null)
         {
-            return new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>()).Create(package, currentUser: user);
+            return new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>()).Create(package, currentUser: user);
         }
     }
 }

--- a/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/ListPackageItemViewModelFacts.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NuGet.Services.Entities;
+using NuGetGallery.Frameworks;
 using NuGetGallery.Helpers;
 using Xunit;
 
@@ -503,7 +504,7 @@ At mei iriure dignissim theophrastus.Meis nostrud te sit, equidem maiorum pri ex
 
         private static ListPackageItemViewModel CreateListPackageItemViewModel(Package package, User user = null)
         {
-            return new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>()).Create(package, currentUser: user);
+            return new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>()).Create(package, currentUser: user);
         }
     }
 }

--- a/tests/NuGetGallery.Facts/ViewModels/UserProfileModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/UserProfileModelFacts.cs
@@ -135,7 +135,7 @@ namespace NuGetGallery.ViewModels
 
             private ListPackageItemViewModel CreatePackageItemViewModel(string version)
             {
-                return new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>()).Create(new Package
+                return new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>(), Mock.Of<IFeatureFlagService>()).Create(new Package
                 {
                     PackageRegistration = new PackageRegistration
                     {

--- a/tests/NuGetGallery.Facts/ViewModels/UserProfileModelFacts.cs
+++ b/tests/NuGetGallery.Facts/ViewModels/UserProfileModelFacts.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Moq;
 using NuGet.Services.Entities;
 using NuGetGallery.Framework;
+using NuGetGallery.Frameworks;
 using Xunit;
 
 namespace NuGetGallery.ViewModels
@@ -134,7 +135,7 @@ namespace NuGetGallery.ViewModels
 
             private ListPackageItemViewModel CreatePackageItemViewModel(string version)
             {
-                return new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>()).Create(new Package
+                return new ListPackageItemViewModelFactory(Mock.Of<IIconUrlProvider>(), Mock.Of<IPackageFrameworkCompatibilityFactory>()).Create(new Package
                 {
                     PackageRegistration = new PackageRegistration
                     {


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9629

This adds TFM badges to package search results:
- We can choose to show either just asset frameworks, or both asset and computed frameworks. This will be based on whether the user selects the 'Include Computed Frameworks' checkbox in the new search filters (will be added with a later change). 
- We will show the lowest (asset/computed) version TFM from each of the 4 Framework generations (`.NET`, `.NET Core`, `.NET Standard`, `.NET Framework`).
- The badges will link to the package's frameworks tab.
- The TFM badges will be behind a feature flight.

We are reusing code previously written to display TFM badges on the package details page, but this needed some refactoring (See `src/NuGetGallery.Core/Frameworks/PackageFrameworkCompatibilityFactory.cs`) that touched a lot of different files.

The changes were primarily made in these files:

- `src/NuGetGallery.Core/*`
- `src/NuGetGallery/Controllers/PackagesController.cs`
- `src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemViewModelFactory.cs`
- `src/NuGetGallery/Infrastructure/Lucene/ExternalSearchService.cs`
- `src/NuGetGallery/ViewModels/ListPackageItemViewModel.cs`
- `src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml`
- `src/NuGetGallery/Views/Shared/_ListPackage.cshtml`
- `tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs`

The remaining files were changed either as a result of refactoring, or to add the feature flight for this change.

Previously,
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/1e9a3102-07f9-4a86-adf1-1cc86a62dcfe)

After this change,

Search page (only asset frameworks):
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/3d67338c-88cd-48da-8a7e-6b1e8c96fdb2)

Search page (including computed frameworks):
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/3b182be0-e3b3-4b07-b7d2-ad0662a52283)

With deprecation/vulnerability indicators:
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/b31d84cd-1991-458e-9451-954372939fa0)

Profiles page:
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/3aa1c319-c5f3-48cd-9e2a-d4ec44d42e69)

Package Details page and the Frameworks tab (**Unchanged**):
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/cd40560e-aafe-4903-bccf-0ea5f6ba9d35)
