### PR TITLE
[CG] Upgrade System.Text.Json

### DIFF
--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -64,6 +64,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -64,7 +64,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
+++ b/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="System.Formats.Asn1" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/NuGetGallery.Services/NuGetGallery.Services.csproj
+++ b/src/NuGetGallery.Services/NuGetGallery.Services.csproj
@@ -57,6 +57,7 @@
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NuGet.StrongName.WebBackgrounder" />
     <PackageReference Include="System.Runtime" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="NuGet.Commands" />
     <PackageReference Include="NuGet.PackageManagement" />
     <PackageReference Include="NuGet.Resolver" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Addresses NuGetGallery part of https://github.com/NuGet/Engineering/issues/5545
CG alert: https://devdiv.visualstudio.com/DevDiv/_componentGovernance/NuGetPipelines/alert/9986282?typeId=20536579

Some projects were pulling in `System.Text.Json v7.0.3` through the `NuGet.Protocol` package. I've made `System.Text.Json` a top-level reference in the affected projects so that it uses `v8.0.4` from the `Directory.Packages.props` file.

I created a release with these changes, and it looks like it fixes the alert: 
![image](https://github.com/user-attachments/assets/d1d98b96-a853-41a0-933a-eecb8081e0f7)
