### PR TITLE
Avoid calling CreateIfNotExists for Feature Flags

### DIFF
--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -205,7 +205,8 @@ namespace NuGet.Jobs
                 .Register(c => new CloudBlobCoreFileStorageService(
                     c.ResolveKeyed<ICloudBlobClient>(FeatureFlagBindingKey),
                     c.Resolve<IDiagnosticsService>(),
-                    c.Resolve<ICloudBlobContainerInformationProvider>()))
+                    c.Resolve<ICloudBlobContainerInformationProvider>(),
+                    initializeContainer: false))
                 .Keyed<ICoreFileStorageService>(FeatureFlagBindingKey);
 
             containerBuilder

--- a/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
+++ b/src/NuGetGallery.Core/Services/CloudBlobCoreFileStorageService.cs
@@ -30,15 +30,18 @@ namespace NuGetGallery
         protected readonly IDiagnosticsSource _trace;
         protected readonly ICloudBlobContainerInformationProvider _cloudBlobFolderInformationProvider;
         protected readonly ConcurrentDictionary<string, ICloudBlobContainer> _containers = new ConcurrentDictionary<string, ICloudBlobContainer>();
+        protected readonly bool _initializeContainer;
 
         public CloudBlobCoreFileStorageService(
             ICloudBlobClient client,
             IDiagnosticsService diagnosticsService,
-            ICloudBlobContainerInformationProvider cloudBlobFolderInformationProvider)
+            ICloudBlobContainerInformationProvider cloudBlobFolderInformationProvider,
+            bool initializeContainer = true)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _trace = diagnosticsService?.SafeGetSource(nameof(CloudBlobCoreFileStorageService)) ?? throw new ArgumentNullException(nameof(diagnosticsService));
             _cloudBlobFolderInformationProvider = cloudBlobFolderInformationProvider ?? throw new ArgumentNullException(nameof(cloudBlobFolderInformationProvider));
+            _initializeContainer = initializeContainer;
         }
 
         public async Task DeleteFileAsync(string folderName, string fileName)
@@ -598,7 +601,11 @@ namespace NuGetGallery
         private async Task<ICloudBlobContainer> PrepareContainer(string folderName, bool isPublic)
         {
             var container = _client.GetContainerReference(folderName);
-            await container.CreateIfNotExistAsync(isPublic);
+
+            if (_initializeContainer)
+            {
+                await container.CreateIfNotExistAsync(isPublic);
+            }
 
             return container;
         }


### PR DESCRIPTION
Feature flags were calling `CreateIfNotExists` to get the container reference for the FF container ('content'). This container already exists, so we don't need to write anything, but the `CreateIfNotExists` call meant that we would need to have read-write permissions enabled regardless, and jobs/services using this path would need the MSI to be over-provisioned (eg. SearchService)

I've made changes so we avoid that call for Feature Flags. I've tested it for the SearchService and it worked, but I haven't tested anything else. Let me know if there's anything else I should try to test.

Related to/Part of https://github.com/NuGet/Engineering/issues/5439