### PR TITLE
[HotFix] Fix update path not being reached.

### DIFF
--- a/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
+++ b/src/GitHubVulnerabilities2v3/Extensions/BlobStorageVulnerabilityWriter.cs
@@ -84,7 +84,7 @@ namespace GitHubVulnerabilities2v3.Extensions
             var currentTime = DateTime.UtcNow.ToString(TimeFormat);
             var indexStorageUri = _storage.ResolveUri(_configuration.IndexFileName);
 
-            if (runMode == RunMode.Update && !await _storage.ExistsAsync(indexStorageUri.ToString(), CancellationToken.None))
+            if (runMode == RunMode.Update && !await _storage.ExistsAsync(_configuration.IndexFileName, CancellationToken.None))
             {
                 _logger.LogWarning("Update mode was set, but {IndexPath} doesn't exist. Falling back to regeneration.", indexStorageUri.ToString());
                 runMode = RunMode.Regenerate;


### PR DESCRIPTION
# Changes
* The `GitHubVulnerabilities2v3` job was not reaching the index file due to a bug on the `FlushAsync` method where the `ExistAsync` require just the file name instead of the whole file uri.
* e.g. It expected only `index.json` instead of the `<storageaccount>/v3-vulnerabilities/index.json`.
* Before the fix, this method was looking for a file named `<storageaccount>/v3-vulnerabilities/<storageaccount>/v3-vulnerabilities/index.json`.
 
Addresses: https://github.com/NuGet/Engineering/issues/5720