### PR TITLE
use Count instead of Where+Count

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Controllers/CorrectIsLatestController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/CorrectIsLatestController.cs
@@ -45,10 +45,10 @@ namespace NuGetGallery.Areas.Admin.Controllers
                         .Where(p => p.IsLatest || p.IsLatestStable || p.IsLatestSemVer2 || p.IsLatestStableSemVer2)
                         .FirstOrDefault()
                         .Version,
-                    IsLatestCount = pr.Packages.Where(p => p.IsLatest).Count(),
-                    IsLatestStableCount = pr.Packages.Where(p => p.IsLatestStable).Count(),
-                    IsLatestSemVer2Count = pr.Packages.Where(p => p.IsLatestSemVer2).Count(),
-                    IsLatestStableSemVer2Count = pr.Packages.Where(p => p.IsLatestStableSemVer2).Count(),
+                    IsLatestCount = pr.Packages.Count(p => p.IsLatest),
+                    IsLatestStableCount = pr.Packages.Count(p => p.IsLatestStable),
+                    IsLatestSemVer2Count = pr.Packages.Count(p => p.IsLatestSemVer2),
+                    IsLatestStableSemVer2Count = pr.Packages.Count(p => p.IsLatestStableSemVer2),
                     HasIsLatestUnlisted = pr.Packages.Any(p =>
                         !p.Listed
                         && (p.IsLatest

--- a/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Frameworks/PackageFrameworkCompatibilityFactoryFacts.cs
@@ -343,7 +343,7 @@ namespace NuGetGallery.Frameworks
 
             var badgeFramework = badges.Single(f => f != null);
             Assert.Equal(packageAssetFramework.FrameworkName, badgeFramework);
-            Assert.Equal(expected: 3, badges.Where(f => f == null).Count());
+            Assert.Equal(expected: 3, badges.Count(f => f == null));
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/ODataV1FeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV1FeedControllerFacts.cs
@@ -26,7 +26,7 @@ namespace NuGetGallery.Controllers
 
             // Assert
             AssertSemVer2PackagesFilteredFromResult(resultSet);
-            Assert.Equal(NonSemVer2Packages.Where(p => !p.IsPrerelease).Count(), resultSet.Count);
+            Assert.Equal(NonSemVer2Packages.Count(p => !p.IsPrerelease), resultSet.Count);
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace NuGetGallery.Controllers
                 "/api/v1/Packages/$count");
 
             // Assert
-            Assert.Equal(NonSemVer2Packages.Where(p => !p.IsPrerelease).Count(), count);
+            Assert.Equal(NonSemVer2Packages.Count(p => !p.IsPrerelease), count);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace NuGetGallery.Controllers
 
             // Assert
             AssertSemVer2PackagesFilteredFromResult(resultSet);
-            Assert.Equal(NonSemVer2Packages.Where(p => !p.IsPrerelease).Count(), resultSet.Count);
+            Assert.Equal(NonSemVer2Packages.Count(p => !p.IsPrerelease), resultSet.Count);
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace NuGetGallery.Controllers
                 $"/api/v1/FindPackagesById/$count?id='{TestPackageId}'");
 
             // Assert
-            Assert.Equal(NonSemVer2Packages.Where(p => !p.IsPrerelease).Count(), count);
+            Assert.Equal(NonSemVer2Packages.Count(p => !p.IsPrerelease), count);
         }
 
         [Fact]
@@ -178,7 +178,7 @@ namespace NuGetGallery.Controllers
 
             // Assert
             AssertSemVer2PackagesFilteredFromResult(resultSet);
-            Assert.Equal(NonSemVer2Packages.Where(p => !p.IsPrerelease).Count(), resultSet.Count);
+            Assert.Equal(NonSemVer2Packages.Count(p => !p.IsPrerelease), resultSet.Count);
         }
 
         [Fact]
@@ -226,7 +226,7 @@ namespace NuGetGallery.Controllers
                 $"/api/v1/Search/$count?searchTerm='{TestPackageId}'");
 
             // Assert
-            Assert.Equal(NonSemVer2Packages.Where(p => !p.IsPrerelease).Count(), searchCount);
+            Assert.Equal(NonSemVer2Packages.Count(p => !p.IsPrerelease), searchCount);
         }
 
         [Theory]

