### PR TITLE
Update TFM Badge Tooltips

### DIFF
--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -2157,6 +2157,33 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This package targets {0}. The package is compatible with this framework or higher..
+        /// </summary>
+        public static string SupportedFrameworks_Asset_Tooltip {
+            get {
+                return ResourceManager.GetString("SupportedFrameworks_Asset_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This package is compatible with {0} or higher..
+        /// </summary>
+        public static string SupportedFrameworks_Computed_Tooltip {
+            get {
+                return ResourceManager.GetString("SupportedFrameworks_Computed_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This package is compatible with all versions of {0}..
+        /// </summary>
+        public static string SupportedFrameworks_EmptyVersion_Template_Tooltip {
+            get {
+                return ResourceManager.GetString("SupportedFrameworks_EmptyVersion_Template_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This package is compatible with all versions of this framework..
         /// </summary>
         public static string SupportedFrameworks_EmptyVersionTooltip {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1269,4 +1269,13 @@ The {1} Team</value>
   <data name="InvalidPackageEntry" xml:space="preserve">
     <value>The package is invalid and cannot be uploaded. The package entry for '{0}' is not valid.</value>
   </data>
+  <data name="SupportedFrameworks_Asset_Tooltip" xml:space="preserve">
+    <value>This package targets {0}. The package is compatible with this framework or higher.</value>
+  </data>
+  <data name="SupportedFrameworks_Computed_Tooltip" xml:space="preserve">
+    <value>This package is compatible with {0} or higher.</value>
+  </data>
+  <data name="SupportedFrameworks_EmptyVersion_Template_Tooltip" xml:space="preserve">
+    <value>This package is compatible with all versions of {0}.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -114,13 +114,13 @@
                     @:data-badge-framework="@Model.NetStandard.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetStandard.IsComputed"
             }>
             <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.NetStandard, Model.NetStandard)" data-content="@GetBadgeTooltip(FrameworkContext.NetStandard, Model.NetStandard)">
-            @if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
+            @if (Model.NetStandard.Framework.GetBadgeVersion().IsEmpty())
             {
                 @:.NET Standard
             }
             else
             {
-                @:.NET Standard @Model.NetCore.Framework.GetBadgeVersion()
+                @:.NET Standard @Model.NetStandard.Framework.GetBadgeVersion()
             }
             </span>
         </a>
@@ -135,13 +135,13 @@
                     @:data-badge-framework="@Model.NetFramework.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetFramework.IsComputed"
             }>
             <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.NetFramework, Model.NetFramework)" data-content="@GetBadgeTooltip(FrameworkContext.NetFramework, Model.NetFramework)">
-            @if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
+            @if (Model.NetFramework.Framework.GetBadgeVersion().IsEmpty())
             {
                 @:.NET Framework
             }
             else
             {
-                @:.NET Framework @Model.NetCore.Framework.GetBadgeVersion()
+                @:.NET Framework @Model.NetFramework.Framework.GetBadgeVersion()
             }
             </span>
         </a>

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -18,6 +18,54 @@
         itemIndex = parsedItemIndex;
     }
 }
+@functions
+{
+    public enum FrameworkContext
+    {
+        DotNet,
+        NetCore,
+        NetStandard,
+        NetFramework
+    }
+
+    public string GetBadgeTooltip(FrameworkContext context, PackageFrameworkCompatibilityData tfmCompatibilityData)
+    {
+        var badgeVersion = tfmCompatibilityData.Framework.GetBadgeVersion();
+        string tfmType;
+        switch (context)
+        {
+            case FrameworkContext.DotNet:
+                tfmType = ".NET";
+                break;
+            case FrameworkContext.NetCore:
+                tfmType = ".NET Core";
+                break;
+            case FrameworkContext.NetStandard:
+                tfmType = ".NET Standard";
+                break;
+            case FrameworkContext.NetFramework:
+                tfmType = ".NET Framework";
+                break;
+            default:
+                tfmType = "";
+                break;
+        }
+
+        if (badgeVersion.IsEmpty())
+        {
+            return string.Format(String.SupportedFrameworks_EmptyVersion_Template_Tooltip, tfmType);
+        }
+
+        var toolTipTemplate = tfmCompatibilityData.IsComputed
+            ? String.SupportedFrameworks_Computed_Tooltip
+            : String.SupportedFrameworks_Asset_Tooltip;
+
+        var tfmName = tfmType + " " + badgeVersion;
+        var toolTip = string.Format(toolTipTemplate, tfmName);
+
+        return toolTip;
+    }
+}
 
 <div class="framework framework-badges">
     @if (Model.Net != null)
@@ -30,102 +78,72 @@
                 @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
                 @:data-badge-framework="@Model.Net.Framework.GetShortFolderName()" data-badge-is-computed="@Model.Net.IsComputed"
             }>
-            <span class=@(Model.Net.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">
+            <span class=@(Model.Net.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.DotNet, Model.Net)" data-content="@GetBadgeTooltip(FrameworkContext.DotNet, Model.Net)">
                 .NET @Model.Net.Framework.GetBadgeVersion()
             </span>
         </a>
     }
     @if (Model.NetCore != null)
     {
-        if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
-        {
-            <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-                @if (itemIndex.HasValue)
-                {
-                     @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                     @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                     @:data-badge-framework="@Model.NetCore.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetCore.IsComputed"
-                }>
-                <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">
-                    .NET Core
-                </span>
-            </a>
-        }
-        else
-        {
-            <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-                @if (itemIndex.HasValue)
-                {
-                     @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                     @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                     @:data-badge-framework="@Model.NetCore.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetCore.IsComputed"
-                }>
-                <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">
-                    .NET Core @Model.NetCore.Framework.GetBadgeVersion()
-                </span>
-            </a>
-        }
+        <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
+            @if (itemIndex.HasValue)
+            {
+                    @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
+                    @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
+                    @:data-badge-framework="@Model.NetCore.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetCore.IsComputed"
+            }>
+            <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.NetCore, Model.NetCore)" data-content="@GetBadgeTooltip(FrameworkContext.NetCore, Model.NetCore)">
+            @if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
+            {
+                @:.NET Core
+            }
+            else
+            {
+                @:.NET Core @Model.NetCore.Framework.GetBadgeVersion()
+            }
+            </span>
+        </a>
     }
     @if (Model.NetStandard != null)
     {
-        if (Model.NetStandard.Framework.GetBadgeVersion().IsEmpty())
-        {
-            <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-                @if (itemIndex.HasValue)
-                {
-                     @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                     @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                     @:data-badge-framework="@Model.NetStandard.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetStandard.IsComputed"
-                }>
-                <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">
-                    .NET Standard
-                </span>
-            </a>
-        }
-        else
-        {
-            <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-                @if (itemIndex.HasValue)
-                {
-                     @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                     @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                     @:data-badge-framework="@Model.NetStandard.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetStandard.IsComputed"
-                }>
-                <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">
-                    .NET Standard @Model.NetStandard.Framework.GetBadgeVersion()
-                </span>
-            </a>
-        }
+        <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
+            @if (itemIndex.HasValue)
+            {
+                    @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
+                    @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
+                    @:data-badge-framework="@Model.NetStandard.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetStandard.IsComputed"
+            }>
+            <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.NetStandard, Model.NetStandard)" data-content="@GetBadgeTooltip(FrameworkContext.NetStandard, Model.NetStandard)">
+            @if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
+            {
+                @:.NET Standard
+            }
+            else
+            {
+                @:.NET Standard @Model.NetCore.Framework.GetBadgeVersion()
+            }
+            </span>
+        </a>
     }
     @if (Model.NetFramework != null)
     {
-        if (Model.NetFramework.Framework.GetBadgeVersion().IsEmpty())
-        {
-            <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-                @if (itemIndex.HasValue)
-                {
-                     @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                     @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                     @:data-badge-framework="@Model.NetFramework.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetFramework.IsComputed"
-                }>
-                <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_EmptyVersionTooltip" data-content="@String.SupportedFrameworks_EmptyVersionTooltip">
-                    .NET Framework
-                </span>
-            </a>
-        }
-        else
-        {
-            <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-                @if (itemIndex.HasValue)
-                {
-                     @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                     @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                     @:data-badge-framework="@Model.NetFramework.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetFramework.IsComputed"
-                }>
-                <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@String.SupportedFrameworks_Tooltip" data-content="@String.SupportedFrameworks_Tooltip">
-                    .NET Framework @Model.NetFramework.Framework.GetBadgeVersion()
-                </span>
-            </a>
-        }
+        <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
+            @if (itemIndex.HasValue)
+            {
+                    @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
+                    @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
+                    @:data-badge-framework="@Model.NetFramework.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetFramework.IsComputed"
+            }>
+            <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.NetFramework, Model.NetFramework)" data-content="@GetBadgeTooltip(FrameworkContext.NetFramework, Model.NetFramework)">
+            @if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
+            {
+                @:.NET Framework
+            }
+            else
+            {
+                @:.NET Framework @Model.NetCore.Framework.GetBadgeVersion()
+            }
+            </span>
+        </a>
     }
 </div>

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -22,7 +22,7 @@
 {
     public enum FrameworkContext
     {
-        DotNet,
+        Net,
         NetCore,
         NetStandard,
         NetFramework
@@ -34,7 +34,7 @@
         string tfmType;
         switch (context)
         {
-            case FrameworkContext.DotNet:
+            case FrameworkContext.Net:
                 tfmType = ".NET";
                 break;
             case FrameworkContext.NetCore:
@@ -78,7 +78,7 @@
                 @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
                 @:data-badge-framework="@Model.Net.Framework.GetShortFolderName()" data-badge-is-computed="@Model.Net.IsComputed"
             }>
-            <span class=@(Model.Net.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.DotNet, Model.Net)" data-content="@GetBadgeTooltip(FrameworkContext.DotNet, Model.Net)">
+            <span class=@(Model.Net.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.Net, Model.Net)" data-content="@GetBadgeTooltip(FrameworkContext.Net, Model.Net)">
                 .NET @Model.Net.Framework.GetBadgeVersion()
             </span>
         </a>


### PR DESCRIPTION
Updates Tooltips on TFM badges to be more descriptive.
Addresses https://github.com/NuGet/NuGetGallery/issues/9814 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1970927

The badges currently say:
This package is compatible with this framework or higher.

This will update these to new strings
Asset framework:
This package targets < framework>. The package is compatible with this framework or higher.
Computed framework
This package is compatible with < framework> or higher.
No Version
This package is compatible with all versions of < framework>.

![image](https://github.com/NuGet/NuGetGallery/assets/11051729/38127b36-3d74-4447-8562-8a7df46b5c81)

![image](https://github.com/NuGet/NuGetGallery/assets/11051729/80537c7c-f4b5-4296-83c0-a4d6401c22d7)
