### PR TITLE
[Package Details] Eagerly load supported frameworks and deprecations.

### DIFF
--- a/src/NuGetGallery.Core/Services/CorePackageService.cs
+++ b/src/NuGetGallery.Core/Services/CorePackageService.cs
@@ -300,23 +300,23 @@ namespace NuGetGallery
             string id, 
             PackageDeprecationFieldsToInclude deprecationFields = PackageDeprecationFieldsToInclude.None)
         {
-            bool includeDeprecation;
+            bool includeDeprecations;
             bool includeDeprecationRelationships;
 
             switch (deprecationFields)
             {
                 case PackageDeprecationFieldsToInclude.None:
-                    includeDeprecation = false;
+                    includeDeprecations = false;
                     includeDeprecationRelationships = false;
                     break;
 
                 case PackageDeprecationFieldsToInclude.Deprecation:
-                    includeDeprecation = true;
+                    includeDeprecations = true;
                     includeDeprecationRelationships = false;
                     break;
 
                 case PackageDeprecationFieldsToInclude.DeprecationAndRelationships:
-                    includeDeprecation = true;
+                    includeDeprecations = true;
                     includeDeprecationRelationships = true;
                     break;
 
@@ -330,8 +330,9 @@ namespace NuGetGallery
                 includePackageRegistration: true,
                 includeUser: true,
                 includeSymbolPackages: true,
-                includeDeprecation: includeDeprecation,
-                includeDeprecationRelationships: includeDeprecationRelationships);
+                includeDeprecations: includeDeprecations,
+                includeDeprecationRelationships: includeDeprecationRelationships,
+                includeSupportedFrameworks: false);
         }
 
         protected IQueryable<Package> GetPackagesByIdQueryable(
@@ -340,8 +341,9 @@ namespace NuGetGallery
             bool includePackageRegistration,
             bool includeUser,
             bool includeSymbolPackages,
-            bool includeDeprecation,
-            bool includeDeprecationRelationships)
+            bool includeDeprecations,
+            bool includeDeprecationRelationships,
+            bool includeSupportedFrameworks)
         {
             var packages = _packageRepository
                 .GetAll()
@@ -373,9 +375,14 @@ namespace NuGetGallery
                     .Include(p => p.Deprecations.Select(d => d.AlternatePackage.PackageRegistration))
                     .Include(p => p.Deprecations.Select(d => d.AlternatePackageRegistration));
             }
-            else if (includeDeprecation)
+            else if (includeDeprecations)
             {
                 packages = packages.Include(p => p.Deprecations);
+            }
+
+            if (includeSupportedFrameworks)
+            {
+                packages = packages.Include(p => p.SupportedFrameworks);
             }
 
             return packages;

--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -38,8 +38,14 @@ namespace NuGetGallery
         /// <summary>
         /// Returns all packages with an <see cref="Package.Id"/> of <paramref name="id"/>.
         /// Includes the <see cref="Package.PackageRegistration"/> fields based on <paramref name="includePackageRegistration"/>.
+        /// Includes the <see cref="Package.Deprecations"/> fields based on <paramref name="includeDeprecations"/>.
+        /// Includes the <see cref="Package.SupportedFrameworks"/> fields based on <paramref name="includeSupportedFrameworks);"/>.
         /// </summary>
-        IReadOnlyCollection<Package> FindPackagesById(string id, bool includePackageRegistration);
+        IReadOnlyCollection<Package> FindPackagesById(
+            string id,
+            bool includePackageRegistration,
+            bool includeDeprecations = false,
+            bool includeSupportedFrameworks = false);
 
         /// <summary>
         /// Gets the package with the given ID and version when exists;

--- a/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/IPackageService.cs
@@ -32,8 +32,16 @@ namespace NuGetGallery
         /// Includes deprecation fields based on <paramref name="deprecationFields"/>.
         /// </summary>
         IReadOnlyCollection<Package> FindPackagesById(
-            string id, 
+            string id,
             PackageDeprecationFieldsToInclude deprecationFields = PackageDeprecationFieldsToInclude.None);
+
+        /// <summary>
+        /// Returns all packages with an <see cref="Package.Id"/> of <paramref name="id"/>.
+        /// Includes the <see cref="Package.PackageRegistration"/> fields based on <paramref name="includePackageRegistration"/>.
+        /// </summary>
+        IReadOnlyCollection<Package> FindPackagesById(
+            string id,
+            bool includePackageRegistration);
 
         /// <summary>
         /// Returns all packages with an <see cref="Package.Id"/> of <paramref name="id"/>.
@@ -44,8 +52,8 @@ namespace NuGetGallery
         IReadOnlyCollection<Package> FindPackagesById(
             string id,
             bool includePackageRegistration,
-            bool includeDeprecations = false,
-            bool includeSupportedFrameworks = false);
+            bool includeDeprecations,
+            bool includeSupportedFrameworks);
 
         /// <summary>
         /// Gets the package with the given ID and version when exists;

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -226,9 +226,31 @@ namespace NuGetGallery
 
         public virtual IReadOnlyCollection<Package> FindPackagesById(
             string id,
+            bool includePackageRegistration)
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            var packages = GetPackagesByIdQueryable(
+                id,
+                includeLicenseReports: false,
+                includePackageRegistration: includePackageRegistration,
+                includeUser: false,
+                includeSymbolPackages: false,
+                includeDeprecations: false,
+                includeDeprecationRelationships: false,
+                includeSupportedFrameworks: false);
+
+            return packages.ToList();
+        }
+
+        public virtual IReadOnlyCollection<Package> FindPackagesById(
+            string id,
             bool includePackageRegistration,
-            bool includeDeprecations = false,
-            bool includeSupportedFrameworks = false)
+            bool includeDeprecations,
+            bool includeSupportedFrameworks)
         {
             if (id == null)
             {

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -226,7 +226,9 @@ namespace NuGetGallery
 
         public virtual IReadOnlyCollection<Package> FindPackagesById(
             string id,
-            bool includePackageRegistration)
+            bool includePackageRegistration,
+            bool includeDeprecations = false,
+            bool includeSupportedFrameworks = false)
         {
             if (id == null)
             {
@@ -239,8 +241,9 @@ namespace NuGetGallery
                 includePackageRegistration: includePackageRegistration,
                 includeUser: false,
                 includeSymbolPackages: false,
-                includeDeprecation: false,
-                includeDeprecationRelationships: false);
+                includeDeprecations: includeDeprecations,
+                includeDeprecationRelationships: false,
+                includeSupportedFrameworks: includeSupportedFrameworks);
 
             return packages.ToList();
         }

