### PR TITLE
[HotFix]Fix rejection of all safety reasons.

### DIFF
--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -1505,14 +1505,6 @@ namespace NuGetGallery
         {
             reportForm.Message = HttpUtility.HtmlEncode(reportForm.Message);
 
-            if (reportForm.Reason == ReportPackageReason.ViolatesALicenseIOwn
-                && string.IsNullOrWhiteSpace(reportForm.Signature))
-            {
-                ModelState.AddModelError(
-                    nameof(ReportAbuseViewModel.Signature),
-                    "The signature is required.");
-            }
-
             var package = _packageService.FindPackageByIdAndVersionStrict(id, version);
 
             if (package == null)

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -80,13 +80,11 @@ namespace NuGetGallery
             ReportPackageReason.OtherNudityOrPornography,
         };
 
-        private static readonly IReadOnlyList<ReportPackageReason> ReportAbuseWithSafetyReasons = new[]
+        private static readonly IReadOnlyList<ReportPackageReason> DisallowedReportAbuseReasons = new[]
         {
             ReportPackageReason.ViolatesALicenseIOwn,
-            ReportPackageReason.ContainsMaliciousCode,
             ReportPackageReason.ContainsSecurityVulnerability,
-            ReportPackageReason.HasABugOrFailedToInstall,
-            ReportPackageReason.Other
+            ReportPackageReason.RevengePorn,
         };
 
         private static readonly IReadOnlyList<ReportPackageReason> ReportMyPackageReasons = new[]
@@ -1528,7 +1526,7 @@ namespace NuGetGallery
                     : ReportAbuseReasons;
 
             var reportReason = (ReportPackageReason)reportForm.Reason;
-            if (!ReasonChoices.Contains(reportReason) || SafetyReportAbuseReasons.Contains(reportReason))
+            if (!ReasonChoices.Contains(reportReason) || DisallowedReportAbuseReasons.Contains(reportReason))
             {
                 return HttpNotFound();
             }

--- a/src/NuGetGallery/Controllers/PackagesController.cs
+++ b/src/NuGetGallery/Controllers/PackagesController.cs
@@ -84,6 +84,7 @@ namespace NuGetGallery
         {
             ReportPackageReason.ViolatesALicenseIOwn,
             ReportPackageReason.ContainsSecurityVulnerability,
+            ReportPackageReason.HasABugOrFailedToInstall,
             ReportPackageReason.RevengePorn,
         };
 

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -5876,7 +5876,7 @@ namespace NuGetGallery
                         It.Is<ReportAbuseMessage>(
                             r => r.Request.FromAddress.Address == ReporterEmailAddress
                                  && r.Request.Package == package
-                                 && r.Request.Reason == EnumHelper.GetDescription(ReportPackageReason.ViolatesALicenseIOwn)
+                                 && r.Request.Reason == EnumHelper.GetDescription(ReportPackageReason.HasABugOrFailedToInstall)
                                  && r.Request.Message == EncodedMessage
                                  && r.AlreadyContactedOwners),
                         false,
@@ -5884,13 +5884,28 @@ namespace NuGetGallery
             }
 
             [Theory]
-            [InlineData(ReportPackageReason.ViolatesALicenseIOwn)]
-            [InlineData(ReportPackageReason.ContainsSecurityVulnerability)]
-            [InlineData(ReportPackageReason.RevengePorn)]
-            public async Task FormRejectsRequestWhenReasonDisallowed(ReportPackageReason reason)
+            [InlineData(ReportPackageReason.ViolatesALicenseIOwn, true)]
+            [InlineData(ReportPackageReason.ContainsSecurityVulnerability, true)]
+            [InlineData(ReportPackageReason.RevengePorn, true)]
+            [InlineData(ReportPackageReason.ContainsMaliciousCode, false)]
+            [InlineData(ReportPackageReason.HasABugOrFailedToInstall, false)]
+            [InlineData(ReportPackageReason.Other,  false)]
+            [InlineData(ReportPackageReason.ChildSexualExploitationOrAbuse, false)]
+            [InlineData(ReportPackageReason.TerrorismOrViolentExtremism, false)]
+            [InlineData(ReportPackageReason.HateSpeech, false)]
+            [InlineData(ReportPackageReason.ImminentHarm, false)]
+            [InlineData(ReportPackageReason.OtherNudityOrPornography, false)]
+            public async Task FormRejectsDisallowedReportReasons(ReportPackageReason reason, bool shouldReject)
             {
                 var result = await GetReportAbuseFormResult(null, Owner, out var package, out var messageService, reason);
-                Assert.IsType<HttpNotFoundResult>(result);
+                if (shouldReject)
+                {
+                    Assert.IsType<HttpNotFoundResult>(result);
+                }
+                else
+                {
+                    Assert.IsNotType<HttpNotFoundResult>(result);
+                }
             }
 
             public static IEnumerable<object[]> FormSendsMessageToGalleryOwnerWithUserInfoWhenAuthenticated_Data
