### PR TITLE
Move to latest ServerCommon version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <EnablePackageVersionOverride>true</EnablePackageVersionOverride>
     <NuGetClientPackageVersion>6.9.1</NuGetClientPackageVersion>
-    <ServerCommonPackageVersion>2.120.0</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.122.0</ServerCommonPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />

--- a/src/Gallery.CredentialExpiration/Job.cs
+++ b/src/Gallery.CredentialExpiration/Job.cs
@@ -9,12 +9,12 @@ using System.Net.Mail;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
+using Azure.Storage.Blobs;
 using Gallery.CredentialExpiration.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json;
 using NuGet.Jobs;
 using NuGet.Services.Messaging;
@@ -52,7 +52,7 @@ namespace Gallery.CredentialExpiration
 
             FromAddress = new MailAddress(InitializationConfiguration.MailFrom);
             
-            var storageAccount = CloudStorageAccount.Parse(InitializationConfiguration.DataStorageAccount);
+            var storageAccount = new BlobServiceClient(AzureStorageFactory.PrepareConnectionString(InitializationConfiguration.DataStorageAccount));
             var storageFactory = new AzureStorageFactory(
                 storageAccount,
                 InitializationConfiguration.ContainerName,

--- a/src/GitHubVulnerabilities2Db/Job.cs
+++ b/src/GitHubVulnerabilities2Db/Job.cs
@@ -6,13 +6,13 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
+using Azure.Storage.Blobs;
 using GitHubVulnerabilities2Db.Configuration;
 using GitHubVulnerabilities2Db.Fakes;
 using GitHubVulnerabilities2Db.Gallery;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage;
 using NuGet.Jobs;
 using NuGet.Jobs.Configuration;
 using NuGet.Services.Cursor;
@@ -164,9 +164,10 @@ namespace GitHubVulnerabilities2Db
                 .Register(ctx =>
                 {
                     var config = ctx.Resolve<GitHubVulnerabilities2DbConfiguration>();
-                    return CloudStorageAccount.Parse(config.StorageConnectionString);
+                    var connectionString = AzureStorageFactory.PrepareConnectionString(config.StorageConnectionString);
+                    return new BlobServiceClient(connectionString);
                 })
-                .As<CloudStorageAccount>();
+                .As<BlobServiceClient>();
 
             containerBuilder
                 .RegisterType<AzureStorageFactory>()

--- a/src/GitHubVulnerabilities2v3/Job.cs
+++ b/src/GitHubVulnerabilities2v3/Job.cs
@@ -7,13 +7,13 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
+using Azure.Storage.Blobs;
 using GitHubVulnerabilities2v3.Configuration;
 using GitHubVulnerabilities2v3.Extensions;
 using GitHubVulnerabilities2v3.Telemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage;
 using NuGet.Jobs;
 using NuGet.Services.Cursor;
 using NuGet.Services.GitHub.Collector;
@@ -116,9 +116,10 @@ namespace GitHubVulnerabilities2v3
                 .Register(ctx =>
                 {
                     var config = ctx.Resolve<GitHubVulnerabilities2v3Configuration>();
-                    return CloudStorageAccount.Parse(config.StorageConnectionString);
+                    var connectionString = AzureStorageFactory.PrepareConnectionString(config.StorageConnectionString);
+                    return new BlobServiceClient(connectionString);
                 })
-                .As<CloudStorageAccount>();
+                .As<BlobServiceClient>();
 
             containerBuilder
                 .RegisterType<AzureStorageFactory>()

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -20,7 +20,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Services.Storage" VersionOverride="2.121.0-ryuyu-newStorageSdk-9662298" />
+    <PackageReference Include="NuGet.Services.Storage" />
     <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
 </Project>

--- a/src/Stats.PostProcessReports/DetailedReportPostProcessor.cs
+++ b/src/Stats.PostProcessReports/DetailedReportPostProcessor.cs
@@ -214,14 +214,14 @@ namespace Stats.PostProcessReports
 
         private async Task<List<StorageListItem>> EnumerateSourceBlobsAsync()
         {
-            var blobs = await _sourceStorage.List(getMetadata: true, cancellationToken: CancellationToken.None);
+            var blobs = await _sourceStorage.ListAsync(getMetadata: true, cancellationToken: CancellationToken.None);
 
             return blobs.ToList();
         }
 
         private async Task<List<StorageListItem>> EnumerateWorkStorageBlobsAsync()
         {
-            var blobs = await _workStorage.List(getMetadata: true, cancellationToken: CancellationToken.None);
+            var blobs = await _workStorage.ListAsync(getMetadata: true, cancellationToken: CancellationToken.None);
 
             return blobs.ToList();
         }

--- a/src/Stats.PostProcessReports/Job.cs
+++ b/src/Stats.PostProcessReports/Job.cs
@@ -4,11 +4,11 @@
 using System.Threading.Tasks;
 using Autofac;
 using Autofac.Core;
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage;
 using NuGet.Jobs;
 using NuGet.Services.Storage;
 
@@ -39,7 +39,7 @@ namespace Stats.PostProcessReports
                 .Register(c =>
                 {
                     var cfg = c.Resolve<IOptionsSnapshot<PostProcessReportsConfiguration>>().Value;
-                    return CloudStorageAccount.Parse(cfg.StorageAccount);
+                    return new BlobServiceClient(AzureStorageFactory.PrepareConnectionString(cfg.StorageAccount));
                 })
                 .AsSelf();
 
@@ -48,11 +48,10 @@ namespace Stats.PostProcessReports
                 {
                     var cfg = c.Resolve<IOptionsSnapshot<PostProcessReportsConfiguration>>().Value;
                     var factory = new AzureStorageFactory(
-                        c.Resolve<CloudStorageAccount>(),
+                        c.Resolve<BlobServiceClient>(),
                         cfg.SourceContainerName,
                         c.Resolve<ILogger<AzureStorage>>(),
                         cfg.SourcePath + cfg.DetailedReportDirectoryName,
-                        useServerSideCopy: true,
                         initializeContainer: false);
                     var storage = factory.Create();
                     storage.Verbose = false;
@@ -65,11 +64,10 @@ namespace Stats.PostProcessReports
                 {
                     var cfg = c.Resolve<IOptionsSnapshot<PostProcessReportsConfiguration>>().Value;
                     var factory = new AzureStorageFactory(
-                        c.Resolve<CloudStorageAccount>(),
+                        c.Resolve<BlobServiceClient>(),
                         cfg.WorkContainerName,
                         c.Resolve<ILogger<AzureStorage>>(),
                         cfg.WorkPath,
-                        useServerSideCopy: true,
                         initializeContainer: false);
                     var storage = factory.Create();
                     storage.Verbose = false;
@@ -82,11 +80,10 @@ namespace Stats.PostProcessReports
                 {
                     var cfg = c.Resolve<IOptionsSnapshot<PostProcessReportsConfiguration>>().Value;
                     var factory = new AzureStorageFactory(
-                        c.Resolve<CloudStorageAccount>(),
+                        c.Resolve<BlobServiceClient>(),
                         cfg.DestinationContainerName,
                         c.Resolve<ILogger<AzureStorage>>(),
                         cfg.DestinationPath,
-                        useServerSideCopy: true,
                         initializeContainer: false);
                     var storage = factory.Create();
                     storage.Verbose = false;

--- a/src/StatusAggregator/Collector/ManualStatusChangeCollectorProcessor.cs
+++ b/src/StatusAggregator/Collector/ManualStatusChangeCollectorProcessor.cs
@@ -59,7 +59,7 @@ namespace StatusAggregator.Collector
                 await _handler.Handle(_table, manualChange);
             }
 
-            return manualChanges.Any() ? manualChanges.Max(c => c.Timestamp.UtcDateTime) : (DateTime?)null;
+            return manualChanges.Any() ? manualChanges.Max(c => c.Timestamp.Value.UtcDateTime) : null;
         }
     }
 }

