### PR TITLE
Fixing JS exceptions on profiles page

### DIFF
--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -56,12 +56,12 @@ $(function() {
 
     if (advancedSearchToggleButton) {
         advancedSearchToggleButton.addEventListener('click', toggleAdvancedSearchPanel);
-
-        window.addEventListener('resize', () => {
-            resized = true;
-            toggleAdvancedSearchPanel();
-        });
     }
+
+    window.addEventListener('resize', () => {
+        resized = true;
+        toggleAdvancedSearchPanel();
+    });
 
     /* For narrow screens only */
     function toggleAdvancedSearchPanel() {
@@ -70,21 +70,21 @@ $(function() {
 
         if (filtersContent) {
             var computedStyle = window.getComputedStyle(filtersContent);
-        }
 
-        if (window.innerWidth <= 992 && !resized) {
-            filtersContent.style.display = (computedStyle.display === 'none') ? 'block' : 'none';
-            chevronIcon.classList.toggle('ms-Icon--ChevronDown');
-            chevronIcon.classList.toggle('ms-Icon--ChevronUp');
-        }
-        else if (window.innerWidth <= 992 && initialScreenSize > 992 && resized) {
-            filtersContent.style.display = 'none';
-            chevronIcon.classList.add('ms-Icon--ChevronDown');
-            chevronIcon.classList.remove('ms-Icon--ChevronUp');
+            if (window.innerWidth <= 992 && !resized) {
+                filtersContent.style.display = (computedStyle.display === 'none') ? 'block' : 'none';
+                chevronIcon.classList.toggle('ms-Icon--ChevronDown');
+                chevronIcon.classList.toggle('ms-Icon--ChevronUp');
+            }
+            else if (window.innerWidth <= 992 && initialScreenSize > 992 && resized) {
+                filtersContent.style.display = 'none';
+                chevronIcon.classList.add('ms-Icon--ChevronDown');
+                chevronIcon.classList.remove('ms-Icon--ChevronUp');
 
-        }
-        else if (window.innerWidth > 992) {
-            filtersContent.style.display = 'block';
+            }
+            else if (window.innerWidth > 992) {
+                filtersContent.style.display = 'block';
+            }
         }
 
         initialScreenSize = window.innerWidth;

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -48,17 +48,29 @@ $(function() {
         collapsible.addEventListener('click', toggleCollapsible);
     }
 
-    const advancedSearchToggleButton = document.getElementById('advancedSearchToggleButton');
-    advancedSearchToggleButton.addEventListener('click', toggleAdvancedSearchPanel);
     var resized = false;
     var initialScreenSize = window.innerWidth;
     const chevronIcon = document.getElementById('advancedSearchToggleChevron');
+
+    const advancedSearchToggleButton = document.getElementById('advancedSearchToggleButton');
+
+    if (advancedSearchToggleButton) {
+        advancedSearchToggleButton.addEventListener('click', toggleAdvancedSearchPanel);
+
+        window.addEventListener('resize', () => {
+            resized = true;
+            toggleAdvancedSearchPanel();
+        });
+    }
 
     /* For narrow screens only */
     function toggleAdvancedSearchPanel() {
 
         const filtersContent = document.getElementById('advancedSearchPanel');
-        var computedStyle = window.getComputedStyle(filtersContent);
+
+        if (filtersContent) {
+            var computedStyle = window.getComputedStyle(filtersContent);
+        }
 
         if (window.innerWidth <= 992 && !resized) {
             filtersContent.style.display = (computedStyle.display === 'none') ? 'block' : 'none';
@@ -78,11 +90,6 @@ $(function() {
         initialScreenSize = window.innerWidth;
         resized = false;
     }
-
-    window.addEventListener('resize', () => {
-        resized = true;
-        toggleAdvancedSearchPanel(); 
-    });
 
     function toggleCollapsible() {
         var dataTab = document.getElementById(this.getAttribute('tab') + 'tab');


### PR DESCRIPTION
We're seeing some javascript exceptions for the profiles page. We use the same scripts file on the search page and the profiles page, and need to deal with null values properly to avoid exceptions. This should be fixed now.