### PR TITLE
Add package version to query string for v2 CDN endpoint (#10082)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -91,20 +91,20 @@ csharp_style_var_when_type_is_apparent = true:silent
 csharp_style_var_elsewhere = false:silent
 
 ; Helpful errors
-dotnet_diagnostic.CA2017.severity = error
-dotnet_diagnostic.CS0105.severity = error
-dotnet_diagnostic.IDE0005.severity = error
-dotnet_diagnostic.CA1304.severity = error
-dotnet_diagnostic.CA1305.severity = error
-dotnet_diagnostic.CA1307.severity = error
-dotnet_diagnostic.CA1309.severity = error
-dotnet_diagnostic.CA1310.severity = error
-dotnet_diagnostic.CA1311.severity = error
+dotnet_diagnostic.CA2017.severity = suggestion
+dotnet_diagnostic.CS0105.severity = suggestion
+dotnet_diagnostic.IDE0005.severity = suggestion
+dotnet_diagnostic.CA1304.severity = suggestion
+dotnet_diagnostic.CA1305.severity = suggestion
+dotnet_diagnostic.CA1307.severity = suggestion
+dotnet_diagnostic.CA1309.severity = suggestion
+dotnet_diagnostic.CA1310.severity = suggestion
+dotnet_diagnostic.CA1311.severity = suggestion
 
 ; Prefer method-like constructs to have a block body
-csharp_style_expression_bodied_methods = when_on_single_line:suggestion
-csharp_style_expression_bodied_constructors = when_on_single_line:suggestion
-csharp_style_expression_bodied_operators = when_on_single_line:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
 
 ; Prefer property-like constructs to have an expression-body
 csharp_style_expression_bodied_properties = true:silent

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,212 @@
+; EditorConfig to support per-solution formatting.
+; Use the EditorConfig VS add-in to make this work.
+; http://editorconfig.org/
+
+; This is the default for the codeline.
+root = true
+
+[*]
+; Don't use tabs for indentation.
+indent_style = space
+; (Please don't specify an indent_size here; that has too many unintended consequences.)
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+; Code files
+[*.{cs}]
+indent_size = 4
+
+; All XML-based file formats
+[*.{config,csproj,nuspec,props,resx,ruleset,targets,vsct,vsixmanifest,xaml,xml,vsmanproj,swixproj}]
+indent_size = 2
+
+; JSON files
+[*.json]
+indent_size = 2
+
+; PowerShell scripts
+[*.{ps1}]
+indent_size = 4
+
+[*.{sh}]
+indent_size = 4
+
+; Dotnet code style settings
+[*.{cs,vb}]
+; Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+; IDE0003 Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+
+; IDE0012 Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+; IDE0013
+dotnet_style_predefined_type_for_member_access = true:silent
+
+; Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+; Licence header
+file_header_template = Copyright (c) .NET Foundation. All rights reserved.\nLicensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+; CSharp code style settings
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_style_readonly_field = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+dotnet_style_allow_multiple_blank_lines_experimental = true:silent
+dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+end_of_line = crlf
+indent_size = 4
+tab_width = 4
+[*.cs]
+; IDE0007 'var' preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = false:silent
+
+; Helpful errors
+dotnet_diagnostic.CA2017.severity = error
+dotnet_diagnostic.CS0105.severity = error
+dotnet_diagnostic.IDE0005.severity = error
+dotnet_diagnostic.CA1304.severity = error
+dotnet_diagnostic.CA1305.severity = error
+dotnet_diagnostic.CA1307.severity = error
+dotnet_diagnostic.CA1309.severity = error
+dotnet_diagnostic.CA1310.severity = error
+dotnet_diagnostic.CA1311.severity = error
+
+; Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors = when_on_single_line:suggestion
+csharp_style_expression_bodied_operators = when_on_single_line:silent
+
+; Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+
+; Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+; Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+
+; Naming styles
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+; Naming rule: async methods end in Async
+dotnet_naming_style.async_method_style.capitalization  = pascal_case
+dotnet_naming_style.async_method_style.required_suffix = Async
+dotnet_naming_symbols.async_method_symbols.applicable_kinds = method
+dotnet_naming_symbols.async_method_symbols.required_modifiers = async
+dotnet_naming_rule.async_methods_rule.severity = suggestion
+dotnet_naming_rule.async_methods_rule.symbols = async_method_symbols
+dotnet_naming_rule.async_methods_rule.style = async_method_style
+
+; Naming rule: Interfaces must be pascal-cased prefixed with I
+dotnet_naming_style.interface_style.capitalization = pascal_case
+dotnet_naming_style.interface_style.required_prefix = I
+dotnet_naming_symbols.interface_symbols.applicable_kinds = interface
+dotnet_naming_symbols.interface_symbols.applicable_accessibilities = *
+dotnet_naming_rule.interfaces_rule.severity = warning
+dotnet_naming_rule.interfaces_rule.symbols  = interface_symbols
+dotnet_naming_rule.interfaces_rule.style = interface_style
+
+; Naming rule: All methods and properties must be pascal-cased
+dotnet_naming_symbols.method_and_property_symbols.applicable_kinds = method,property,class,struct,enum:property,namespace
+dotnet_naming_symbols.method_and_property_symbols.applicable_accessibilities = *
+dotnet_naming_rule.methods_and_properties_rule.severity = warning
+dotnet_naming_rule.methods_and_properties_rule.symbols  = method_and_property_symbols
+dotnet_naming_rule.methods_and_properties_rule.style = pascal_case_style
+
+; Naming rule: Static fields must be pascal-cased
+dotnet_naming_symbols.static_member_symbols.applicable_kinds = field
+dotnet_naming_symbols.static_member_symbols.applicable_accessibilities = *
+dotnet_naming_symbols.static_member_symbols.required_modifiers = static
+dotnet_naming_symbols.const_member_symbols.applicable_kinds = field
+dotnet_naming_symbols.const_member_symbols.applicable_accessibilities = *
+dotnet_naming_symbols.const_member_symbols.required_modifiers = const
+dotnet_naming_rule.static_fields_rule.severity = warning
+dotnet_naming_rule.static_fields_rule.symbols  = static_member_symbols
+dotnet_naming_rule.static_fields_rule.style = pascal_case_style
+
+; Naming rule: Private members must be camel-cased and prefixed with underscore
+dotnet_naming_style.private_member_style.capitalization = camel_case
+dotnet_naming_style.private_member_style.required_prefix = _
+dotnet_naming_symbols.private_field_symbols.applicable_kinds = field,event
+dotnet_naming_symbols.private_field_symbols.applicable_accessibilities = private,protected,internal
+dotnet_naming_rule.private_field_rule.severity = warning
+dotnet_naming_rule.private_field_rule.symbols  = private_field_symbols
+dotnet_naming_rule.private_field_rule.style = private_member_style
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_prefer_static_anonymous_function = true:suggestion
+csharp_prefer_static_local_function = true:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_prefer_readonly_struct_member = true:suggestion
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_space_around_binary_operators = before_and_after
+csharp_indent_labels = no_change

--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -27,6 +27,8 @@ namespace NuGetGallery
 
         public const string DefaultCacheControl = "max-age=120";
 
+        public const string PackageVersionParameterName = "packageVersion";
+
         public static class Folders
         {
             public const string UserCertificatesFolderName = "user-certificates";

--- a/src/NuGetGallery.Services/Storage/CloudBlobFileStorageService.cs
+++ b/src/NuGetGallery.Services/Storage/CloudBlobFileStorageService.cs
@@ -106,10 +106,9 @@ namespace NuGetGallery
 
         private static NameValueCollection ParseQueryString(Uri uri)
         {
-            int queryIndex = uri.Query?.LastIndexOf("?") ?? -1;
-            if (queryIndex == -1) return HttpUtility.ParseQueryString(string.Empty);
+            if (string.IsNullOrEmpty(uri.Query)) return HttpUtility.ParseQueryString(string.Empty);
 
-            string query = uri.Query.Substring(queryIndex);
+            string query = uri.Query.Substring(1);
 
             var nvcol = HttpUtility.ParseQueryString(query);
             return nvcol;

--- a/src/NuGetGallery.Services/Storage/CloudBlobFileStorageService.cs
+++ b/src/NuGetGallery.Services/Storage/CloudBlobFileStorageService.cs
@@ -1,8 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-using NuGetGallery.Configuration;
-using NuGetGallery.Diagnostics;
 
 using System;
 using System.Collections.Specialized;
@@ -10,6 +7,8 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
+using NuGetGallery.Configuration;
+using NuGetGallery.Diagnostics;
 
 namespace NuGetGallery
 {
@@ -86,7 +85,7 @@ namespace NuGetGallery
                 ? blobUri
                 : requestUrl;
 
-            var queryValues = ParseQueryString(queryStringUri);
+            NameValueCollection queryValues = ParseQueryString(queryStringUri);
             queryValues.Add(CoreConstants.PackageVersionParameterName, versionParameter);
 
             var urlBuilder = new UriBuilder(scheme, host, port)
@@ -110,7 +109,7 @@ namespace NuGetGallery
 
             string query = uri.Query.Substring(1);
 
-            var nvcol = HttpUtility.ParseQueryString(query);
+            NameValueCollection nvcol = HttpUtility.ParseQueryString(query);
             return nvcol;
         }
     }

--- a/src/NuGetGallery.Services/Storage/CloudBlobFileStorageService.cs
+++ b/src/NuGetGallery.Services/Storage/CloudBlobFileStorageService.cs
@@ -107,7 +107,7 @@ namespace NuGetGallery
         private static NameValueCollection ParseQueryString(Uri uri)
         {
             int queryIndex = uri.Query?.LastIndexOf("?") ?? -1;
-            if (queryIndex == -1) return new NameValueCollection();
+            if (queryIndex == -1) return HttpUtility.ParseQueryString(string.Empty);
 
             string query = uri.Query.Substring(queryIndex);
 

--- a/src/NuGetGallery.Services/Storage/IFileStorageService.cs
+++ b/src/NuGetGallery.Services/Storage/IFileStorageService.cs
@@ -9,7 +9,7 @@ namespace NuGetGallery
 {
     public interface IFileStorageService : ICoreFileStorageService
     {
-        Task<ActionResult> CreateDownloadFileActionResultAsync(Uri requestUrl, string folderName, string fileName);
+        Task<ActionResult> CreateDownloadFileActionResultAsync(Uri requestUrl, string folderName, string fileName, string versionParameter);
 
         Task<bool> IsAvailableAsync();
     }

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGetGallery.Configuration;
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -8,7 +10,6 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Web.Hosting;
 using System.Web.Mvc;
-using NuGetGallery.Configuration;
 
 namespace NuGetGallery
 {
@@ -23,7 +24,7 @@ namespace NuGetGallery
             _fileSystemService = fileSystemService;
         }
 
-        public Task<ActionResult> CreateDownloadFileActionResultAsync(Uri requestUrl, string folderName, string fileName)
+        public Task<ActionResult> CreateDownloadFileActionResultAsync(Uri requestUrl, string folderName, string fileName, string versionParameter)
         {
             if (string.IsNullOrWhiteSpace(folderName))
             {
@@ -270,7 +271,7 @@ namespace NuGetGallery
 
         public Task SetPropertiesAsync(
             string folderName,
-            string fileName, 
+            string fileName,
             Func<Lazy<Task<Stream>>, ICloudBlobProperties, Task<bool>> updatePropertiesAsync)
         {
             return Task.CompletedTask;

--- a/src/NuGetGallery/Services/PackageFileService.cs
+++ b/src/NuGetGallery/Services/PackageFileService.cs
@@ -28,19 +28,44 @@ namespace NuGetGallery
 
         public Task<ActionResult> CreateDownloadPackageActionResultAsync(Uri requestUrl, Package package)
         {
+            if (requestUrl is null)
+            {
+                throw new ArgumentNullException(nameof(requestUrl));
+            }
+
+            if (package is null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
             var fileName = FileNameHelper.BuildFileName(package, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetPackageFileExtension);
 
-            var packageVersion = NuGetVersionFormatter.GetNormalizedPackageVersion(package).ToLowerInvariant(); // will not return null bc BuildFileName will throw if values are null
+            var packageVersion = NuGetVersionFormatter.GetNormalizedPackageVersion(package);
 
             return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.PackagesFolderName, fileName, packageVersion);
         }
 
         public Task<ActionResult> CreateDownloadPackageActionResultAsync(Uri requestUrl, string id, string version)
         {
+            if (requestUrl is null)
+            {
+                throw new ArgumentNullException(nameof(requestUrl));
+            }
+
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException(CoreStrings.PackageIsMissingRequiredData, nameof(id));
+            }
+
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                throw new ArgumentException(CoreStrings.PackageIsMissingRequiredData, nameof(version));
+            }
+
             var fileName = FileNameHelper.BuildFileName(id, version, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetPackageFileExtension);
 
             // version cannot be null here as BuildFileName will throw if it is
-            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.PackagesFolderName, fileName, NuGetVersionFormatter.Normalize(version).ToLowerInvariant());
+            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.PackagesFolderName, fileName, NuGetVersionFormatter.Normalize(version));
         }
 
         /// <summary>

--- a/src/NuGetGallery/Services/SymbolPackageFileService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageFileService.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.Services.Entities;
+
 using System;
 using System.Threading.Tasks;
 using System.Web.Mvc;
-using NuGet.Services.Entities;
 
 namespace NuGetGallery
 {
@@ -21,13 +22,18 @@ namespace NuGetGallery
         public Task<ActionResult> CreateDownloadSymbolPackageActionResultAsync(Uri requestUrl, SymbolPackage symbolPackage)
         {
             var fileName = FileNameHelper.BuildFileName(symbolPackage.Package, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetSymbolPackageFileExtension);
-            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.SymbolPackagesFolderName, fileName);
+
+            var packageVersion = NuGetVersionFormatter.GetNormalizedPackageVersion(symbolPackage.Package).ToLowerInvariant(); // will not return null bc BuildFileName will throw if values are null
+
+            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.SymbolPackagesFolderName, fileName, packageVersion);
         }
 
         public Task<ActionResult> CreateDownloadSymbolPackageActionResultAsync(Uri requestUrl, string id, string version)
         {
             var fileName = FileNameHelper.BuildFileName(id, version, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetSymbolPackageFileExtension);
-            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.SymbolPackagesFolderName, fileName);
+
+            // version cannot be null here as BuildFileName will throw if it is
+            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.SymbolPackagesFolderName, fileName, NuGetVersionFormatter.Normalize(version).ToLowerInvariant());
         }
     }
 }