--- a/src/StatusAggregator/Container/ContainerWrapper.cs
+++ b/src/StatusAggregator/Container/ContainerWrapper.cs
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Azure.Storage.Blobs;
 
 namespace StatusAggregator.Container
 {
     public class ContainerWrapper : IContainerWrapper
     {
-        private readonly CloudBlobContainer _container;
+        private readonly BlobContainerClient _container;
 
-        public ContainerWrapper(CloudBlobContainer container)
+        public ContainerWrapper(BlobContainerClient container)
         {
             _container = container;
         }
@@ -22,8 +22,8 @@ namespace StatusAggregator.Container
 
         public Task SaveBlobAsync(string name, string contents)
         {
-            var blob = _container.GetBlockBlobReference(name);
-            return blob.UploadTextAsync(contents);
+            var blob = _container.GetBlobClient(name);
+            return blob.UploadAsync(contents);
         }
     }
 }

--- a/src/StatusAggregator/Container/IContainerWrapper.cs
+++ b/src/StatusAggregator/Container/IContainerWrapper.cs
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage.Blob;
 
 namespace StatusAggregator.Container
 {
     /// <summary>
-    /// Simple wrapper for <see cref="CloudBlobContainer"/> that exists for unit-testing.
+    /// Simple wrapper for <see cref="Azure.Storage.Blobs.BlobContainerClient"/> that exists for unit-testing.
     /// </summary>
     public interface IContainerWrapper
     {

--- a/src/StatusAggregator/Factory/IComponentAffectingEntityFactory.cs
+++ b/src/StatusAggregator/Factory/IComponentAffectingEntityFactory.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage.Table;
+using Azure.Data.Tables;
 using StatusAggregator.Parse;
 
 namespace StatusAggregator.Factory
@@ -11,7 +11,7 @@ namespace StatusAggregator.Factory
     /// Creates a <typeparamref name="TEntity"/> given a <see cref="ParsedIncident"/>.
     /// </summary>
     public interface IComponentAffectingEntityFactory<TEntity>
-        where TEntity : TableEntity
+        where TEntity : ITableEntity
     {
         Task<TEntity> CreateAsync(ParsedIncident input);
     }

--- a/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
@@ -22,13 +22,13 @@ namespace StatusAggregator.Manual
 
         public async Task Handle(AddStatusEventManualChangeEntity entity)
         {
-            var time = entity.Timestamp.UtcDateTime;
+            var time = entity.Timestamp.Value.UtcDateTime;
 
             var eventEntity = new EventEntity(
                 entity.EventAffectedComponentPath,
                 time,
                 affectedComponentStatus: (ComponentStatus)entity.EventAffectedComponentStatus,
-                endTime: entity.EventIsActive ? (DateTime?)null : time);
+                endTime: entity.EventIsActive ? null : time);
 
             var messageEntity = new MessageEntity(
                 eventEntity,

--- a/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
@@ -21,7 +21,7 @@ namespace StatusAggregator.Manual
 
         public async Task Handle(AddStatusMessageManualChangeEntity entity)
         {
-            var time = entity.Timestamp.UtcDateTime;
+            var time = entity.Timestamp.Value.UtcDateTime;
 
             var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
             var eventEntity = await _table.RetrieveAsync<EventEntity>(eventRowKey);

--- a/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
@@ -29,7 +29,7 @@ namespace StatusAggregator.Manual
             }
 
             eventEntity.AffectedComponentStatus = entity.EventAffectedComponentStatus;
-            ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, entity.EventIsActive, entity.Timestamp.UtcDateTime);
+            ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, entity.EventIsActive, entity.Timestamp.Value.UtcDateTime);
 
             await _table.ReplaceAsync(eventEntity);
         }

