### PR TITLE
Add a handler startup test to SubscriptionProcessorJob and Orchestrator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -106,6 +106,8 @@ namespace NuGet.Services.Validation.Orchestrator
 
             try
             {
+                _serviceProvider.ValidateMessageHandlerInitialization<PackageValidationMessageData>();
+
                 var runner = GetRequiredService<OrchestrationRunner>();
                 await runner.RunOrchestrationAsync();
             }

--- a/src/Validation.Common.Job/ServiceProviderExtensions.cs
+++ b/src/Validation.Common.Job/ServiceProviderExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.ServiceBus;
+
+namespace NuGet.Jobs.Validation
+{
+    public static class ServiceProviderExtensions
+    {
+        public static void ValidateMessageHandlerInitialization<TMessage>(this IServiceProvider serviceProvider)
+        {
+            // To detect any start-up errors, test initializing the actual message processor.
+            // The message processor initialized in the main path uses a wrapper message handler, which defers initilization until a message arrives.
+            // This startup test allows the app to crash prior to recieving a message which it wouldn't be able to handle properly anyways.
+            // Having the app crash in this case is preferable since messages won't be dead-lettered and the job heartbeats will indicate a problem.
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var logger = scope.ServiceProvider.GetRequiredService<ILogger<IMessageHandler<TMessage>>>();
+                logger.LogInformation("Verifying that the message handler for message type {MessageType} can be resolved.", typeof(TMessage).FullName);
+                try
+                {
+                    var handler = scope.ServiceProvider.GetRequiredService<IMessageHandler<TMessage>>();
+                    logger.LogInformation("Successfully initialized message handler type {MessageType}.", handler.GetType().FullName);
+                }
+                catch
+                {
+                    logger.LogError("Failed to initialize message handler for message type {MessageType}. The subscription processor job cannot start. See the exception logs for more details.", typeof(TMessage).FullName);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Validation.Common.Job/SubscriptionProcessorJob.cs
+++ b/src/Validation.Common.Job/SubscriptionProcessorJob.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -33,7 +33,7 @@ namespace NuGet.Jobs.Validation
 
                 if (processor == null)
                 {
-                    throw new Exception($"DI container was not set up to produce instances of ISubscriptionProcessor<{typeof(T).Name}>. " +
+                    throw new InvalidOperationException($"DI container was not set up to produce instances of ISubscriptionProcessor<{typeof(T).Name}>. " +
                         $"Call SubcriptionProcessorJob<T>.{nameof(ConfigureDefaultSubscriptionProcessor)}() or set it up your way.");
                 }
 
@@ -41,9 +41,11 @@ namespace NuGet.Jobs.Validation
 
                 if (configuration == null || configuration.Value == null)
                 {
-                    throw new Exception($"Failed to get the SubscriptionProcessorJob configuration. Call " +
+                    throw new InvalidOperationException($"Failed to get the SubscriptionProcessorJob configuration. Call " +
                         $"SubcriptionProcessorJob<T>.{nameof(SetupDefaultSubscriptionProcessorConfiguration)}() or set it up your way.");
                 }
+
+                _serviceProvider.ValidateMessageHandlerInitialization<T>();
 
                 await processor.StartAsync(configuration.Value.MaxConcurrentCalls);
 

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <Compile Remove="ServiceProviderExtensions.cs" />
     <Compile Remove="Storage\IValidatorStateService.cs" />
     <Compile Remove="Storage\ValidatorStateService.cs" />
     <Compile Remove="Storage\ValidatorStatusExtensions.cs" />


### PR DESCRIPTION
For jobs like AccountDeleter, they can have complex dependency injection (DI) setup, sometimes loading assembly built across multiple projects. 

To improve the visibility of DI/startup errors, this adds a step to our subscription processor jobs to test initializing the message handler prior to accepting messages.

If there is indeed a DI problem with the message handler, it will be detected prior to receiving messages. This will make job heartbeats go red (good) and prevent unnecessary message dead lettering (good).