### PR TITLE
Delete unused downloads and status folders

### DIFF
--- a/src/NuGetGallery.Core/CoreConstants.cs
+++ b/src/NuGetGallery.Core/CoreConstants.cs
@@ -33,7 +33,6 @@ namespace NuGetGallery
         {
             public const string UserCertificatesFolderName = "user-certificates";
             public const string ContentFolderName = "content";
-            public const string DownloadsFolderName = "downloads";
             public const string PackageBackupsFolderName = "package-backups";
             public const string PackageReadMesFolderName = "readmes";
             public const string PackagesFolderName = "packages";
@@ -41,7 +40,6 @@ namespace NuGetGallery
             public const string UploadsFolderName = "uploads";
             public const string ValidationFolderName = "validation";
             public const string RevalidationFolderName = "revalidation";
-            public const string StatusFolderName = "status";
             public const string SymbolPackagesFolderName = "symbol-packages";
             public const string SymbolPackageBackupsFolderName = "symbol-package-backups";
             public const string FlatContainerFolderName = "v3-flatcontainer";

--- a/src/NuGetGallery.Core/Services/GalleryCloudBlobContainerInformationProvider.cs
+++ b/src/NuGetGallery.Core/Services/GalleryCloudBlobContainerInformationProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,7 +11,6 @@ namespace NuGetGallery
     {
         private static readonly HashSet<string> KnownPublicFolders = new HashSet<string> {
             CoreConstants.Folders.PackagesFolderName,
-            CoreConstants.Folders.DownloadsFolderName,
             CoreConstants.Folders.SymbolPackagesFolderName,
             CoreConstants.Folders.FlatContainerFolderName,
         };
@@ -23,7 +22,6 @@ namespace NuGetGallery
             CoreConstants.Folders.ValidationFolderName,
             CoreConstants.Folders.UserCertificatesFolderName,
             CoreConstants.Folders.RevalidationFolderName,
-            CoreConstants.Folders.StatusFolderName,
             CoreConstants.Folders.PackagesContentFolderName,
             CoreConstants.Folders.PackageBackupsFolderName,
             CoreConstants.Folders.SymbolPackageBackupsFolderName,
@@ -41,11 +39,9 @@ namespace NuGetGallery
                 case CoreConstants.Folders.PackageBackupsFolderName:
                 case CoreConstants.Folders.UploadsFolderName:
                 case CoreConstants.Folders.SymbolPackageBackupsFolderName:
-                case CoreConstants.Folders.DownloadsFolderName:
                 case CoreConstants.Folders.PackageReadMesFolderName:
                 case CoreConstants.Folders.ContentFolderName:
                 case CoreConstants.Folders.RevalidationFolderName:
-                case CoreConstants.Folders.StatusFolderName:
                 case CoreConstants.Folders.UserCertificatesFolderName:
                 case CoreConstants.Folders.PackagesContentFolderName:
                 case CoreConstants.Folders.FlatContainerFolderName:
@@ -70,15 +66,11 @@ namespace NuGetGallery
                 case CoreConstants.Folders.FlatContainerFolderName:
                     return CoreConstants.PackageContentType;
 
-                case CoreConstants.Folders.DownloadsFolderName:
-                    return CoreConstants.OctetStreamContentType;
-
                 case CoreConstants.Folders.PackageReadMesFolderName:
                     return CoreConstants.TextContentType;
 
                 case CoreConstants.Folders.ContentFolderName:
                 case CoreConstants.Folders.RevalidationFolderName:
-                case CoreConstants.Folders.StatusFolderName:
                     return CoreConstants.JsonContentType;
 
                 case CoreConstants.Folders.UserCertificatesFolderName:

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGetGallery.Configuration;
@@ -308,9 +308,6 @@ namespace NuGetGallery
                 case CoreConstants.Folders.PackagesFolderName:
                 case CoreConstants.Folders.SymbolPackagesFolderName:
                     return CoreConstants.PackageContentType;
-
-                case CoreConstants.Folders.DownloadsFolderName:
-                    return CoreConstants.OctetStreamContentType;
 
                 default:
                     throw new InvalidOperationException(

--- a/tests/NuGetGallery.Core.Facts/Services/FolderNamesDataAttribute.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/FolderNamesDataAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -26,7 +26,6 @@ namespace NuGetGallery
                 {
                     // Folder name, is public, content type
                     new object[] { CoreConstants.Folders.ContentFolderName, false, CoreConstants.JsonContentType, },
-                    new object[] { CoreConstants.Folders.DownloadsFolderName, true, CoreConstants.OctetStreamContentType },
                     new object[] { CoreConstants.Folders.PackageBackupsFolderName, false, CoreConstants.PackageContentType },
                     new object[] { CoreConstants.Folders.PackageReadMesFolderName, false, CoreConstants.TextContentType },
                     new object[] { CoreConstants.Folders.PackagesFolderName, true, CoreConstants.PackageContentType },
@@ -37,7 +36,6 @@ namespace NuGetGallery
                     new object[] { CoreConstants.Folders.ValidationFolderName, false, CoreConstants.PackageContentType },
                     new object[] { CoreConstants.Folders.PackagesContentFolderName, false, CoreConstants.OctetStreamContentType },
                     new object[] { CoreConstants.Folders.RevalidationFolderName, false, CoreConstants.JsonContentType },
-                    new object[] { CoreConstants.Folders.StatusFolderName, false, CoreConstants.JsonContentType },
                     new object[] { CoreConstants.Folders.FlatContainerFolderName, true, CoreConstants.PackageContentType },
                 };
 


### PR DESCRIPTION
The "status" folder is managed by the status page and StatusAggregator. It is a config value not a constant.
The "downloads" folder was removed long ago with https://github.com/NuGet/NuGetGallery/pull/5483.