### PR TITLE
[OIDC 11] Add method to delete policy and associated API keys

### DIFF
--- a/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialRepositoryFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialRepositoryFacts.cs
@@ -64,8 +64,8 @@ namespace NuGetGallery.Services.Authentication
                 await Target.SaveFederatedCredentialAsync(credential, saveChanges: false);
 
                 // Assert
-                CredentialRepository.Verify(x => x.InsertOnCommit(credential), Times.Once);
-                CredentialRepository.Verify(x => x.CommitChangesAsync(), Times.Never);
+                FederatedCredentialRepository.Verify(x => x.InsertOnCommit(credential), Times.Once);
+                FederatedCredentialRepository.Verify(x => x.CommitChangesAsync(), Times.Never);
             }
 
             [Fact]
@@ -78,8 +78,8 @@ namespace NuGetGallery.Services.Authentication
                 await Target.SaveFederatedCredentialAsync(credential, saveChanges: true);
 
                 // Assert
-                CredentialRepository.Verify(x => x.InsertOnCommit(credential), Times.Once);
-                CredentialRepository.Verify(x => x.CommitChangesAsync(), Times.Once);
+                FederatedCredentialRepository.Verify(x => x.InsertOnCommit(credential), Times.Once);
+                FederatedCredentialRepository.Verify(x => x.CommitChangesAsync(), Times.Once);
             }
         }
 
@@ -133,10 +133,38 @@ namespace NuGetGallery.Services.Authentication
             }
         }
 
+        public class TheGetShortLivedApiKeysForPolicyMethod : FederatedCredentialRepositoryFacts
+        {
+            [Fact]
+            public void FiltersByPolicyKey()
+            {
+                // Act
+                var credentials = Target.GetShortLivedApiKeysForPolicy(policyKey: 1);
+
+                // Assert
+                Assert.Single(credentials);
+                Assert.Equal(6, credentials[0].Key);
+            }
+
+            [Fact]
+            public void ExcludesWrongCredentialType()
+            {
+                // Arrange
+                Credentials[0].Type = CredentialTypes.ApiKey.V1;
+
+                // Act
+                var credentials = Target.GetShortLivedApiKeysForPolicy(policyKey: 1);
+
+                // Assert
+                Assert.Empty(credentials);
+            }
+        }
+
         public FederatedCredentialRepositoryFacts()
         {
-            CredentialRepository = new Mock<IEntityRepository<FederatedCredential>>();
+            FederatedCredentialRepository = new Mock<IEntityRepository<FederatedCredential>>();
             PolicyRepository = new Mock<IEntityRepository<FederatedCredentialPolicy>>();
+            CredentialRepository = new Mock<IEntityRepository<Credential>>();
 
             Policies = new List<FederatedCredentialPolicy>
             {
@@ -146,14 +174,24 @@ namespace NuGetGallery.Services.Authentication
             };
             PolicyRepository.Setup(x => x.GetAll()).Returns(() => Policies.AsQueryable());
 
+            Credentials = new List<Credential>
+            {
+                new() { Key = 6, Type = CredentialTypes.ApiKey.V4, FederatedCredentialPolicyKey = 1 },
+                new() { Key = 7, Type = CredentialTypes.ApiKey.V4, FederatedCredentialPolicyKey = 3 },
+            };
+            CredentialRepository.Setup(x => x.GetAll()).Returns(() => Credentials.AsQueryable());
+
             Target = new FederatedCredentialRepository(
                 PolicyRepository.Object,
+                FederatedCredentialRepository.Object,
                 CredentialRepository.Object);
         }
 
-        public Mock<IEntityRepository<FederatedCredential>> CredentialRepository { get; }
+        public Mock<IEntityRepository<FederatedCredential>> FederatedCredentialRepository { get; }
         public Mock<IEntityRepository<FederatedCredentialPolicy>> PolicyRepository { get; }
+        public Mock<IEntityRepository<Credential>> CredentialRepository { get; }
         public List<FederatedCredentialPolicy> Policies { get; }
+        public List<Credential> Credentials { get; }
         public FederatedCredentialRepository Target { get; }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/10212.
Depends on https://github.com/NuGet/NuGetGallery/pull/10288.

This PR add a new service method to delete an existing federated credential policy entity. It is the responsibility of the caller to fetch the entity from the entity context prior to calling the method.

Since short-lived API keys can be associated with a federated credential policy, this PR also adds a new method to the `IFederatedCredentialRepository` interface to retrieve all short-lived API keys associated with a given policy so they can be deleted.

I chose to manually cascade the deletion so that proper "credential delete" audit records (via the existing flow) are created, instead of depending on the DB to automatically cascade deletion. This also ensures the business logic of credential deletion we encapsulate in `IAuthenticationService.RemoveCredential` is respected.

In the short term, this method will be called by an admin panel to view and manage federated credential policies.