@@ -5924,7 +5939,7 @@ namespace NuGetGallery
                                  && r.Request.FromAddress.Address == currentUser.EmailAddress
                                  && r.Request.FromAddress.DisplayName == currentUser.Username
                                  && r.Request.Package == package
-                                 && r.Request.Reason == EnumHelper.GetDescription(ReportPackageReason.ViolatesALicenseIOwn)
+                                 && r.Request.Reason == EnumHelper.GetDescription(ReportPackageReason.HasABugOrFailedToInstall)
                                  && r.AlreadyContactedOwners),
                         false,
                         false));

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -5883,6 +5883,16 @@ namespace NuGetGallery
                         false));
             }
 
+            [Theory]
+            [InlineData(ReportPackageReason.ViolatesALicenseIOwn)]
+            [InlineData(ReportPackageReason.ContainsSecurityVulnerability)]
+            [InlineData(ReportPackageReason.RevengePorn)]
+            public async Task FormRejectsRequestWhenReasonDisallowed(ReportPackageReason reason)
+            {
+                var result = await GetReportAbuseFormResult(null, Owner, out var package, out var messageService, reason);
+                Assert.IsType<HttpNotFoundResult>(result);
+            }
+
             public static IEnumerable<object[]> FormSendsMessageToGalleryOwnerWithUserInfoWhenAuthenticated_Data
             {
                 get
@@ -5920,7 +5930,7 @@ namespace NuGetGallery
                         false));
             }
 
-            public Task<ActionResult> GetReportAbuseFormResult(User currentUser, User owner, out Package package, out Mock<IMessageService> messageService)
+            public Task<ActionResult> GetReportAbuseFormResult(User currentUser, User owner, out Package package, out Mock<IMessageService> messageService, ReportPackageReason reason = ReportPackageReason.HasABugOrFailedToInstall)
             {
                 messageService = new Mock<IMessageService>();
                 messageService.Setup(
@@ -5943,7 +5953,7 @@ namespace NuGetGallery
                 {
                     Email = ReporterEmailAddress,
                     Message = UnencodedMessage,
-                    Reason = ReportPackageReason.ViolatesALicenseIOwn,
+                    Reason = reason,
                     AlreadyContactedOwner = true,
                     Signature = Signature
                 };

--- a/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/PackagesControllerFacts.cs
@@ -5876,7 +5876,7 @@ namespace NuGetGallery
                         It.Is<ReportAbuseMessage>(
                             r => r.Request.FromAddress.Address == ReporterEmailAddress
                                  && r.Request.Package == package
-                                 && r.Request.Reason == EnumHelper.GetDescription(ReportPackageReason.HasABugOrFailedToInstall)
+                                 && r.Request.Reason == EnumHelper.GetDescription(ReportPackageReason.ContainsMaliciousCode)
                                  && r.Request.Message == EncodedMessage
                                  && r.AlreadyContactedOwners),
                         false,
@@ -5887,9 +5887,9 @@ namespace NuGetGallery
             [InlineData(ReportPackageReason.ViolatesALicenseIOwn, true)]
             [InlineData(ReportPackageReason.ContainsSecurityVulnerability, true)]
             [InlineData(ReportPackageReason.RevengePorn, true)]
+            [InlineData(ReportPackageReason.HasABugOrFailedToInstall, true)]
             [InlineData(ReportPackageReason.ContainsMaliciousCode, false)]
-            [InlineData(ReportPackageReason.HasABugOrFailedToInstall, false)]
-            [InlineData(ReportPackageReason.Other,  false)]
+            [InlineData(ReportPackageReason.Other, false)]
             [InlineData(ReportPackageReason.ChildSexualExploitationOrAbuse, false)]
             [InlineData(ReportPackageReason.TerrorismOrViolentExtremism, false)]
             [InlineData(ReportPackageReason.HateSpeech, false)]
@@ -5939,13 +5939,13 @@ namespace NuGetGallery
                                  && r.Request.FromAddress.Address == currentUser.EmailAddress
                                  && r.Request.FromAddress.DisplayName == currentUser.Username
                                  && r.Request.Package == package
-                                 && r.Request.Reason == EnumHelper.GetDescription(ReportPackageReason.HasABugOrFailedToInstall)
+                                 && r.Request.Reason == EnumHelper.GetDescription(ReportPackageReason.ContainsMaliciousCode)
                                  && r.AlreadyContactedOwners),
                         false,
                         false));
             }
 
-            public Task<ActionResult> GetReportAbuseFormResult(User currentUser, User owner, out Package package, out Mock<IMessageService> messageService, ReportPackageReason reason = ReportPackageReason.HasABugOrFailedToInstall)
+            public Task<ActionResult> GetReportAbuseFormResult(User currentUser, User owner, out Package package, out Mock<IMessageService> messageService, ReportPackageReason reason = ReportPackageReason.ContainsMaliciousCode)
             {
                 messageService = new Mock<IMessageService>();
                 messageService.Setup(


### PR DESCRIPTION
Fix a bug introduced in https://github.com/NuGet/NuGetGallery/pull/9727 where we were rejecting all safety reasons reported instead of a small subset of them.