### PR TITLE
Solve Package Page Tooltip Accessibility Bugs and Framework Filter Ch…

### DIFF
--- a/src/Bootstrap/dist/css/bootstrap-theme.css
+++ b/src/Bootstrap/dist/css/bootstrap-theme.css
@@ -1929,6 +1929,10 @@ p.frameworktableinfo-text {
 .page-list-packages .no-margin {
   margin: 0 !important;
 }
+.page-list-packages .frameworkfilters-info {
+  color: #333;
+  text-decoration: none;
+}
 @media (max-width: 992px) {
   .page-list-packages .btn-filter {
     text-align: left;
@@ -2158,6 +2162,35 @@ p.frameworktableinfo-text {
   .page-list-packages .advanced-search-panel {
     display: none;
   }
+}
+/* For tooltip */
+.tooltip-target {
+  position: relative;
+  text-decoration: none;
+}
+.tooltip-wrapper.popover {
+  min-width: 276px;
+  left: -6px;
+  position: absolute;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  -o-transform: translateY(-50%);
+  transform: translateY(-50%);
+  top: -webkit-calc(50% - 6px);
+  top: calc(50% - 6px);
+}
+.tooltip-wrapper.popover.tooltip-with-icon {
+  left: -7px;
+  top: -webkit-calc(50% - 6px);
+  top: calc(50% - 6px);
+}
+.tooltip-block {
+  position: relative;
+  display: inline-block;
+  color: #333;
+}
+.tooltip-block .popover-content {
+  display: block;
 }
 .page-manage-deprecation .full-line {
   display: block;

--- a/src/Bootstrap/less/theme/page-list-packages.less
+++ b/src/Bootstrap/less/theme/page-list-packages.less
@@ -11,6 +11,11 @@
     margin: 0 !important;
   }
 
+  .frameworkfilters-info {
+    color: #333;
+    text-decoration: none;
+  }
+
   @media (max-width: @screen-md) {
     .btn-filter {
       text-align: left;
@@ -219,7 +224,7 @@
   }
 
   @media (min-width: 992px) {
-    .advanced-search-panel{
+    .advanced-search-panel {
       position: relative;
       top: 0;
       margin-top: 30px;
@@ -227,8 +232,8 @@
     }
   }
 
-  @media (max-width: 992px){
-    .advanced-search-panel{
+  @media (max-width: 992px) {
+    .advanced-search-panel {
       margin-top: 0px;
     }
   }
@@ -263,12 +268,40 @@
   }
 
   @media (max-width: 992px) {
-    .toggle-advanced-search-panel{
+    .toggle-advanced-search-panel {
       display: block;
     }
-    .advanced-search-panel{
+
+    .advanced-search-panel {
       display: none;
     }
   }
-  
+}
+/* For tooltip */
+.tooltip-target {
+  position: relative;
+  text-decoration: none;
+}
+
+.tooltip-wrapper.popover {
+  min-width: 276px;
+  left: -6px;
+  position: absolute;
+  transform: translateY(-50%);
+  top: calc(50% - 6px);
+}
+
+.tooltip-wrapper.popover.tooltip-with-icon {
+  left: -7px;
+  top: calc(50% - 6px);
+}
+
+.tooltip-block {
+  position: relative;
+  display: inline-block;
+  color: #333;
+
+  .popover-content {
+    display: block;
+  }
 }

--- a/src/NuGetGallery/Scripts/gallery/page-list-packages.js
+++ b/src/NuGetGallery/Scripts/gallery/page-list-packages.js
@@ -204,8 +204,31 @@ $(function() {
     $(".reserved-indicator").each(window.nuget.setPopovers);
     $(".package-warning--vulnerable").each(window.nuget.setPopovers);
     $(".package-warning--deprecated").each(window.nuget.setPopovers);
-    $(".frameworkfiltermode-info").each(window.nuget.setPopovers);
-    $(".framework-badge-asset").each(window.nuget.setPopovers);
-    $(".framework-badge-computed").each(window.nuget.setPopovers);
-    $(".frameworkfilters-info").each(window.nuget.setPopovers);
+    //for tooltip hover and focus
+    $('.tooltip-target').each(function () {
+        $(this).on('mouseenter focusin', function () {
+            $(this).find('.tooltip-wrapper').addClass('show');
+        });
+        $(this).on('mouseleave focusout', function () {
+            $(this).find('.tooltip-wrapper').removeClass('show');
+        });
+    });
+
+    // for using arrow keys in Framwork filter mode checkbox tree 
+    $('.tfmTab li input').each(function () {
+        $(this).on('keydown', function (e) {
+            switch (e.key) {
+                case "ArrowDown":
+                    if ($(this).parent().next().length > 0) {
+                        $(this).parent().next().find('.tfm').focus();
+                    }
+                    break;
+                case "ArrowUp":
+                    if ($(this).parent().prev().length > 0) {
+                        $(this).parent().prev().find('.tfm').focus();
+                    }
+                    break;
+            }
+        });
+    });
 });

--- a/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
+++ b/src/NuGetGallery/Views/Packages/_SupportedFrameworksBadges.cshtml
@@ -84,14 +84,21 @@
 @helper DisplayFrameworkBadge(PackageFrameworkCompatibilityData tfmCompatibilityData, FrameworkContext context, int? itemIndex, string eventName)
 {
     <a href=@Url.FrameworksTab(Model.PackageId, Model.PackageVersion)
-       @if (itemIndex.HasValue)
-       {
-            @: data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
-            @: data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
-            @: data-badge-framework="@tfmCompatibilityData.Framework.GetShortFolderName()" data-badge-is-computed="@tfmCompatibilityData.IsComputed"
+       @if (itemIndex.HasValue) { @: data-track="@eventName" data-track-value="@itemIndex" data-click-source="FrameworkBadge"
+        @: data-package-id="@Model.PackageId" data-package-version="@Model.PackageVersion"
+        @: data-badge-framework="@tfmCompatibilityData.Framework.GetShortFolderName()" data-badge-is-computed="@tfmCompatibilityData.IsComputed"
+        @: class="tooltip-target"
        }>
-        <span class=@(tfmCompatibilityData.IsComputed ? "framework-badge-computed" : "framework-badge-asset") aria-label="@GetBadgeTooltip(context, tfmCompatibilityData)" data-content="@GetBadgeTooltip(context, tfmCompatibilityData)">
+        <span class=@(tfmCompatibilityData.IsComputed ? "framework-badge-computed" : "framework-badge-asset")>
             @GetBadgeDisplayName(context, tfmCompatibilityData)
+        </span>
+        <span class="tooltip-block">
+            <span class="tooltip-wrapper popover right" role="tooltip">
+                <span class="arrow"></span>
+                <span class="popover-content">
+                    @GetBadgeTooltip(context, tfmCompatibilityData)
+                </span>
+            </span>
         </span>
     </a>
 }

--- a/src/NuGetGallery/Views/Shared/ListPackages.cshtml
+++ b/src/NuGetGallery/Views/Shared/ListPackages.cshtml
@@ -88,11 +88,21 @@
                             <div>
                                 <fieldset id="frameworkfilters">
                                     <legend>
-                                        Frameworks
                                         <a href="@(Model.FrameworksFilteringInformationLink)" class="frameworkfilters-info"
                                            data-content="@NuGetGallery.Strings.FrameworkFilters_Tooltip"
                                            aria-label="@NuGetGallery.Strings.FrameworkFilters_Tooltip">
+                                            Frameworks
+                                        </a>
+                                        <a class="tooltip-target" href="javascript:void(0)">
                                             <i class="framework-filter-info-icon ms-Icon ms-Icon--Info"></i>
+                                            <span class="tooltip-block" role="tooltip">
+                                                <span class="tooltip-wrapper tooltip-with-icon popover right">
+                                                    <span class="arrow"></span>
+                                                    <span class="popover-content">
+                                                        @NuGetGallery.Strings.FrameworkFilters_Tooltip
+                                                    </span>
+                                                </span>
+                                            </span>
                                         </a>
                                     </legend>
                                     @if (Model.IsAdvancedFrameworkFilteringEnabled)
@@ -102,10 +112,20 @@
                                             <input type="checkbox" id="computed-frameworks-checkbox" checked="@Model.IncludeComputedFrameworks">
                                             <input type="hidden" id="includeComputedFrameworks" name="includeComputedFrameworks" value="@Model.IncludeComputedFrameworks.ToString().ToLower()">
                                         </div>
-                                        <div class="framework-filter-mode-option" aria-label="ALL/ANY toggle that decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them.">
+                                        <div class="framework-filter-mode-option">
                                             <p>
                                                 Framework Filter Mode
-                                                <i class="frameworkfiltermode-info ms-Icon ms-Icon--Info" tabindex="0" data-content="Decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them."></i>
+                                                <a class="tooltip-target" href="javascript:void(0)">
+                                                    <i class="frameworkfiltermode-info ms-Icon ms-Icon--Info"></i>
+                                                    <span class="tooltip-block" role="tooltip">
+                                                        <span class="tooltip-wrapper tooltip-with-icon popover right">
+                                                            <span class="arrow"></span>
+                                                            <span class="popover-content">
+                                                                Decides whether to show packages matching ALL of the selected Target Frameworks (TFMs), or ANY of them.
+                                                            </span>
+                                                        </span>
+                                                    </span>
+                                                </a>
                                             </p>
                                             <div class="toggle-switch-control">
                                                 <input type="radio" id="all-selector" name="frameworkFilterMode" value="all" tabindex="0" @(Model.FrameworkFilterMode == "any" ? "" : "checked") />


### PR DESCRIPTION
**Accessibility issues on production:**

1.Narrator is unable to read the tooltip content when hover or use tab key to activate "Framework" tooltip.
2.When press tab key on package badges, screen reader reads the aria label content but without tooltip display.
3.When any of the "Framework filter mode" checkbox selected and dropdown open, user unable to use up and down arrow key to move the selection.
**Solution:**
1.Disable Bootstrap popover JavaScript on framework filter and support framework badges, keep the popover classes and layout, add JavaScript function to make the tooltip popup, narrator can read the tooltip.
2. Add up and down arrow key JavaScript function to make users are able to use arrow keys to move between framework filter mode checkboxes.
**Bug links:**

1.https://devdiv.visualstudio.com/DevDiv/_queries/edit/?tempQueryId=91c293b3-665c-4cb3-876f-e7e4c119b7d1&id=1970893
2.https://devdiv.visualstudio.com/DevDiv/_queries/edit/?tempQueryId=91c293b3-665c-4cb3-876f-e7e4c119b7d1&id=1970906
**Screenshots and video**
Framwork tooltip Before 
![image](https://github.com/NuGet/NuGetGallery/assets/34078976/2fdfaf05-fc14-4595-9a0d-9db1677208e5)

Package badge tooltip before:
![image](https://github.com/NuGet/NuGetGallery/assets/34078976/84cf6b4c-958d-4c9d-b5da-bac1fcc74fc7)

Package badge tooltip after:
![image](https://github.com/NuGet/NuGetGallery/assets/34078976/15b2f25a-905a-40df-a7ed-a2a4e826af07)
Before:
[before.webm](https://github.com/NuGet/NuGetGallery/assets/34078976/3b6713c9-ed79-4cca-85d8-80ab0aa1af83)
After:
[after.webm](https://github.com/NuGet/NuGetGallery/assets/34078976/10ae7aae-995e-41fc-9194-81193cf333c5)





