### PR TITLE
Fix BlobServiceClient Constructor

### DIFF
--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -92,12 +92,9 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
 
             var blobEndpoint = new Uri(storageBaseUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped));
             // Create BlobServiceClient with anonymous credentials
-            var blobServiceClient = new BlobServiceClient(blobEndpoint, new AzureSasCredential(""));
+            var blobServiceClient = new BlobServiceClient(blobEndpoint);
 
             string containerName = pathSegments[0];
-            // Get a reference to a container
-            BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(containerName);
-
             string pathInContainer = string.Join("/", pathSegments.Skip(1));
             return new CloudBlobDirectoryWrapper(blobServiceClient, containerName, pathInContainer);
         }

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -614,6 +614,10 @@
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
       </dependentAssembly>


### PR DESCRIPTION
Fixes a blob service client constructor that was throwing null or whitespace Argument exceptions and causing the Ctalog2Icons job to restart repeatedly.