### PR TITLE
Move SecretDictionary away from sync-over-async

### DIFF
--- a/src/NuGet.Services.Configuration/SecretDictionary.cs
+++ b/src/NuGet.Services.Configuration/SecretDictionary.cs
@@ -1,11 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using NuGet.Services.KeyVault;
 
 namespace NuGet.Services.Configuration
@@ -122,14 +121,9 @@ namespace NuGet.Services.Configuration
         {
             if (!_notInjectedKeys.Contains(key))
             {
-                return Inject(value).Result;
+                return _secretInjector.Inject(value);
             }
             return value;
-        }
-
-        private Task<string> Inject(string value)
-        {
-            return _secretInjector.InjectAsync(value);
         }
     }
 }

--- a/src/NuGet.Services.KeyVault/EmptySecretReader.cs
+++ b/src/NuGet.Services.KeyVault/EmptySecretReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
@@ -8,6 +8,16 @@ namespace NuGet.Services.KeyVault
 {
     public class EmptySecretReader : ICachingSecretReader
     {
+        public string GetSecret(string secretName)
+        {
+            return GetSecret(secretName, logger: null);
+        }
+
+        public string GetSecret(string secretName, ILogger logger)
+        {
+            return secretName;
+        }
+
         public Task<string> GetSecretAsync(string secretName) => GetSecretAsync(secretName, logger: null);
 
         public Task<string> GetSecretAsync(string secretName, ILogger logger)
@@ -15,11 +25,21 @@ namespace NuGet.Services.KeyVault
             return Task.FromResult(secretName);
         }
 
+        public ISecret GetSecretObject(string secretName)
+        {
+            return GetSecretObject(secretName, logger: null);
+        }
+
+        public ISecret GetSecretObject(string secretName, ILogger logger)
+        {
+            return new KeyVaultSecret(secretName, secretName, null);
+        }
+
         public Task<ISecret> GetSecretObjectAsync(string secretName) => GetSecretObjectAsync(secretName, logger: null);
 
         public Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger)
         {
-            return Task.FromResult((ISecret)new KeyVaultSecret(secretName, secretName, null));
+            return Task.FromResult(GetSecretObject(secretName, logger));
         }
 
         public bool TryGetCachedSecret(string secretName, out string secretValue) => TryGetCachedSecret(secretName, logger: null, out secretValue);

