### PR TITLE
Allow if conflict with package from same owner

### DIFF
--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -352,6 +352,7 @@
     <Compile Include="RequestModels\UpdateListedRequest.cs" />
     <Compile Include="Services\ListedVerb.cs" />
     <Compile Include="Services\MissingLicenseValidationMessageV2.cs" />
+    <Compile Include="Services\NormalizedPackageIdInfo.cs" />
     <Compile Include="Services\NullTyposquattingService.cs" />
     <Compile Include="Services\UploadPackageMissingReadme.cs" />
     <Compile Include="Services\MissingLicenseValidationMessage.cs" />

--- a/src/NuGetGallery/Services/ITyposquattingCheckListCacheService.cs
+++ b/src/NuGetGallery/Services/ITyposquattingCheckListCacheService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,6 +17,6 @@ namespace NuGetGallery
         /// <param name="checkListLength">The length of the checklist for typosquatting</param>
         /// <param name="checkListExpireTime">The expire time for checklist caching</param>
         /// <param name="packageService">The package service for checklist retrieval from database</param>
-        IReadOnlyCollection<string> GetTyposquattingCheckList(int checkListLength, TimeSpan checkListExpireTime, IPackageService packageService);
+        IReadOnlyCollection<(string originalId, string normalizedId)> GetTyposquattingCheckList(int checkListLength, TimeSpan checkListExpireTime, IPackageService packageService);
     }
 }

--- a/src/NuGetGallery/Services/ITyposquattingCheckListCacheService.cs
+++ b/src/NuGetGallery/Services/ITyposquattingCheckListCacheService.cs
@@ -17,6 +17,6 @@ namespace NuGetGallery
         /// <param name="checkListLength">The length of the checklist for typosquatting</param>
         /// <param name="checkListExpireTime">The expire time for checklist caching</param>
         /// <param name="packageService">The package service for checklist retrieval from database</param>
-        IReadOnlyCollection<(string originalId, string normalizedId)> GetTyposquattingCheckList(int checkListLength, TimeSpan checkListExpireTime, IPackageService packageService);
+        IReadOnlyCollection<NormalizedPackageIdInfo> GetTyposquattingCheckList(int checkListLength, TimeSpan checkListExpireTime, IPackageService packageService);
     }
 }

