### PR TITLE
[OIDC 1] Add basic Entra ID token validation

### DIFF
--- a/src/NuGetGallery.Services/Authentication/Federated/EntraIdTokenValidator.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/EntraIdTokenValidator.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Validators;
+
+#nullable enable
+
+namespace NuGetGallery.Services.Authentication
+{
+    /// <summary>
+    /// This interface is used to ensure a given token is issued by Entra ID.
+    /// </summary>
+    public interface IEntraIdTokenValidator
+    {
+        /// <summary>
+        /// Perform minimal validation of the token to ensure it was issued by Entra ID. Validations:
+        /// - Expected issuer (Entra ID)
+        /// - Expected audience
+        /// - Valid signature
+        /// - Not expired
+        /// </summary>
+        /// <param name="token">The parsed JWT</param>
+        /// <returns>The token validation result, check the <see cref="TokenValidationResult.IsValid"/> for success or failure.</returns>
+        Task<TokenValidationResult> ValidateAsync(JsonWebToken token);
+    }
+
+    public class EntraIdTokenValidator : IEntraIdTokenValidator
+    {
+        private static string EntraIdAuthority { get; } = "https://login.microsoftonline.com/common/v2.0";
+        public static string MetadataAddress { get; } = $"{EntraIdAuthority}/.well-known/openid-configuration";
+
+        private readonly ConfigurationManager<OpenIdConnectConfiguration> _oidcConfigManager;
+        private readonly JsonWebTokenHandler _jsonWebTokenHandler;
+        private readonly IFederatedCredentialConfiguration _configuration;
+
+        public EntraIdTokenValidator(
+            ConfigurationManager<OpenIdConnectConfiguration> oidcConfigManager,
+            JsonWebTokenHandler jsonWebTokenHandler,
+            IFederatedCredentialConfiguration configuration)
+        {
+            _oidcConfigManager = oidcConfigManager ?? throw new ArgumentNullException(nameof(oidcConfigManager));
+            _jsonWebTokenHandler = jsonWebTokenHandler ?? throw new ArgumentNullException(nameof(jsonWebTokenHandler));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+        public async Task<TokenValidationResult> ValidateAsync(JsonWebToken token)
+        {
+            if (string.IsNullOrWhiteSpace(_configuration.EntraIdAudience))
+            {
+                throw new InvalidOperationException("Unable to validate Entra ID token. Entra ID audience is not configured.");
+            }
+
+            var tokenValidationParameters = new TokenValidationParameters
+            {
+                IssuerValidator = AadIssuerValidator.GetAadIssuerValidator(EntraIdAuthority).Validate,
+                ValidAudience = _configuration.EntraIdAudience,
+                ConfigurationManager = _oidcConfigManager,
+            };
+
+            tokenValidationParameters.EnableAadSigningKeyIssuerValidation();
+
+            var result = await _jsonWebTokenHandler.ValidateTokenAsync(token, tokenValidationParameters);
+
+            return result;
+        }
+    }
+}

--- a/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialConfiguration.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialConfiguration.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+namespace NuGetGallery.Services.Authentication
+{
+    public interface IFederatedCredentialConfiguration
+    {
+        /// <summary>
+        /// The expected audience for the incoming token. This is the "aud" claim and should be specific to the gallery
+        /// service itself (not shared between multiple services). This is used only for Entra ID token validation.
+        /// </summary>
+        string? EntraIdAudience { get; }
+    }
+
+    public class FederatedCredentialConfiguration : IFederatedCredentialConfiguration
+    {
+        public string? EntraIdAudience { get; set; }
+    }
+}

--- a/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
+++ b/src/NuGetGallery.Services/Configuration/ConfigurationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -14,6 +14,7 @@ using System.Web.Configuration;
 using NuGet.Services.Configuration;
 using NuGet.Services.KeyVault;
 using NuGetGallery.Configuration.SecretReader;
+using NuGetGallery.Services.Authentication;
 
 namespace NuGetGallery.Configuration
 {
@@ -23,6 +24,7 @@ namespace NuGetGallery.Configuration
         protected const string FeaturePrefix = "Feature.";
         protected const string ServiceBusPrefix = "AzureServiceBus.";
         protected const string PackageDeletePrefix = "PackageDelete.";
+        protected const string FederatedCredentialPrefix = "FederatedCredential.";
 
         private readonly Lazy<string> _httpSiteRootThunk;
         private readonly Lazy<string> _httpsSiteRootThunk;
@@ -31,6 +33,7 @@ namespace NuGetGallery.Configuration
         private readonly Lazy<FeatureConfiguration> _lazyFeatureConfiguration;
         private readonly Lazy<IServiceBusConfiguration> _lazyServiceBusConfiguration;
         private readonly Lazy<IPackageDeleteConfiguration> _lazyPackageDeleteConfiguration;
+        private readonly Lazy<FederatedCredentialConfiguration> _lazyFederatedCredentialConfiguration;
 
         private static readonly HashSet<string> NotInjectedSettingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             SettingPrefix + "SqlServer",
@@ -66,6 +69,7 @@ namespace NuGetGallery.Configuration
             _lazyFeatureConfiguration = new Lazy<FeatureConfiguration>(() => ResolveFeatures().Result);
             _lazyServiceBusConfiguration = new Lazy<IServiceBusConfiguration>(() => ResolveServiceBus().Result);
             _lazyPackageDeleteConfiguration = new Lazy<IPackageDeleteConfiguration>(() => ResolvePackageDelete().Result);
+            _lazyFederatedCredentialConfiguration = new Lazy<FederatedCredentialConfiguration>(() => ResolveFederatedCredential().Result);
         }
 
         public static IEnumerable<PropertyDescriptor> GetConfigProperties<T>(T instance)
@@ -80,6 +84,8 @@ namespace NuGetGallery.Configuration
         public IServiceBusConfiguration ServiceBus => _lazyServiceBusConfiguration.Value;
 
         public IPackageDeleteConfiguration PackageDelete => _lazyPackageDeleteConfiguration.Value;
+
+        public FederatedCredentialConfiguration FederatedCredential => _lazyFederatedCredentialConfiguration.Value;
 
         /// <summary>
         /// Gets the site root using the specified protocol
@@ -204,6 +210,11 @@ namespace NuGetGallery.Configuration
         private async Task<IPackageDeleteConfiguration> ResolvePackageDelete()
         {
             return await ResolveConfigObject(new PackageDeleteConfiguration(), PackageDeletePrefix);
+        }
+
+        private async Task<FederatedCredentialConfiguration> ResolveFederatedCredential()
+        {
+            return await ResolveConfigObject(new FederatedCredentialConfiguration(), FederatedCredentialPrefix);
         }
 
         protected virtual string GetAppSetting(string settingName)

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -25,6 +25,9 @@ using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols;
 using Microsoft.WindowsAzure.ServiceRuntime;
 using NuGet.Services.Configuration;
 using NuGet.Services.Entities;
@@ -55,6 +58,7 @@ using NuGetGallery.Infrastructure.Search;
 using NuGetGallery.Infrastructure.Search.Correlation;
 using NuGetGallery.Security;
 using NuGetGallery.Services;
+using NuGetGallery.Services.Authentication;
 using Role = NuGet.Services.Entities.Role;
 
 namespace NuGetGallery
@@ -150,6 +154,8 @@ namespace NuGetGallery
 
             builder.Register(c => configuration.PackageDelete)
                 .As<IPackageDeleteConfiguration>();
+
+            ConfigureFederatedCredentials(builder, configuration);
 
             var telemetryService = new TelemetryService(
                 new TraceDiagnosticsSource(nameof(TelemetryService), telemetryClient),
@@ -529,6 +535,39 @@ namespace NuGetGallery
 
             ConfigureAutocomplete(builder, configuration);
             builder.Populate(services);
+        }
+
+        private static void ConfigureFederatedCredentials(ContainerBuilder builder, ConfigurationService configuration)
+        {
+            builder
+                .Register(c => configuration.FederatedCredential)
+                .As<IFederatedCredentialConfiguration>();
+
+            builder
+                .Register(_ => new OpenIdConnectConfigurationRetriever())
+                .As<IConfigurationRetriever<OpenIdConnectConfiguration>>();
+
+            const string EntraIdKey = "EntraId";
+
+            // this is a singleton to provide caching of the OIDC metadata
+            builder
+                .Register(p => new ConfigurationManager<OpenIdConnectConfiguration>(
+                    metadataAddress: EntraIdTokenValidator.MetadataAddress,
+                    p.Resolve<IConfigurationRetriever<OpenIdConnectConfiguration>>()))
+                .SingleInstance()
+                .Keyed<ConfigurationManager<OpenIdConnectConfiguration>>(EntraIdKey);
+
+            builder
+                .RegisterType<JsonWebTokenHandler>()
+                .InstancePerLifetimeScope();
+
+            builder
+                .Register(p => new EntraIdTokenValidator(
+                    p.ResolveKeyed<ConfigurationManager<OpenIdConnectConfiguration>>(EntraIdKey),
+                    p.Resolve<JsonWebTokenHandler>(),
+                    p.Resolve<IFederatedCredentialConfiguration>()))
+                .As<IEntraIdTokenValidator>()
+                .InstancePerLifetimeScope();
         }
 
         // Internal for testing purposes

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -203,6 +203,7 @@
     <add key="PackageDelete.MaximumDownloadsForPackageVersion" value=""/>
     <add key="Gallery.BlockLegacyLicenseUrl" value="false"/>
     <add key="Gallery.AllowLicenselessPackages" value="true"/>
+    <add key="FederatedCredential.EntraIdAudience" value=""/>
   </appSettings>
   <connectionStrings>
     <add name="Gallery.SqlServer" connectionString="Data Source=(localdb)\mssqllocaldb; Initial Catalog=NuGetGallery; Integrated Security=True; MultipleActiveResultSets=True" providerName="System.Data.SqlClient"/>

--- a/tests/NuGetGallery.Facts/Authentication/Federated/EntraIdTokenValidatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/EntraIdTokenValidatorFacts.cs
@@ -1,0 +1,177 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Xunit;
+
+#nullable enable
+
+namespace NuGetGallery.Services.Authentication
+{
+    public class EntraIdTokenValidatorFacts
+    {
+        public class TheValidateAsyncMethod : EntraIdTokenValidatorFacts
+        {
+            [Fact]
+            public async Task RejectsMissingAudience()
+            {
+                // Arrange
+                Configuration.Setup(x => x.EntraIdAudience).Returns((string?)null);
+
+                // Act & Assert
+                await Assert.ThrowsAsync<InvalidOperationException>(() => Target.ValidateAsync(Token));
+            }
+
+            [Fact]
+            public async Task ReturnsTokenValidationResultDirectly()
+            {
+                // Arrange
+                var result = new TokenValidationResult();
+                JsonWebTokenHandler
+                    .Setup(x => x.ValidateTokenAsync(It.IsAny<JsonWebToken>(), It.IsAny<TokenValidationParameters>()))
+                    .ReturnsAsync(result);
+
+                // Act
+                var actual = await Target.ValidateAsync(Token);
+
+                // Assert
+                Assert.Same(result, actual);
+            }
+
+            [Fact]
+            public async Task ConfiguresTokenValidationParameters()
+            {
+                // Arrange
+                var token = Token;
+
+                // Act
+                await Target.ValidateAsync(token);
+
+                // Assert
+                JsonWebTokenHandler.Verify(x => x.ValidateTokenAsync(token, It.IsAny<TokenValidationParameters>()), Times.Once);
+                var invocation = Assert.Single(JsonWebTokenHandler.Invocations);
+                var tokenValidationParameters = (TokenValidationParameters)invocation.Arguments[1];
+                Assert.Equal("nuget-audience", tokenValidationParameters.ValidAudience);
+                Assert.NotNull(tokenValidationParameters.IssuerValidator);
+                Assert.NotNull(tokenValidationParameters.IssuerSigningKeyValidatorUsingConfiguration);
+                Assert.Same(OidcConfigManager.Object, tokenValidationParameters.ConfigurationManager);
+            }
+
+            [Fact]
+            public async Task AcceptsEntraIdIssuer()
+            {
+                // Arrange
+                await Target.ValidateAsync(Token);
+                JsonWebTokenHandler.Verify(x => x.ValidateTokenAsync(It.IsAny<JsonWebToken>(), It.IsAny<TokenValidationParameters>()), Times.Once);
+                var invocation = Assert.Single(JsonWebTokenHandler.Invocations);
+                var tokenValidationParameters = (TokenValidationParameters)invocation.Arguments[1];
+
+                // Act
+                var issuer = tokenValidationParameters.IssuerValidator(Issuer, Token, tokenValidationParameters);
+
+                // Assert
+                Assert.Equal(Issuer, issuer);
+            }
+
+            [Fact]
+            public async Task RejectsOtherIssuer()
+            {
+                // Arrange
+                Issuer = "https://localhost/my-issuer";
+                await Target.ValidateAsync(Token);
+                JsonWebTokenHandler.Verify(x => x.ValidateTokenAsync(It.IsAny<JsonWebToken>(), It.IsAny<TokenValidationParameters>()), Times.Once);
+                var invocation = Assert.Single(JsonWebTokenHandler.Invocations);
+                var tokenValidationParameters = (TokenValidationParameters)invocation.Arguments[1];
+
+                // Act & Assert
+                Assert.Throws<SecurityTokenInvalidIssuerException>(
+                    () => tokenValidationParameters.IssuerValidator(Issuer, Token, tokenValidationParameters));
+            }
+
+            [Fact]
+            public async Task AcceptsSigningKeyWithMatchingIssuer()
+            {
+                // Arrange
+                await Target.ValidateAsync(Token);
+                JsonWebTokenHandler.Verify(x => x.ValidateTokenAsync(It.IsAny<JsonWebToken>(), It.IsAny<TokenValidationParameters>()), Times.Once);
+                var invocation = Assert.Single(JsonWebTokenHandler.Invocations);
+                var tokenValidationParameters = (TokenValidationParameters)invocation.Arguments[1];
+
+                // Act
+                var valid = tokenValidationParameters.IssuerSigningKeyValidatorUsingConfiguration(JsonWebKey, Token, tokenValidationParameters, OpenIdConnectConfiguration);
+
+                // Assert
+                Assert.True(valid);
+            }
+
+            [Fact]
+            public async Task RejectsSigningKeyWithDifferentIssuer()
+            {
+                // Arrange
+                await Target.ValidateAsync(Token);
+                JsonWebTokenHandler.Verify(x => x.ValidateTokenAsync(It.IsAny<JsonWebToken>(), It.IsAny<TokenValidationParameters>()), Times.Once);
+                var invocation = Assert.Single(JsonWebTokenHandler.Invocations);
+                var tokenValidationParameters = (TokenValidationParameters)invocation.Arguments[1];
+                var key = new JsonWebKey { Kid = "key-id", AdditionalData = { { "issuer", "https://localhost/my-issuer" } } };
+                var config = new OpenIdConnectConfiguration { JsonWebKeySet = new JsonWebKeySet { Keys = { key } } };
+
+                // Act & Assert
+                Assert.Throws<SecurityTokenInvalidIssuerException>(
+                    () => tokenValidationParameters.IssuerSigningKeyValidatorUsingConfiguration(key, Token, tokenValidationParameters, config));
+            }
+        }
+
+        public EntraIdTokenValidatorFacts()
+        {
+            ConfigurationRetriever = new Mock<IConfigurationRetriever<OpenIdConnectConfiguration>>();
+            OidcConfigManager = new Mock<ConfigurationManager<OpenIdConnectConfiguration>>(
+                EntraIdTokenValidator.MetadataAddress,
+                ConfigurationRetriever.Object);
+            JsonWebTokenHandler = new Mock<JsonWebTokenHandler>();
+            Configuration = new Mock<IFederatedCredentialConfiguration>();
+            Configuration.Setup(x => x.EntraIdAudience).Returns("nuget-audience");
+
+            TenantId = "c311b905-19a2-483e-a014-41d0fcdc99cf";
+            Issuer = $"https://login.microsoftonline.com/{TenantId}/v2.0";
+
+            Target = new EntraIdTokenValidator(
+                OidcConfigManager.Object,
+                JsonWebTokenHandler.Object,
+                Configuration.Object);
+        }
+
+        public EntraIdTokenValidator Target { get; }
+        public Mock<IConfigurationRetriever<OpenIdConnectConfiguration>> ConfigurationRetriever { get; }
+        public Mock<ConfigurationManager<OpenIdConnectConfiguration>> OidcConfigManager { get; }
+        public Mock<JsonWebTokenHandler> JsonWebTokenHandler { get; }
+        public Mock<IFederatedCredentialConfiguration> Configuration { get; }
+        public string TenantId { get; }
+        public string Issuer { get; set; }
+
+        public JsonWebToken Token
+        {
+            get
+            {
+                var handler = new JsonWebTokenHandler();
+                return handler.ReadJsonWebToken(handler.CreateToken(new SecurityTokenDescriptor
+                {
+                    Claims = new Dictionary<string, object>
+                    {
+                        { "tid", TenantId },
+                        { "iss", Issuer },
+                    }
+                }));
+            }
+        }
+
+        public JsonWebKey JsonWebKey => new() { Kid = "key-id", AdditionalData = { { "issuer", Issuer } } };
+        public OpenIdConnectConfiguration OpenIdConnectConfiguration => new() { JsonWebKeySet = new JsonWebKeySet { Keys = { JsonWebKey } } };
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/10212.

This adds an `IEntraIdTokenValidator` interface which accepts a parsed JWT (JSON web token) and performs basic Entra ID validation. This will be used by higher level code in a future PR.

The goal of this class is to assert that a given JWT is issued by Entra ID and is valid. The following checks are performed:

1. The JWT signature is valid per Entra ID's signing keys, fetched via JWKS. This is done inside `ConfigurationManager<OpenIdConnectConfiguration>`.
2. The issuer is an expected Entra ID value (`iss` claim and `issuer` property on the key). This is done via `AadIssuerValidator.GetAadIssuerValidator` and `EnableAadSigningKeyIssuerValidation`.
3. The token is not expired (`nbf` and `exp` claims). This is done inside `JsonWebTokenHandler.ValidateTokenAsync`.
4. The token has a valid audience (`aud` claim). A valid `aud` claim is our configured app client ID. This is done inside `JsonWebTokenHandler.ValidateTokenAsync`.

Other validations like replay protection, matching tenant ID/object ID, etc will be done elsewhere.

This minimal set of validations mimic the OWIN integration in Microsoft.Identity.Web:
https://github.com/AzureAD/microsoft-identity-web/blob/011bd155ce3ddedeb43daa7348e09584cfa20552/src/Microsoft.Identity.Web.OWIN/AppBuilderExtension.cs#L62-L73