### PR TITLE
Use auth for downloads.v1.json in stats and search jobs

### DIFF
--- a/src/Catalog/Downloads/DownloadsV1JsonClient.cs
+++ b/src/Catalog/Downloads/DownloadsV1JsonClient.cs
@@ -40,6 +40,7 @@ namespace NuGet.Services.Metadata.Catalog
             await Retry.IncrementalAsync(
                 async () =>
                 {
+                    _logger.LogInformation("Attempting to download {Url}", _blobClient.Uri.GetLeftPart(UriPartial.Path));
                     using (BlobDownloadStreamingResult result = await _blobClient.DownloadStreamingAsync())
                     using (var textReader = new StreamReader(result.Content))
                     using (var jsonReader = new JsonTextReader(textReader))

--- a/src/Catalog/Downloads/DownloadsV1JsonClient.cs
+++ b/src/Catalog/Downloads/DownloadsV1JsonClient.cs
@@ -1,11 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Net.Http;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using NuGet.Services.Metadata.Catalog.Helpers;
@@ -14,46 +16,42 @@ namespace NuGet.Services.Metadata.Catalog
 {
     public class DownloadsV1JsonClient : IDownloadsV1JsonClient
     {
-        private readonly HttpClient _httpClient;
+        private readonly BlobClient _blobClient;
         private readonly ILogger<DownloadsV1JsonClient> _logger;
 
-        public DownloadsV1JsonClient(HttpClient httpClient, ILogger<DownloadsV1JsonClient> logger)
+        public DownloadsV1JsonClient(BlobClient blobClient, ILogger<DownloadsV1JsonClient> logger)
         {
-            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _blobClient = blobClient ?? throw new ArgumentNullException(nameof(blobClient));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<DownloadData> ReadAsync(string url)
+        public async Task<DownloadData> ReadAsync()
         {
             var downloadData = new DownloadData();
-            await ReadAsync(url, downloadData.SetDownloadCount);
+            await ReadAsync(downloadData.SetDownloadCount);
             return downloadData;
         }
 
-        public async Task ReadAsync(string url, AddDownloadCount addCount)
+        public async Task ReadAsync(AddDownloadCount addCount)
         {
             var stopwatch = Stopwatch.StartNew();
             var packageCount = 0;
-            
+
             await Retry.IncrementalAsync(
                 async () =>
                 {
-                    _logger.LogInformation("Attempting to download {Url}", url);
-                    using (var response = await _httpClient.GetAsync(url))
+                    using (BlobDownloadStreamingResult result = await _blobClient.DownloadStreamingAsync())
+                    using (var textReader = new StreamReader(result.Content))
+                    using (var jsonReader = new JsonTextReader(textReader))
                     {
-                        response.EnsureSuccessStatusCode();
-                        using (var textReader = new StreamReader(await response.Content.ReadAsStreamAsync()))
-                        using (var jsonReader = new JsonTextReader(textReader))
+                        DownloadsV1Reader.Load(jsonReader, (id, version, count) =>
                         {
-                            DownloadsV1Reader.Load(jsonReader, (id, version, count) =>
-                            {
-                                packageCount++;
-                                addCount(id, version, count);
-                            });
-                        }
+                            packageCount++;
+                            addCount(id, version, count);
+                        });
                     }
                 },
-                ex => ex is HttpRequestException,
+                ex => ex is RequestFailedException,
                 maxRetries: 5,
                 initialWaitInterval: TimeSpan.Zero,
                 waitIncrement: TimeSpan.FromSeconds(20));

--- a/src/Catalog/Downloads/IDownloadsV1JsonClient.cs
+++ b/src/Catalog/Downloads/IDownloadsV1JsonClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
@@ -9,7 +9,7 @@ namespace NuGet.Services.Metadata.Catalog
 
     public interface IDownloadsV1JsonClient
     {
-        Task<DownloadData> ReadAsync(string url);
-        Task ReadAsync(string url, AddDownloadCount addCount);
+        Task<DownloadData> ReadAsync();
+        Task ReadAsync(AddDownloadCount addCount);
     }
 }

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -73,6 +73,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Protocol.Catalog\NuGet.Protocol.Catalog.csproj" />
+    <ProjectReference Include="..\NuGet.Services.Configuration\NuGet.Services.Configuration.csproj" />
     <ProjectReference Include="..\NuGet.Services.Logging\NuGet.Services.Logging.csproj" />
     <ProjectReference Include="..\NuGet.Services.Sql\NuGet.Services.Sql.csproj" />
     <ProjectReference Include="..\NuGetGallery.Core\NuGetGallery.Core.csproj" />

--- a/src/Catalog/ServiceCollectionExtensions.cs
+++ b/src/Catalog/ServiceCollectionExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.Configuration;
+using NuGet.Services.Metadata.Catalog;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddDownloadsV1JsonClient(this IServiceCollection services, Func<IServiceProvider, string> urlFactory)
+        {
+            services.AddSingleton<IDownloadsV1JsonClient>(provider =>
+            {
+                var url = urlFactory(provider);
+
+                var configuration = provider.GetRequiredService<IConfiguration>();
+                var blobClient = new BlobClient(new Uri(url), configuration.GetTokenCredential());
+
+                var logger = provider.GetRequiredService<ILogger<DownloadsV1JsonClient>>();
+
+                return new DownloadsV1JsonClient(blobClient, logger);
+            });
+            return services;
+        }
+    }
+}

--- a/src/NuGet.Jobs.Auxiliary2AzureSearch/Job.cs
+++ b/src/NuGet.Jobs.Auxiliary2AzureSearch/Job.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.Auxiliary2AzureSearch;
 
@@ -19,6 +20,11 @@ namespace NuGet.Jobs
             services.Configure<Auxiliary2AzureSearchConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.Configure<AzureSearchJobConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.Configure<AzureSearchConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
+            services.AddDownloadsV1JsonClient(provider =>
+            {
+                var jsonConfigurationAccessor = provider.GetRequiredService<IOptionsSnapshot<Auxiliary2AzureSearchConfiguration>>();
+                return jsonConfigurationAccessor.Value.DownloadsV1JsonUrl;
+            });
         }
     }
 }

