### PR TITLE
Fix for issues with root page styling

### DIFF
--- a/src/NuGetGallery/Views/Shared/Gallery/Layout.cshtml
+++ b/src/NuGetGallery/Views/Shared/Gallery/Layout.cshtml
@@ -63,7 +63,7 @@
     @ViewHelpers.ReleaseMeta()
     @ViewHelpers.InstrumentationScript(ViewBag)
 </head>
-<body id=@Url.Current()>
+<body @{if (Request.Url.GetComponents(UriComponents.Path, UriFormat.UriEscaped) == "") { <text>id="/"</text> } }>
     @Html.Partial("Gallery/Header")
     <div id="skippedToContent">
     @RenderBody()


### PR DESCRIPTION
We only have [custom styles](https://github.com/NuGet/NuGetGallery/blob/f1434e76555bf7c8f8b29b0e9a7d08f1f1b76982/src/Bootstrap/less/theme/base.less#L624-L636) for when `id="/"`, no need to have it specified in any other case. Also fixes incorrect styling when query parameters are present for the root page.

Addresses https://github.com/NuGet/Engineering/issues/5636