### PR TITLE
[Hotfix] Allow unrelated entity changes to be committed in PackageDeprecationService

### DIFF
--- a/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageDeprecationServiceFacts.cs
@@ -520,6 +520,107 @@ namespace NuGetGallery.Services
                     auditingService.WroteNoRecords();
                 }
             }
+
+            [Fact]
+            public async Task SavesChangesWithExtraEntityChangesButNoDeprecationChanges()
+            {
+                // Arrange
+                var lastTimestamp = new DateTime(2019, 3, 4);
+
+                var id = "theId";
+                var registration = new PackageRegistration { Id = id };
+
+                var customMessage = "message";
+                var user = new User { Key = 1 };
+                var status = (PackageDeprecationStatus)99;
+
+                var alternatePackageRegistration = new PackageRegistration { Key = 1 };
+                var alternatePackage = new Package { Key = 1 };
+
+                var packageWithDeprecation = new Package
+                {
+                    PackageRegistration = registration,
+                    NormalizedVersion = "3.0.0",
+                    LastEdited = lastTimestamp,
+                    Deprecations = new List<PackageDeprecation>
+                    {
+                        new PackageDeprecation
+                        {
+                            DeprecatedByUserKey = user.Key,
+                            CustomMessage = customMessage,
+                            Status = status,
+                            AlternatePackageKey = alternatePackage.Key,
+                            AlternatePackage = alternatePackage,
+                            AlternatePackageRegistrationKey = alternatePackageRegistration.Key,
+                            AlternatePackageRegistration = alternatePackageRegistration,
+                        }
+                    }
+                };
+
+                var packages = new[]
+                {
+                    packageWithDeprecation,
+                };
+
+                var transactionMock = new Mock<IDbContextTransaction>();
+                transactionMock
+                    .Setup(x => x.Commit())
+                    .Verifiable();
+
+                var databaseMock = new Mock<IDatabase>();
+                databaseMock
+                    .Setup(x => x.BeginTransaction())
+                    .Returns(transactionMock.Object);
+
+                var context = GetFakeContext();
+                context.HasChanges = true;
+                context.SetupDatabase(databaseMock.Object);
+                context.Deprecations.AddRange(
+                    packages
+                        .Select(p => p.Deprecations.SingleOrDefault())
+                        .Where(d => d != null));
+
+                var packageUpdateService = GetMock<IPackageUpdateService>();
+                var auditingService = GetService<IAuditingService>();
+
+                var telemetryService = GetMock<ITelemetryService>();
+                telemetryService
+                    .Setup(x => x.TrackPackageDeprecate(packages, status, alternatePackageRegistration, alternatePackage, true, false))
+                    .Verifiable();
+
+                var service = Get<PackageDeprecationService>();
+
+                // Act
+                await service.UpdateDeprecation(
+                    packages,
+                    status,
+                    alternatePackageRegistration,
+                    alternatePackage,
+                    customMessage,
+                    user,
+                    ListedVerb.Unchanged,
+                    PackageUndeprecatedVia.Web);
+
+                // Assert
+                context.VerifyCommitChanges();
+                databaseMock.Verify();
+                transactionMock.Verify();
+                packageUpdateService.Verify();
+                telemetryService.Verify();
+
+                Assert.Equal(packages.Count(), context.Deprecations.Count());
+                foreach (var package in packages)
+                {
+                    var deprecation = package.Deprecations.Single();
+                    Assert.Contains(deprecation, context.Deprecations);
+                    Assert.Equal(status, deprecation.Status);
+                    Assert.Equal(alternatePackageRegistration, deprecation.AlternatePackageRegistration);
+                    Assert.Equal(alternatePackage, deprecation.AlternatePackage);
+                    Assert.Equal(customMessage, deprecation.CustomMessage);
+
+                    auditingService.WroteNoRecords();
+                }
+            }
         }
 
         public class TheGetDeprecationByPackageMethod : TestContainer


### PR DESCRIPTION
Mitigation for https://github.com/NuGet/NuGetGallery/issues/9950 in the package deprecation path.

**Hotfix justification:** deprecation API calls that would otherwise no-op sometimes return HTTP 500. Since this is a private preview API, there is no data correctness impact, and non-no-op deprecations work just fine, we could choose to not do a hotfix. I would just to prefer to get this fixed ASAP to eliminate a source of HTTP 500s.

Currently, if a deprecation call no-ops all package version and the node handling the deprecation has a different download count cached for a package version than is what in the DB, an HTTP 500 occurs.

This is because the package entity has changes (per the issue referenced above) but the deprecation service does not detect any changes on the entity. `IPackageUpdateService.UpdatePackagesAsync` is called with an empty list and throws an argument exception which is causing the HTTP 500. We have seen this about 300 times on the deprecation API in the past week, all of which are first party packages or are related to https://github.com/DefinitelyTyped/NugetAutomation/issues/21.

This was not detected locally because storage-based statistics are not used. This was not detected on DEV or INT because the package used for testing had the same download count in DB and in the downloads.v1.json file therefore the `DownloadCountObjectMaterializedInterceptor` did not introduce any entity changes.