### PR TITLE
elide Task.FromResult asyncs

### DIFF
--- a/src/NuGetGallery/Infrastructure/Lucene/SearchClientPolicies.cs
+++ b/src/NuGetGallery/Infrastructure/Lucene/SearchClientPolicies.cs
@@ -132,9 +132,9 @@ namespace NuGetGallery.Infrastructure.Search
                         .OrResult(r => r.StatusCode == HttpStatusCode.Forbidden)
                         .Or<Exception>()
                         .FallbackAsync(
-                                fallbackAction: async (context, cancellationToken) =>
+                                fallbackAction: (context, cancellationToken) =>
                                 {
-                                    return await Task.FromResult(new HttpResponseMessage()
+                                    return Task.FromResult(new HttpResponseMessage()
                                     {
                                         Content = new StringContent(Strings.SearchServiceIsNotAvailable),
                                         StatusCode = HttpStatusCode.ServiceUnavailable

--- a/tests/NuGetGallery.Facts/Services/StatusServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/StatusServiceFacts.cs
@@ -173,10 +173,10 @@ namespace NuGetGallery.Services
                         _config = config;
                     }
 
-                    public async Task<bool> IsAvailableAsync(BlobRequestOptions options, OperationContext operationContext)
+                    public Task<bool> IsAvailableAsync(BlobRequestOptions options, OperationContext operationContext)
                     {
                         AssertConfigLocationMode(_config, options);
-                        return await Task.FromResult(true);
+                        return Task.FromResult(true);
                     }
                 }
 
@@ -189,10 +189,10 @@ namespace NuGetGallery.Services
                         _config = config;
                     }
 
-                    public async Task<bool> IsAvailableAsync(BlobRequestOptions options, OperationContext operationContext)
+                    public Task<bool> IsAvailableAsync(BlobRequestOptions options, OperationContext operationContext)
                     {
                         AssertConfigLocationMode(_config, options);
-                        return await Task.FromResult(false);
+                        return Task.FromResult(false);
                     }
                 }
 


### PR DESCRIPTION
given these are not actual state machines, there is no dependability concerns