### PR TITLE
Avoid calling CreateIfNotExists for Feature Flags

### DIFF
--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -205,7 +205,8 @@ namespace NuGet.Jobs
                 .Register(c => new CloudBlobCoreFileStorageService(
                     c.ResolveKeyed<ICloudBlobClient>(FeatureFlagBindingKey),
                     c.Resolve<IDiagnosticsService>(),
-                    c.Resolve<ICloudBlobContainerInformationProvider>()))
+                    c.Resolve<ICloudBlobContainerInformationProvider>(),
+                    initializeContainer: false))
                 .Keyed<ICoreFileStorageService>(FeatureFlagBindingKey);
 
             containerBuilder

--- a/src/NuGetGallery.Core/Features/FeatureFlagFileStorageService.cs
+++ b/src/NuGetGallery.Core/Features/FeatureFlagFileStorageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -38,7 +38,7 @@ namespace NuGetGallery.Features
 
         public async Task<FeatureFlags> GetAsync()
         {
-            using (var stream = await _storage.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName))
+            using (var stream = await _storage.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName, initializeContainer: false))
             {
                 return ReadFeatureFlagsFromStream(stream);
             }

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -14,7 +14,7 @@ namespace NuGetGallery
 
         Task<bool> FileExistsAsync(string folderName, string fileName);
 
-        Task<Stream> GetFileAsync(string folderName, string fileName, bool initializeContainer = true);
+        Task<Stream> GetFileAsync(string folderName, string fileName);
 
         /// <summary>
         /// Gets a reference to a file in the storage service, which can be used to open the full file data.

--- a/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/ICoreFileStorageService.cs
@@ -14,7 +14,7 @@ namespace NuGetGallery
 
         Task<bool> FileExistsAsync(string folderName, string fileName);
 
-        Task<Stream> GetFileAsync(string folderName, string fileName);
+        Task<Stream> GetFileAsync(string folderName, string fileName, bool initializeContainer = true);
 
         /// <summary>
         /// Gets a reference to a file in the storage service, which can be used to open the full file data.

--- a/src/NuGetGallery/Services/FileSystemFileStorageService.cs
+++ b/src/NuGetGallery/Services/FileSystemFileStorageService.cs
@@ -89,7 +89,7 @@ namespace NuGetGallery
             return Task.FromResult(fileExists);
         }
 
-        public Task<Stream> GetFileAsync(string folderName, string fileName)
+        public Task<Stream> GetFileAsync(string folderName, string fileName, bool initializeContainer = true)
         {
             if (string.IsNullOrWhiteSpace(folderName))
             {

--- a/src/NuGetGallery/Services/PackageFileService.cs
+++ b/src/NuGetGallery/Services/PackageFileService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Services.Entities;

--- a/tests/NuGet.Services.Revalidate.Tests/Services/HealthServiceFacts.cs
+++ b/tests/NuGet.Services.Revalidate.Tests/Services/HealthServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -37,7 +37,7 @@ namespace NuGet.Services.Revalidate.Tests.Services
         public async Task ReturnsHealthyIfStatusBlobIndicatesHealthyComponent(string resourceName, bool expectsHealthy)
         {
             _storage
-                .Setup(s => s.GetFileAsync(_config.ContainerName, _config.StatusBlobName))
+                .Setup(s => s.GetFileAsync(_config.ContainerName, _config.StatusBlobName, true))
                 .ReturnsAsync(TestResources.GetResourceStream(resourceName));
 
             Assert.Equal(expectsHealthy, await _target.IsHealthyAsync());
@@ -47,7 +47,7 @@ namespace NuGet.Services.Revalidate.Tests.Services
         public async Task AssumesUnhealthyIfComponentCannotBeFoundInStatusBlob()
         {
             _storage
-                .Setup(s => s.GetFileAsync(_config.ContainerName, _config.StatusBlobName))
+                .Setup(s => s.GetFileAsync(_config.ContainerName, _config.StatusBlobName, true))
                 .ReturnsAsync(TestResources.GetResourceStream(TestResources.PackagePublishingMissingStatus));
 
             Assert.False(await _target.IsHealthyAsync());
@@ -60,7 +60,7 @@ namespace NuGet.Services.Revalidate.Tests.Services
             var expectedException = new Exception("Look ma, I'm an exception!");
 
             _storage
-                .Setup(s => s.GetFileAsync(_config.ContainerName, _config.StatusBlobName))
+                .Setup(s => s.GetFileAsync(_config.ContainerName, _config.StatusBlobName, true))
                 .ThrowsAsync(expectedException);
 
             // Act & Assert

--- a/tests/NuGetGallery.Core.Facts/Features/EditableFeatureFlagFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Features/EditableFeatureFlagFileStorageServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -75,7 +75,7 @@ namespace NuGetGallery.Features
             {
                 // Arrange
                 _storage
-                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName))
+                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName, true))
                     .ReturnsAsync(BuildStream(ExampleJson));
 
                 // Act
@@ -89,7 +89,7 @@ namespace NuGetGallery.Features
             public async Task ThrowsOnInvalidJson()
             {
                 _storage
-                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName))
+                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName, true))
                     .ReturnsAsync(BuildStream("Bad"));
 
                 await Assert.ThrowsAsync<JsonReaderException>(() => _target.GetAsync());

