### PR TITLE
Copy list of scopes before removing them from the EF context

### DIFF
--- a/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
+++ b/src/NuGetGallery.Services/Authentication/AuthenticationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -714,7 +714,7 @@ namespace NuGetGallery.Authentication
 
         public virtual async Task EditCredentialScopes(User user, Credential cred, ICollection<Scope> newScopes)
         {
-            foreach (var oldScope in cred.Scopes)
+            foreach (var oldScope in cred.Scopes.ToList())
             {
                 Entities.Scopes.Remove(oldScope);
             }


### PR DESCRIPTION
A collection modified exception is thrown since internally the DbContext modifies the collection we are enumerating.

Over 99% of requests are failing on this endpoint and this has been happening since 2024-08-22.
 
Fix https://github.com/NuGet/NuGetGallery/issues/10273.