### PR TITLE
Update Trusted-Image-Domains.json

### DIFF
--- a/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
+++ b/src/NuGetGallery/App_Data/Files/Content/Trusted-Image-Domains.json
@@ -3,6 +3,7 @@
         "api.codacy.com",
         "app.codacy.com",
         "api.codeclimate.com",
+        "app.deepsource.com",
         "api.dependabot.com",
         "api.travis-ci.com",
         "api.reuse.software",


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Add the `app.deepsource.com` domain to the trusted image domains list.

Close #9953 