--- a/tests/NuGetGallery.Core.Facts/Features/EditableFeatureFlagFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Features/EditableFeatureFlagFileStorageServiceFacts.cs
@@ -75,7 +75,7 @@ namespace NuGetGallery.Features
             {
                 // Arrange
                 _storage
-                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName, true))
+                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName, false))
                     .ReturnsAsync(BuildStream(ExampleJson));
 
                 // Act
@@ -89,7 +89,7 @@ namespace NuGetGallery.Features
             public async Task ThrowsOnInvalidJson()
             {
                 _storage
-                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName, true))
+                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.FeatureFlagsFileName, false))
                     .ReturnsAsync(BuildStream("Bad"));
 
                 await Assert.ThrowsAsync<JsonReaderException>(() => _target.GetAsync());

--- a/tests/NuGetGallery.Core.Facts/Login/EditableLoginConfigurationFileStorageServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Login/EditableLoginConfigurationFileStorageServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -66,7 +66,7 @@ namespace NuGetGallery.Login
             {
                 // Arrange
                 _storage
-                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.LoginDiscontinuationConfigFileName))
+                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.LoginDiscontinuationConfigFileName, true))
                     .ReturnsAsync(BuildStream(ExampleJson));
 
                 // Act
@@ -80,7 +80,7 @@ namespace NuGetGallery.Login
             public async Task ThrowsOnInvalidJson()
             {
                 _storage
-                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.LoginDiscontinuationConfigFileName))
+                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.LoginDiscontinuationConfigFileName, true))
                     .ReturnsAsync(BuildStream("Bad"));
 
                 await Assert.ThrowsAsync<JsonReaderException>(() => _target.GetAsync());
@@ -445,7 +445,7 @@ namespace NuGetGallery.Login
             public async Task GetListOfExceptionEmailListSuccessfully()
             {
                 _storage
-                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.LoginDiscontinuationConfigFileName))
+                    .Setup(s => s.GetFileAsync(CoreConstants.Folders.ContentFolderName, CoreConstants.LoginDiscontinuationConfigFileName, true))
                     .ReturnsAsync(BuildStream(ExampleJson));
 
                 // Act

--- a/tests/NuGetGallery.Core.Facts/Services/CoreLicenseFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CoreLicenseFileServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -274,10 +274,10 @@ namespace NuGetGallery.Services
                 await service.DownloadLicenseFileAsync(package);
 
                 fileStorageSvc
-                    .Verify(fss => fss.GetFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildLicenseFileName("theId", "1.1.1")),
+                    .Verify(fss => fss.GetFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildLicenseFileName("theId", "1.1.1"), true),
                         Times.Once);
                 fileStorageSvc