--- a/src/NuGetGallery/Services/SymbolPackageFileService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageFileService.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using NuGet.Services.Entities;
-
 using System;
 using System.Threading.Tasks;
 using System.Web.Mvc;
+using NuGet.Services.Entities;
 
 namespace NuGetGallery
 {
@@ -23,7 +22,7 @@ namespace NuGetGallery
         {
             var fileName = FileNameHelper.BuildFileName(symbolPackage.Package, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetSymbolPackageFileExtension);
 
-            var packageVersion = NuGetVersionFormatter.GetNormalizedPackageVersion(symbolPackage.Package).ToLowerInvariant(); // will not return null bc BuildFileName will throw if values are null
+            var packageVersion = NuGetVersionFormatter.GetNormalizedPackageVersion(symbolPackage.Package);
 
             return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.SymbolPackagesFolderName, fileName, packageVersion);
         }
@@ -33,7 +32,7 @@ namespace NuGetGallery
             var fileName = FileNameHelper.BuildFileName(id, version, CoreConstants.PackageFileSavePathTemplate, CoreConstants.NuGetSymbolPackageFileExtension);
 
             // version cannot be null here as BuildFileName will throw if it is
-            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.SymbolPackagesFolderName, fileName, NuGetVersionFormatter.Normalize(version).ToLowerInvariant());
+            return _fileStorageService.CreateDownloadFileActionResultAsync(requestUrl, CoreConstants.Folders.SymbolPackagesFolderName, fileName, NuGetVersionFormatter.Normalize(version));
         }
     }
 }