--- a/tests/NuGetGallery.Facts/Controllers/ODataV2FeedControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/ODataV2FeedControllerFacts.cs
@@ -300,7 +300,7 @@ namespace NuGetGallery.Controllers
 
             // Assert
             AssertSemVer2PackagesFilteredFromResult(resultSet);
-            Assert.Equal(NonSemVer2Packages.Where(p => !p.IsPrerelease).Count(), resultSet.Count);
+            Assert.Equal(NonSemVer2Packages.Count(p => !p.IsPrerelease), resultSet.Count);
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/Controllers/SupportControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/SupportControllerFacts.cs
@@ -88,7 +88,7 @@ namespace NuGetGallery.Controllers
                 // Assert
                 Assert.NotNull(model);
                 Assert.Equal<int>(2, model.Issues.Count);
-                Assert.Equal<int>(2, model.Issues.Where(i => i.CreatedBy != null).Count());
+                Assert.Equal<int>(2, model.Issues.Count(i => i.CreatedBy != null));
             }
         }
 

--- a/tests/NuGetGallery.Facts/Infrastructure/Lucene/SearchPolicyFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Lucene/SearchPolicyFacts.cs
@@ -58,11 +58,11 @@ namespace NuGetGallery.Infrastructure.Search
 
             var r = await invalidHttpClient.GetAsync(uri);
 
-            var retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            var onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            var circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
-            var onCircuitBreakerReset = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!")).Count();
-            var onCircuitBreakerHalfOpen = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!")).Count();
+            var retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            var onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            var circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
+            var onCircuitBreakerReset = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!"));
+            var onCircuitBreakerHalfOpen = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!"));
 
             Assert.Equal(2, retryInfo);
             Assert.Equal(1, onCircuitBreakerfallBackInfo);
@@ -74,9 +74,9 @@ namespace NuGetGallery.Infrastructure.Search
             // Request again. The circuit breaker should be open and not allowing requests to pass through
             var r2 = await invalidHttpClient.GetAsync(uri);
 
-            retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
+            retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
 
             // No other info added 
             Assert.Equal(2, retryInfo);
@@ -89,9 +89,9 @@ namespace NuGetGallery.Infrastructure.Search
             // Request again with correct uri. The circuit breaker should be open and not allowing requests to pass through
             var r3 = await invalidHttpClient.GetAsync(validUri);
 
-            retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
+            retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
 
             // No other info added 
             Assert.Equal(2, retryInfo);
@@ -111,9 +111,9 @@ namespace NuGetGallery.Infrastructure.Search
 
             var r = await invalidHttpClient.GetAsync(uri);
 
-            var retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            var onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            var circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
+            var retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            var onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            var circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
 
             Assert.Equal(0, retryInfo);
             Assert.Equal(1, onCircuitBreakerfallBackInfo);
@@ -123,9 +123,9 @@ namespace NuGetGallery.Infrastructure.Search
             // Request again. The circuit breaker should be open and not allowing requests to pass through
             var r2 = await invalidHttpClient.GetAsync(uri);
 
-            retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
+            retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
 
             // No other info added 
             Assert.Equal(0, retryInfo);
@@ -136,9 +136,9 @@ namespace NuGetGallery.Infrastructure.Search
             // Request again with correct uri. The circuit breaker should be open and not allowing requests to pass through
             var r3 = await invalidHttpClient.GetAsync(validUri);
 
-            retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
+            retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
 
             // No other info added 
             Assert.Equal(0, retryInfo);
@@ -156,10 +156,10 @@ namespace NuGetGallery.Infrastructure.Search
 
             var r = await invalidHttpClient.GetAsync(uri);
 
-            var timeoutInfo = _logger.Informations.Where(s => s.StartsWith("Policy timeout - it will timeout after")).Count();
-            var retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            var onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            var circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
+            var timeoutInfo = _logger.Informations.Count(s => s.StartsWith("Policy timeout - it will timeout after"));
+            var retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            var onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            var circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
 
             Assert.Equal(1, timeoutInfo);
             Assert.Equal(0, retryInfo);
@@ -170,10 +170,10 @@ namespace NuGetGallery.Infrastructure.Search
             // Request again. The circuit breaker should be open and not allowing requests to pass through
             var r2 = await invalidHttpClient.GetAsync(uri);
 
