### PR TITLE
Remove unnecessary usings

### DIFF
--- a/src/GitHubVulnerabilities2Db/Configuration/GitHubVulnerabilities2DbConfiguration.cs
+++ b/src/GitHubVulnerabilities2Db/Configuration/GitHubVulnerabilities2DbConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using NuGet.Services.GitHub.Configuration;
 
 namespace GitHubVulnerabilities2Db.Configuration

--- a/src/GitHubVulnerabilities2v3/Configuration/GitHubVulnerabilities2v3Configuration.cs
+++ b/src/GitHubVulnerabilities2v3/Configuration/GitHubVulnerabilities2v3Configuration.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using NuGet.Services.GitHub.Configuration;
 
 namespace GitHubVulnerabilities2v3.Configuration

--- a/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
+++ b/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
@@ -17,8 +17,6 @@ using NuGet.Services.Cursor;
 using NuGet.Services.Entities;
 using NuGet.Services.GitHub.Ingest;
 using NuGet.Services.Storage;
-using Microsoft.Owin.Security.Provider;
-using System.Configuration;
 
 namespace GitHubVulnerabilities2v3.Extensions
 {

--- a/src/NuGet.Services.Entities/PackageDeprecation.cs
+++ b/src/NuGet.Services.Entities/PackageDeprecation.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace NuGet.Services.Entities
 {

--- a/src/NuGet.Services.Entities/UserCertificate.cs
+++ b/src/NuGet.Services.Entities/UserCertificate.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.ComponentModel.DataAnnotations.Schema;
-
 namespace NuGet.Services.Entities
 {
     /// <summary>

--- a/src/NuGet.Services.GitHub/Ingest/AdvisoryIngestor.cs
+++ b/src/NuGet.Services.GitHub/Ingest/AdvisoryIngestor.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using NuGet.Services.GitHub.GraphQL;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.Entities;
-using NuGetGallery;
 
 namespace NuGet.Services.GitHub.Ingest
 {

--- a/src/NuGetGallery.Core/Auditing/FeatureFlagsAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/FeatureFlagsAuditRecord.cs
@@ -4,7 +4,6 @@
 using System;
 using NuGet.Services.FeatureFlags;
 using NuGetGallery.Auditing.AuditedEntities;
-using NuGetGallery.Features;
 using NuGetGallery.Shared;
 
 namespace NuGetGallery.Auditing

--- a/src/NuGetGallery.Core/Auditing/Obfuscation/Obfuscator.cs
+++ b/src/NuGetGallery.Core/Auditing/Obfuscation/Obfuscator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Text;
 using System.Net;
 
 namespace NuGetGallery.Auditing

--- a/src/NuGetGallery.Core/Entities/EntitiesContext.cs
+++ b/src/NuGetGallery.Core/Entities/EntitiesContext.cs
@@ -7,7 +7,6 @@ using System.Data.Common;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.Infrastructure.Annotations;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Services.Entities;

--- a/src/NuGetGallery.Core/Login/IEditableLoginConfigurationFileStorageService.cs
+++ b/src/NuGetGallery.Core/Login/IEditableLoginConfigurationFileStorageService.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGetGallery.Shared;

--- a/src/NuGetGallery.Core/Login/ILoginDiscontinuationFileStorageService.cs
+++ b/src/NuGetGallery.Core/Login/ILoginDiscontinuationFileStorageService.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace NuGetGallery.Login

--- a/src/NuGetGallery.Core/Login/LoginDiscontinuation.cs
+++ b/src/NuGetGallery.Core/Login/LoginDiscontinuation.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NuGet.Services.Entities;
 

--- a/src/NuGetGallery.Core/Login/LoginDiscontinuationFileStorageService.cs
+++ b/src/NuGetGallery.Core/Login/LoginDiscontinuationFileStorageService.cs
@@ -4,12 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using NuGet.Services.FeatureFlags;
 
 namespace NuGetGallery.Login
 {

--- a/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/LoginDiscontinuationConfiguration.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net.Mail;
 using Newtonsoft.Json;
-using NuGet.Services.Entities;
 using NuGetGallery.Authentication;
 using NuGetGallery.Login;
 

--- a/src/NuGetGallery/App_Start/OwinStartup.cs
+++ b/src/NuGetGallery/App_Start/OwinStartup.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 using System.Web.Hosting;
 using System.Web.Http;
 using System.Web.Mvc;
@@ -23,7 +22,6 @@ using NuGetGallery.Authentication.Providers;
 using NuGetGallery.Authentication.Providers.Cookie;
 using NuGetGallery.Configuration;
 using NuGetGallery.Diagnostics;
-using NuGetGallery.Infrastructure;
 using Owin;
 
 [assembly: OwinStartup(typeof(NuGetGallery.OwinStartup))]

--- a/src/NuGetGallery/Areas/Admin/Controllers/PasswordAuthenticationController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/PasswordAuthenticationController.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using Microsoft.Ajax.Utilities;

--- a/src/NuGetGallery/Areas/Admin/ViewModels/UserCredentialSearchResult.cs
+++ b/src/NuGetGallery/Areas/Admin/ViewModels/UserCredentialSearchResult.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
-using NuGet.Services.Entities;
 
 namespace NuGetGallery.Areas.Admin.ViewModels
 {

--- a/src/NuGetGallery/Controllers/ApiController.cs
+++ b/src/NuGetGallery/Controllers/ApiController.cs
@@ -28,7 +28,6 @@ using NuGetGallery.Filters;
 using NuGetGallery.Infrastructure.Authentication;
 using NuGetGallery.Infrastructure.Mail.Messages;
 using NuGetGallery.Packaging;
-using NuGetGallery.RequestModels;
 using NuGetGallery.Security;
 using PackageIdValidator = NuGetGallery.Packaging.PackageIdValidator;
 

--- a/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/ListPackageItemViewModelFactory.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using NuGet.Services.Entities;
-using NuGetGallery;
 using NuGetGallery.Frameworks;
 using NuGetGallery.Helpers;
 

--- a/src/NuGetGallery/Services/SymbolPackageUploadService.cs
+++ b/src/NuGetGallery/Services/SymbolPackageUploadService.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
 using NuGet.Packaging;

--- a/tests/NuGetGallery.Core.Facts/Login/EditableLoginConfigurationFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Login/EditableLoginConfigurationFileStorageServiceFacts.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/tests/NuGetGallery.Core.Facts/Services/CloudBlobWrapperFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CloudBlobWrapperFacts.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
-using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Moq;

--- a/tests/NuGetGallery.Facts/Areas/Admin/HelperFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/HelperFacts.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using Xunit;
 
 namespace NuGetGallery.Areas.Admin

--- a/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Controllers/StatisticsControllerFacts.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using System.Web.Http.Results;
 using System.Web.Mvc;
 using System.Web.Routing;
 using Moq;

--- a/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ContactOwnersMessageFacts.cs
+++ b/tests/NuGetGallery.Facts/Infrastructure/Mail/Messages/ContactOwnersMessageFacts.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Mail;
-using Moq;
 using NuGet.Services.Entities;
 using NuGet.Services.Messaging.Email;
 using Xunit;

--- a/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using Moq;
 using Xunit;
 using NuGet.Services.Entities;
-using NuGetGallery.TestUtils;
 using NuGetGallery.Services;
 
 namespace NuGetGallery


### PR DESCRIPTION
This makes a future repository merge easier because it minimizes the number of project references that I might need to add when a PackageReference changes to a ProjectReference. For legacy csproj, project references are not transitive so I want as few type references as possible, including namespace usings.