--- a/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
@@ -137,7 +137,7 @@ namespace NuGetGallery
                 var result = await service.CreateDownloadFileActionResultAsync(requestUri, CoreConstants.Folders.PackagesFolderName, "theFileName", "theVersion") as RedirectResult;
 
                 Assert.NotNull(result);
-                Assert.Equal(scheme + "theuri/", result.Url);
+                Assert.Equal(scheme + "theuri/?packageVersion=theVersion", result.Url);
             }
 
             [Theory]
@@ -158,52 +158,6 @@ namespace NuGetGallery
                 var result = await service.CreateDownloadFileActionResultAsync(new Uri(requestUrl), CoreConstants.Folders.PackagesFolderName, "theFileName", "theVersion") as RedirectResult;
                 var redirectUrl = new Uri(result.Url);
                 Assert.Equal(expectedPort, redirectUrl.Port);
-            }
-
-            [Theory]
-            [InlineData(HttpRequestUrlString, "https://theUri", "1.1.1", "1.1.1")]
-            [InlineData(HttpsRequestUrlString, "https://theUri", "01.01.01", "1.1.1")]
-            public async Task WillReturnARedirectResultWithTheNormalizedPackageVersion(string requestUrl, string blobUrl, string version, string expectedVersion)
-            {
-                var fakeBlobClient = new Mock<ICloudBlobClient>();
-                var fakeBlobContainer = new Mock<ICloudBlobContainer>();
-                var fakeBlob = new Mock<ISimpleCloudBlob>();
-                fakeBlobClient.Setup(x => x.GetContainerReference(It.IsAny<string>())).Returns(fakeBlobContainer.Object);
-                fakeBlobContainer.Setup(x => x.GetBlobReference(It.IsAny<string>())).Returns(fakeBlob.Object);
-                fakeBlobContainer.Setup(x => x.CreateIfNotExistAsync(It.IsAny<bool>())).Returns(Task.FromResult(0));
-                var requestUri = new Uri(requestUrl);
-                fakeBlob.Setup(x => x.Uri).Returns(new Uri(blobUrl));
-                var service = CreateService(fakeBlobClient: fakeBlobClient);
-
-                var result = await service.CreateDownloadFileActionResultAsync(requestUri, CoreConstants.Folders.PackagesFolderName, "theFileName", version) as RedirectResult;
-
-                Assert.NotNull(result);
-
-                var uri = new Uri(result.Url);
-                var qs = HttpUtility.ParseQueryString(uri.Query);
-                Assert.Equal(expectedVersion, qs["version"]);
-            }
-
-            [Theory]
-            [InlineData(HttpRequestUrlString, "https://theUri", null)]
-            [InlineData(HttpsRequestUrlString, "https://theUri", "")]
-            public async Task WillThrowIfVersionIsNullOrEmpty(string requestUrl, string blobUrl, string version)
-            {
-                var fakeBlobClient = new Mock<ICloudBlobClient>();
-                var fakeBlobContainer = new Mock<ICloudBlobContainer>();
-                var fakeBlob = new Mock<ISimpleCloudBlob>();
-                fakeBlobClient.Setup(x => x.GetContainerReference(It.IsAny<string>())).Returns(fakeBlobContainer.Object);
-                fakeBlobContainer.Setup(x => x.GetBlobReference(It.IsAny<string>())).Returns(fakeBlob.Object);
-                fakeBlobContainer.Setup(x => x.CreateIfNotExistAsync(It.IsAny<bool>())).Returns(Task.FromResult(0));
-                var requestUri = new Uri(requestUrl);
-                fakeBlob.Setup(x => x.Uri).Returns(new Uri(blobUrl));
-                var service = CreateService(fakeBlobClient: fakeBlobClient);
-
-                await Assert.ThrowsAsync<ArgumentException>(
-              () => service.CreateDownloadFileActionResultAsync(
-                  new Uri(HttpsRequestUrlString),
-                  CoreConstants.Folders.PackagesFolderName, "theFileName", version)
-              );
             }
 
             [Fact]

