### PR TITLE
Fixes to CI build template to enable building from forks

### DIFF
--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -33,6 +33,8 @@ variables:
     value: $(Agent.BuildDirectory)\$(NuGetGalleryDirectory)
   - name: NuGetGalleryBranch
     value: $(Build.SourceBranchName)
+  - name: GDN_SUPPRESS_FORKED_BUILD_WARNING
+    value: true
 
 resources:
   repositories:

--- a/.pipelines/NuGetGallery-CI.yml
+++ b/.pipelines/NuGetGallery-CI.yml
@@ -53,6 +53,8 @@ extends:
       os: windows
     customBuildTags:
       - ES365AIMigrationTooling
+    settings:
+      skipBuildTagsForGitHubPullRequests: true      
     stages:
       - stage: common
         displayName: NuGet.Server.Common.sln

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.303",
+    "version": "8.0.403",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.403",
+    "version": "8.0.303",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
This fixes the CI build YAML to enable building from forks. The fixes are:

1. skip tagging builds coming from GitHub forks where tagging isn't supported 
2. disable a warning being generated 

Fixes https://github.com/NuGet/Engineering/issues/5246