### PR TITLE
Fix sign for internal repo

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -212,7 +212,7 @@ Function Sign-Binaries {
     $projectsToSignProperty = $ProjectsToSign -join ';'
 
     $ProjectPath = Join-Path $PSScriptRoot "sign-binaries.proj"
-    Build-Solution $Configuration $BuildNumber -MSBuildVersion "$MSBuildVersion" $ProjectPath -MSBuildProperties "/p:ProjectsToSign=`"$projectsToSignProperty`"" -BinLog:$BinLog
+    Build-Solution $Configuration $BuildNumber -MSBuildVersion "$MSBuildVersion" $ProjectPath -MSBuildProperties "/p:ProjectsToSign=$projectsToSignProperty" -BinLog:$BinLog
 }
 
 Function Sign-Packages {


### PR DESCRIPTION
Partially addresses https://github.com/NuGet/Engineering/issues/5593
So far both this repo and other internal repo both compile without sign.proj error.
I have another draft PR for internal repo which can merged after merging this.