### PR TITLE
Update EntityFramework package for vulnerability alert 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -133,7 +133,7 @@
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Diagnostics.Debug" Version="4.3.0" />
-    <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />
+    <PackageVersion Include="System.Drawing.Common" Version="9.0.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.Linq.Expressions" Version="4.3.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="d3" Version="5.4.0" />
     <PackageVersion Include="Dapper.StrongName" Version="1.50.2" />
     <PackageVersion Include="dotNetRDF" Version="1.0.8.3533" />
-    <PackageVersion Include="EntityFramework" Version="6.4.4" />
+    <PackageVersion Include="EntityFramework" Version="6.5.1" />
     <PackageVersion Include="FluentAssertions" Version="5.5.0" />
     <PackageVersion Include="FluentLinkChecker" Version="1.0.0.10" />
     <PackageVersion Include="HtmlSanitizer" Version="8.1.870" />


### PR DESCRIPTION
EntityFramework 6.4.4 is deprecated with vulnerable, update to latest stable. 

Note: There is change:  New SQL Server / Azure SQL Database provider (contributed by the community) - [Microsoft.EntityFramework.SqlServer](https://www.nuget.org/packages/Microsoft.EntityFramework.SqlServer/). This new provider uses the modern SQL Server client [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient). For more information about configuration of this provider, see [Microsoft.EntityFramework.SqlServer Guide](https://learn.microsoft.com/en-us/ef/ef6/what-is-new/microsoft-ef6-sqlserver).

It provides new provider configuration, no changes on default one. We should be good

Addresses https://github.com/NuGet/Engineering/issues/5732