--- a/src/StatusAggregator/Table/ITableWrapper.cs
+++ b/src/StatusAggregator/Table/ITableWrapper.cs
@@ -3,7 +3,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage.Table;
+using Azure.Data.Tables;
 
 namespace StatusAggregator.Table
 {
@@ -26,6 +26,6 @@ namespace StatusAggregator.Table
 
         Task DeleteAsync(ITableEntity tableEntity);
 
-        IQueryable<T> CreateQuery<T>() where T : ITableEntity, new();
+        IQueryable<T> CreateQuery<T>() where T : class, ITableEntity, new();
     }
 }

--- a/src/StatusAggregator/Table/TableWrapperExtensions.cs
+++ b/src/StatusAggregator/Table/TableWrapperExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.WindowsAzure.Storage.Table;
+using Azure.Data.Tables;
 using NuGet.Services.Status.Table;
 
 namespace StatusAggregator.Table
@@ -18,7 +18,7 @@ namespace StatusAggregator.Table
         }
 
         public static IQueryable<TChild> GetChildEntities<TChild, TParent>(this ITableWrapper table, TParent entity)
-            where TChild : ITableEntity, IChildEntity<TParent>, new()
+            where TChild : class, ITableEntity, IChildEntity<TParent>, new()
             where TParent : ITableEntity
         {
             return table

--- a/src/Validation.PackageSigning.ProcessSignature/Job.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/Job.cs
@@ -1,12 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Autofac;
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage;
 using NuGet.Jobs.Configuration;
 using NuGet.Jobs.Validation.PackageSigning.Configuration;
 using NuGet.Jobs.Validation.PackageSigning.Messages;
@@ -50,7 +50,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             services.AddTransient<ICertificateStore>(p =>
             {
                 var config = p.GetRequiredService<IOptionsSnapshot<CertificateStoreConfiguration>>().Value;
-                var targetStorageAccount = CloudStorageAccount.Parse(config.DataStorageAccount);
+                var targetStorageAccount = new BlobServiceClient(AzureStorageFactory.PrepareConnectionString(config.DataStorageAccount));
 
                 var storageFactory = new AzureStorageFactory(targetStorageAccount, config.ContainerName, LoggerFactory.CreateLogger<AzureStorage>());
                 var storage = storageFactory.Create();

--- a/src/Validation.PackageSigning.ValidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/Job.cs
@@ -1,12 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Autofac;
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage;
 using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.PackageSigning.Configuration;
 using NuGet.Jobs.Validation.PackageSigning.Messages;
@@ -31,7 +31,7 @@ namespace Validation.PackageSigning.ValidateCertificate
             services.AddTransient<ICertificateStore>(p =>
             {
                 var config = p.GetRequiredService<IOptionsSnapshot<CertificateStoreConfiguration>>().Value;
-                var targetStorageAccount = CloudStorageAccount.Parse(config.DataStorageAccount);
+                var targetStorageAccount = new BlobServiceClient(AzureStorageFactory.PrepareConnectionString(config.DataStorageAccount));
 
                 var storageFactory = new AzureStorageFactory(targetStorageAccount, config.ContainerName, LoggerFactory.CreateLogger<AzureStorage>());
                 var storage = storageFactory.Create();

--- a/tests/GitHubVulnerabilities2v3.Facts/BlobStorageVulnerabilityWriterFacts.cs
+++ b/tests/GitHubVulnerabilities2v3.Facts/BlobStorageVulnerabilityWriterFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -155,9 +155,14 @@ namespace GitHubVulnerabilities2v3.Facts
                 return _storage.ExistsAsync(fileName, cancellationToken);
             }
 
-            public override Task<IEnumerable<StorageListItem>> List(bool getMetadata, CancellationToken cancellationToken)
+            public override IEnumerable<StorageListItem> List(bool getMetadata)
             {
-                return _storage.List(getMetadata, cancellationToken);
+                return _storage.List(getMetadata);
+            }
+
+            public override Task<IEnumerable<StorageListItem>> ListAsync(bool getMetadata, CancellationToken cancellationToken)
+            {
+                return _storage.ListAsync(getMetadata, cancellationToken);
             }
 
             public override Task SetMetadataAsync(Uri resourceUri, IDictionary<string, string> metadata)

--- a/tests/Stats.PostProcessReports.Tests/DetailedReportPostProcessorFacts.cs
+++ b/tests/Stats.PostProcessReports.Tests/DetailedReportPostProcessorFacts.cs
@@ -33,13 +33,13 @@ namespace Stats.PostProcessReports.Tests
         public async Task DoesntStartIfNoSuccessFile()
         {
             _sourceStorageMock
-                .Setup(ss => ss.List(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((IEnumerable<StorageListItem>)new List<StorageListItem>());
+                .Setup(ss => ss.ListAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<StorageListItem>());
 
             await _target.CopyReportsAsync();
 
             _sourceStorageMock
-                .Verify(ss => ss.List(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+                .Verify(ss => ss.ListAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
             _sourceStorageMock.VerifyNoOtherCalls();
             _workStorageMock.VerifyNoOtherCalls();
             _destinationStorageMock.VerifyNoOtherCalls();
@@ -186,8 +186,8 @@ namespace Stats.PostProcessReports.Tests
                 { "FilesCreated", "123" }
             };
             _workStorageMock
-                .Setup(ss => ss.List(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(() => (IEnumerable<StorageListItem>)new List<StorageListItem>(_workFiles.Select(f => Blob(
+                .Setup(ss => ss.ListAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new List<StorageListItem>(_workFiles.Select(f => Blob(
                     _workStorageMock,
                     f,
                     f == file1 ? file1Metadata : null))));
@@ -278,7 +278,7 @@ namespace Stats.PostProcessReports.Tests
                 .Returns(new Uri(baseUrl));
             mock
                 .Setup(s => s.Load(It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((StorageContent)new StringStorageContent(""));
+                .ReturnsAsync(new StringStorageContent(""));
             mock
                 .Setup(s => s.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((string filename, CancellationToken _) =>
@@ -286,8 +286,8 @@ namespace Stats.PostProcessReports.Tests
                     return files().Contains(filename);
                 });
             mock
-                .Setup(s => s.List(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(() => (IEnumerable<StorageListItem>)new List<StorageListItem>(files().Select(f => Blob(mock, f))));
+                .Setup(s => s.ListAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new List<StorageListItem>(files().Select(f => Blob(mock, f))));
             mock
                 .Setup(s => s.ResolveUri(It.IsAny<string>()))
                 .Returns((string f) => Blob(mock, f).Uri);

--- a/tests/StatusAggregator.Tests/Collector/ManualStatusChangeCollectorProcessorTests.cs
+++ b/tests/StatusAggregator.Tests/Collector/ManualStatusChangeCollectorProcessorTests.cs
@@ -67,14 +67,14 @@ namespace StatusAggregator.Tests.Collector
                     .Returns(Task.CompletedTask)
                     .Callback<ITableWrapper, ManualStatusChangeEntity>((table, entity) =>
                     {
-                        var nextTimestamp = entity.Timestamp;
+                        var nextTimestamp = entity.Timestamp.Value;
                         Assert.True(nextTimestamp > lastTimestamp);
                         lastTimestamp = nextTimestamp;
                     });
 
                 var result = await Processor.FetchSince(Cursor);
 
-                Assert.Equal(secondChange.Timestamp.UtcDateTime, result);
+                Assert.Equal(secondChange.Timestamp.Value.UtcDateTime, result);
 
                 Handler
                     .Verify(
@@ -109,7 +109,7 @@ namespace StatusAggregator.Tests.Collector
 
                 var result = await Processor.FetchSince(Cursor);
 
-                Assert.Equal(change.Timestamp.UtcDateTime, result);
+                Assert.Equal(change.Timestamp.Value.UtcDateTime, result);
 
                 Handler.Verify();
             }

--- a/tests/StatusAggregator.Tests/Factory/EventFactoryTests.cs
+++ b/tests/StatusAggregator.Tests/Factory/EventFactoryTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Table;
 using Moq;
 using NuGet.Services.Incidents;
 using NuGet.Services.Status;

--- a/tests/StatusAggregator.Tests/Factory/IncidentFactoryTests.cs
+++ b/tests/StatusAggregator.Tests/Factory/IncidentFactoryTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Table;
 using Moq;
 using NuGet.Services.Incidents;
 using NuGet.Services.Status;

--- a/tests/StatusAggregator.Tests/Factory/IncidentGroupFactoryTests.cs
+++ b/tests/StatusAggregator.Tests/Factory/IncidentGroupFactoryTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Table;
 using Moq;
 using NuGet.Services.Incidents;
 using NuGet.Services.Status;

--- a/tests/StatusAggregator.Tests/Manual/AddStatusEventManualChangeHandlerTests.cs
+++ b/tests/StatusAggregator.Tests/Manual/AddStatusEventManualChangeHandlerTests.cs
@@ -36,7 +36,7 @@ namespace StatusAggregator.Tests.Manual
                     Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
                 };
 
-                var time = entity.Timestamp.UtcDateTime;
+                var time = entity.Timestamp.Value.UtcDateTime;
                 var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, time);
 
                 _table.Setup(x => x.InsertAsync(

--- a/tests/StatusAggregator.Tests/Manual/AddStatusMessageManualChangeHandlerTests.cs
+++ b/tests/StatusAggregator.Tests/Manual/AddStatusMessageManualChangeHandlerTests.cs
@@ -35,7 +35,7 @@ namespace StatusAggregator.Tests.Manual
                     Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
                 };
 
-                var time = entity.Timestamp.UtcDateTime;
+                var time = entity.Timestamp.Value.UtcDateTime;
                 var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
 
                 _table
@@ -80,7 +80,7 @@ namespace StatusAggregator.Tests.Manual
                     Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
                 };
 
-                var time = entity.Timestamp.UtcDateTime;
+                var time = entity.Timestamp.Value.UtcDateTime;
                 var existingEntity =
                     new EventEntity(
                         entity.EventAffectedComponentPath,

--- a/tests/StatusAggregator.Tests/Manual/EditStatusEventManualChangeHandlerTests.cs
+++ b/tests/StatusAggregator.Tests/Manual/EditStatusEventManualChangeHandlerTests.cs
@@ -35,7 +35,7 @@ namespace StatusAggregator.Tests.Manual
                     Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
                 };
 
-                var time = entity.Timestamp.UtcDateTime;
+                var time = entity.Timestamp.Value.UtcDateTime;
                 var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
 
                 _table
@@ -68,7 +68,7 @@ namespace StatusAggregator.Tests.Manual
                     Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
                 };
 
-                var time = entity.Timestamp.UtcDateTime;
+                var time = entity.Timestamp.Value.UtcDateTime;
                 var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
 
                 var existingEntity =

--- a/tests/StatusAggregator.Tests/Messages/MessageFactoryTests.cs
+++ b/tests/StatusAggregator.Tests/Messages/MessageFactoryTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Table;
 using Moq;
 using NuGet.Services.Status;
 using NuGet.Services.Status.Table;

--- a/tests/StatusAggregator.Tests/TestUtility/MockTableWrapperExtensions.cs
+++ b/tests/StatusAggregator.Tests/TestUtility/MockTableWrapperExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.WindowsAzure.Storage.Table;
+using Azure.Data.Tables;
 using Moq;
 using StatusAggregator.Table;
 
@@ -13,7 +13,7 @@ namespace StatusAggregator.Tests.TestUtility
         public static void SetupQuery<T>(
             this Mock<ITableWrapper> mock,
             params T[] results)
-            where T : ITableEntity, new()
+            where T : class, ITableEntity, new()
         {
             mock
                 .Setup(x => x.CreateQuery<T>())

--- a/tests/StatusAggregator.Tests/Update/AggregationEntityUpdaterTests.cs
+++ b/tests/StatusAggregator.Tests/Update/AggregationEntityUpdaterTests.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Table;
 using Moq;
 using NuGet.Services.Status.Table;
 using StatusAggregator.Table;

--- a/tests/StatusAggregator.Tests/Update/IncidentUpdaterTests.cs
+++ b/tests/StatusAggregator.Tests/Update/IncidentUpdaterTests.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using Azure.Data.Tables;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Table;
 using Moq;
 using NuGet.Services.Incidents;
 using NuGet.Services.Status.Table;


### PR DESCRIPTION
This bring Azure.Data.Tables and Azure.Storage.Blobs into several new places. NuGet.Services.Storage has a new constructor affecting a lot of DI setup.

The following jobs were impacted, and need to be assessed for managed identity support. They should be closer, since they have the new storage SDK, at least in part.

- Gallery:
  - GitHubVulnerabilities2Db
  - GitHubVulnerabilities2V3
- Jobs:
  - Gallery.CredentialExpiration
  - Stats.PostProcessReports
  - StatusAggregator
  - Validation.PackageSigning.ProcessSignature
  - Validation.PackageSigning.ValidateCertificate