### PR TITLE
[OIDC 3] Add flight for using federated credentials

### DIFF
--- a/src/AccountDeleter/EmptyFeatureFlagService.cs
+++ b/src/AccountDeleter/EmptyFeatureFlagService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Services.Entities;
@@ -320,6 +320,11 @@ namespace NuGetGallery.AccountDeleter
         }
 
         public bool IsAdvancedFrameworkFilteringEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool CanUseFederatedCredentials(User user)
         {
             throw new NotImplementedException();
         }

--- a/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
+++ b/src/GitHubVulnerabilities2Db/Fakes/FakeFeatureFlagService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -321,6 +321,11 @@ namespace GitHubVulnerabilities2Db.Fakes
         }
 
         public bool IsAdvancedFrameworkFilteringEnabled(User user)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool CanUseFederatedCredentials(User user)
         {
             throw new NotImplementedException();
         }

--- a/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/FeatureFlagService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -63,6 +63,7 @@ namespace NuGetGallery
         private const string FrameworkFilteringFeatureName = GalleryPrefix + "FrameworkFiltering";
         private const string DisplayTfmBadgesFeatureName = GalleryPrefix + "DisplayTfmBadges";
         private const string AdvancedFrameworkFilteringFeatureName = GalleryPrefix + "AdvancedFrameworkFiltering";
+        private const string FederatedCredentialsFeatureName = GalleryPrefix + "FederatedCredentials";
 
         private const string ODataV1GetAllNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllNonHijacked";
         private const string ODataV1GetAllCountNonHijackedFeatureName = GalleryPrefix + "ODataV1GetAllCountNonHijacked";
@@ -120,7 +121,7 @@ namespace NuGetGallery
         /// <summary>
         /// The number of versions a package needs to have before it should be flighted using <see cref="ManageDeprecationForManyVersionsFeatureName"/> instead of <see cref="ManageDeprecationFeatureName"/>.
         /// </summary>
-        private const int _manageDeprecationForManyVersionsThreshold = 500;
+        private const int ManageDeprecationForManyVersionsThreshold = 500;
 
         public bool IsManageDeprecationEnabled(User user, PackageRegistration registration)
         {
@@ -144,7 +145,7 @@ namespace NuGetGallery
                 return false;
             }
 
-            return allVersions.Count() < _manageDeprecationForManyVersionsThreshold
+            return allVersions.Count() < ManageDeprecationForManyVersionsThreshold
                 || _client.IsEnabled(ManageDeprecationForManyVersionsFeatureName, user, defaultValue: true);
         }
 
@@ -420,6 +421,11 @@ namespace NuGetGallery
         public bool IsAdvancedFrameworkFilteringEnabled(User user)
         {
             return _client.IsEnabled(AdvancedFrameworkFilteringFeatureName, user, defaultValue: false);
+        }
+
+        public bool CanUseFederatedCredentials(User user)
+        {
+            return _client.IsEnabled(FederatedCredentialsFeatureName, user, defaultValue: false);
         }
     }
 }

--- a/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
+++ b/src/NuGetGallery.Services/Configuration/IFeatureFlagService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -342,5 +342,10 @@ namespace NuGetGallery
         /// Whether or not to allow filtering by frameworks on NuGet.org search
         /// </summary>
         bool IsAdvancedFrameworkFilteringEnabled(User user);
+
+        /// <summary>
+        /// Whether or not the user specified in a package owner scope can use federated credentials.
+        /// </summary>
+        bool CanUseFederatedCredentials(User user);
     }
 }

--- a/src/NuGetGallery/App_Data/Files/Content/flags.json
+++ b/src/NuGetGallery/App_Data/Files/Content/flags.json
@@ -145,6 +145,12 @@
       "SiteAdmins": false,
       "Accounts": [],
       "Domains": []
+    },
+    "NuGetGallery.FederatedCredentials": {
+      "All": true,
+      "SiteAdmins": false,
+      "Accounts": [],
+      "Domains": []
     }
   }
 }

--- a/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
+++ b/src/VerifyMicrosoftPackage/Fakes/FakeFeatureFlagService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -135,5 +135,7 @@ namespace NuGet.VerifyMicrosoftPackage.Fakes
         public bool IsDisplayTfmBadgesEnabled(User user) => throw new NotImplementedException();
 
         public bool IsAdvancedFrameworkFilteringEnabled(User user) => throw new NotImplementedException();
+
+        public bool CanUseFederatedCredentials(User user) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/10212.
Depends on https://github.com/NuGet/NuGetGallery/pull/10252.

We want to be able to control exactly which package owners should be using this feature. This adds a flight (i.e. a feature flag specific to the user) for the new federated credentials (OIDC) feature.

I did some minor private const renaming to address an IDE suggestion (per `.editorconfig`) which is unrelated to the other changes.

The flight defaults to false meaning it is opt-in.

We generally do not have UTs for these changes since they are so simple.