### PR TITLE
[OIDC 14] Rename FederatedCredentialEvaluator to FederatedCredentialPolicyEvaluator

### DIFF
--- a/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialPolicyEvaluator.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialPolicyEvaluator.cs
@@ -16,21 +16,21 @@ using NuGet.Services.Entities;
 
 namespace NuGetGallery.Services.Authentication
 {
-    public interface IFederatedCredentialEvaluator
+    public interface IFederatedCredentialPolicyEvaluator
     {
         Task<EvaluatedFederatedCredentialPolicies> GetMatchingPolicyAsync(IReadOnlyCollection<FederatedCredentialPolicy> policies, string bearerToken);
     }
 
-    public class FederatedCredentialEvaluator : IFederatedCredentialEvaluator
+    public class FederatedCredentialPolicyEvaluator : IFederatedCredentialPolicyEvaluator
     {
         private readonly IEntraIdTokenValidator _entraIdTokenValidator;
         private readonly IDateTimeProvider _dateTimeProvider;
-        private readonly ILogger<FederatedCredentialEvaluator> _logger;
+        private readonly ILogger<FederatedCredentialPolicyEvaluator> _logger;
 
-        public FederatedCredentialEvaluator(
+        public FederatedCredentialPolicyEvaluator(
             IEntraIdTokenValidator entraIdTokenValidator,
             IDateTimeProvider dateTimeProvider,
-            ILogger<FederatedCredentialEvaluator> logger)
+            ILogger<FederatedCredentialPolicyEvaluator> logger)
         {
             _entraIdTokenValidator = entraIdTokenValidator ?? throw new ArgumentNullException(nameof(entraIdTokenValidator));
             _dateTimeProvider = dateTimeProvider ?? throw new ArgumentNullException(nameof(dateTimeProvider));

--- a/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialService.cs
+++ b/src/NuGetGallery.Services/Authentication/Federated/FederatedCredentialService.cs
@@ -46,7 +46,7 @@ namespace NuGetGallery.Services.Authentication
     {
         private readonly IUserService _userService;
         private readonly IFederatedCredentialRepository _repository;
-        private readonly IFederatedCredentialEvaluator _evaluator;
+        private readonly IFederatedCredentialPolicyEvaluator _evaluator;
         private readonly IEntraIdTokenValidator _entraIdTokenValidator;
         private readonly ICredentialBuilder _credentialBuilder;
         private readonly IAuthenticationService _authenticationService;
@@ -57,7 +57,7 @@ namespace NuGetGallery.Services.Authentication
         public FederatedCredentialService(
             IUserService userService,
             IFederatedCredentialRepository repository,
-            IFederatedCredentialEvaluator evaluator,
+            IFederatedCredentialPolicyEvaluator evaluator,
             IEntraIdTokenValidator entraIdTokenValidator,
             ICredentialBuilder credentialBuilder,
             IAuthenticationService authenticationService,

--- a/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
+++ b/src/NuGetGallery/App_Start/DefaultDependenciesModule.cs
@@ -587,8 +587,8 @@ namespace NuGetGallery
                 .InstancePerLifetimeScope();
 
             builder
-                .RegisterType<FederatedCredentialEvaluator>()
-                .As<IFederatedCredentialEvaluator>()
+                .RegisterType<FederatedCredentialPolicyEvaluator>()
+                .As<IFederatedCredentialPolicyEvaluator>()
                 .InstancePerLifetimeScope();
 
             builder

--- a/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialPolicyEvaluatorFacts.cs
+++ b/tests/NuGetGallery.Facts/Authentication/Federated/FederatedCredentialPolicyEvaluatorFacts.cs
@@ -16,9 +16,9 @@ using Xunit;
 
 namespace NuGetGallery.Services.Authentication
 {
-    public class FederatedCredentialEvaluatorFacts
+    public class FederatedCredentialPolicyEvaluatorFacts
     {
-        public class TheGetMatchingPolicyAsyncMethod : FederatedCredentialEvaluatorFacts
+        public class TheGetMatchingPolicyAsyncMethod : FederatedCredentialPolicyEvaluatorFacts
         {
             [Fact]
             public async Task ReturnsNoMatchingPolicyWhenNoneAreProvided()
@@ -158,7 +158,7 @@ namespace NuGetGallery.Services.Authentication
             }
         }
 
-        public class EntraId : FederatedCredentialEvaluatorFacts
+        public class EntraId : FederatedCredentialPolicyEvaluatorFacts
         {
             [Fact]
             public async Task RejectsTokenWhenEntraIdEvaluatorRejectsIt()
@@ -238,7 +238,7 @@ namespace NuGetGallery.Services.Authentication
             }
         }
 
-        public class EntraIdServicePrincipal : FederatedCredentialEvaluatorFacts
+        public class EntraIdServicePrincipal : FederatedCredentialPolicyEvaluatorFacts
         {
             [Theory]
             [InlineData("tid")]
@@ -384,11 +384,11 @@ namespace NuGetGallery.Services.Authentication
             }
         }
 
-        public FederatedCredentialEvaluatorFacts()
+        public FederatedCredentialPolicyEvaluatorFacts()
         {
             EntraIdTokenValidator = new Mock<IEntraIdTokenValidator>();
             DateTimeProvider = new Mock<IDateTimeProvider>();
-            Logger = new Mock<ILogger<FederatedCredentialEvaluator>>();
+            Logger = new Mock<ILogger<FederatedCredentialPolicyEvaluator>>();
 
             TenantId = new Guid("c311b905-19a2-483e-a014-41d0fcdc99cf");
             ObjectId = new Guid("d17083b8-74e0-46c6-b69f-764da2e6fc0e");
@@ -428,7 +428,7 @@ namespace NuGetGallery.Services.Authentication
                 .Setup(x => x.UtcNow)
                 .Returns(() => UtcNow.UtcDateTime);
 
-            Target = new FederatedCredentialEvaluator(
+            Target = new FederatedCredentialPolicyEvaluator(
                 EntraIdTokenValidator.Object,
                 DateTimeProvider.Object,
                 Logger.Object);
@@ -436,7 +436,7 @@ namespace NuGetGallery.Services.Authentication
 
         public Mock<IEntraIdTokenValidator> EntraIdTokenValidator { get; }
         public Mock<IDateTimeProvider> DateTimeProvider { get; }
-        public Mock<ILogger<FederatedCredentialEvaluator>> Logger { get; }
+        public Mock<ILogger<FederatedCredentialPolicyEvaluator>> Logger { get; }
         public Guid TenantId { get; }
         public Guid ObjectId { get; }
         public Dictionary<string, object> Claims { get; }
@@ -447,6 +447,6 @@ namespace NuGetGallery.Services.Authentication
 
         public string BearerToken => new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor { Claims = Claims, Expires = Expires.UtcDateTime });
 
-        public FederatedCredentialEvaluator Target { get; }
+        public FederatedCredentialPolicyEvaluator Target { get; }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/10212.
Depends on https://github.com/NuGet/NuGetGallery/pull/10291.

This PR is a simple rename of a previously introduce service. 

Old name: `IFederatedCredentialEvaluator` (interface) and `FederatedCredentialEvaluator` (class)
New name: `IFederatedCredentialPolicyEvaluator` (interface) and `FederatedCredentialPolicyEvaluator` (class)

The reason for this change is I will be adding a new abstraction called `IFederatedCredentialValidator` which I felt is too close of a name to `IFederatedCredentialEvaluator`. 

In the end, this thing evaluates whether a bearer token matches a list of policies. So "policy evaluator" is probably more clear anyway.