### PR TITLE
Running NSSM with PowerShell to get proper parameter quoting

### DIFF
--- a/src/AccountDeleter/Scripts/Functions.ps1
+++ b/src/AccountDeleter/Scripts/Functions.ps1
@@ -21,8 +21,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/GitHubVulnerabilities2Db/Scripts/Functions.ps1
+++ b/src/GitHubVulnerabilities2Db/Scripts/Functions.ps1
@@ -21,8 +21,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/GitHubVulnerabilities2v3/Scripts/Functions.ps1
+++ b/src/GitHubVulnerabilities2v3/Scripts/Functions.ps1
@@ -21,8 +21,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/VerifyGitHubVulnerabilities/Scripts/Functions.ps1
+++ b/src/VerifyGitHubVulnerabilities/Scripts/Functions.ps1
@@ -21,8 +21,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/5226
Related to https://github.com/NuGet/NuGet.Jobs/pull/1188

Running NSSM with PowerShell directly instead of [incorrectly] constructing command line for cmd. Helps when `$ScriptToRun` needs some proper quoting.