--- a/src/NuGet.Services.KeyVault/IRefreshableSecretReaderFactory.cs
+++ b/src/NuGet.Services.KeyVault/IRefreshableSecretReaderFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
@@ -11,6 +11,13 @@ namespace NuGet.Services.KeyVault
     /// </summary>
     public interface IRefreshableSecretReaderFactory : ISecretReaderFactory
     {
+        /// <summary>
+        /// Refresh the values of the secrets that have already been read and cached. Since the cache is shared between
+        /// all <see cref="ISecretReader"/> instances creates, this refresh applies to all secret readers created by
+        /// this factory.
+        /// </summary>
+        void Refresh();
+
         /// <summary>
         /// Refresh the values of the secrets that have already been read and cached. Since the cache is shared between
         /// all <see cref="ISecretReader"/> instances creates, this refresh applies to all secret readers created by

--- a/src/NuGet.Services.KeyVault/ISecretInjector.cs
+++ b/src/NuGet.Services.KeyVault/ISecretInjector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
@@ -8,6 +8,8 @@ namespace NuGet.Services.KeyVault
 {
     public interface ISecretInjector
     {
+        string Inject(string input);
+        string Inject(string input, ILogger logger);
         Task<string> InjectAsync(string input);
         Task<string> InjectAsync(string input, ILogger logger);
     }

--- a/src/NuGet.Services.KeyVault/ISecretReader.cs
+++ b/src/NuGet.Services.KeyVault/ISecretReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
@@ -8,8 +8,12 @@ namespace NuGet.Services.KeyVault
 {
     public interface ISecretReader
     {
+        string GetSecret(string secretName);
+        string GetSecret(string secretName, ILogger logger);
         Task<string> GetSecretAsync(string secretName);
         Task<string> GetSecretAsync(string secretName, ILogger logger);
+        ISecret GetSecretObject(string secretName);
+        ISecret GetSecretObject(string secretName, ILogger logger);
         Task<ISecret> GetSecretObjectAsync(string secretName);
         Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger);
     }

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -33,6 +33,17 @@ namespace NuGet.Services.KeyVault
             _keyVaultClient = new Lazy<SecretClient>(InitializeClient);
         }
 
+        public string GetSecret(string secretName)
+        {
+            return GetSecret(secretName, logger: null);
+        }
+
+        public string GetSecret(string secretName, ILogger logger)
+        {
+            AzureSecurityKeyVaultSecret secret = _keyVaultClient.Value.GetSecret(secretName);
+            return secret.Value;
+        }
+
         public async Task<string> GetSecretAsync(string secretName)
         {
             return await GetSecretAsync(secretName, logger: null);
@@ -44,6 +55,17 @@ namespace NuGet.Services.KeyVault
             return secret.Value;
         }
 
+        public ISecret GetSecretObject(string secretName)
+        {
+            return GetSecretObject(secretName, logger: null);
+        }
+
+        public ISecret GetSecretObject(string secretName, ILogger logger)
+        {
+            AzureSecurityKeyVaultSecret secret = _keyVaultClient.Value.GetSecret(secretName);
+            return MapSecret(secretName, secret);
+        }
+
         public async Task<ISecret> GetSecretObjectAsync(string secretName)
         {
             return await GetSecretObjectAsync(secretName, logger: null);
@@ -52,6 +74,11 @@ namespace NuGet.Services.KeyVault
         public async Task<ISecret> GetSecretObjectAsync(string secretName, ILogger logger)
         {
             AzureSecurityKeyVaultSecret secret = await _keyVaultClient.Value.GetSecretAsync(secretName);
+            return MapSecret(secretName, secret);
+        }
+
+        private static ISecret MapSecret(string secretName, AzureSecurityKeyVaultSecret secret)
+        {
             return new KeyVaultSecret(secretName, secret.Value, secret.Properties.ExpiresOn);
         }
 

--- a/src/NuGet.Services.KeyVault/RefreshableSecretReaderFactory.cs
+++ b/src/NuGet.Services.KeyVault/RefreshableSecretReaderFactory.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 
 namespace NuGet.Services.KeyVault
 {
@@ -23,6 +24,11 @@ namespace NuGet.Services.KeyVault
             _underlyingFactory = underlyingFactory ?? throw new ArgumentNullException(nameof(underlyingFactory));
             _cache = new ConcurrentDictionary<string, ISecret>();
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        }
+
+        public void Refresh()
+        {
+            GetRefreshableSecretReader().Refresh();
         }
 
         public async Task RefreshAsync(CancellationToken token)

--- a/src/NuGet.Services.KeyVault/RefreshableSecretReaderFactory.cs
+++ b/src/NuGet.Services.KeyVault/RefreshableSecretReaderFactory.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 
 namespace NuGet.Services.KeyVault
 {

--- a/src/NuGet.Services.KeyVault/SecretInjector.cs
+++ b/src/NuGet.Services.KeyVault/SecretInjector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -35,6 +35,30 @@ namespace NuGet.Services.KeyVault
             _frame = frame;
             _secretReader = secretReader;
             _cachingSecretReader = secretReader as ICachingSecretReader;
+        }
+
+        public string Inject(string input)
+        {
+            return Inject(input, logger: null);
+        }
+
+        public string Inject(string input, ILogger logger)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return input;
+            }
+
+            var output = new StringBuilder(input);
+            var secretNames = GetSecretNames(input);
+
+            foreach (var secretName in secretNames)
+            {
+                var secretValue = _secretReader.GetSecret(secretName, logger);
+                output.Replace($"{_frame}{secretName}{_frame}", secretValue);
+            }
+
+            return output.ToString();
         }
 
         public Task<string> InjectAsync(string input)

--- a/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
+++ b/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build" ToolsVersion="15.0">
   <Import Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>

