### PR TITLE
Fix Monitoring2Monitoring blob name generation, handle size mismatch when checking if blobs are synchronized

### DIFF
--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -454,8 +454,8 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             {
                 if (await sourceBlockBlob.ExistsAsync(CancellationToken.None))
                 {
-                    var sourceBlobAttributes = await sourceBlockBlob.FetchAttributesAsync(CancellationToken.None);
-                    var destinationBlobAttributes = await destinationBlockBlob.FetchAttributesAsync(CancellationToken.None);
+                    BlobProperties sourceBlobAttributes = await sourceBlockBlob.FetchAttributesAsync(CancellationToken.None);
+                    BlobProperties destinationBlobAttributes = await destinationBlockBlob.FetchAttributesAsync(CancellationToken.None);
                     if (sourceBlobAttributes?.Metadata == null || destinationBlobAttributes?.Metadata == null)
                     {
                         return false;

--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -456,7 +456,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
                 {
                     var sourceBlobAttributes = await sourceBlockBlob.FetchAttributesAsync(CancellationToken.None);
                     var destinationBlobAttributes = await destinationBlockBlob.FetchAttributesAsync(CancellationToken.None);
-                    if (sourceBlobAttributes == null || destinationBlobAttributes == null)
+                    if (sourceBlobAttributes?.Metadata == null || destinationBlobAttributes?.Metadata == null)
                     {
                         return false;
                     }

--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -454,15 +454,21 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             {
                 if (await sourceBlockBlob.ExistsAsync(CancellationToken.None))
                 {
-                    var sourceBlobMetadata = await sourceBlockBlob.GetMetadataAsync(CancellationToken.None);
-                    var destinationBlobMetadata = await destinationBlockBlob.GetMetadataAsync(CancellationToken.None);
-                    if (sourceBlobMetadata == null || destinationBlobMetadata == null)
+                    var sourceBlobAttributes = await sourceBlockBlob.FetchAttributesAsync(CancellationToken.None);
+                    var destinationBlobAttributes = await destinationBlockBlob.FetchAttributesAsync(CancellationToken.None);
+                    if (sourceBlobAttributes == null || destinationBlobAttributes == null)
                     {
                         return false;
                     }
 
-                    var sourceBlobHasSha512Hash = sourceBlobMetadata.TryGetValue(Sha512HashAlgorithmId, out var sourceBlobSha512Hash);
-                    var destinationBlobHasSha512Hash = destinationBlobMetadata.TryGetValue(Sha512HashAlgorithmId, out var destinationBlobSha512Hash);
+                    if (sourceBlobAttributes.ContentLength !=  destinationBlobAttributes.ContentLength)
+                    {
+                        Trace.WriteLine($"The source blob ({RemoveQueryString(sourceBlockBlob.Uri)}) and destination blob ({RemoveQueryString(destinationBlockBlob.Uri)}) have different sizes.");
+                        return false;
+                    }
+
+                    var sourceBlobHasSha512Hash = sourceBlobAttributes.Metadata.TryGetValue(Sha512HashAlgorithmId, out var sourceBlobSha512Hash);
+                    var destinationBlobHasSha512Hash = destinationBlobAttributes.Metadata.TryGetValue(Sha512HashAlgorithmId, out var destinationBlobSha512Hash);
                     if (!sourceBlobHasSha512Hash)
                     {
                         Trace.TraceWarning($"The source blob ({RemoveQueryString(sourceBlockBlob.Uri)}) doesn't have the SHA512 hash.");

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -199,15 +199,19 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             {
                 address += "/";
             }
-            var uriString = uri.ToString();
+            var uriString = uri.GetLeftPart(UriPartial.Path);
 
             int baseAddressLength = address.Length;
 
-            var name = uriString.Substring(baseAddressLength);
+            // handle mismatched scheme (http vs https)
+            var schemeLengthDifference = uri.Scheme.Length - BaseAddress.Scheme.Length;
+
+            var name = uriString.Substring(baseAddressLength + schemeLengthDifference);
             if (name.Contains("#"))
             {
                 name = name.Substring(0, name.IndexOf("#"));
             }
+
             return name;
         }
 
@@ -229,7 +233,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             {
                 //The Uri depends on the storage implementation.
                 Uri storageUri = GetUri(GetName(resourceUri));
-                Trace.WriteLine(String.Format("{0} {1}", method, storageUri));
+                Trace.WriteLine(String.Format("{0} {1}", method, RemoveQueryString(storageUri)));
             }
         }
 
@@ -240,7 +244,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
 
         private string TraceException(string method, Uri resourceUri, Exception exception)
         {
-            string message = $"{method} EXCEPTION: {GetUri(GetName(resourceUri))} {exception.ToString()}";
+            string message = $"{method} EXCEPTION: {RemoveQueryString(GetUri(GetName(resourceUri)))} {exception.ToString()}";
             Trace.WriteLine(message);
             return message;
         }


### PR DESCRIPTION
This PR fix two bugs I've found in `dev` based on SDK move (1 and 2, below), and one pre-existing bug found due to blob corruption in DEV (3, below)

Summary of changes:
1. Scrub blob URL in logging, so we don't log SAS (query string)
2. Handle mismatch of scheme between base URL (http) and blob item from list blobs (https)
   - This difference was leading to a substring being off by 1 ("http" is shorter than "https")
   - It would be a much larger change to make it so we never use "http" in memory, this behavior pre-existed in the SDK move ([example](https://github.com/NuGet/NuGet.Jobs/blob/5b34c8e8ab48516f289db7d37a67c48f62f4667f/src/Catalog/Persistence/AzureStorage.cs#L148-L157))
3. When blob sizes are different, do not consider them synchronized.
   - In DEV, there were some old blobs that had matching SHA-512 metadata but they were actually different. This was causing `catalog2dnx` to no-op. This can be easily avoided by also checking the file size. Of course this doesn't fix all problems if the SHA-512 is different, but it's an easy, safe improvement.

