### PR TITLE
Allow images from media.githubusercontent.com

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
@@ -26,6 +26,7 @@
         "img.shields.io",
         "i.imgur.com",
         "isitmaintained.com",
+        "media.githubusercontent.com",
         "opencollective.com",
         "snyk.io",
         "sonarcloud.io",


### PR DESCRIPTION
Allow LFS tracked images from GitHub repositories which are served on media.githubusercontent.com

Fixes https://github.com/NuGet/NuGetGallery/issues/9856