### PR TITLE
Small fixes to the framework filters

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -207,4 +207,5 @@ $(function() {
     $(".frameworkfiltermode-info").each(window.nuget.setPopovers);
     $(".framework-badge-asset").each(window.nuget.setPopovers);
     $(".framework-badge-computed").each(window.nuget.setPopovers);
+    $(".frameworkfilters-info").each(window.nuget.setPopovers);
 });

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -86,21 +86,21 @@
                                 <fieldset id="frameworkfilters">
                                     <legend>
                                         Frameworks
-                                        <a href="@(Model.FrameworksFilteringInformationLink)" title="Filters packages based on the target frameworks included in the NuGet Package. Click here to learn more.">
+                                        <a href="@(Model.FrameworksFilteringInformationLink)" class="frameworkfilters-info" data-content="Filters packages based on the target frameworks they are compatible with. Click here to learn more.">
                                             <i class="framework-filter-info-icon ms-Icon ms-Icon--Info"></i>
                                         </a>
                                     </legend>
                                     @if (Model.IsAdvancedFrameworkFilteringEnabled)
                                     {
                                         <div class="computed-frameworks-option">
-                                            <label for="computed-frameworks-checkbox" aria-label="Include computed frameworks when filtering for packages.">Include computed frameworks</label>
+                                            <label for="computed-frameworks-checkbox" aria-label="Include computed compatible frameworks when filtering for packages.">Include computed frameworks</label>
                                             <input type="checkbox" id="computed-frameworks-checkbox" checked="@Model.IncludeComputedFrameworks">
                                             <input type="hidden" id="includeComputedFrameworks" name="includeComputedFrameworks" value="@Model.IncludeComputedFrameworks.ToString().ToLower()">
                                         </div>
                                         <div class="framework-filter-mode-option" aria-label="ALL/ANY toggle that decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them.">
                                             <p>
                                                 Framework Filter Mode
-                                                <i class="frameworkfiltermode-info ms-Icon ms-Icon--Info" data-content="Decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them."></i>
+                                                <i class="frameworkfiltermode-info ms-Icon ms-Icon--Info" tabindex="0" data-content="Decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them."></i>
                                             </p>
                                             <div class="toggle-switch-control">
                                                 <input type="radio" id="all-selector" name="frameworkFilterMode" value="all" tabindex="0" @(Model.FrameworkFilterMode == "any" ? "" : "checked") />

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -93,7 +93,7 @@
                                     @if (Model.IsAdvancedFrameworkFilteringEnabled)
                                     {
                                         <div class="computed-frameworks-option">
-                                            <label for="computed-frameworks-checkbox" aria-label="Include computed compatible frameworks when filtering for packages.">Include computed frameworks</label>
+                                            <label for="computed-frameworks-checkbox" aria-label="Include computed compatible frameworks when filtering for packages.">Include compatible frameworks</label>
                                             <input type="checkbox" id="computed-frameworks-checkbox" checked="@Model.IncludeComputedFrameworks">
                                             <input type="hidden" id="includeComputedFrameworks" name="includeComputedFrameworks" value="@Model.IncludeComputedFrameworks.ToString().ToLower()">
                                         </div>


### PR DESCRIPTION
Fixes a couple of small things before we release the new framework filters:

- Change "Include **computed** frameworks" to "Include **compatible** frameworks" in light of this change to the terminology: https://github.com/NuGet/NuGetGallery/pull/9835
- https://github.com/NuGet/NuGetGallery/issues/9816: The tooltip on the Frameworks heading was browser-native, and not bootstrap like all the other tooltips.
- The tooltip used to say that it 'filters packages based on the frameworks **included in the package**'. Now that the default includes 'computed' compatible frameworks too, I've changed this to say 'filters packages based on the frameworks **they are compatible with**'.
- **[A11y bug]** https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1970827: The Framework Filter Mode tooltip was not receiving tab focus, so I added "tabindex=0" to add it to the tab order.

Previously,
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/aabb2118-3345-4f55-b17b-94555f12faa9)
I can't take a screenshot of the browser native tooltip, but you can try hovering over the tooltip on https://www.nuget.org/packages

After the changes,
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/f4885c80-5098-413c-8712-61d432da3d08)
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/ed740309-175b-4737-980b-ed6e5c48c9a5)
