### PR TITLE
Introduce delegation SAS

### DIFF
--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" />
+    <PackageReference Include="Azure.Data.Tables" />
     <PackageReference Include="Dapper.StrongName" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />

--- a/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
+++ b/src/NuGet.Jobs.Common/StorageAccountExtensions.cs
@@ -118,7 +118,7 @@ namespace NuGet.Jobs
                 throw new ArgumentException($"{nameof(storageConnectionString)} cannot be null or empty.", nameof(storageConnectionString));
             }
 
-            var msiConfiguration = serviceProvider.GetRequiredService<IOptions<StorageMsiConfiguration>>().Value;
+            StorageMsiConfiguration msiConfiguration = serviceProvider.GetRequiredService<IOptions<StorageMsiConfiguration>>().Value;
             return CreateTableServiceClientClient(
                 msiConfiguration,
                 storageConnectionString);
@@ -140,9 +140,9 @@ namespace NuGet.Jobs
 
             return builder.Register(c =>
             {
-                var options = c.Resolve<IOptionsSnapshot<TConfiguration>>();
+                IOptionsSnapshot<TConfiguration> options = c.Resolve<IOptionsSnapshot<TConfiguration>>();
                 string storageConnectionString = getConnectionString(options.Value);
-                var msiConfiguration = c.Resolve<IOptions<StorageMsiConfiguration>>().Value;
+                StorageMsiConfiguration msiConfiguration = c.Resolve<IOptions<StorageMsiConfiguration>>().Value;
                 return CreateTableServiceClientClient(
                     msiConfiguration,
                     storageConnectionString);

--- a/src/NuGetGallery.Core/Extensions/UriExtensions.cs
+++ b/src/NuGetGallery.Core/Extensions/UriExtensions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGetGallery.Extensions
+{
+    public static class UriExtensions
+    {
+        /// <summary>
+        /// Appends the given SAS token to the Uri, ensuring the query string is correctly formatted.
+        /// </summary>
+        /// <param name="uri">The base Uri to which the query string will be appended.</param>
+        /// <param name="sas">The SAS string to append, which may or may not start with a '?' character.</param>
+        /// <returns>A new Uri with the SAS string appended.</returns>
+        public static Uri BlobStorageAppendSas(this Uri uri, string sas)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (string.IsNullOrEmpty(sas))
+            {
+                throw new ArgumentNullException(nameof(sas));
+            }
+
+            // Trim any leading '?' from the query string to avoid double '?'
+            string trimmedQueryString = sas.TrimStart('?');
+
+            var uriBuilder = new UriBuilder(uri)
+            {
+                Query = trimmedQueryString
+            };
+
+            return uriBuilder.Uri;
+        }
+    }
+}

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -377,7 +377,11 @@ namespace NuGetGallery
             return new Uri(blob.Uri, sas);
         }
 
-        public async Task<Uri> GetPrivilegedFileUriWithDelegationSasAsync(string folderName, string fileName, FileUriPermissions permissions, DateTimeOffset endOfAccess)
+        public async Task<Uri> GetPrivilegedFileUriWithDelegationSasAsync(
+            string folderName,
+            string fileName,
+            FileUriPermissions permissions,
+            DateTimeOffset endOfAccess)
         {
             if (endOfAccess < DateTimeOffset.UtcNow)
             {

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 using NuGetGallery.Diagnostics;
+using NuGetGallery.Extensions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace NuGetGallery
@@ -374,7 +375,7 @@ namespace NuGetGallery
             ISimpleCloudBlob blob = await GetBlobForUriAsync(folderName, fileName);
             string sas = await blob.GetSharedAccessSignature(permissions, endOfAccess);
 
-            return new Uri(blob.Uri, sas);
+            return blob.Uri.BlobStorageAppendSas(sas);
         }
 
         public async Task<Uri> GetPrivilegedFileUriWithDelegationSasAsync(
@@ -391,7 +392,7 @@ namespace NuGetGallery
             ISimpleCloudBlob blob = await GetBlobForUriAsync(folderName, fileName);
             string sas = await blob.GetDelegationSasAsync(permissions, endOfAccess);
 
-            return new Uri(blob.Uri, sas);
+            return blob.Uri.BlobStorageAppendSas(sas);
         }
 
         public async Task<Uri> GetFileReadUriAsync(string folderName, string fileName, DateTimeOffset? endOfAccess)
@@ -415,7 +416,7 @@ namespace NuGetGallery
 
             string sas = await blob.GetSharedAccessSignature(FileUriPermissions.Read, endOfAccess.Value);
 
-            return new Uri(blob.Uri, sas);
+            return blob.Uri.BlobStorageAppendSas(sas);
         }
 
         /// <summary>

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -371,8 +371,21 @@ namespace NuGetGallery
                 throw new ArgumentOutOfRangeException(nameof(endOfAccess), $"{nameof(endOfAccess)} is in the past");
             }
 
-            var blob = await GetBlobForUriAsync(folderName, fileName);
+            ISimpleCloudBlob blob = await GetBlobForUriAsync(folderName, fileName);
             string sas = await blob.GetSharedAccessSignature(permissions, endOfAccess);
+
+            return new Uri(blob.Uri, sas);
+        }
+
+        public async Task<Uri> GetPrivilegedFileUriWithDelegationSasAsync(string folderName, string fileName, FileUriPermissions permissions, DateTimeOffset endOfAccess)
+        {
+            if (endOfAccess < DateTimeOffset.UtcNow)
+            {
+                throw new ArgumentOutOfRangeException(nameof(endOfAccess), $"{nameof(endOfAccess)} is in the past");
+            }
+
+            ISimpleCloudBlob blob = await GetBlobForUriAsync(folderName, fileName);
+            string sas = await blob.GetDelegationSasAsync(permissions, endOfAccess);
 
             return new Uri(blob.Uri, sas);
         }

