### PR TITLE
Fix EF runtime error

### DIFF
--- a/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
+++ b/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
@@ -46,13 +46,14 @@ namespace NuGetGallery
                     if (ShouldCacheBeUpdated(checkListConfiguredLength, checkListExpireTime))
                     {
                         TyposquattingCheckListConfiguredLength = checkListConfiguredLength;
-                        IQueryable<string> cacheQuery = packageService.GetAllPackageRegistrations()
+                        List<string> cachedPackages = packageService.GetAllPackageRegistrations()
                             .OrderByDescending(pr => pr.IsVerified)
                             .ThenByDescending(pr => pr.DownloadCount)
                             .Select(pr => pr.Id)
-                            .Take(TyposquattingCheckListConfiguredLength);
+                            .Take(TyposquattingCheckListConfiguredLength)
+                            .ToList();
 
-                        Cache = cacheQuery
+                        Cache = cachedPackages
                             .Select(pr => _typosquattingServiceHelper.NormalizeString(pr))
                             .ToList();
 


### PR DESCRIPTION
Related to https://github.com/NuGet/Engineering/issues/5080
At runtime we're getting this error.
NormalizeString needs to be called after the EF query is materialized, right now it is trying to map it to a SQL function.
![image](https://github.com/NuGet/NuGetGallery/assets/8766776/4b667525-67e1-4976-9648-4990b7f8788d)

It works fine on my local, not sure why failing on dev. 