### PR TITLE
Fixes a11y bug on search page tooltip

### DIFF
--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1121,6 +1121,15 @@ namespace NuGetGallery {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filters packages based on the target frameworks they are compatible with. Click here to learn more..
+        /// </summary>
+        public static string FrameworkFilters_Tooltip {
+            get {
+                return ResourceManager.GetString("FrameworkFilters_Tooltip", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The API key &apos;{0}&apos; is invalid..
         /// </summary>
         public static string InvalidApiKey {

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -1278,4 +1278,7 @@ The {1} Team</value>
   <data name="SupportedFrameworks_EmptyVersion_Template_Tooltip" xml:space="preserve">
     <value>This package is compatible with all versions of {0}.</value>
   </data>
+  <data name="FrameworkFilters_Tooltip" xml:space="preserve">
+    <value>Filters packages based on the target frameworks they are compatible with. Click here to learn more.</value>
+  </data>
 </root>

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -74,8 +74,11 @@
                 @if (Model.IsAdvancedSearchFlightEnabled)
                 {
                     <div class="toggle-advanced-search-panel">
-                        Advanced search filters <button class ="advanced-search-toggle-button" aria-label="Toggles search filters on narrow screens" aria-expanded="false" aria-controls="advancedSearchToggleButton" tabindex="0" id="advancedSearchToggleButton" type="button">
-                        <i class="ms-Icon ms-Icon--ChevronDown" id="advancedSearchToggleChevron" ></i></button>
+                        Advanced search filters
+                        <button class="advanced-search-toggle-button" aria-label="Toggles search filters on narrow screens" aria-expanded="false"
+                                aria-controls="advancedSearchToggleButton" tabindex="0" id="advancedSearchToggleButton" type="button">
+                            <i class="ms-Icon ms-Icon--ChevronDown" id="advancedSearchToggleChevron"></i>
+                        </button>
                     </div>
                     <div class="row clearfix advanced-search-panel" id="advancedSearchPanel">
                         <input type="text" hidden id="frameworks" name="frameworks" value="@Model.Frameworks">
@@ -86,7 +89,9 @@
                                 <fieldset id="frameworkfilters">
                                     <legend>
                                         Frameworks
-                                        <a href="@(Model.FrameworksFilteringInformationLink)" class="frameworkfilters-info" data-content="Filters packages based on the target frameworks they are compatible with. Click here to learn more.">
+                                        <a href="@(Model.FrameworksFilteringInformationLink)" class="frameworkfilters-info"
+                                           data-content="@NuGetGallery.Strings.FrameworkFilters_Tooltip"
+                                           aria-label="@NuGetGallery.Strings.FrameworkFilters_Tooltip">
                                             <i class="framework-filter-info-icon ms-Icon ms-Icon--Info"></i>
                                         </a>
                                     </legend>


### PR DESCRIPTION
Some of my previous changes introduced a new a11y bug. The 'Frameworks' filter tooltip was missing an aria-label, which I've now fixed.

I also took the chance to change the aria-label string to a `NuGetGallery.Strings` resource so that we don't have to change the text in multiple places the next time we need changes.

This clears a11y Fast Pass now. There's no visible UI changes.

NOTE: The changes on lines 77-81 are just whitespace changes.