--- a/src/NuGet.Jobs.Db2AzureSearch/Job.cs
+++ b/src/NuGet.Jobs.Db2AzureSearch/Job.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Db2AzureSearch;
@@ -26,6 +27,11 @@ namespace NuGet.Jobs
                 configurationRoot.GetSection(DevelopmentConfigurationSectionName));
             services.Configure<Db2AzureSearchDevelopmentConfiguration>(
                 configurationRoot.GetSection(DevelopmentConfigurationSectionName));
+            services.AddDownloadsV1JsonClient(provider =>
+            {
+                var jsonConfigurationAccessor = provider.GetRequiredService<IOptionsSnapshot<Db2AzureSearchConfiguration>>();
+                return jsonConfigurationAccessor.Value.DownloadsV1JsonUrl;
+            });
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/UpdateDownloadsCommand.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/UpdateDownloadsCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -117,7 +117,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 
             // The "new" data in this case is from the statistics pipeline.
             _logger.LogInformation("Fetching new download count data by URL.");
-            var newData = await _downloadsV1JsonClient.ReadAsync(_options.Value.DownloadsV1JsonUrl);
+            var newData = await _downloadsV1JsonClient.ReadAsync();
 
             _logger.LogInformation("Removing invalid IDs and versions from the old downloads data.");
             CleanDownloadData(oldResult.Data);

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationFromDbProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationFromDbProducer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -94,7 +94,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             // Fetch the download data from the auxiliary file, since this is what is used for displaying download
             // counts in the search service. We don't use the gallery DB values as they are different from the
             // auxiliary file.
-            var downloads = await _downloadsV1JsonClient.ReadAsync(_options.Value.DownloadsV1JsonUrl);
+            var downloads = await _downloadsV1JsonClient.ReadAsync();
             var popularityTransfers = await GetPopularityTransfersAsync();
 
             // Apply changes from popularity transfers.

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -26,7 +26,6 @@ using NuGet.Services.AzureSearch.Catalog2AzureSearch;
 using NuGet.Services.AzureSearch.Db2AzureSearch;
 using NuGet.Services.AzureSearch.SearchService;
 using NuGet.Services.AzureSearch.Wrappers;
-using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Persistence;
 using NuGet.Services.V3;
 using NuGetGallery;
@@ -316,7 +315,6 @@ namespace NuGet.Services.AzureSearch
                     }
                 });
 
-            services.AddTransient<IDownloadsV1JsonClient, DownloadsV1JsonClient>();
             services.AddSingleton<IAuxiliaryDataCache, AuxiliaryDataCache>();
             services.AddScoped(p => p.GetRequiredService<IAuxiliaryDataCache>().Get());
             services.AddSingleton<IAuxiliaryFileReloader, AuxiliaryFileReloader>();

--- a/src/NuGet.Services.Configuration/ConfigurationExtensions.cs
+++ b/src/NuGet.Services.Configuration/ConfigurationExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using Azure.Core;
+using Azure.Identity;
+using Microsoft.Extensions.Configuration;
+
+namespace NuGet.Services.Configuration
+{
+    public static class ConfigurationExtensions
+    {
+        public static TokenCredential GetTokenCredential(this IConfiguration configuration)
+        {
+            string clientId = configuration[Constants.ManagedIdentityClientIdKey];
+
+            if (!string.IsNullOrWhiteSpace(clientId))
+            {
+                return new ManagedIdentityCredential(clientId);
+            }
+
+            return new DefaultAzureCredential();
+        }
+    }
+}

