### PR TITLE
Test:  fix removal of test certificate from root store

### DIFF
--- a/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -338,7 +338,11 @@ namespace Validation.PackageSigning.Core.Tests.Support
                 StoreLocation.LocalMachine);
 
             var timestampService = TimestampService.Create(rootCa);
-            var disposable = new DisposableList<IDisposable> { rootCertificate, trust };
+
+            // Do not add `rootCertificate`, because its disposal will cause subsequent disposal
+            // of `trust` to fail and trust removal to fail.
+            // Disposing `trust` already disposes `rootCertificate`.
+            var disposable = new DisposableList<IDisposable> { trust };
 
             Task WaitForResponseExpirationAsync()
             {


### PR DESCRIPTION
Summary of the changes (in less than 80 characters):

This change ensures that test certificates are removed from the root store.

Addresses https://github.com/NuGet/NuGetGallery/issues/10259

## Details

This change fixes a bug where the disposal of an `X509Certificate2` instance causes the subsequent disposal (removal) of that certificate's trust because the `TrustedTestCert<X509Certificate2>` instance references the same certificate instance.  When the `X509Certificate2` instance is disposed, `TrustedTestCert<X509Certificate2>` cannot remove the certificate from the root store because its certificate reference is disposed.

The fix is to only dispose the `TrustedTestCert<X509Certificate2>` instance.