### PR TITLE
Suppress warning on CS4014

### DIFF
--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -381,7 +381,7 @@ namespace NuGetGallery
             builder.RegisterType<MarkdownService>()
                 .As<IMarkdownService>()
                 .InstancePerLifetimeScope();
-            
+
             builder.RegisterType<ImageDomainValidator>()
                 .As<IImageDomainValidator>()
                 .InstancePerLifetimeScope();
@@ -405,7 +405,7 @@ namespace NuGetGallery
                 .AsSelf()
                 .As<ICertificateService>()
                 .InstancePerLifetimeScope();
-            
+
             RegisterTyposquattingServiceHelper(builder, loggerFactory);
 
             builder.RegisterType<TyposquattingService>()
@@ -812,7 +812,9 @@ namespace NuGetGallery
                 .Register(c => new TopicClientWrapper(asyncAccountDeleteConnectionString, asyncAccountDeleteTopicName, configuration.ServiceBus.ManagedIdentityClientId))
                 .SingleInstance()
                 .Keyed<ITopicClient>(BindingKeys.AccountDeleterTopic)
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 .OnRelease(x => x.CloseAsync());
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
             builder
                 .RegisterType<AsynchronousDeleteAccountService>()
@@ -948,7 +950,9 @@ namespace NuGetGallery
                 .As<ITopicClient>()
                 .SingleInstance()
                 .Keyed<ITopicClient>(BindingKeys.EmailPublisherTopic)
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 .OnRelease(x => x.CloseAsync());
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
             builder
                 .RegisterType<EmailMessageEnqueuer>()
@@ -1103,14 +1107,18 @@ namespace NuGetGallery
                     .As<ITopicClient>()
                     .SingleInstance()
                     .Keyed<ITopicClient>(BindingKeys.PackageValidationTopic)
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                     .OnRelease(x => x.CloseAsync());
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
                 builder
                     .Register(c => new TopicClientWrapper(symbolsValidationConnectionString, symbolsValidationTopicName, configuration.ServiceBus.ManagedIdentityClientId))
                     .As<ITopicClient>()
                     .SingleInstance()
                     .Keyed<ITopicClient>(BindingKeys.SymbolsPackageValidationTopic)
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                     .OnRelease(x => x.CloseAsync());
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
             else
             {


### PR DESCRIPTION
These are fire and forget tasks performed during app shutdown.

These errors appear in the IDE due to our .editorconfig settings, and can be suppressed. 

This is a little clean-up I found while working on https://github.com/NuGet/NuGetGallery/issues/10212.