### PR TITLE
Add relist and deprecate to unlist scope

### DIFF
--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -661,6 +661,12 @@ namespace NuGetGallery.Authentication
                 }
             }
 
+            var isDeprecateApiEnabled = _featureFlagService != null && credential
+                .Scopes
+                .Select(s => s.Owner ?? credential.User)
+                .Where(u => u != null)
+                .Any(_featureFlagService.IsManageDeprecationApiEnabled);
+
             var credentialViewModel = new CredentialViewModel
             {
                 Key = credential.Key,
@@ -675,7 +681,7 @@ namespace NuGetGallery.Authentication
                 Scopes = credential.Scopes.Select(s => new ScopeViewModel(
                         s.Owner?.Username ?? credential.User.Username,
                         s.Subject,
-                        NuGetScopes.Describe(s.AllowedAction)))
+                        NuGetScopes.Describe(s.AllowedAction, isDeprecateApiEnabled)))
                     .ToList(),
                 ExpirationDuration = credential.ExpirationTicks != null ? new TimeSpan?(new TimeSpan(credential.ExpirationTicks.Value)) : null,
                 RevocationSource = credential.RevocationSourceKey != null ? Enum.GetName(typeof(CredentialRevocationSource), credential.RevocationSourceKey) : null,

--- a/src/NuGetGallery.Services/Authentication/NuGetScopes.cs
+++ b/src/NuGetGallery.Services/Authentication/NuGetScopes.cs
@@ -11,7 +11,7 @@ namespace NuGetGallery.Authentication
         public const string PackageUnlist = "package:unlist";
         public const string PackageVerify = "package:verify";
 
