### PR TITLE
Hotfix for web tests

### DIFF
--- a/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
+++ b/tests/NuGetGallery.FunctionalTests.Core/NuGetGallery.FunctionalTests.Core.csproj
@@ -9,7 +9,13 @@
     <Reference Include="System.IO.Compression" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <!--
+    	NuGet.Services.Configuration wants Microsoft.Extensions.* at 2.2.0.
+    	Without it, web tests fail to run and proper fix is not trivial, so
+    	this would have to do for now.
+    	Proper fix tracked here: https://github.com/NuGet/Engineering/issues/5669
+    -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="2.2.0" />
     <PackageReference Include="Microsoft.Web.Xdt" />
     <PackageReference Include="NuGet.Core" />
     <PackageReference Include="NuGet.Services.Configuration" VersionOverride="2.94.0" />


### PR DESCRIPTION
Recent package update broke web tests and we didn't notice.

This is not a proper fix, but something fast to unblock deployments.

https://github.com/NuGet/Engineering/issues/5669 filed to track proper fix.