### PR TITLE
Add admin panel for federated credential policies

### DIFF
--- a/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialRepository.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialRepository.cs
@@ -19,6 +19,7 @@ namespace NuGetGallery.Services.Authentication
         IReadOnlyList<FederatedCredentialPolicy> GetPoliciesCreatedByUser(int userKey);
         FederatedCredentialPolicy? GetPolicyByKey(int policyKey);
         IReadOnlyList<Credential> GetShortLivedApiKeysForPolicy(int policyKey);
+        IReadOnlyList<FederatedCredentialPolicy> GetPoliciesRelatedToUserKeys(IReadOnlyList<int> userKeys);
         Task DeletePolicyAsync(FederatedCredentialPolicy policy, bool saveChanges);
     }
 
@@ -64,6 +65,16 @@ namespace NuGetGallery.Services.Authentication
                 .GetAll()
                 .Where(c => c.FederatedCredentialPolicyKey == policyKey)
                 .Where(c => c.Type == CredentialTypes.ApiKey.V4)
+                .ToList();
+        }
+
+        public IReadOnlyList<FederatedCredentialPolicy> GetPoliciesRelatedToUserKeys(IReadOnlyList<int> userKeys)
+        {
+            return _policyRepository
+                .GetAll()
+                .Where(x => userKeys.Contains(x.CreatedByUserKey) || userKeys.Contains(x.PackageOwnerUserKey))
+                .Include(x => x.CreatedBy)
+                .Include(x => x.PackageOwner)
                 .ToList();
         }
 

