### PR TITLE
First ResolveUri in NuGet.Services.Storage

### DIFF
--- a/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
+++ b/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -113,7 +113,7 @@ namespace GitHubVulnerabilities2v3.Extensions
 
         public async Task<int> WriteVulnerabilitiesAsync(IEnumerable<Tuple<PackageVulnerability, bool>> vulnerabilities)
         {
-            _firstVulnWrittenTimestamp = _firstVulnWrittenTimestamp == DateTime.MinValue ? DateTimeOffset.UtcNow : _firstVulnWrittenTimestamp;
+            _firstVulnWrittenTimestamp = _firstVulnWrittenTimestamp == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow : _firstVulnWrittenTimestamp;
             foreach (var vulnerability in vulnerabilities)
             {
                 await WriteVulnerabilityAsync(vulnerability.Item1, vulnerability.Item2);
@@ -124,7 +124,7 @@ namespace GitHubVulnerabilities2v3.Extensions
 
         public Task WriteVulnerabilityAsync(PackageVulnerability packageVulnerability, bool wasWithdrawn)
         {
-            _firstVulnWrittenTimestamp = _firstVulnWrittenTimestamp == DateTime.MinValue ? DateTimeOffset.UtcNow : _firstVulnWrittenTimestamp;
+            _firstVulnWrittenTimestamp = _firstVulnWrittenTimestamp == DateTimeOffset.MinValue ? DateTimeOffset.UtcNow : _firstVulnWrittenTimestamp;
             try
             {
                 if (!wasWithdrawn)

--- a/src/NuGet.Services.Storage/Storage.cs
+++ b/src/NuGet.Services.Storage/Storage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -190,7 +190,7 @@ namespace NuGet.Services.Storage
 
         public Uri ResolveUri(string relativeUri)
         {
-            return new Uri(BaseAddress, relativeUri);
+            return new Uri(BaseAddress.GetLeftPart(UriPartial.Path).TrimEnd('/') + "/" + relativeUri.TrimStart('/'));
         }
 
         protected string GetName(Uri uri)


### PR DESCRIPTION
This fixes the following jobs on the new storage SDK.

`ResolveUri` was not working since the container URL lost it's trailing `/`, leading to `new Uri(base, blob)` behavior changing. The cursor URL was resolving to the root of the blob storage account, not in the storage container. 

`GitHubVulnerabilities2Db` and `GitHubVulnernabilities2v3` were impacted.

Summary of changes:
- Fix `Storage.ResolveUri` to be tolerant of trailing and leading `/`. This fixes the GitHubVulnerabilities job cursors.
- Fix `DateTimeOffset.MinValue` comparison.
  - On a UTC machine `DateTimeOffset.MinValue == DateTime.MinValue` (our VMs). Locally this is not true. This makes local debugging harder. I think this was left over from a `DateTime` to `DateTimeOffset` refactoring that was uncaught cause it works on VM.