### PR TITLE
Update System.Formats.Asn1 package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -129,11 +129,11 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageVersion Include="SharpZipLib" Version="1.3.3" />
     <PackageVersion Include="Strathweb.CacheOutput.WebApi2.StrongName" Version="0.9.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Diagnostics.Debug" Version="4.3.0" />
+    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />
     <PackageVersion Include="System.Linq.Expressions" Version="4.3.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -129,6 +129,7 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageVersion Include="SharpZipLib" Version="1.3.3" />
     <PackageVersion Include="Strathweb.CacheOutput.WebApi2.StrongName" Version="0.9.0" />
+    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <EnablePackageVersionOverride>true</EnablePackageVersionOverride>
-    <NuGetClientPackageVersion>6.10.1</NuGetClientPackageVersion>
+    <NuGetClientPackageVersion>6.9.1</NuGetClientPackageVersion>
     <ServerCommonPackageVersion>2.120.0</ServerCommonPackageVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <EnablePackageVersionOverride>true</EnablePackageVersionOverride>
-    <NuGetClientPackageVersion>6.9.1</NuGetClientPackageVersion>
+    <NuGetClientPackageVersion>6.10.1</NuGetClientPackageVersion>
     <ServerCommonPackageVersion>2.120.0</ServerCommonPackageVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
+++ b/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
 
 </Project>

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="EntityFramework" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="NuGet.Services.FeatureFlags" />
+    <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="WindowsAzure.Storage" />
+    <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Engineering/issues/5532

In general since transitive `system.formats.asn1` package depends on NuGet root package, just updating direct NuGet package should be enough, but not in this case. So I updated transitive package `System.Formats.Asn1` too.