### PR TITLE
Do not audit values for removed/revoked API keys

### DIFF
--- a/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/CredentialAuditRecord.cs
@@ -21,7 +21,7 @@ namespace NuGetGallery.Auditing
         public string TenantId { get; }
         public string RevocationSource { get; }
 
-        public CredentialAuditRecord(Credential credential, bool removedOrRevoked)
+        public CredentialAuditRecord(Credential credential)
         {
             if (credential == null)
             {
@@ -34,22 +34,11 @@ namespace NuGetGallery.Auditing
             Identity = credential.Identity;
             TenantId = credential.TenantId;
 
-            // Track the value for credentials that are external (object id) or definitely revocable (API Key, etc.) and have been removed
+            // Track the value for credentials that are external (object id)
+            // Do not track the credential valid for API keys or passwords, even if they are revoked.
             if (credential.IsExternal())
             {
                 Value = credential.Value;
-            }
-            else if (removedOrRevoked)
-            {
-                if (Type == null)
-                {
-                    throw new ArgumentNullException(nameof(credential.Type));
-                }
-
-                if (!credential.IsPassword())
-                {
-                    Value = credential.Value;
-                }
             }
 
             Created = credential.Created;
@@ -65,8 +54,8 @@ namespace NuGetGallery.Auditing
             }
         }
 
-        public CredentialAuditRecord(Credential credential, bool removedOrRevoked, string revocationSource)
-                : this(credential, removedOrRevoked)
+        public CredentialAuditRecord(Credential credential, string revocationSource)
+                : this(credential)
         {
             RevocationSource = revocationSource;
         }

--- a/src/NuGetGallery.Core/Auditing/FailedAuthenticatedOperationAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/FailedAuthenticatedOperationAuditRecord.cs
@@ -31,7 +31,7 @@ namespace NuGetGallery.Auditing
 
             if (attemptedCredential != null)
             {
-                AttemptedCredential = new CredentialAuditRecord(attemptedCredential, removedOrRevoked: false);
+                AttemptedCredential = new CredentialAuditRecord(attemptedCredential);
             }
         }
 

--- a/src/NuGetGallery.Core/Auditing/UserAuditRecord.cs
+++ b/src/NuGetGallery.Core/Auditing/UserAuditRecord.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -56,7 +56,7 @@ namespace NuGetGallery.Auditing
             Roles = user.Roles.Select(r => r.Name).ToArray();
 
             Credentials = user.Credentials.Where(CredentialTypes.IsSupportedCredential)
-                                          .Select(c => new CredentialAuditRecord(c, removedOrRevoked: false)).ToArray();
+                                          .Select(c => new CredentialAuditRecord(c)).ToArray();
 
             AffectedCredential = Array.Empty<CredentialAuditRecord>();
             AffectedPolicies = Array.Empty<AuditedUserSecurityPolicy>();
@@ -70,8 +70,7 @@ namespace NuGetGallery.Auditing
         public UserAuditRecord(User user, AuditedUserAction action, IEnumerable<Credential> affected, string revocationSource)
             : this(user, action)
         {
-            AffectedCredential = affected.Select(c => new CredentialAuditRecord(c,
-                removedOrRevoked: action == AuditedUserAction.RemoveCredential || action == AuditedUserAction.RevokeCredential, revocationSource: revocationSource)).ToArray();
+            AffectedCredential = affected.Select(c => new CredentialAuditRecord(c, revocationSource: revocationSource)).ToArray();
         }
 
         public UserAuditRecord(User user, AuditedUserAction action, Credential affected)
@@ -82,8 +81,7 @@ namespace NuGetGallery.Auditing
         public UserAuditRecord(User user, AuditedUserAction action, IEnumerable<Credential> affected)
             : this(user, action)
         {
-            AffectedCredential = affected.Select(c => new CredentialAuditRecord(c,
-                removedOrRevoked: action == AuditedUserAction.RemoveCredential || action == AuditedUserAction.RevokeCredential)).ToArray();
+            AffectedCredential = affected.Select(c => new CredentialAuditRecord(c)).ToArray();
         }
 
         public UserAuditRecord(User user, AuditedUserAction action, string affectedEmailAddress)

--- a/tests/NuGetGallery.Core.Facts/Auditing/CredentialAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/CredentialAuditRecordTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,31 +13,23 @@ namespace NuGetGallery.Auditing
         [Fact]
         public void Constructor_ThrowsForNullCredential()
         {
-            Assert.Throws<ArgumentNullException>(() => new CredentialAuditRecord(credential: null, removedOrRevoked: true));
+            Assert.Throws<ArgumentNullException>(() => new CredentialAuditRecord(credential: null));
         }
 
         [Fact]
