### PR TITLE
Dummy pipeline to have actual release pipeline trigger source in AzDO

### DIFF
--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -15,4 +15,4 @@ pool:
   vmImage: 'windows-latest'
 
 steps:
-- powershell: Write-Host "Dummy task"
+- powershell: Write-Host "Dummy task."

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -15,4 +15,4 @@ pool:
   vmImage: 'windows-latest'
 
 steps:
-- powershell: Write-Host "Release trigger fired!"
+- powershell: Write-Host "Release trigger fired"

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -15,4 +15,4 @@ pool:
   vmImage: 'windows-latest'
 
 steps:
-- powershell: Write-Host "Release trigger fired"
+- powershell: Write-Host "Dummy task"

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -7,6 +7,10 @@ trigger:
     - dev
     - agr-*
 
+variables:
+- name: NugetMultifeedWarnLevel
+  value: none
+  
 pool:
   vmImage: 'windows-latest'
 

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -15,4 +15,4 @@ pool:
   vmImage: 'windows-latest'
 
 steps:
-- powershell: Write-Host "Dummy task."
+- powershell: Write-Host "Dummy task"

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -1,0 +1,14 @@
+name: Gallery release trigger $(Build.BuildId) - $(Date:yyyyMMdd)
+
+trigger:
+  branches:
+    include:
+    - main
+    - dev
+    - agr-*
+
+pool:
+  vmImage: 'windows-latest'
+
+steps:
+- powershell: Write-Host "Release trigger fired"

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -5,7 +5,6 @@ trigger:
     include:
     - main
     - dev
-    - agr-*
 
 variables:
 - name: NugetMultifeedWarnLevel

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -11,4 +11,4 @@ pool:
   vmImage: 'windows-latest'
 
 steps:
-- powershell: Write-Host "Release trigger fired"
+- powershell: Write-Host "Release trigger fired!"


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/5226

With migration to YAML pipelines we're having issues with triggering build pipelines that are not stored in GitHub based on changes happening in GitHub. This pipeline is created to work around that. Since it is stored in GH, it will get properly triggered when changes are made to main/dev branches and other pipelines can then reference this pipeline to get triggered on its success.