-                    .Verify(fss => fss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    .Verify(fss => fss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true),
                         Times.Once);
             }
         }

--- a/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CorePackageFileServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -297,10 +297,10 @@ namespace NuGetGallery
                 await _service.DownloadValidationPackageFileAsync(_package);
 
                 _fileStorageService.Verify(
-                    x => x.GetFileAsync(ValidationFolderName, ValidationFileName),
+                    x => x.GetFileAsync(ValidationFolderName, ValidationFileName, true),
                     Times.Once);
                 _fileStorageService.Verify(
-                    x => x.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    x => x.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true),
                     Times.Once);
             }
 
@@ -310,10 +310,10 @@ namespace NuGetGallery
                 await _service.DownloadValidationPackageFileAsync(_package);
 
                 _fileStorageService.Verify(
-                    x => x.GetFileAsync(ValidationFolderName, ValidationFileName),
+                    x => x.GetFileAsync(ValidationFolderName, ValidationFileName, true),
                     Times.Once);
                 _fileStorageService.Verify(
-                    x => x.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    x => x.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true),
                     Times.Once);
             }
         }

--- a/tests/NuGetGallery.Core.Facts/Services/CoreReadmeFileServiceFacts.cs
+++ b/tests/NuGetGallery.Core.Facts/Services/CoreReadmeFileServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -178,10 +178,10 @@ namespace NuGetGallery.Services
                 await service.DownloadReadmeFileAsync(package);
 
                 fileStorageSvc
-                    .Verify(fss => fss.GetFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildReadmeFileName("theId", "1.1.1")),
+                    .Verify(fss => fss.GetFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildReadmeFileName("theId", "1.1.1"), true),
                         Times.Once);
                 fileStorageSvc
-                    .Verify(fss => fss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    .Verify(fss => fss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true),
                         Times.Once);
             }
 
@@ -205,7 +205,7 @@ namespace NuGetGallery.Services
                         Version = "01.1.01"
                     };
 
-                    fileStorageSvc.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+                    fileStorageSvc.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true))
                         .Returns(Task.FromResult(stream))
                         .Verifiable();
 
@@ -215,7 +215,7 @@ namespace NuGetGallery.Services
                     // Assert.
                     Assert.Equal(expectedMd, actualMd);
 
-                    fileStorageSvc.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildReadmeFileName("Foo", "1.1.1")), Times.Once);
+                    fileStorageSvc.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildReadmeFileName("Foo", "1.1.1"), true), Times.Once);
                 }
             }
 
@@ -235,7 +235,7 @@ namespace NuGetGallery.Services
                     Version = "01.1.01"
                 };
 
-                fileStorageSvc.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+                fileStorageSvc.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true))
                     .Returns(Task.FromResult((Stream)null))
                     .Verifiable();
 
@@ -245,7 +245,7 @@ namespace NuGetGallery.Services
                 // Assert
                 Assert.Null(result);
 
-                fileStorageSvc.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildReadmeFileName("Foo", "1.1.1")), Times.Once);
+                fileStorageSvc.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackagesContentFolderName, BuildReadmeFileName("Foo", "1.1.1"), true), Times.Once);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/PackageFileServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Moq;
@@ -321,7 +321,7 @@ namespace NuGetGallery
                         },
                         Version = "01.1.01"
                     };
-                    fileServiceMock.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+                    fileServiceMock.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true))
                         .Returns(Task.FromResult(stream))
                         .Verifiable();
 
@@ -331,7 +331,7 @@ namespace NuGetGallery
                     // Assert.
                     Assert.Equal(expectedMd, actualMd);
 
-                    fileServiceMock.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackageReadMesFolderName, "active/foo/1.1.1.md"), Times.Once);
+                    fileServiceMock.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackageReadMesFolderName, "active/foo/1.1.1.md", true), Times.Once);
                 }
             }
 
@@ -350,7 +350,7 @@ namespace NuGetGallery
                     },
                     Version = "01.1.01"
                 };
