### PR TITLE
Fix Framework Filter Mode tooltip colors

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -209,25 +209,30 @@ $(function() {
     $(".framework-badge-computed").each(window.nuget.setPopovers);
 
     // Set the background color on the FrameworkFilterMode tooltip - https://github.com/NuGet/NuGetGallery/issues/9818
-    const filterModetooltip = document.querySelector('.frameworkfiltermode-info');
+    const filterModeTooltip = document.querySelector('.frameworkfiltermode-info');
 
     const tooltipObserver = new MutationObserver(function (mutations) {
         mutations.forEach(function (mutation) {
             if (mutation.type === "attributes"
                 && mutation.attributeName === "aria-describedby"
-                && filterModetooltip.hasAttribute("aria-describedby")) {
+                && filterModeTooltip.hasAttribute("aria-describedby")) {
 
-                const popoverId = filterModetooltip.getAttribute("aria-describedby");
+                const popoverId = filterModeTooltip.getAttribute("aria-describedby");
                 const filterModePopover = document.getElementById(popoverId);
 
-                filterModePopover.querySelector(".popover-title").style.border = "none";
-                filterModePopover.querySelector(".popover-title").style.background = "white";
-                filterModePopover.querySelector(".popover-content").remove();
+                if (filterModePopover) {
+                    $(filterModePopover).find(".popover-title").css({
+                        border: "none",
+                        background: "white"
+                    });
+
+                    $(filterModePopover).find(".popover-content").remove();
+                }
             }
         });
     });
 
-    tooltipObserver.observe(filterModetooltip, {
+    tooltipObserver.observe(filterModeTooltip, {
         attributeFilter: ["aria-describedby"]
     });
 });

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -1,11 +1,6 @@
 $(function() {
     'use strict';
 
-    $(".reserved-indicator").each(window.nuget.setPopovers);
-    $(".package-warning--vulnerable").each(window.nuget.setPopovers);
-    $(".package-warning--deprecated").each(window.nuget.setPopovers);
-    $(".frameworkfiltermode-info").each(window.nuget.setPopovers);
-
     const storage = window['localStorage'];
     const focusResultsColumnKey = 'focus_results_column';
 
@@ -206,6 +201,33 @@ $(function() {
         initializeFrameworkAndTfmCheckboxes();
     }
 
+    $(".reserved-indicator").each(window.nuget.setPopovers);
+    $(".package-warning--vulnerable").each(window.nuget.setPopovers);
+    $(".package-warning--deprecated").each(window.nuget.setPopovers);
+    $(".frameworkfiltermode-info").each(window.nuget.setPopovers);
     $(".framework-badge-asset").each(window.nuget.setPopovers);
     $(".framework-badge-computed").each(window.nuget.setPopovers);
+
+    // Set the background color on the FrameworkFilterMode tooltip - https://github.com/NuGet/NuGetGallery/issues/9818
+    const filterModetooltip = document.querySelector('.frameworkfiltermode-info');
+
+    const tooltipObserver = new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+            if (mutation.type === "attributes"
+                && mutation.attributeName === "aria-describedby"
+                && filterModetooltip.hasAttribute("aria-describedby")) {
+
+                const popoverId = filterModetooltip.getAttribute("aria-describedby");
+                const filterModePopover = document.getElementById(popoverId);
+
+                filterModePopover.querySelector(".popover-title").style.border = "none";
+                filterModePopover.querySelector(".popover-title").style.background = "white";
+                filterModePopover.querySelector(".popover-content").remove();
+            }
+        });
+    });
+
+    tooltipObserver.observe(filterModetooltip, {
+        attributeFilter: ["aria-describedby"]
+    });
 });

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -207,32 +207,4 @@ $(function() {
     $(".frameworkfiltermode-info").each(window.nuget.setPopovers);
     $(".framework-badge-asset").each(window.nuget.setPopovers);
     $(".framework-badge-computed").each(window.nuget.setPopovers);
-
-    // Set the background color on the FrameworkFilterMode tooltip - https://github.com/NuGet/NuGetGallery/issues/9818
-    const filterModeTooltip = document.querySelector('.frameworkfiltermode-info');
-
-    const tooltipObserver = new MutationObserver(function (mutations) {
-        mutations.forEach(function (mutation) {
-            if (mutation.type === "attributes"
-                && mutation.attributeName === "aria-describedby"
-                && filterModeTooltip.hasAttribute("aria-describedby")) {
-
-                const popoverId = filterModeTooltip.getAttribute("aria-describedby");
-                const filterModePopover = document.getElementById(popoverId);
-
-                if (filterModePopover) {
-                    $(filterModePopover).find(".popover-title").css({
-                        border: "none",
-                        background: "white"
-                    });
-
-                    $(filterModePopover).find(".popover-content").remove();
-                }
-            }
-        });
-    });
-
-    tooltipObserver.observe(filterModeTooltip, {
-        attributeFilter: ["aria-describedby"]
-    });
 });

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -100,7 +100,7 @@
                                         <div class="framework-filter-mode-option" aria-label="ALL/ANY toggle that decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them.">
                                             <p>
                                                 Framework Filter Mode
-                                                <i class="frameworkfiltermode-info ms-Icon ms-Icon--Info" title="Decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them."></i>
+                                                <i class="frameworkfiltermode-info ms-Icon ms-Icon--Info" data-content="Decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them."></i>
                                             </p>
                                             <div class="toggle-switch-control">
                                                 <input type="radio" id="all-selector" name="frameworkFilterMode" value="all" tabindex="0" @(Model.FrameworkFilterMode == "any" ? "" : "checked") />


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/9818

The bootstrap popover on the Framework Filter Mode tooltip had different colors within it:
<img src="https://github.com/NuGet/NuGetGallery/assets/82980589/a6ec1bb3-331e-4644-8323-da8e97d8d074" width="600px"></img>

We were using a `title` attribute for the text earlier. Switching to a `data-content` attribute fixes this issue:
<img src="https://github.com/NuGet/NuGetGallery/assets/82980589/41e67f92-401a-4f06-a2f0-5e771c40fa9c" width="600px"></img>