### PR TITLE
[Dark Theme] Render default package image on error

### DIFF
--- a/src/NuGetGallery/App_Code/ViewHelpers.cshtml
+++ b/src/NuGetGallery/App_Code/ViewHelpers.cshtml
@@ -162,6 +162,11 @@
     <text>onerror="this.src='@url'; this.onerror = null;"</text>
 }
 
+@helper PackageImageFallback()
+{
+    <text>onerror="this.className='package-icon img-responsive package-default-icon'; this.onerror = null;"</text>
+}
+
 @helper Option(string value, string label, string currentValue)
 {
     <option value="@value" @if (value == currentValue)

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -269,7 +269,7 @@
                         <h1>
                             <span class="pull-left">
                                 <img class="package-icon img-responsive @(PackageHelper.ShouldRenderUrl(Model.IconUrl) && Model.ShowDetailsAndLinks ? null : "package-default-icon")" aria-hidden="true" alt=""
-                                     src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) && Model.ShowDetailsAndLinks ? Model.IconUrl : null)" />
+                                     src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) && Model.ShowDetailsAndLinks ? Model.IconUrl : null)" @ViewHelpers.ImageFallback(Url.Absolute("~/Content/gallery/img/default-package-icon-256x256.png")) />
                             </span>
                             <span class="title">
                                 @Html.BreakWord(Model.Id)

--- a/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
+++ b/src/NuGetGallery/Views/Shared/_ListPackage.cshtml
@@ -31,7 +31,7 @@
     <div class="row">
         <div class="col-sm-1 hidden-xs hidden-sm col-package-icon">
             <img class="package-icon img-responsive @(!PackageHelper.ShouldRenderUrl(Model.IconUrl) ? "package-default-icon" : null)" aria-hidden="true" alt=""
-                 src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : null)" />
+                 src="@(PackageHelper.ShouldRenderUrl(Model.IconUrl) ? Model.IconUrl : null)" @ViewHelpers.PackageImageFallback()/>
         </div>
         <div class="col-sm-11">
             <div class="package-header">

--- a/src/NuGetGallery/Views/Users/_UserPackagesListForDeletedAccount.cshtml
+++ b/src/NuGetGallery/Views/Users/_UserPackagesListForDeletedAccount.cshtml
@@ -44,7 +44,7 @@
                             </td>
                             <td class="align-middle hidden-xs">
                                 <img class="package-icon img-responsive @(!PackageHelper.ShouldRenderUrl(package.IconUrl) ? "package-default-icon" : null)" aria-hidden="true" alt="Package Icon"
-                                     src="@(PackageHelper.ShouldRenderUrl(package.IconUrl) ? package.IconUrl : null)" />
+                                     src="@(PackageHelper.ShouldRenderUrl(package.IconUrl) ? package.IconUrl : null)" @ViewHelpers.PackageImageFallback()/>
                             </td>
                             <td class="align-middle package-id"><a href="@Url.Package(package.Id)">@Html.BreakWord(package.Id.Abbreviate(40))</a></td>
                             <td class="align-middle">


### PR DESCRIPTION
There was no onerror handle for packages images, this was removed during but never added again. Since we want to make this default image responsive to the theme, my solution is to tie the image to a class `package-default-icon` and this class overrides the image from the component. 

### Before
![image](https://github.com/NuGet/NuGetGallery/assets/43253759/20172c8c-5b3b-45e3-8c6f-9272699f36f2)

### After
![image](https://github.com/NuGet/NuGetGallery/assets/43253759/a4c51880-5ae0-46dd-9a49-350752bd2eec)


Addresses https://github.com/NuGet/NuGetGallery/issues/123