### PR TITLE
Mooncake log ingestion options to not write headers and add original filename column

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
@@ -44,8 +44,8 @@ namespace Stats.AzureCdnLogs.Common.Collect
             ILogSource source,
             ILogDestination destination,
             ILogger<Collector> logger,
-            bool writeHeader = true,
-            bool addSourceFilenameColumn = false)
+            bool writeHeader,
+            bool addSourceFilenameColumn)
         {
             _source = source;
             _destination = destination;

--- a/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,6 +25,8 @@ namespace Stats.AzureCdnLogs.Common.Collect
         protected ILogSource _source;
         protected ILogDestination _destination;
         protected readonly ILogger<Collector> _logger;
+
+        public bool WriteHeader { get; set; } = true;
 
         /// <summary>
         /// Used by UnitTests
@@ -151,7 +153,10 @@ namespace Stats.AzureCdnLogs.Common.Collect
                 using (var sourceStreamReader = new StreamReader(sourceStream))
                 using (var targetStreamWriter = new StreamWriter(targetStream))
                 {
-                    targetStreamWriter.WriteLine(OutputLogLine.Header);
+                    if (WriteHeader)
+                    {
+                        targetStreamWriter.WriteLine(OutputLogLine.Header);
+                    }
 
                     while (!sourceStreamReader.EndOfStream)
                     {

--- a/src/Stats.AzureCdnLogs.Common/Collect/OutputLogLine.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/OutputLogLine.cs
@@ -87,7 +87,7 @@ namespace Stats.AzureCdnLogs.Common.Collect
             return $"{TimeStamp} {TimeTaken} {CIp} {FileSize} {SIp} {SPort} {ScStatus} {ScBytes} {CsMethod} {CsUriStem} - {RsDuration} {RsBytes} {CReferrer} {Quote(CUserAgent)} {CustomerId} {Quote(XEc_Custom_1)}";
         }
 
-        private static string Quote(string input)
+        public static string Quote(string input)
         {
             if (input.StartsWith("\"") && input.EndsWith("\""))
             {

--- a/src/Stats.AzureCdnLogs.Common/Collect/OutputLogLine.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/OutputLogLine.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Stats.AzureCdnLogs.Common.Collect
@@ -79,7 +79,7 @@ namespace Stats.AzureCdnLogs.Common.Collect
 
         public static string Header
         {
-            get { return "#Fields: timestamp time-taken c-ip filesize s-ip s-port sc-status sc-bytes cs-method cs-uri-stem - rs-duration rs-bytes c-referrer c-user-agent customer-id x-ec_custom-1\n"; }
+            get { return "#Fields: timestamp time-taken c-ip filesize s-ip s-port sc-status sc-bytes cs-method cs-uri-stem - rs-duration rs-bytes c-referrer c-user-agent customer-id x-ec_custom-1"; }
         }
 
         public override string ToString()

--- a/src/Stats.CollectAzureChinaCDNLogs/ChinaStatsCollector.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/ChinaStatsCollector.cs
@@ -39,8 +39,8 @@ namespace Stats.CollectAzureChinaCDNLogs
             ILogSource source,
             ILogDestination destination,
             ILogger<ChinaStatsCollector> logger,
-            bool writeHeader = true,
-            bool addSourceFilenameColumn = false)
+            bool writeHeader,
+            bool addSourceFilenameColumn)
             : base(source, destination, logger, writeHeader, addSourceFilenameColumn)
         {}
 

--- a/src/Stats.CollectAzureChinaCDNLogs/ChinaStatsCollector.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/ChinaStatsCollector.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -35,7 +35,13 @@ namespace Stats.CollectAzureChinaCDNLogs
             sip = 11
         }
 
-        public ChinaStatsCollector(ILogSource source, ILogDestination destination, ILogger<ChinaStatsCollector> logger) : base(source, destination, logger)
+        public ChinaStatsCollector(
+            ILogSource source,
+            ILogDestination destination,
+            ILogger<ChinaStatsCollector> logger,
+            bool writeHeader = true,
+            bool addSourceFilenameColumn = false)
+            : base(source, destination, logger, writeHeader, addSourceFilenameColumn)
         {}
 
         public override OutputLogLine TransformRawLogLine(string line)

--- a/src/Stats.CollectAzureChinaCDNLogs/Configuration/CollectAzureChinaCdnLogsConfiguration.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/Configuration/CollectAzureChinaCdnLogsConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Stats.CollectAzureChinaCDNLogs
@@ -16,5 +16,7 @@ namespace Stats.CollectAzureChinaCDNLogs
         public string DestinationFilePrefix { get; set; }
 
         public int? ExecutionTimeoutInSeconds { get; set; }
+
+        public bool WriteOutputHeader { get; set; } = true;
     }
 }

