### PR TITLE
TFM Badges: Fixed focus underline and outline + Added missing tooltip

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -861,6 +861,13 @@ img.reserved-indicator-icon {
   line-height: 20px;
   margin-bottom: 14px;
 }
+.framework-badges a {
+  display: inline-block;
+}
+.framework-badges a:hover,
+.framework-badges a:focus {
+  text-decoration: none;
+}
 .framework-badge {
   padding: 1px 8px;
   border-radius: 2px;

--- a/src/Bootstrap/less/theme/common-supported-frameworks.less
+++ b/src/Bootstrap/less/theme/common-supported-frameworks.less
@@ -10,6 +10,15 @@
 .framework-badges {
   .framework;
   margin-bottom: 14px;
+
+  a {
+    display: inline-block;
+  }
+  
+  a:hover,
+  a:focus {
+    text-decoration: none;
+  }
 }
 
 .framework-badge {

--- a/src/Bootstrap/less/theme/common-supported-frameworks.less
+++ b/src/Bootstrap/less/theme/common-supported-frameworks.less
@@ -13,11 +13,11 @@
 
   a {
     display: inline-block;
-  }
-  
-  a:hover,
-  a:focus {
-    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
   }
 }
 

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -188,4 +188,7 @@ $(function() {
         searchForm.addEventListener('submit', submitSearchForm);
         initializeFrameworkAndTfmCheckboxes();
     }
+
+    $(".framework-badge-asset").each(window.nuget.setPopovers);
+    $(".framework-badge-computed").each(window.nuget.setPopovers);
 });


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9795

This fixes:

1. The TFM badges were showing a trailing underline when someone hovered over it. This has now been removed.
    ![image](https://github.com/NuGet/NuGetGallery/assets/82980589/9b788d50-d795-4e9a-aa92-8c0fb52e890c)

2. When someone brought tab focus to the badges, it showed an outline, but the outline was distorted because the child elements (`<span>`) had different dimensions to the parent (`<a>`). This has been fixed.

    Previously,
    ![image](https://github.com/NuGet/NuGetGallery/assets/82980589/4710f491-e1ea-4479-bbb3-eee727eab101)
    Now,
    ![image](https://github.com/NuGet/NuGetGallery/assets/82980589/82d68881-5e99-4d8d-a591-80501c56be90)

3. The TFM badges are supposed to have a tooltip when you hover over them (See the package display page: https://www.nuget.org/packages/Newtonsoft.Json). This tooltip was missing on the search page, but it's been added now.
    ![image](https://github.com/NuGet/NuGetGallery/assets/82980589/c05796ce-b498-4159-bcde-887584f63806)
