### PR TITLE
Change password login page 'Username or Email' field to just 'Email'

### DIFF
--- a/src/NuGetGallery/ViewModels/LogOnViewModel.cs
+++ b/src/NuGetGallery/ViewModels/LogOnViewModel.cs
@@ -49,8 +49,8 @@ namespace NuGetGallery
     public class SignInViewModel
     {
         [Required]
-        [Display(Name = "Username or Email")]
-        [Hint("Enter your username or email address.")]
+        [Display(Name = "Email Address")]
+        [Hint("Enter your email address.")]
         public string UserNameOrEmail { get; set; }
 
         [Required]


### PR DESCRIPTION
Fixes https://github.com/NuGet/Engineering/issues/5309

The Password login page (deprecated, but still used for password-based account recovery) has a 'Username or Email' field that only accepts Emails. Usernames do not work here, and this has caused confusion for customers multiple times. This field should just say 'Email' or 'Email Address', so I've fixed that now.

This will also change how the password login page appears in local development, although usernames should still work there as they used to. This just changes the string we show in the Login form UI.

Previously,
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/f3c154d6-9a19-4b52-85ac-b46e48fc59a4)

Now,
![image](https://github.com/NuGet/NuGetGallery/assets/82980589/81d5b075-eb23-4794-8fb6-2a753b157b42)
(the 'no longer supported' info bar is missing because this is a screenshot from my local deployment, but it should still be there in an actual environment)