--- a/src/Stats.CollectAzureChinaCDNLogs/Configuration/CollectAzureChinaCdnLogsConfiguration.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/Configuration/CollectAzureChinaCdnLogsConfiguration.cs
@@ -18,5 +18,6 @@ namespace Stats.CollectAzureChinaCDNLogs
         public int? ExecutionTimeoutInSeconds { get; set; }
 
         public bool WriteOutputHeader { get; set; } = true;
+        public bool AddSourceFilenameColumn { get; set; } = false;
     }
 }

--- a/src/Stats.CollectAzureChinaCDNLogs/Job.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/Job.cs
@@ -53,10 +53,12 @@ namespace Stats.CollectAzureChinaCDNLogs
                 _configuration.AzureContainerNameDestination,
                 serviceProvider.GetRequiredService<ILogger<AzureStatsLogDestination>>());
 
-            _chinaCollector = new ChinaStatsCollector(source, dest, serviceProvider.GetRequiredService<ILogger<ChinaStatsCollector>>())
-            {
-                WriteHeader = _configuration.WriteOutputHeader,
-            };
+            _chinaCollector = new ChinaStatsCollector(
+                source,
+                dest,
+                serviceProvider.GetRequiredService<ILogger<ChinaStatsCollector>>(),
+                _configuration.WriteOutputHeader,
+                _configuration.AddSourceFilenameColumn);
         }
 
         public override async Task Run()

--- a/src/Stats.CollectAzureChinaCDNLogs/Job.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/Job.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -53,7 +53,10 @@ namespace Stats.CollectAzureChinaCDNLogs
                 _configuration.AzureContainerNameDestination,
                 serviceProvider.GetRequiredService<ILogger<AzureStatsLogDestination>>());
 
-            _chinaCollector = new ChinaStatsCollector(source, dest, serviceProvider.GetRequiredService<ILogger<ChinaStatsCollector>>());
+            _chinaCollector = new ChinaStatsCollector(source, dest, serviceProvider.GetRequiredService<ILogger<ChinaStatsCollector>>())
+            {
+                WriteHeader = _configuration.WriteOutputHeader,
+            };
         }
 
         public override async Task Run()

--- a/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
+++ b/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
@@ -35,7 +35,9 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
             var collector = new ChinaStatsCollector(
                 Mock.Of<ILogSource>(),
                 Mock.Of<ILogDestination>(),
-                Mock.Of<ILogger<ChinaStatsCollector>>());
+                Mock.Of<ILogger<ChinaStatsCollector>>(),
+                writeHeader: true,
+                addSourceFilenameColumn: false);
 
             var transformedInput = collector.TransformRawLogLine(input);
             string output = transformedInput == null ? null : transformedInput.ToString();
@@ -51,7 +53,9 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
             var collector = new ChinaStatsCollector(
                 Mock.Of<ILogSource>(),
                 Mock.Of<ILogDestination>(),
-                Mock.Of<ILogger<ChinaStatsCollector>>());
+                Mock.Of<ILogger<ChinaStatsCollector>>(),
+                writeHeader: true,
+                addSourceFilenameColumn: false);
 
             var transformedInput = collector.TransformRawLogLine(input);
             if (transformedInput == null)
@@ -74,7 +78,9 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
             var collector = new ChinaStatsCollector(
                 Mock.Of<ILogSource>(),
                 Mock.Of<ILogDestination>(),
-                Mock.Of<ILogger<ChinaStatsCollector>>());
+                Mock.Of<ILogger<ChinaStatsCollector>>(),
+                writeHeader: true,
+                addSourceFilenameColumn: false);
 
             OutputLogLine transformedInput = null;
 
@@ -130,7 +136,9 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
             var collector = new ChinaStatsCollector(
                 sourceMock.Object,
                 destinationMock.Object,
-                Mock.Of<ILogger<ChinaStatsCollector>>());
+                Mock.Of<ILogger<ChinaStatsCollector>>(),
+                writeHeader: true,
+                addSourceFilenameColumn: false);
 
             await collector.TryProcessAsync(
                 maxFileCount: 10,
@@ -164,7 +172,8 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
                 sourceMock.Object,
                 destinationMock.Object,
                 Mock.Of<ILogger<ChinaStatsCollector>>(),
-                writeHeader: false);
+                writeHeader: false,
+                addSourceFilenameColumn: false);
 
             await collector.TryProcessAsync(
                 maxFileCount: 10,
@@ -196,6 +205,7 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
                 sourceMock.Object,
                 destinationMock.Object,
                 Mock.Of<ILogger<ChinaStatsCollector>>(),
+                writeHeader: true,
                 addSourceFilenameColumn: true);
 
             await collector.TryProcessAsync(


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/5601.

Added options to not write headers and add an extra column with original filename for HTTP logs ingested from Mooncake CDN. This aligns Mooncake log ingestion with other ingestion paths.