### PR TITLE
Explicitly triggering release pipelines

### DIFF
--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -18,9 +18,8 @@ pool:
 steps:
 - powershell: |-
     $body = @{
-      "templateParameters":
-      {
-        "NuGetGallerySubmoduleBranch": "$(Build.SourceBranchName)"
+      "templateParameters" = @{
+        "NuGetGallerySubmoduleBranch" = "$(Build.SourceBranchName)"
       }
     }
     $headers = @{ "Authorization" = "Bearer $env:ACCESS_TOKEN" };

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -8,22 +8,32 @@ trigger:
 
 pr: none
 
+parameters:
+- name: TargetPipelines
+  type: object
+  default:
+  - id: 21120
+    paramName: NuGetGallerySubmoduleBranch
+  - id: 21280
+    paramName: NuGetGalleryBranch
+
 variables:
 - name: NugetMultifeedWarnLevel
   value: none
-  
+
 pool:
   vmImage: 'windows-latest'
 
 steps:
-- powershell: |-
-    $body = @{
-      "templateParameters" = @{
-        "NuGetGallerySubmoduleBranch" = "$(Build.SourceBranchName)"
+- ${{ each pipeline in parameters.TargetPipelines }}:
+  - powershell: |-
+      $body = @{
+        "templateParameters" = @{
+          "$(pipeline.paramName)" = "$(Build.SourceBranchName)"
+        }
       }
-    }
-    $headers = @{ "Authorization" = "Bearer $env:ACCESS_TOKEN" };
-    $url = "$(System.CollectionUri)$(System.TeamProject)/_apis/pipelines/21120/runs?api-version=7.0"
-    Invoke-RestMethod -Uri $url -Method POST -Headers $headers -Body ($body | ConvertTo-Json) -ContentType "application/json"
-  env:
-    ACCESS_TOKEN: $(System.AccessToken)
+      $headers = @{ "Authorization" = "Bearer $env:ACCESS_TOKEN" };
+      $url = "$(System.CollectionUri)$(System.TeamProject)/_apis/pipelines/$(pipeline.id)/runs?api-version=7.0"
+      Invoke-RestMethod -Uri $url -Method POST -Headers $headers -Body ($body | ConvertTo-Json) -ContentType "application/json"
+    env:
+      ACCESS_TOKEN: $(System.AccessToken)

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -29,11 +29,11 @@ steps:
   - powershell: |-
       $body = @{
         "templateParameters" = @{
-          "$(pipeline.paramName)" = "$(Build.SourceBranchName)"
+          "${{ pipeline.paramName }}" = "$(Build.SourceBranchName)"
         }
       }
       $headers = @{ "Authorization" = "Bearer $env:ACCESS_TOKEN" };
-      $url = "$(System.CollectionUri)$(System.TeamProject)/_apis/pipelines/$(pipeline.id)/runs?api-version=7.0"
+      $url = "$(System.CollectionUri)$(System.TeamProject)/_apis/pipelines/${{ pipeline.id }}/runs?api-version=7.0"
       Invoke-RestMethod -Uri $url -Method POST -Headers $headers -Body ($body | ConvertTo-Json) -ContentType "application/json"
     env:
       ACCESS_TOKEN: $(System.AccessToken)

--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -16,4 +16,15 @@ pool:
   vmImage: 'windows-latest'
 
 steps:
-- powershell: Write-Host "Dummy task"
+- powershell: |-
+    $body = @{
+      "templateParameters":
+      {
+        "NuGetGallerySubmoduleBranch": "$(Build.SourceBranchName)"
+      }
+    }
+    $headers = @{ "Authorization" = "Bearer $env:ACCESS_TOKEN" };
+    $url = "$(System.CollectionUri)$(System.TeamProject)/_apis/pipelines/21120/runs?api-version=7.0"
+    Invoke-RestMethod -Uri $url -Method POST -Headers $headers -Body ($body | ConvertTo-Json) -ContentType "application/json"
+  env:
+    ACCESS_TOKEN: $(System.AccessToken)


### PR DESCRIPTION
Existing trigger pipeline does not pass through triggering pipeline properly, so instead I wrote a script that just starts target pipelines explicitly using AzDO REST API.

Had to add a parameter to this pipeline that contains information about target pipelines because only parameters support complex values (arrays, objects).