--- a/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/CloudBlobFileStorageServiceFacts.cs
@@ -1,10 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Moq;
-
-using NuGetGallery.Configuration;
-using NuGetGallery.Diagnostics;
 
 using System;
 using System.Collections.Generic;
@@ -14,6 +10,9 @@ using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
 
+using Moq;
+using NuGetGallery.Configuration;
+using NuGetGallery.Diagnostics;
 using Xunit;
 using Xunit.Sdk;
 

--- a/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/FileSystemFileStorageServiceFacts.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Moq;
+
+using NuGetGallery.Configuration;
+using NuGetGallery.Utilities;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,9 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Mvc;
-using Moq;
-using NuGetGallery.Configuration;
-using NuGetGallery.Utilities;
+
 using Xunit;
 
 namespace NuGetGallery
@@ -61,7 +64,7 @@ namespace NuGetGallery
                     () => service.CreateDownloadFileActionResultAsync(
                         HttpRequestUrl,
                         folderName,
-                        "theFileName"));
+                        "theFileName", "theVersion"));
 
                 Assert.Equal("folderName", ex.ParamName);
             }
@@ -77,7 +80,7 @@ namespace NuGetGallery
                     () => service.CreateDownloadFileActionResultAsync(
                         HttpRequestUrl,
                         CoreConstants.Folders.PackagesFolderName,
-                        fileName));
+                        fileName, "theVersion"));
 
                 Assert.Equal("fileName", ex.ParamName);
             }
