### PR TITLE
NuGet Job, don't rethrow exceptions if blob is not found

### DIFF
--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -421,7 +421,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             string blobName = GetName(resourceUri);
             BlobRequestConditions accessCondition = (deleteRequestOptions as DeleteRequestOptionsWithAccessCondition)?.BlobRequestConditions;
             BlockBlobClient blobClient = GetBlockBlobReference(blobName);
-            await blobClient.DeleteAsync(DeleteSnapshotsOption.IncludeSnapshots, accessCondition, cancellationToken);
+            await blobClient.DeleteIfExistsAsync(DeleteSnapshotsOption.IncludeSnapshots, accessCondition, cancellationToken);
         }
 
         public override Uri GetUri(string name)

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -129,16 +129,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             }
             catch (RequestFailedException ex)
             {
-                WebException webException = ex.InnerException as WebException;
-                if (webException != null)
-                {
-                    HttpStatusCode statusCode = ((HttpWebResponse)webException.Response).StatusCode;
-                    if (statusCode != HttpStatusCode.NotFound)
-                    {
-                        throw;
-                    }
-                }
-                else
+                if (ex.ErrorCode != BlobErrorCode.BlobNotFound)
                 {
                     throw;
                 }

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -127,9 +127,21 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             {
                 await OnDeleteAsync(resourceUri, deleteRequestOptions, cancellationToken);
             }
-            catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
+            catch (RequestFailedException ex)
             {
-                // No need to rethrow, same as below statusCode != HttpStatusCode.NotFound for CloudBlobStorageException exception
+                WebException webException = ex.InnerException as WebException;
+                if (webException != null)
+                {
+                    HttpStatusCode statusCode = ((HttpWebResponse)webException.Response).StatusCode;
+                    if (statusCode != HttpStatusCode.NotFound)
+                    {
+                        throw;
+                    }
+                }
+                else
+                {
+                    throw;
+                }
             }
             catch (CloudBlobStorageException e)
             {

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -8,6 +8,8 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Blobs.Models;
 using Newtonsoft.Json;
 using NuGetGallery;
 
@@ -124,6 +126,10 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             try
             {
                 await OnDeleteAsync(resourceUri, deleteRequestOptions, cancellationToken);
+            }
+            catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
+            {
+                throw new CloudBlobNotFoundException(ex);
             }
             catch (CloudBlobStorageException e)
             {

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -127,12 +127,9 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             {
                 await OnDeleteAsync(resourceUri, deleteRequestOptions, cancellationToken);
             }
-            catch (RequestFailedException ex)
+            catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
             {
-                if (ex.ErrorCode != BlobErrorCode.BlobNotFound)
-                {
-                    throw;
-                }
+                // Ignore this same as CloudBlobStorageException for below.
             }
             catch (CloudBlobStorageException e)
             {

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -129,7 +129,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             }
             catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
             {
-                throw new CloudBlobNotFoundException(ex);
+                // No need to rethrow, same as below statusCode != HttpStatusCode.NotFound for CloudBlobStorageException exception
             }
             catch (CloudBlobStorageException e)
             {

--- a/src/Catalog/Persistence/Storage.cs
+++ b/src/Catalog/Persistence/Storage.cs
@@ -9,9 +9,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
-using Azure.Storage.Blobs.Models;
 using Newtonsoft.Json;
-using NuGetGallery;
 
 namespace NuGet.Services.Metadata.Catalog.Persistence
 {
@@ -127,25 +125,9 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             {
                 await OnDeleteAsync(resourceUri, deleteRequestOptions, cancellationToken);
             }
-            catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
+            catch (RequestFailedException e) when (e.Status == (int)HttpStatusCode.NotFound)
             {
-                // Ignore this same as CloudBlobStorageException for below.
-            }
-            catch (CloudBlobStorageException e)
-            {
-                WebException webException = e.InnerException as WebException;
-                if (webException != null)
-                {
-                    HttpStatusCode statusCode = ((HttpWebResponse)webException.Response).StatusCode;
-                    if (statusCode != HttpStatusCode.NotFound)
-                    {
-                        throw;
-                    }
-                }
-                else
-                {
-                    throw;
-                }
+                // continue
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Engineering/issues/5628
Context is [here on teams](https://teams.microsoft.com/l/message/19:d10cd9192de2492986fba3baeea3093c@thread.skype/1726693433772?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=ad34ac55-6785-4e7c-82c3-7ba405d30c3c&parentMessageId=1726693433772&teamName=NuGet&channelName=Server&createdTime=1726693433772).
Deployment: [1550336](https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1550336)

Previously there was many exceptions for NuGet.Jobs `Catalog2Icon`, after deployment it's no more.
**Before:** ![image](https://github.com/user-attachments/assets/06871a7a-0c43-44af-a174-cda2d77a28d0)

**After:** 
![image](https://github.com/user-attachments/assets/0ba7527b-2d74-4860-9910-3b112a8cca96)