--- a/src/NuGetGallery/Services/NormalizedPackageIdInfo.cs
+++ b/src/NuGetGallery/Services/NormalizedPackageIdInfo.cs
@@ -1,11 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 namespace NuGetGallery
 {
     public sealed class NormalizedPackageIdInfo

--- a/src/NuGetGallery/Services/NormalizedPackageIdInfo.cs
+++ b/src/NuGetGallery/Services/NormalizedPackageIdInfo.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace NuGetGallery
 {
     public sealed class NormalizedPackageIdInfo

--- a/src/NuGetGallery/Services/NormalizedPackageIdInfo.cs
+++ b/src/NuGetGallery/Services/NormalizedPackageIdInfo.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace NuGetGallery
+{
+    public sealed class NormalizedPackageIdInfo
+    {
+        public string OriginalId { get; }
+        public string NormalizedId { get; }
+
+        public NormalizedPackageIdInfo(string originalId, string normalizedId)
+        {
+            OriginalId = originalId ?? throw new ArgumentNullException(nameof(originalId));
+            NormalizedId = normalizedId ?? throw new ArgumentNullException(nameof(normalizedId));
+        }
+
+    }
+}

--- a/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
+++ b/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,7 +12,7 @@ namespace NuGetGallery
         private readonly object Locker = new object();
         private readonly ITyposquattingServiceHelper _typosquattingServiceHelper;
 
-        private List<string> Cache;
+        private List<(string originalId, string normalizedId)> Cache;
         private DateTime LastRefreshTime;
 
         private int TyposquattingCheckListConfiguredLength;
@@ -24,7 +24,7 @@ namespace NuGetGallery
             _typosquattingServiceHelper = typosquattingServiceHelper;
         }
 
-        public IReadOnlyCollection<string> GetTyposquattingCheckList(int checkListConfiguredLength, TimeSpan checkListExpireTime, IPackageService packageService)
+        public IReadOnlyCollection<(string originalId, string normalizedId)> GetTyposquattingCheckList(int checkListConfiguredLength, TimeSpan checkListExpireTime, IPackageService packageService)
         {
             if (packageService == null)
             {
@@ -54,7 +54,7 @@ namespace NuGetGallery
                             .ToList();
 
                         Cache = cachedPackages
-                            .Select(pr => _typosquattingServiceHelper.NormalizeString(pr))
+                            .Select(pr => (pr, _typosquattingServiceHelper.NormalizeString(pr)))
                             .ToList();
 
                         LastRefreshTime = DateTime.UtcNow;

--- a/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
+++ b/src/NuGetGallery/Services/TyposquattingCheckListCacheService.cs
@@ -12,7 +12,7 @@ namespace NuGetGallery
         private readonly object Locker = new object();
         private readonly ITyposquattingServiceHelper _typosquattingServiceHelper;
 
-        private List<(string originalId, string normalizedId)> Cache;
+        private List<NormalizedPackageIdInfo> Cache;
         private DateTime LastRefreshTime;
 
         private int TyposquattingCheckListConfiguredLength;
@@ -24,7 +24,7 @@ namespace NuGetGallery
             _typosquattingServiceHelper = typosquattingServiceHelper;
         }
 
-        public IReadOnlyCollection<(string originalId, string normalizedId)> GetTyposquattingCheckList(int checkListConfiguredLength, TimeSpan checkListExpireTime, IPackageService packageService)
+        public IReadOnlyCollection<NormalizedPackageIdInfo> GetTyposquattingCheckList(int checkListConfiguredLength, TimeSpan checkListExpireTime, IPackageService packageService)
         {
             if (packageService == null)
             {
@@ -54,7 +54,7 @@ namespace NuGetGallery
                             .ToList();
 
                         Cache = cachedPackages
-                            .Select(pr => (pr, _typosquattingServiceHelper.NormalizeString(pr)))
+                            .Select(pr => new NormalizedPackageIdInfo(originalId: pr, normalizedId: _typosquattingServiceHelper.NormalizeString(pr)))
                             .ToList();
 
                         LastRefreshTime = DateTime.UtcNow;

--- a/src/NuGetGallery/Services/TyposquattingService.cs
+++ b/src/NuGetGallery/Services/TyposquattingService.cs
@@ -62,7 +62,7 @@ namespace NuGetGallery
             var checklistRetrievalStopwatch = Stopwatch.StartNew();
 
             // It must be normalized during initial list creation
-            IReadOnlyCollection<(string originalId, string normalizedId)> normalizedPackageIdsCheckList = _typosquattingCheckListCacheService.GetTyposquattingCheckList(checkListConfiguredLength, checkListExpireTimeInHours, _packageService);
+            IReadOnlyCollection<NormalizedPackageIdInfo> normalizedPackageIdsCheckList = _typosquattingCheckListCacheService.GetTyposquattingCheckList(checkListConfiguredLength, checkListExpireTimeInHours, _packageService);
             checklistRetrievalStopwatch.Stop();
 
             _telemetryService.TrackMetricForTyposquattingChecklistRetrievalTime(uploadedPackageId, checklistRetrievalStopwatch.Elapsed);
@@ -71,9 +71,9 @@ namespace NuGetGallery
             var collisionIds = new ConcurrentBag<string>();
             Parallel.ForEach(normalizedPackageIdsCheckList, (normalizedPackageIdPair, loopState) =>
             {
-                if (_typosquattingServiceHelper.IsDistanceLessThanOrEqualToThresholdWithNormalizedPackageId(uploadedPackageId, normalizedPackageIdPair.normalizedId))
+                if (_typosquattingServiceHelper.IsDistanceLessThanOrEqualToThresholdWithNormalizedPackageId(uploadedPackageId, normalizedPackageIdPair.NormalizedId))
                 {
-                    collisionIds.Add(normalizedPackageIdPair.originalId);
+                    collisionIds.Add(normalizedPackageIdPair.OriginalId);
                 }
             });
             algorithmProcessingStopwatch.Stop();

--- a/src/NuGetGallery/Services/TyposquattingService.cs
+++ b/src/NuGetGallery/Services/TyposquattingService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -60,20 +60,20 @@ namespace NuGetGallery
 
             var totalTimeStopwatch = Stopwatch.StartNew();
             var checklistRetrievalStopwatch = Stopwatch.StartNew();
-            
+
             // It must be normalized during initial list creation
-            var normalizedPackageIdsCheckList = _typosquattingCheckListCacheService.GetTyposquattingCheckList(checkListConfiguredLength, checkListExpireTimeInHours, _packageService);
+            IReadOnlyCollection<(string originalId, string normalizedId)> normalizedPackageIdsCheckList = _typosquattingCheckListCacheService.GetTyposquattingCheckList(checkListConfiguredLength, checkListExpireTimeInHours, _packageService);
             checklistRetrievalStopwatch.Stop();
 
             _telemetryService.TrackMetricForTyposquattingChecklistRetrievalTime(uploadedPackageId, checklistRetrievalStopwatch.Elapsed);
 
             var algorithmProcessingStopwatch = Stopwatch.StartNew();
             var collisionIds = new ConcurrentBag<string>();
-            Parallel.ForEach(normalizedPackageIdsCheckList, (normalizedPackageId, loopState) =>
+            Parallel.ForEach(normalizedPackageIdsCheckList, (normalizedPackageIdPair, loopState) =>
             {
-                if (_typosquattingServiceHelper.IsDistanceLessThanOrEqualToThresholdWithNormalizedPackageId(uploadedPackageId, normalizedPackageId))
+                if (_typosquattingServiceHelper.IsDistanceLessThanOrEqualToThresholdWithNormalizedPackageId(uploadedPackageId, normalizedPackageIdPair.normalizedId))
                 {
-                    collisionIds.Add(normalizedPackageId);
+                    collisionIds.Add(normalizedPackageIdPair.originalId);
                 }
             });
             algorithmProcessingStopwatch.Stop();

--- a/tests/NuGetGallery.Facts/Services/TyposquattingCheckListCacheServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TyposquattingCheckListCacheServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -44,6 +44,8 @@ namespace NuGetGallery
                 .Returns(PacakgeRegistrationsList);
 
             var mockTyposquattingServiceHelper = new Mock<ITyposquattingServiceHelper>();
+            mockTyposquattingServiceHelper.Setup(helper => helper.NormalizeString(It.IsAny<string>()))
+                .Returns((string str) => str.ToLower());
 
             var newService = new TyposquattingCheckListCacheService(mockTyposquattingServiceHelper.Object);
 
@@ -76,6 +78,8 @@ namespace NuGetGallery
                 .Returns(PacakgeRegistrationsList);
 
             var mockTyposquattingServiceHelper = new Mock<ITyposquattingServiceHelper>();
+            mockTyposquattingServiceHelper.Setup(helper => helper.NormalizeString(It.IsAny<string>()))
+                  .Returns((string str) => str.ToLower());
             var newService = new TyposquattingCheckListCacheService(mockTyposquattingServiceHelper.Object);
 
             // Act
@@ -99,6 +103,8 @@ namespace NuGetGallery
                 .Returns(PacakgeRegistrationsList);
 
             var mockTyposquattingServiceHelper = new Mock<ITyposquattingServiceHelper>();
+            mockTyposquattingServiceHelper.Setup(helper => helper.NormalizeString(It.IsAny<string>()))
+                .Returns((string str) => str.ToLower());
             var newService = new TyposquattingCheckListCacheService(mockTyposquattingServiceHelper.Object);
 
             // Act

--- a/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -24,7 +24,7 @@ namespace NuGetGallery
             "System.Spatial"
         };
 
-        private static IQueryable<PackageRegistration> PacakgeRegistrationsList = Enumerable.Range(0, _packageIds.Count()).Select(i =>
+        private static IQueryable<PackageRegistration> PackageRegistrationsList = Enumerable.Range(0, _packageIds.Count()).Select(i =>
                 new PackageRegistration()
                 {
                     Id = _packageIds[i],
@@ -48,7 +48,7 @@ namespace NuGetGallery
                 packageService = new Mock<IPackageService>();
                 packageService
                     .Setup(x => x.GetAllPackageRegistrations())
-                    .Returns(PacakgeRegistrationsList);
+                    .Returns(PackageRegistrationsList);
             }
 
             if (contentObjectService == null)
@@ -88,10 +88,15 @@ namespace NuGetGallery
 
             if (typosquattingCheckListCacheService == null)
             {
+                List<(string, string)> tupleList = PackageRegistrationsList
+                    .ToList()
+                    .Select(pr => (pr.Id, pr.Id))
+                    .ToList();
+
                 typosquattingCheckListCacheService = new Mock<ITyposquattingCheckListCacheService>();
                 typosquattingCheckListCacheService
                     .Setup(x => x.GetTyposquattingCheckList(It.IsAny<int>(), It.IsAny<TimeSpan>(), It.IsAny<IPackageService>()))
-                    .Returns(PacakgeRegistrationsList.Select(pr => pr.Id).ToList());
+                    .Returns(tupleList);
             }
 
             return new TyposquattingService(
@@ -220,7 +225,7 @@ namespace NuGetGallery
             var mockTyposquattingCheckListCacheService = new Mock<ITyposquattingCheckListCacheService>();
             mockTyposquattingCheckListCacheService
                 .Setup(x => x.GetTyposquattingCheckList(It.IsAny<int>(), It.IsAny<TimeSpan>(), It.IsAny<IPackageService>()))
-                .Returns(new List<string>());
+                .Returns(new List<(string, string)>());
 
             var newService = CreateService(packageService: mockPackageService, typosquattingCheckListCacheService: mockTyposquattingCheckListCacheService);
 

--- a/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
@@ -88,7 +88,7 @@ namespace NuGetGallery
 
             if (typosquattingCheckListCacheService == null)
             {
-                List<NormalizedPackageIdInfo> tupleList = PackageRegistrationsList
+                List<NormalizedPackageIdInfo> normalizedPackageIdInfos = PackageRegistrationsList
                     .ToList()
                     .Select(pr => new NormalizedPackageIdInfo(pr.Id, pr.Id))
                     .ToList();
@@ -96,7 +96,7 @@ namespace NuGetGallery
                 typosquattingCheckListCacheService = new Mock<ITyposquattingCheckListCacheService>();
                 typosquattingCheckListCacheService
                     .Setup(x => x.GetTyposquattingCheckList(It.IsAny<int>(), It.IsAny<TimeSpan>(), It.IsAny<IPackageService>()))
-                    .Returns(tupleList);
+                    .Returns(normalizedPackageIdInfos);
             }
 
             return new TyposquattingService(

--- a/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
@@ -88,9 +88,9 @@ namespace NuGetGallery
 
             if (typosquattingCheckListCacheService == null)
             {
-                List<(string, string)> tupleList = PackageRegistrationsList
+                List<NormalizedPackageIdInfo> tupleList = PackageRegistrationsList
                     .ToList()
-                    .Select(pr => (pr.Id, pr.Id))
+                    .Select(pr => new NormalizedPackageIdInfo(pr.Id, pr.Id))
                     .ToList();
 
                 typosquattingCheckListCacheService = new Mock<ITyposquattingCheckListCacheService>();
@@ -225,7 +225,7 @@ namespace NuGetGallery
             var mockTyposquattingCheckListCacheService = new Mock<ITyposquattingCheckListCacheService>();
             mockTyposquattingCheckListCacheService
                 .Setup(x => x.GetTyposquattingCheckList(It.IsAny<int>(), It.IsAny<TimeSpan>(), It.IsAny<IPackageService>()))
-                .Returns(new List<(string, string)>());
+                .Returns(new List<NormalizedPackageIdInfo>());
 
             var newService = CreateService(packageService: mockPackageService, typosquattingCheckListCacheService: mockTyposquattingCheckListCacheService);
 

--- a/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/TyposquattingServiceFacts.cs
@@ -321,6 +321,83 @@ namespace NuGetGallery
         }
 
         [Fact]
+        public void CheckIsTyposquattingBlockDifferentOwnersUploadBlocked()
+        {
+            // Arrange
+            var uploadedPackageId = "Microsoft_NetFramework_v1";
+            string conflictingPackageId = "microsoft_netframework_v1";
+            User conflictingPackageOwner = PackageRegistrationsList
+                .Single(pr => pr.Id == conflictingPackageId)
+                .Owners
+                .First();
+
+            // Make sure they have different owners.
+            Assert.NotEqual(_uploadedPackageOwner.Key, conflictingPackageOwner.Key);
+
+            var featureFlagService = new Mock<IFeatureFlagService>();
+            featureFlagService
+                .Setup(f => f.IsTyposquattingEnabled())
+                .Returns(true);
+            featureFlagService
+                .Setup(f => f.IsTyposquattingEnabled(_uploadedPackageOwner))
+                .Returns(true);
+
+            var newService = CreateService(featureFlagService: featureFlagService);
+
+            // Act
+
+            var typosquattingCheckResult = newService.IsUploadedPackageIdTyposquatting(uploadedPackageId, _uploadedPackageOwner, out List<string> typosquattingCheckCollisionIds);
+
+            // Assert
+            Assert.True(typosquattingCheckResult);
+            Assert.Single(typosquattingCheckCollisionIds);
+            Assert.Equal(conflictingPackageId, typosquattingCheckCollisionIds[0]);
+
+            featureFlagService
+                .Verify(f => f.IsTyposquattingEnabled(), Times.Once);
+            featureFlagService
+                .Verify(f => f.IsTyposquattingEnabled(_uploadedPackageOwner), Times.Once);
+        }
+
+        [Fact]
+        public void CheckIsTyposquattingBlockSameOwnerUploadNotBlocked()
+        {
+            // Arrange
+            var uploadedPackageId = "Microsoft_NetFramework_v1";
+            string conflictingPackageId = "microsoft_netframework_v1";
+
+            var featureFlagService = new Mock<IFeatureFlagService>();
+
+            // Use same owner for both packages.
+            User samePackageOwner =  PackageRegistrationsList
+                .Single(pr => pr.Id == conflictingPackageId)
+                .Owners
+                .First();
+
+            featureFlagService
+                .Setup(f => f.IsTyposquattingEnabled())
+                .Returns(true);
+            featureFlagService
+                .Setup(f => f.IsTyposquattingEnabled(samePackageOwner))
+                .Returns(true);
+
+            var newService = CreateService(featureFlagService: featureFlagService);
+
+            // Act
+
+            var typosquattingCheckResult = newService.IsUploadedPackageIdTyposquatting(uploadedPackageId, samePackageOwner, out List<string> typosquattingCheckCollisionIds);
+
+            // Assert
+            Assert.False(typosquattingCheckResult);
+            Assert.Empty(typosquattingCheckCollisionIds);
+
+            featureFlagService
+                .Verify(f => f.IsTyposquattingEnabled(), Times.Once);
+            featureFlagService
+                .Verify(f => f.IsTyposquattingEnabled(samePackageOwner), Times.Once);
+        }
+
+        [Fact]
         public void CheckTelemetryServiceLogOriginalUploadedPackageId()
         {
             // Arrange


### PR DESCRIPTION
Addresses: https://github.com/NuGet/Engineering/issues/5583

My [previous PR](https://github.com/NuGet/NuGetGallery/commit/ca170345892cddb68c83be446c39e2b138190660), I inadvertently made typosquatting check too strict, this change would allow if they're from same owners by keeping both original and normalized values in cache. It would add few mb memory, but not big deal, main concern was CPU time previously.