### PR TITLE
Fix file exist logic in init.ps1 file

### DIFF
--- a/build/init.ps1
+++ b/build/init.ps1
@@ -76,11 +76,13 @@ Function Get-BuildTools {
         $FileDirectory = Join-Path $NuGetClientRoot $Path
         $FilesToMove = Get-ChildItem -Path $FolderUri -File
         foreach ($File in $FilesToMove) {
-            if (-not (Test-Path (Join-Path $FileDirectory $File))) {
-                $File | Move-Item -Destination $FileDirectory
+            $DestinationFile = Join-Path $FileDirectory $File.Name
+            
+            if (-not (Test-Path $DestinationFile)) {
+                Move-Item -Path $File.FullName -Destination $FileDirectory
             }
             else {
-                Write-Host "File '$File' already exists, skipping" -ForegroundColor Blue
+                Write-Host "File '$($File.Name)' already exists, skipping" -ForegroundColor Blue
             }
         }
 


### PR DESCRIPTION
Related to https://github.com/NuGet/Engineering/issues/5593
After pointing the NuGetGallery instead of ServerCommon in internal repo, now we see this error on local build.
Please note you'll notice this error only during 1st build after cloning the repo.

In the original command, $File is an object of type FileInfo (or PSObject if not directly typed). When you pass the entire $File object to Join-Path, it may not behave as expected because Join-Path expects a string (or strings) that represent the components of a path. Passing a FileInfo object directly might cause unexpected results, especially since Join-Path isn't designed to handle objects but rather strings.
In the modified command, $File.Name is a string representing the name of the file, such as "example.txt". This is the correct component to pass to Join-Path when you want to create a full path to the destination file, combining the directory path with the file name.

Before this change in internal repo:
![image](https://github.com/user-attachments/assets/adc5f001-fbdd-4d32-967e-c8f56abf0e72)

After this change in internal repo:
![image](https://github.com/user-attachments/assets/a57a6530-2392-4469-bed9-6cce3c6375f8)
