### PR TITLE
Update NuGet Jobs packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <NuGetClientPackageVersion>6.9.1</NuGetClientPackageVersion>
     <ServerCommonPackageVersion>2.117.0</ServerCommonPackageVersion>
-    <NuGetJobsPackageVersion>4.3.0-main-9110993</NuGetJobsPackageVersion>
+    <NuGetJobsPackageVersion>4.3.0-dev-9116469</NuGetJobsPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">


### PR DESCRIPTION
NuGet gallery and NuGet jobs are dependency packages for each other.  we updated NuGet.jobs with latest NuGetGallery.  Need update the NuGet Jobs again in Gallery.

Related CG Alert: https://nuget.visualstudio.com/NuGetBuild/_componentGovernance/113192/alert/10834413?typeId=568825&pipelinesTrackingFilter=0 

Addresses: https://github.com/NuGet/Engineering/issues/5251