### PR TITLE
Fix endpoint suffix (Azure China) not being used

### DIFF
--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -214,11 +214,11 @@ namespace Ng
                 var storageAccountName = arguments.GetOrThrow<string>(argumentNameMap[Arguments.StorageAccountName]);
                 var storageContainer = arguments.GetOrThrow<string>(argumentNameMap[Arguments.StorageContainer]);
                 var storagePath = arguments.GetOrDefault<string>(argumentNameMap[Arguments.StoragePath]);
-                var storageSuffix = arguments.GetOrDefault<string>(argumentNameMap[Arguments.StorageSuffix]);
+                var storageSuffix = arguments.GetOrDefault(argumentNameMap[Arguments.StorageSuffix], "core.windows.net");
                 var storageOperationMaxExecutionTime = MaxExecutionTime(arguments.GetOrDefault<int>(argumentNameMap[Arguments.StorageOperationMaxExecutionTimeInSeconds]));
                 var storageServerTimeout = MaxExecutionTime(arguments.GetOrDefault<int>(argumentNameMap[Arguments.StorageServerTimeoutInSeconds]));
                 var storageUseServerSideCopy = arguments.GetOrDefault<bool>(argumentNameMap[Arguments.StorageUseServerSideCopy]);
-                var storageInitializeContainer = arguments.GetOrDefault<bool>(argumentNameMap[Arguments.StorageInitializeContainer], defaultValue: true);
+                var storageInitializeContainer = arguments.GetOrDefault(argumentNameMap[Arguments.StorageInitializeContainer], defaultValue: true);
 
                 BlobServiceClient account = GetBlobServiceClient(storageAccountName, storageSuffix, arguments, argumentNameMap);
 
@@ -382,7 +382,7 @@ namespace Ng
                     storageSasValue = storageSasValue.Substring(1);
                 }
 
-                connectionString = $"BlobEndpoint=https://{storageAccountName}.blob.core.windows.net/;SharedAccessSignature={storageSasValue}";
+                connectionString = $"BlobEndpoint=https://{storageAccountName}.blob.{endpointSuffix}/;SharedAccessSignature={storageSasValue}";
             }
             else
             {
@@ -401,7 +401,7 @@ namespace Ng
             if (string.IsNullOrEmpty(storageKeyValue))
             {
                 var storageSasValue = arguments.GetOrThrow<string>(argumentNameMap[Arguments.StorageSasValue]);
-                connectionString = $"BlobEndpoint=https://{storageAccountName}.blob.core.windows.net/;SharedAccessSignature={storageSasValue}";
+                connectionString = $"BlobEndpoint=https://{storageAccountName}.blob.{endpointSuffix}/;SharedAccessSignature={storageSasValue}";
             }
             else
             {

--- a/tests/NgTests/StorageFactoryTests.cs
+++ b/tests/NgTests/StorageFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -11,33 +11,52 @@ namespace NgTests
 {
     public class StorageFactoryTests
     {
-        [Theory]
-        [Description("The regular azure factory should not compress the content if.")]
-        [InlineData("http://localhost/reg", "testAccount", "DummyDUMMYpZxLeDumMyyN52gJj+ZlGE0ipRi9PaTcn9AU4epwvsngE5rLSMk9TwpazxUtzeyBnFeWFAdummyw==", "testContainer", "testStoragePath", "azure", "core.windows.net")]
-        public void AzureFactory(string storageBaseAddress,
-                                 string storageAccountName,
-                                 string storageKeyValue,
-                                 string storageContainer,
-                                 string storagePath,
-                                 string storageType,
-                                 string storageSuffix)
+        private const string DummyKey = "DummyDUMMYpZxLeDumMyyN52gJj+ZlGE0ipRi9PaTcn9AU4epwvsngE5rLSMk9TwpazxUtzeyBnFeWFAdummyw==";
+
+        [Fact]
+        public void AzureFactory_DefaultsToAzurePublicWithNoCompression()
         {
+            // Arrange
             Dictionary<string, string> arguments = new Dictionary<string, string>()
             {
-                { Arguments.StorageBaseAddress, storageBaseAddress },
-                { Arguments.StorageAccountName, storageAccountName },
-                { Arguments.StorageKeyValue, storageKeyValue },
-                { Arguments.StorageContainer, storageContainer },
-                { Arguments.StoragePath, storagePath },
-                { Arguments.StorageType, storageType},
-                { Arguments.StorageSuffix, storageSuffix} // Without BlobServiceClient couldn't create new instance. 
+                { Arguments.StorageBaseAddress, "http://localhost/reg" },
+                { Arguments.StorageAccountName, "testAccount" },
+                { Arguments.StorageKeyValue, DummyKey },
+                { Arguments.StorageContainer, "testContainer" },
+                { Arguments.StoragePath, "testStoragePath" },
+                { Arguments.StorageType, "azure" },
             };
 
+            // Act
             StorageFactory factory = CommandHelpers.CreateStorageFactory(arguments, true);
-            AzureStorageFactory azureFactory = factory as AzureStorageFactory;
+
             // Assert
-            Assert.True(azureFactory != null, "The CreateCompressedStorageFactory should return an AzureStorageFactory type.");
+            var azureFactory = Assert.IsType<AzureStorageFactory>(factory);
             Assert.False(azureFactory.CompressContent, "The azure storage factory should not compress the content.");
+            Assert.Equal("https://testaccount.blob.core.windows.net/testContainer/testStoragePath/", azureFactory.DestinationAddress.AbsoluteUri);
+        }
+
+        [Fact]
+        public void AzureFactory_AllowsCustomStorageSuffix()
+        {
+            // Arrange
+            Dictionary<string, string> arguments = new Dictionary<string, string>()
+            {
+                { Arguments.StorageBaseAddress, "http://localhost/reg" },
+                { Arguments.StorageAccountName, "testAccount" },
+                { Arguments.StorageKeyValue, DummyKey },
+                { Arguments.StorageContainer, "testContainer" },
+                { Arguments.StoragePath, "testStoragePath" },
+                { Arguments.StorageType, "azure" },
+                { Arguments.StorageSuffix, "core.chinacloudapi.cn" },
+            };
+
+            // Act
+            StorageFactory factory = CommandHelpers.CreateStorageFactory(arguments, true);
+
+            // Assert
+            var azureFactory = Assert.IsType<AzureStorageFactory>(factory);
+            Assert.Equal("https://testaccount.blob.core.chinacloudapi.cn/testContainer/testStoragePath/", azureFactory.DestinationAddress.AbsoluteUri);
         }
     }
 }


### PR DESCRIPTION
This is blocking `catalog2dnx` job from running against Azure China storage.