### PR TITLE
Downloads page changed

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-downloads.js
+++ b/src/NuGetGallery/Scripts/gallery/page-downloads.js
@@ -7,16 +7,16 @@
 
     var chevronIcon;
     var olderVersionsElement;
-
+    
     function makeOlderVersionsCollapsible() {
-        const listContainer = document.getElementById('win-x86-versions').children[1];   //children[0] is the headline, children[1] is the list of versions
-        const listContainerParent = document.getElementById('win-x86-versions');
+        const listContainer = document.getElementById('nuget-exe').children[1];   //children[0] is the headline, children[1] is the list of versions
+        const listContainerParent = document.getElementById('nuget-exe');
         olderVersionsElement = document.createElement('div');
 
         // We want to display 2 versions to the users. Others should be collapsed.
         const allVersions = listContainer.querySelectorAll('li');
         var collapsedVersions = Array.from(allVersions).slice(2);
-
+        
         // If the first two versions in json file are the same, we only want to show the first.
         // The following code checks if they're the same, and if so, removes the second.
         // It checks if they're the same based on the last word, which is a version identifier.
@@ -33,7 +33,7 @@
         if (firstVersionLastWord === secondVersionLastWord) {
             listContainer.removeChild(secondElement);
         }
-
+        
         olderVersionsElement.setAttribute('class', 'older-versions-dropdown');
         olderVersionsElement.innerHTML = 'Older versions ' +
             '<button class="toggle-older-versions-button"' +
@@ -45,8 +45,7 @@
             'type="button">' +
             '<i class="ms-Icon ms-Icon--ChevronDown"' +
             'id="olderVersionsToggleChevron"></i>' +
-            '</button>' +
-            '<p> These versions are no longer supported and might have vulnerabilities. </p>';
+            '</button>';
 
         const versionsList = document.createElement('ul');
 

--- a/src/NuGetGallery/Views/Pages/Downloads.cshtml
+++ b/src/NuGetGallery/Views/Pages/Downloads.cshtml
@@ -11,22 +11,28 @@
     </div>
     <div class="row">
         <div class="col-md-4">
-            <h2 class="ms-fontSize-xxl">Windows x86 Commandline</h2>
+            <h2 class="ms-fontSize-xxl">NuGet.exe</h2>
             <ul class="list-unstyled list-tools">
                 <li><a href="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe">nuget.exe - recommended latest</a></li>
             </ul>
         </div>
         <div class="col-md-4">
-            <h2 class="ms-fontSize-xxl">Visual Studio 2015</h2>
+            <h2 class="ms-fontSize-xxl">Visual Studio</h2>
+            <p>
+                NuGet Package Manager (PM UI and PM Console) is included with Visual Studio. Latest NuGet releases are delivered as part of Visual Studio updates. Note: nuget.exe itself is not included with any version of Visual Studio.
+            </p>
             <ul class="list-unstyled list-tools">
-                <li><a href="https://dist.nuget.org/visualstudio-2015-vsix/latest/NuGet.Tools.vsix">VS 2015 VSIX - latest</a></li>
+                <li><a href="https://visualstudio.microsoft.com/downloads/">Download Visual Studio</a></li>
             </ul>
         </div>
         <div class="col-md-4">
-            <h2 class="ms-fontSize-xxl">Visual Studio 2017</h2>
+            <h2 class="ms-fontSize-xxl">.NET SDK</h2>
             <p>
-                NuGet 4.x is included in the Visual Studio 2017 installation. Latest NuGet releases are delivered as part of Visual Studio updates.
+                The CLI tool for .NET Core and .NET Standard libraries, and for any SDK-style project such as one that targets the .NET Framework. This CLI tool is included with the .NET Core SDK and provides core NuGet features on all platforms.
             </p>
+            <ul class="list-unstyled list-tools">
+                <li><a href="https://dotnet.microsoft.com/en-us/download">Download .NET SDK</a></li>
+            </ul>
         </div>
     </div>
 </section>
@@ -40,21 +46,21 @@
     <div class="row">
         <div class="col-md-4">
             <!-- ko foreach: artifacts -->
-            <!-- ko if: name == "win-x86-commandline" -->
-            <div id="win-x86-versions" data-bind="template: { name: 'tool-list-template', data: $data }"></div>
+            <!-- ko if: name == "nuget-exe" -->
+            <div id="nuget-exe" data-bind="template: { name: 'tool-list-template', data: $data }"></div>
             <!-- /ko -->
             <!-- /ko -->
         </div>
         <div class="col-md-4">
             <!-- ko foreach: artifacts -->
-            <!-- ko if: name == "visualstudio-2017-vsix" -->
+            <!-- ko if: name == "visualstudio-vsix" -->
             <div data-bind="template: { name: 'tool-list-template', data: $data }"></div>
             <!-- /ko -->
             <!-- /ko -->
         </div>
         <div class="col-md-4">
             <!-- ko foreach: artifacts -->
-            <!-- ko if: name != "win-x86-commandline" && name != "visualstudio-2017-vsix" -->
+            <!-- ko if: name != "nuget-exe" && name != "visualstudio-vsix" -->
             <div data-bind="template: { name: 'tool-list-template', data: $data }"></div>
             <!-- /ko -->
             <!-- /ko -->


### PR DESCRIPTION
The download page is now updated. Here's how it looked like before:
<img width="878" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/844e62df-5794-4520-8f20-56d41ee3880b">

Here is how it looks like now:
<img width="891" alt="image" src="https://github.com/NuGet/NuGetGallery/assets/58230697/98630c30-36ea-4532-ac3b-1d0086453d1f">

Rationale for changes:
Having old versions of VS is not relevant anymore.
The list of versions has been updated and approved in a different PR.
There is no warning message anymore because the versions included are supported.

Testing:
Go to [this file](https://github.com/NuGet/NuGet.Services.Index/blob/main/PROD/dist.nuget.org-index/index.json). Click on "raw" (see image)
![image](https://github.com/NuGet/NuGetGallery/assets/58230697/c801df72-b56e-4560-9c7c-fe17ae58ea76)

Copy the URL of the raw file. Now, go to Downloads.cshtml line 86 and instead of //dist.nuget.org/index.json, paste the URL you previously copied. Run the code. Go to Downloads. Older versions of win-x86 should be collapsible. There should also be a red message indicating that these versions are unsupported.

Addresses https://github.com/NuGet/Engineering/issues/5067