### PR TITLE
Targeting netstandard2.0 for scanandsign.core

### DIFF
--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <PackageVersion Condition="'$(PackageVersion)' == ''">$(JobsPackageVersion)</PackageVersion>
     <RootNamespace>NuGet.Jobs.Validation.ScanAndSign</RootNamespace>
     <AssemblyName>NuGet.Jobs.Validation.ScanAndSign.Core</AssemblyName>


### PR DESCRIPTION
At least one project consuming this package targets net6.0. Not sure how it worked so far, but multitargeting should address warnings produced while building that project.