### PR TITLE
[SDKMigration] Update Gallery.CredentialExpiration to use ManagedIdentity

### DIFF
--- a/src/Gallery.CredentialExpiration/Configuration/InitializationConfiguration.cs
+++ b/src/Gallery.CredentialExpiration/Configuration/InitializationConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Jobs.Configuration;
@@ -10,6 +10,8 @@ namespace Gallery.CredentialExpiration
         public string ContainerName { get; set; }
 
         public string DataStorageAccount { get; set; }
+
+        public string DataStorageAccountUrl { get; set; }
 
         public string EmailPublisherConnectionString { get; set; }
 

--- a/src/Gallery.CredentialExpiration/Job.cs
+++ b/src/Gallery.CredentialExpiration/Job.cs
@@ -9,6 +9,8 @@ using System.Net.Mail;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
+using Azure.Core;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Gallery.CredentialExpiration.Models;
 using Microsoft.Extensions.Configuration;
@@ -51,8 +53,10 @@ namespace Gallery.CredentialExpiration
                 InitializationConfiguration);
 
             FromAddress = new MailAddress(InitializationConfiguration.MailFrom);
-            
-            var storageAccount = new BlobServiceClientFactory(AzureStorageFactory.PrepareConnectionString(InitializationConfiguration.DataStorageAccount));
+
+            var tokenCredential = _serviceProvider.GetRequiredService<TokenCredential>();
+            var storageAccount = new BlobServiceClientFactory(new Uri(InitializationConfiguration.DataStorageAccountUrl), tokenCredential);
+
             var storageFactory = new AzureStorageFactory(
                 storageAccount,
                 InitializationConfiguration.ContainerName,

--- a/src/NuGet.Services.Configuration/Constants.cs
+++ b/src/NuGet.Services.Configuration/Constants.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Net.NetworkInformation;
+
 namespace NuGet.Services.Configuration
 {
     public static class Constants
@@ -17,5 +19,6 @@ namespace NuGet.Services.Configuration
         public static string KeyVaultSendX5c = "KeyVault_SendX5c";
         public static string StorageUseManagedIdentityPropertyName = "Storage_UseManagedIdentity";
         public static string StorageManagedIdentityClientIdPropertyName = "Storage_ManagedIdentityClientId";
+        public static string ConfigureForLocalDevelopment = "Local_Development";
     }
 }

--- a/src/NuGet.Services.Configuration/Constants.cs
+++ b/src/NuGet.Services.Configuration/Constants.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Net.NetworkInformation;
-
 namespace NuGet.Services.Configuration
 {
     public static class Constants


### PR DESCRIPTION
Update Gallery.CredentialExpiration job to use Managed Identity for storage access.
This changeset also includes changes to add a new setting for local development.

Adding "Local_Development": boolean to the top level of app.json will now inject the relevant TokenCredential for use (DefaultAzureCredential for local development true, and ManagedIdentityCredential for local development false).