### PR TITLE
collapse the preview and vulnerable versions in the version tab

### DIFF
--- a/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
+++ b/src/NuGetGallery/Helpers/ViewModelExtensions/DisplayPackageViewModelFactory.cs
@@ -215,6 +215,7 @@ namespace NuGetGallery
                 && packageKeyToVulnerabilities.TryGetValue(package.Key, out var vulnerabilities)
                 && vulnerabilities != null && vulnerabilities.Any())
             {
+                viewModel.IsVulnerable = true;
                 viewModel.Vulnerabilities = vulnerabilities.OrderByDescending(vul => vul.Severity).ToList().AsReadOnly();
                 maxVulnerabilitySeverity = viewModel.Vulnerabilities.Max(v => v.Severity); // cache for messaging
                 viewModel.MaxVulnerabilitySeverity = maxVulnerabilitySeverity.Value;

--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -889,7 +889,116 @@
                     }
                 </div>
                 <div role="tabpanel" class="tab-pane @(activeBodyTab == "versions" ? "active" : "")" id="versions-tab" aria-label="Versions tab content">
-                    <div class="version-history" id="version-history">
+                    <h2>
+                        <a href="#" role="button" data-toggle="collapse" data-target="#stable-version-history"
+                           aria-expanded="true" aria-controls="stable-version-history" id="show-stable-version-history">
+                            <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                            <span>Stable Versions</span>
+                        </a>
+                    </h2>
+                    <div class="version-history collapse in" id="stable-version-history">
+                        <table aria-label="Version History of @Model.Id" class="table borderless">
+                            <thead>
+                                <tr>
+                                    <th scope="col" role="columnheader">Version</th>
+                                    <th scope="col" role="columnheader">Downloads</th>
+                                    <th scope="col" role="columnheader">Last updated</th>
+                                    @if (Model.CanDisplayPrivateMetadata)
+                                    {
+                                        <th scope="col" role="columnheader">Status</th>
+                                    }
+                                    @if (Model.IsCertificatesUIEnabled)
+                                    {
+                                        <th scope="col" role="columnheader" aria-hidden="true" abbr="Signature Information"></th>
+                                    }
+                                </tr>
+                            </thead>
+                            <tbody class="no-border">
+                                @foreach (var packageVersion in Model.PackageVersions.Where(a => !a.Prerelease && !a.IsDeprecated && !a.IsVulnerable))
+                                {
+                                    if ((packageVersion.Available && packageVersion.Listed && Model.ShowDetailsAndLinks)
+                                        || (!packageVersion.Deleted && Model.CanDisplayPrivateMetadata))
+                                    {
+                                        <tr class="@(packageVersion.IsCurrent(Model) ? "bg-brand-info" : null)">
+                                            <td>
+                                                <a href="@Url.Package(packageVersion)" title="@packageVersion.Version">
+                                                    @packageVersion.Version.Abbreviate(30)
+                                                </a>
+                                            </td>
+                                            <td>
+                                                @packageVersion.DownloadCount.ToNuGetNumberString()
+                                            </td>
+                                            <td>
+                                                <span data-datetime="@packageVersion.LastUpdated.ToString("O")">@packageVersion.LastUpdated.ToNuGetShortDateString()</span>
+                                                @if (packageVersion.PushedBy != null)
+                                                {
+                                                    <text>
+                                                        by <span title="@packageVersion.PushedBy">@packageVersion.PushedBy.Abbreviate(15)</span>
+                                                    </text>
+                                                }
+                                            </td>
+                                            @if (packageVersion.CanDisplayPrivateMetadata)
+                                            {
+                                                var packageStatusSummary = packageVersion.PackageStatusSummary;
+
+                                                <td>
+                                                    @if (packageStatusSummary == PackageStatusSummary.Listed ||
+                                                            packageStatusSummary == PackageStatusSummary.Unlisted)
+                                                    {
+                                                        <a href="@Url.ManagePackage(packageVersion)">@NuGetGallery.Helpers.EnumHelper.GetDescription(packageStatusSummary)</a>
+                                                    }
+                                                    else
+                                                    {
+                                                        @NuGetGallery.Helpers.EnumHelper.GetDescription(packageStatusSummary)
+                                                    }
+                                                </td>
+                                            }
+
+                                            @if (Model.IsCertificatesUIEnabled)
+                                            {
+                                                if (string.IsNullOrEmpty(packageVersion.SignatureInformation))
+                                                {
+                                                    <td class="package-icon-cell" aria-hidden="true"></td>
+                                                }
+                                                else
+                                                {
+                                                    <td class="package-icon-cell">
+                                                        <i class="ms-Icon ms-Icon--Ribbon package-icon" title="@packageVersion.SignatureInformation"></i>
+                                                    </td>
+                                                }
+                                            }
+                                        </tr>
+                                    }
+                                    else if (packageVersion.Deleted && packageVersion.CanDisplayPrivateMetadata)
+                                    {
+                                        <tr class="deleted">
+                                            <td class="version">
+                                                @packageVersion.Version
+                                            </td>
+                                            <td>
+                                                @packageVersion.DownloadCount
+                                            </td>
+                                            <td>
+                                                <span data-datetime="@packageVersion.LastUpdated.ToString("O")">@packageVersion.LastUpdated.ToNuGetShortDateString()</span>
+                                            </td>
+                                            <td>
+                                                Deleted
+                                            </td>
+                                            <td colspan="2"></td>
+                                        </tr>
+                                    }
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+                    <h2>
+                        <a href="#" role="button" data-toggle="collapse" data-target="#unstable-version-history"
+                           aria-expanded="false" aria-controls="unstable-version-history" id="show-unstable-version-history">
+                            <i class="ms-Icon ms-Icon--ChevronDown" aria-hidden="true"></i>
+                            <span>Unstable Versions</span>
+                        </a>
+                    </h2>
+                    <div class="version-history collapse" id="unstable-version-history">
                         <table aria-label="Version History of @Model.Id" class="table borderless">
                             <thead>
                                 <tr>
@@ -911,7 +1020,7 @@
                                 </tr>
                             </thead>
                             <tbody class="no-border">
-                                @foreach (var packageVersion in Model.PackageVersions)
+                                @foreach (var packageVersion in Model.PackageVersions.Where(a => a.Prerelease || a.IsDeprecated || a.IsVulnerable))
                                 {
                                     if ((packageVersion.Available && packageVersion.Listed && Model.ShowDetailsAndLinks)
                                         || (!packageVersion.Deleted && Model.CanDisplayPrivateMetadata))
@@ -972,7 +1081,7 @@
                                             else
                                             {
                                                 <td class="package-icon-cell package-warning-icon">
-                                                    <a class="tooltip-target tooltip-icon--black-icon" href="javascript:void(0)" role="button"  aria-describedby="package-icon-@packageVersion.Version" >
+                                                    <a class="tooltip-target tooltip-icon--black-icon" href="javascript:void(0)" role="button" aria-describedby="package-icon-@packageVersion.Version">
                                                         <i class="ms-Icon ms-Icon--Warning package-icon"></i>
                                                         <span class="tooltip-block" role="tooltip" id="package-icon-@packageVersion.Version">
                                                             <span class="tooltip-wrapper tooltip-with-icon popover right">


### PR DESCRIPTION
## Before
![d0af605c6802e38506f0c824dcb1c968](https://github.com/user-attachments/assets/91e7f6bc-05b1-421e-a12e-7ae505ada773)

## After
![f6f2ad81303f26be6d7cd9b2471444f3](https://github.com/user-attachments/assets/816a86b6-b1eb-43ad-972e-4dc13b8a0ee5)

fix #10172