### PR TITLE
Migrating Validation jobs to new SDK + MSI (subset of jobs that had migrating NuGetGallery dependencies)

### DIFF
--- a/src/NuGet.Jobs.Catalog2Registration/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/DependencyInjectionExtensions.cs
@@ -28,13 +28,8 @@ namespace NuGet.Jobs.Catalog2Registration
             RegisterCursorStorage(containerBuilder);
 
             containerBuilder
-                .Register<ICloudBlobClient>(c =>
-                {
-                    var options = c.Resolve<IOptionsSnapshot<Catalog2RegistrationConfiguration>>();
-                    return new CloudBlobClientWrapper(
-                        options.Value.StorageConnectionString,
-                        requestTimeout: DefaultBlobRequestOptions.ServerTimeout);
-                });
+                .RegisterStorageAccount<Catalog2RegistrationConfiguration>(c => c.StorageConnectionString, requestTimeout: DefaultBlobRequestOptions.ServerTimeout)
+                .As<ICloudBlobClient>();
 
             containerBuilder.Register(c => new Catalog2RegistrationCommand(
                 c.Resolve<ICollector>(),

--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -197,13 +197,7 @@ namespace NuGet.Jobs
         public static void ConfigureFeatureFlagAutofacServices(ContainerBuilder containerBuilder)
         {
             containerBuilder
-                .Register(c =>
-                {
-                    var options = c.Resolve<IOptionsSnapshot<FeatureFlagConfiguration>>();
-                    return new CloudBlobClientWrapper(
-                        options.Value.ConnectionString,
-                        requestTimeout: TimeSpan.FromMinutes(2));
-                })
+                .RegisterStorageAccount<FeatureFlagConfiguration>(c => c.ConnectionString, requestTimeout: TimeSpan.FromMinutes(2))
                 .Keyed<ICloudBlobClient>(FeatureFlagBindingKey);
 
             containerBuilder

--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -167,6 +167,7 @@ namespace NuGet.Jobs
             services.Configure<ValidationDbConfiguration>(configurationRoot.GetSection(ValidationDbConfigurationSectionName));
             services.Configure<ServiceBusConfiguration>(configurationRoot.GetSection(ServiceBusConfigurationSectionName));
             services.Configure<ValidationStorageConfiguration>(configurationRoot.GetSection(ValidationStorageConfigurationSectionName));
+            services.ConfigureStorageMsi(configurationRoot);
 
             services.AddSingleton(new TelemetryClient(ApplicationInsightsConfiguration.TelemetryConfiguration));
             services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();

--- a/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
+++ b/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
@@ -13,8 +13,8 @@ namespace NuGet.Jobs
 {
     public static class StorageAccountHelper
     {
-        private const string StorageUseManagedIdentityProperyName = "Storage_UseManagedIdentity";
-        private const string StorageManagedIdentityClientIdProperyName = "Storage_ManagedIdentityClientId";
+        private const string StorageUseManagedIdentityPropertyName = "Storage_UseManagedIdentity";
+        private const string StorageManagedIdentityClientIdPropertyName = "Storage_ManagedIdentityClientId";
 
         public static IServiceCollection ConfigureStorageMsi(this IServiceCollection serviceCollection, IConfiguration configuration)
         {
@@ -27,8 +27,8 @@ namespace NuGet.Jobs
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            string useManagedIdentityStr = configuration[StorageUseManagedIdentityProperyName];
-            string managedIdentityClientId = configuration[StorageManagedIdentityClientIdProperyName];
+            string useManagedIdentityStr = configuration[StorageUseManagedIdentityPropertyName];
+            string managedIdentityClientId = configuration[StorageManagedIdentityClientIdPropertyName];
             bool useManagedIdentity = false;
             if (!string.IsNullOrWhiteSpace(useManagedIdentityStr))
             {

--- a/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
+++ b/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
@@ -7,20 +7,18 @@ using Autofac.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NuGet.Services.Configuration;
 using NuGetGallery;
 
 namespace NuGet.Jobs
 {
     public static class StorageAccountHelper
     {
-        private const string StorageUseManagedIdentityPropertyName = "Storage_UseManagedIdentity";
-        private const string StorageManagedIdentityClientIdPropertyName = "Storage_ManagedIdentityClientId";
-
         public static IServiceCollection ConfigureStorageMsi(
             this IServiceCollection serviceCollection,
             IConfiguration configuration,
-            string useManageIdentityPropertyName = null,
-            string managedIdentityClientIdPropertyName = null)
+            string storageUseManagedIdentityPropertyName = null,
+            string storageManagedIdentityClientIdPropertyName = null)
         {
             if (serviceCollection == null)
             {
@@ -31,11 +29,13 @@ namespace NuGet.Jobs
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            useManageIdentityPropertyName ??= StorageUseManagedIdentityPropertyName;
-            managedIdentityClientIdPropertyName ??= StorageManagedIdentityClientIdPropertyName;
+            storageUseManagedIdentityPropertyName ??= Constants.StorageUseManagedIdentityPropertyName;
+            storageManagedIdentityClientIdPropertyName ??= Constants.StorageManagedIdentityClientIdPropertyName;
 
-            string useManagedIdentityStr = configuration[useManageIdentityPropertyName];
-            string managedIdentityClientId = configuration[managedIdentityClientIdPropertyName];
+            string useManagedIdentityStr = configuration[storageUseManagedIdentityPropertyName];
+            string managedIdentityClientId = string.IsNullOrEmpty(configuration[storageManagedIdentityClientIdPropertyName])
+                                                ? configuration[Constants.ManagedIdentityClientIdKey]
+                                                : configuration[storageManagedIdentityClientIdPropertyName];
             bool useManagedIdentity = false;
             if (!string.IsNullOrWhiteSpace(useManagedIdentityStr))
             {

--- a/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
+++ b/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
@@ -4,6 +4,8 @@
 using System;
 using Autofac;
 using Autofac.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NuGetGallery;
 
@@ -11,12 +13,52 @@ namespace NuGet.Jobs
 {
     public static class StorageAccountHelper
     {
+        private const string StorageUseManagedIdentityProperyName = "Storage_UseManagedIdentity";
+        private const string StorageManagedIdentityClientIdProperyName = "Storage_ManagedIdentityClientId";
+
+        public static IServiceCollection ConfigureStorageMsi(this IServiceCollection serviceCollection, IConfiguration configuration)
+        {
+            if (serviceCollection == null)
+            {
+                throw new ArgumentNullException(nameof(serviceCollection));
+            }
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            string useManagedIdentityStr = configuration[StorageUseManagedIdentityProperyName];
+            string managedIdentityClientId = configuration[StorageManagedIdentityClientIdProperyName];
+            bool useManagedIdentity = false;
+            if (!string.IsNullOrWhiteSpace(useManagedIdentityStr))
+            {
+                useManagedIdentity = bool.Parse(useManagedIdentityStr);
+            }
+            return serviceCollection.Configure<StorageMsiConfiguration>(storageConfiguration =>
+            {
+                storageConfiguration.UseManagedIdentity = useManagedIdentity;
+                storageConfiguration.ManagedIdentityClientId = managedIdentityClientId;
+            });
+        }
+
         public static CloudBlobClientWrapper CreateCloudBlobClient(
+            this IServiceProvider serviceProvider,
             string storageConnectionString,
             bool readAccessGeoRedundant = false,
             TimeSpan? requestTimeout = null)
         {
-            return new CloudBlobClientWrapper(
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+            if (string.IsNullOrWhiteSpace(storageConnectionString))
+            {
+                throw new ArgumentException($"{nameof(storageConnectionString)} cannot be null or empty.", nameof(storageConnectionString));
+            }
+
+            var msiConfiguration = serviceProvider.GetRequiredService<IOptions<StorageMsiConfiguration>>().Value;
+            return CreateCloudBlobClient(
+                msiConfiguration,
                 storageConnectionString,
                 readAccessGeoRedundant,
                 requestTimeout);
@@ -29,16 +71,58 @@ namespace NuGet.Jobs
             TimeSpan? requestTimeout = null)
             where TConfiguration : class, new()
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (getConnectionString == null)
+            {
+                throw new ArgumentNullException(nameof(getConnectionString));
+            }
+
             return builder.Register(c =>
             {
                 var options = c.Resolve<IOptionsSnapshot<TConfiguration>>();
                 string storageConnectionString = getConnectionString(options.Value);
                 bool readAccessGeoRedundant = getReadAccessGeoRedundant?.Invoke(options.Value) ?? false;
+                var msiConfiguration = c.Resolve<IOptions<StorageMsiConfiguration>>().Value;
                 return CreateCloudBlobClient(
+                    msiConfiguration,
                     storageConnectionString,
                     readAccessGeoRedundant,
                     requestTimeout);
             });
+        }
+
+        private static CloudBlobClientWrapper CreateCloudBlobClient(
+            StorageMsiConfiguration msiConfiguration,
+            string storageConnectionString,
+            bool readAccessGeoRedundant = false,
+            TimeSpan? requestTimeout = null)
+        {
+            if (msiConfiguration.UseManagedIdentity)
+            {
+                if (string.IsNullOrWhiteSpace(msiConfiguration.ManagedIdentityClientId))
+                {
+                    return CloudBlobClientWrapper.UsingDefaultAzureCredential(
+                        storageConnectionString,
+                        readAccessGeoRedundant: readAccessGeoRedundant,
+                        requestTimeout: requestTimeout);
+                }
+                else
+                {
+                    return CloudBlobClientWrapper.UsingMsi(
+                        storageConnectionString,
+                        msiConfiguration.ManagedIdentityClientId,
+                        readAccessGeoRedundant,
+                        requestTimeout);
+                }
+            }
+
+            return new CloudBlobClientWrapper(
+                storageConnectionString,
+                readAccessGeoRedundant,
+                requestTimeout);
         }
     }
 }

--- a/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
+++ b/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Autofac;
+using Autofac.Builder;
+using Microsoft.Extensions.Options;
+using NuGetGallery;
+
+namespace NuGet.Jobs
+{
+    public static class StorageAccountHelper
+    {
+        public static CloudBlobClientWrapper CreateCloudBlobClient(
+            string storageConnectionString,
+            bool readAccessGeoRedundant = false,
+            TimeSpan? requestTimeout = null)
+        {
+            return new CloudBlobClientWrapper(
+                storageConnectionString,
+                readAccessGeoRedundant,
+                requestTimeout);
+        }
+
+        public static IRegistrationBuilder<CloudBlobClientWrapper, SimpleActivatorData, SingleRegistrationStyle> RegisterStorageAccount<TConfiguration>(
+            this ContainerBuilder builder,
+            Func<TConfiguration, string> getConnectionString,
+            Func<TConfiguration, bool> getReadAccessGeoRedundant = null,
+            TimeSpan? requestTimeout = null)
+            where TConfiguration : class, new()
+        {
+            return builder.Register(c =>
+            {
+                var options = c.Resolve<IOptionsSnapshot<TConfiguration>>();
+                string storageConnectionString = getConnectionString(options.Value);
+                bool readAccessGeoRedundant = getReadAccessGeoRedundant?.Invoke(options.Value) ?? false;
+                return CreateCloudBlobClient(
+                    storageConnectionString,
+                    readAccessGeoRedundant,
+                    requestTimeout);
+            });
+        }
+    }
+}

--- a/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
+++ b/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,7 +16,11 @@ namespace NuGet.Jobs
         private const string StorageUseManagedIdentityPropertyName = "Storage_UseManagedIdentity";
         private const string StorageManagedIdentityClientIdPropertyName = "Storage_ManagedIdentityClientId";
 
-        public static IServiceCollection ConfigureStorageMsi(this IServiceCollection serviceCollection, IConfiguration configuration)
+        public static IServiceCollection ConfigureStorageMsi(
+            this IServiceCollection serviceCollection,
+            IConfiguration configuration,
+            string useManageIdentityPropertyName = null,
+            string managedIdentityClientIdPropertyName = null)
         {
             if (serviceCollection == null)
             {
@@ -27,8 +31,11 @@ namespace NuGet.Jobs
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            string useManagedIdentityStr = configuration[StorageUseManagedIdentityPropertyName];
-            string managedIdentityClientId = configuration[StorageManagedIdentityClientIdPropertyName];
+            useManageIdentityPropertyName ??= StorageUseManagedIdentityPropertyName;
+            managedIdentityClientIdPropertyName ??= StorageManagedIdentityClientIdPropertyName;
+
+            string useManagedIdentityStr = configuration[useManageIdentityPropertyName];
+            string managedIdentityClientId = configuration[managedIdentityClientIdPropertyName];
             bool useManagedIdentity = false;
             if (!string.IsNullOrWhiteSpace(useManagedIdentityStr))
             {

--- a/src/NuGet.Jobs.Common/StorageMsiConfiguration.cs
+++ b/src/NuGet.Jobs.Common/StorageMsiConfiguration.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Jobs
+{
+    public class StorageMsiConfiguration
+    {
+        public bool UseManagedIdentity { get; set; }
+        public string ManagedIdentityClientId { get; set; }
+    }
+}

--- a/src/NuGet.Jobs.GitHubIndexer/Job.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/Job.cs
@@ -42,16 +42,15 @@ namespace NuGet.Jobs.GitHubIndexer
             services.AddTransient<IRepositoriesCache, DiskRepositoriesCache>();
             services.AddTransient<IConfigFileParser, ConfigFileParser>();
             services.AddTransient<IRepoFetcher, RepoFetcher>();
-            services.AddTransient<ICloudBlobClient>(provider => {
-                var config = provider.GetRequiredService<IOptionsSnapshot<GitHubIndexerConfiguration>>();
-                return new CloudBlobClientWrapper(config.Value.StorageConnectionString, config.Value.StorageReadAccessGeoRedundant);
-            });
 
             services.Configure<GitHubIndexerConfiguration>(configurationRoot.GetSection(GitHubIndexerConfigurationSectionName));
         }
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder, IConfigurationRoot configurationRoot)
         {
+            containerBuilder
+                .RegisterStorageAccount<GitHubIndexerConfiguration>(c => c.StorageConnectionString, c => c.StorageReadAccessGeoRedundant)
+                .As<ICloudBlobClient>();
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Rest;
+using NuGet.Jobs;
 using NuGet.Protocol;
 using NuGet.Services.AzureSearch.Auxiliary2AzureSearch;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -109,13 +109,7 @@ namespace NuGet.Services.AzureSearch
         private static void RegisterAzureSearchStorageServices(ContainerBuilder containerBuilder, string key)
         {
             containerBuilder
-                .Register<ICloudBlobClient>(c =>
-                {
-                    var options = c.Resolve<IOptionsSnapshot<AzureSearchConfiguration>>();
-                    return new CloudBlobClientWrapper(
-                        options.Value.StorageConnectionString,
-                        requestTimeout: DefaultBlobRequestOptions.ServerTimeout);
-                })
+                .RegisterStorageAccount<AzureSearchConfiguration>(c => c.StorageConnectionString, requestTimeout: DefaultBlobRequestOptions.ServerTimeout)
                 .Keyed<ICloudBlobClient>(key);
 
             containerBuilder
@@ -222,13 +216,9 @@ namespace NuGet.Services.AzureSearch
         private static void RegisterAuxiliaryDataStorageServices(ContainerBuilder containerBuilder, string key)
         {
             containerBuilder
-                .Register<ICloudBlobClient>(c =>
-                {
-                    var options = c.Resolve<IOptionsSnapshot<AuxiliaryDataStorageConfiguration>>();
-                    return new CloudBlobClientWrapper(
-                        options.Value.AuxiliaryDataStorageConnectionString,
-                        requestTimeout: DefaultBlobRequestOptions.ServerTimeout);
-                })
+                .RegisterStorageAccount<AuxiliaryDataStorageConfiguration>(
+                    c => c.AuxiliaryDataStorageConnectionString,
+                    requestTimeout: DefaultBlobRequestOptions.ServerTimeout)
                 .Keyed<ICloudBlobClient>(key);
 
             containerBuilder

--- a/src/NuGet.Services.Configuration/Constants.cs
+++ b/src/NuGet.Services.Configuration/Constants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.Services.Configuration
@@ -15,5 +15,7 @@ namespace NuGet.Services.Configuration
         public static string KeyVaultStoreNameKey = "KeyVault_StoreName";
         public static string KeyVaultStoreLocationKey = "KeyVault_StoreLocation";
         public static string KeyVaultSendX5c = "KeyVault_SendX5c";
+        public static string StorageUseManagedIdentityPropertyName = "Storage_UseManagedIdentity";
+        public static string StorageManagedIdentityClientIdPropertyName = "Storage_ManagedIdentityClientId";
     }
 }

--- a/src/NuGet.Services.V3/NuGet.Services.V3.csproj
+++ b/src/NuGet.Services.V3/NuGet.Services.V3.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="WindowsAzure.Storage" />
     <ProjectReference Include="..\Catalog\NuGet.Services.Metadata.Catalog.csproj" />
     <ProjectReference Include="..\Validation.Common.Job\Validation.Common.Job.csproj" />
   </ItemGroup>

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Autofac;
 using Autofac.Core;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -181,13 +181,6 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<IBrokeredMessageSerializer<PackageValidationMessageData>, PackageValidationMessageDataSerializationAdapter>();
             services.AddTransient<ICriteriaEvaluator<Package>, PackageCriteriaEvaluator>();
             services.AddTransient<IProcessSignatureEnqueuer, ProcessSignatureEnqueuer>();
-            services.AddTransient<ICloudBlobClient>(c =>
-            {
-                var configurationAccessor = c.GetRequiredService<IOptionsSnapshot<ValidationConfiguration>>();
-                return new CloudBlobClientWrapper(
-                    configurationAccessor.Value.ValidationStorageConnectionString,
-                    readAccessGeoRedundant: false);
-            });
             services.AddTransient<ICloudBlobContainerInformationProvider, GalleryCloudBlobContainerInformationProvider>();
             services.AddTransient<ICoreFileStorageService, CloudBlobCoreFileStorageService>();
             services.AddTransient<IFileDownloader, FileDownloader>();
@@ -237,6 +230,10 @@ namespace NuGet.Services.Validation.Orchestrator
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder, IConfigurationRoot configurationRoot)
         {
+            containerBuilder
+                .RegisterStorageAccount<ValidationConfiguration>(c => c.ValidationStorageConnectionString)
+                .As<ICloudBlobClient>();
+
             containerBuilder
                 .Register(c =>
                 {
@@ -457,13 +454,7 @@ namespace NuGet.Services.Validation.Orchestrator
         private static void ConfigureFlatContainer(ContainerBuilder builder)
         {
             builder
-                .Register<CloudBlobClientWrapper>(c =>
-                {
-                    var configurationAccessor = c.Resolve<IOptionsSnapshot<FlatContainerConfiguration>>();
-                    return new CloudBlobClientWrapper(
-                        configurationAccessor.Value.ConnectionString,
-                        readAccessGeoRedundant: false);
-                })
+                .RegisterStorageAccount<FlatContainerConfiguration>(c => c.ConnectionString)
                 .Keyed<ICloudBlobClient>(FlatContainerBindingKey);
 
             builder

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Autofac;
 using Autofac.Core;
 using Azure.Storage.Blobs;
-using Azure.Storage.Blobs;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/NuGetGallery.Core/Extensions/ConnectionStringExtensions.cs
+++ b/src/NuGetGallery.Core/Extensions/ConnectionStringExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+
+namespace NuGetGallery
+{
+    public static class ConnectionStringExtensions
+    {
+        public static Uri GetBlobEndpointFromConnectionString(string connectionString)
+        {
+            var tempClient = new BlobServiceClient(connectionString);
+            // if _storageConnectionString has SAS token, Uri will contain SAS signature, we need to strip it
+            var uriBuilder = new UriBuilder(tempClient.Uri);
+            uriBuilder.Query = "";
+            uriBuilder.Fragment = "";
+            return uriBuilder.Uri;
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -177,12 +177,7 @@ namespace NuGetGallery
 
         private Uri GetPrimaryServiceUri()
         {
-            var tempClient = new BlobServiceClient(_storageConnectionString);
-            // if _storageConnectionString has SAS token, Uri will contain SAS signature, we need to strip it
-            var uriBuilder = new UriBuilder(tempClient.Uri);
-            uriBuilder.Query = "";
-            uriBuilder.Fragment = "";
-            return uriBuilder.Uri;
+            return ConnectionStringExtensions.GetBlobEndpointFromConnectionString(_storageConnectionString);
         }
 
         private Uri GetSecondaryServiceUri()

--- a/src/Validation.Common.Job/Leases/CloudBlobLeaseService.cs
+++ b/src/Validation.Common.Job/Leases/CloudBlobLeaseService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="NuGet.Packaging" />
-    <PackageReference Include="WindowsAzure.Storage" />
     <PackageReference Include="System.Formats.Asn1" />
   </ItemGroup>
 

--- a/src/Validation.Common.Job/ValidationJobBase.cs
+++ b/src/Validation.Common.Job/ValidationJobBase.cs
@@ -50,13 +50,6 @@ namespace NuGet.Jobs.Validation
             services.AddTransient<IFileDownloader, FileDownloader>();
             services.AddTransient<IServiceBusMessageSerializer, ServiceBusMessageSerializer>();
 
-            services.AddTransient<ICloudBlobClient>(c =>
-            {
-                var configurationAccessor = c.GetRequiredService<IOptionsSnapshot<ValidationStorageConfiguration>>();
-                return new CloudBlobClientWrapper(
-                    configurationAccessor.Value.ConnectionString,
-                    readAccessGeoRedundant: false);
-            });
             services.AddTransient<ICoreFileStorageService, CloudBlobCoreFileStorageService>();
             services.AddTransient<ISharedAccessSignatureService, SharedAccessSignatureService>();
 
@@ -96,6 +89,10 @@ namespace NuGet.Jobs.Validation
             base.ConfigureDefaultAutofacServices(containerBuilder, configurationRoot);
 
             ConfigureFeatureFlagAutofacServices(containerBuilder);
+
+            containerBuilder
+                .RegisterStorageAccount<ValidationStorageConfiguration>(c => c.ConnectionString)
+                .As<ICloudBlobClient>();
 
             containerBuilder
                 .Register(c =>

--- a/src/Validation.Symbols/Job.cs
+++ b/src/Validation.Symbols/Job.cs
@@ -5,6 +5,7 @@ using Autofac;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NuGet.Jobs;
 using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.Storage;
 using NuGet.Jobs.Validation.Symbols.Core;
@@ -32,16 +33,14 @@ namespace Validation.Symbols
             {
                 var configurationAccessor = c.GetRequiredService<IOptionsSnapshot<SymbolsValidatorConfiguration>>();
                 var packageStorageService = new CloudBlobCoreFileStorageService(
-                    new CloudBlobClientWrapper(
-                        configurationAccessor.Value.PackageConnectionString,
-                        readAccessGeoRedundant: false),
+                    StorageAccountHelper.CreateCloudBlobClient(
+                        configurationAccessor.Value.PackageConnectionString),
                     c.GetRequiredService<IDiagnosticsService>(),
                     c.GetRequiredService<ICloudBlobContainerInformationProvider>());
 
                 var packageValidationStorageService = new CloudBlobCoreFileStorageService(
-                    new CloudBlobClientWrapper(
-                        configurationAccessor.Value.ValidationPackageConnectionString,
-                        readAccessGeoRedundant: false),
+                    StorageAccountHelper.CreateCloudBlobClient(
+                        configurationAccessor.Value.ValidationPackageConnectionString),
                     c.GetRequiredService<IDiagnosticsService>(),
                     c.GetRequiredService<ICloudBlobContainerInformationProvider>());
 

--- a/src/Validation.Symbols/Job.cs
+++ b/src/Validation.Symbols/Job.cs
@@ -33,14 +33,12 @@ namespace Validation.Symbols
             {
                 var configurationAccessor = c.GetRequiredService<IOptionsSnapshot<SymbolsValidatorConfiguration>>();
                 var packageStorageService = new CloudBlobCoreFileStorageService(
-                    StorageAccountHelper.CreateCloudBlobClient(
-                        configurationAccessor.Value.PackageConnectionString),
+                    c.CreateCloudBlobClient(configurationAccessor.Value.PackageConnectionString),
                     c.GetRequiredService<IDiagnosticsService>(),
                     c.GetRequiredService<ICloudBlobContainerInformationProvider>());
 
                 var packageValidationStorageService = new CloudBlobCoreFileStorageService(
-                    StorageAccountHelper.CreateCloudBlobClient(
-                        configurationAccessor.Value.ValidationPackageConnectionString),
+                    c.CreateCloudBlobClient(configurationAccessor.Value.ValidationPackageConnectionString),
                     c.GetRequiredService<IDiagnosticsService>(),
                     c.GetRequiredService<ICloudBlobContainerInformationProvider>());
 

--- a/tests/Validation.Common.Job.Tests/Leases/BlobStorageFixture.cs
+++ b/tests/Validation.Common.Job.Tests/Leases/BlobStorageFixture.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Azure.Storage.Blobs;
 
 namespace Validation.Common.Job.Tests.Leases
 {
@@ -30,7 +29,7 @@ namespace Validation.Common.Job.Tests.Leases
             TestRunId = Guid.NewGuid().ToString();
             ConnectionString = GetEnvironmentVariable(ConnectionStringName, required: true);
 
-            GetContainerReference().CreateIfNotExists();
+            GetBlobContainerClient().CreateIfNotExists();
         }
 
         public string TestRunId { get; }
@@ -38,15 +37,13 @@ namespace Validation.Common.Job.Tests.Leases
 
         public void Dispose()
         {
-            GetContainerReference().DeleteIfExists();
+            GetBlobContainerClient().DeleteIfExists();
         }
 
-        private CloudBlobContainer GetContainerReference()
+        private BlobContainerClient GetBlobContainerClient()
         {
-            var account = CloudStorageAccount.Parse(ConnectionString);
-            var blobClient = account.CreateCloudBlobClient();
-            var container = blobClient.GetContainerReference(TestRunId);
-            return container;
+            var blobServiceClient = new BlobServiceClient(ConnectionString);
+            return blobServiceClient.GetBlobContainerClient(TestRunId);
         }
 
         private static string GetEnvironmentVariable(string name, bool required)


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/5440

### Background

This migrates some of the Validation Jobs to use MSI with the new SDKs. I've deployed these changes to DEV using these config files: https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetDeployment/pullrequest/2473, and E2E tests pass + I don't see any exceptions in AI logs.

These are the jobs I tested:
- [[NuGet][Continuous] Validation.Orchestrator](https://devdiv.visualstudio.com/DevDiv/_release?_a=releases&view=all&definitionId=1617)
- [[NuGet][Continuous] Validation.Symbols.Job](https://devdiv.visualstudio.com/DevDiv/_release?_a=releases&view=all&definitionId=1584)
- [[NuGet][Continuous] Validation.SymbolsOrchestrator](https://devdiv.visualstudio.com/DevDiv/_release?_a=releases&view=all&definitionId=1605)
- [[NuGet][Daily] Validation.PackageSigning.RevalidateCertificate](https://devdiv.visualstudio.com/DevDiv/_release?_a=releases&view=all&definitionId=1609)

### Description of the changes

1. @agr added support for the new SDK and MSI setup with the first few commits here. Some of these changes touch other jobs/projects too, like `GitHubIndexer` and `NuGet.Services.V3`. I haven't tested these jobs.
2. `Validation.Common.Job` had a reference for `WindowsAzure.Storage` that I had to remove. `NuGet.Services.V3` is downstream and consumes this package via `Validation.Common.Job`, so I had to add an explicit reference to this package in `NuGet.Services.V3`.
3. Configured the Lease service (used by the Validation Orchestrator jobs) to use MSI
4. There's some minor refactoring in `src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs`. I wanted to reuse some of the code in a private method there, so I extracted the logic to a public helper method in a new class: `src/NuGetGallery.Core/Extensions/ConnectionStringExtensions.cs`. If people have ideas on how to manage this better, I'm happy to hear them and make changes!

**Question:** `Validation.Common.Job` is consumed by many other projects and jobs, both in this repo and in `NuGet.Internal.Jobs`, so we will want to test everything together as well. Is there anything I should look to test _right now_ before we merge these changes? Or will we test these other jobs once their changes have been completed as well?