### PR TITLE
Explicitly disabling PR validation trigger for release trigger pipeline.

### DIFF
--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -6,6 +6,8 @@ trigger:
     - main
     - dev
 
+pr: none
+
 variables:
 - name: NugetMultifeedWarnLevel
   value: none


### PR DESCRIPTION
The pipeline we use to trigger releases from main and dev branches gets triggered on  PRs, too. Explicitly disabling it.