--- a/src/NuGetGallery/Areas/Admin/Controllers/FederatedCredentialsController.cs
+++ b/src/NuGetGallery/Areas/Admin/Controllers/FederatedCredentialsController.cs
@@ -1,0 +1,265 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+using NuGet.Services.Entities;
+using NuGetGallery.Services.Authentication;
+
+#nullable enable
+
+namespace NuGetGallery.Areas.Admin.Controllers.FederatedCredentials
+{
+    public class ViewPoliciesViewModel
+    {
+        public ViewPoliciesViewModel(
+            IReadOnlyList<string> usernames,
+            IReadOnlyList<string> usernamesDoNoExist,
+            IReadOnlyList<UserPoliciesViewModel> userPolices,
+            AddPolicyViewModel addPolicy)
+        {
+            Usernames = usernames;
+            UsernamesDoNotExist = usernamesDoNoExist;
+            UserPolices = userPolices;
+            AddPolicy = addPolicy;
+        }
+
+        public IReadOnlyList<string> Usernames { get; }
+        public IReadOnlyList<string> UsernamesDoNotExist { get; }
+        public IReadOnlyList<UserPoliciesViewModel> UserPolices { get; }
+        public AddPolicyViewModel AddPolicy { get; }
+    }
+
+    public class AddPolicyViewModel
+    {
+        public string? PolicyUser { get; set; }
+        public string? PolicyPackageOwner { get; set; }
+        public FederatedCredentialType? PolicyType { get; set; }
+        public string? PolicyCriteria { get; set; }
+    }
+
+    public class UserPoliciesViewModel
+    {
+        public UserPoliciesViewModel(User user, IReadOnlyList<FederatedCredentialPolicy> policies)
+        {
+            User = user;
+            Policies = policies;
+        }
+
+        public User User { get; }
+        public IReadOnlyList<FederatedCredentialPolicy> Policies { get; }
+    }
+
+    public class FederatedCredentialsController : AdminControllerBase
+    {
+        private readonly IFederatedCredentialRepository _federatedCredentialRepository;
+        private readonly IEntityRepository<User> _userEntityRepository;
+        private readonly IUserService _userService;
+        private readonly IFederatedCredentialService _federatedCredentialService;
+
+        public FederatedCredentialsController(
+            IFederatedCredentialRepository federatedCredentialRepository,
+            IEntityRepository<User> userEntityRepository,
+            IUserService userService,
+            IFederatedCredentialService federatedCredentialService)
+        {
+            _federatedCredentialRepository = federatedCredentialRepository ?? throw new ArgumentNullException(nameof(federatedCredentialRepository));
+            _userEntityRepository = userEntityRepository ?? throw new ArgumentNullException(nameof(userEntityRepository));
+            _userService = userService ?? throw new ArgumentNullException(nameof(userService));
+            _federatedCredentialService = federatedCredentialService ?? throw new ArgumentNullException(nameof(federatedCredentialService));
+        }
+
+        [HttpGet]
+        public ActionResult Index(
+            string usernames = "",
+            bool addOrganizationMembers = false,
+            bool addUserOrganizations = false)
+        {
+            var splitUsernames = (usernames ?? string.Empty)
+                .Split('\r', '\n')
+                .Select(u => u.Trim())
+                .Where(u => !string.IsNullOrWhiteSpace(u))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (splitUsernames.Count == 0
+                && (addOrganizationMembers || addUserOrganizations))
+            {
+                // clear boolean query parameters, do nothing
+                return RedirectToAction(nameof(Index));
+            }
+
+            var users = _userEntityRepository
+                .GetAll()
+                .Where(x => splitUsernames.Contains(x.Username))
+                .Where(x => !x.IsDeleted)
+                .Include(x => x.Credentials)
+                .ToList();
+            var foundUsernames = users
+                .Select(x => x.Username)
+                .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (addOrganizationMembers)
+            {
+                splitUsernames.AddRange(users
+                    .OfType<Organization>()
+                    .SelectMany(x => x.Members)
+                    .Select(x => x.Member.Username));
+            }
+
+            if (addUserOrganizations)
+            {
+                splitUsernames.AddRange(users
+                    .SelectMany(x => x.Organizations)
+                    .Select(x => x.Organization.Username));
+            }
+
+            if (addOrganizationMembers || addUserOrganizations)
+            {
+                splitUsernames = splitUsernames.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+                return RedirectToAction(nameof(Index), new { usernames = string.Join(Environment.NewLine, splitUsernames) });
+            }
+
+            var userKeys = users.Select(x => x.Key).ToList();
+            var policies = _federatedCredentialRepository.GetPoliciesRelatedToUserKeys(userKeys);
+
+            var userPoliciesViewModels = new List<UserPoliciesViewModel>();
+            var remainingUsernames = new HashSet<string>(foundUsernames, StringComparer.OrdinalIgnoreCase);
+            foreach (var group in policies.GroupBy(x => x.CreatedBy))
+            {
+                userPoliciesViewModels.Add(new UserPoliciesViewModel(
+                    group.Key,
+                    group.OrderBy(x => x.Created).ToList()));
+
+                foreach (var policy in group)
+                {
+                    remainingUsernames.Remove(policy.CreatedBy.Username);
+                    remainingUsernames.Remove(policy.PackageOwner.Username);
+                }
+            }
+
+            foreach (var username in remainingUsernames)
+            {
+                var user = users.SingleOrDefault(x => x.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
+                userPoliciesViewModels.Add(new UserPoliciesViewModel(user, []));
+            }
+
+            userPoliciesViewModels.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.User.Username, b.User.Username));
+
+            return View(new ViewPoliciesViewModel(
+                splitUsernames,
+                splitUsernames.Except(foundUsernames, StringComparer.OrdinalIgnoreCase).ToList(),
+                userPoliciesViewModels,
+                new AddPolicyViewModel()));
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<ActionResult> DeletePolicy(int policyKey)
+        {
+            var policy = _federatedCredentialRepository.GetPolicyByKey(policyKey);
+
+            if (policy is null)
+            {
+                TempData["WarningMessage"] = $"The policy with key {policyKey} does not exist.";
+                return RedirectToAction(nameof(Index));
+            }
+
+            var username = policy.CreatedBy.Username;
+
+            await _federatedCredentialService.DeletePolicyAsync(policy);
+
+            return RedirectForUser(username, $"Policy with key {policyKey} deleted successfully.");
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<ActionResult> CreatePolicy(AddPolicyViewModel addPolicy)
+        {
+            var modelPrefix = $"{nameof(ViewPoliciesViewModel.AddPolicy)}.";
+
+            if (string.IsNullOrWhiteSpace(addPolicy.PolicyUser))
+            {
+                ModelState.AddModelError(modelPrefix + nameof(addPolicy.PolicyUser), "The policy user field is required.");
+            }
+
+            var policyUser = _userService.FindByUsername(addPolicy.PolicyUser);
+            if (policyUser is null)
+            {
+                ModelState.AddModelError(modelPrefix + nameof(addPolicy.PolicyUser), "The policy user does not exist.");
+            }
+
+            if (string.IsNullOrWhiteSpace(addPolicy.PolicyPackageOwner))
+            {
+                ModelState.AddModelError(modelPrefix + nameof(addPolicy.PolicyPackageOwner), "The policy package owner field is required.");
+            }
+
+            var policyPackageOwner = _userService.FindByUsername(addPolicy.PolicyPackageOwner);
+            if (policyPackageOwner is null)
+            {
+                ModelState.AddModelError(modelPrefix + nameof(addPolicy.PolicyPackageOwner), "The policy package owner does not exist.");
+            }
+
+            if (!addPolicy.PolicyType.HasValue)
+            {
+                ModelState.AddModelError(modelPrefix + nameof(addPolicy.PolicyType), "The policy type field is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(addPolicy.PolicyCriteria))
+            {
+                ModelState.AddModelError(modelPrefix + nameof(addPolicy.PolicyCriteria), "The policy criteria field is required.");
+            }
+
+            if (addPolicy.PolicyType == FederatedCredentialType.EntraIdServicePrincipal)
+            {
+                EntraIdServicePrincipalCriteria? criteria = null;
+                try
+                {
+                    criteria = JsonSerializer.Deserialize<EntraIdServicePrincipalCriteria>(addPolicy.PolicyCriteria!);
+                    if (criteria is null)
+                    {
+                        ModelState.AddModelError(modelPrefix + nameof(addPolicy.PolicyCriteria), $"The policy criteria parsed as null.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ModelState.AddModelError(modelPrefix + nameof(addPolicy.PolicyCriteria), $"The policy criteria field could not be parsed as a {nameof(EntraIdServicePrincipalCriteria)}. Exception: " + ex.Message);
+                }
+
+                if (criteria is not null)
+                {
+                    var result = await _federatedCredentialService.AddEntraIdServicePrincipalPolicyAsync(
+                        policyUser!,
+                        policyPackageOwner!,
+                        criteria);
+
+                    switch (result.Type)
+                    {
+                        case AddFederatedCredentialPolicyResultType.BadRequest:
+                            ModelState.AddModelError(nameof(ViewPoliciesViewModel.AddPolicy), result.UserMessage);
+                            break;
+                        case AddFederatedCredentialPolicyResultType.Created:
+                            return RedirectForUser(policyUser!.Username, $"Policy with key {result.Policy.Key} added successfully.");
+                        default:
+                            throw new NotImplementedException($"Unexpected result type: {result.Type}");
+                    }
+                }
+            }
+
+            return View(nameof(Index), new ViewPoliciesViewModel([], [], [], addPolicy));
+        }
+
+        private RedirectResult RedirectForUser(string username, string message)
+        {
+            TempData["MessageFor" + username] = message;
+            return Redirect(Url.Action(nameof(Index), new { usernames = username }) + $"#user-{username}");
+        }
+    }
+}

--- a/src/NuGetGallery/Areas/Admin/Views/FederatedCredentials/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/FederatedCredentials/Index.cshtml
@@ -1,0 +1,281 @@
+﻿@using NuGetGallery.Areas.Admin.Controllers.FederatedCredentials
+@model ViewPoliciesViewModel
+@{
+    ViewBag.Title = "Federated credentials";
+}
+
+@helper RenderTimestamp(DateTime? timestamp)
+{
+    if (timestamp.HasValue)
+    {
+        <span class="text-nowrap small">@timestamp.Value.ToString("yyyy-MM-ddTHH:mm:ss")</span>
+        <span class="text-nowrap small">(@(Math.Round((DateTimeOffset.UtcNow - new DateTime(timestamp.Value.Ticks, DateTimeKind.Utc)).TotalDays, 1)) days ago)</span>
+    }
+}
+
+@helper RenderUsername(User user)
+{
+    if (Model.Usernames.Contains(user.Username, StringComparer.Ordinal))
+    {
+        <mark><a href="@Url.User(user)">@user.Username</a></mark>
+    }
+    else
+    {
+        <a href="@Url.User(user)">@user.Username</a>
+    }
+}
+
+<section role="main" class="container main-container">
+    <h1>@ViewBag.Title</h1>
+
+    <h2>Search for federated credential policies</h2>
+
+    <p>
+        Use this form to search for users or organizations. Federated credential policies <i>managed by</i> these accounts or have
+        these accounts set as the <i>package owner</i> will be returned. A federated credential policy is owned by a user account
+        and can have either the user itself as the specified package owner or an organization they are a member of.
+    </p>
+
+    <form class="form-horizontal" method="get" action="@Url.Action("Index")">
+        <div class="form-group">
+            <div class="col-xs-12">
+                <label for="packageIds" class="control-label">Search for policies related to specific accounts</label>
+                <textarea class="form-control textarea-brand" rows="3" id="usernames" name="usernames"
+                          placeholder="User or organization usernames, one per line">@string.Join(Environment.NewLine, Model.Usernames)</textarea>
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="col-xs-4">
+                <button type="submit" class="btn btn-block btn-brand">Search</button>
+            </div>
+            <div class="col-xs-4">
+                <button type="submit" class="btn btn-block btn-brand" name="addOrganizationMembers" value="true">Add organization's members</button>
+            </div>
+            <div class="col-xs-4">
+                <button type="submit" class="btn btn-block btn-brand" name="addUserOrganizations" value="true">Add user's organizations</button>
+            </div>
+        </div>
+    </form>
+
+    @if (Model.Usernames.Count > 0)
+    {
+        if (Model.UsernamesDoNotExist.Count > 0)
+        {
+            <p><b>Accounts that do not exist:</b> @(string.Join(", ", Model.UsernamesDoNotExist))</p>
+        }
+
+        if (Model.UserPolices.Count == 0)
+        {
+            @ViewHelpers.AlertInfo(@<text>No user policies were found.</text>)
+        }
+
+        foreach (var userPolicy in Model.UserPolices)
+        {
+            <hr />
+            var user = userPolicy.User;
+            <h3 id="user-@(user.Username)">Policies owned by user @RenderUsername(user)</h3>
+
+            if (TempData.ContainsKey("MessageFor" + user.Username))
+            {
+                @ViewHelpers.AlertInfo(@<text>@TempData["MessageFor" + user.Username]</text>)
+            }
+
+            <p>
+                <b>Member of organizations:</b>
+                @{ var first = true; }
+                @foreach (var membership in userPolicy.User.Organizations)
+                {
+                    if (!first)
+                    {
+                        <text>,</text>
+                    }
+                    { first = false; }
+                    <text>@RenderUsername(membership.Organization) (@(membership.IsAdmin ? "admin" : "contributor"))</text>
+                }
+
+                @if (first)
+                {
+                    <text>(none)</text>
+                }
+            </p>
+
+            if (!Model.Usernames.Contains(userPolicy.User.Username, StringComparer.OrdinalIgnoreCase))
+            {
+
+                <p>
+                    <b>Note:</b> not all policies may be shown because user <code>@userPolicy.User.Username</code> is not in the search query.
+                </p>
+            }
+
+            if (userPolicy.Policies.Count > 0)
+            {
+                <table class="table table-condensed table-bordered">
+                    <thead>
+                        <tr>
+                            <th class="text-nowrap">Policy key</th>
+                            <th class="text-nowrap">Package owner</th>
+                            <th class="text-nowrap">Type</th>
+                            <th class="text-nowrap">Criteria</th>
+                            <th class="text-nowrap">Created on</th>
+                            <th class="text-nowrap">Last used</th>
+                            <th class="text-nowrap">Delete</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var policy in userPolicy.Policies)
+                        {
+                            <tr>
+                                <td>@policy.Key</td>
+                                <td>@RenderUsername(policy.PackageOwner)</td>
+                                <td><code>@policy.Type</code></td>
+                                <td><code>@policy.Criteria</code></td>
+                                <td>@RenderTimestamp(policy.Created)</td>
+                                <td>@RenderTimestamp(policy.LastMatched)</td>
+                                <td>
+                                    <form method="post" action="@Url.Action("DeletePolicy")"
+                                          onsubmit="return confirm('Are you sure you want to delete this policy, owned by @policy.CreatedBy.Username? This will also delete all assocated short-lived API keys.');">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="policyKey" value="@policy.Key" />
+                                        <button type="submit" label="Delete this policy" class="btn btn-outline-primary">🗑️</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+            else
+            {
+                <p>This user owns no federated credential policies.</p>
+            }
+
+        }
+    }
+
+    <h2>Add a new federated credential policy</h2>
+    <p>
+        Use this form to create a new federated credential policy owned by a specific user and scoped to a specific package owner.
+        The policy package owner can be the same as the policy user or an organization the policy user is a member of.
+    </p>
+
+    <form method="post" action="@Url.Action("CreatePolicy")" onsubmit="return confirm('Are you sure you want to add this policy?');">
+        @Html.AntiForgeryToken()
+        <div class="row @Html.HasErrorFor(m => m.AddPolicy)">
+            @if (Html.IsError(m => m.AddPolicy))
+            {
+                <div class="col-xs-12">
+                    @Html.ShowValidationMessagesFor(m => m.AddPolicy)
+                </div>
+            }
+            <div class="form-group col-xs-4 @Html.HasErrorFor(m => m.AddPolicy.PolicyUser)">
+                <label for="policyUser">Policy user</label>
+                <input type="text" class="form-control" id="policyUser" name="policyUser"
+                       placeholder="Username of policy user" value="@Model.AddPolicy.PolicyUser">
+                @Html.ShowValidationMessagesFor(m => m.AddPolicy.PolicyUser)
+            </div>
+            <div class="form-group col-xs-4 @Html.HasErrorFor(m => m.AddPolicy.PolicyPackageOwner)">
+                <label for="policyPackageOwner">Policy package owner</label>
+                <input type="text" class="form-control" id="policyPackageOwner" name="policyPackageOwner"
+                       placeholder="Username of policy package owner" value="@Model.AddPolicy.PolicyPackageOwner">
+                @Html.ShowValidationMessagesFor(m => m.AddPolicy.PolicyPackageOwner)
+            </div>
+            <div class="form-group col-xs-4 @Html.HasErrorFor(m => m.AddPolicy.PolicyType)">
+                <label for="policyType">Policy type</label>
+                <select id="policyType" name="policyType" class="form-control">
+                    @foreach (var type in Enum.GetValues(typeof(FederatedCredentialType)).Cast<FederatedCredentialType>())
+                    {
+                        <option selected="@(type == Model.AddPolicy.PolicyType)">@type</option>
+                    }
+                </select>
+                @Html.ShowValidationMessagesFor(m => m.AddPolicy.PolicyType)
+            </div>
+        </div>
+        <div class="form-group row @Html.HasErrorFor(m => m.AddPolicy.PolicyCriteria)">
+            <div class="col-xs-12">
+                <label for="policyCriteria" class="control-label">Policy criteria (JSON)</label>
+                <textarea class="form-control textarea-brand" rows="3" id="policyCriteria" name="policyCriteria">@Model.AddPolicy.PolicyCriteria</textarea>
+                @Html.ShowValidationMessagesFor(m => m.AddPolicy.PolicyCriteria)
+            </div>
+        </div>
+        <div class="form-group row">
+            <div class="col-xs-12">
+                <button type="submit" class="btn btn-block btn-brand">Create</button>
+            </div>
+        </div>
+    </form>
+
+    <h2>Terminology</h2>
+    <p>
+        <dl>
+            <dt>Federated credential</dt>
+            <dd>
+                A credential from an external system can be traded for a short-lived API key.
+                When a federated credential is used, it is tracked in the database to avoid credential replay (reuse).
+                An example federated credential would be an OpenID Connect (OIDC) token from a trusted external
+                identity provider, such as Entra ID.
+            </dd>
+
+            <dt>Federated credential policy</dt>
+            <dd>
+                A set of criteria to determine whether a given federated credential is acceptable to be used to operate on behalf of a specific user.
+                This can be considered a trust policy of an external identity provided, expressed by a user of NuGet Gallery.
+            </dd>
+
+            <dt>Policy user</dt>
+            <dd>
+                This is the user account that manages the federated credential policy.
+                This will be the user that the generated short-lived API keys will be owned by.
+            </dd>
+
+            <dt>Policy package owner</dt>
+            <dd>
+                This is the user or organization account that the API key will act on behalf of.
+                This is different from the policy user because the package owner can be an organization.
+                The policy package owner will become the owner scope on the short-lived API key created from the policy.
+            </dd>
+
+            <dt>Policy type</dt>
+            <dd>
+                This is the type of federated credential that is accepted by the policy.
+                The policy type determines how the policy criteria are interpreted. An example policy type would be an
+                Entra ID service principal policy, which would accept Entra ID OIDC bearer tokens containing a
+                specific tenant ID and object ID referring to a service principal.
+            </dd>
+
+            <dt>Policy criteria</dt>
+            <dd>
+                These are criteria specific to a certain policy type and specified by the user.
+                An example of some policy criteria would be a tenant ID and object ID pair for an Entra ID service
+                principal.
+            </dd>
+        </dl>
+    </p>
+</section>
+
+
+@section BottomScripts {
+    <script type="text/javascript">
+        function setPolicyCriteriaTemplate(replace) {
+            const policyType = $('#policyType').val();
+            let policyCriteria;
+            switch (policyType) {
+                case '@(FederatedCredentialType.EntraIdServicePrincipal)':
+                    policyCriteria = JSON.stringify({ tid: 'tenant ID (GUID)', oid: 'object ID (GUID)' })
+                    break;
+                default:
+                    policyCriteria = "{}"
+                    break;
+            }
+            const policyCriteriaEl = $('#policyCriteria');
+            if (replace || !policyCriteriaEl.val()) {
+                policyCriteriaEl.val(policyCriteria);
+            }
+        }
+
+        setPolicyCriteriaTemplate(false);
+
+        $('#policyType').on('change', function () {
+            setPolicyCriteriaTemplate(true);
+        })
+    </script>
+}

--- a/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
+++ b/src/NuGetGallery/Areas/Admin/Views/Home/Index.cshtml
@@ -255,6 +255,17 @@
                     Correct IsLatest state from packages.
                 </p>
             </li>
+            <li class="col-sm-6 col-xs-12">
+                <h2>
+                    <a href="@Url.Action(actionName: "Index", controllerName: "FederatedCredentials")">
+                        <i class="ms-Icon ms-Icon--BranchLocked"></i>
+                        <span>Federated credentials</span>
+                    </a>
+                </h2>
+                <p class="text-muted">
+                    View and manage federated credential policies for users.
+                </p>
+            </li>
         </ul>
     </div>
 </section>

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Areas\Admin\Controllers\DeleteController.cs" />
     <Compile Include="Areas\Admin\Controllers\FeaturesController.cs" />
     <Compile Include="Areas\Admin\Controllers\CorrectIsLatestController.cs" />
+    <Compile Include="Areas\Admin\Controllers\FederatedCredentialsController.cs" />
     <Compile Include="Areas\Admin\Controllers\LockUserController.cs" />
     <Compile Include="Areas\Admin\Controllers\LockPackageController.cs" />
     <Compile Include="Areas\Admin\Controllers\PasswordAuthenticationController.cs" />
@@ -2287,6 +2288,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\Shared\_AccountChangeTheme.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Areas\Admin\Views\FederatedCredentials\Index.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/tests/NuGetGallery.Facts/Areas/Admin/Controllers/FederatedCredentialsControllerFacts.cs
+++ b/tests/NuGetGallery.Facts/Areas/Admin/Controllers/FederatedCredentialsControllerFacts.cs
@@ -1,0 +1,149 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Mvc;
+using Moq;
+using NuGet.Services.Entities;
+using NuGetGallery.Services.Authentication;
+using Xunit;
+
+namespace NuGetGallery.Areas.Admin.Controllers.FederatedCredentials;
+
+public class FederatedCredentialsControllerFacts
+{
+    public class TheIndexMethod : FederatedCredentialsControllerFacts
+    {
+        [Fact]
+        public void ReturnsView()
+        {
+            // Act
+            var result = Target.Index(usernames: "mac\ncheese");
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<ViewPoliciesViewModel>(viewResult.Model);
+            Assert.Equal(["cheese", "mac"], model.Usernames);
+            Assert.Equal("cheese", Assert.Single(model.UsernamesDoNotExist));
+            var userPolicies = Assert.Single(model.UserPolices);
+            Assert.Same(UserA, userPolicies.User);
+            Assert.Equal(2, userPolicies.Policies.Count);
+            Assert.Same(Policies[0], userPolicies.Policies[1]);
+            Assert.Same(Policies[1], userPolicies.Policies[0]);
+        }
+    }
+
+    public class TheDeletePolicyMethod : FederatedCredentialsControllerFacts
+    {
+        [Fact]
+        public async Task DeletesPolicy()
+        {
+            // Act
+            var result = await Target.DeletePolicy(policyKey: 4);
+
+            // Assert
+            Assert.IsType<RedirectResult>(result);
+            FederatedCredentialService.Verify(x => x.DeletePolicyAsync(Policies[0]), Times.Once);
+        }
+    }
+
+    public class TheCreatePolicyMethod : FederatedCredentialsControllerFacts
+    {
+        [Fact]
+        public async Task CreatedPolicy()
+        {
+            // Arrange
+            var input = new AddPolicyViewModel
+            {
+                PolicyUser = "mac",
+                PolicyPackageOwner = "mac-farm",
+                PolicyType = FederatedCredentialType.EntraIdServicePrincipal,
+                PolicyCriteria =
+                """
+                {
+                    "tid": "acf6141a-b108-45dd-bf31-9afaa7403463",
+                    "oid": "07f3a0d5-1da7-4fee-ac38-6893653eba08"
+                }
+                """
+            };
+
+            FederatedCredentialService
+                .Setup(x => x.AddEntraIdServicePrincipalPolicyAsync(
+                    It.IsAny<User>(),
+                    It.IsAny<User>(),
+                    It.IsAny<EntraIdServicePrincipalCriteria>()))
+                .ReturnsAsync(() => AddFederatedCredentialPolicyResult.Created(new FederatedCredentialPolicy { Key = 6 }));
+
+            // Act
+            var result = await Target.CreatePolicy(input);
+
+            // Assert
+            Assert.IsType<RedirectResult>(result);
+            var invocation = Assert.Single(FederatedCredentialService.Invocations);
+            Assert.Equal(nameof(FederatedCredentialService.Object.AddEntraIdServicePrincipalPolicyAsync), invocation.Method.Name);
+            Assert.Same(UserA, invocation.Arguments[0]);
+            Assert.Same(OrgA, invocation.Arguments[1]);
+            var criteria = Assert.IsType<EntraIdServicePrincipalCriteria>(invocation.Arguments[2]);
+            Assert.Equal("acf6141a-b108-45dd-bf31-9afaa7403463", criteria.TenantId.ToString());
+            Assert.Equal("07f3a0d5-1da7-4fee-ac38-6893653eba08", criteria.ObjectId.ToString());
+        }
+    }
+
+    public FederatedCredentialsControllerFacts()
+    {
+        FederatedCredentialRepository = new Mock<IFederatedCredentialRepository>();
+        UserRepository = new Mock<IEntityRepository<User>>();
+        UserService = new Mock<IUserService>();
+        FederatedCredentialService = new Mock<IFederatedCredentialService>();
+
+        UserA = new User { Key = 2, Username = "mac" };
+        OrgA = new Organization { Key = 3, Username = "mac-farm" };
+        var baseTime = new DateTime(2024, 11, 7, 0, 0, 0, DateTimeKind.Utc);
+        Users = new List<User>
+        {
+            UserA,
+            OrgA,
+        };
+        Policies = new List<FederatedCredentialPolicy>
+        {
+            new FederatedCredentialPolicy { Key = 4, Created = baseTime.AddHours(2), CreatedByUserKey = UserA.Key, CreatedBy = UserA, PackageOwnerUserKey = UserA.Key, PackageOwner = UserA },
+            new FederatedCredentialPolicy { Key = 5, Created = baseTime.AddHours(1), CreatedByUserKey = UserA.Key, CreatedBy = UserA, PackageOwnerUserKey = OrgA.Key, PackageOwner = OrgA },
+        };
+
+        FederatedCredentialRepository
+            .Setup(x => x.GetPoliciesRelatedToUserKeys(It.IsAny<IReadOnlyList<int>>()))
+            .Returns(() => Policies);
+        FederatedCredentialRepository
+            .Setup(x => x.GetPolicyByKey(It.IsAny<int>()))
+            .Returns<int>(k => Policies.FirstOrDefault(p => p.Key == k));
+        UserRepository
+            .Setup(x => x.GetAll())
+            .Returns(() => new[] { UserA, OrgA }.AsQueryable());
+        UserService
+            .Setup(x => x.FindByUsername(It.IsAny<string>(), It.IsAny<bool>()))
+            .Returns<string, bool>((u, _) => Users.FirstOrDefault(x => x.Username == u));
+
+        Target = new FederatedCredentialsController(
+            FederatedCredentialRepository.Object,
+            UserRepository.Object,
+            UserService.Object,
+            FederatedCredentialService.Object);
+
+        TestUtility.SetupHttpContextMockForUrlGeneration(new Mock<HttpContextBase>(), Target);
+    }
+
+    public Mock<IFederatedCredentialRepository> FederatedCredentialRepository { get; }
+    public Mock<IEntityRepository<User>> UserRepository { get; }
+    public Mock<IUserService> UserService { get; }
+    public Mock<IFederatedCredentialService> FederatedCredentialService { get; }
+    public User UserA { get; }
+    public Organization OrgA { get; }
+    public int CreatedByUserKey { get; }
+    public List<User> Users { get; }
+    public List<FederatedCredentialPolicy> Policies { get; }
+    public FederatedCredentialsController Target { get; }
+}

--- a/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialRepositoryFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialRepositoryFacts.cs
@@ -160,6 +160,32 @@ namespace NuGetGallery.Services.Authentication
             }
         }
 
+        public class TheGetPoliciesRelatedToUserKeysMethod : FederatedCredentialRepositoryFacts
+        {
+            [Fact]
+            public void FiltersByUserKeys()
+            {
+                // Act
+                var policies = Target.GetPoliciesRelatedToUserKeys([4]);
+
+                // Assert
+                Assert.Equal(2, policies.Count);
+                Assert.Equal(1, policies[0].Key);
+                Assert.Equal(2, policies[1].Key);
+            }
+
+            [Fact]
+            public void FiltersByOwnerKeys()
+            {
+                // Act
+                var policies = Target.GetPoliciesRelatedToUserKeys([8]);
+
+                // Assert
+                Assert.Single(policies);
+                Assert.Equal(2, policies[0].Key);
+            }
+        }
+
         public FederatedCredentialRepositoryFacts()
         {
             FederatedCredentialRepository = new Mock<IEntityRepository<FederatedCredential>>();
@@ -168,9 +194,9 @@ namespace NuGetGallery.Services.Authentication
 
             Policies = new List<FederatedCredentialPolicy>
             {
-                new() { Key = 1, CreatedByUserKey = 4 },
-                new() { Key = 2, CreatedByUserKey = 4 },
-                new() { Key = 3, CreatedByUserKey = 5 },
+                new() { Key = 1, CreatedByUserKey = 4, PackageOwnerUserKey = 4 },
+                new() { Key = 2, CreatedByUserKey = 4, PackageOwnerUserKey = 8 },
+                new() { Key = 3, CreatedByUserKey = 5, PackageOwnerUserKey = 9 },
             };
             PolicyRepository.Setup(x => x.GetAll()).Returns(() => Policies.AsQueryable());
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/10212.
Depends on https://github.com/NuGet/NuGetGallery/pull/10289.

This PR adds a new admin panel for our team to manage federated credential policies on behalf of other users. We will use this to manual onboard users to the OIDC feature.

The new option on the admin panel index looks like this:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/a8580536-3874-450b-b786-7c8d8af31f3f">

The admin panel looks like this:
![image](https://github.com/user-attachments/assets/77e14180-c1b3-45f3-8b71-85b14205a7d8)

You can add a federated credential policy for a user here:
![image](https://github.com/user-attachments/assets/fa01ccac-a806-46bc-952c-7e680e18101a)

Search results look like this:
![image](https://github.com/user-attachments/assets/d4a05218-c84a-4fc9-87a5-5bb79a39fddd)

There is a "terminology" section at the bottom as a reference for the feature.

> ### Terminology
> **Federated credential**
> A credential from an external system can be traded for a short-lived API key. When a federated credential is used, it is tracked in the database to avoid credential replay (reuse). An example federated credential would be an OpenID Connect (OIDC) token from a trusted external identity provider, such as Entra ID.
>
> **Federated credential policy**
> A set of criteria to determine whether a given federated credential is acceptable to be used to operate on behalf of a specific user. This can be considered a trust policy of an external identity provided, expressed by a user of NuGet Gallery.
>
> **Policy user**
> This is the user account that manages the federated credential policy. This will be the user that the generated short-lived API keys will be owned by.
>
> **Policy package owner**
> This is the user or organization account that the API key will act on behalf of. This is different from the policy user because the package owner can be an organization. The policy package owner will become the owner scope on the short-lived API key created from the policy.
> 
> **Policy type**
> This is the type of federated credential that is accepted by the policy. The policy type determines how the policy criteria are interpreted. An example policy type would be an Entra ID service principal policy, which would accept Entra ID OIDC bearer tokens containing a specific tenant ID and object ID referring to a service principal.
> 
> **Policy criteria**
> These are criteria specific to a certain policy type and specified by the user. An example of some policy criteria would be a tenant ID and object ID pair for an Entra ID service principal.