--- a/src/NuGetGallery.Services/PackageManagement/PackageService.cs
+++ b/src/NuGetGallery.Services/PackageManagement/PackageService.cs
@@ -246,7 +246,7 @@ namespace NuGetGallery
             return packages.ToList();
         }
 
-        public virtual IReadOnlyCollection<Package> FindPackagesById(
+        public IReadOnlyCollection<Package> FindPackagesById(
             string id,
             bool includePackageRegistration,
             bool includeDeprecations,

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -925,7 +925,11 @@ namespace NuGetGallery
             }
 
             // Load all packages with the ID.
-            var allVersions = _packageService.FindPackagesById(id, includePackageRegistration: true);
+            var allVersions = _packageService.FindPackagesById(id,
+                includePackageRegistration: true,
+                includeDeprecations: true,
+                includeSupportedFrameworks: true);
+
             var filterContext = new PackageFilterContext(RouteData?.Route, version);
             var package = _packageFilter.GetFiltered(allVersions, filterContext);
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -508,7 +508,10 @@ namespace NuGetGallery
 
                 var packages = new List<Package> { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterExactPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<string>()))
@@ -713,7 +716,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -840,7 +846,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -911,7 +920,10 @@ namespace NuGetGallery
                 };
 
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(new[] { notLatestPackage, latestPackage, latestButNotPackage });
 
                 indexingService.Setup(i => i.GetLastWriteTime()).Returns(Task.FromResult((DateTime?)DateTime.UtcNow));
@@ -956,7 +968,10 @@ namespace NuGetGallery
 
                 var packages = new[] { notLatestPackage };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1002,7 +1017,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById("Foo", /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById("Foo",
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1101,7 +1119,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1148,7 +1169,11 @@ namespace NuGetGallery
                 };
 
                 var packages = new[] { package };
-                packageService.Setup(p => p.FindPackagesById("Foo", /*includePackageRegistration:*/ true))
+                packageService
+                    .Setup(p => p.FindPackagesById("Foo",
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService.Setup(p => p.FilterLatestPackage(packages, SemVerLevelKey.SemVer2, true))
@@ -1204,7 +1229,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1256,7 +1284,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1315,7 +1346,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1389,7 +1423,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1482,7 +1519,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1588,7 +1628,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1671,7 +1714,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1738,7 +1784,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1796,7 +1845,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -1844,7 +1896,10 @@ namespace NuGetGallery
                     .Setup(f => f.IsPackageDependentsEnabled(It.IsAny<User>()))
                     .Returns(false);
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -1893,7 +1948,10 @@ namespace NuGetGallery
                    .Returns(false);
                 var packages = new List<Package> { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -1947,8 +2005,12 @@ namespace NuGetGallery
 
                 var packages = new List<Package> { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
+
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
                     .Returns(package);
@@ -2003,7 +2065,10 @@ namespace NuGetGallery
                 var gitHubInformation = new NuGetPackageGitHubInformation(new List<RepositoryInformation>());
 
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2067,7 +2132,10 @@ namespace NuGetGallery
                 var gitHubInformation = new NuGetPackageGitHubInformation(new List<RepositoryInformation>());
 
                 packageService
-                    .Setup(p => p.FindPackagesById(It.IsAny<string>(), /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(It.IsAny<string>(),
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2133,7 +2201,10 @@ namespace NuGetGallery
                 var gitHubInformation = new NuGetPackageGitHubInformation(new List<RepositoryInformation>());
 
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
                 packageService
                     .Setup(p => p.FilterLatestPackage(It.IsAny<IReadOnlyCollection<Package>>(), It.IsAny<int?>(), true))
@@ -2187,7 +2258,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService
@@ -2249,7 +2323,10 @@ namespace NuGetGallery
 
                 var packages = new[] { package };
                 packageService
-                    .Setup(p => p.FindPackagesById(id, /*includePackageRegistration:*/ true))
+                    .Setup(p => p.FindPackagesById(id,
+                    /*includePackageRegistration:*/ true,
+                    /*includeDeprecations:*/ true,
+                    /*includeSupportedFrameworks:*/ true))
                     .Returns(packages);
 
                 packageService


### PR DESCRIPTION
As the package details page loads the metadata of all package versions: https://github.com/NuGet/NuGetGallery/blob/e043791f59cc939c09df7802ae552dde5500039d/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs#L79-L87
it is better [eagerly loading](https://learn.microsoft.com/en-us/ef/ef6/querying/related-data) supported frameworks and deprecations of all versions together, rather than loading each version one by one.

Add another API rather than change the shape of existing ones, to avoid breaking other dependencies on [`IPackageService`](https://github.com/NuGet/NuGetGallery/blob/main/src/NuGetGallery.Services/PackageManagement/IPackageService.cs).