### PR TITLE
Targeting netstandard 2.1 for more projects

### DIFF
--- a/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
+++ b/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Shared server-side storage component for NuGet services</Description>
   </PropertyGroup>

--- a/src/NuGet.Services.Validation/Entities/EntitiesConfiguration.cs
+++ b/src/NuGet.Services.Validation/Entities/EntitiesConfiguration.cs
@@ -1,15 +1,18 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.SqlServer;
+#if NETFRAMEWORK
 using System.Runtime.Remoting.Messaging;
+#endif
 
 namespace NuGet.Services.Validation
 {
     public class EntitiesConfiguration : DbConfiguration
     {
+#if NETFRAMEWORK
         public EntitiesConfiguration()
         {
             // Configure Connection Resiliency / Retry Logic
@@ -24,5 +27,11 @@ namespace NuGet.Services.Validation
             get => (bool?)CallContext.LogicalGetData("SuspendExecutionStrategy") ?? false;
             set => CallContext.LogicalSetData("SuspendExecutionStrategy", value);
         }
+#else
+        public EntitiesConfiguration()
+        {
+            SetExecutionStrategy("System.Data.SqlClient", () => new SqlAzureExecutionStrategy());
+        }
+#endif
     }
 }

--- a/src/NuGet.Services.Validation/NuGet.Services.Validation.csproj
+++ b/src/NuGet.Services.Validation/NuGet.Services.Validation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(CommonPackageVersion)</PackageVersion>
     <Description>Logic shared between the front-end and back-end concerning asynchronous validation</Description>
 


### PR DESCRIPTION
Internal projects targeting .net depend on those packages and produce build warnings because of unsupported targets. Nothing really prevents those from targeting netstandard 2.1 (not netstandard2.0 because of [EF](https://www.nuget.org/packages/EntityFramework#supportedframeworks-body-tab)).

Had to apply a fix to Validation DB's `EntitiesConfiguration` similar to what we have for Gallery DB:
https://github.com/NuGet/NuGetGallery/blob/febd3fb35bbf25b4a4d40f56859693e0bbf5d6f0/src/NuGetGallery.Core/Entities/EntitiesConfiguration.cs#L7-L43

Functionally, there are no changes for projects consuming those that target net472 and projects targeting .net can actually now use those.