### PR TITLE
Statistics and Auditing storage access update.

### DIFF
--- a/src/NuGetGallery.Services/Configuration/IBlobStorageConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/IBlobStorageConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGetGallery.Services
@@ -7,5 +7,7 @@ namespace NuGetGallery.Services
     {
         string ConnectionString { get; }
         bool ReadAccessGeoRedundant { get; }
+        string MsiClientId { get; }
+        bool UseMsi { get; }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/SimpleBlobStorageConfiguration.cs
+++ b/src/NuGetGallery.Services/Configuration/SimpleBlobStorageConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGetGallery.Services
@@ -17,10 +17,24 @@ namespace NuGetGallery.Services
             private set;
         }
 
-    public SimpleBlobStorageConfiguration(string connectionString, bool readAccessGeoRedundant)
+        public bool UseMsi
+        {
+            get;
+            private set;
+        }
+
+        public string MsiClientId
+        {
+            get;
+            private set;
+        }
+
+    public SimpleBlobStorageConfiguration(string connectionString, bool readAccessGeoRedundant, bool useMsi, string msiClientId)
         {
             ConnectionString = connectionString;
             ReadAccessGeoRedundant = readAccessGeoRedundant;
+            UseMsi = useMsi;
+            MsiClientId = msiClientId;
         }
     }
 }


### PR DESCRIPTION
Apparently, it was missed during the migration. Added an option to use MSI for statistics and auditing storage access.

Extracted the code that creates `CloudBlobClientWrapper` in different ways depending on configuration into a method of its own and reused it for statistics and audit storage.