### PR TITLE
Fix BlobServiceClient Constructor

### DIFF
--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -92,12 +92,9 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
 
             var blobEndpoint = new Uri(storageBaseUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped));
             // Create BlobServiceClient with anonymous credentials
-            var blobServiceClient = new BlobServiceClient(blobEndpoint, new AzureSasCredential(""));
+            var blobServiceClient = new BlobServiceClient(blobEndpoint);
 
             string containerName = pathSegments[0];
-            // Get a reference to a container
-            BlobContainerClient containerClient = blobServiceClient.GetBlobContainerClient(containerName);
-
             string pathInContainer = string.Join("/", pathSegments.Skip(1));
             return new CloudBlobDirectoryWrapper(blobServiceClient, containerName, pathInContainer);
         }


### PR DESCRIPTION
Fixes a blob service client constructor that was throwing null or whitespace Argument exceptions and causing the Ctalog2Icons job to restart repeatedly.

Had to close the previous PR as that was branched off main, and would have brough in extra commits.