### PR TITLE
Fetch and copy HTTP headers if they are being updated

### DIFF
--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -6,16 +6,9 @@ trigger:
       - "*"
   batch: True
 
-parameters:
-  - name: BuildConfiguration
-    displayName: Build configuration
-    type: string
-    default: Release
-    values: ["Release", "Debug"]
-
 variables:
   - name: BuildConfiguration
-    value: ${{ parameters.BuildConfiguration }}
+    value: Release
   - name: Codeql.Enabled
     value: true
   - name: NugetSecurityAnalysisWarningLevel

--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -247,8 +247,19 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             // Set destination properties if provided
             if (destinationProperties?.Count > 0)
             {
-                BlobHttpHeaders headers = new BlobHttpHeaders();
-                
+                // Use the existing properties of the destination blob to ensure that all properties are copied
+                // Source: https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-properties-metadata#set-and-retrieve-properties
+                BlobProperties properties = await destinationBlockBlob.GetPropertiesAsync();
+                var headers = new BlobHttpHeaders
+                {
+                    CacheControl = properties.CacheControl,
+                    ContentType = properties.ContentType,
+                    ContentDisposition = properties.ContentDisposition,
+                    ContentEncoding = properties.ContentEncoding,
+                    ContentLanguage = properties.ContentLanguage,
+                    ContentHash = properties.ContentHash,
+                };
+
                 // The copy statement copied all properties from the source blob to the destination blob; however,
                 // there may be required properties on destination blob, all of which may have not already existed
                 // on the source blob at the time of copy.

--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -247,7 +247,18 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             // Set destination properties if provided
             if (destinationProperties?.Count > 0)
             {
-                BlobHttpHeaders headers = await GetExistingHttpHeadersAsync(destinationBlockBlob);
+                // Use the existing properties of the destination blob to ensure that all properties are copied
+                // Source: https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-properties-metadata#set-and-retrieve-properties
+                BlobProperties properties = await destinationBlockBlob.GetPropertiesAsync();
+                var headers = new BlobHttpHeaders
+                {
+                    CacheControl = properties.CacheControl,
+                    ContentType = properties.ContentType,
+                    ContentDisposition = properties.ContentDisposition,
+                    ContentEncoding = properties.ContentEncoding,
+                    ContentLanguage = properties.ContentLanguage,
+                    ContentHash = properties.ContentHash,
+                };
 
                 // The copy statement copied all properties from the source blob to the destination blob; however,
                 // there may be required properties on destination blob, all of which may have not already existed
@@ -273,28 +284,16 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             }
         }
 
-        private static async Task<BlobHttpHeaders> GetExistingHttpHeadersAsync(BlockBlobClient blob)
-        {
-            // Source: https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-properties-metadata#set-and-retrieve-properties
-            BlobProperties properties = await blob.GetPropertiesAsync();
-
-            return new BlobHttpHeaders
-            {
-                CacheControl = properties.CacheControl,
-                ContentType = properties.ContentType,
-                ContentDisposition = properties.ContentDisposition,
-                ContentEncoding = properties.ContentEncoding,
-                ContentLanguage = properties.ContentLanguage,
-                ContentHash = properties.ContentHash,
-            };
-        }
-
         protected override async Task OnSaveAsync(Uri resourceUri, StorageContent content, CancellationToken cancellationToken)
         {
             string blobName = GetName(resourceUri);
             BlockBlobClient blockBlobClient = GetBlockBlobReference(blobName);
 
-            BlobHttpHeaders headers = await GetExistingHttpHeadersAsync(blockBlobClient);
+            var headers = new BlobHttpHeaders
+            {
+                ContentType = content.ContentType,
+                CacheControl = content.CacheControl
+            };
 
             if (_compressContent)
             {


### PR DESCRIPTION
I will also copy this implementation to ServerCommon. Great catch by @dannyjdev!

Without this, we loose any additional HTTP headers existing on the blob, not overridden on the `BlobHttpHeaders` instance. `SetHttpHeadersAsync` replaces ALL headers that can possible be set by it, not just the ones you explicitly assign.

Also, unrelated, remove a BuildConfiguration parameter from the CI YAML. Perhaps that is what is preventing the automatic CI build from working. (it's a guess, it's something I added as a nicety but it's not required at this time)