### PR TITLE
Push BuildScopes and VerifyScopes into ICredentialBuilder

### DIFF
--- a/src/NuGetGallery.Services/Authentication/CredentialBuilder.cs
+++ b/src/NuGetGallery.Services/Authentication/CredentialBuilder.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NuGet.Services.Entities;
 using NuGetGallery.Authentication;
@@ -11,6 +12,14 @@ namespace NuGetGallery.Infrastructure.Authentication
     public class CredentialBuilder : ICredentialBuilder
     {
         public const string LatestPasswordType = CredentialTypes.Password.V3;
+
+        private static readonly IReadOnlyDictionary<string, IReadOnlyList<IActionRequiringEntityPermissions>> AllowedActionToActionRequiringEntityPermissionsMap = new Dictionary<string, IReadOnlyList<IActionRequiringEntityPermissions>>
+        {
+            { NuGetScopes.PackagePush, new IActionRequiringEntityPermissions[] { ActionsRequiringPermissions.UploadNewPackageId, ActionsRequiringPermissions.UploadNewPackageVersion } },
+            { NuGetScopes.PackagePushVersion, new [] { ActionsRequiringPermissions.UploadNewPackageVersion } },
+            { NuGetScopes.PackageUnlist, new [] { ActionsRequiringPermissions.UnlistOrRelistPackage } },
+            { NuGetScopes.PackageVerify, new [] { ActionsRequiringPermissions.VerifyPackage } },
+        };
 
         public Credential CreatePasswordCredential(string plaintextPassword)
         {
@@ -71,6 +80,78 @@ namespace NuGetGallery.Infrastructure.Authentication
                 Identity = identity,
                 TenantId = tenantId
             };
+        }
+
+        public IList<Scope> BuildScopes(User scopeOwner, string[] scopes, string[] subjects)
+        {
+            var result = new List<Scope>();
+
+            var subjectsList = subjects?.Where(s => !string.IsNullOrWhiteSpace(s)).ToList() ?? new List<string>();
+
+            // No package filtering information was provided. So allow any pattern.
+            if (!subjectsList.Any())
+            {
+                subjectsList.Add(NuGetPackagePattern.AllInclusivePattern);
+            }
+
+            if (scopes != null)
+            {
+                foreach (var scope in scopes)
+                {
+                    result.AddRange(subjectsList.Select(subject => new Scope(scopeOwner, subject, scope)));
+                }
+            }
+            else
+            {
+                result.AddRange(subjectsList.Select(subject => new Scope(scopeOwner, subject, NuGetScopes.All)));
+            }
+
+            return result;
+        }
+
+        public bool VerifyScopes(User currentUser, IEnumerable<Scope> scopes)
+        {
+            if (!scopes.Any())
+            {
+                // All API keys must have at least one scope.
+                return false;
+            }
+
+            foreach (var scope in scopes)
+            {
+                if (string.IsNullOrEmpty(scope.AllowedAction))
+                {
+                    // All scopes must have an allowed action.
+                    return false;
+                }
+
+                // Get the list of actions allowed by this scope.
+                var actions = new List<IActionRequiringEntityPermissions>();
+                foreach (var allowedAction in AllowedActionToActionRequiringEntityPermissionsMap.Keys)
+                {
+                    if (scope.AllowsActions(allowedAction))
+                    {
+                        actions.AddRange(AllowedActionToActionRequiringEntityPermissionsMap[allowedAction]);
+                    }
+                }
+
+                if (!actions.Any())
+                {
+                    // A scope should allow at least one action.
+                    return false;
+                }
+
+                foreach (var action in actions)
+                {
+                    if (!action.IsAllowedOnBehalfOfAccount(currentUser, scope.Owner))
+                    {
+                        // The user must be able to perform the actions allowed by the scope on behalf of the scope's owner.
+                        return false;
+                    }
+                }
+            }
+
+            return true;
         }
 
         private static string CreateKeyString()

--- a/src/NuGetGallery.Services/Authentication/IAuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/IAuthenticationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
@@ -43,5 +43,12 @@ namespace NuGetGallery.Authentication
         /// </summary>
         /// <returns>Returns whether the API key credential is active or not</returns>
         bool IsActiveApiKeyCredential(Credential credential);
+
+        /// <summary>
+        /// Adds a new credential to the user. This method saves changes in the entity context.
+        /// </summary>
+        /// <param name="user">The user who owns the credental.</param>
+        /// <param name="credential">The credential to be added.</param>
+        Task AddCredential(User user, Credential credential);
     }
 }

--- a/src/NuGetGallery.Services/Authentication/IAuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/IAuthenticationService.cs
@@ -47,7 +47,7 @@ namespace NuGetGallery.Authentication
         /// <summary>
         /// Adds a new credential to the user. This method saves changes in the entity context.
         /// </summary>
-        /// <param name="user">The user who owns the credental.</param>
+        /// <param name="user">The user who owns the credential.</param>
         /// <param name="credential">The credential to be added.</param>
         Task AddCredential(User user, Credential credential);
     }

--- a/src/NuGetGallery.Services/Authentication/ICredentialBuilder.cs
+++ b/src/NuGetGallery.Services/Authentication/ICredentialBuilder.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using NuGet.Services.Entities;
 
 namespace NuGetGallery.Infrastructure.Authentication
@@ -15,5 +16,9 @@ namespace NuGetGallery.Infrastructure.Authentication
         Credential CreatePackageVerificationApiKey(Credential originalApiKey, string id);
 
         Credential CreateExternalCredential(string issuer, string value, string identity, string tenantId = null);
+
+        IList<Scope> BuildScopes(User scopeOwner, string[] scopes, string[] subjects);
+
+        bool VerifyScopes(User currentUser, IEnumerable<Scope> scopes);
     }
 }


### PR DESCRIPTION
This allows more code sharing for other places that create credentials (such as a new endpoint to create a short-lived API key from an OIDC token).

Also, add a method to `IAuthenticationService` which is on the concrete implementation (`AuthenticationService`) to make mocking easier.

Progress on https://github.com/NuGet/NuGetGallery/issues/10212.