### PR TITLE
Hotfix: add UTF-8 BOM for package details page Razor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,11 @@ insert_final_newline = true
 [*.{cs}]
 indent_size = 4
 
+; Razor files
+[*.{cshtml}]
+; Needed to avoid incorrect charset detection in the Razor compiler
+charset = utf-8-bom
+
 ; All XML-based file formats
 [*.{config,csproj,nuspec,props,resx,ruleset,targets,vsct,vsixmanifest,xaml,xml,vsmanproj,swixproj}]
 indent_size = 2

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -1,4 +1,4 @@
-@using NuGet.Services.Validation
+﻿@using NuGet.Services.Validation
 @using NuGet.Services.Licenses
 
 @model DisplayPackageViewModel


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/bfe9db99-3be5-4260-a723-d1ad528d66c4)

After:
![image](https://github.com/user-attachments/assets/a88f4089-2805-4d64-98e6-25a68b0dfa7c)
