### PR TITLE
Set PackageVersion in MSBuild to allow different versions at pack time

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -144,10 +144,12 @@ Invoke-BuildStep 'Signing the binaries' {
     -skip:$SkipArtifacts `
     -ev +BuildErrors
 
+$packageVersions = "/p:CommonPackageVersion=$CommonPackageVersion;GalleryPackageVersion=$GalleryPackageVersion;JobsPackageVersion=$JobsPackageVersion"
+
 Invoke-BuildStep 'Creating common artifacts' {
         $CommonPackages = $CommonProjects | Where-Object { $_.IsSrc }
         $CommonPackages | ForEach-Object {
-            New-ProjectPackage $_.Path -Configuration $Configuration -BuildNumber $BuildNumber -Version $CommonPackageVersion
+            New-ProjectPackage $_.Path -Configuration $Configuration -Symbols -Options $packageVersions
         }
     } `
     -skip:($SkipCommon -or $SkipArtifacts) `
@@ -160,7 +162,7 @@ Invoke-BuildStep 'Creating gallery artifacts' { `
             "src\NuGetGallery.Core\NuGetGallery.Core.csproj",
             "src\NuGetGallery.Services\NuGetGallery.Services.csproj"
         $GalleryProjects | ForEach-Object {
-            New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -BuildNumber $BuildNumber -Version $GalleryPackageVersion -Branch $Branch -Symbols
+            New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -Symbols -Options $packageVersions
         }
         
         $GalleryNuspecProjects =
@@ -197,7 +199,7 @@ Invoke-BuildStep 'Creating jobs artifacts' {
             "src\Validation.ScanAndSign.Core\Validation.ScanAndSign.Core.csproj",
             "src\Validation.Symbols.Core\Validation.Symbols.Core.csproj"
         $JobsProjects | ForEach-Object {
-            New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -BuildNumber $BuildNumber -Version $JobsPackageVersion -Branch $Branch -Symbols
+            New-ProjectPackage (Join-Path $PSScriptRoot $_) -Configuration $Configuration -Symbols -Options $packageVersions
         }
 
         $JobsNuspecProjects =

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -762,7 +762,8 @@ Function New-ProjectPackage {
         [string]$Branch,
         [switch]$IncludeReferencedProjects,
         [switch]$Sign,
-        [switch]$BinLog
+        [switch]$BinLog,
+        [string[]]$Options
     )
     Trace-Log "Creating package from @""$TargetFilePath"""
     
@@ -789,6 +790,8 @@ Function New-ProjectPackage {
     }
     elseif ($ReleaseLabel) {
         $PackageVersion = Get-PackageVersion $ReleaseLabel $BuildNumber
+    } else {
+        $PackageVersion = $null
     }
     
     if ($PackageVersion) {
@@ -809,6 +812,10 @@ Function New-ProjectPackage {
     
     if ($BinLog) {
         $opts += "/bl"
+    }
+
+    if ($Options) {
+        $opts += $Options
     }
 
     if (-not (Test-Path $Artifacts)) {

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <Description>Create, edit, or read the package metadata catalog.</Description>
     <PackageTags>nuget;services;search;catalog;metadata;collector</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.PackageManagement.Search.Web/Microsoft.PackageManagement.Search.Web.csproj
+++ b/src/Microsoft.PackageManagement.Search.Web/Microsoft.PackageManagement.Search.Web.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <RootNamespace>NuGet.Jobs</RootNamespace>
     <Description>Common infrastructure for running the NuGetGallery back-end jobs.</Description>
   </PropertyGroup>

--- a/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
+++ b/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <Description>A .NET library for consuming the NuGet API's catalog resource.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <Description>Push NuGetGallery DB packages or catalog leaves to Azure Search.</Description>
     <PackageTags>nuget azure search catalog leaf details incremental collector</PackageTags>
   </PropertyGroup>

--- a/src/NuGet.Services.Build/NuGet.Services.Build.csproj
+++ b/src/NuGet.Services.Build/NuGet.Services.Build.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Shared component to assist NuGet build scripts.</Description>
 
     <!--

--- a/src/NuGet.Services.Configuration/NuGet.Services.Configuration.csproj
+++ b/src/NuGet.Services.Configuration/NuGet.Services.Configuration.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Shared configuration management NuGet services.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
+++ b/src/NuGet.Services.Contracts/NuGet.Services.Contracts.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Interfaces used for NuGet services</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Cursor/NuGet.Services.Cursor.csproj
+++ b/src/NuGet.Services.Cursor/NuGet.Services.Cursor.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Shared cursor classes</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
+++ b/src/NuGet.Services.DatabaseMigration/NuGet.Services.DatabaseMigration.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\SdkProjects.props" />
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(GalleryPackageVersion)</PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Description>Core support library for NuGet database migration</Description>

--- a/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
+++ b/src/NuGet.Services.Entities/NuGet.Services.Entities.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(GalleryPackageVersion)</PackageVersion>
     <Description>Entities used for NuGet services</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.FeatureFlags/NuGet.Services.FeatureFlags.csproj
+++ b/src/NuGet.Services.FeatureFlags/NuGet.Services.FeatureFlags.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Dynamic feature toggles</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Incidents/NuGet.Services.Incidents.csproj
+++ b/src/NuGet.Services.Incidents/NuGet.Services.Incidents.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>A framework to access the NuGet incident API.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Key vault access for NuGet services</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Licenses/NuGet.Services.Licenses.csproj
+++ b/src/NuGet.Services.Licenses/NuGet.Services.Licenses.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Common license expression code</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
+++ b/src/NuGet.Services.Logging/NuGet.Services.Logging.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Shared server-side logging component for NuGet services.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
+++ b/src/NuGet.Services.Messaging.Email/NuGet.Services.Messaging.Email.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Components shared between the front-end and back-end concerning email messaging</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Messaging/NuGet.Services.Messaging.csproj
+++ b/src/NuGet.Services.Messaging/NuGet.Services.Messaging.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Logic shared between the front-end and back-end concerning asynchronous messaging</Description>
   </PropertyGroup>
         

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/NuGet.Services.Metadata.Catalog.Monitoring.csproj
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/NuGet.Services.Metadata.Catalog.Monitoring.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\SdkProjects.props" />
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Description>Monitor the package metadata catalog.</Description>

--- a/src/NuGet.Services.Owin/NuGet.Services.Owin.csproj
+++ b/src/NuGet.Services.Owin/NuGet.Services.Owin.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Shared OWIN code for the NuGet projects</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
+++ b/src/NuGet.Services.ServiceBus/NuGet.Services.ServiceBus.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Integration with Azure Service Bus</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Sql/NuGet.Services.Sql.csproj
+++ b/src/NuGet.Services.Sql/NuGet.Services.Sql.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Azure SQL access for NuGet services</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Status.Table/NuGet.Services.Status.Table.csproj
+++ b/src/NuGet.Services.Status.Table/NuGet.Services.Status.Table.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Contract to store NuGet service status in tables.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Status/NuGet.Services.Status.csproj
+++ b/src/NuGet.Services.Status/NuGet.Services.Status.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>A framework to produce and consume status reported about NuGet services.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
+++ b/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Shared server-side storage component for NuGet services</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Testing.Entities/NuGet.Services.Testing.Entities.csproj
+++ b/src/NuGet.Services.Testing.Entities/NuGet.Services.Testing.Entities.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Infrastructure to unit test Entity Framework entities.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.V3/NuGet.Services.V3.csproj
+++ b/src/NuGet.Services.V3/NuGet.Services.V3.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <Description>Common infrastructure for V3 back-end jobs, including catalog abstractions and dependency injection setup.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Validation.Issues/NuGet.Services.Validation.Issues.csproj
+++ b/src/NuGet.Services.Validation.Issues/NuGet.Services.Validation.Issues.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>User-visible issues emitted by NuGet services</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Validation/NuGet.Services.Validation.csproj
+++ b/src/NuGet.Services.Validation/NuGet.Services.Validation.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Logic shared between the front-end and back-end concerning asynchronous validation</Description>
 
     <!--

--- a/src/NuGetGallery.Core/NuGetGallery.Core.csproj
+++ b/src/NuGetGallery.Core/NuGetGallery.Core.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(GalleryPackageVersion)</PackageVersion>
     <RootNamespace>NuGetGallery</RootNamespace>
     <Description>Core support library for NuGet Gallery Frontend and Backend</Description>
   </PropertyGroup>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(GalleryPackageVersion)</PackageVersion>
     <Description>Services library for NuGet Gallery Frontend and Backend</Description>
   </PropertyGroup>
 

--- a/src/Stats.LogInterpretation/Stats.LogInterpretation.csproj
+++ b/src/Stats.LogInterpretation/Stats.LogInterpretation.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <PackageId>NuGet.Stats.LogInterpretation</PackageId>
   </PropertyGroup>
 

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <RootNamespace>NuGet.Jobs.Validation</RootNamespace>
     <AssemblyName>NuGet.Services.Validation.Common.Job</AssemblyName>
     <Description>Common job infrastructure for validation jobs and basic dependency injection setup.</Description>

--- a/src/Validation.ContentScan.Core/Validation.ContentScan.Core.csproj
+++ b/src/Validation.ContentScan.Core/Validation.ContentScan.Core.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\SdkProjects.props" />
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <RootNamespace>NuGet.Jobs.Validation.ContentScan</RootNamespace>
     <AssemblyName>NuGet.Jobs.Validation.ContentScan.Core</AssemblyName>
   </PropertyGroup>

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\SdkProjects.props" />
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <RootNamespace>NuGet.Jobs.Validation.ScanAndSign</RootNamespace>
     <AssemblyName>NuGet.Jobs.Validation.ScanAndSign.Core</AssemblyName>
   </PropertyGroup>

--- a/src/Validation.Symbols.Core/Validation.Symbols.Core.csproj
+++ b/src/Validation.Symbols.Core/Validation.Symbols.Core.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\SdkProjects.props" />
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <RootNamespace>NuGet.Jobs.Validation.Symbols.Core</RootNamespace>
     <AssemblyName>NuGet.Jobs.Validation.Symbols.Core</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
Currently, package references that are converted to project references by our `New-ProjectPackage` use the same version for all dependencies. This means references to ServerCommon packages in, say, NuGetGallery core would have `4.4.5-blah` version which is wrong.

This allows the proper package version to be set on each package not just when it is being packed (already works) but when it is being referred to during pack of another project.