-            timeoutInfo = _logger.Informations.Where(s => s.StartsWith("Policy timeout - it will timeout after")).Count();
-            retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
+            timeoutInfo = _logger.Informations.Count(s => s.StartsWith("Policy timeout - it will timeout after"));
+            retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
 
             Assert.Equal(2, timeoutInfo);
             Assert.Equal(0, retryInfo);
@@ -184,10 +184,10 @@ namespace NuGetGallery.Infrastructure.Search
             // Request again with correct uri. The circuit breaker should be open and not allowing requests to pass through
             var r3 = await invalidHttpClient.GetAsync(validUri);
 
-            timeoutInfo = _logger.Informations.Where(s => s.StartsWith("Policy timeout - it will timeout after")).Count();
-            retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
+            timeoutInfo = _logger.Informations.Count(s => s.StartsWith("Policy timeout - it will timeout after"));
+            retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
 
             Assert.Equal(2, timeoutInfo);
             Assert.Equal(0, retryInfo);
@@ -205,11 +205,11 @@ namespace NuGetGallery.Infrastructure.Search
 
             var r = await invalidHttpClient.GetAsync(uri);
 
-            var retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            var onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            var circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
-            var onCircuitBreakerReset = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!")).Count();
-            var onCircuitBreakerHalfOpen = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!")).Count();
+            var retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            var onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            var circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
+            var onCircuitBreakerReset = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!"));
+            var onCircuitBreakerHalfOpen = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!"));
 
             Assert.Equal(2, retryInfo);
             Assert.Equal(1, onCircuitBreakerfallBackInfo);
@@ -223,11 +223,11 @@ namespace NuGetGallery.Infrastructure.Search
             // Request again with correct uri. The circuit breaker delay should be expired and will do the trial and pass 
             var r2 = await invalidHttpClient.GetAsync(validUri);
 
-            retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
-            onCircuitBreakerReset = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!")).Count();
-            onCircuitBreakerHalfOpen = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!")).Count();
+            retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
+            onCircuitBreakerReset = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!"));
+            onCircuitBreakerHalfOpen = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!"));
 
             // No other info added 
             Assert.Equal(2, retryInfo);
@@ -246,11 +246,11 @@ namespace NuGetGallery.Infrastructure.Search
 
             var r = await validClient.GetAsync(uri);
 
-            var retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            var onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            var circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
-            var onCircuitBreakerReset = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!")).Count();
-            var onCircuitBreakerHalfOpen = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!")).Count();
+            var retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            var onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            var circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
+            var onCircuitBreakerReset = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!"));
+            var onCircuitBreakerHalfOpen = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!"));
 
             Assert.Equal(0, retryInfo);
             Assert.Equal(0, onCircuitBreakerfallBackInfo);
@@ -268,11 +268,11 @@ namespace NuGetGallery.Infrastructure.Search
 
             var r = await invalidClient.GetAsync(uri);
 
-            var retryInfo = _logger.Informations.Where(s => s.StartsWith("Policy retry - it will retry after")).Count();
-            var onCircuitBreakerfallBackInfo = _logger.Informations.Where(s => s.StartsWith("On circuit breaker fallback.")).Count();
-            var circuitBreakerWarning = _logger.Warnings.Where(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for")).Count();
-            var onCircuitBreakerReset = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!")).Count();
-            var onCircuitBreakerHalfOpen = _logger.Informations.Where(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!")).Count();
+            var retryInfo = _logger.Informations.Count(s => s.StartsWith("Policy retry - it will retry after"));
+            var onCircuitBreakerfallBackInfo = _logger.Informations.Count(s => s.StartsWith("On circuit breaker fallback."));
+            var circuitBreakerWarning = _logger.Warnings.Count(s => s.StartsWith("SearchCircuitBreaker logging: Breaking the circuit for"));
+            var onCircuitBreakerReset = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Call ok! Closed the circuit again!"));
+            var onCircuitBreakerHalfOpen = _logger.Informations.Count(s => s.StartsWith("SearchCircuitBreaker logging: Half-open: Next call is a trial!"));
 
             Assert.Equal(_retryCount_2, retryInfo);
             Assert.Equal(1, onCircuitBreakerfallBackInfo);


### PR DESCRIPTION
Shorten Linq syntax by using just Count instead of Where+Count.