### PR TITLE
Solve Package Page Tooltip Accessibility Bugs and Framework Filter Checkbox List Accessibility Bug

### DIFF
--- a/src/NuGetGallery/Content/Site.css
+++ b/src/NuGetGallery/Content/Site.css
@@ -1726,3 +1726,36 @@ img.contributors-contributor-avatar {
     font-size: 1.1em;
     padding: 5px 15px 5px 15px;
 }
+/* Packages page tooltip */
+.page-list-packages .frameworkfilters-info {
+    color: #333;
+    text-decoration: none;
+}
+
+.tooltip-target {
+    position: relative;
+    text-decoration: none;
+}
+
+.tooltip-block {
+    position: relative;
+    display: inline-block;
+    color: #333;
+}
+
+.tooltip-wrapper.popover {
+    min-width: 276px;
+    left: -6px;
+    position: absolute;
+    transform: translateY(-50%);
+    top: calc(50% - 6px);
+}
+
+.tooltip-wrapper.popover.tooltip-with-icon {
+    left: -7px;
+    top: calc(50% - 6px);
+}
+
+.tooltip-block .popover-content {
+    display: block;
+}

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -204,8 +204,32 @@ $(function() {
     $(".reserved-indicator").each(window.nuget.setPopovers);
     $(".package-warning--vulnerable").each(window.nuget.setPopovers);
     $(".package-warning--deprecated").each(window.nuget.setPopovers);
-    $(".frameworkfiltermode-info").each(window.nuget.setPopovers);
-    $(".framework-badge-asset").each(window.nuget.setPopovers);
-    $(".framework-badge-computed").each(window.nuget.setPopovers);
-    $(".frameworkfilters-info").each(window.nuget.setPopovers);
+    //for tooltip hover and focus
+    $('.tooltip-target').each(function () {
+        $(this).on('mouseenter focusin', function () {  
+            $(this).find('.tooltip-wrapper').addClass('show');
+        });
+        $(this).on('mouseleave focusout', function () {
+            $(this).find('.tooltip-wrapper').removeClass('show');
+        });
+    });
+
+    // for using arrow keys in Framwork filter mode checkbox tree 
+    $('.tfmTab li input').each(function () {
+        $(this).on('keydown', function (e) {
+            switch (e.key) {
+                case "ArrowDown":
+                    if ($(this).parent().next().length > 0) {
+                        $(this).parent().next().find('.tfm').focus();
+                    }
+                    break;
+                case "ArrowUp":
+                    if ($(this).parent().prev().length > 0) {
+                        $(this).parent().prev().find('.tfm').focus();
+                    }
+                    break;
+            }
+        });
+    });
+  
 });

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -1,5 +1,6 @@
 ﻿@using String = NuGetGallery.Strings;
 @using NuGetGallery.Frameworks;
+
 @model PackageFrameworkCompatibilityBadges
 @{
     var eventName = "search-selection";
@@ -18,6 +19,7 @@
         itemIndex = parsedItemIndex;
     }
 }
