### PR TITLE
Remove aria-expanded Attribute from Div

### DIFF
--- a/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/UploadPackage.cshtml
@@ -45,7 +45,7 @@
                             <span>Upload</span>
                         </a>
                     </h2>
-                    <div class="collapse in" id="upload-package-form" aria-expanded="true">
+                    <div class="collapse in" id="upload-package-form">
                         <form aria-hidden="true" id="cancel-form">
                             @Html.AntiForgeryToken()
                         </form>


### PR DESCRIPTION
Remove aria-expanded="true" from div id="upload-package-form" from UploadPackage.cshtml to fix accessibility bug #1979939
Bug link:
https://devdiv.visualstudio.com/DevDiv/_queries/edit/?tempQueryId=86f20051-1835-446b-b283-b35a28cb6618&id=1979939
