### PR TITLE
[OIDC 4] Add method to create a short-lived API key (minimal)

### DIFF
--- a/src/NuGetGallery.Services/Authentication/CredentialBuilder.cs
+++ b/src/NuGetGallery.Services/Authentication/CredentialBuilder.cs
@@ -36,6 +36,11 @@ namespace NuGetGallery.Infrastructure.Authentication
                 throw new ArgumentException($"The {nameof(policy.PackageOwner)} property on the policy must not be null.");
             }
 
+            if (expiration <= TimeSpan.Zero || expiration > TimeSpan.FromHours(1))
+            {
+                throw new ArgumentOutOfRangeException(nameof(expiration));
+            }
+
             // TODO: introduce a new API key type for short-lived API keys
             // Tracking: https://github.com/NuGet/NuGetGallery/issues/10212
             var credential = CreateApiKey(expiration, out plaintextApiKey);

--- a/src/NuGetGallery.Services/Authentication/ICredentialBuilder.cs
+++ b/src/NuGetGallery.Services/Authentication/ICredentialBuilder.cs
@@ -20,5 +20,7 @@ namespace NuGetGallery.Infrastructure.Authentication
         IList<Scope> BuildScopes(User scopeOwner, string[] scopes, string[] subjects);
 
         bool VerifyScopes(User currentUser, IEnumerable<Scope> scopes);
+
+        Credential CreateShortLivedApiKey(TimeSpan expiration, FederatedCredentialPolicy policy, out string plaintextApiKey);
     }
 }

--- a/tests/NuGetGallery.Facts/Authentication/CredentialBuilderFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/CredentialBuilderFacts.cs
@@ -45,6 +45,19 @@ namespace NuGetGallery.Infrastructure.Authentication
                 Assert.Throws<ArgumentException>(() => Target.CreateShortLivedApiKey(Expiration, Policy, out var plaintextApiKey));
             }
 
+            [Theory]
+            [InlineData(-1)]
+            [InlineData(0)]
+            [InlineData(61)]
+            public void RejectsOutOfRangeExpiration(int expirationMinutes)
+            {
+                // Arrange
+                Expiration = TimeSpan.FromMinutes(expirationMinutes);
+
+                // Act
+                Assert.Throws<ArgumentOutOfRangeException>(() => Target.CreateShortLivedApiKey(Expiration, Policy, out var plaintextApiKey));
+            }
+
             public FederatedCredentialPolicy Policy { get; }
 
             public TheCreateShortLivedApiKeyMethod()
@@ -58,7 +71,7 @@ namespace NuGetGallery.Infrastructure.Authentication
             }
         }
 
-        public TimeSpan Expiration { get; }
+        public TimeSpan Expiration { get; set; }
 
         public CredentialBuilderFacts()
         {

--- a/tests/NuGetGallery.Facts/Authentication/CredentialBuilderFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/CredentialBuilderFacts.cs
@@ -10,8 +10,6 @@ namespace NuGetGallery.Infrastructure.Authentication
 {
     public class CredentialBuilderFacts
     {
-        public CredentialBuilder Target { get; }
-
         public class TheCreateShortLivedApiKeyMethod : CredentialBuilderFacts
         {
             [Fact]
@@ -72,6 +70,8 @@ namespace NuGetGallery.Infrastructure.Authentication
         }
 
         public TimeSpan Expiration { get; set; }
+
+        public CredentialBuilder Target { get; }
 
         public CredentialBuilderFacts()
         {

--- a/tests/NuGetGallery.Facts/Authentication/CredentialBuilderFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/CredentialBuilderFacts.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Services.Entities;
+using NuGetGallery.Authentication;
+using Xunit;
+
+namespace NuGetGallery.Infrastructure.Authentication
+{
+    public class CredentialBuilderFacts
+    {
+        public CredentialBuilder Target { get; }
+
+        public class TheCreateShortLivedApiKeyMethod : CredentialBuilderFacts
+        {
+            [Fact]
+            public void CreatesShortLivedApiKey()
+            {
+                // Act
+                var credential = Target.CreateShortLivedApiKey(Expiration, Policy, out var plaintextApiKey);
+
+                // Assert
+                Assert.Null(credential.User);
+                Assert.Equal(default, credential.UserKey);
+                Assert.StartsWith("oy2", plaintextApiKey, StringComparison.Ordinal);
+                Assert.Equal(CredentialTypes.ApiKey.V4, credential.Type);
+                Assert.Equal("Short-lived API key generated via a federated credential", credential.Description);
+                Assert.Equal(Expiration.Ticks, credential.ExpirationTicks);
+                Assert.Null(credential.User);
+
+                var scope = Assert.Single(credential.Scopes);
+                Assert.Equal(NuGetScopes.All, scope.AllowedAction);
+                Assert.Equal(NuGetPackagePattern.AllInclusivePattern, scope.Subject);
+                Assert.Same(Policy.PackageOwner, scope.Owner);
+            }
+
+            [Fact]
+            public void RejectsMissingPackageOwner()
+            {
+                // Arrange
+                Policy.PackageOwner = null;
+
+                // Act
+                Assert.Throws<ArgumentException>(() => Target.CreateShortLivedApiKey(Expiration, Policy, out var plaintextApiKey));
+            }
+
+            public FederatedCredentialPolicy Policy { get; }
+
+            public TheCreateShortLivedApiKeyMethod()
+            {
+                Policy = new FederatedCredentialPolicy
+                {
+                    Key = 23,
+                    PackageOwner = new User { Key = 42 },
+                    CreatedBy = new User { Key = 43 },
+                };
+            }
+        }
+
+        public TimeSpan Expiration { get; }
+
+        public CredentialBuilderFacts()
+        {
+            Expiration = TimeSpan.FromMinutes(13);
+
+            Target = new CredentialBuilder();
+        }
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/10212.
Depends on https://github.com/NuGet/NuGetGallery/pull/10262.

This adds a new method to `CredentialBuilder` which creates a short-lived API key given a federated credential trust policy.

This method has a TODO in it linking to the OIDC work item because the exact shape of the short lived API key is still in discussion. The created credential is not yet associated with a user (the created by user account) because this is the responsibility of `IAuthenticationService.AddCredential`:
https://github.com/NuGet/NuGetGallery/blob/0ec99618043ae7f7e54a3ed8fdbbb47acc5e30b1/src/NuGetGallery.Services/Authentication/AuthenticationService.cs#L629-L641

This will be called in a future PR while executing the token trade endpoint.

This stub allows me to perform the token trade flow with a current V4 API key, without any of the improvements we will need (such as hiding this API keys from the API key page, not sending API key expiration messages, etc.).