### PR TITLE
Move unique constraint check to extension method

### DIFF
--- a/src/NuGet.Services.Entities/Extensions/ExceptionExtensions.cs
+++ b/src/NuGet.Services.Entities/Extensions/ExceptionExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.SqlClient;
+
+namespace NuGet.Services.Entities
+{
+    public static class ExceptionExtensions
+    {
+        public static bool IsSqlUniqueConstraintViolation(this DataException exception)
+        {
+            Exception current = exception;
+            while (current is not null)
+            {
+                if (current is SqlException sqlException)
+                {
+                    switch (sqlException.Number)
+                    {
+                        case 547:  // Constraint check violation: https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-0-to-999
+                        case 2601: // Duplicated key row error: https://learn.microsoft.com/en-us/sql/relational-databases/replication/mssql-eng002601
+                        case 2627: // Unique constraint error: https://learn.microsoft.com/en-us/sql/relational-databases/replication/mssql-eng002627
+                            return true;
+                    }
+                }
+
+                current = current.InnerException;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/NuGetGallery/Services/PackageUploadService.cs
+++ b/src/NuGetGallery/Services/PackageUploadService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -283,21 +283,9 @@ namespace NuGetGallery
             {
                 return true;
             }
-            else if (ex is DbUpdateException dbUpdateEx)
+            else if (ex is DbUpdateException dbUpdateEx && dbUpdateEx.IsSqlUniqueConstraintViolation())
             {
-                if (dbUpdateEx.InnerException?.InnerException != null)
-                {
-                    if (dbUpdateEx.InnerException.InnerException is SqlException sqlException)
-                    {
-                        switch (sqlException.Number)
-                        {
-                            case 547:   // Constraint check violation
-                            case 2601:  // Duplicated key row error
-                            case 2627:  // Unique constraint error
-                                return true;
-                        }
-                    }
-                }
+                return true;
             }
 
             return false;


### PR DESCRIPTION
Also, make the inner exception layer check be tolerant of changes or exception wrapping.

The existing semantics of actually accepting several API SQL error codes is unchanged.

This allows other code to use this check also. 

Supports https://github.com/NuGet/NuGetGallery/issues/10212.