### PR TITLE
Order of operations update for `UploadAsync`

### DIFF
--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -332,11 +332,11 @@ namespace NuGet.Services.Storage
             {
                 using (Stream stream = content.GetContentStream())
                 {
-                    await blob.SetHttpHeadersAsync(headers);
                     await blob.UploadAsync(
                         stream,
                         options: null,
                         cancellationToken: cancellationToken);
+                    await blob.SetHttpHeadersAsync(headers);
 
                     if (Verbose)
                     {


### PR DESCRIPTION
Can't update headers for a blob that haven't been uploaded yet. This change fixes the ProcessSignature job.