### PR TITLE
Show DONE trace outside of the collapse build step block

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -158,10 +158,10 @@ Function Invoke-BuildStep {
         [switch]$SkipExecution
     )
     if (-not $SkipExecution) {
-        Trace-Log "[BEGIN] $BuildStep"
         if ($env:TF_BUILD) {
             Write-Output "##[group]$BuildStep"
         }
+        Trace-Log "[BEGIN] $BuildStep"
         $sw = [Diagnostics.Stopwatch]::StartNew()
         $completed = $false
 

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -158,11 +158,10 @@ Function Invoke-BuildStep {
         [switch]$SkipExecution
     )
     if (-not $SkipExecution) {
+        Trace-Log "[BEGIN] $BuildStep"
         if ($env:TF_BUILD) {
             Write-Output "##[group]$BuildStep"
         }
-
-        Trace-Log "[BEGIN] $BuildStep"
         $sw = [Diagnostics.Stopwatch]::StartNew()
         $completed = $false
 
@@ -173,6 +172,9 @@ Function Invoke-BuildStep {
         finally {
             $sw.Stop()
             Reset-Colors
+            if ($env:TF_BUILD) {
+                Write-Output "##[endgroup]"
+            }
             if ($completed) {
                 Trace-Log "[DONE +$(Format-ElapsedTime $sw.Elapsed)] $BuildStep"
             }
@@ -184,14 +186,10 @@ Function Invoke-BuildStep {
                     Error-Log "[FAILED +$(Format-ElapsedTime $sw.Elapsed)] $BuildStep"
                 }
             }
-
-            if ($env:TF_BUILD) {
-                Write-Output "##[endgroup]"
-            }
         }
     }
     else {
-        Warning-Log "[SKIP] $BuildStep"
+        Trace-Log "[SKIP] $BuildStep"
     }
 }
 


### PR DESCRIPTION
The build log looks like this in Azure DevOps:
![image](https://github.com/user-attachments/assets/294d1626-688c-4d3c-a5b8-9f2eab259889)

It's nice, but it could be even better if the stop lines are visible. This lets us see DONE/STOPPED/FAILED status as well as the step duration. Change SKIP to a warning since it's not a warning. Steps are disabled on demand.