### PR TITLE
Add cloudback.it to trusted image domains list

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
@@ -17,6 +17,7 @@
         "cdn.syncfusion.com",
         "ci.appveyor.com",
         "circleci.com",
+        "cloudback.it",
         "codecov.io",
         "codefactor.io",
         "coveralls.io",


### PR DESCRIPTION
Cloudback is a SaaS providing automatic daily backups and instant restores of GitHub repositories, metadata, and LFS. The service is  available via [GitHub Marketplace](https://github.com/marketplace/cloudback). The domain of the service is [cloudback.it](https://cloudback.it/).

One of the features of Cloudback is a [backup status badge](https://cloudback.it/docs/status-badge), which is used to display the repository backup status. Please see the badge example below:

[![Backup Status](https://cloudback.it/badge/cloudback/docs)](https://cloudback.it)

According to the NuGet documentation, there is [a list of allowed domains](https://learn.microsoft.com/en-us/nuget/nuget-org/package-readme-on-nuget-org#allowed-domains-for-images-and-badges) for images and badges. 

We would like to add the `cloudback.it` domain to the allowed domains list.

Thank you!

Addresses https://github.com/NuGet/NuGetGallery/issues/9942