### PR TITLE
Introduced third party library called HtmlSanitizer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="EntityFramework" Version="6.4.4" />
     <PackageVersion Include="FluentAssertions" Version="5.5.0" />
     <PackageVersion Include="FluentLinkChecker" Version="1.0.0.10" />
+    <PackageVersion Include="HtmlSanitizer" Version="8.1.870" />
     <PackageVersion Include="Knapcode.MiniZip" Version="0.20.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.26.0" />
     <PackageVersion Include="Lucene.Net.Contrib" Version="3.0.3" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -12,6 +12,8 @@
     <clear />
     <packageSource key="NuGet.org">
       <package pattern="Antlr" />
+      <package pattern="AngleSharp.*" />      
+      <package pattern="AngleSharp" />
       <package pattern="Autofac.*" />
       <package pattern="Autofac" />
       <package pattern="Azure.*" />
@@ -26,6 +28,7 @@
       <package pattern="FluentAssertions" />
       <package pattern="FluentLinkChecker" />
       <package pattern="HtmlAgilityPack" />
+      <package pattern="HtmlSanitizer" />
       <package pattern="Hyak.Common" />
       <package pattern="Knapcode.MiniZip" />
       <package pattern="LibGit2Sharp.NativeBinaries" />

--- a/sign.thirdparty.props
+++ b/sign.thirdparty.props
@@ -1,5 +1,7 @@
 <Project>
   <ItemGroup>
+    <ThirdPartyBinaries Include="AngleSharp.dll" />
+    <ThirdPartyBinaries Include="AngleSharp.Css.dll" />
     <ThirdPartyBinaries Include="AnglicanGeek.MarkdownMailer.dll" />
     <ThirdPartyBinaries Include="Antlr3.Runtime.dll" />
     <ThirdPartyBinaries Include="Autofac.dll" />
@@ -16,6 +18,7 @@
     <ThirdPartyBinaries Include="Elmah.dll" />
     <ThirdPartyBinaries Include="git2-572e4d8.dll" />
     <ThirdPartyBinaries Include="HtmlAgilityPack.dll" />
+    <ThirdPartyBinaries Include="HtmlSanitizer.dll" />
     <ThirdPartyBinaries Include="ICSharpCode.SharpZipLib.dll" />
     <ThirdPartyBinaries Include="json-ld.net.StrongName.dll" />
     <ThirdPartyBinaries Include="Knapcode.MiniZip.dll" />

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -20,6 +20,7 @@ using AnglicanGeek.MarkdownMailer;
 using Autofac;
 using Autofac.Core;
 using Autofac.Extensions.DependencyInjection;
+using Ganss.Xss;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.Extensions.DependencyInjection;
@@ -132,6 +133,7 @@ namespace NuGetGallery
 
             services.AddSingleton(loggerFactory);
             services.AddSingleton(typeof(ILogger<>), typeof(Logger<>));
+            services.AddSingleton<IHtmlSanitizer, HtmlSanitizer>();
 
             UrlHelperExtensions.SetConfigurationService(configuration);
             builder.RegisterType<UrlHelperWrapper>()

--- a/src/NuGetGallery/NuGetGallery.csproj
+++ b/src/NuGetGallery/NuGetGallery.csproj
@@ -2211,6 +2211,7 @@
     <PackageReference Include="NuGet.StrongName.elmah.sqlserver" />
     <PackageReference Include="NuGet.StrongName.elmah" />
     <PackageReference Include="EntityFramework" />
+    <PackageReference Include="HtmlSanitizer" />
     <PackageReference Include="Lucene.Net" />
     <PackageReference Include="Lucene.Net.Contrib" />
     <PackageReference Include="Microsoft.ApplicationInsights.TraceListener" />

--- a/src/NuGetGallery/Web.config
+++ b/src/NuGetGallery/Web.config
@@ -739,6 +739,10 @@
         <assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.9.1.0" newVersion="4.9.1.0"/>
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="AngleSharp" publicKeyToken="e83494dcdc6d31ea" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-0.17.1.0" newVersion="0.17.1.0"/>
+      </dependentAssembly>      
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Introduced third party library called HtmlSanitizer
with default tags. By default, it removes script
tags, event handlers (e.g.,onclick), and other inline JavaScript code that can be used for XSS attacks.
Test: ran all markdown features on readme. Looks fine.

Address the issue: https://github.com/NuGet/Engineering/issues/5650 