-        public static string Describe(string scope)
+        public static string Describe(string scope, bool isDeprecateApiEnabled)
         {
             switch (scope.ToLowerInvariant())
             {
@@ -22,7 +22,7 @@ namespace NuGetGallery.Authentication
                 case PackagePushVersion:
                     return ServicesStrings.ScopeDescription_PushPackageVersion;
                 case PackageUnlist:
-                    return ServicesStrings.ScopeDescription_UnlistPackage;
+                    return isDeprecateApiEnabled ? ServicesStrings.ScopeDescription_UnlistDeprecatePackage : ServicesStrings.ScopeDescription_UnlistPackage;
                 case PackageVerify:
                     return ServicesStrings.ScopeDescription_VerifyPackage;
             }

--- a/src/NuGetGallery.Services/ServicesStrings.Designer.cs
+++ b/src/NuGetGallery.Services/ServicesStrings.Designer.cs
@@ -1832,7 +1832,16 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unlist package.
+        ///   Looks up a localized string similar to Unlist, relist, or deprecate package versions.
+        /// </summary>
+        public static string ScopeDescription_UnlistDeprecatePackage {
+            get {
+                return ResourceManager.GetString("ScopeDescription_UnlistDeprecatePackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unlist or relist package version versions.
         /// </summary>
         public static string ScopeDescription_UnlistPackage {
             get {

--- a/src/NuGetGallery.Services/ServicesStrings.Designer.cs
+++ b/src/NuGetGallery.Services/ServicesStrings.Designer.cs
@@ -1841,7 +1841,7 @@ namespace NuGetGallery {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unlist or relist package version versions.
+        ///   Looks up a localized string similar to Unlist or relist package versions.
         /// </summary>
         public static string ScopeDescription_UnlistPackage {
             get {

--- a/src/NuGetGallery.Services/ServicesStrings.resx
+++ b/src/NuGetGallery.Services/ServicesStrings.resx
@@ -359,7 +359,7 @@
     <value>Push only new package versions</value>
   </data>
   <data name="ScopeDescription_UnlistPackage" xml:space="preserve">
-    <value>Unlist package</value>
+    <value>Unlist or relist package version versions</value>
   </data>
   <data name="ScopeDescription_Unknown" xml:space="preserve">
     <value>Unknown</value>
@@ -1141,5 +1141,8 @@ The {1} Team</value>
   </data>
   <data name="AuthenticationProviderNotFound" xml:space="preserve">
     <value>The given authentication provider is not supported.</value>
+  </data>
+  <data name="ScopeDescription_UnlistDeprecatePackage" xml:space="preserve">
+    <value>Unlist, relist, or deprecate package versions</value>
   </data>
 </root>

--- a/src/NuGetGallery.Services/ServicesStrings.resx
+++ b/src/NuGetGallery.Services/ServicesStrings.resx
@@ -359,7 +359,7 @@
     <value>Push only new package versions</value>
   </data>
   <data name="ScopeDescription_UnlistPackage" xml:space="preserve">
-    <value>Unlist or relist package version versions</value>
+    <value>Unlist or relist package versions</value>
   </data>
   <data name="ScopeDescription_Unknown" xml:space="preserve">
     <value>Unknown</value>

--- a/src/NuGetGallery/Controllers/UsersController.cs
+++ b/src/NuGetGallery/Controllers/UsersController.cs
@@ -480,11 +480,16 @@ namespace NuGetGallery
             owners.AddRange(currentUser.Organizations
                 .Select(o => CreateApiKeyOwnerViewModel(currentUser, o.Organization)));
 
+            var anyWithDeprecationApi =
+                _featureFlagService.IsManageDeprecationApiEnabled(currentUser)
+                || currentUser.Organizations.Any(m => _featureFlagService.IsManageDeprecationApiEnabled(m.Organization));
+
             var model = new ApiKeyListViewModel
             {
                 ApiKeys = apiKeys,
                 ExpirationInDaysForApiKeyV1 = _config.ExpirationInDaysForApiKeyV1,
                 PackageOwners = owners.Where(o => o.CanPushNew || o.CanPushExisting || o.CanUnlist).ToList(),
+                IsDeprecationApiEnabled = anyWithDeprecationApi,
             };
 
             return View("ApiKeys", model);

--- a/src/NuGetGallery/Strings.Designer.cs
+++ b/src/NuGetGallery/Strings.Designer.cs
@@ -1128,7 +1128,7 @@ namespace NuGetGallery {
                 return ResourceManager.GetString("FrameworkFilters_Tooltip", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The API key &apos;{0}&apos; is invalid..
         /// </summary>
@@ -1954,60 +1954,6 @@ namespace NuGetGallery {
         public static string ReservedNamespace_UserNotFound {
             get {
                 return ResourceManager.GetString("ReservedNamespace_UserNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to All.
-        /// </summary>
-        public static string ScopeDescription_All {
-            get {
-                return ResourceManager.GetString("ScopeDescription_All", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Push new packages and package versions.
-        /// </summary>
-        public static string ScopeDescription_PushPackage {
-            get {
-                return ResourceManager.GetString("ScopeDescription_PushPackage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Push only new package versions.
-        /// </summary>
-        public static string ScopeDescription_PushPackageVersion {
-            get {
-                return ResourceManager.GetString("ScopeDescription_PushPackageVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unknown.
-        /// </summary>
-        public static string ScopeDescription_Unknown {
-            get {
-                return ResourceManager.GetString("ScopeDescription_Unknown", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unlist package.
-        /// </summary>
-        public static string ScopeDescription_UnlistPackage {
-            get {
-                return ResourceManager.GetString("ScopeDescription_UnlistPackage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Verify package ownership.
-        /// </summary>
-        public static string ScopeDescription_VerifyPackage {
-            get {
-                return ResourceManager.GetString("ScopeDescription_VerifyPackage", resourceCulture);
             }
         }
         

--- a/src/NuGetGallery/Strings.resx
+++ b/src/NuGetGallery/Strings.resx
@@ -349,21 +349,6 @@
   <data name="UserAccountLocked" xml:space="preserve">
     <value>Your account was locked after too many unsuccessful sign-in attempts. Please try again in {0}.</value>
   </data>
-  <data name="ScopeDescription_All" xml:space="preserve">
-    <value>All</value>
-  </data>
-  <data name="ScopeDescription_PushPackage" xml:space="preserve">
-    <value>Push new packages and package versions</value>
-  </data>
-  <data name="ScopeDescription_PushPackageVersion" xml:space="preserve">
-    <value>Push only new package versions</value>
-  </data>
-  <data name="ScopeDescription_UnlistPackage" xml:space="preserve">
-    <value>Unlist package</value>
-  </data>
-  <data name="ScopeDescription_Unknown" xml:space="preserve">
-    <value>Unknown</value>
-  </data>
   <data name="ApiKeyDescriptionRequired" xml:space="preserve">
     <value>Can't generate an API key without a description.</value>
   </data>
@@ -384,9 +369,6 @@
   </data>
   <data name="NonScopedApiKeyDescription" xml:space="preserve">
     <value>Full access API key</value>
-  </data>
-  <data name="ScopeDescription_VerifyPackage" xml:space="preserve">
-    <value>Verify package ownership</value>
   </data>
   <data name="WarningApiDeprecated" xml:space="preserve">
     <value>API '{0}' is deprecated and may be removed in a future version.</value>

--- a/src/NuGetGallery/ViewModels/ApiKeyListViewModel.cs
+++ b/src/NuGetGallery/ViewModels/ApiKeyListViewModel.cs
@@ -10,5 +10,6 @@ namespace NuGetGallery
         public IList<ApiKeyViewModel> ApiKeys { get; set; }
         public int ExpirationInDaysForApiKeyV1 { get; set; }
         public IList<ApiKeyOwnerViewModel> PackageOwners { get; set; }
+        public bool IsDeprecationApiEnabled { get; set; }
     }
 }

--- a/src/NuGetGallery/Views/Users/ApiKeys.cshtml
+++ b/src/NuGetGallery/Views/Users/ApiKeys.cshtml
@@ -366,7 +366,7 @@
                                     </div>
                                     <label id="select-scopes-push-package" data-bind="attr: { for: PackagePushId }"
                                            aria-labelledby="select-scopes-push-package select-scopes">
-                                        @NuGetScopes.Describe(NuGetScopes.PackagePush)
+                                        @NuGetScopes.Describe(NuGetScopes.PackagePush, Model.IsDeprecationApiEnabled)
                                     </label>
                                 </div>
                             </li>
@@ -379,7 +379,7 @@
                                     </div>
                                     <label id="select-scopes-push-package-version" data-bind="attr: { for: PackagePushVersionId }" 
                                            aria-labelledby="select-scopes-push-package-version select-scopes">
-                                        @NuGetScopes.Describe(NuGetScopes.PackagePushVersion)
+                                        @NuGetScopes.Describe(NuGetScopes.PackagePushVersion, Model.IsDeprecationApiEnabled)
                                     </label>
                                 </div>
                             </li>
@@ -391,7 +391,7 @@
                                 <input type="checkbox" value="@NuGetScopes.PackageUnlist"
                                        aria-labelledby="select-scopes-unlist select-scopes"
                                        data-bind="checked: UnlistScopeChecked, enable: UnlistEnabled" />
-                                @NuGetScopes.Describe(NuGetScopes.PackageUnlist)
+                                @NuGetScopes.Describe(NuGetScopes.PackageUnlist, Model.IsDeprecationApiEnabled)
                             </label>
                         </div>
                     </li>

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -586,138 +586,138 @@
   </system.diagnostics>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-		<dependentAssembly>
-			<assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-			<bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0"/>
-		</dependentAssembly>
-		<dependentAssembly>
-			<assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-			<bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0"/>
-		</dependentAssembly>
-		<dependentAssembly>
-			<assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-			<bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0"/>
-		</dependentAssembly>
-		<dependentAssembly>
-			<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-			<bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0"/>
-		</dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Text.Json" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-7.0.0.3" newVersion="7.0.0.3"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-6.9.1.3" newVersion="6.9.1.3"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-6.9.1.3" newVersion="6.9.1.3"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-2.21.0.429" newVersion="2.21.0.429"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="EntityFramework" publicKeyToken="B77A5C561934E089" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-1.36.0.0" newVersion="1.36.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Autofac.Integration.Owin" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
-	    </dependentAssembly>
-	    <dependentAssembly>
-		    <assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
-		    <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0"/>
-	    </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.JsonWebTokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.3.1.0" newVersion="7.3.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.3" newVersion="7.0.0.3"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.9.1.3" newVersion="6.9.1.3"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.9.1.3" newVersion="6.9.1.3"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.21.0.429" newVersion="2.21.0.429"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EntityFramework" publicKeyToken="B77A5C561934E089" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Azure.Core" publicKeyToken="92742159E12E44C8" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.36.0.0" newVersion="1.36.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac.Integration.Owin" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -2209,9 +2209,9 @@ namespace NuGetGallery.Authentication
                 Assert.Null(description.RevocationSource);
 
                 Assert.True(description.Scopes.Count == 2);
-                Assert.Equal(NuGetScopes.Describe(NuGetScopes.PackagePushVersion), description.Scopes[0].AllowedAction);
+                Assert.Equal(NuGetScopes.Describe(NuGetScopes.PackagePushVersion, isDeprecateApiEnabled: false), description.Scopes[0].AllowedAction);
                 Assert.Equal("123", description.Scopes[0].Subject);
-                Assert.Equal(NuGetScopes.Describe(NuGetScopes.PackageUnlist), description.Scopes[1].AllowedAction);
+                Assert.Equal(NuGetScopes.Describe(NuGetScopes.PackageUnlist, isDeprecateApiEnabled: false), description.Scopes[1].AllowedAction);
                 Assert.Equal("123", description.Scopes[1].Subject);
                 Assert.Equal(cred.ExpirationTicks.Value, description.ExpirationDuration.Value.Ticks);
             }

--- a/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/UsersControllerFacts.cs
@@ -2402,7 +2402,7 @@ namespace NuGetGallery
                             new [] { "abc", "def" },
                             new []
                             {
-                               new Scope("abc", NuGetScopes.PackageUnlist),
+                                new Scope("abc", NuGetScopes.PackageUnlist),
                                 new Scope("abc", NuGetScopes.PackagePush),
                                 new Scope("def", NuGetScopes.PackageUnlist),
                                 new Scope("def", NuGetScopes.PackagePush)
@@ -2477,7 +2477,7 @@ namespace NuGetGallery
 
                 foreach (var expectedScope in expectedScopes)
                 {
-                    var expectedAction = NuGetScopes.Describe(expectedScope.AllowedAction);
+                    var expectedAction = NuGetScopes.Describe(expectedScope.AllowedAction, isDeprecateApiEnabled: false);
                     var actualScope = viewModel.Scopes.First(x => x == expectedAction);
                     Assert.NotNull(actualScope);
                 }


### PR DESCRIPTION
The existing unlist API key scope already has the relist and deprecate capabilities. This updates the supporting text used on the API keys page to mention these capabilities.

Progress on https://github.com/NuGet/NuGetGallery/issues/8873.

Summary of changes:
- Add relist to the API key label since it's always been there
- Make wording of package vs. package versions consistent (unlist/relist/deprecate is done at the version level)
- Show deprecate capability on the API key if the user is in the flight
- Delete some unused string in `src/NuGetGallery/Strings.resx`
- Fix web.config indentation for binding redirects

### Before

![image](https://github.com/NuGet/NuGetGallery/assets/94054/579b4830-f80d-4426-88e7-fbdb29c82cc8)

### After

![image](https://github.com/NuGet/NuGetGallery/assets/94054/10942375-cc71-418b-905c-b88e204b50e2)