+
 @functions
 {
     public enum FrameworkContext
@@ -31,25 +33,7 @@
     public string GetBadgeTooltip(FrameworkContext context, PackageFrameworkCompatibilityData tfmCompatibilityData)
     {
         var badgeVersion = tfmCompatibilityData.Framework.GetBadgeVersion();
-        string tfmType;
-        switch (context)
-        {
-            case FrameworkContext.Net:
-                tfmType = ".NET";
-                break;
-            case FrameworkContext.NetCore:
-                tfmType = ".NET Core";
-                break;
-            case FrameworkContext.NetStandard:
-                tfmType = ".NET Standard";
-                break;
-            case FrameworkContext.NetFramework:
-                tfmType = ".NET Framework";
-                break;
-            default:
-                tfmType = "";
-                break;
-        }
+        string tfmType = GetFrameworkProductName(context);
 
         if (badgeVersion.IsEmpty())
         {
@@ -65,85 +49,77 @@
 
         return toolTip;
     }
+
+    public string GetBadgeDisplayName(FrameworkContext context, PackageFrameworkCompatibilityData tfmCompatibilityData)
+    {
+        var badgeVersion = tfmCompatibilityData.Framework.GetBadgeVersion();
+        string displayName = GetFrameworkProductName(context);
+
+        if (badgeVersion.IsEmpty())
+        {
+            return displayName;
+        }
+
+        return displayName + " " + badgeVersion;
+    }
+
+    public string GetFrameworkProductName(FrameworkContext context)
+    {
+        switch (context)
+        {
+            case FrameworkContext.Net:
+                return ".NET";
+            case FrameworkContext.NetCore:
+                return ".NET Core";
+            case FrameworkContext.NetStandard:
+                return ".NET Standard";
+            case FrameworkContext.NetFramework:
+                return ".NET Framework";
+            default:
+                return "";
+        }
+    }
+}
+
+@helper DisplayFrameworkBadge(PackageFrameworkCompatibilityData tfmCompatibilityData, FrameworkContext context, int? itemIndex, string eventName)
+{
+    <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
+        @if (itemIndex.HasValue) 
+        { 
+            @: data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
+            @: data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
+            @: data-badge-framework="@tfmCompatibilityData.Framework.GetShortFolderName()" data-badge-is-computed="@tfmCompatibilityData.IsComputed"
+            @: class="tooltip-target"
+       }>
+        <span class=@(tfmCompatibilityData.IsComputed ? "framework-badge-computed" : "framework-badge-asset")>
+            @GetBadgeDisplayName(context, tfmCompatibilityData)
+        </span>
+        <span class="tooltip-block">
+            <span class="tooltip-wrapper popover right" role="tooltip">
+                <span class="arrow"></span>
+                <span class="popover-content">
+                    @GetBadgeTooltip(context, tfmCompatibilityData)
+                </span>
+            </span>
+        </span>
+    </a>
 }
 
 <div class="framework framework-badges">
     @if (Model.Net != null)
     {
-        <!-- .NET cannot be an empty version since the lowest version for this framework is "net5.0", if the package contains just "net" framework it will fall into .NET Framework badge instead.' -->
-        <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-            @if (itemIndex.HasValue)
-            {
-                @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                @:data-badge-framework="@Model.Net.Framework.GetShortFolderName()" data-badge-is-computed="@Model.Net.IsComputed"
-            }>
-            <span class=@(Model.Net.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.Net, Model.Net)" data-content="@GetBadgeTooltip(FrameworkContext.Net, Model.Net)">
-                .NET @Model.Net.Framework.GetBadgeVersion()
-            </span>
-        </a>
+        @DisplayFrameworkBadge(Model.Net, FrameworkContext.Net, itemIndex, eventName)
     }
     @if (Model.NetCore != null)
     {
-        <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-            @if (itemIndex.HasValue)
-            {
-                    @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                    @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                    @:data-badge-framework="@Model.NetCore.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetCore.IsComputed"
-            }>
-            <span class=@(Model.NetCore.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.NetCore, Model.NetCore)" data-content="@GetBadgeTooltip(FrameworkContext.NetCore, Model.NetCore)">
-            @if (Model.NetCore.Framework.GetBadgeVersion().IsEmpty())
-            {
-                @:.NET Core
-            }
-            else
-            {
-                @:.NET Core @Model.NetCore.Framework.GetBadgeVersion()
-            }
-            </span>
-        </a>
+        @DisplayFrameworkBadge(Model.NetCore, FrameworkContext.NetCore, itemIndex, eventName)
     }
     @if (Model.NetStandard != null)
     {
-        <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-            @if (itemIndex.HasValue)
-            {
-                    @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                    @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                    @:data-badge-framework="@Model.NetStandard.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetStandard.IsComputed"
-            }>
-            <span class=@(Model.NetStandard.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.NetStandard, Model.NetStandard)" data-content="@GetBadgeTooltip(FrameworkContext.NetStandard, Model.NetStandard)">
-            @if (Model.NetStandard.Framework.GetBadgeVersion().IsEmpty())
-            {
-                @:.NET Standard
-            }
-            else
-            {
-                @:.NET Standard @Model.NetStandard.Framework.GetBadgeVersion()
-            }
-            </span>
-        </a>
+        @DisplayFrameworkBadge(Model.NetStandard, FrameworkContext.NetStandard, itemIndex, eventName)
     }
     @if (Model.NetFramework != null)
     {
-        <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-            @if (itemIndex.HasValue)
-            {
-                    @:data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-                    @:data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-                    @:data-badge-framework="@Model.NetFramework.Framework.GetShortFolderName()" data-badge-is-computed="@Model.NetFramework.IsComputed"
-            }>
-            <span class=@(Model.NetFramework.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(FrameworkContext.NetFramework, Model.NetFramework)" data-content="@GetBadgeTooltip(FrameworkContext.NetFramework, Model.NetFramework)">
-            @if (Model.NetFramework.Framework.GetBadgeVersion().IsEmpty())
-            {
-                @:.NET Framework
-            }
-            else
-            {
-                @:.NET Framework @Model.NetFramework.Framework.GetBadgeVersion()
-            }
-            </span>
-        </a>
+        @DisplayFrameworkBadge(Model.NetFramework, FrameworkContext.NetFramework, itemIndex, eventName)
     }
 </div>

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -88,11 +88,20 @@
                             <div>
                                 <fieldset id="frameworkfilters">
                                     <legend>
-                                        Frameworks
                                         <a href="@(Model.FrameworksFilteringInformationLink)" class="frameworkfilters-info"
                                            data-content="@NuGetGallery.Strings.FrameworkFilters_Tooltip"
                                            aria-label="@NuGetGallery.Strings.FrameworkFilters_Tooltip">
-                                            <i class="framework-filter-info-icon ms-Icon ms-Icon--Info"></i>
+                                            Frameworks
+                                        </a>
+                                        <a class="tooltip-target" href="javascript:void(0)"><i class="framework-filter-info-icon ms-Icon ms-Icon--Info"></i>
+                                            <span class="tooltip-block"  role="tooltip">
+                                                <span class="tooltip-wrapper tooltip-with-icon popover right">
+                                                    <span class="arrow"></span>
+                                                    <span class="popover-content">
+                                                        @NuGetGallery.Strings.FrameworkFilters_Tooltip
+                                                    </span>
+                                                </span>
+                                            </span>
                                         </a>
                                     </legend>
                                     @if (Model.IsAdvancedFrameworkFilteringEnabled)
@@ -102,10 +111,20 @@
                                             <input type="checkbox" id="computed-frameworks-checkbox" checked="@Model.IncludeComputedFrameworks">
                                             <input type="hidden" id="includeComputedFrameworks" name="includeComputedFrameworks" value="@Model.IncludeComputedFrameworks.ToString().ToLower()">
                                         </div>
-                                        <div class="framework-filter-mode-option" aria-label="ALL/ANY toggle that decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them.">
+                                        <div class="framework-filter-mode-option">
                                             <p>
                                                 Framework Filter Mode
-                                                <i class="frameworkfiltermode-info ms-Icon ms-Icon--Info" tabindex="0" data-content="Decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them."></i>
+                                                <a class="tooltip-target" href="javascript:void(0)">
+                                                    <i class="frameworkfiltermode-info ms-Icon ms-Icon--Info"></i>
+                                                    <span class="tooltip-block" role="tooltip">
+                                                        <span class="tooltip-wrapper tooltip-with-icon popover right" >
+                                                            <span class="arrow"></span>
+                                                            <span class="popover-content">
+                                                                Decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them.
+                                                            </span>
+                                                        </span>
+                                                    </span>
+                                                </a>
                                             </p>
                                             <div class="toggle-switch-control">
                                                 <input type="radio" id="all-selector" name="frameworkFilterMode" value="all" tabindex="0" @(Model.FrameworkFilterMode == "any" ? "" : "checked") />


### PR DESCRIPTION
Disable Bootstrap popover JavaScript on framework filter and support framework badges, keep the popover classes and layout, add JavaScript function to make the tooltip popup,  narrator can read the tooltip.

Add up and down arrow key JavaScript function to make users are able to use arrow keys to move between framework filter mode checkboxes.

