### PR TITLE
Additional config changes to support AccountDeleter migration

### DIFF
--- a/src/AccountDeleter/app.config
+++ b/src/AccountDeleter/app.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -42,8 +42,13 @@ namespace NuGetGallery
 
         private CloudBlobClientWrapper(string storageConnectionString)
         {
-            // workaround for https://github.com/Azure/azure-sdk-for-net/issues/44373
-            _storageConnectionString = storageConnectionString.Replace("SharedAccessSignature=?", "SharedAccessSignature=");
+            _storageConnectionString = null;
+            if (storageConnectionString is not null)
+            {
+                // workaround for https://github.com/Azure/azure-sdk-for-net/issues/44373
+                _storageConnectionString = storageConnectionString.Replace("SharedAccessSignature=?", "SharedAccessSignature=");
+            }
+
             _primaryServiceUri = new Lazy<Uri>(GetPrimaryServiceUri);
             _secondaryServiceUri = new Lazy<Uri>(GetSecondaryServiceUri);
             _blobClient = new Lazy<BlobServiceClient>(CreateBlobServiceClient);

--- a/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobClientWrapper.cs
@@ -42,13 +42,8 @@ namespace NuGetGallery
 
         private CloudBlobClientWrapper(string storageConnectionString)
         {
-            _storageConnectionString = null;
-            if (storageConnectionString is not null)
-            {
-                // workaround for https://github.com/Azure/azure-sdk-for-net/issues/44373
-                _storageConnectionString = storageConnectionString.Replace("SharedAccessSignature=?", "SharedAccessSignature=");
-            }
-
+            // workaround for https://github.com/Azure/azure-sdk-for-net/issues/44373
+            _storageConnectionString = storageConnectionString.Replace("SharedAccessSignature=?", "SharedAccessSignature=");
             _primaryServiceUri = new Lazy<Uri>(GetPrimaryServiceUri);
             _secondaryServiceUri = new Lazy<Uri>(GetSecondaryServiceUri);
             _blobClient = new Lazy<BlobServiceClient>(CreateBlobServiceClient);


### PR DESCRIPTION
Addresses: https://github.com/NuGet/Engineering/issues/5586 alongside https://github.com/NuGet/NuGetGallery/pull/10165.

This completes the migration for `AccountDeleter`--there was a null ref issue with configs in `AccountDeleter`'s `Job`'s base classes `ValidationJobBase` (which configures validation storage access) and `JsonConfigurationJob` (which configures feature flag storage access). Neither storage accounts are used by `AccountDeleter` and recent changes to `CloudBlobClientWrapper` had removed a tolerance for nulls in the connection strings. An experimental change to `CloudBlobWrapperClient` sought to address this but wasn't successful, but left a BOM removal in code which is an acceptable push. FYI @agr.

The `app.config` change is necessary for a break introduced in our deployment pipeline. I will discuss it in the context of an internal PR on this.