### PR TITLE
Set `SendCertificateChain` option in KeyVaultReader to enable SN+I authentication

### DIFF
--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -13,7 +13,7 @@ namespace NuGet.Services.KeyVault
 {
     /// <summary>
     /// Reads secretes from KeyVault.
-    /// Authentication with KeyVault is done using either a managed identity or a certificate in location:LocalMachine store name:My 
+    /// Authentication with KeyVault is done using either a managed identity or a certificate in location:LocalMachine store name:My
     /// </summary>
     public class KeyVaultReader : ISecretReader
     {
@@ -99,7 +99,19 @@ namespace NuGet.Services.KeyVault
             }
             else
             {
-                credential = new ClientCertificateCredential(_configuration.TenantId, _configuration.ClientId, _configuration.Certificate);
+                if (_configuration.SendX5c)
+                {
+                    var clientCredentialOptions = new ClientCertificateCredentialOptions
+                    {
+                        SendCertificateChain = true
+                    };
+
+                    credential = new ClientCertificateCredential(_configuration.TenantId, _configuration.ClientId, _configuration.Certificate, clientCredentialOptions);
+                }
+                else
+                {
+                    credential = new ClientCertificateCredential(_configuration.TenantId, _configuration.ClientId, _configuration.Certificate);
+                }
             }
             return new SecretClient(GetKeyVaultUri(_configuration), credential);
         }

--- a/src/NuGet.Services.KeyVault/KeyVaultReader.cs
+++ b/src/NuGet.Services.KeyVault/KeyVaultReader.cs
@@ -20,6 +20,9 @@ namespace NuGet.Services.KeyVault
         private readonly KeyVaultConfiguration _configuration;
         private readonly Lazy<SecretClient> _keyVaultClient;
 
+        // This is used to determine if the client is using SendX5c for unit testing purposes
+        internal bool isUsingSendX5c;
+
         protected SecretClient KeyVaultClient => _keyVaultClient.Value;
 
         public KeyVaultReader(KeyVaultConfiguration configuration)
@@ -85,6 +88,7 @@ namespace NuGet.Services.KeyVault
         private SecretClient InitializeClient()
         {
             TokenCredential credential = null;
+            isUsingSendX5c = false;
 
             if (_configuration.UseManagedIdentity)
             {
@@ -107,12 +111,15 @@ namespace NuGet.Services.KeyVault
                     };
 
                     credential = new ClientCertificateCredential(_configuration.TenantId, _configuration.ClientId, _configuration.Certificate, clientCredentialOptions);
+                    isUsingSendX5c = true;
                 }
                 else
                 {
                     credential = new ClientCertificateCredential(_configuration.TenantId, _configuration.ClientId, _configuration.Certificate);
+
                 }
             }
+
             return new SecretClient(GetKeyVaultUri(_configuration), credential);
         }
 

--- a/src/NuGet.Services.KeyVault/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Services.KeyVault/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+#if SIGNED_BUILD
+[assembly: InternalsVisibleTo("NuGet.Services.KeyVault.Tests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+#else
+[assembly: InternalsVisibleTo("NuGet.Services.KeyVault.Tests")]
+#endif

--- a/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFacts.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Security.KeyVault.Secrets
+using Moq;
+using Xunit;
+
+namespace NuGet.Services.KeyVault.Tests
+{
+    public class SecretReaderFacts
+    {
+        [Fact]
+        public void GetSecretObjectWithSendX5c()
+        {
+            // Arrange
+            const string vaultName = "vaultName";
+            const string tenantId = "tenantId";
+            const string clientId = "clientId";
+            const string secret = "secretvalue";
+
+            X509Certificate2 certificate = new X509Certificate2();
+
+            KeyVaultConfiguration keyVaultConfiguration = new KeyVaultConfiguration("vaultName", "tenantId", "clientId", certificate, sendX5c:true);
+
+            // Act
+            var keyvaultReader = new KeyVaultReader(keyVaultConfiguration);
+
+            // Assert
+            Assert.True(keyvaultReader.isUsingSendX5c);
+        }
+    }
+}

--- a/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFacts.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Azure.Security.KeyVault.Secrets;
 using Moq;
 using Xunit;
 
@@ -12,23 +13,28 @@ namespace NuGet.Services.KeyVault.Tests
     public class KeyVaultReaderFacts
     {
         [Fact]
-        public void GetSecretObjectWithSendX5c()
+        public void VerifyKeyvaultReaderSendX5c()
         {
             // Arrange
             const string vaultName = "vaultName";
             const string tenantId = "tenantId";
             const string clientId = "clientId";
-            const string secret = "secretvalue";
 
             X509Certificate2 certificate = new X509Certificate2();
+            KeyVaultConfiguration keyVaultConfiguration = new KeyVaultConfiguration(vaultName, tenantId, clientId, certificate, sendX5c:true);
 
-            KeyVaultConfiguration keyVaultConfiguration = new KeyVaultConfiguration("vaultName", "tenantId", "clientId", certificate, sendX5c:true);
+            var mockSecretClient = new Mock<SecretClient>();
 
             // Act
-            var keyvaultReader = new KeyVaultReader(keyVaultConfiguration);
+            var keyvaultReader = new KeyVaultReader(mockSecretClient.Object, keyVaultConfiguration, testMode: true);
 
             // Assert
-            Assert.True(keyvaultReader.isUsingSendX5c);
+
+            // The KeyVaultReader constructor is internal which accepts a SecretClient object, KeyVaultConfiguration object and a boolean testMode parameter
+            // The KeyVaultConfiguration object has the sendX5c property which is set to true
+            // The KeyVaultReader object has an internal boolean _isUsingSendx5c which is set to true if the sendX5c property is set to true
+            // The KeyVaultReader shot-circuits when the testMode is set to true instead of calling Azure KeyVault
+            Assert.True(keyvaultReader._isUsingSendx5c);
         }
     }
 }

--- a/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFacts.cs
+++ b/tests/NuGet.Services.KeyVault.Tests/KeyVaultReaderFacts.cs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using Azure.Security.KeyVault.Secrets
 using Moq;
 using Xunit;
 
 namespace NuGet.Services.KeyVault.Tests
 {
-    public class SecretReaderFacts
+    public class KeyVaultReaderFacts
     {
         [Fact]
         public void GetSecretObjectWithSendX5c()


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

* Set the ClientCertificateCredentialOptions with SendCertificateChain when the KeyVaultConfiguration is configured with SendCertificateChain
