### PR TITLE
Update Frameworks table to use clearer "Included/Compatible framework" framing

### DIFF
--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksTable.cshtml
@@ -41,12 +41,12 @@
 </table>
 <div>
     <div>
-        <i class="frameworktableinfo-asset-icon"></i>
+        <i class="frameworktableinfo-computed-icon framework-badge-computed"></i>
         <span class="frameworktableinfo-text">Compatible target framework(s)</span>
     </div>
     <div>
-        <i class="frameworktableinfo-computed-icon framework-badge-computed"></i>
-        <span class="frameworktableinfo-text">Additional computed target framework(s)</span>
+        <i class="frameworktableinfo-asset-icon"></i>
+        <span class="frameworktableinfo-text">Included target framework(s) (in package)</span>
     </div>
     <span class="frameworktableinfo-text"><i>Learn more about <a href='https://docs.microsoft.com/dotnet/standard/frameworks' aria-label="Learn more about Target Frameworks">Target Frameworks</a> and <a href='https://docs.microsoft.com/dotnet/standard/net-standard' aria-label="Learn more about .NET Standard">.NET Standard</a>.</i></span>
 </div>


### PR DESCRIPTION
- The idea of "compatible" and "computed" is an odd distinction
- "Compatible" and "included" seems much more useful, with the former being the high-value distinction
- More generally, we should ensure that we have common developer workflows that align with this checkerbox display.
- Sure would be nice to get EOL information in here

Example: https://www.nuget.org/packages/Microsoft.Extensions.Logging/9.0.0-preview.1.24080.9#supportedframeworks-body-tab