--- a/src/NuGetGallery.Core/Services/CloudBlobWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobWrapper.cs
@@ -554,9 +554,8 @@ namespace NuGetGallery
 
         private async Task<string> GenerateDelegationSasAsync(BlobSasBuilder sasBuilder)
         {
-            // user delegation SAS
-            var userDelegationKey = (await _container.Account.Client.GetUserDelegationKeyAsync(sasBuilder.StartsOn, sasBuilder.ExpiresOn)).Value;
-            var blobUriBuilder = new BlobUriBuilder(_blob.Uri)
+            UserDelegationKey userDelegationKey = (await _container.Account.Client.GetUserDelegationKeyAsync(sasBuilder.StartsOn, sasBuilder.ExpiresOn)).Value;
+            BlobUriBuilder blobUriBuilder = new BlobUriBuilder(_blob.Uri)
             {
                 Sas = sasBuilder.ToSasQueryParameters(userDelegationKey, _blob.AccountName),
             };

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -54,6 +54,22 @@ namespace NuGetGallery
         /// <param name="endOfAccess">The time when the access ends.</param>
         /// <returns>The URI with privileged access.</returns>
         Task<Uri> GetPrivilegedFileUriAsync(
+            string folderName,
+            string fileName,
+            FileUriPermissions permissions,
+            DateTimeOffset endOfAccess);
+
+        /// <summary>
+        /// Generates a storage file URI giving certain permissions for the specific file via delegation SAS. For example, this method can
+        /// be used to generate a URI that allows the caller to either delete (via
+        /// <see cref="FileUriPermissions.Delete"/>) or read (via <see cref="FileUriPermissions.Read"/>) the file.
+        /// </summary>
+        /// <param name="folderName">The folder name containing the file.</param>
+        /// <param name="fileName">The file name.</param>
+        /// <param name="permissions">The permissions to give to the privileged URI.</param>
+        /// <param name="endOfAccess">The time when the access ends.</param>
+        /// <returns>The URI with privileged access.</returns>
+        Task<Uri> GetPrivilegedFileUriWithDelegationSasAsync(
             string folderName,
             string fileName,
             FileUriPermissions permissions,

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -68,7 +68,7 @@ namespace NuGetGallery
         /// <param name="fileName">The file name.</param>
         /// <param name="permissions">The permissions to give to the privileged URI.</param>
         /// <param name="endOfAccess">The time when the access ends.</param>
-        /// <returns>The URI with privileged access.</returns>
+        /// <returns>The URI with privileged delegation SAS access.</returns>
         Task<Uri> GetPrivilegedFileUriWithDelegationSasAsync(
             string folderName,
             string fileName,

--- a/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -51,6 +51,20 @@ namespace NuGetGallery
         /// </param>
         /// <returns>Shared access signature in form of URI query portion.</returns>
         Task<string> GetSharedAccessSignature(FileUriPermissions permissions, DateTimeOffset endOfAccess);
+
+        /// <summary>
+        /// Generates a new delegation sas token that if appended to the blob URI
+        /// would allow actions matching the provided <paramref name="permissions"/> without having access to the
+        /// access keys of the storage account.
+        /// </summary>
+        /// <param name="permissions">The permissions to include in the SAS token.</param>
+        /// <param name="endOfAccess">
+        /// "End of access" timestamp. After the specified timestamp,
+        /// the returned signature becomes invalid if implementation supports it.
+        /// Null for no time limit.
+        /// </param>
+        /// <returns>Shared access signature in form of URI query portion.</returns>
+        Task<string> GetDelegationSasAsync(FileUriPermissions permissions, DateTimeOffset endOfAccess);
 
         /// <summary>
         /// Opens the seekable read stream to the file in blob storage.

--- a/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
+++ b/src/NuGetGallery.Core/Services/ISimpleCloudBlob.cs
@@ -63,7 +63,7 @@ namespace NuGetGallery
         /// the returned signature becomes invalid if implementation supports it.
         /// Null for no time limit.
         /// </param>
-        /// <returns>Shared access signature in form of URI query portion.</returns>
+        /// <returns>Delegation SAS in form of URI query portion.</returns>
         Task<string> GetDelegationSasAsync(FileUriPermissions permissions, DateTimeOffset endOfAccess);
 
         /// <summary>

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -261,6 +261,11 @@ namespace NuGetGallery
             throw new NotImplementedException();
         }
 
+        public Task<Uri> GetPrivilegedFileUriWithDelegationSasAsync(string folderName, string fileName, FileUriPermissions permissions, DateTimeOffset endOfAccess)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task SetMetadataAsync(
             string folderName,
             string fileName,

--- a/tests/NuGet.Services.V3.Tests/Support/InMemoryCloudBlob.cs
+++ b/tests/NuGet.Services.V3.Tests/Support/InMemoryCloudBlob.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -102,6 +102,11 @@ namespace NuGet.Services
         }
 
         public Task<bool> FetchAttributesIfExistsAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<string> GetDelegationSasAsync(FileUriPermissions permissions, DateTimeOffset endOfAccess)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Partially addresses: https://github.com/NuGet/Engineering/issues/5387 and https://github.com/NuGet/Engineering/issues/5433

Introduce delegation SAS, which is more secure than SAK-based SAS. 
I didn't reuse or extend the existing SAS generate method and created a new `GetDelegationSasAsync` and `GetPrivilegedFileUriWithDelegationSasAsync` because I want to be explicit when the customer generates the SAS token and not accidentally consume the old SAK one. Eventually, we can deprecate the SAK-based one without worry later.
Also extending the old SAK based on caused API breaking change.