### PR TITLE
Fixing VerifyGitHubVulnerabilities Dependency Injection

### DIFF
--- a/src/VerifyGitHubVulnerabilities/Job.cs
+++ b/src/VerifyGitHubVulnerabilities/Job.cs
@@ -19,6 +19,7 @@ using NuGet.Jobs.Configuration;
 using NuGetGallery;
 using VerifyGitHubVulnerabilities.Configuration;
 using VerifyGitHubVulnerabilities.Verify;
+using GitHubVulnerabilities2Db.Gallery;
 
 namespace VerifyGitHubVulnerabilities
 {
@@ -71,6 +72,10 @@ namespace VerifyGitHubVulnerabilities
             containerBuilder
                 .RegisterType<GitHubVersionRangeParser>()
                 .As<IGitHubVersionRangeParser>();
+
+            containerBuilder
+                .RegisterType<GalleryDbVulnerabilityWriter>()
+                .As<IVulnerabilityWriter>();
 
             containerBuilder
                 .RegisterType<AdvisoryIngestor>()


### PR DESCRIPTION
The changeset that introduced the GitHubVulnerabilities library failed to account for the changed DI requirements in VerifyGitHubVulnerabilities.

Unfortunately, this only surfaced at runtime.
This change fixes the DI.