### PR TITLE
Add UseNuGetBuildExtensions to all entry points

### DIFF
--- a/SdkProjects.props
+++ b/SdkProjects.props
@@ -3,6 +3,7 @@
   These properties are only meant for projects using the newer SDK-based project style. Properties that are meant for
   all projects (both legacy .csproj and SDK-based .csproj) should be put in Directory.Build.props.
   -->
+
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -24,4 +25,12 @@
   <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
   <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
   <!-- NuGet signing block: end -->
+
+  <!-- Enable custom build tools for jobs and web apps. -->
+  <PropertyGroup>
+    <UseNuGetBuildExtensions Condition="'$(UseNuGetBuildExtensions)' == '' And '$(UsingMicrosoftNETSdkWeb)' == 'true'">true</UseNuGetBuildExtensions>
+    <UseNuGetBuildExtensions Condition="'$(UseNuGetBuildExtensions)' == '' And '$(UsingMicrosoftNETSdk)' == 'true' And '$(OutputType)' == 'Exe'">true</UseNuGetBuildExtensions>
+  </PropertyGroup>
+  <Import Condition="'$(UseNuGetBuildExtensions)' == 'true' And '$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" Project="$(NuGetBuildExtensions)" />
+
 </Project>

--- a/SdkProjects.props
+++ b/SdkProjects.props
@@ -26,11 +26,13 @@
   <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
   <!-- NuGet signing block: end -->
 
-  <!-- Enable custom build tools for jobs and web apps. -->
   <PropertyGroup>
+    <!-- Enabled for SDK-based web projects. -->
     <UseNuGetBuildExtensions Condition="'$(UseNuGetBuildExtensions)' == '' And '$(UsingMicrosoftNETSdkWeb)' == 'true'">true</UseNuGetBuildExtensions>
+    <!-- Enabled for EXE (console app) projects, which are jobs. -->
     <UseNuGetBuildExtensions Condition="'$(UseNuGetBuildExtensions)' == '' And '$(UsingMicrosoftNETSdk)' == 'true' And '$(OutputType)' == 'Exe'">true</UseNuGetBuildExtensions>
+    <!-- Other projects can opt in by setting the UseNuGetBuildExtensions property to true. -->
   </PropertyGroup>
-  <Import Condition="'$(UseNuGetBuildExtensions)' == 'true' And '$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" Project="$(NuGetBuildExtensions)" />
+  <Import Project="$(NuGetBuildExtensions)" Condition="'$(UseNuGetBuildExtensions)' == 'true' And '$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" />
 
 </Project>

--- a/src/NuGet.Services.SearchService.Core/NuGet.Services.SearchService.Core.csproj
+++ b/src/NuGet.Services.SearchService.Core/NuGet.Services.SearchService.Core.csproj
@@ -11,6 +11,4 @@
     <ProjectReference Include="..\Microsoft.PackageManagement.Search.Web\Microsoft.PackageManagement.Search.Web.csproj" />
   </ItemGroup>
 
-  <Import Project="$(NuGetBuildExtensions)" Condition="'$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" />
-
 </Project>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2298,7 +2298,7 @@
   <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
   <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
   <!-- NuGet signing block: end -->
-  <Import Condition="'$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" Project="$(NuGetBuildExtensions)" />
+  <Import Project="$(NuGetBuildExtensions)" Condition="'$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2298,7 +2298,7 @@
   <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
   <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
   <!-- NuGet signing block: end -->
-  <Import Project="$(NuGetBuildExtensions)" Condition="'$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" />
+  <Import Condition="'$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" Project="$(NuGetBuildExtensions)" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">


### PR DESCRIPTION
This line was lost accidentally during the move to SDK-based .csproj prior to the repo merge. This is needed for our release build pipelines so that heartbeat monitoring and other metrics emitted from our OSS code works as expected.