### PR TITLE
Remove Focus on Package Page Tables

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1,4 +1,4 @@
-﻿@using NuGet.Services.Validation
+@using NuGet.Services.Validation
 @using NuGet.Services.Licenses
 
 @model DisplayPackageViewModel
@@ -799,15 +799,15 @@
                                     <table class="table borderless" aria-label="Packages that depend on @Model.Id">
                                         <thead>
                                             <tr>
-                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader" tabindex="0">Package</th>
-                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader" tabindex="0">Downloads</th>
+                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader">Package</th>
+                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader">Downloads</th>
                                             </tr>
                                         </thead>
                                         <tbody class="no-border">
                                             @foreach (var item in Model.PackageDependents.TopPackages)
                                             {
                                                 <tr>
-                                                    <td class="used-by-desc-column" tabindex="0">
+                                                    <td class="used-by-desc-column">
                                                         <a class="text-left ngp-link" href="@Url.Package(item.Id)">
                                                             @(item.Id)
                                                         </a>
@@ -818,7 +818,7 @@
                                                         }
                                                         <p class="used-by-desc">@item.Description</p>
                                                     </td>
-                                                    <td tabindex="0">
+                                                    <td>
                                                         <i class="ms-Icon ms-Icon--Download used-by-download-icon" aria-hidden="true"></i> <label class="used-by-count">@(item.DownloadCount.ToKiloFormat())</label>
                                                     </td>
                                                 </tr>
@@ -850,15 +850,15 @@
                                     <table class="table borderless" aria-label="GitHub repositories that depend on @Model.Id">
                                         <thead>
                                             <tr>
-                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader" tabindex="0">Repository</th>
-                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader" tabindex="0">Stars</th>
+                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader">Repository</th>
+                                                <th class="used-by-adjust-table-head" scope="col" role="columnheader">Stars</th>
                                             </tr>
                                         </thead>
                                         <tbody class="no-border">
                                             @foreach (var item in Model.GitHubDependenciesInformation.Repos.Select((elem, i) => new { Value = elem, Idx = i }))
                                             {
                                                 <tr>
-                                                    <td class="used-by-desc-column" tabindex="0">
+                                                    <td class="used-by-desc-column">
                                                         <a data-index-number="@item.Idx" class="text-left gh-link" href="@item.Value.Url" target="_blank">
                                                             @(item.Value.Id)
                                                         </a>
@@ -866,7 +866,7 @@
                                                             <span>@(item.Value.Description)</span>
                                                         </div>
                                                     </td>
-                                                    <td tabindex="0">
+                                                    <td>
                                                         <i class="ms-Icon ms-Icon--FavoriteStarFill gh-star" aria-hidden="true"></i> <label class="used-by-count">@(item.Value.Stars.ToKiloFormat())</label>
                                                     </td>
                                                 </tr>
@@ -893,12 +893,12 @@
                         <table aria-label="Version History of @Model.Id" class="table borderless">
                             <thead>
                                 <tr>
-                                    <th scope="col" role="columnheader" tabindex="0">Version</th>
-                                    <th scope="col" role="columnheader" tabindex="0">Downloads</th>
-                                    <th scope="col" role="columnheader" tabindex="0">Last updated</th>
+                                    <th scope="col" role="columnheader">Version</th>
+                                    <th scope="col" role="columnheader">Downloads</th>
+                                    <th scope="col" role="columnheader">Last updated</th>
                                     @if (Model.CanDisplayPrivateMetadata)
                                     {
-                                        <th scope="col" role="columnheader" tabindex="0">Status</th>
+                                        <th scope="col" role="columnheader">Status</th>
                                     }
                                     @if (Model.IsCertificatesUIEnabled)
                                     {
@@ -917,15 +917,15 @@
                                         || (!packageVersion.Deleted && Model.CanDisplayPrivateMetadata))
                                     {
                                         <tr class="@(packageVersion.IsCurrent(Model) ? "bg-brand-info" : null)">
-                                            <td tabindex="0">
+                                            <td>
                                                 <a href="@Url.Package(packageVersion)" title="@packageVersion.Version">
                                                     @packageVersion.Version.Abbreviate(30)
                                                 </a>
                                             </td>
-                                            <td tabindex="0">
+                                            <td>
                                                 @packageVersion.DownloadCount.ToNuGetNumberString()
                                             </td>
-                                            <td tabindex="0">
+                                            <td>
                                                 <span data-datetime="@packageVersion.LastUpdated.ToString("O")">@packageVersion.LastUpdated.ToNuGetShortDateString()</span>
                                                 @if (packageVersion.PushedBy != null)
                                                 {
@@ -938,7 +938,7 @@
                                             {
                                                 var packageStatusSummary = packageVersion.PackageStatusSummary;
 
-                                                <td tabindex="0">
+                                                <td>
                                                     @if (packageStatusSummary == PackageStatusSummary.Listed ||
                                                             packageStatusSummary == PackageStatusSummary.Unlisted)
                                                     {
@@ -959,7 +959,7 @@
                                                 }
                                                 else
                                                 {
-                                                    <td tabindex="0" class="package-icon-cell">
+                                                    <td class="package-icon-cell">
                                                         <i class="ms-Icon ms-Icon--Ribbon package-icon" title="@packageVersion.SignatureInformation"></i>
                                                     </td>
                                                 }
@@ -971,7 +971,7 @@
                                             }
                                             else
                                             {
-                                                <td tabindex="0" class="package-icon-cell package-warning-icon">
+                                                <td class="package-icon-cell package-warning-icon">
                                                     <a class="tooltip-target tooltip-icon--black-icon" href="javascript:void(0)" role="button"  aria-describedby="package-icon-@packageVersion.Version" >
                                                         <i class="ms-Icon ms-Icon--Warning package-icon"></i>
                                                         <span class="tooltip-block" role="tooltip" id="package-icon-@packageVersion.Version">
@@ -990,16 +990,16 @@
                                     else if (packageVersion.Deleted && packageVersion.CanDisplayPrivateMetadata)
                                     {
                                         <tr class="deleted">
-                                            <td tabindex="0" class="version">
+                                            <td class="version">
                                                 @packageVersion.Version
                                             </td>
-                                            <td tabindex="0">
+                                            <td>
                                                 @packageVersion.DownloadCount
                                             </td>
-                                            <td tabindex="0">
+                                            <td>
                                                 <span data-datetime="@packageVersion.LastUpdated.ToString("O")">@packageVersion.LastUpdated.ToNuGetShortDateString()</span>
                                             </td>
-                                            <td tabindex="0">
+                                            <td>
                                                 Deleted
                                             </td>
                                             <td colspan="2"></td>


### PR DESCRIPTION
Links and buttons inside package page tables receive double focus, need to remove the focus on table cell to make links and buttons receive single focus

* remove tabindex from all table cell from package page

![image](https://github.com/user-attachments/assets/ad637ee1-b9c2-4fa3-9e3e-171cdd748cbc)


Bug URL: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2175594