@@ -87,7 +90,7 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName") as FilePathResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName", "theVersion") as FilePathResult;
 
                 Assert.NotNull(result);
                 Assert.Equal(
@@ -102,7 +105,7 @@ namespace NuGetGallery
                 fakeFileSystemService.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
                 var service = CreateService(fileSystemService: fakeFileSystemService);
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName") as HttpNotFoundResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName", "theVersion") as HttpNotFoundResult;
 
                 Assert.NotNull(result);
             }
@@ -112,7 +115,7 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName") as FilePathResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName", "theVersion") as FilePathResult;
 
                 Assert.NotNull(result);
                 Assert.Equal(CoreConstants.PackageContentType, result.ContentType);
@@ -123,7 +126,7 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.SymbolPackagesFolderName, "theFileName") as FilePathResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.SymbolPackagesFolderName, "theFileName", "theVersion") as FilePathResult;
 
                 Assert.NotNull(result);
                 Assert.Equal(CoreConstants.PackageContentType, result.ContentType);
@@ -134,7 +137,7 @@ namespace NuGetGallery
             {
                 var service = CreateService();
 
-                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName") as FilePathResult;
+                var result = await service.CreateDownloadFileActionResultAsync(HttpRequestUrl, CoreConstants.Folders.PackagesFolderName, "theFileName", "theVersion") as FilePathResult;
 
                 Assert.NotNull(result);
                 Assert.Equal(

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
@@ -123,6 +123,32 @@ namespace NuGetGallery
                 Assert.Equal("package", ex.ParamName);
             }
 
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public void WillThrowIfPackageIsMissingVersionStringNullOrEmpty(string version)
+            {
+                var service = CreateService();
+
+                var ex = Assert.Throws<ArgumentException>(() => service.CreateDownloadPackageActionResultAsync(new Uri("http://fake"), "theId", version).Wait());
+
+                Assert.StartsWith("The package is missing required data.", ex.Message);
+                Assert.Equal("version", ex.ParamName);
+            }
+
+            [Theory]
+            [InlineData("")]
+            [InlineData(null)]
+            public void WillThrowIfPackageIsMissingIdStringNullOrEmpty(string theId)
+            {
+                var service = CreateService();
+
+                var ex = Assert.Throws<ArgumentException>(() => service.CreateDownloadPackageActionResultAsync(new Uri("http://fake"), theId, "theVersion").Wait());
+
+                Assert.StartsWith("The package is missing required data.", ex.Message);
+                Assert.Equal("id", ex.ParamName);
+            }
+
             [Fact]
             public async Task WillGetAResultFromTheFileStorageServiceUsingThePackagesFolder()
             {

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Moq;
+
+using NuGet.Services.Entities;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web.Mvc;
-using Moq;
-using NuGet.Services.Entities;
+
 using Xunit;
 
 namespace NuGetGallery
@@ -125,7 +128,7 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), CoreConstants.Folders.PackagesFolderName, It.IsAny<string>()))
+                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), CoreConstants.Folders.PackagesFolderName, It.IsAny<string>(), It.IsAny<string>()))
                     .CompletesWithNull()
                     .Verifiable();
 