-        public void Constructor_ThrowsForRemovalWithNullType()
-        {
-            var credential = new Credential();
-
-            Assert.Throws<ArgumentNullException>(() => new CredentialAuditRecord(credential, removedOrRevoked: true));
-        }
-
-        [Fact]
-        public void Constructor_RemovalOfNonPasswordSetsValue()
+        public void Constructor_RemovalOfNonPasswordDoesNotSetValue()
         {
             var credential = new Credential(type: "a", value: "b");
-            var record = new CredentialAuditRecord(credential, removedOrRevoked: true);
+            var record = new CredentialAuditRecord(credential);
 
-            Assert.Equal("b", record.Value);
+            Assert.Null(record.Value);
         }
 
         [Fact]
         public void Constructor_RemovalOfPasswordDoesNotSetValue()
         {
             var credential = new Credential(type: CredentialTypes.Password.V3, value: "a");
-            var record = new CredentialAuditRecord(credential, removedOrRevoked: true);
+            var record = new CredentialAuditRecord(credential);
 
             Assert.Null(record.Value);
         }
@@ -46,7 +38,7 @@ namespace NuGetGallery.Auditing
         public void Constructor_NonRemovalOfNonPasswordDoesNotSetsValue()
         {
             var credential = new Credential(type: "a", value: "b");
-            var record = new CredentialAuditRecord(credential, removedOrRevoked: false);
+            var record = new CredentialAuditRecord(credential);
 
             Assert.Null(record.Value);
         }
@@ -57,7 +49,7 @@ namespace NuGetGallery.Auditing
         public void Constructor_ExternalCredentialSetsValue(string externalType)
         {
             var credential = new Credential(type: externalType, value: "b");
-            var record = new CredentialAuditRecord(credential, removedOrRevoked: false);
+            var record = new CredentialAuditRecord(credential);
 
             Assert.Equal("b", record.Value);
         }
@@ -66,7 +58,7 @@ namespace NuGetGallery.Auditing
         public void Constructor_NonRemovalOfPasswordDoesNotSetValue()
         {
             var credential = new Credential(type: CredentialTypes.Password.V3, value: "a");
-            var record = new CredentialAuditRecord(credential, removedOrRevoked: false);
+            var record = new CredentialAuditRecord(credential);
 
             Assert.Null(record.Value);
         }
@@ -90,7 +82,7 @@ namespace NuGetGallery.Auditing
                 Type = "e",
                 Value = "f"
             };
-            var record = new CredentialAuditRecord(credential, removedOrRevoked: true);
+            var record = new CredentialAuditRecord(credential);
 
             Assert.Equal(created, record.Created);
             Assert.Equal("a", record.Description);
@@ -104,7 +96,7 @@ namespace NuGetGallery.Auditing
             Assert.Equal("c", scope.Subject);
             Assert.Equal("d", scope.AllowedAction);
             Assert.Equal("e", record.Type);
-            Assert.Equal("f", record.Value);
+            Assert.Null(record.Value);
         }
 
         [Fact]
@@ -112,11 +104,11 @@ namespace NuGetGallery.Auditing
         {
             var testRevocationSource = "TestRevocationSource";
             var credential = new Credential(type: "a", value: "b");
-            var record = new CredentialAuditRecord(credential, removedOrRevoked: true, revocationSource: testRevocationSource);
+            var record = new CredentialAuditRecord(credential, revocationSource: testRevocationSource);
 
             Assert.Equal(testRevocationSource, record.RevocationSource);
             Assert.Equal("a", record.Type);
-            Assert.Equal("b", record.Value);
+            Assert.Null(record.Value);
         }
     }
 }

--- a/tests/NuGetGallery.Core.Facts/Auditing/UserAuditRecordTests.cs
+++ b/tests/NuGetGallery.Core.Facts/Auditing/UserAuditRecordTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -108,7 +108,7 @@ namespace NuGetGallery.Auditing
             Assert.Single(record.AffectedCredential);
             Assert.Equal(testRevocationSource, record.AffectedCredential[0].RevocationSource);
             Assert.Equal("b", record.AffectedCredential[0].Type);
-            Assert.Equal("c", record.AffectedCredential[0].Value);
+            Assert.Null(record.AffectedCredential[0].Value);
         }
 
         [Fact]

--- a/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/AuthenticationServiceFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1605,7 +1605,7 @@ namespace NuGetGallery.Authentication
                     ar.AffectedCredential.Length == 1 &&
                     ar.AffectedCredential[0].Type == existingCred.Type &&
                     ar.AffectedCredential[0].Identity == existingCred.Identity &&
-                    ar.AffectedCredential[0].Value == existingCred.Value &&
+                    ar.AffectedCredential[0].Value is null &&
                     ar.AffectedCredential[0].Created == existingCred.Created &&
                     ar.AffectedCredential[0].Expires == existingCred.Expires));
             }


### PR DESCRIPTION
Today we audit the hashed API key value when a credential is deleted/revoked. This is not very useful (it is hashed) and it could trigger credential scanner in our audit logs at some point. I would like to remove it so our audit logs don't have this useless value.

Vaguely related to https://github.com/NuGet/NuGetGallery/issues/10212.