### PR TITLE
[Fix] GithubVulnerability2V3 use only HTTPS

### DIFF
--- a/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
+++ b/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
@@ -83,8 +83,6 @@ namespace GitHubVulnerabilities2v3.Extensions
 
             var currentTime = DateTime.UtcNow.ToString(TimeFormat);
             var indexStorageUri = _storage.ResolveUri(_configuration.IndexFileName);
-            StringBuilder updateUriPathBuilder = new StringBuilder();
-            updateUriPathBuilder.Append(_configuration.V3VulnerabilityContainerName + "/");
 
             if (runMode == RunMode.Update && !await _storage.ExistsAsync(indexStorageUri.ToString(), CancellationToken.None))
             {

--- a/src/GitHubVulnerabilities2v3/Job.cs
+++ b/src/GitHubVulnerabilities2v3/Job.cs
@@ -131,8 +131,7 @@ namespace GitHubVulnerabilities2v3
                         ctx.Resolve<BlobServiceClientFactory>(),
                         ctx.Resolve<GitHubVulnerabilities2v3Configuration>().V3VulnerabilityContainerName,
                         enablePublicAccess: true,
-                        azureStorageLogger: ctx.Resolve<ILogger<AzureStorage>>(),
-                        baseAddress: new Uri(ctx.Resolve<GitHubVulnerabilities2v3Configuration>().StorageConnectionString));
+                        azureStorageLogger: ctx.Resolve<ILogger<AzureStorage>>());
                 })
                 .As<StorageFactory>()
                 .As<IStorageFactory>();

--- a/src/GitHubVulnerabilities2v3/Job.cs
+++ b/src/GitHubVulnerabilities2v3/Job.cs
@@ -131,7 +131,8 @@ namespace GitHubVulnerabilities2v3
                         ctx.Resolve<BlobServiceClientFactory>(),
                         ctx.Resolve<GitHubVulnerabilities2v3Configuration>().V3VulnerabilityContainerName,
                         enablePublicAccess: true,
-                        ctx.Resolve<ILogger<AzureStorage>>());
+                        azureStorageLogger: ctx.Resolve<ILogger<AzureStorage>>(),
+                        baseAddress: new Uri(ctx.Resolve<GitHubVulnerabilities2v3Configuration>().StorageConnectionString));
                 })
                 .As<StorageFactory>()
                 .As<IStorageFactory>();

--- a/src/NuGet.Services.Storage/AzureStorage.cs
+++ b/src/NuGet.Services.Storage/AzureStorage.cs
@@ -117,13 +117,7 @@ namespace NuGet.Services.Storage
 
         static Uri GetDirectoryUri(BlobContainerClient directory)
         {
-            Uri uri = new UriBuilder(directory.Uri)
-            {
-                Scheme = "http",
-                Port = 80
-            }.Uri;
-
-            return uri;
+            return directory.Uri;
         }
 
         //Blob exists

--- a/src/NuGet.Services.Storage/AzureStorageFactory.cs
+++ b/src/NuGet.Services.Storage/AzureStorageFactory.cs
@@ -50,13 +50,7 @@ namespace NuGet.Services.Storage
 
             if (baseAddress == null)
             {
-                Uri blobEndpoint = new UriBuilder(account.Uri)
-                {
-                    Scheme = "http", // Convert base address to http. 'https' can be used for communication but is not part of the names.
-                    Port = 80
-                }.Uri;
-
-                BaseAddress = new Uri(blobEndpoint, containerName + "/" + _path ?? string.Empty);
+                BaseAddress = new Uri(account.Uri, containerName + "/" + _path ?? string.Empty);
             }
             else
             {


### PR DESCRIPTION
# Changes
* Removed explicit http scheme when creating storages.
* Not related: 2 unused lines on `src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs`

Addresses https://github.com/NuGet/NuGetGallery/issues/123