@@ -139,7 +142,8 @@ namespace NuGetGallery
             {
                 var fileStorageSvc = new Mock<IFileStorageService>();
                 var service = CreateService(fileStorageSvc: fileStorageSvc);
-                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), It.IsAny<string>(), BuildFileName("theId", "theNormalizedVersion", CoreConstants.NuGetPackageFileExtension, CoreConstants.PackageFileSavePathTemplate)))
+                var normalizedVersion = "theNormalizedVersion";
+                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), It.IsAny<string>(), BuildFileName("theId", normalizedVersion, CoreConstants.NuGetPackageFileExtension, CoreConstants.PackageFileSavePathTemplate), normalizedVersion))
                     .CompletesWithNull()
                     .Verifiable();
 
@@ -156,7 +160,7 @@ namespace NuGetGallery
                 var packageRegistraion = new PackageRegistration { Id = "theId" };
                 var package = new Package { PackageRegistration = packageRegistraion, NormalizedVersion = null, Version = "01.01.01" };
 
-                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), It.IsAny<string>(), BuildFileName("theId", "1.1.1", CoreConstants.NuGetPackageFileExtension, CoreConstants.PackageFileSavePathTemplate)))
+                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), It.IsAny<string>(), BuildFileName("theId", "1.1.1", CoreConstants.NuGetPackageFileExtension, CoreConstants.PackageFileSavePathTemplate), "1.1.1"))
                     .CompletesWithNull()
                     .Verifiable();
 
@@ -170,7 +174,7 @@ namespace NuGetGallery
             {
                 ActionResult fakeResult = new RedirectResult("http://aUrl");
                 var fileStorageSvc = new Mock<IFileStorageService>();
-                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), It.IsAny<string>(), It.IsAny<string>()))
+                fileStorageSvc.Setup(x => x.CreateDownloadFileActionResultAsync(new Uri("http://fake"), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                     .CompletesWith(fakeResult);
 
                 var service = CreateService(fileStorageSvc: fileStorageSvc);


### PR DESCRIPTION
#### PR Classification
New feature: Added support for handling a version parameter in cloud blob storage services

Implements #10082 

#### PR Summary
Introduced a version parameter to enhance file storage service methods and updated related tests.
- `CloudBlobFileStorageService.cs`: Modified constructor and methods to handle `versionParameter`.
- `IFileStorageService`: Updated interface to include `versionParameter`.
- `FileSystemFileStorageService.cs`: Updated methods to handle `versionParameter`.
- `PackageFileService`: Passed `versionParameter` in method calls.
- Updated tests in `CloudBlobFileStorageServiceFacts`, `FileSystemFileStorageServiceFacts`, and `PackageFileServiceFacts` to include `versionParameter`.