--- a/tests/NuGet.Services.Configuration.Tests/SecretDictionaryFacts.cs
+++ b/tests/NuGet.Services.Configuration.Tests/SecretDictionaryFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Moq;
@@ -18,7 +18,7 @@ namespace NuGet.Services.Configuration.Tests
         {
             // Arrange
             var mockSecretInjector = new Mock<ISecretInjector>();
-            mockSecretInjector.Setup(x => x.InjectAsync(It.IsAny<string>())).Returns(Task.FromResult(Secret1.InjectedValue));
+            mockSecretInjector.Setup(x => x.Inject(It.IsAny<string>())).Returns(Secret1.InjectedValue);
 
             var unprocessedDictionary = new Dictionary<string, string>()
             {
@@ -32,19 +32,19 @@ namespace NuGet.Services.Configuration.Tests
             var value2 = secretDict[Secret1.Key];
 
             // Assert
-            mockSecretInjector.Verify(x => x.InjectAsync(It.IsAny<string>()), Times.Exactly(2));
+            mockSecretInjector.Verify(x => x.Inject(It.IsAny<string>()), Times.Exactly(2));
             Assert.Equal(Secret1.InjectedValue, value1);
             Assert.Equal(value1, value2);
 
             // Arrange 2
-            mockSecretInjector.Setup(x => x.InjectAsync(It.IsAny<string>())).Returns(Task.FromResult(Secret2.InjectedValue));
+            mockSecretInjector.Setup(x => x.Inject(It.IsAny<string>())).Returns(Secret2.InjectedValue);
 
             // Act 2
             var value3 = secretDict[Secret1.Key];
             var value4 = secretDict[Secret1.Key];
 
             // Assert 2
-            mockSecretInjector.Verify(x => x.InjectAsync(It.IsAny<string>()), Times.Exactly(4));
+            mockSecretInjector.Verify(x => x.Inject(It.IsAny<string>()), Times.Exactly(4));
             Assert.Equal(Secret2.InjectedValue, value3);
             Assert.Equal(value3, value4);
         }
@@ -349,7 +349,7 @@ namespace NuGet.Services.Configuration.Tests
             var notInjectedKeys = new HashSet<string> { key };
 
             var mockSecretInjector = new Mock<ISecretInjector>();
-            mockSecretInjector.Setup(x => x.InjectAsync(It.IsAny<string>()));
+            mockSecretInjector.Setup(x => x.Inject(It.IsAny<string>()));
 
             var secretDict = CreatSecretDictionaryWithNotInjectedKeys(mockSecretInjector.Object,
                 unprocessedDictionary,
@@ -381,7 +381,7 @@ namespace NuGet.Services.Configuration.Tests
             // Act and Assert 6
             Assert.True(secretDict.Remove(key));
 
-            mockSecretInjector.Verify(x => x.InjectAsync(It.IsAny<string>()), Times.Never);
+            mockSecretInjector.Verify(x => x.Inject(It.IsAny<string>()), Times.Never);
         }
 
         /// <summary>
@@ -429,7 +429,7 @@ namespace NuGet.Services.Configuration.Tests
         private static Mock<ISecretInjector> CreateMappedSecretInjectorMock(IDictionary<string, string> keyToValue)
         {
             var mockSecretInjector = new Mock<ISecretInjector>();
-            mockSecretInjector.Setup(x => x.InjectAsync(It.IsAny<string>())).Returns<string>(key => Task.FromResult(keyToValue[key]));
+            mockSecretInjector.Setup(x => x.Inject(It.IsAny<string>())).Returns<string>(key => keyToValue[key]);
             return mockSecretInjector;
         }
         

--- a/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFormatterFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -58,16 +58,29 @@ namespace NuGet.Services.KeyVault.Tests
             var mockKeyVault = new Mock<ISecretReader>();
             mockKeyVault.Setup(x => x.GetSecretAsync(It.IsAny<string>(), It.IsAny<ILogger>()))
                 .Returns((string s, ILogger logger) => Task.FromResult(s.ToUpper()));
+            mockKeyVault.Setup(x => x.GetSecret(It.IsAny<string>(), It.IsAny<ILogger>()))
+                .Returns((string s, ILogger logger) => s.ToUpper());
 
             _secretInjector = new SecretInjector(mockKeyVault.Object);
         }
 
         [Theory]
         [MemberData(nameof(_testFormatParameters))]
-        public async Task TestFormat(string input, string expectedOutput)
+        public async Task TestFormatAsync(string input, string expectedOutput)
         {
             // Act
             string formattedString = await _secretInjector.InjectAsync(input);
+
+            // Assert
+            formattedString.Should().BeEquivalentTo(expectedOutput);
+        }
+
+        [Theory]
+        [MemberData(nameof(_testFormatParameters))]
+        public void TestFormat(string input, string expectedOutput)
+        {
+            // Act
+            string formattedString = _secretInjector.Inject(input);
 
             // Assert
             formattedString.Should().BeEquivalentTo(expectedOutput);

--- a/tests/NuGet.Services.KeyVault.Tests/SecretReaderFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/SecretReaderFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -10,6 +10,31 @@ namespace NuGet.Services.KeyVault.Tests
 {
     public class SecretReaderFacts
     {
+        [Fact]
+        public void GetSecretObjectReturnsSecretExpiry()
+        {
+            // Arrange
+            const string secretName = "secretname";
+            const string secretValue = "testValue";
+            DateTime secretExpiration = DateTime.UtcNow.AddSeconds(3);
+            KeyVaultSecret secret = new KeyVaultSecret(secretName, secretValue, secretExpiration);
+
+            var mockSecretReader = new Mock<ISecretReader>();
+            mockSecretReader
+                .SetupSequence(x => x.GetSecretObject(It.IsAny<string>()))
+                .Returns(secret);
+
+            var cachingSecretReader = new CachingSecretReader(mockSecretReader.Object);
+
+            // Act
+            var secretObject = cachingSecretReader.GetSecretObject(secretName);
+
+            // Assert
+            mockSecretReader.Verify(x => x.GetSecretObject(It.IsAny<string>()), Times.Once);
+            Assert.Equal(secretValue, secretObject.Value);
+            Assert.Equal(secretObject.Expiration, secretExpiration);
+        }
+
         [Fact]
         public async Task GetSecretObjectAsyncReturnsSecretExpiry()
         {


### PR DESCRIPTION
The new KeyVault SDK has a sync path that we can use. This adds `GetSecret` methods in addition to `GetSecretAsync` methods. The `SecretDictionary` can now use proper sync methods all the way through.

I saw MonitoringProcessor deadlock in DEV and INT, but not in PROD, all on the same bits. I captured a dump and saw it blocked on async KeyVault APIs inside a sync context. I believe this is a sync-over-async deadlock.

Progress on https://github.com/NuGet/NuGetGallery/issues/10146.