-                fileServiceMock.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+                fileServiceMock.Setup(f => f.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true))
                     .Returns(Task.FromResult((Stream)null))
                     .Verifiable();
 
@@ -360,7 +360,7 @@ namespace NuGetGallery
                 // Assert
                 Assert.Null(result);
 
-                fileServiceMock.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackageReadMesFolderName, "active/foo/1.1.1.md"), Times.Once);
+                fileServiceMock.Verify(f => f.GetFileAsync(CoreConstants.Folders.PackageReadMesFolderName, "active/foo/1.1.1.md", true), Times.Once);
             }
         }
 

--- a/tests/NuGetGallery.Facts/Services/UploadFileServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Services/UploadFileServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 using System;
 using System.IO;
@@ -76,7 +76,7 @@ namespace NuGetGallery
 
                 service.GetUploadFileAsync(1);
 
-                fakeFileStorageService.Verify(x => x.GetFileAsync(CoreConstants.Folders.UploadsFolderName, It.IsAny<string>()));
+                fakeFileStorageService.Verify(x => x.GetFileAsync(CoreConstants.Folders.UploadsFolderName, It.IsAny<string>(), true));
             }
 
             [Fact]
@@ -88,7 +88,7 @@ namespace NuGetGallery
 
                 service.GetUploadFileAsync(1);
 
-                fakeFileStorageService.Verify(x => x.GetFileAsync(It.IsAny<string>(), expectedFileName));
+                fakeFileStorageService.Verify(x => x.GetFileAsync(It.IsAny<string>(), expectedFileName, true));
             }
 
             [Fact]
@@ -97,7 +97,7 @@ namespace NuGetGallery
                 var expectedFileName = String.Format(GalleryConstants.UploadFileNameTemplate, 1, CoreConstants.NuGetPackageFileExtension);
                 var fakeFileStorageService = new Mock<IFileStorageService>();
                 var fakeFileStream = new MemoryStream();
-                fakeFileStorageService.Setup(x => x.GetFileAsync(CoreConstants.Folders.UploadsFolderName, expectedFileName))
+                fakeFileStorageService.Setup(x => x.GetFileAsync(CoreConstants.Folders.UploadsFolderName, expectedFileName, true))
                                       .Returns(Task.FromResult<Stream>(fakeFileStream));
                 var service = CreateService(fakeFileStorageService: fakeFileStorageService);
 

--- a/tests/Validation.Symbols.Tests/SymbolsFileServiceTests.cs
+++ b/tests/Validation.Symbols.Tests/SymbolsFileServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -61,7 +61,7 @@ namespace Validation.Symbols.Tests
             var stream = await service.DownloadNupkgFileAsync(PackageId, PackageNormalizedVersion, CancellationToken.None);
 
             // Assert
-            _packageValidationStorageService.Verify(pss => pss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _packageValidationStorageService.Verify(pss => pss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true), Times.Once);
         }
 
         [Fact]
@@ -76,8 +76,8 @@ namespace Validation.Symbols.Tests
             var stream = await service.DownloadNupkgFileAsync(PackageId, PackageNormalizedVersion, CancellationToken.None);
 
             // Assert
-            _packageStorageService.Verify(pss => pss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            _packageValidationStorageService.Verify(pss => pss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            _packageStorageService.Verify(pss => pss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true), Times.Once);
+            _packageValidationStorageService.Verify(pss => pss.GetFileAsync(It.IsAny<string>(), It.IsAny<string>(), true), Times.Never);
         }
 
         [Fact]


### PR DESCRIPTION
Feature flags were calling `CreateIfNotExists` to get the container reference for the FF container ('content'). This container already exists, so we don't need to write anything, but the `CreateIfNotExists` call meant that we would need to have read-write permissions enabled regardless, and jobs/services using this path would need the MSI to be over-provisioned (eg. SearchService)

I've made changes so we avoid that call for Feature Flags. I've tested it for the SearchService and it worked, but I haven't tested anything else. Let me know if there's anything else I should try to test.

UPDATE: working on some changes to this