### PR TITLE
Fix project name to fix build.ps1 build error

### DIFF
--- a/NuGetGallery.sln
+++ b/NuGetGallery.sln
@@ -63,7 +63,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Services.GitHub", "src\NuGet.Services.Github\NuGet.Services.GitHub.csproj", "{043645D5-129F-4BA1-BD17-77153294F2BD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubVulnerabilities2v3", "src\GitHubVulnerabilities2v3\GitHubVulnerabilities2v3.csproj", "{DD9073AF-838E-44E8-91FE-995586E8134A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubVulnerabilities2V3", "src\GitHubVulnerabilities2v3\GitHubVulnerabilities2V3.csproj", "{DD9073AF-838E-44E8-91FE-995586E8134A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubVulnerabilities2v3.Facts", "tests\GitHubVulnerabilities2v3.Facts\GitHubVulnerabilities2v3.Facts.csproj", "{46A2C2EB-B7DC-4FAB-ABE2-A2CE6118585C}"
 EndProject
@@ -150,6 +150,7 @@ Global
 		{043645D5-129F-4BA1-BD17-77153294F2BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{043645D5-129F-4BA1-BD17-77153294F2BD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DD9073AF-838E-44E8-91FE-995586E8134A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD9073AF-838E-44E8-91FE-995586E8134A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DD9073AF-838E-44E8-91FE-995586E8134A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DD9073AF-838E-44E8-91FE-995586E8134A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{46A2C2EB-B7DC-4FAB-ABE2-A2CE6118585C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/tests/GitHubVulnerabilities2v3.Facts/GitHubVulnerabilities2v3.Facts.csproj
+++ b/tests/GitHubVulnerabilities2v3.Facts/GitHubVulnerabilities2v3.Facts.csproj
@@ -46,9 +46,9 @@
     <Compile Include="BlobStorageVulnerabilityWriterFacts.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\GitHubVulnerabilities2v3\GitHubVulnerabilities2v3.csproj">
+    <ProjectReference Include="..\..\src\GitHubVulnerabilities2v3\GitHubVulnerabilities2V3.csproj">
       <Project>{dd9073af-838e-44e8-91fe-995586e8134a}</Project>
-      <Name>GitHubVulnerabilities2v3</Name>
+      <Name>GitHubVulnerabilities2V3</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\NuGet.Services.Entities\NuGet.Services.Entities.csproj">
       <Project>{6262f4fc-29be-4226-b676-db391c89d396}</Project>


### PR DESCRIPTION
Currently build.ps1 fails due to a casing difference in the project name. Strangely Visual Studio build works just fine.