### PR TITLE
[SDKMigration]Attempt to fix missing authentication.

### DIFF
--- a/src/Catalog/Dnx/DnxCatalogCollector.cs
+++ b/src/Catalog/Dnx/DnxCatalogCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -193,7 +193,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             return processedCatalogEntries;
         }
 
-        private async Task<bool> AreRequiredPropertiesPresentAsync(Storage destinationStorage, Uri destinationUri)
+        private async Task<bool> AreRequiredPropertiesPresentAsync(Persistence.Storage destinationStorage, Uri destinationUri)
         {
             var azureStorage = destinationStorage as IAzureStorage;
 

--- a/src/Catalog/Dnx/DnxMaker.cs
+++ b/src/Catalog/Dnx/DnxMaker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -16,6 +16,7 @@ using NuGet.Services.Metadata.Catalog.Persistence;
 using NuGet.Versioning;
 
 using ILogger = Microsoft.Extensions.Logging.ILogger;
+using Storage = NuGet.Services.Metadata.Catalog.Persistence.Storage;
 
 namespace NuGet.Services.Metadata.Catalog.Dnx
 {
@@ -154,7 +155,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             await DeleteNupkgAsync(storage, id, normalizedVersion, cancellationToken);
         }
 
-        public async Task<bool> HasPackageInIndexAsync(Storage storage, string id, string version, CancellationToken cancellationToken)
+        public async Task<bool> HasPackageInIndexAsync(Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
         {
             if (storage == null)
             {
@@ -179,7 +180,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             return versionsContext.Versions.Contains(parsedVersion);
         }
 
-        private async Task<Uri> SaveNuspecAsync(Storage storage, string id, string version, string nuspec, CancellationToken cancellationToken)
+        private async Task<Uri> SaveNuspecAsync(Persistence.Storage storage, string id, string version, string nuspec, CancellationToken cancellationToken)
         {
             var relativeAddress = GetRelativeAddressNuspec(id, version);
             var nuspecUri = new Uri(storage.BaseAddress, relativeAddress);
@@ -230,7 +231,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             }
         }
 
-        private async Task<VersionsResult> GetVersionsAsync(Storage storage, CancellationToken cancellationToken)
+        private async Task<VersionsResult> GetVersionsAsync(Persistence.Storage storage, CancellationToken cancellationToken)
         {
             var relativeAddress = "index.json";
             var resourceUri = new Uri(storage.BaseAddress, relativeAddress);
@@ -265,7 +266,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             return new StringStorageContent(obj.ToString(), "application/json", Constants.NoStoreCacheControl);
         }
 
-        private async Task<Uri> SaveNupkgAsync(Stream nupkgStream, Storage storage, string id, string version, CancellationToken cancellationToken)
+        private async Task<Uri> SaveNupkgAsync(Stream nupkgStream, Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
         {
             Uri nupkgUri = new Uri(storage.BaseAddress, GetRelativeAddressNupkg(id, version));
             var content = new StreamStorageContent(
@@ -280,7 +281,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
 
         private async Task<Uri> CopyNupkgAsync(
             IStorage sourceStorage,
-            Storage destinationStorage,
+            Persistence.Storage destinationStorage,
             string id, string version, CancellationToken cancellationToken)
         {
             var packageFileName = PackageUtility.GetPackageFileName(id, version);
@@ -300,7 +301,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
 
         private async Task CopyIconFromAzureStorageIfExistAsync(
             IAzureStorage sourceStorage,
-            Storage destinationStorage,
+            Persistence.Storage destinationStorage,
             string packageId,
             string normalizedPackageVersion,
             string iconFilename,
@@ -321,7 +322,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
         private async Task CopyIconFromNupkgStreamAsync(
             Stream nupkgStream,
             string iconFilename,
-            Storage destinationStorage,
+            Persistence.Storage destinationStorage,
             string packageId,
             string normalizedPackageVersion,
             CancellationToken cancellationToken)
@@ -338,7 +339,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
         private async Task CopyIconAsync(
             Stream packageStream,
             string iconFilename,
-            Storage destinationStorage,
+            Persistence.Storage destinationStorage,
             string packageId,
             string normalizedPackageVersion,
             CancellationToken cancellationToken)
@@ -366,7 +367,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
         private async Task ExtractAndStoreIconAsync(
             Stream packageStream,
             string iconPath,
-            Storage destinationStorage,
+            Persistence.Storage destinationStorage,
             Uri destinationUri,
             CancellationToken cancellationToken,
             string packageId,
@@ -406,7 +407,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             return await packageSourceBlob.GetStreamAsync(cancellationToken);
         }
 
-        private async Task DeleteNuspecAsync(Storage storage, string id, string version, CancellationToken cancellationToken)
+        private async Task DeleteNuspecAsync(Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
         {
             string relativeAddress = GetRelativeAddressNuspec(id, version);
             Uri nuspecUri = new Uri(storage.BaseAddress, relativeAddress);
@@ -416,7 +417,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             }
         }
 
-        private async Task DeleteNupkgAsync(Storage storage, string id, string version, CancellationToken cancellationToken)
+        private async Task DeleteNupkgAsync(Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
         {
             string relativeAddress = GetRelativeAddressNupkg(id, version);
             Uri nupkgUri = new Uri(storage.BaseAddress, relativeAddress);
@@ -426,7 +427,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             }
         }
 
-        private async Task DeleteIconAsync(Storage storage, string id, string version, CancellationToken cancellationToken)
+        private async Task DeleteIconAsync(Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
         {
             string relativeAddress = GetRelativeAddressIcon(id, version);
             Uri iconUri = new Uri(storage.BaseAddress, relativeAddress);

--- a/src/Catalog/Dnx/DnxMaker.cs
+++ b/src/Catalog/Dnx/DnxMaker.cs
@@ -16,7 +16,7 @@ using NuGet.Services.Metadata.Catalog.Persistence;
 using NuGet.Versioning;
 
 using ILogger = Microsoft.Extensions.Logging.ILogger;
-using Storage = NuGet.Services.Metadata.Catalog.Persistence.Storage;
+using CatalogStorage = NuGet.Services.Metadata.Catalog.Persistence.Storage;
 
 namespace NuGet.Services.Metadata.Catalog.Dnx
 {
@@ -155,7 +155,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             await DeleteNupkgAsync(storage, id, normalizedVersion, cancellationToken);
         }
 
-        public async Task<bool> HasPackageInIndexAsync(Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
+        public async Task<bool> HasPackageInIndexAsync(CatalogStorage storage, string id, string version, CancellationToken cancellationToken)
         {
             if (storage == null)
             {
@@ -180,7 +180,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             return versionsContext.Versions.Contains(parsedVersion);
         }
 
-        private async Task<Uri> SaveNuspecAsync(Persistence.Storage storage, string id, string version, string nuspec, CancellationToken cancellationToken)
+        private async Task<Uri> SaveNuspecAsync(CatalogStorage storage, string id, string version, string nuspec, CancellationToken cancellationToken)
         {
             var relativeAddress = GetRelativeAddressNuspec(id, version);
             var nuspecUri = new Uri(storage.BaseAddress, relativeAddress);
@@ -231,7 +231,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             }
         }
 
-        private async Task<VersionsResult> GetVersionsAsync(Persistence.Storage storage, CancellationToken cancellationToken)
+        private async Task<VersionsResult> GetVersionsAsync(CatalogStorage storage, CancellationToken cancellationToken)
         {
             var relativeAddress = "index.json";
             var resourceUri = new Uri(storage.BaseAddress, relativeAddress);
@@ -266,7 +266,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             return new StringStorageContent(obj.ToString(), "application/json", Constants.NoStoreCacheControl);
         }
 
-        private async Task<Uri> SaveNupkgAsync(Stream nupkgStream, Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
+        private async Task<Uri> SaveNupkgAsync(Stream nupkgStream, CatalogStorage storage, string id, string version, CancellationToken cancellationToken)
         {
             Uri nupkgUri = new Uri(storage.BaseAddress, GetRelativeAddressNupkg(id, version));
             var content = new StreamStorageContent(
@@ -281,7 +281,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
 
         private async Task<Uri> CopyNupkgAsync(
             IStorage sourceStorage,
-            Persistence.Storage destinationStorage,
+            CatalogStorage destinationStorage,
             string id, string version, CancellationToken cancellationToken)
         {
             var packageFileName = PackageUtility.GetPackageFileName(id, version);
@@ -301,7 +301,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
 
         private async Task CopyIconFromAzureStorageIfExistAsync(
             IAzureStorage sourceStorage,
-            Persistence.Storage destinationStorage,
+            CatalogStorage destinationStorage,
             string packageId,
             string normalizedPackageVersion,
             string iconFilename,
@@ -322,7 +322,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
         private async Task CopyIconFromNupkgStreamAsync(
             Stream nupkgStream,
             string iconFilename,
-            Persistence.Storage destinationStorage,
+            CatalogStorage destinationStorage,
             string packageId,
             string normalizedPackageVersion,
             CancellationToken cancellationToken)
@@ -339,7 +339,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
         private async Task CopyIconAsync(
             Stream packageStream,
             string iconFilename,
-            Persistence.Storage destinationStorage,
+            CatalogStorage destinationStorage,
             string packageId,
             string normalizedPackageVersion,
             CancellationToken cancellationToken)
@@ -367,7 +367,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
         private async Task ExtractAndStoreIconAsync(
             Stream packageStream,
             string iconPath,
-            Persistence.Storage destinationStorage,
+            CatalogStorage destinationStorage,
             Uri destinationUri,
             CancellationToken cancellationToken,
             string packageId,
@@ -407,7 +407,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             return await packageSourceBlob.GetStreamAsync(cancellationToken);
         }
 
-        private async Task DeleteNuspecAsync(Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
+        private async Task DeleteNuspecAsync(CatalogStorage storage, string id, string version, CancellationToken cancellationToken)
         {
             string relativeAddress = GetRelativeAddressNuspec(id, version);
             Uri nuspecUri = new Uri(storage.BaseAddress, relativeAddress);
@@ -417,7 +417,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             }
         }
 
-        private async Task DeleteNupkgAsync(Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
+        private async Task DeleteNupkgAsync(CatalogStorage storage, string id, string version, CancellationToken cancellationToken)
         {
             string relativeAddress = GetRelativeAddressNupkg(id, version);
             Uri nupkgUri = new Uri(storage.BaseAddress, relativeAddress);
@@ -427,7 +427,7 @@ namespace NuGet.Services.Metadata.Catalog.Dnx
             }
         }
 
-        private async Task DeleteIconAsync(Persistence.Storage storage, string id, string version, CancellationToken cancellationToken)
+        private async Task DeleteIconAsync(CatalogStorage storage, string id, string version, CancellationToken cancellationToken)
         {
             string relativeAddress = GetRelativeAddressIcon(id, version);
             Uri iconUri = new Uri(storage.BaseAddress, relativeAddress);

--- a/src/Catalog/DurableCursor.cs
+++ b/src/Catalog/DurableCursor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,10 +12,10 @@ namespace NuGet.Services.Metadata.Catalog
     public class DurableCursor : ReadWriteCursor
     {
         Uri _address;
-        Storage _storage;
+        Persistence.Storage _storage;
         DateTime _defaultValue;
 
-        public DurableCursor(Uri address, Storage storage, DateTime defaultValue)
+        public DurableCursor(Uri address, Persistence.Storage storage, DateTime defaultValue)
         {
             _address = address;
             _storage = storage;

--- a/src/Catalog/Helpers/DeletionAuditEntry.cs
+++ b/src/Catalog/Helpers/DeletionAuditEntry.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -163,7 +163,7 @@ namespace NuGet.Services.Metadata.Catalog.Helpers
             DateTime? maxTime = null,
             ILogger logger = null)
         {
-            Storage storage = auditingStorageFactory.Create(package != null ? GetAuditRecordPrefixFromPackage(package) : null);
+            Persistence.Storage storage = auditingStorageFactory.Create(package != null ? GetAuditRecordPrefixFromPackage(package) : null);
             return GetAsync(storage, cancellationToken, minTime, maxTime, logger);
         }
 

--- a/src/Catalog/Icons/CatalogLeafDataProcessor.cs
+++ b/src/Catalog/Icons/CatalogLeafDataProcessor.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 using NuGet.Services.Metadata.Catalog.Helpers;
 using NuGet.Services.Metadata.Catalog.Persistence;
 
-using Storage = NuGet.Services.Metadata.Catalog.Persistence.Storage;
+using CatalogStorage = NuGet.Services.Metadata.Catalog.Persistence.Storage;
 
 namespace NuGet.Services.Metadata.Catalog.Icons
 {
@@ -44,7 +44,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task ProcessPackageDeleteLeafAsync(Persistence.Storage storage, CatalogCommitItem item, CancellationToken cancellationToken)
+        public async Task ProcessPackageDeleteLeafAsync(CatalogStorage storage, CatalogCommitItem item, CancellationToken cancellationToken)
         {
             var targetStoragePath = GetTargetStorageIconPath(item);
             await _iconProcessor.DeleteIconAsync(storage, targetStoragePath, cancellationToken, item.PackageIdentity.Id, item.PackageIdentity.Version.ToNormalizedString());

--- a/src/Catalog/Icons/CatalogLeafDataProcessor.cs
+++ b/src/Catalog/Icons/CatalogLeafDataProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,6 +11,8 @@ using Azure;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.Metadata.Catalog.Helpers;
 using NuGet.Services.Metadata.Catalog.Persistence;
+
+using Storage = NuGet.Services.Metadata.Catalog.Persistence.Storage;
 
 namespace NuGet.Services.Metadata.Catalog.Icons
 {
@@ -42,7 +44,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task ProcessPackageDeleteLeafAsync(Storage storage, CatalogCommitItem item, CancellationToken cancellationToken)
+        public async Task ProcessPackageDeleteLeafAsync(Persistence.Storage storage, CatalogCommitItem item, CancellationToken cancellationToken)
         {
             var targetStoragePath = GetTargetStorageIconPath(item);
             await _iconProcessor.DeleteIconAsync(storage, targetStoragePath, cancellationToken, item.PackageIdentity.Id, item.PackageIdentity.Version.ToNormalizedString());

--- a/src/Catalog/Icons/ICatalogLeafDataProcessor.cs
+++ b/src/Catalog/Icons/ICatalogLeafDataProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;
@@ -9,7 +9,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
 {
     public interface ICatalogLeafDataProcessor
     {
-        Task ProcessPackageDeleteLeafAsync(Storage storage, CatalogCommitItem item, CancellationToken cancellationToken);
+        Task ProcessPackageDeleteLeafAsync(Persistence.Storage storage, CatalogCommitItem item, CancellationToken cancellationToken);
         Task ProcessPackageDetailsLeafAsync(IStorage destinationStorage, IStorage iconCacheStorage, CatalogCommitItem item, string iconUrlString, string iconFile, CancellationToken cancellationToken);
     }
 }

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -76,6 +76,7 @@
     <ProjectReference Include="..\NuGet.Services.Configuration\NuGet.Services.Configuration.csproj" />
     <ProjectReference Include="..\NuGet.Services.Logging\NuGet.Services.Logging.csproj" />
     <ProjectReference Include="..\NuGet.Services.Sql\NuGet.Services.Sql.csproj" />
+    <ProjectReference Include="..\NuGet.Services.Storage\NuGet.Services.Storage.csproj" />
     <ProjectReference Include="..\NuGetGallery.Core\NuGetGallery.Core.csproj" />
   </ItemGroup>
 

--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -11,11 +11,13 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using NuGet.Protocol;
 using NuGet.Services.Metadata.Catalog.Extensions;
+using NuGet.Services.Storage;
 using NuGetGallery;
 
 namespace NuGet.Services.Metadata.Catalog.Persistence
@@ -33,7 +35,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         public static readonly TimeSpan DefaultMaxExecutionTime = TimeSpan.FromMinutes(10);
 
         public AzureStorage(
-            BlobServiceClient blobServiceClient,
+            IBlobServiceClientFactory blobServiceClient,
             string containerName,
             string path,
             Uri baseAddress,
@@ -92,7 +94,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
 
             var blobEndpoint = new Uri(storageBaseUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped));
             // Create BlobServiceClient with anonymous credentials
-            var blobServiceClient = new BlobServiceClient(blobEndpoint);
+            var blobServiceClient = new BlobServiceClientFactory(blobEndpoint, new DefaultAzureCredential());
 
             string containerName = pathSegments[0];
             string pathInContainer = string.Join("/", pathSegments.Skip(1));

--- a/src/Catalog/Persistence/AzureStorageFactory.cs
+++ b/src/Catalog/Persistence/AzureStorageFactory.cs
@@ -1,15 +1,16 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Azure.Storage.Blobs;
 using NuGet.Protocol;
+using NuGet.Services.Storage;
 
 namespace NuGet.Services.Metadata.Catalog.Persistence
 {
     public class AzureStorageFactory : StorageFactory
     {
-        private readonly BlobServiceClient _blobServiceClient;
+        private readonly IBlobServiceClientFactory _blobServiceClient;
         private readonly string _containerName;
         private readonly string _path;
         private readonly Uri _differentBaseAddress = null;
@@ -19,7 +20,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
         private readonly bool _initializeContainer;
 
         public AzureStorageFactory(
-            BlobServiceClient blobServiceClient,
+            IBlobServiceClientFactory blobServiceClient,
             string containerName,
             TimeSpan maxExecutionTime,
             TimeSpan serverTimeout,

--- a/src/Catalog/Persistence/CloudBlobDirectoryWrapper.cs
+++ b/src/Catalog/Persistence/CloudBlobDirectoryWrapper.cs
@@ -5,27 +5,32 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Core.Pipeline;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using NuGet.Services.Storage;
 
 namespace NuGet.Services.Metadata.Catalog.Persistence
 {
     public class CloudBlobDirectoryWrapper : ICloudBlobDirectory
     {
+        private readonly IBlobServiceClientFactory _blobServiceClientFactory;
         private readonly BlobContainerClient _containerClient;
         private readonly string _directoryPrefix;
         private readonly IBlobContainerClientWrapper _blobContainerClientWrapper;
         private readonly BlobClientOptions _defaultClientOptions;
 
-        public BlobServiceClient ServiceClient => _containerClient.GetParentBlobServiceClient();
+        public IBlobServiceClientFactory ServiceClient => new SimpleBlobServiceClientFactory(_containerClient.GetParentBlobServiceClient());
         public Uri Uri { get; }
         public string DirectoryPrefix => _directoryPrefix;
         public BlobClientOptions ContainerOptions => _defaultClientOptions;
         public IBlobContainerClientWrapper ContainerClientWrapper => _blobContainerClientWrapper;
 
-        public CloudBlobDirectoryWrapper(BlobServiceClient serviceClient, string containerName, string directoryPrefix, BlobClientOptions blobClientOptions = null)
+        public CloudBlobDirectoryWrapper(IBlobServiceClientFactory serviceClient, string containerName, string directoryPrefix, BlobClientOptions blobClientOptions = null)
         {
+            _blobServiceClientFactory = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
             _directoryPrefix = directoryPrefix ?? throw new ArgumentNullException(nameof(directoryPrefix));
 
             if (string.IsNullOrWhiteSpace(containerName))
@@ -39,14 +44,14 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             if (blobClientOptions != null)
             {
                 // Extract necessary information
-                Uri serviceUri = serviceClient.Uri;
+                //Uri serviceUri = serviceClient.Uri;
                 // Create a new BlobServiceClient instance with the new options
-                var newServiceClient = new BlobServiceClient(serviceUri, _defaultClientOptions);
+                var newServiceClient = _blobServiceClientFactory.GetBlobServiceClient(blobClientOptions);
                 _containerClient = newServiceClient.GetBlobContainerClient(containerName);
             }
             else
             {
-                _containerClient = serviceClient.GetBlobContainerClient(containerName);
+                _containerClient = _blobServiceClientFactory.GetBlobServiceClient(null).GetBlobContainerClient(containerName);
             }
 
             Uri = new Uri(Storage.RemoveQueryString(_containerClient.Uri).TrimEnd('/') + "/" + _directoryPrefix);

--- a/src/Catalog/Persistence/CloudBlobDirectoryWrapper.cs
+++ b/src/Catalog/Persistence/CloudBlobDirectoryWrapper.cs
@@ -43,15 +43,13 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             // Create the container client using the provided or default options
             if (blobClientOptions != null)
             {
-                // Extract necessary information
-                //Uri serviceUri = serviceClient.Uri;
-                // Create a new BlobServiceClient instance with the new options
+                // Request a new BlobServiceClient instance with the new options
                 var newServiceClient = _blobServiceClientFactory.GetBlobServiceClient(blobClientOptions);
                 _containerClient = newServiceClient.GetBlobContainerClient(containerName);
             }
             else
             {
-                _containerClient = _blobServiceClientFactory.GetBlobServiceClient(null).GetBlobContainerClient(containerName);
+                _containerClient = _blobServiceClientFactory.GetBlobServiceClient(blobClientOptions: null).GetBlobContainerClient(containerName);
             }
 
             Uri = new Uri(Storage.RemoveQueryString(_containerClient.Uri).TrimEnd('/') + "/" + _directoryPrefix);

--- a/src/Catalog/Persistence/ICloudBlobDirectory.cs
+++ b/src/Catalog/Persistence/ICloudBlobDirectory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,12 +8,13 @@ using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using NuGet.Services.Storage;
 
 namespace NuGet.Services.Metadata.Catalog.Persistence
 {
     public interface ICloudBlobDirectory
     {
-        BlobServiceClient ServiceClient { get; }
+        IBlobServiceClientFactory ServiceClient { get; }
         IBlobContainerClientWrapper ContainerClientWrapper { get; }
         string DirectoryPrefix { get; }
         Uri Uri { get; }

--- a/src/Gallery.CredentialExpiration/Job.cs
+++ b/src/Gallery.CredentialExpiration/Job.cs
@@ -52,7 +52,7 @@ namespace Gallery.CredentialExpiration
 
             FromAddress = new MailAddress(InitializationConfiguration.MailFrom);
             
-            var storageAccount = new BlobServiceClient(AzureStorageFactory.PrepareConnectionString(InitializationConfiguration.DataStorageAccount));
+            var storageAccount = new BlobServiceClientFactory(AzureStorageFactory.PrepareConnectionString(InitializationConfiguration.DataStorageAccount));
             var storageFactory = new AzureStorageFactory(
                 storageAccount,
                 InitializationConfiguration.ContainerName,

--- a/src/GitHubVulnerabilities2Db/Job.cs
+++ b/src/GitHubVulnerabilities2Db/Job.cs
@@ -168,15 +168,15 @@ namespace GitHubVulnerabilities2Db
                 {
                     var config = ctx.Resolve<GitHubVulnerabilities2DbConfiguration>();
                     var credential = new ManagedIdentityCredential(configurationRoot[ManagedIdentityClientIdKey]);
-                    return new BlobServiceClient(new Uri(config.StorageConnectionString), credential);
+                    return new BlobServiceClientFactory(new Uri(config.StorageConnectionString), credential);
                 })
-                .As<BlobServiceClient>();
+                .As<BlobServiceClientFactory>();
 
             containerBuilder
                 .Register(ctx =>
                 {
                     return new AzureStorageFactory(
-                        ctx.Resolve<BlobServiceClient>(),
+                        ctx.Resolve<BlobServiceClientFactory>(),
                         ctx.Resolve<GitHubVulnerabilities2DbConfiguration>().CursorContainerName,
                         enablePublicAccess: true,
                         ctx.Resolve<ILogger<AzureStorage>>());

--- a/src/GitHubVulnerabilities2v3/Job.cs
+++ b/src/GitHubVulnerabilities2v3/Job.cs
@@ -118,15 +118,15 @@ namespace GitHubVulnerabilities2v3
                 {
                     var config = ctx.Resolve<GitHubVulnerabilities2v3Configuration>();
                     var connectionString = AzureStorageFactory.PrepareConnectionString(config.StorageConnectionString);
-                    return new BlobServiceClient(connectionString);
+                    return new BlobServiceClientFactory(connectionString);
                 })
-                .As<BlobServiceClient>();
+                .As<BlobServiceClientFactory>();
 
             containerBuilder
                 .Register(ctx =>
                 {
                     return new AzureStorageFactory(
-                        ctx.Resolve<BlobServiceClient>(),
+                        ctx.Resolve<BlobServiceClientFactory>(),
                         ctx.Resolve<GitHubVulnerabilities2v3Configuration>().V3VulnerabilityContainerName,
                         enablePublicAccess: true,
                         ctx.Resolve<ILogger<AzureStorage>>());

--- a/src/Ng/Arguments.cs
+++ b/src/Ng/Arguments.cs
@@ -39,6 +39,7 @@ namespace Ng
         public const string StoragePath = "storagePath";
         public const string StorageQueueName = "storageQueueName";
         public const string StorageType = "storageType";
+        public const string StorageUseManagedIdentity = "storageUseManagedIdentity";
 
         public const string StorageSuffix = "storageSuffix";
         public const string StorageOperationMaxExecutionTimeInSeconds = "storageOperationMaxExecutionTimeInSeconds";

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -51,6 +51,7 @@ namespace Ng
             { Arguments.StorageOperationMaxExecutionTimeInSeconds, Arguments.StorageOperationMaxExecutionTimeInSeconds },
             { Arguments.StorageServerTimeoutInSeconds, Arguments.StorageServerTimeoutInSeconds },
             { Arguments.StorageInitializeContainer, Arguments.StorageInitializeContainer },
+            { Arguments.ClientId, Arguments.ClientId },
         };
 
         public static IDictionary<string, string> GetArguments(string[] args, int start, out ICachingSecretInjector secretInjector)

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -431,7 +431,7 @@ namespace Ng
             {
                 var managedIdentityClientId = arguments.GetOrThrow<string>(argumentNameMap[Arguments.ClientId]);
                 var identity = new ManagedIdentityCredential(managedIdentityClientId);
-                var serviceUri = GetServiceUri(arguments, argumentNameMap, "BlobEndpoint", "blob");
+                var serviceUri = GetServiceUri(arguments, argumentNameMap, "blob");
                 return new BlobServiceClientFactory(serviceUri, identity);
             }
 
@@ -448,7 +448,7 @@ namespace Ng
             {
                 var managedIdentityClientId = arguments.GetOrThrow<string>(argumentNameMap[Arguments.ClientId]);
                 var identity = new ManagedIdentityCredential(managedIdentityClientId);
-                var serviceUri = GetServiceUri(arguments, argumentNameMap, "QueueEndpoint", "queue");
+                var serviceUri = GetServiceUri(arguments, argumentNameMap, "queue");
                 return new QueueServiceClient(serviceUri, identity, new QueueClientOptions
                 {
                     MessageEncoding = QueueMessageEncoding.Base64,
@@ -497,7 +497,6 @@ namespace Ng
         private static Uri GetServiceUri(
             IDictionary<string, string> arguments,
             IDictionary<string, string> argumentNameMap,
-            string endpointKey,
             string endpointDomain)
         {
             var storageAccountName = arguments.GetOrThrow<string>(argumentNameMap[Arguments.StorageAccountName]);

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -424,14 +424,15 @@ namespace Ng
             IDictionary<string, string> argumentNameMap)
         {
             bool storageUseManagedIdentity = arguments.GetOrDefault(argumentNameMap[Arguments.StorageUseManagedIdentity], defaultValue: true);
-            string connectionString = GetConnectionString(arguments, argumentNameMap, "BlobEndpoint", "blob");
             if (storageUseManagedIdentity)
             {
                 var managedIdentityClientId = arguments.GetOrThrow<string>(argumentNameMap[Arguments.ClientId]);
                 var identity = new ManagedIdentityCredential(managedIdentityClientId);
                 var serviceUri = GetServiceUri(arguments, argumentNameMap, "BlobEndpoint", "blob");
-                return new BlobServiceClient(managedIdentityClientId);
+                return new BlobServiceClient(serviceUri, identity);
             }
+
+            string connectionString = GetConnectionString(arguments, argumentNameMap, "BlobEndpoint", "blob");
             return new BlobServiceClient(connectionString);
         }
 
@@ -439,6 +440,18 @@ namespace Ng
             IDictionary<string, string> arguments,
             IDictionary<string, string> argumentNameMap)
         {
+            bool storageUseManagedIdentity = arguments.GetOrDefault(argumentNameMap[Arguments.StorageUseManagedIdentity], defaultValue: true);
+            if (storageUseManagedIdentity)
+            {
+                var managedIdentityClientId = arguments.GetOrThrow<string>(argumentNameMap[Arguments.ClientId]);
+                var identity = new ManagedIdentityCredential(managedIdentityClientId);
+                var serviceUri = GetServiceUri(arguments, argumentNameMap, "QueueEndpoint", "queue");
+                return new QueueServiceClient(serviceUri, identity, new QueueClientOptions
+                {
+                    MessageEncoding = QueueMessageEncoding.Base64,
+                });
+            }
+
             string connectionString = GetConnectionString(arguments, argumentNameMap, "QueueEndpoint", "queue");
             return new QueueServiceClient(connectionString, new QueueClientOptions
             {

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -423,7 +423,7 @@ namespace Ng
             IDictionary<string, string> arguments,
             IDictionary<string, string> argumentNameMap)
         {
-            bool storageUseManagedIdentity = arguments.GetOrDefault(argumentNameMap[Arguments.StorageUseManagedIdentity], defaultValue: true);
+            bool storageUseManagedIdentity = arguments.GetOrDefault(argumentNameMap[Arguments.StorageUseManagedIdentity], defaultValue: false);
             if (storageUseManagedIdentity)
             {
                 var managedIdentityClientId = arguments.GetOrThrow<string>(argumentNameMap[Arguments.ClientId]);
@@ -440,7 +440,7 @@ namespace Ng
             IDictionary<string, string> arguments,
             IDictionary<string, string> argumentNameMap)
         {
-            bool storageUseManagedIdentity = arguments.GetOrDefault(argumentNameMap[Arguments.StorageUseManagedIdentity], defaultValue: true);
+            bool storageUseManagedIdentity = arguments.GetOrDefault(argumentNameMap[Arguments.StorageUseManagedIdentity], defaultValue: false);
             if (storageUseManagedIdentity)
             {
                 var managedIdentityClientId = arguments.GetOrThrow<string>(argumentNameMap[Arguments.ClientId]);

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -14,6 +14,7 @@ using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
 using Microsoft.Extensions.Logging;
+using NuGet.Jobs;
 using NuGet.Protocol;
 using NuGet.Services.Configuration;
 using NuGet.Services.KeyVault;
@@ -225,7 +226,7 @@ namespace Ng
                 var storageUseServerSideCopy = arguments.GetOrDefault<bool>(argumentNameMap[Arguments.StorageUseServerSideCopy]);
                 var storageInitializeContainer = arguments.GetOrDefault(argumentNameMap[Arguments.StorageInitializeContainer], defaultValue: true);
 
-                BlobServiceClient account = GetBlobServiceClient(arguments, argumentNameMap);
+                IBlobServiceClientFactory account = GetBlobServiceClient(arguments, argumentNameMap);
 
                 return new CatalogAzureStorageFactory(
                     account,
@@ -421,7 +422,7 @@ namespace Ng
             }
         }
 
-        private static BlobServiceClient GetBlobServiceClient(
+        private static IBlobServiceClientFactory GetBlobServiceClient(
             IDictionary<string, string> arguments,
             IDictionary<string, string> argumentNameMap)
         {
@@ -431,11 +432,11 @@ namespace Ng
                 var managedIdentityClientId = arguments.GetOrThrow<string>(argumentNameMap[Arguments.ClientId]);
                 var identity = new ManagedIdentityCredential(managedIdentityClientId);
                 var serviceUri = GetServiceUri(arguments, argumentNameMap, "BlobEndpoint", "blob");
-                return new BlobServiceClient(serviceUri, identity);
+                return new BlobServiceClientFactory(serviceUri, identity);
             }
 
             string connectionString = GetConnectionString(arguments, argumentNameMap, "BlobEndpoint", "blob");
-            return new BlobServiceClient(connectionString);
+            return new BlobServiceClientFactory(connectionString);
         }
 
         private static QueueServiceClient GetQueueServiceClient(

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -164,6 +164,7 @@ namespace Ng
             {
                 { Arguments.StorageBaseAddress, Arguments.StorageBaseAddress + suffix },
                 { Arguments.StorageAccountName, Arguments.StorageAccountName + suffix },
+                { Arguments.StorageUseManagedIdentity, Arguments.StorageUseManagedIdentity + suffix },
                 { Arguments.StorageKeyValue, Arguments.StorageKeyValue + suffix },
                 { Arguments.StorageSasValue, Arguments.StorageSasValue + suffix },
                 { Arguments.StorageContainer, Arguments.StorageContainer + suffix },

--- a/src/Ng/Jobs/Db2MonitoringJob.cs
+++ b/src/Ng/Jobs/Db2MonitoringJob.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -28,8 +28,10 @@ using NuGet.Services.AzureSearch.Db2AzureSearch;
 using NuGet.Services.AzureSearch.SearchService;
 using NuGet.Services.AzureSearch.Wrappers;
 using NuGet.Services.Metadata.Catalog.Persistence;
+using NuGet.Services.Storage;
 using NuGet.Services.V3;
 using NuGetGallery;
+using IStorageFactory = NuGet.Services.Metadata.Catalog.Persistence.IStorageFactory;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -135,12 +137,12 @@ namespace NuGet.Services.AzureSearch
                 .Register<IStorageFactory>(c =>
                 {
                     var options = c.Resolve<IOptionsSnapshot<AzureSearchConfiguration>>();
-                    BlobServiceClient blobServiceClient = c.ResolveKeyed<BlobServiceClient>(key);
-                    return new AzureStorageFactory(
+                    BlobServiceClientFactory blobServiceClient = c.ResolveKeyed<BlobServiceClientFactory>(key);
+                    return new Metadata.Catalog.Persistence.AzureStorageFactory(
                         blobServiceClient,
                         options.Value.StorageContainer,
-                        maxExecutionTime: AzureStorage.DefaultMaxExecutionTime,
-                        serverTimeout: AzureStorage.DefaultServerTimeout,
+                        maxExecutionTime: Metadata.Catalog.Persistence.AzureStorage.DefaultMaxExecutionTime,
+                        serverTimeout: Metadata.Catalog.Persistence.AzureStorage.DefaultServerTimeout,
                         path: options.Value.NormalizeStoragePath(),
                         baseAddress: null,
                         useServerSideCopy: true,

--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -23,7 +23,7 @@ namespace NuGet.Services.Storage
         private readonly string _path;
 
         public AzureStorage(
-            BlobServiceClient account,
+            BlobServiceClientFactory account,
             string containerName,
             string path,
             Uri baseAddress,
@@ -31,7 +31,7 @@ namespace NuGet.Services.Storage
             bool enablePublicAccess,
             ILogger<AzureStorage> logger)
             : this(
-                  account.GetBlobContainerClient(containerName),
+                  account.GetBlobServiceClient().GetBlobContainerClient(containerName),
                   baseAddress,
                   initializeContainer,
                   enablePublicAccess,

--- a/src/NuGet.Services.Storage/AzureStorageFactory.cs
+++ b/src/NuGet.Services.Storage/AzureStorageFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,7 +9,7 @@ namespace NuGet.Services.Storage
 {
     public class AzureStorageFactory : StorageFactory
     {
-        BlobServiceClient _account;
+        BlobServiceClientFactory _account;
         string _containerName;
         private readonly bool _enablePublicAccess;
         string _path;
@@ -26,7 +26,7 @@ namespace NuGet.Services.Storage
         }
 
         public AzureStorageFactory(
-            BlobServiceClient account,
+            BlobServiceClientFactory account,
             string containerName,
             bool enablePublicAccess,
             ILogger<AzureStorage> azureStorageLogger,

--- a/src/NuGet.Services.Storage/BlobServiceClientFactory.cs
+++ b/src/NuGet.Services.Storage/BlobServiceClientFactory.cs
@@ -35,7 +35,7 @@ namespace NuGet.Services.Storage
             _useTokenCredential = true;
         }
 
-        public BlobServiceClient GetBlobServiceClient(BlobClientOptions blobClientOptions = null)
+        public virtual BlobServiceClient GetBlobServiceClient(BlobClientOptions blobClientOptions = null)
         {
             if (_useTokenCredential)
             {

--- a/src/NuGet.Services.Storage/BlobServiceClientFactory.cs
+++ b/src/NuGet.Services.Storage/BlobServiceClientFactory.cs
@@ -32,6 +32,7 @@ namespace NuGet.Services.Storage
         {
             this.Uri = serviceUri;
             _credential = credential ?? throw new ArgumentNullException(nameof(credential));
+            _useTokenCredential = true;
         }
 
         public BlobServiceClient GetBlobServiceClient(BlobClientOptions blobClientOptions = null)

--- a/src/NuGet.Services.Storage/BlobServiceClientFactory.cs
+++ b/src/NuGet.Services.Storage/BlobServiceClientFactory.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+
+namespace NuGet.Services.Storage
+{
+    public class BlobServiceClientFactory : IBlobServiceClientFactory
+    {
+        private bool _useTokenCredential = false;
+        private TokenCredential _credential;
+        private string _connectionString = "";
+
+        public virtual Uri Uri { get; set; }
+
+        public BlobServiceClientFactory() { }
+
+        public BlobServiceClientFactory(string connectionString)
+        {
+            _connectionString = connectionString;
+            this.Uri = new BlobServiceClient(connectionString).Uri;
+        }
+
+        public BlobServiceClientFactory(Uri serviceUri, TokenCredential credential)
+        {
+            this.Uri = serviceUri;
+            _credential = credential ?? throw new ArgumentNullException(nameof(credential));
+        }
+
+        public BlobServiceClient GetBlobServiceClient(BlobClientOptions blobClientOptions = null)
+        {
+            if (_useTokenCredential)
+            {
+                return new BlobServiceClient(this.Uri, _credential, blobClientOptions);
+            }
+            else
+            {
+                return new BlobServiceClient(_connectionString, blobClientOptions);
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.Storage/IBlobServiceClientFactory.cs
+++ b/src/NuGet.Services.Storage/IBlobServiceClientFactory.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Azure.Storage.Blobs;
+
+namespace NuGet.Services.Storage
+{
+    public interface IBlobServiceClientFactory
+    {
+        public Uri Uri { get; }
+
+        public BlobServiceClient GetBlobServiceClient(BlobClientOptions blobClientOptions);
+    }
+}

--- a/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
+++ b/src/NuGet.Services.Storage/NuGet.Services.Storage.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/NuGet.Services.Storage/SimpleBlobServiceClientFactory.cs
+++ b/src/NuGet.Services.Storage/SimpleBlobServiceClientFactory.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+
+namespace NuGet.Services.Storage
+{
+    // This class is a simple wrapper around a BlobServiceClient to enable backwards compatibility
+    // and avoid use cases where we would create unnecessary instances of BlobServiceClient
+    public class SimpleBlobServiceClientFactory : IBlobServiceClientFactory
+    {
+        private BlobServiceClient _blobServiceClient;
+
+        public Uri Uri => _blobServiceClient.Uri;
+
+        public SimpleBlobServiceClientFactory(BlobServiceClient blobServiceClient)
+        {
+            _blobServiceClient = blobServiceClient ?? throw new ArgumentNullException(nameof(blobServiceClient));
+        }
+
+        public BlobServiceClient GetBlobServiceClient(BlobClientOptions blobClientOptions = null)
+        {
+            return _blobServiceClient;
+        }
+    }
+}

--- a/src/Stats.PostProcessReports/Job.cs
+++ b/src/Stats.PostProcessReports/Job.cs
@@ -39,7 +39,7 @@ namespace Stats.PostProcessReports
                 .Register(c =>
                 {
                     var cfg = c.Resolve<IOptionsSnapshot<PostProcessReportsConfiguration>>().Value;
-                    return new BlobServiceClient(AzureStorageFactory.PrepareConnectionString(cfg.StorageAccount));
+                    return new BlobServiceClientFactory(AzureStorageFactory.PrepareConnectionString(cfg.StorageAccount));
                 })
                 .AsSelf();
 
@@ -48,7 +48,7 @@ namespace Stats.PostProcessReports
                 {
                     var cfg = c.Resolve<IOptionsSnapshot<PostProcessReportsConfiguration>>().Value;
                     var factory = new AzureStorageFactory(
-                        c.Resolve<BlobServiceClient>(),
+                        c.Resolve<BlobServiceClientFactory>(),
                         cfg.SourceContainerName,
                         enablePublicAccess: false,
                         c.Resolve<ILogger<AzureStorage>>(),
@@ -65,7 +65,7 @@ namespace Stats.PostProcessReports
                 {
                     var cfg = c.Resolve<IOptionsSnapshot<PostProcessReportsConfiguration>>().Value;
                     var factory = new AzureStorageFactory(
-                        c.Resolve<BlobServiceClient>(),
+                        c.Resolve<BlobServiceClientFactory>(),
                         cfg.WorkContainerName,
                         enablePublicAccess: false,
                         c.Resolve<ILogger<AzureStorage>>(),
@@ -82,7 +82,7 @@ namespace Stats.PostProcessReports
                 {
                     var cfg = c.Resolve<IOptionsSnapshot<PostProcessReportsConfiguration>>().Value;
                     var factory = new AzureStorageFactory(
-                        c.Resolve<BlobServiceClient>(),
+                        c.Resolve<BlobServiceClientFactory>(),
                         cfg.DestinationContainerName,
                         enablePublicAccess: true,
                         c.Resolve<ILogger<AzureStorage>>(),

--- a/src/Validation.PackageSigning.ProcessSignature/Job.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/Job.cs
@@ -55,7 +55,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                 var useStorageManagedIdentity = bool.Parse(configurationRoot[Constants.StorageUseManagedIdentityPropertyName]);
                 var config = p.GetRequiredService<IOptionsSnapshot<CertificateStoreConfiguration>>().Value;
 
-                BlobServiceClient targetStorageAccount;
+                BlobServiceClientFactory targetStorageAccount;
                 if (useStorageManagedIdentity)
                 {
                     var managedIdentityClientId =
@@ -63,12 +63,12 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                         configurationRoot[Constants.ManagedIdentityClientIdKey] :
                         configurationRoot[Constants.StorageManagedIdentityClientIdPropertyName];
                     var storageAccountUri = AzureStorage.GetPrimaryServiceUri(config.DataStorageAccount);
-                    var managedIdentity = new ManagedIdentityCredential(managedIdentityClientId);
-                    targetStorageAccount = new BlobServiceClient(storageAccountUri, managedIdentity);
+                    var managedIdentityCredential = new ManagedIdentityCredential(managedIdentityClientId);
+                    targetStorageAccount = new BlobServiceClientFactory(storageAccountUri, managedIdentityCredential);
                 }
                 else
                 {
-                    targetStorageAccount = new BlobServiceClient(AzureStorageFactory.PrepareConnectionString(config.DataStorageAccount));
+                    targetStorageAccount = new BlobServiceClientFactory(AzureStorageFactory.PrepareConnectionString(config.DataStorageAccount));
                 }
 
                 var storageFactory = new AzureStorageFactory(

--- a/src/Validation.PackageSigning.ValidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/Job.cs
@@ -37,7 +37,7 @@ namespace Validation.PackageSigning.ValidateCertificate
                 var useStorageManagedIdentity = bool.Parse(configurationRoot[Constants.StorageUseManagedIdentityPropertyName]);
                 var config = p.GetRequiredService<IOptionsSnapshot<CertificateStoreConfiguration>>().Value;
 
-                BlobServiceClient targetStorageAccount;
+                BlobServiceClientFactory targetStorageAccount;
                 if (useStorageManagedIdentity)
                 {
                     var managedIdentityClientId =
@@ -45,12 +45,12 @@ namespace Validation.PackageSigning.ValidateCertificate
                         configurationRoot[Constants.ManagedIdentityClientIdKey] :
                         configurationRoot[Constants.StorageManagedIdentityClientIdPropertyName];
                     var storageAccountUri = AzureStorage.GetPrimaryServiceUri(config.DataStorageAccount);
-                    var managedIdentity = new ManagedIdentityCredential(managedIdentityClientId);
-                    targetStorageAccount = new BlobServiceClient(storageAccountUri, managedIdentity);
+                    var managedIdentityCredential = new ManagedIdentityCredential(managedIdentityClientId);
+                    targetStorageAccount = new BlobServiceClientFactory(storageAccountUri, managedIdentityCredential);
                 }
                 else
                 {
-                    targetStorageAccount = new BlobServiceClient(AzureStorageFactory.PrepareConnectionString(config.DataStorageAccount));
+                    targetStorageAccount = new BlobServiceClientFactory(AzureStorageFactory.PrepareConnectionString(config.DataStorageAccount));
                 }
 
                 var storageFactory = new AzureStorageFactory(

--- a/tests/CatalogMetadataTests/AzureStorageFacts.cs
+++ b/tests/CatalogMetadataTests/AzureStorageFacts.cs
@@ -10,6 +10,8 @@ using Xunit;
 using NuGet.Services.Metadata.Catalog.Persistence;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using NuGet.Services.Storage;
+using AzureStorage = NuGet.Services.Metadata.Catalog.Persistence.AzureStorage;
 
 namespace CatalogMetadataTests
 {
@@ -138,13 +140,14 @@ namespace CatalogMetadataTests
 
     public abstract class AzureStorageBaseFacts
     {
+        protected readonly string _baseAddressString = "DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=fake";
         protected readonly Uri _baseAddress = new Uri("https://test");
         protected readonly AzureStorage _storage;
 
         public AzureStorageBaseFacts()
         {
             // Mock the BlobServiceClient
-            var mockBlobServiceClient = new Mock<BlobServiceClient>(_baseAddress, null);
+            var mockBlobServiceClient = new Mock<BlobServiceClientFactory>(_baseAddressString);
             mockBlobServiceClient.Setup(x => x.Uri).Returns(_baseAddress);
 
             // Mock the BlobContainerClient

--- a/tests/CatalogMetadataTests/CloudBlobDirectoryWrapperFacts.cs
+++ b/tests/CatalogMetadataTests/CloudBlobDirectoryWrapperFacts.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Xunit;
 using NuGet.Services.Metadata.Catalog.Persistence;
-using Azure.Storage.Blobs;
+using NuGet.Services.Storage;
+using Xunit;
 
 namespace CatalogMetadataTests
 {
@@ -13,13 +13,13 @@ namespace CatalogMetadataTests
         public class TheUriProperty
         {
             [Theory]
-            [InlineData("", "https://test/containerName/")]
-            [InlineData("directoryPrefix", "https://test/containerName/directoryPrefix")]
-            [InlineData("directoryPrefix/foo", "https://test/containerName/directoryPrefix/foo")]
+            [InlineData("", "https://devstoreaccount1.blob.core.windows.net/containerName/")]
+            [InlineData("directoryPrefix", "https://devstoreaccount1.blob.core.windows.net/containerName/directoryPrefix")]
+            [InlineData("directoryPrefix/foo", "https://devstoreaccount1.blob.core.windows.net/containerName/directoryPrefix/foo")]
             public void ReturnsTheUriWithVariousPrefixes(string directoryPrefix, string expectedUri)
             {
                 // Arrange
-                var serviceClient = new BlobServiceClient(new Uri("https://test"));
+                var serviceClient = new BlobServiceClientFactory("DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=fake");
                 var directory = new CloudBlobDirectoryWrapper(serviceClient, "containerName", directoryPrefix);
 
                 // Act

--- a/tests/NgTests/CommandHelpersTests.cs
+++ b/tests/NgTests/CommandHelpersTests.cs
@@ -202,6 +202,7 @@ namespace NgTests
                     { Arguments.StorageKeyValue, DummyKey },
                     { Arguments.StorageContainer, "testContainer" },
                     { Arguments.StoragePath, "testStoragePath" },
+                    { Arguments.StorageUseManagedIdentity, "false" },
                 };
 
                 // Act
@@ -226,6 +227,7 @@ namespace NgTests
                     { Arguments.StorageContainer, "testContainer" },
                     { Arguments.StoragePath, "testStoragePath" },
                     { Arguments.StorageSuffix, "core.chinacloudapi.cn" },
+                    { Arguments.StorageUseManagedIdentity, "false" }
                 };
 
                 // Act

--- a/tests/NuGet.Services.Storage.Tests/AzureStorageNewFacts.cs
+++ b/tests/NuGet.Services.Storage.Tests/AzureStorageNewFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -21,6 +21,7 @@ namespace NuGet.Services.Storage.Tests
     {
         private Mock<BlockBlobClient> _blobClientMock = new Mock<BlockBlobClient>();
         private Mock<BlobServiceClient> _blobServiceClientMock = new Mock<BlobServiceClient>();
+        private Mock<BlobServiceClientFactory> _blobServiceClientFactoryMock = new Mock<BlobServiceClientFactory>();
         private Mock<BlobContainerClient> _blobContainerClientMock = new Mock<BlobContainerClient>();
         private Mock<ILogger<AzureStorage>> _loggerMock = new Mock<ILogger<AzureStorage>>();
 
@@ -34,13 +35,16 @@ namespace NuGet.Services.Storage.Tests
             _blobServiceClientMock
                 .Setup(x => x.GetBlobContainerClient(It.IsAny<string>()))
                 .Returns(_blobContainerClientMock.Object);
+            _blobServiceClientFactoryMock
+                .Setup(x => x.GetBlobServiceClient(It.IsAny<BlobClientOptions>()))
+                .Returns(_blobServiceClientMock.Object);
         }
 
         [Fact]
         public void Constructor_DoNotInitialize()
         {
             var azureStorage = new AzureStorage(
-                _blobServiceClientMock.Object,
+                _blobServiceClientFactoryMock.Object,
                 "containerName",
                 "path",
                 new Uri("http://baseAddress"),
@@ -75,7 +79,7 @@ namespace NuGet.Services.Storage.Tests
                 .Throws(new RequestFailedException(404, "Not found"));
 
             var azureStorage = new AzureStorage(
-                _blobServiceClientMock.Object,
+                _blobServiceClientFactoryMock.Object,
                 "containerName",
                 "path",
                 new Uri("http://baseAddress"),
@@ -109,7 +113,7 @@ namespace NuGet.Services.Storage.Tests
                     Mock.Of<Response>()));
 
             var azureStorage = new AzureStorage(
-                _blobServiceClientMock.Object,
+                _blobServiceClientFactoryMock.Object,
                 "containerName",
                 "path",
                 new Uri("http://baseAddress"),
@@ -143,7 +147,7 @@ namespace NuGet.Services.Storage.Tests
                     Mock.Of<Response>()));
 
             var azureStorage = new AzureStorage(
-                _blobServiceClientMock.Object,
+                _blobServiceClientFactoryMock.Object,
                 "containerName",
                 "path",
                 new Uri("http://baseAddress"),
@@ -172,7 +176,7 @@ namespace NuGet.Services.Storage.Tests
             _blobClientMock.Setup(c => c.Exists(It.IsAny<CancellationToken>())).Returns(Response.FromValue(expected, azureResponse.Object));
             _blobContainerClientMock.Protected().Setup<BlockBlobClient>("GetBlockBlobClientCore",ItExpr.IsAny<string>())
                 .Returns(_blobClientMock.Object);
-            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, enablePublicAccess: false, _loggerMock.Object);
+            var azureStorage = new AzureStorage(_blobServiceClientFactoryMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, enablePublicAccess: false, _loggerMock.Object);
 
             Assert.Equal(azureStorage.Exists("file"), expected);
         }
@@ -186,7 +190,7 @@ namespace NuGet.Services.Storage.Tests
             _blobClientMock.Setup(c => c.ExistsAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(Response.FromValue(expected, azureResponse.Object)));
             _blobContainerClientMock.Protected().Setup<BlockBlobClient>("GetBlockBlobClientCore", ItExpr.IsAny<string>())
                 .Returns(_blobClientMock.Object);
-            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, enablePublicAccess: false, _loggerMock.Object);
+            var azureStorage = new AzureStorage(_blobServiceClientFactoryMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, enablePublicAccess: false, _loggerMock.Object);
 
             Assert.Equal(await azureStorage.ExistsAsync("file", CancellationToken.None), expected);
         }
@@ -211,7 +215,7 @@ namespace NuGet.Services.Storage.Tests
 
             _blobContainerClientMock.Protected().Setup<BlockBlobClient>("GetBlockBlobClientCore", ItExpr.IsAny<string>())
                 .Returns(_blobClientMock.Object);
-            var azureStorage = new AzureStorage(_blobServiceClientMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, enablePublicAccess: false, _loggerMock.Object);
+            var azureStorage = new AzureStorage(_blobServiceClientFactoryMock.Object, "containerName", "path", new Uri("http://baseAddress"), initializeContainer: true, enablePublicAccess: false, _loggerMock.Object);
 
             await azureStorage.Save(new Uri("http://testUri.com/blob.json"), new StringStorageContent("content"), overwrite: overwrite, CancellationToken.None);
 


### PR DESCRIPTION
When a set of non null blob options are passed through to [src/Catalog/Persistence/CloudBlobDirectoryWrapper.cs](https://github.com/NuGet/NuGetGallery/compare/dev...ryuyu-monitoring-migration-test?expand=1#diff-faf95e19f981de74760ceb3fc4d23f572379edf12a8c2da4b3ee61665c49cf9f), the BlobServiceClient is recreated with the correct options to create the ContainerClient (containerClient inherits blob options from the creating service client).

Unfortunately, this is created without authentication information, and the authentication information is not available here.

This change attempts to "work around" this issue by instead passing through a serviceClientFactory so we can recreate with whatever options we need whenever we want. 
Note that this adds a reference from NuGet.Service.Storage to Catalog project, which has its own Storage implementation. This requires us to disambiguate Storage (between NuGet.Services.Storage and catalog.persistence.Storage).

Things we tried that didn't work:
 1. Extract auth information from the BlobServiceClient. The authentication information is not available on the service client
 2. Pipe through additional parameters so we can pipe auth information through directly. This resulted in a changeset of roughly the same size. (Thanks @advay26 for exploring this option)
 3. Modify the blob options on the BlobServiceClient instead of creating a new one. This doesn't seem possible.

Related to https://github.com/NuGet/Engineering/issues/5584