### PR TITLE
Fix flaky test CanRetryOnConflict

### DIFF
--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -47,10 +47,6 @@ extends:
       name: NuGet-1ES-Hosted-Pool
       image: NuGet-1ESPT-Win2022
       os: windows
-    sdl:
-      armory:
-        enabled: false
-        targetFiles: f|**\*.json;-|.gdn\**;-|**\TestData\*.nupkg
     customBuildTags:
       - ES365AIMigrationTooling
     stages:

--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -47,6 +47,10 @@ extends:
       name: NuGet-1ES-Hosted-Pool
       image: NuGet-1ESPT-Win2022
       os: windows
+    sdl:
+      armory:
+        enabled: false
+        targetFiles: f|**\*.json;-|.gdn\**;-|**\TestData\*.nupkg
     customBuildTags:
       - ES365AIMigrationTooling
     stages:

--- a/tests/NuGet.Services.AzureSearch.Tests/IndexBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/IndexBuilderFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -50,7 +50,10 @@ namespace NuGet.Services.AzureSearch
                 sw.Stop();
 
                 _cloudBlobContainer.Verify(x => x.CreateAsync(true), Times.Exactly(2));
-                Assert.InRange(sw.Elapsed, _retryDuration, TimeSpan.MaxValue);
+
+                // allow for some variance in the retry duration
+                // 15ms due to Windows clock: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.delay
+                Assert.InRange(sw.Elapsed, _retryDuration - TimeSpan.FromMilliseconds(16), TimeSpan.MaxValue);
             }
 
             [Fact]
@@ -140,7 +143,7 @@ namespace NuGet.Services.AzureSearch
                     StorageContainer = "container-name",
                 };
                 _logger = output.GetLogger<BlobContainerBuilder>();
-                _retryDuration = TimeSpan.FromMilliseconds(10);
+                _retryDuration = TimeSpan.FromMilliseconds(100);
 
                 _options
                     .Setup(x => x.Value)
@@ -160,7 +163,7 @@ namespace NuGet.Services.AzureSearch
             {
                 _cloudBlobContainer
                     .SetupSequence(x => x.CreateAsync(It.IsAny<bool>()))
-                    .Throws(new CloudBlobConflictException(null))
+                    .ThrowsAsync(new CloudBlobConflictException(null))
                     .Returns(Task.CompletedTask);
             }
 


### PR DESCRIPTION
This test is flaky. It fails with:

```
  Failed NuGet.Services.AzureSearch.BlobContainerBuilderFacts+CreateAsync.CanRetryOnConflict [22 ms]
  Error Message:
   Assert.InRange() Failure: Value not in range
Range:  (00:00:00.0100000 - 10675199.02:48:05.4775807)
Actual: 00:00:00.0098249
```