### PR TITLE
Support blob hierarchy operations with a custom delimiter

### DIFF
--- a/src/NuGet.Services.Storage/AzureStorageFactory.cs
+++ b/src/NuGet.Services.Storage/AzureStorageFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,6 +16,7 @@ namespace NuGet.Services.Storage
         private Uri _differentBaseAddress = null;
         private readonly ILogger<AzureStorage> _azureStorageLogger;
         private readonly bool _initializeContainer;
+        private readonly string _delimiter;
 
         public static string PrepareConnectionString(string connectionString)
         {
@@ -32,7 +33,8 @@ namespace NuGet.Services.Storage
             ILogger<AzureStorage> azureStorageLogger,
             string path = null,
             Uri baseAddress = null,
-            bool initializeContainer = true)
+            bool initializeContainer = true,
+            string delimiter = null)
         {
             _account = account;
             _containerName = containerName;
@@ -40,6 +42,7 @@ namespace NuGet.Services.Storage
             _path = null;
             _azureStorageLogger = azureStorageLogger;
             _initializeContainer = initializeContainer;
+            _delimiter = delimiter;
 
             if (path != null)
             {
@@ -94,6 +97,7 @@ namespace NuGet.Services.Storage
                 _account,
                 _containerName,
                 path,
+                _delimiter,
                 newBase,
                 _initializeContainer,
                 _enablePublicAccess,


### PR DESCRIPTION
#### PR Summary
Introduces a `delimiter` parameter to the `AzureStorage` class and its methods for blob hierarchy operations.
- `AzureStorage.cs`: Added `_delimiter` field, updated constructor, `List`, and `ListAsync` methods to use `delimiter`.
- `AzureStorageFactory.cs`: Added `_delimiter` field, updated constructor, and `Create` method to pass `delimiter`.

Part of https://github.com/NuGet/Engineering/issues/5645