### PR TITLE
Make license text part of sidebar license link

### DIFF
--- a/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
+++ b/src/NuGetGallery/Views/Packages/DisplayPackage.cshtml
@@ -256,8 +256,8 @@
 
 @* The following two helpers must be on a single line each so no extra whitespace is introduced in the expression when rendered. *@
 @* Helpers themselves are needed not to introduce that extra whitespce, which happens if they are inlined. *@
-@helper MakeLicenseLink(CompositeLicenseExpressionSegment segment) {<a href="@LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(segment.Value)" aria-label="License @segment.Value">@segment.Value</a>}
-@helper MakeLicenseSpan(CompositeLicenseExpressionSegment segment) {<span>@segment.Value</span>}
+@helper MakeLicenseLink(CompositeLicenseExpressionSegment segment) {<a href="@LicenseExpressionRedirectUrlHelper.GetLicenseExpressionRedirectUrl(segment.Value)" aria-label="License @segment.Value">@segment.Value license</a>}
+@helper MakeLicenseSpan(CompositeLicenseExpressionSegment segment) {<span>@segment.Value license</span>}
 
 <section role="main" class="container main-container page-package-details">
     <div class="row">
@@ -1107,7 +1107,6 @@
                                             @MakeLicenseSpan(segment);
                                         }
                                     }
-                                    @:license
                                 }
                                 else
                                 {


### PR DESCRIPTION
1.Accessibility Issue:
AI4W reported packages page sidebar link "MIT" and surrounding text "license" having issue.
![image](https://github.com/user-attachments/assets/a3152407-a820-4ad7-b2aa-b8062ef31ece)
2. Fixed the issue by removing "license" text into the link.
3. Result: 
![image](https://github.com/user-attachments/assets/fa8f7d13-5874-43c2-ad86-c18231fd6de7)
![image](https://github.com/user-attachments/assets/fa065457-6d4b-47cb-925d-7b09bdbdf8f9)

Bug created from sitewide scan.