--- a/src/Stats.AggregateCdnDownloadsInGallery/AggregateCdnDownloadsJob.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/AggregateCdnDownloadsJob.cs
@@ -207,13 +207,13 @@ namespace Stats.AggregateCdnDownloadsInGallery
                     }
                     if (newDownloadCount < currentDownloadCount)
                     {
-                        Logger.LogCritical(LogEvents.DownloadCountDecreaseDetected, "{PackageId} {CurrentDownloadCount} {NewDownloadCount}", packageRegistrationGroup.Key, currentDownloadCount, newDownloadCount);
+                        Logger.LogWarning(LogEvents.DownloadCountDecreaseDetected, "Decrease detected: {PackageId} {CurrentDownloadCount} -> {NewDownloadCount}", packageRegistrationGroup.Key, currentDownloadCount, newDownloadCount);
                     }
                 }
                 else
                 {
                     // This is not expected to happen as it should be one id per group. 
-                    Logger.LogCritical(LogEvents.IncorrectIdsInGroupBatch, "{GroupKey} {Ids}", packageRegistrationGroup.Key, string.Join(",", packageRegistrationGroup.Select(g => g.PackageId).Distinct()));
+                    Logger.LogCritical(LogEvents.IncorrectIdsInGroupBatch, "Incorrect IDs in group: {GroupKey} {Ids}", packageRegistrationGroup.Key, string.Join(",", packageRegistrationGroup.Select(g => g.PackageId).Distinct()));
                 }
             }
 

--- a/src/Stats.AggregateCdnDownloadsInGallery/Configuration/DownloadsV1JsonConfiguration.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Configuration/DownloadsV1JsonConfiguration.cs
@@ -1,11 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Stats.AggregateCdnDownloadsInGallery
 {
     public class DownloadsV1JsonConfiguration
     {
-        public string SqlPipelineUrl { get; set; }
         public string SynapsePipelineUrl { get; set; }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Integration/PopularityTransferIntegrationTests.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Integration/PopularityTransferIntegrationTests.cs
@@ -44,6 +44,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch.Integration
             _featureFlags = new Mock<IFeatureFlagService>();
             _telemetry = new Mock<IAzureSearchTelemetryService>();
             var mockBlockClient = new Mock<BlobClient>();
+            mockBlockClient.Setup(x => x.Uri).Returns(new Uri("https://example/downloads.v1.json"));
             mockBlockClient
                 .Setup(x => x.DownloadStreamingAsync(It.IsAny<BlobDownloadOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => Response.FromValue(

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/UpdateDownloadsCommandFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/UpdateDownloadsCommandFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -42,7 +42,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                 BatchPusher.Verify(x => x.TryFinishAsync(), Times.Never);
                 BatchPusher.Verify(x => x.TryPushFullBatchesAsync(), Times.Never);
                 DownloadsV1JsonClient.Verify(
-                    x => x.ReadAsync(Config.DownloadsV1JsonUrl),
+                    x => x.ReadAsync(),
                     Times.Once);
                 DownloadDataClient.Verify(
                     x => x.ReplaceLatestIndexedAsync(It.IsAny<DownloadData>(), It.IsAny<IAccessCondition>()),
@@ -502,7 +502,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
                     .Setup(x => x.ReadLatestIndexedAsync(It.IsAny<IAccessCondition>(), It.IsAny<StringCache>()))
                     .ReturnsAsync(() => OldDownloadResult);
                 NewDownloadData = new DownloadData();
-                DownloadsV1JsonClient.Setup(x => x.ReadAsync(It.IsAny<string>())).ReturnsAsync(() => NewDownloadData);
+                DownloadsV1JsonClient.Setup(x => x.ReadAsync()).ReturnsAsync(() => NewDownloadData);
 
                 Changes = new SortedDictionary<string, long>();
                 DownloadSetComparer

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationFromDbProducerFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationFromDbProducerFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -73,7 +73,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 _downloadsV1JsonClient = new Mock<IDownloadsV1JsonClient>();
                 _downloads = new DownloadData();
                 _downloadsV1JsonClient
-                    .Setup(x => x.ReadAsync(It.IsAny<string>()))
+                    .Setup(x => x.ReadAsync())
                     .ReturnsAsync(() => _downloads);
 
                 _popularityTransfers = new PopularityTransferData();


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/5576.

This changes `DownloadsV1JsonClient` to use `BlobClient` instead of `HttpClient`. The initialized blob client (`BlobClient`) in this case is meant to be a singleton so I inverted the control so the downloads.v1.json is provided via DI. This works because we really only have one downloads.v1.json URL at a time, coming from config. It doesn't need to be a parameter.

