### PR TITLE
Remove DMCA message from SR edit dialog

### DIFF
--- a/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/SupportRequest/Index.cshtml
@@ -76,7 +76,6 @@
                     <div class="form-field">
                         <label for="editIssueComment">Add comment</label>
                         <textarea id="editIssueComment" name="editIssueComment" data-bind="value: editIssueComment" rows="10"
-                                  placeholder="Add a comment. If resolving a DMCA request add offender account names (in single quotes, comma-delimited), offending package id, and resolution (no action, withdrawn, upheld). Example: accounts:'foo1','foo2' id:BarPkg resolution: upheld"
                                   autocomplete="off" autofocus></textarea>
                     </div>
                 </fieldset>


### PR DESCRIPTION
We can remove this comment for reasons described in the bug.

Addresses https://github.com/NuGet/Engineering/issues/5485